### PR TITLE
When a session-details component is loaded scroll to the top

### DIFF
--- a/app/components/session-details.js
+++ b/app/components/session-details.js
@@ -1,9 +1,13 @@
 import Ember from 'ember';
+import scrollTo from '../utils/scroll-to';
 
 export default Ember.Component.extend({
   availableTopics: [],
   sessionTypes: [],
   session: null,
+  didInsertElement: function(){
+    scrollTo("#session-" + this.get('session.id'));
+  },
   actions: {
     save: function(){
       var self = this;

--- a/app/templates/components/session-details.hbs
+++ b/app/templates/components/session-details.hbs
@@ -1,4 +1,4 @@
-<div class='detail-view'>
+<div class='detail-view' id="session-{{session.id}}">
   <div class='detail-view-details'>
     {{session-overview
       course=course


### PR DESCRIPTION
The fixes #403 so that when you follow a link to a session from a course you will scroll to the session header and not be stranded in the middle of the session details.