### PR TITLE
Preload Changes

### DIFF
--- a/app/styles/components/_initialpage.scss
+++ b/app/styles/components/_initialpage.scss
@@ -1,0 +1,10 @@
+#initialpageloader {
+  p {
+    border: 2px dashed $ilios-orange;
+    color: $ilios-orange;
+    background-color: $background-grey;
+    margin: 2em;
+    padding: 2em;
+    font-weight: bold;
+  }
+}

--- a/app/styles/components/_noscript.scss
+++ b/app/styles/components/_noscript.scss
@@ -1,0 +1,11 @@
+noscript {
+  p {
+    border: 2px dashed $ilios-orange;
+    color: $ilios-orange;
+    background-color: $background-grey;
+    margin: 2em;
+    padding: 2em;
+    font-weight: bold;
+  }
+
+}

--- a/app/styles/components/_waveloader.scss
+++ b/app/styles/components/_waveloader.scss
@@ -4,9 +4,6 @@
     @include align-items(center);
     @include display(flex);
   }
-  &.is-full-screen {
-    margin-left: 86px;
-  }
   .wrapper {
       height: 60px;
       .text {

--- a/app/styles/global/application.scss
+++ b/app/styles/global/application.scss
@@ -17,3 +17,4 @@
 @import '../components/waveloader';
 @import '../components/objectivemanager';
 @import '../components/noscript';
+@import '../components/initialpage';

--- a/app/styles/global/application.scss
+++ b/app/styles/global/application.scss
@@ -15,4 +15,5 @@
 @import '../components/livesearch';
 @import '../components/resultslist';
 @import '../components/waveloader';
-@import '../components/_objectivemanager';
+@import '../components/objectivemanager';
+@import '../components/noscript';

--- a/app/styles/layout/_layout.scss
+++ b/app/styles/layout/_layout.scss
@@ -3,22 +3,6 @@ body {
   margin-bottom: 40px;
 }
 
-#initialpageloader {
-  .content {
-    display: block;
-    margin: auto;
-    text-align: center;
-  }
-  p {
-    border: 2px dashed $ilios-orange;
-    color: $ilios-orange;
-    background-color: $background-grey;
-    margin: 2em;
-    padding: 2em;
-    font-weight: bold;
-  }
-}
-
 #site-container {
   @include outer-container;
   padding-left: 40px;

--- a/lib/ilios-prerender/index.js
+++ b/lib/ilios-prerender/index.js
@@ -46,13 +46,6 @@ module.exports = {
             "Please refresh this page or try a different browser." +
           "</p>" +
           "</div>" +
-          "<noscript>" +
-            "<p>" +
-              "For full functionality of this site it is necessary to enable JavaScript." +
-              "Here are the <a href='http://www.enable-javascript.com/' target='_blank'>" +
-              "instructions how to enable JavaScript in your web browser</a>." +
-            "</p>" +
-          "</noscript>" +
         "</div>" +
       "</div>";
     }

--- a/lib/ilios-prerender/index.js
+++ b/lib/ilios-prerender/index.js
@@ -2,21 +2,11 @@ module.exports = {
   name: 'ilios-prerender',
   contentFor: function(type, config) {
     if (type === 'body-footer') {
-      return "<script type='text/javascript'>" +
-          "setTimeout(function(){" +
-            "$('#browsererrormessage').removeClass('hidden');" +
-            "$('#initialpageloader .waveloader').remove();" +
-          "}, 10000);" +
-      "</script>";
+      return '<script src="ilios-prerender/scripts.js"></script>';
     }
-    //in tests remove this immediatly
     if (type === 'test-body-footer') {
-      return "<script type='text/javascript'>" +
-          "$('#initialpageloader').remove();" +
-      "</script>";
+      return '<script src="ilios-prerender/test-scripts.js"></script>';
     }
-
-
 
     if( type === 'body') {
       return "<div id='initialpageloader'>" +
@@ -42,7 +32,7 @@ module.exports = {
             "</div>" +
           "</div>" +
           "<p id='browsererrormessage' class='hidden'>" +
-            "It is possible that your browser is not supported by Ilios." +
+            "It is possible that your browser is not supported by Ilios.  " +
             "Please refresh this page or try a different browser." +
           "</p>" +
           "</div>" +

--- a/lib/ilios-prerender/index.js
+++ b/lib/ilios-prerender/index.js
@@ -25,7 +25,7 @@ module.exports = {
             "<img src='images/ilios-logo.png' alt='Ilios Logo' title='Ilios Logo' />" +
           "</span>" +
         "</header>" +
-        "<div class='content'>" +
+        "<div id='site-container'>" +
           "<div class='waveloader is-full-screen is-full-size'>" +
             "<div class='wrapper'>" +
               "<div class='text'>Loading Ilios ...</div>" +

--- a/lib/ilios-prerender/public/scripts.js
+++ b/lib/ilios-prerender/public/scripts.js
@@ -1,0 +1,5 @@
+//after 10 second display the error message
+setTimeout(function(){
+  $('#initialpageloader .waveloader').remove();
+  $('#browsererrormessage').removeClass('hidden');
+}, 10000);

--- a/lib/ilios-prerender/public/test-scripts.js
+++ b/lib/ilios-prerender/public/test-scripts.js
@@ -1,0 +1,2 @@
+//remove loading stuff immediatly when testing
+$('#initialpageloader').remove();

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "moment": "^2.8.4",
     "morgan": "^1.5.0",
     "pluralize": "^1.1.2",
-    "precommit-hook": "^1.0.7"
+    "precommit-hook": "^1.0.7",
+    "ember-noscript": "^1.0.0"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
Use an add-on to provide no script message.
Enclose initial loading in indicator in the same structure as the final site. (Fixes #155)
Refactor the pre-loader to put JS into include files and load them. (Fixes #145)