### PR TITLE
Quick Fix course header component

### DIFF
--- a/app/templates/components/course-header.hbs
+++ b/app/templates/components/course-header.hbs
@@ -1,9 +1,11 @@
 <div class='detail-header'>
   <span class='title'>
     {{#if editable}}
-      {{editable-text tagName='h2' model=course property='title'}}
+      {{#if course}}
+        {{editable-text tagName='h2' model=course property='title'}}
+      {{/if}}
     {{else}}
-      {{course.title}}
+      <h2>{{course.title}}</h2>
     {{/if}}
     <h4>{{course.academicYear}}</h4>
   </span>

--- a/server/helpers/fixtureStorage.js
+++ b/server/helpers/fixtureStorage.js
@@ -5,8 +5,12 @@ module.exports = {
     var fixtures = require ('../fixtures/' + name + '.js');
     var changes = this.getChanges(name);
     changes.forEach(function(obj){
-      for(var key in obj){
-        fixtures[obj.id][key] = obj[key];
+      if(!(obj.id in fixtures)){
+        fixtures[obj.id] = obj;
+      } else {
+        for(var key in obj){
+          fixtures[obj.id][key] = obj[key];
+        }
       }
     });
 


### PR DESCRIPTION
The edit in place component is not currently capable of watching for changes on the model so when it doesn't get passed a good course on first load it looses track of the title property.  The component needs to be updated, but this is a quick fix to display the course title.