### PR TITLE
Sort offerings correctly within a day

### DIFF
--- a/app/components/session-offerings.js
+++ b/app/components/session-offerings.js
@@ -79,7 +79,7 @@ var OfferingDateBlock = OfferingBlock.extend({
       offeringGroupArray.pushObject(offeringGroups[key]);
     }
 
-    return offeringGroupArray.sortBy('startTime');
+    return offeringGroupArray.sortBy('timeKey');
   }.property('offerings.@each.{startDate,endDate}')
 });
 


### PR DESCRIPTION
Offerings were sorting alphabetically by time, now they sort numerically.

Fixes #339