### PR TITLE
Prevent travis from timeout during install and test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,14 @@ before_install:
 
 install:
   - npm install -g bower
-  - npm install
+  - travis_retry npm install
 
 before_script:
   # Create a sauce tunnel
   - if [ "$START_SAUCE_CONNECT" = true ]; then ember start-sauce-connect; fi
 
 script:
-  - ember try ${EMBER_VERSION} test --port=8080 --launch=${TESTEM_LAUNCHER} --skip-cleanup
+  - travis_wait ember try ${EMBER_VERSION} test --port=8080 --launch=${TESTEM_LAUNCHER} --skip-cleanup
 
 after_script:
   # Destroy the sauce tunnel

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ matrix:
     - env: EMBER_VERSION='ember-canary'
     - env: "TESTEM_LAUNCHER='SauceLabs_IE_10' START_SAUCE_CONNECT=true"
   include:
-    - env: "TESTEM_LAUNCHER='SauceLabs_Chrome,SauceLabs_Firefox' START_SAUCE_CONNECT=true"
+    - env: "TESTEM_LAUNCHER='SauceLabs_Chrome' START_SAUCE_CONNECT=true"
+    - env: "TESTEM_LAUNCHER='SauceLabs_Firefox' START_SAUCE_CONNECT=true"
     - env: "TESTEM_LAUNCHER='SauceLabs_IE_10' START_SAUCE_CONNECT=true"
     - env: "TESTEM_LAUNCHER='SauceLabs_IE_11' START_SAUCE_CONNECT=true"
     - env: "TESTEM_LAUNCHER='SauceLabs_Safari_7' START_SAUCE_CONNECT=true"


### PR DESCRIPTION
Adding travis_wait to a command should prevent a timeout due to no output.
Fixes #480 