### PR TITLE
Fix some travis / sauce issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,14 @@ matrix:
   allow_failures:
     - env: EMBER_VERSION='ember-beta'
     - env: EMBER_VERSION='ember-canary'
-    - env: "TESTEM_LAUNCHER='SauceLabs_IE_10' START_SAUCE_CONNECT=true"
+    - env: "TESTEM_LAUNCHER='SL_internet_explorer_10' START_SAUCE_CONNECT=true"
   include:
-    - env: "TESTEM_LAUNCHER='SauceLabs_Chrome' START_SAUCE_CONNECT=true"
-    - env: "TESTEM_LAUNCHER='SauceLabs_Firefox' START_SAUCE_CONNECT=true"
-    - env: "TESTEM_LAUNCHER='SauceLabs_IE_10' START_SAUCE_CONNECT=true"
-    - env: "TESTEM_LAUNCHER='SauceLabs_IE_11' START_SAUCE_CONNECT=true"
-    - env: "TESTEM_LAUNCHER='SauceLabs_Safari_7' START_SAUCE_CONNECT=true"
+    - env: "TESTEM_LAUNCHER='SL_chrome' START_SAUCE_CONNECT=true"
+    - env: "TESTEM_LAUNCHER='SL_firefox' START_SAUCE_CONNECT=true"
+    - env: "TESTEM_LAUNCHER='SL_internet_explorer_10' START_SAUCE_CONNECT=true"
+    - env: "TESTEM_LAUNCHER='SL_internet_explorer_11' START_SAUCE_CONNECT=true"
+    - env: "TESTEM_LAUNCHER='SL_safari_7' START_SAUCE_CONNECT=true"
+    - env: "TESTEM_LAUNCHER='SL_safari_8' START_SAUCE_CONNECT=true"
     - env: "EMBER_VERSION='ember-beta'"
     - env: "EMBER_VERSION='ember-canary'"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ matrix:
     - env: "TESTEM_LAUNCHER='SL_internet_explorer_10' START_SAUCE_CONNECT=true"
     - env: "TESTEM_LAUNCHER='SL_internet_explorer_11' START_SAUCE_CONNECT=true"
     - env: "TESTEM_LAUNCHER='SL_safari_7' START_SAUCE_CONNECT=true"
-    - env: "TESTEM_LAUNCHER='SL_safari_8' START_SAUCE_CONNECT=true"
     - env: "EMBER_VERSION='ember-beta'"
     - env: "EMBER_VERSION='ember-canary'"
 

--- a/testem.json
+++ b/testem.json
@@ -1,37 +1,86 @@
 {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
-  "parallel": 2,
-  "launchers": {
-    "SauceLabs_Chrome": {
-      "command": "./node_modules/.bin/ember-cli-sauce --platformSL='Windows 7' --no-ct -u <url>",
-      "protocol": "tap"
-    },
-    "SauceLabs_Firefox": {
-      "command": "./node_modules/.bin/ember-cli-sauce --platformSL='Windows 7' --browserNameSL='firefox' --no-ct -u <url>",
-      "protocol": "tap"
-    },
-    "SauceLabs_IE_10": {
-      "command": "./node_modules/.bin/ember-cli-sauce --browserNameSL='internet explorer' --versionSL='10' --platformSL='Windows 8' --no-ct -u <url>",
-      "protocol": "tap"
-    },
-    "SauceLabs_IE_11": {
-      "command": "./node_modules/.bin/ember-cli-sauce --browserNameSL='internet explorer' --versionSL='11' --platformSL='Windows 8.1' --no-ct -u <url>",
-      "protocol": "tap"
-    },
-    "SauceLabs_Safari_7": {
-      "command": "./node_modules/.bin/ember-cli-sauce --browserNameSL='safari' --versionSL='7' --platformSL='OS X 10.9' --no-ct -u <url>",
-      "protocol": "tap"
-    },
-    "SauceLabs_Safari_8": {
-      "command": "./node_modules/.bin/ember-cli-sauce --browserNameSL='safari' --versionSL='8' --platformSL='OS X 10.10' --no-ct -u <url>",
-      "protocol": "tap"
-    }
-  },
   "launch_in_ci": [
     "PhantomJS"
   ],
   "launch_in_dev": [
     "PhantomJS"
-  ]
+  ],
+  "launchers": {
+    "SL_chrome": {
+      "exe": "./node_modules/.bin/ember-cli-sauce",
+      "args": [
+        "-b",
+        "chrome",
+        "--at",
+        "--no-ct",
+        "--u"
+      ],
+      "protocol": "browser"
+    },
+    "SL_firefox": {
+      "exe": "./node_modules/.bin/ember-cli-sauce",
+      "args": [
+        "-b",
+        "firefox",
+        "--at",
+        "--no-ct",
+        "--u"
+      ],
+      "protocol": "browser"
+    },
+    "SL_internet_explorer_11": {
+      "exe": "./node_modules/.bin/ember-cli-sauce",
+      "args": [
+        "-b",
+        "internet explorer",
+        "-v",
+        "11",
+        "--at",
+        "--no-ct",
+        "--u"
+      ],
+      "protocol": "browser"
+    },
+    "SL_internet_explorer_10": {
+      "exe": "./node_modules/.bin/ember-cli-sauce",
+      "args": [
+        "-b",
+        "internet explorer",
+        "-v",
+        "10",
+        "--at",
+        "--no-ct",
+        "--u"
+      ],
+      "protocol": "browser"
+    },
+    "SL_safari_7": {
+      "exe": "./node_modules/.bin/ember-cli-sauce",
+      "args": [
+        "-b",
+        "safari",
+        "-v",
+        "7",
+        "--at",
+        "--no-ct",
+        "--u"
+      ],
+      "protocol": "browser"
+    },
+    "SL_safari_8": {
+      "exe": "./node_modules/.bin/ember-cli-sauce",
+      "args": [
+        "-b",
+        "safari",
+        "-v",
+        "8",
+        "--at",
+        "--no-ct",
+        "--u"
+      ],
+      "protocol": "browser"
+    }
+  }
 }


### PR DESCRIPTION
I used the ember-cli-sauce addon  to generate browser configurations.
Also removed the parallel option it seems to cause some browsers to run tests twice.