### PR TITLE
Update api environment

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -40,8 +40,8 @@ module.exports = function(environment) {
     ENV.contentSecurityPolicy['script-src'] += " 'unsafe-eval'";
   }
 
-  if (environment === 'tryapi') {
-    ENV.adapterHost = 'http://localhost:8400';
+  if (environment === 'vagrant') {
+    ENV.adapterHost = 'http://ilios.dev';
     ENV.adapterNamespace = 'app_dev.php/api/v1';
     ENV.contentSecurityPolicy['script-src'] += " 'unsafe-eval'";
     ENV.contentSecurityPolicy['connect-src'] += " localhost:8400";


### PR DESCRIPTION
It should now be possible once starting the backend:
```vagrant up``` to run the fronted with ```ember serve —env=vagrant```
and they will connect.