### PR TITLE
Fix css conflict between header and editor actions

### DIFF
--- a/app/mirage/config.js
+++ b/app/mirage/config.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 
 export default function() {
     this.namespace = 'api';
-    this.timing = 1000;
+    this.timing = 100;
 
     //hardcode the current session user id
     this.get('/currentsession', {currentsession: {userId: 4136}});

--- a/app/styles/components/_detailview.scss
+++ b/app/styles/components/_detailview.scss
@@ -247,14 +247,17 @@ $collapse-control-shadow-grey: #e2e2e2;
     padding: .8em;
 
     .title {
-      @include span-columns(9 of 12);
+      @include span-columns(8 of 12);
       h2,
       h4 {
         display: inline;
       }
+      input {
+        @include span-columns(6 of 8);
+      }
     }
 
-    .actions,
+    .header-actions,
     .info {
       @include span-columns(2 of 12);
       @include shift(1);

--- a/app/styles/components/_detailview.scss
+++ b/app/styles/components/_detailview.scss
@@ -252,6 +252,7 @@ $collapse-control-shadow-grey: #e2e2e2;
       h4 {
         display: inline;
       }
+      
       input {
         @include span-columns(6 of 8);
       }

--- a/app/templates/components/course-header.hbs
+++ b/app/templates/components/course-header.hbs
@@ -11,7 +11,7 @@
     {{/if}}
     <h4>{{course.academicYear}}</h4>
   </span>
-  <span class ='actions'>
+  <span class ='header-actions'>
     {{#action-menu title=menuTitle icon=menuIcon classNameBindings='publicationStatus :publication-menu :course-publication-menu :right-edge'}}
       {{#if showAsIs}}
         <li class='danger' {{action 'publish'}}>{{t 'publish.publishAsIs'}}</li>

--- a/app/templates/components/session-overview.hbs
+++ b/app/templates/components/session-overview.hbs
@@ -6,7 +6,7 @@
       <h2>{{session.title}}</h2>
     {{/if}}
   </span>
-  <span class ='actions'>
+  <span class ='header-actions'>
     {{#action-menu title=menuTitle icon=menuIcon classNameBindings='publicationStatus :publication-menu :session-publication-menu :right-edge'}}
       {{#if showAsIs}}
         <li class='danger' {{action 'publish'}}>{{t 'publish.publishAsIs'}}</li>


### PR DESCRIPTION
This fixes the mis-alignment of the save buttons for editing course and
session titles.

Fixes #401