### PR TITLE
added Yes/No to learning materials required column, fixes #59

### DIFF
--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -22,7 +22,13 @@
             <td colspan=2>{{fa-icon 'external-link-square'}} {{lm.learningMaterial.title}}</td>
             <td>{{lm.learningMaterial.type}}</td>
             <td>{{lm.learningMaterial.originalAuthor}}</td>
-            <td>{{lm.required}}</td>
+            <td>
+	    {{#if lm.required}}
+	      <span class='add'>{{t 'general.yes'}}</span>
+	    {{else}}
+	      <span class='remove'>{{t 'general.no'}}</span>
+	    {{/if}}
+	    </td>
             <td>{{lm.learningMaterial.notes}}</td>
           </t>
         {{/each}}


### PR DESCRIPTION
Added Yes/No results as requested, but we may actually prefer a blank for 'no'.  I can quickly change if that is the case.