### PR TITLE
Help user make a good choice when publishing session and course

### DIFF
--- a/app/templates/components/course-header.hbs
+++ b/app/templates/components/course-header.hbs
@@ -12,8 +12,10 @@
     <h4>{{course.academicYear}}</h4>
   </span>
   <span class ='actions'>
-    <button class='publish' {{bind-attr disabled=course.isNotPublished}}>{{t 'general.unPublish'}}</button>
-    <button class='unpublish' {{bind-attr disabled=course.isPublished}}>{{t 'general.publish'}}</button>
+    {{#if editable}}
+      <button class='publish' {{bind-attr disabled=course.isNotPublished}}>{{t 'general.unPublish'}}</button>
+      <button class='unpublish' {{bind-attr disabled=course.isPublished}}>{{t 'general.publish'}}</button>
+    {{/if}}
     {{publication-status item=course}}
   </span>
 </div>


### PR DESCRIPTION
Fixes #202

@saschaben - see if this will work, or if we need to look at another way to make accidentally publishing a course more difficult.  Buttons are now hidden on course objective manager and when the course details more/edit gizmo is closed.