### PR TITLE
Faster Course List Loading

### DIFF
--- a/app/components/detail-competencies.js
+++ b/app/components/detail-competencies.js
@@ -5,27 +5,23 @@ export default Ember.Component.extend({
   domains: function(){
     var domainContainer = {};
     var domainIds = [];
-    var competencies = this.get('competencies');
-    if(competencies){
-      this.get('competencies').forEach(function(competency){
-        var domain = competency.get('domain');
-        if(!domainContainer.hasOwnProperty(domain.get('id'))){
-          domainIds.pushObject(domain.get('id'));
-          domainContainer[domain.get('id')] = Ember.ObjectProxy.create({
-            content: domain,
-            subCompetencies: []
-          });
+    this.get('competencies').forEach(function(competency){
+      var domain = competency.get('domain');
+      if(!domainContainer.hasOwnProperty(domain.get('id'))){
+        domainIds.pushObject(domain.get('id'));
+        domainContainer[domain.get('id')] = Ember.ObjectProxy.create({
+          content: domain,
+          subCompetencies: []
+        });
+      }
+      if(competency.get('id') !== domain.get('id')){
+        var subCompetencies = domainContainer[domain.get('id')].get('subCompetencies');
+        if(!subCompetencies.contains(competency)){
+          subCompetencies.pushObject(competency);
+          subCompetencies.sortBy('title');
         }
-        if(competency.get('id') !== domain.get('id')){
-          var subCompetencies = domainContainer[domain.get('id')].get('subCompetencies');
-          if(!subCompetencies.contains(competency)){
-            subCompetencies.pushObject(competency);
-            subCompetencies.sortBy('title');
-          }
-        }
-      });
-    }
-
+      }
+    });
     var domains = domainIds.map(function(id){
       return domainContainer[id];
     });

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -8,7 +8,6 @@ export default Ember.ArrayController.extend(Ember.I18n.TranslateableProperties, 
     userCoursesOnly: 'mycourses'
   },
   placeholderValueTranslation: 'courses.titleFilterPlaceholder',
-  newCourseTitleTranslation: 'courses.newCourseTitle',
   schoolId: null,
   yearTitle: null,
   titleFilter: null,
@@ -33,11 +32,10 @@ export default Ember.ArrayController.extend(Ember.I18n.TranslateableProperties, 
     var currentUser = this.get('currentUser');
     return this.get('content').filter(function(course) {
       if(title == null || course.get('title').match(exp)){
-        if(filterMyCourses === true){
+        if(filterMyCourses){
           return currentUser.get('allRelatedCourses').contains(course);
         }
         return true;
-
       }
 
       return false;

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -43,12 +43,6 @@ export default Ember.ArrayController.extend(Ember.I18n.TranslateableProperties, 
       return false;
     }).sortBy('title');
   }.property('debouncedFilter', 'content.@each', 'userCoursesOnly', 'currentUser.allRelatedCourses.@each'),
-  watchSelectedSchool: function(){
-    this.set('schoolId', this.get('selectedSchool.id'));
-  }.observes('selectedSchool'),
-  watchSelectedCohort: function(){
-    this.set('yearTitle', this.get('selectedYear.title'));
-  }.observes('selectedYear'),
   actions: {
     editCourse: function(course){
       this.transitionToRoute('course', course);
@@ -80,9 +74,11 @@ export default Ember.ArrayController.extend(Ember.I18n.TranslateableProperties, 
       this.get('newCourses').removeObject(newCourse);
     },
     changeSelectedYear: function(year){
+      this.set('yearTitle', year.get('title'));
       this.set('selectedYear', year);
     },
     changeSelectedSchool: function(school){
+      this.set('schoolId', school.get('id'));
       this.set('selectedSchool', school);
     }
   },

--- a/app/models/educational-year.js
+++ b/app/models/educational-year.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  title: DS.attr('string'),
+  title: DS.attr('number'),
   academicYearTitle: function(){
     return this.get('title') + ' - ' + (parseInt(this.get('title')) + 1);
   }.property('title'),

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -53,7 +53,7 @@ var User = DS.Model.extend({
       return first + ' ' + last;
   }.property('firstName', 'lastName'),
   events: [],
-  allRelatedCourses: Ember.computed.alias('directedCourses'),
+  allRelatedCourses: Ember.computed.oneWay('directedCourses'),
 });
 
 export default User;

--- a/app/routes/courses.js
+++ b/app/routes/courses.js
@@ -46,9 +46,7 @@ export default Ember.Route.extend({
     Ember.run.later(function(){
       if(!controller.get('isDestroyed')){
         controller.set('model', hash.courses);
-        controller.set('schoolId', parseInt(hash.school.get('id')));
         controller.set('schools', hash.schools);
-        controller.set('yearTitle', parseInt(hash.year.get('title')));
         controller.set('selectedSchool', hash.school);
         controller.set('selectedYear', hash.year);
         controller.set('years', hash.years);


### PR DESCRIPTION
Refactor course/objective/competency properties to be PromiseArrays instead of observers.  This ensures the courses list doesn't have to load everything.

Fix an issue with the course list double loading on some requests.

Fixes #207