### PR TITLE
Kill sauce connect tunnel when tests are done

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ before_script:
 script:
   - ember try ${EMBER_VERSION} test --port=8080 --launch=${TESTEM_LAUNCHER} --skip-cleanup
 
+after_script:
+  # Destroy the sauce tunnel
+  - if [ "$START_SAUCE_CONNECT" = true ]; then ember stop-sauce-connect; fi
+
 #encrypted the IRC room chat.freenode.net##ilios so that it doesn't run on pull requests
 notifications:
   irc:


### PR DESCRIPTION
We were leaving the sauce connect tunnel open on every test which quickly becomes a problem when we reach our limit of 5 open connection.