### PR TITLE
added userName and userEmail properties to live search results, separated each with respective classname

### DIFF
--- a/app/components/course-overview.js
+++ b/app/components/course-overview.js
@@ -27,6 +27,12 @@ export default Ember.Component.extend({
         return this.get('user.fullName') + ' ' +
           this.get('user.email');
       }.property('user.fullName', 'user.email'),
+      userName: function(){
+        return this.get('user.fullName');
+      }.property('user.fullName'),
+      userEmail: function(){
+        return this.get('user.email');
+      }.property('user.email'),
       isActive: function(){
         return !this.get('directors').contains(this.get('user'));
       }.property('user', 'directors.@each'),

--- a/app/templates/components/live-search.hbs
+++ b/app/templates/components/live-search.hbs
@@ -14,9 +14,9 @@
         <ul class='results'>
           {{#each result in sortedSearchResults}}
             {{#if result.isActive}}
-              <li class='active' {{action 'add' result.targetObject}}>{{result.title}}</li>
+              <li class='active' {{action 'add' result.targetObject}}><div class='livesearch-results-name'>{{result.userName}}</div> <div class='livesearch-results-email'>{{result.userEmail}}</div></li>
             {{else}}
-              <li class='inactive' > {{result.title}}</li>
+              <li class='inactive'><div class='livesearch-results-name'>{{result.userName}}</div> <div class='livesearch-results-email'>{{result.userEmail}}</div></li>
             {{/if}}
           {{/each}}
         </ul>


### PR DESCRIPTION
added/using 'result.userName' and 'result.userEmail' properties instead of combined 'result.Title' value, so each can be classed for css.

CSS classes added are 'livesearch-results-name' and 'livesearch-results-email'