### PR TITLE
Removed plus icon from the detail-actions 'add' buttons

### DIFF
--- a/app/templates/components/action-menu.hbs
+++ b/app/templates/components/action-menu.hbs
@@ -1,7 +1,4 @@
 <button class="button rl-dropdown-toggle" {{action "toggleDropdown"}}>
-  {{#if icon}}
-    {{fa-icon icon}}
-  {{/if}}
   {{title}}
 </button>
 <ul class='dropdown-menu' {{action "toggleDropdown"}}>


### PR DESCRIPTION
removes the '+' icon from the add button for learning materials and offerings, fixes #395