### PR TITLE
wrapped label/data blocks in div with class inline-label-data-block, fixes #50

### DIFF
--- a/app/templates/components/course-overview.hbs
+++ b/app/templates/components/course-overview.hbs
@@ -7,10 +7,22 @@
   </div>
   <div class='detail-content'>
     {{#if editing}}
-      <label>{{t "general.start"}}: {{editable-date model=course property='startDate'}}</label>
-      <label>{{t "courses.externalId"}}: {{editable-text model=course property='externalId'}}</label>
-      <label>{{t "courses.level"}}: {{editable-select model=course property='level' options=levelOptions}}</label>
-      <label>{{t "general.end"}}: {{editable-date model=course property='endDate'}}</label>
+      <div class="inline-label-data-block">
+        <label>{{t "general.start"}}:</label>
+        <div>{{editable-date model=course property='startDate'}}</div>
+      </div>
+      <div class="inline-label-data-block">
+        <label>{{t "courses.externalId"}}:</label>
+        <div>{{editable-text model=course property='externalId'}}</div>
+      </div>
+      <div class="inline-label-data-block">
+        <label>{{t "courses.level"}}:</label>
+        <div>{{editable-select model=course property='level' options=levelOptions}}</div>
+      </div>
+      <div class="inline-label-data-block">
+        <label>{{t "general.end"}}:</label>
+        <div>{{editable-date model=course property='endDate'}}</div>
+      </div>
       <br />
       <label>{{t "general.directors"}}:
         <span>


### PR DESCRIPTION
Created a '.inline-label-data-block' div wrapper for items like this. @jenzweben, can you add a 'inline-label-data-block' class to css and give it a style of 'display: inline-block'