### PR TITLE
Fix Topics count for missing publication items

### DIFF
--- a/app/components/course-publicationcheck.js
+++ b/app/components/course-publicationcheck.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  classNames: ['course-publication-check'],
   course: null
 });

--- a/app/components/session-publicationcheck.js
+++ b/app/components/session-publicationcheck.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  session: null
+  classNames: ['session-publication-check'],
+  session: null,
 });

--- a/app/mirage/factories/discipline.js
+++ b/app/mirage/factories/discipline.js
@@ -1,0 +1,5 @@
+import Mirage from 'ember-cli-mirage';
+
+export default Mirage.Factory.extend({
+  title: (i) => `topic ${i}`,
+});

--- a/app/models/course.js
+++ b/app/models/course.js
@@ -145,7 +145,7 @@ var Course = DS.Model.extend({
 
     return issues;
   }.property(
-    'topics.length',
+    'disciplines.length',
     'objectives.length',
     'meshDescriptors.length'
   ),

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -53,6 +53,7 @@ var Session = DS.Model.extend({
   isPublished: Ember.computed.notEmpty('publishEvent.content'),
   isNotPublished: Ember.computed.not('isPublished'),
   isScheduled: Ember.computed.oneWay('publishedAsTbd'),
+  isIndependentLearning: Ember.computed.notEmpty('ilmSessionFacet.content'),
   status: function(){
     if(this.get('publishedAsTbd')){
       return Ember.I18n.t('general.scheduled');
@@ -112,11 +113,9 @@ var Session = DS.Model.extend({
 
     return issues;
   }.property(
-    'topics.length',
+    'disciplines.length',
     'objectives.length',
-    'meshDescriptors.length',
-    'offerings.length',
-    'isIndependentLearning'
+    'meshDescriptors.length'
   ),
   associatedLearnerGroups: function(){
     var deferred = Ember.RSVP.defer();
@@ -137,7 +136,6 @@ var Session = DS.Model.extend({
       promise: deferred.promise
     });
   }.property('offerings.@each.learnerGroups.@each'),
-  isIndependentLearning: Ember.computed.notEmpty('ilmSessionFacet.content'),
 });
 
 export default Session;

--- a/app/templates/components/session-publicationcheck.hbs
+++ b/app/templates/components/session-publicationcheck.hbs
@@ -21,7 +21,7 @@
           {{else}}
             <td class='no'>{{t 'general.no'}}</td>
           {{/if}}
-          {{#if sessions.disciplines.length}}
+          {{#if session.disciplines.length}}
             <td class='yes'>{{t 'general.yes'}} ({{session.disciplines.length}})</td>
           {{else}}
             <td class='no'>{{t 'general.no'}}</td>

--- a/tests/acceptance/course/publicationcheck-test.js
+++ b/tests/acceptance/course/publicationcheck-test.js
@@ -1,0 +1,71 @@
+/* global moment */
+import Ember from 'ember';
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from 'ilios/tests/helpers/start-app';
+
+var application;
+var fixtures = {};
+module('Acceptance: Course - Publication Check', {
+  beforeEach: function() {
+    application = startApp();
+    server.create('user', {id: 4136});
+    server.create('school');
+    server.create('cohort', {
+      courses: [1],
+    });
+    server.create('objective', {
+      courses: [1],
+    });
+    server.create('discipline', {
+      courses: [1],
+    });
+    server.create('meshDescriptor', {
+      courses: [1],
+    });
+    fixtures.fullCourse = server.create('course', {
+      year: 2013,
+      owningSchool: 1,
+      cohorts: [1],
+      objectives: [1],
+      disciplines: [1],
+      meshDescriptors: [1],
+    });
+    fixtures.emptyCourse = server.create('course', {
+      year: 2013,
+      owningSchool: 1
+    });
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('full course count', function(assert) {
+  visit('/course/' + fixtures.fullCourse.id + '/publicationcheck');
+  andThen(function() {
+    assert.equal(currentPath(), 'course-publicationcheck');
+    var items = find('.course-publication-check .detail-content table tbody td');
+    assert.equal(getElementText(items.eq(0)), getText('course 0'));
+    assert.equal(getElementText(items.eq(1)), getText('Yes (1)'));
+    assert.equal(getElementText(items.eq(2)), getText('Yes (1)'));
+    assert.equal(getElementText(items.eq(3)), getText('Yes (1)'));
+    assert.equal(getElementText(items.eq(4)), getText('Yes (1)'));
+  });
+});
+
+test('empty course count', function(assert) {
+  visit('/course/' + fixtures.emptyCourse.id + '/publicationcheck');
+  andThen(function() {
+    assert.equal(currentPath(), 'course-publicationcheck');
+    var items = find('.course-publication-check .detail-content table tbody td');
+    assert.equal(getElementText(items.eq(0)), getText('course 1'));
+    assert.equal(getElementText(items.eq(1)), getText('No'));
+    assert.equal(getElementText(items.eq(2)), getText('No'));
+    assert.equal(getElementText(items.eq(3)), getText('No'));
+    assert.equal(getElementText(items.eq(4)), getText('No'));
+  });
+});

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -1,0 +1,73 @@
+/* global moment */
+import Ember from 'ember';
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from 'ilios/tests/helpers/start-app';
+
+var application;
+var fixtures = {};
+module('Acceptance: Session - Publication Check', {
+  beforeEach: function() {
+    application = startApp();
+    server.create('user', {id: 4136});
+    server.create('course', {
+      sessions: [1,2]
+    });
+    server.create('sessionType');
+    server.create('school');
+    server.create('offering', {
+      sessions: [1],
+    });
+    server.create('objective', {
+      sessions: [1],
+    });
+    server.create('discipline', {
+      sessions: [1],
+    });
+    server.create('meshDescriptor', {
+      sessions: [1],
+    });
+    fixtures.fullSession = server.create('session', {
+      course: 1,
+      offerings: [1],
+      objectives: [1],
+      disciplines: [1],
+      meshDescriptors: [1],
+    });
+    fixtures.emptySession = server.create('session', {
+      course: 1
+    });
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('full session count', function(assert) {
+  visit('/course/1/session/' + fixtures.fullSession.id + '/publicationcheck');
+  andThen(function() {
+    assert.equal(currentPath(), 'course.sessionpublicationcheck');
+    var items = find('.session-publication-check .detail-content table tbody td');
+    assert.equal(getElementText(items.eq(0)), getText('session 0'));
+    assert.equal(getElementText(items.eq(1)), getText('Yes (1)'));
+    assert.equal(getElementText(items.eq(2)), getText('Yes (1)'));
+    assert.equal(getElementText(items.eq(3)), getText('Yes (1)'));
+    assert.equal(getElementText(items.eq(4)), getText('Yes (1)'));
+  });
+});
+
+test('empty course count', function(assert) {
+  visit('/course/1/session/' + fixtures.emptySession.id + '/publicationcheck');
+  andThen(function() {
+    assert.equal(currentPath(), 'course.sessionpublicationcheck');
+    var items = find('.session-publication-check .detail-content table tbody td');
+    assert.equal(getElementText(items.eq(0)), getText('session 1'));
+    assert.equal(getElementText(items.eq(1)), getText('No'));
+    assert.equal(getElementText(items.eq(2)), getText('No'));
+    assert.equal(getElementText(items.eq(3)), getText('No'));
+    assert.equal(getElementText(items.eq(4)), getText('No'));
+  });
+});

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -53,6 +53,30 @@ moduleForModel('course', 'Course', {
 
 test('it exists', function(assert) {
   var model = this.subject();
-  // var store = this.store();
   assert.ok(!!model);
+});
+
+test('check required publication items', function(assert) {
+  var model = this.subject();
+  var store = this.store();
+  assert.equal(model.get('requiredPublicationIssues').length, 3);
+  var cohort = store.createRecord('cohort');
+  model.get('cohorts').addObject(cohort);
+  assert.equal(model.get('requiredPublicationIssues').length, 2);
+  model.set('startDate', 'nothing');
+  assert.equal(model.get('requiredPublicationIssues').length, 1);
+  model.set('endDate', 'nothing');
+  assert.equal(model.get('requiredPublicationIssues').length, 0);
+});
+
+test('check optional publication items', function(assert) {
+  var model = this.subject();
+  var store = this.store();
+  assert.equal(model.get('optionalPublicationIssues').length, 3);
+  model.get('disciplines').addObject(store.createRecord('discipline'));
+  assert.equal(model.get('optionalPublicationIssues').length, 2);
+  model.get('objectives').addObject(store.createRecord('objective'));
+  assert.equal(model.get('optionalPublicationIssues').length, 1);
+  model.get('meshDescriptors').addObject(store.createRecord('meshDescriptor'));
+  assert.equal(model.get('optionalPublicationIssues').length, 0);
 });

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -2,6 +2,7 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import Ember from 'ember';
 
 moduleForModel('session', 'Session', {
   needs: [
@@ -54,4 +55,37 @@ test('it exists', function(assert) {
   var model = this.subject();
   // var store = this.store();
   assert.ok(!!model);
+});
+
+test('check required publication items', function(assert) {
+  var model = this.subject();
+  var store = this.store();
+  assert.equal(model.get('requiredPublicationIssues').length, 2);
+  model.set('title', 'nothing');
+  assert.equal(model.get('requiredPublicationIssues').length, 1);
+  model.get('offerings').addObject(store.createRecord('offering'));
+  assert.equal(model.get('requiredPublicationIssues').length, 0);
+});
+
+test('check rquired ILM publication items', function(assert) {
+  var model = this.subject();
+  var store = this.store();
+  Ember.run(function(){
+    model.set('title', 'nothing');
+    assert.equal(model.get('requiredPublicationIssues').length, 1);
+    model.set('ilmSessionFacet', store.createRecord('ilmSession'));
+    assert.equal(model.get('requiredPublicationIssues').length, 0);
+  });
+});
+
+test('check optional publication items', function(assert) {
+  var model = this.subject();
+  var store = this.store();
+  assert.equal(model.get('optionalPublicationIssues').length, 3);
+  model.get('disciplines').addObject(store.createRecord('discipline'));
+  assert.equal(model.get('optionalPublicationIssues').length, 2);
+  model.get('objectives').addObject(store.createRecord('objective'));
+  assert.equal(model.get('optionalPublicationIssues').length, 1);
+  model.get('meshDescriptors').addObject(store.createRecord('meshDescriptor'));
+  assert.equal(model.get('optionalPublicationIssues').length, 0);
 });


### PR DESCRIPTION
The computed property was bound incorrectly to topics instead of
disciplines.
Added unit tests for the course and session models to test this.

Fixes #318