### PR TITLE
Improved saucelabs integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ before_install:
 
 install:
   - npm install -g bower
-  - npm install -g saucie
   - npm install
   - bower install
 
 before_script:
+  - curl -L https://gist.githubusercontent.com/johanneswuerbach/e4950820c0d685fc545e/raw/sauce_connect_setup.sh | bash # Create a sauce tunnel
   - ember s --live-reload=false & # Start a server so we can hit the fake API from integration tests
   - sleep 10 # wait for the server to be started
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.1.2",
+    "ember-cli-sauce": "0.0.7",
     "ember-data": "1.0.0-beta.14",
     "ember-export-application-global": "^1.0.0",
     "ember-pikaday": "^0.2.1",

--- a/testemci.json
+++ b/testemci.json
@@ -3,31 +3,31 @@
   "test_page": "tests/index.html",
   "launchers": {
     "SauceLabs_Chrome": {
-      "command": "saucie --platformSL='Windows 7' --host='http://localhost' --port=8080",
+      "command": "./node_modules/.bin/ember-cli-sauce --platformSL='Windows 7' --no-ct -u <url>",
       "protocol": "tap"
     },
     "SauceLabs_Firefox": {
-      "command": "saucie --platformSL='Windows 7' --browserNameSL='firefox' --host='http://localhost' --port=8080",
+      "command": "./node_modules/.bin/ember-cli-sauce --platformSL='Windows 7' --browserNameSL='firefox' --no-ct -u <url>",
       "protocol": "tap"
     },
     "SauceLabs_IE_9": {
-      "command": "saucie --browserNameSL='internet explorer' --versionSL='9' --platformSL='Windows 7' --host='http://localhost' --port=8080",
+      "command": "./node_modules/.bin/ember-cli-sauce --browserNameSL='internet explorer' --versionSL='9' --platformSL='Windows 7' --no-ct -u <url>",
       "protocol": "tap"
     },
     "SauceLabs_IE_10": {
-      "command": "saucie --browserNameSL='internet explorer' --versionSL='10' --platformSL='Windows 8' --host='http://localhost' --port=8080",
+      "command": "./node_modules/.bin/ember-cli-sauce --browserNameSL='internet explorer' --versionSL='10' --platformSL='Windows 8' --no-ct -u <url>",
       "protocol": "tap"
     },
     "SauceLabs_IE_11": {
-      "command": "saucie --browserNameSL='internet explorer' --versionSL='11' --platformSL='Windows 8.1' --host='http://localhost' --port=8080",
+      "command": "./node_modules/.bin/ember-cli-sauce --browserNameSL='internet explorer' --versionSL='11' --platformSL='Windows 8.1' --no-ct -u <url>",
       "protocol": "tap"
     },
     "SauceLabs_Safari_7": {
-      "command": "saucie --browserNameSL='safari' --versionSL='7' --platformSL='OS X 10.9' --host='http://localhost' --port=8080",
+      "command": "./node_modules/.bin/ember-cli-sauce --browserNameSL='safari' --versionSL='7' --platformSL='OS X 10.9' --no-ct -u <url>",
       "protocol": "tap"
     },
     "SauceLabs_Safari_8": {
-      "command": "saucie --browserNameSL='safari' --versionSL='8' --platformSL='OS X 10.10' --host='http://localhost' --port=8080",
+      "command": "./node_modules/.bin/ember-cli-sauce --browserNameSL='safari' --versionSL='8' --platformSL='OS X 10.10' --no-ct -u <url>",
       "protocol": "tap"
     }
   },


### PR DESCRIPTION
Hey I just extracted some saucelabs browser testing improvements I made for htmlbars into an ember-cli addon: ember-cli-sauce

This has some advantages over your current implementation:
Use only a single tunnel (faster)
Test results available on SauceLabs
And we can collect further improvements in a central place: https://github.com/johanneswuerbach/ember-cli-sauce

What do you think?