### PR TITLE
Improve our heroku build environment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: ./node_modules/ember-cli/bin/ember serve --port $PORT --live-reload=false

--- a/app.json
+++ b/app.json
@@ -1,14 +1,7 @@
 {
   "name": "ilios-frontend",
-  "description": "",
+  "description": "Demo of ilios ember application",
   "scripts": {},
-  "env": {
-    "NPM_CONFIG_LOGLEVEL": {
-      "required": true
-    },
-    "NPM_CONFIG_PRODUCTION": {
-      "required": true
-    }
-  },
+  "env": {},
   "addons": []
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -63,9 +63,12 @@ module.exports = function(environment) {
     ENV.contentSecurityPolicy['style-src'] += " 'unsafe-inline'";
 
   }
-
+  //production is what we use to deploy to heroku for demo purposes
+  //this is not really production, but its hard to change the name
   if (environment === 'production') {
-
+    ENV['ember-cli-mirage'] = {
+      enabled: true
+    };
   }
 
   return ENV;

--- a/package.json
+++ b/package.json
@@ -7,15 +7,10 @@
     "doc": "doc",
     "test": "tests"
   },
-  "cacheDirectories": [
-    "node_modules",
-    "bower_components"
-  ],
   "scripts": {
-    "start": "./node_modules/ember-cli/bin/ember serve",
+    "start": "ember serve",
     "build": "ember build",
-    "test": "ember test",
-    "postinstall": "./node_modules/bower/bin/bower install"
+    "test": "ember test"
   },
   "repository": "https://github.com/ilios/frontend",
   "engines": {


### PR DESCRIPTION
We’re using a better build pack now that handles bower install,
building, and deploying.  We have to use the production environment for
this so i activated mirage there.

There are no tests here, please review for bad decisions and merge.