### PR TITLE
Only display the manager title not the section or count

### DIFF
--- a/app/templates/components/detail-cohorts.hbs
+++ b/app/templates/components/detail-cohorts.hbs
@@ -1,6 +1,12 @@
 <section class='detail-block'>
   <div class='detail-title'>
-    {{t 'courses.cohorts'}} ({{cohorts.length}})
+    {{#if isManaging}}
+      <span class='detail-specific-title'>
+        {{t 'courses.cohortsManageTitle'}}
+      </span>
+    {{else}}
+      {{t 'courses.cohorts'}} ({{cohorts.length}})
+    {{/if}}
   </div>
 
   <div class='detail-actions'>

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -1,10 +1,11 @@
 <section class='detail-block'>
   <div class='detail-title'>
-    {{t 'general.learningMaterials'}} ({{materials.length}})
     {{#if isManaging}}
       <span class='detail-specific-title'>
         {{t 'courses.learningMaterialManageTitle'}}
       </span>
+    {{else}}
+      {{t 'general.learningMaterials'}} ({{materials.length}})
     {{/if}}
   </div>
   <div class='detail-actions'>

--- a/app/templates/components/detail-objectives.hbs
+++ b/app/templates/components/detail-objectives.hbs
@@ -1,6 +1,8 @@
 <section class='detail-block'>
   <div class='detail-title'>
-    {{t 'general.objectives'}} ({{subject.objectives.length}})
+    {{#unless isManaging}}
+      {{t 'general.objectives'}} ({{subject.objectives.length}})
+    {{/unless}}
     {{#if isManagingParents}}
       <span class='detail-specific-title'>
         {{t 'courses.objectiveParentTitle'}}

--- a/app/templates/components/detail-topics.hbs
+++ b/app/templates/components/detail-topics.hbs
@@ -1,10 +1,11 @@
 <section class='detail-block'>
   <div class='detail-title'>
-    {{t 'general.topics'}} ({{subject.disciplines.length}})
     {{#if isManaging}}
       <span class='detail-specific-title'>
         {{t 'courses.topicsManageTitle'}}
       </span>
+    {{else}}
+      {{t 'general.topics'}} ({{subject.disciplines.length}})
     {{/if}}
   </div>
 

--- a/app/templates/components/programyear-competencies.hbs
+++ b/app/templates/components/programyear-competencies.hbs
@@ -1,12 +1,13 @@
 <section class='detail-block'>
   <div class='detail-title'>
-    {{t 'general.competencies'}}
+    {{#if isManaging}}
+      <span class='detail-specific-title'>
+        {{t 'programs.competenciesManageTitle'}}
+      </span>
+    {{else}}
+      {{t 'general.competencies'}}
+    {{/if}}
   </div>
-  {{#if isManaging}}
-    <span class='detail-specific-title'>
-      {{t 'programs.competenciesManageTitle'}}
-    </span>
-  {{/if}}
 
   <div class='detail-actions'>
     {{#if isManaging}}


### PR DESCRIPTION
Changes cohorts, lms, objectives, topics, program year competencies
components so that when the manager is opened ‘Manage Topics’ is
displayed and not Topics (9) Manage Topics

Fixes #521