### PR TITLE
Hide the availalbe cohorts box until it is needed

### DIFF
--- a/app/components/detail-cohorts.js
+++ b/app/components/detail-cohorts.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   cohorts: [],
   programs: [],
+  isAvailalbeCohortsShowing: false,
   filteredPrograms: function(){
     var self = this;
     var programProxy = Ember.ObjectProxy.extend({
@@ -24,11 +25,15 @@ export default Ember.Component.extend({
     }).sortBy('title');
 
     return programs;
-    
+
   }.property('cohorts.@each', 'programs.@each'),
   actions: {
+    showAvailableCohorts: function(){
+      this.set('isAvailalbeCohortsShowing', true);
+    },
     add: function(cohort){
       this.sendAction('add', cohort);
+      this.set('isAvailalbeCohortsShowing', false);
     }
   }
 });

--- a/app/templates/components/detail-cohorts.hbs
+++ b/app/templates/components/detail-cohorts.hbs
@@ -2,7 +2,30 @@
   <div class='detail-title'>
     {{t 'courses.cohorts'}} ({{cohorts.length}})
   </div>
+
+  <div class='detail-actions'>
+    <button {{action 'showAvailableCohorts'}} class='add'>{{t 'general.addNew'}}</button>
+  </div>
   <div class='detail-content'>
+    {{#if isAvailalbeCohortsShowing}}
+      <div class='selectable-list'>
+        <h5>{{t 'courses.availableCohorts'}}</h5>
+        <ul>
+          {{#each program in filteredPrograms}}
+            <li class='static'>{{program.title}}
+              <ul>
+                {{#each cohort in program.availableCohorts}}
+                  <li {{action 'add' cohort}}>{{cohort.displayTitle}}</li>
+
+                {{else}}
+                  <li class='static'>{{t 'courses.noAvailableCohorts'}}</li>
+                {{/each}}
+              </ul>
+            </li>
+          {{/each}}
+        </ul>
+      </div>
+    {{/if}}
     <table>
       <thead>
         <tr>
@@ -21,22 +44,5 @@
         {{/each}}
       </tbody>
     </table>
-
-    <div class='selectable-list'>
-      <ul>
-        {{#each program in filteredPrograms}}
-          <li class='static'>{{program.title}}
-            <ul>
-              {{#each cohort in program.availableCohorts}}
-                <li {{action 'add' cohort}}>{{cohort.displayTitle}}</li>
-
-              {{else}}
-                <li class='static'>{{t 'courses.noAvailableCohorts'}}</li>
-              {{/each}}
-            </ul>
-          </li>
-        {{/each}}
-      </ul>
-    </div>
   </div>
 </section>

--- a/app/translations/en.js
+++ b/app/translations/en.js
@@ -173,6 +173,7 @@ var courses = {
   'backToCourses': 'Back to Courses List',
   'details': 'Course Details',
   'cohorts': 'Program Cohorts',
+  'availableCohorts': 'Availalbe Cohorts',
   'noAvailableCohorts': 'No available cohorts',
   'titleFilterPlaceholder': 'Filter by course title',
   'findDirector': 'Find Director',


### PR DESCRIPTION
I also moved the box above the table closer to the button that reveals it.

The whole thing will need a @jenzweben passover because its not very pretty.

Fixes #60