### PR TITLE
Bind classname instead of wrapping icon

### DIFF
--- a/app/templates/components/course-overview.hbs
+++ b/app/templates/components/course-overview.hbs
@@ -29,7 +29,7 @@
         <span>
           <ul class='removable-list'>
             {{#each user in sortedDirectors}}
-            <li {{action 'removeDirector' user}}>{{user.fullName}} <div class="removex">{{fa-icon 'remove'}}</div></li>
+            <li {{action 'removeDirector' user}}>{{user.fullName}}{{fa-icon 'remove' classNames='removex'}}</li>
             {{/each}}
           </ul>
         </span>


### PR DESCRIPTION
Reverts a change in #161 that used a div to add class information to the delete icon instead of binding that classname to the actual icon.

@jenzweben please ensure I didn't mess up the style, I think this is just a code change.