### PR TITLE
Add a Medium Editor to text area elements

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,8 @@
     "document",
     "window",
     "-Promise",
-    "$"
+    "$",
+    "MediumEditor"
   ],
   "browser": true,
   "boss": true,

--- a/app/components/inplace-textarea.js
+++ b/app/components/inplace-textarea.js
@@ -3,4 +3,11 @@ import InPlace from 'ilios/mixins/inplace';
 
 export default Ember.Component.extend(InPlace, {
   classNames: ['editinplace', 'inplace-textarea'],
+  options: '{' +
+    '"autoLink": true,' +
+    '"forcePlainText": false,' +
+    '"cleanPastedHTML": true,' +
+    '"imageDragging": false,' +
+    '"buttons": ["unorderedlist", "orderedlist","bold", "italic", "underline", "anchor", "header1", "header2", "quote"]' +
+  '}',
 });

--- a/app/templates/components/inplace-textarea.hbs
+++ b/app/templates/components/inplace-textarea.hbs
@@ -6,7 +6,10 @@
   {{else}}
     <span class='editor'>
       <span class='control'>
-        {{textarea type='text' value=workingValue action='save'}}
+        {{medium-content-editable
+          value=workingValue
+          options=options
+        }}
       </span>
       <span class='actions'>
         <button class='save icon' title='{{t "general.save"}}' {{action 'save'}}>{{fa-icon 'check' classNames='add'}}</button>

--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "pretender": "~0.6.0",
     "qunit": "~1.17.1",
     "pikaday": "~1.3.2",
-    "moment": "~2.10.0"
+    "moment": "~2.10.0",
+    "medium-editor": "3.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-cli-htmlbars": "0.7.6",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
+    "ember-cli-medium-editor": "^1.0.4",
     "ember-cli-mirage": "0.0.26",
     "ember-cli-neat": "0.0.3",
     "ember-cli-qunit": "0.3.13",


### PR DESCRIPTION
**UPDATE 5/26:**
good to go with medium editor. Issues to address are:
1. when you click to manage it needs to open the editor immediately, rather than requiring two clicks to open the editor.
2. we need to provide a plain text editor option along with WYSIWYG
3. Objective display needs to show styling
4. we need to find an appropriate means of scrubbing existing extraneous code tags from the objective data, along with our cut&paste solution to scrubbing new input data.

**Solutions**
- determine a tag whitelist for accepted markup
- find a means of both scrubbing and validating the scrub

QUESTIONS:
can we do this without users having to look and approve?
can we add a column to track cleansing of data?


*Try out the medium editor when changing objective titles.*

*Thoughts?*

Refs #458