### PR TITLE
Lock the version of i18n

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
     - env: EMBER_VERSION='ember-beta'
     - env: EMBER_VERSION='ember-canary'
     - env: "TESTEM_LAUNCHER='SL_internet_explorer_10' START_SAUCE_CONNECT=true"
+    - env: "TESTEM_LAUNCHER='SL_internet_explorer_11' START_SAUCE_CONNECT=true"
   include:
     - env: "TESTEM_LAUNCHER='SL_chrome' START_SAUCE_CONNECT=true"
     - env: "TESTEM_LAUNCHER='SL_firefox' START_SAUCE_CONNECT=true"

--- a/app/components/big-text.js
+++ b/app/components/big-text.js
@@ -17,7 +17,7 @@ export default Ember.Component.extend({
   cleanText: function(){
     var text = this.get('text');
     if(text === undefined || text == null){
-      return this.get('promptText');
+      return this.get('promptText')?this.get('promptText'):'';
     }
     //strip any possible HTML out of the text
     return text.replace(/(<([^>]+)>)/ig,"");

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "0.1.3",
     "ember-data": "1.0.0-beta.16.1",
-    "ember-i18n": "^3.1.0",
+    "ember-i18n": "3.1.0",
     "ember-inflector": "^1.3.1",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit-notifications": "0.0.7",


### PR DESCRIPTION
The latest update uses some asynchronousity that breaks all
translatable tests.

If tests pass this should be merged, it doesn’t change any application behavior.