### PR TITLE
Simplified button styles

### DIFF
--- a/app/styles/components/_editinplace.scss
+++ b/app/styles/components/_editinplace.scss
@@ -27,7 +27,6 @@
       display: inline;
 
       button {
-        background: transparent;
         margin: 0;
         padding: 0 .2em;
       }

--- a/app/styles/components/_global.scss
+++ b/app/styles/components/_global.scss
@@ -46,12 +46,6 @@ button {
     font-weight: bold;
     width: 1.5em;
 
-    &.text {
-      border-style: solid;
-      border-width: 1px;
-      width: 95px;
-    }
-
     &:hover {
       color: $white;
     }
@@ -81,6 +75,12 @@ button {
     &:hover {
       background-color: $ilios-green;
     }
+  }
+  
+  &.text {
+    border-style: solid;
+    border-width: 1px;
+    width: 95px;
   }
 }
 

--- a/app/styles/components/_global.scss
+++ b/app/styles/components/_global.scss
@@ -19,6 +19,7 @@ button {
   background-color: $base-link-color;
   border: 0;
   border-radius: $base-border-radius;
+  box-sizing: border-box;
   color: $white;
   cursor: pointer;
   display: inline-block;
@@ -26,30 +27,6 @@ button {
   padding: .3em 1em;
   vertical-align: middle;
   white-space: nowrap;
-
-  &.add,
-  &.remove,
-  &.bigadd,
-  &.bigremove {
-    color: $white;
-  }
-
-  &.cancel,
-  &.done {
-    background-color: $white;
-    box-sizing: border-box;
-    font-weight: bold;
-
-    &:hover {
-      color: $white;
-    }
-
-    //force the width of the done/cancel buttons, so they are always the same size
-    &.text {
-      width: 95px;
-    }
-  }
-
 
   &.bigadd {
     background-color: $ilios-green;
@@ -63,29 +40,46 @@ button {
     background-color: $ilios-remove-color;
   }
 
+  &.done,
   &.cancel {
+    background-color: transparent;
+    font-weight: bold;
+    width: 1.5em;
 
     &.text {
-      border: 1px solid $ilios-red;
-      color: $ilios-red;
+      border-style: solid;
+      border-width: 1px;
+      width: 95px;
+    }
 
-      &:hover {
-        background-color: $ilios-red;
-        color: $white;
-      }
+    &:hover {
+      color: $white;
     }
   }
 
-  &.done {
+  &.cancel {
+    color: $ilios-red;
 
     &.text {
-      border: 1px solid $ilios-green;
-      color: $ilios-green;
+      border-color: $ilios-red;
+    }
 
-      &:hover {
-        background-color: $ilios-green;
-        color: $white;
-      }
+    &:hover {
+      background-color: $ilios-red;
+    }
+
+
+  }
+
+  &.done {
+    color: $ilios-green;
+
+    &.text {
+      border-color: $ilios-green;
+    }
+
+    &:hover {
+      background-color: $ilios-green;
     }
   }
 }

--- a/app/styles/components/_resultslist.scss
+++ b/app/styles/components/_resultslist.scss
@@ -12,7 +12,7 @@
     padding: .4em;
 
     .resultslist-title {
-      @include span-columns(1 of 12);
+      @include span-columns(2 of 12);
       h2 {
         font-size: $base-font-size;
         margin: .3em 1em;
@@ -66,7 +66,8 @@
 
   .resultslist-actions {
     @include span-columns(2 of 12);
-    @include shift(9);
+    @include shift(8);
+    text-align: right;
   }
 
   tbody .confirm-removal {

--- a/app/styles/components/_resultslist.scss
+++ b/app/styles/components/_resultslist.scss
@@ -95,6 +95,11 @@
     .remove {
       background-color: $white;
       color: $ilios-remove-color;
+
+      &:hover {
+        background-color: $ilios-remove-color;
+        color: $white;
+      }
     }
   }
 

--- a/app/templates/components/course-objective-list.hbs
+++ b/app/templates/components/course-objective-list.hbs
@@ -31,7 +31,7 @@
             <br />
           {{/each}}
         {{else}}
-          <button class='add' {{action 'manageParents' objective}}>{{t 'general.addNew'}}</button>
+          <button {{action 'manageParents' objective}}>{{t 'general.addNew'}}</button>
         {{/if}}
       </td>
       <td class='text-left text-top'>
@@ -44,7 +44,7 @@
             </a>
           </ul>
         {{else}}
-          <button class='add' {{action 'manageDescriptors' objective}}>{{t 'general.addNew'}}</button>
+          <button {{action 'manageDescriptors' objective}}>{{t 'general.addNew'}}</button>
         {{/if}}
       </td>
     </tr>

--- a/app/templates/components/detail-cohorts.hbs
+++ b/app/templates/components/detail-cohorts.hbs
@@ -14,7 +14,7 @@
       <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
       <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
     {{else}}
-      <button class='add' {{action 'manage'}}>{{t 'courses.cohortsManageTitle'}}</button>
+      <button {{action 'manage'}}>{{t 'courses.cohortsManageTitle'}}</button>
     {{/if}}
   </div>
   <div class='detail-content'>

--- a/app/templates/components/detail-instructors.hbs
+++ b/app/templates/components/detail-instructors.hbs
@@ -13,7 +13,7 @@
         <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
         <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
     {{else}}
-      <button class='add' {{action 'manage'}}>{{t 'courses.instructorsManageTitle'}}</button>
+      <button {{action 'manage'}}>{{t 'courses.instructorsManageTitle'}}</button>
     {{/if}}
   </div>
   <div class='detail-content'>

--- a/app/templates/components/detail-learnergroups.hbs
+++ b/app/templates/components/detail-learnergroups.hbs
@@ -13,7 +13,7 @@
         <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
         <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
     {{else}}
-      <button class='add' {{action 'manage'}}>{{t 'courses.learnerGroupsManageTitle'}}</button>
+      <button {{action 'manage'}}>{{t 'courses.learnerGroupsManageTitle'}}</button>
     {{/if}}
   </div>
   <div class='detail-content'>

--- a/app/templates/components/detail-mesh.hbs
+++ b/app/templates/components/detail-mesh.hbs
@@ -14,7 +14,7 @@
         <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
         <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
     {{else}}
-      <button class='add' {{action 'manage'}}>{{t 'courses.meshManageTitle'}}</button>
+      <button {{action 'manage'}}>{{t 'courses.meshManageTitle'}}</button>
     {{/if}}
   </div>
   <div class='detail-content'>

--- a/app/templates/components/detail-objectives.hbs
+++ b/app/templates/components/detail-objectives.hbs
@@ -25,7 +25,7 @@
       <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
       <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
     {{else}}
-      <button class='add' {{action 'addObjective'}}>{{t 'general.addNew'}}</button>
+      <button {{action 'addObjective'}}>{{t 'general.addNew'}}</button>
     {{/liquid-if}}
   </div>
   <div class='detail-content'>

--- a/app/templates/components/detail-stewards.hbs
+++ b/app/templates/components/detail-stewards.hbs
@@ -13,7 +13,7 @@
         <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
         <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
     {{else}}
-      <button class='add' {{action 'manage'}}>{{t 'programs.stewardsManageTitle'}}</button>
+      <button {{action 'manage'}}>{{t 'programs.stewardsManageTitle'}}</button>
     {{/if}}
   </div>
   <div class='detail-content'>

--- a/app/templates/components/detail-topics.hbs
+++ b/app/templates/components/detail-topics.hbs
@@ -14,7 +14,7 @@
         <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
         <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
     {{else}}
-      <button class='add' {{action 'manage'}}>{{t 'courses.topicsManageTitle'}}</button>
+      <button {{action 'manage'}}>{{t 'courses.topicsManageTitle'}}</button>
     {{/if}}
   </div>
   <div class='detail-content'>

--- a/app/templates/components/ilios-course-list.hbs
+++ b/app/templates/components/ilios-course-list.hbs
@@ -41,7 +41,7 @@
             {{t 'courses.confirmRemove' publishedOfferingCountBinding='course.publishedOfferingCount'}} <br />
            <div class="confirm-buttons">
             <button {{action 'remove' course}} class='remove text'>{{t 'general.yes'}}</button>
-            <button {{action 'cancelRemove' course}} class='cancel text'>{{t 'general.cancel'}}</button>
+            <button {{action 'cancelRemove' course}} class='done text'>{{t 'general.cancel'}}</button>
           </div>
           </div>
         </td></tr>

--- a/app/templates/components/ilios-sessions-list.hbs
+++ b/app/templates/components/ilios-sessions-list.hbs
@@ -8,7 +8,7 @@
     </div>
   </div>
   <div class='detail-actions'>
-    <button class='add' {{action 'addNewSession'}}>{{t 'general.addNew'}}</button>
+    <button {{action 'addNewSession'}}>{{t 'general.addNew'}}</button>
   </div>
   <section class='resultslist'>
     {{#if newSessions.length}}

--- a/app/templates/components/inplace-date.hbs
+++ b/app/templates/components/inplace-date.hbs
@@ -12,8 +12,8 @@
       {{pikaday-input value=workingValue format=dateFormat}}
     </span>
     <span class='actions'>
-      <button class='save icon' title='{{t "general.save"}}' {{action 'save'}}>{{fa-icon 'check' classNames='add'}}</button>
-      <button class='cancel icon' title='{{t "general.cancel"}}' {{action 'cancel'}}>{{fa-icon 'times' classNames='remove'}}</button>
+      <button class='done icon' title='{{t "general.save"}}' {{action 'save'}}>{{fa-icon 'check'}}</button>
+      <button class='cancel icon' title='{{t "general.cancel"}}' {{action 'cancel'}}>{{fa-icon 'times'}}</button>
     </span>
   </span>
 {{/unless}}

--- a/app/templates/components/inplace-select.hbs
+++ b/app/templates/components/inplace-select.hbs
@@ -13,8 +13,8 @@
       {{/x-select}}
     </span>
     <span class='actions'>
-      <button class='save icon' title='{{t "general.save"}}' {{action 'save'}}>{{fa-icon 'check' classNames='add'}}</button>
-      <button class='cancel icon' title='{{t "general.cancel"}}' {{action 'cancel'}}>{{fa-icon 'times' classNames='remove'}}</button>
+      <button class='done icon' title='{{t "general.save"}}' {{action 'save'}}>{{fa-icon 'check'}}</button>
+      <button class='cancel icon' title='{{t "general.cancel"}}' {{action 'cancel'}}>{{fa-icon 'times'}}</button>
     </span>
   </span>
 {{/unless}}

--- a/app/templates/components/inplace-text.hbs
+++ b/app/templates/components/inplace-text.hbs
@@ -13,8 +13,8 @@
         {{input type='text' value=workingValue action='save'}}
       </span>
       <span class='actions'>
-        <button class='save icon' title='{{t "general.save"}}' {{action 'save'}}>{{fa-icon 'check' classNames='add'}}</button>
-        <button class='cancel icon' title='{{t "general.cancel"}}' {{action 'cancel'}}>{{fa-icon 'times' classNames='remove'}}</button>
+        <button class='done icon' title='{{t "general.save"}}' {{action 'save'}}>{{fa-icon 'check'}}</button>
+        <button class='cancel icon' title='{{t "general.cancel"}}' {{action 'cancel'}}>{{fa-icon 'times'}}</button>
       </span>
     </span>
   {{/unless}}

--- a/app/templates/components/inplace-textarea.hbs
+++ b/app/templates/components/inplace-textarea.hbs
@@ -9,8 +9,8 @@
         {{textarea type='text' value=workingValue action='save'}}
       </span>
       <span class='actions'>
-        <button class='save icon' title='{{t "general.save"}}' {{action 'save'}}>{{fa-icon 'check' classNames='add'}}</button>
-        <button class='cancel icon' title='{{t "general.cancel"}}' {{action 'cancel'}}>{{fa-icon 'times' classNames='remove'}}</button>
+        <button class='done icon' title='{{t "general.save"}}' {{action 'save'}}>{{fa-icon 'check'}}</button>
+        <button class='cancel icon' title='{{t "general.cancel"}}' {{action 'cancel'}}>{{fa-icon 'times'}}</button>
       </span>
     </span>
   {{/unless}}

--- a/app/templates/components/instructorgroup-list.hbs
+++ b/app/templates/components/instructorgroup-list.hbs
@@ -29,8 +29,8 @@
           <div class='confirm-message'>
             {{t 'instructorGroups.confirmRemove' instructorCount=instructorGroup.users.length courseCount=instructorGroup.courses.length}} <br />
            <div class="confirm-buttons">
-            <button {{action 'remove' instructorGroup}} class='remove'>{{t 'general.yes'}}</button>
-            <button {{action 'cancelRemove' instructorGroup}} class='cancel'>{{t 'general.cancel'}}</button>
+            <button {{action 'remove' instructorGroup}} class='remove text'>{{t 'general.yes'}}</button>
+            <button {{action 'cancelRemove' instructorGroup}} class='done text'>{{t 'general.cancel'}}</button>
           </div>
           </div>
         </td></tr>

--- a/app/templates/components/learnergroup-list.hbs
+++ b/app/templates/components/learnergroup-list.hbs
@@ -29,8 +29,8 @@
           <div class='confirm-message'>
             {{t 'learnerGroups.confirmRemove' learnerCount=learnerGroup.usersCount subgroupCount=learnerGroup.children.length}} <br />
            <div class="confirm-buttons">
-            <button {{action 'remove' learnerGroup}} class='remove'>{{t 'general.yes'}}</button>
-            <button {{action 'cancelRemove' learnerGroup}} class='cancel'>{{t 'general.cancel'}}</button>
+            <button {{action 'remove' learnerGroup}} class='remove text'>{{t 'general.yes'}}</button>
+            <button {{action 'cancelRemove' learnerGroup}} class='done text'>{{t 'general.cancel'}}</button>
           </div>
           </div>
         </td></tr>

--- a/app/templates/components/learnergroup-subgroup-list.hbs
+++ b/app/templates/components/learnergroup-subgroup-list.hbs
@@ -3,7 +3,7 @@
     {{t 'learnerGroups.subgroups'}} ({{learnerGroups.length}})
   </div>
   <div class='detail-actions'>
-    <button class='add' {{action 'addLearnerGroup'}}>{{t 'general.addNew'}}</button>
+    <button {{action 'addLearnerGroup'}}>{{t 'general.addNew'}}</button>
   </div>
   <div class='detail-content'>
     {{#if newLearnerGroups.length}}

--- a/app/templates/components/learnergroup-subgroup-list.hbs
+++ b/app/templates/components/learnergroup-subgroup-list.hbs
@@ -41,7 +41,7 @@
                   {{t 'learnerGroups.confirmRemove' learnerCount=learnerGroup.usersCount subgroupCount=learnerGroup.children.length}} <br />
                  <div class="confirm-buttons">
                   <button {{action 'removeLearnerGroup' learnerGroup}} class='text remove'>{{t 'general.yes'}}</button>
-                  <button {{action 'cancelRemove' learnerGroup}} class='text cancel'>{{t 'general.cancel'}}</button>
+                  <button {{action 'cancelRemove' learnerGroup}} class='text done'>{{t 'general.cancel'}}</button>
                 </div>
                 </div>
               </td></tr>

--- a/app/templates/components/program-list.hbs
+++ b/app/templates/components/program-list.hbs
@@ -29,8 +29,8 @@
           <div class='confirm-message'>
             {{t 'programs.confirmRemove' programYearCount=program.programYears.length courseCount=program.courseCount}} <br />
            <div class="confirm-buttons">
-            <button {{action 'remove' program}} class='remove'>{{t 'general.yes'}}</button>
-            <button {{action 'cancelRemove' program}} class='cancel'>{{t 'general.cancel'}}</button>
+            <button {{action 'remove' program}} class='remove text'>{{t 'general.yes'}}</button>
+            <button {{action 'cancelRemove' program}} class='done text'>{{t 'general.cancel'}}</button>
           </div>
           </div>
         </td></tr>

--- a/app/templates/components/programyear-competencies.hbs
+++ b/app/templates/components/programyear-competencies.hbs
@@ -14,7 +14,7 @@
         <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
         <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
     {{else}}
-      <button class='add' {{action 'manage'}}>{{t 'programs.competenciesManageTitle'}}</button>
+      <button {{action 'manage'}}>{{t 'programs.competenciesManageTitle'}}</button>
     {{/if}}
   </div>
   <div class='detail-content'>

--- a/app/templates/components/programyear-list.hbs
+++ b/app/templates/components/programyear-list.hbs
@@ -3,7 +3,7 @@
     {{t 'general.programYears'}} ({{programYears.length}})
   </div>
   <div class='detail-actions'>
-        <button class='add' {{action 'addNewProgramYear'}}>{{t 'general.addNew'}}</button>
+        <button {{action 'addNewProgramYear'}}>{{t 'general.addNew'}}</button>
   </div>
   <section class='resultslist'>
     {{#if newProgramYears.length}}

--- a/app/templates/components/programyear-objective-list.hbs
+++ b/app/templates/components/programyear-objective-list.hbs
@@ -19,7 +19,7 @@
           </a>
           ({{objective.competency.domain.title}})
         {{else}}
-          <button class='add' {{action 'mangeCompetency' objective}}>{{t 'general.addNew'}}</button>
+          <button {{action 'mangeCompetency' objective}}>{{t 'general.addNew'}}</button>
         {{/if}}
       </td>
       <td class='text-left text-top'>
@@ -32,7 +32,7 @@
             </a>
           </ul>
         {{else}}
-          <button class='add' {{action 'manageDescriptors' objective}}>{{t 'general.addNew'}}</button>
+          <button {{action 'manageDescriptors' objective}}>{{t 'general.addNew'}}</button>
         {{/if}}
       </td>
     </tr>

--- a/app/templates/components/session-objective-list.hbs
+++ b/app/templates/components/session-objective-list.hbs
@@ -23,7 +23,7 @@
             {{/if}}
           {{/each}}
         {{else}}
-          <button class='add' {{action 'manageParents' objective}}>{{t 'general.addNew'}}</button>
+          <button {{action 'manageParents' objective}}>{{t 'general.addNew'}}</button>
         {{/if}}
       </td>
       <td class='text-left text-top'>
@@ -36,7 +36,7 @@
             </a>
           </ul>
         {{else}}
-          <button class='add' {{action 'manageDescriptors' objective}}>{{t 'general.addNew'}}</button>
+          <button {{action 'manageDescriptors' objective}}>{{t 'general.addNew'}}</button>
         {{/if}}
       </td>
     </tr>

--- a/app/templates/courses.hbs
+++ b/app/templates/courses.hbs
@@ -35,7 +35,7 @@
         <h2>{{t 'general.courses'}}</h2>
       </div>
       <div class='resultslist-actions'>
-        <button class='add' {{action 'addCourse'}}>{{t 'general.addNew'}}</button>
+        <button {{action 'addCourse'}}>{{t 'general.addNew'}}</button>
       </div>
     </div>
     {{#if newCourses.length}}

--- a/app/templates/instructor-groups.hbs
+++ b/app/templates/instructor-groups.hbs
@@ -29,7 +29,7 @@
         <h2>{{t 'general.instructorGroups'}}</h2>
       </div>
       <div class='resultslist-actions'>
-        <button class='add' {{action 'addInstructorGroup'}}>{{t 'general.addNew'}}</button>
+        <button {{action 'addInstructorGroup'}}>{{t 'general.addNew'}}</button>
       </div>
     </div>
 

--- a/app/templates/learner-groups.hbs
+++ b/app/templates/learner-groups.hbs
@@ -58,7 +58,7 @@
         <h2>{{t 'general.learnerGroups'}}</h2>
       </div>
       <div class='resultslist-actions'>
-        <button class='add' {{action 'addLearnerGroup'}}>{{t 'general.addNew'}}</button>
+        <button {{action 'addLearnerGroup'}}>{{t 'general.addNew'}}</button>
       </div>
     </div>
 

--- a/app/templates/programs.hbs
+++ b/app/templates/programs.hbs
@@ -29,7 +29,7 @@
         <h2>{{t 'general.programs'}}</h2>
       </div>
       <div class='resultslist-actions'>
-        <button class='add' {{action 'addProgram'}}>{{t 'general.addNew'}}</button>
+        <button {{action 'addProgram'}}>{{t 'general.addNew'}}</button>
       </div>
     </div>
 

--- a/tests/acceptance/course/cohorts-test.js
+++ b/tests/acceptance/course/cohorts-test.js
@@ -81,7 +81,7 @@ test('manage cohorts', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-cohorts');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       assert.equal(find('.removable-list li', container).length, 1);
       assert.equal(getElementText(find('.selectable-list li ul li', container)), getText('cohort 1'));
@@ -94,7 +94,7 @@ test('save cohort chages', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-cohorts');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       click(find('.removable-list li:eq(0)', container)).then(function(){
         click(find('.selectable-list li ul li:eq(1)', container)).then(function(){
@@ -114,7 +114,7 @@ test('cancel cohort chages', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-cohorts');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       click(find('.removable-list li:eq(0)', container)).then(function(){
         click(find('.selectable-list li ul li:eq(1)', container)).then(function(){
@@ -136,7 +136,7 @@ test('removing a cohort remove course objectives parents linked to that cohort',
     var parents = find('.course-objective-list tbody tr:eq(0) td:eq(1) a');
     assert.equal(parents.length, 2);
     var container = find('');
-    click('.detail-cohorts .detail-actions .add');
+    click('.detail-cohorts .detail-actions button');
     andThen(function(){
       click('.detail-cohorts .removable-list li:eq(0)');
       click('.detail-cohorts button.bigadd');

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -380,7 +380,7 @@ test('edit learning material', function(assert) {
       click(find('.publicnotes input', container));
       click(find('.status .editable', container)).then(function(){
         pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
-        click(find('.status .save', container));
+        click(find('.status .done', container));
       });
       andThen(function(){
         let removableItems = find('.removable-list li', container);
@@ -425,7 +425,7 @@ test('cancel editing learning material', function(assert) {
       click(find('.publicnotes input', container));
       click(find('.status .editable', container)).then(function(){
         pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
-        click(find('.status .save', container));
+        click(find('.status .done', container));
       });
       let removableItems = find('.removable-list li', container);
       let searchBox = find('.search-box', container).eq(0);

--- a/tests/acceptance/course/mesh-test.js
+++ b/tests/acceptance/course/mesh-test.js
@@ -50,7 +50,7 @@ test('manage mesh', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-mesh');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function() {
       let meshManager = find('.mesh-manager', container);
       let removableItems = find('.removable-list li', meshManager);
@@ -103,7 +103,7 @@ test('save mesh changes', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-mesh');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function() {
       let meshManager = find('.mesh-manager', container);
       fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');
@@ -133,7 +133,7 @@ test('cancel mesh changes', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-mesh');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function() {
       let meshManager = find('.mesh-manager', container);
       fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');

--- a/tests/acceptance/course/objectivecreate-test.js
+++ b/tests/acceptance/course/objectivecreate-test.js
@@ -39,7 +39,7 @@ test('save new objective', function(assert) {
   andThen(function() {
     let objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
     assert.equal(objectiveRows.length, fixtures.course.objectives.length);
-    click('.detail-objectives .detail-actions button.add');
+    click('.detail-objectives .detail-actions button');
     fillIn('.detail-objectives .newobjective textarea', newObjectiveTitle);
     click('.detail-objectives .newobjective button.done');
   });
@@ -63,7 +63,7 @@ test('cancel new objective', function(assert) {
   andThen(function() {
     let objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
     assert.equal(objectiveRows.length, fixtures.course.objectives.length);
-    click('.detail-objectives .detail-actions button.add');
+    click('.detail-objectives .detail-actions button');
     fillIn('.detail-objectives .newobjective textarea', 'random junk, GO TEAM ILIOS!');
     click('.detail-objectives .newobjective button.cancel');
   });

--- a/tests/acceptance/course/objectivelist-test.js
+++ b/tests/acceptance/course/objectivelist-test.js
@@ -153,7 +153,7 @@ test('edit objective title', function(assert) {
       var textArea = find('textarea', td);
       assert.equal(getText(textArea.val()), getText(objective.title));
       fillIn(textArea, 'new title');
-      click(find('.actions .save', td));
+      click(find('.actions .done', td));
     });
     andThen(function(){
       assert.equal(getElementText(find('tbody tr:eq(0) td:eq(0)', container)), getText('new title'));

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -99,7 +99,7 @@ test('pick clerkship type', function(assert) {
         assert.equal(getElementText(options.eq(i)), getText(title));
       }
       pickOption(find('.clerkshiptype select', container), fixtures.clerkshipTypes[1].title, assert);
-      click(find('.clerkshiptype .actions .save', container));
+      click(find('.clerkshiptype .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.clerkshiptype .editable', container)), getText(fixtures.clerkshipTypes[1].title));
       });
@@ -123,7 +123,7 @@ test('remove clerkship type', function(assert) {
     click(find('.clerkshiptype .editable', container));
     andThen(function(){
       pickOption(find('.clerkshiptype select', container), 'Not a Clerkship', assert);
-      click(find('.clerkshiptype .actions .save', container));
+      click(find('.clerkshiptype .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.clerkshiptype .editable', container)), getText('Not a Clerkship'));
       });
@@ -176,7 +176,7 @@ test('change title', function(assert) {
       var input = find('.title .editinplace input', container);
       assert.equal(getText(input.val()), getText('course 0'));
       fillIn(input, 'test new title');
-      click(find('.title .editinplace .actions .save', container));
+      click(find('.title .editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.title h2', container)), getText('test new title'));
       });
@@ -206,7 +206,7 @@ test('change start date', function(assert) {
       assert.equal(interactor.selectedYear(), moment(course.startDate).format('YYYY'));
       var newDate = moment(course.startDate).add(1, 'year').add(1, 'month');
       interactor.selectDate(newDate.toDate());
-      click(find('.coursestartdate .editinplace .actions .save', container));
+      click(find('.coursestartdate .editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.coursestartdate div', container)), newDate.format('MM/DD/YY'));
       });
@@ -237,7 +237,7 @@ test('change end date', function(assert) {
       assert.equal(interactor.selectedYear(), moment(course.endDate).format('YYYY'));
       var newDate = moment(course.endDate).add(1, 'year').add(1, 'month');
       interactor.selectDate(newDate.toDate());
-      click(find('.courseenddate .editinplace .actions .save', container));
+      click(find('.courseenddate .editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.courseenddate div', container)), newDate.format('MM/DD/YY'));
       });
@@ -265,7 +265,7 @@ test('change externalId', function(assert) {
       var input = find('.courseexternalid .editinplace input', container);
       assert.equal(getText(input.val()), getText('abc123'));
       fillIn(input, 'testnewid');
-      click(find('.courseexternalid .editinplace .actions .save', container));
+      click(find('.courseexternalid .editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.courseexternalid div', container)), getText('testnewid'));
       });
@@ -294,7 +294,7 @@ test('change level', function(assert) {
         assert.equal(getElementText(options.eq(i)), i+1);
       }
       pickOption(find('.courselevel select', container), '1', assert);
-      click(find('.courselevel .actions .save', container));
+      click(find('.courselevel .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.courselevel .editable', container)), 1);
       });

--- a/tests/acceptance/course/session/ilm-test.js
+++ b/tests/acceptance/course/session/ilm-test.js
@@ -125,7 +125,7 @@ test('check learner groups', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-learnergroups');
-    click('.detail-actions .add', container);
+    click('.detail-actions button', container);
     andThen(function(){
       var cohorts = find('.selectable-list li.static');
       assert.equal(cohorts.length, fixtures.course.cohorts.length);
@@ -140,7 +140,7 @@ test('filter learner groups', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-learnergroups');
-    click('.detail-actions .add', container);
+    click('.detail-actions button', container);
     andThen(function(){
       fillIn(find('input', container), 'group 5').then(function(){
         assert.equal(getElementText(find('.selectable-list li.static').eq(0)), getText('cohort0learnergroup1->learnergroup5learnergroup1->learnergroup5->learnergroup6'));
@@ -154,7 +154,7 @@ test('add learner group', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-learnergroups');
-    click('.detail-actions .add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       click('.selectable-list ul li.static:eq(1) ul li:eq(0)', container);
     });
     andThen(function(){
@@ -175,7 +175,7 @@ test('add learner sub group', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-learnergroups');
-    click('.detail-actions .add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       click('.selectable-list ul li.static:eq(0) ul li:eq(1)', container);
     });
     andThen(function(){
@@ -196,7 +196,7 @@ test('add learner group with children', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-learnergroups');
-    click('.detail-actions .add', container);
+    click('.detail-actions button', container);
     andThen(function(){
       click('.selectable-list ul li.static:eq(0) ul li:eq(0)', container);
       click('.bigadd', container);
@@ -213,7 +213,7 @@ test('add learner group with children and remove one child', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-learnergroups');
-    click('.detail-actions .add', container);
+    click('.detail-actions button', container);
     andThen(function(){
       click('.selectable-list ul li.static:eq(0) ul li:eq(0)', container);
       click('.removable-list li:eq(2)', container);
@@ -235,7 +235,7 @@ test('remove learner group', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-learnergroups');
-    click('.detail-actions .add', container);
+    click('.detail-actions button', container);
     andThen(function(){
       click('.removable-list li:eq(0)', container);
       click('.bigadd', container);
@@ -252,7 +252,7 @@ test('undo learner group change', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-learnergroups');
-    click('.detail-actions .add', container);
+    click('.detail-actions button', container);
     andThen(function(){
       click('.selectable-list ul li ul li:eq(0)', container);
       click('.removable-list li:eq(0)', container);
@@ -290,7 +290,7 @@ test('manage instructors lists', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-instructors');
-    click('.detail-actions .add', container);
+    click('.detail-actions button', container);
     andThen(function(){
       var selectedGroups = find('.inline-list:eq(0) li', container);
       assert.equal(selectedGroups.length, fixtures.ilmSession.instructorGroups.length);
@@ -308,7 +308,7 @@ test('manage instructors search users', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-instructors');
-    click('.detail-actions .add', container);
+    click('.detail-actions button', container);
     andThen(function(){
       let searchBox = find('.search-box', container);
       assert.equal(searchBox.length, 1);
@@ -338,7 +338,7 @@ test('manage instructors search groups', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-instructors');
-    click('.detail-actions .add', container);
+    click('.detail-actions button', container);
     andThen(function(){
       let searchBox = find('.search-box', container);
       assert.equal(searchBox.length, 1);
@@ -367,7 +367,7 @@ test('add instructor group', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-instructors');
-    click('.detail-actions .add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       let input = find('.search-box input', container);
       fillIn(input, 'group');
       click('span.search-icon', container).then(()=>{
@@ -401,7 +401,7 @@ test('add instructor', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-instructors');
-    click('.detail-actions .add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       let input = find('.search-box input', container);
       fillIn(input, 'guy');
       click('span.search-icon', container).then(()=>{
@@ -435,7 +435,7 @@ test('remove instructor group', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-instructors');
-    click('.detail-actions .add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       click('.inline-list:eq(0) li:eq(0)', container);
     });
     andThen(function(){
@@ -465,7 +465,7 @@ test('remove instructor', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-instructors');
-    click('.detail-actions .add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       click('.inline-list:eq(1) li:eq(0)', container);
     });
     andThen(function(){
@@ -495,7 +495,7 @@ test('undo instructor/group changes', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.detail-instructors');
-    click('.detail-actions .add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       click('.inline-list:eq(0) li:eq(0)', container);
       click('.inline-list:eq(1) li:eq(0)', container);
     });

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -380,7 +380,7 @@ test('edit learning material', function(assert) {
       click(find('.publicnotes input', container));
       click(find('.status .editable', container)).then(function(){
         pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
-        click(find('.status .save', container));
+        click(find('.status .done', container));
       });
       andThen(function(){
         let removableItems = find('.removable-list li', container);
@@ -425,7 +425,7 @@ test('cancel editing learning material', function(assert) {
       click(find('.publicnotes input', container));
       click(find('.status .editable', container)).then(function(){
         pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
-        click(find('.status .save', container));
+        click(find('.status .done', container));
       });
       let removableItems = find('.removable-list li', container);
       let searchBox = find('.search-box', container).eq(0);

--- a/tests/acceptance/course/session/mesh-test.js
+++ b/tests/acceptance/course/session/mesh-test.js
@@ -53,7 +53,7 @@ test('manage mesh', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-mesh');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function() {
       let meshManager = find('.mesh-manager', container);
       let removableItems = find('.removable-list li', meshManager);
@@ -106,7 +106,7 @@ test('save mesh changes', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-mesh');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function() {
       let meshManager = find('.mesh-manager', container);
       fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');
@@ -136,7 +136,7 @@ test('cancel mesh changes', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-mesh');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function() {
       let meshManager = find('.mesh-manager', container);
       fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');

--- a/tests/acceptance/course/session/objectivecreate-test.js
+++ b/tests/acceptance/course/session/objectivecreate-test.js
@@ -36,7 +36,7 @@ test('save new objective', function(assert) {
   andThen(function() {
     let objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
     assert.equal(objectiveRows.length, fixtures.session.objectives.length);
-    click('.detail-objectives .detail-actions button.add');
+    click('.detail-objectives .detail-actions button');
     fillIn('.detail-objectives .newobjective textarea', newObjectiveTitle);
     click('.detail-objectives .newobjective button.done');
   });
@@ -60,7 +60,7 @@ test('cancel new objective', function(assert) {
   andThen(function() {
     let objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
     assert.equal(objectiveRows.length, fixtures.session.objectives.length);
-    click('.detail-objectives .detail-actions button.add');
+    click('.detail-objectives .detail-actions button');
     fillIn('.detail-objectives .newobjective textarea', 'random junk, GO TEAM ILIOS!');
     click('.detail-objectives .newobjective button.cancel');
   });

--- a/tests/acceptance/course/session/objectivelist-test.js
+++ b/tests/acceptance/course/session/objectivelist-test.js
@@ -142,7 +142,7 @@ test('edit objective title', function(assert) {
       var textArea = find('textarea', td);
       assert.equal(getText(textArea.val()), getText(objective.title));
       fillIn(textArea, 'new title');
-      click(find('.actions .save', td));
+      click(find('.actions .done', td));
     });
     andThen(function(){
       assert.equal(getElementText(find('tbody tr:eq(0) td:eq(0)', container)), getText('new title'));

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -120,7 +120,7 @@ test('change ilm hours', function(assert) {
       var input = find('.editinplace input', container);
       assert.equal(getText(input.val()), ilmSession.hours);
       fillIn(input, 23);
-      click(find('.editinplace .actions .save', container));
+      click(find('.editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.content', container)), 23);
       });
@@ -149,7 +149,7 @@ test('change ilm due date', function(assert) {
       assert.equal(interactor.selectedYear(), moment(ilmSession.dueDate).format('YYYY'));
       var newDate = moment(ilmSession.dueDate).add(1, 'year').add(1, 'month');
       interactor.selectDate(newDate.toDate());
-      click(find('.editinplace .actions .save', container));
+      click(find('.editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('div', container)), newDate.format('MM/DD/YY'));
       });
@@ -171,7 +171,7 @@ test('change title', function(assert) {
       var input = find('.editinplace input', container);
       assert.equal(getText(input.val()), getText('session 0'));
       fillIn(input, 'test new title');
-      click(find('.editinplace .actions .save', container));
+      click(find('.editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(container), getText('test new title'));
       });
@@ -195,7 +195,7 @@ test('change type', function(assert) {
       assert.equal(getElementText(options.eq(0)), getText(fixtures.selectedSessionType.title));
       assert.equal(getElementText(options.eq(1)), getText(fixtures.otherSessionType.title));
       pickOption(find('.sessiontype select', container), fixtures.otherSessionType.title, assert);
-      click(find('.sessiontype .actions .save', container));
+      click(find('.sessiontype .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.sessiontype .editable', container)), getText(fixtures.otherSessionType.title));
       });
@@ -267,7 +267,7 @@ test('change description', function(assert) {
       var input = find('.editinplace textarea', container);
       assert.equal(getText(input.val()), description);
       fillIn(input, 'test new description');
-      click(find('.editinplace .actions .save', container));
+      click(find('.editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.content', container)), getText('test new description'));
       });
@@ -289,7 +289,7 @@ test('add description', function(assert) {
       var input = find('.editinplace textarea', container);
       assert.equal(getText(input.val()), '');
       fillIn(input, 'test new description');
-      click(find('.editinplace .actions .save', container));
+      click(find('.editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.content', container)), getText('test new description'));
       });

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -172,7 +172,7 @@ test('change ilm hours', function(assert) {
       var input = find('.editinplace input', container);
       assert.equal(getText(input.val()), ilmSession.hours);
       fillIn(input, 23);
-      click(find('.editinplace .actions .save', container));
+      click(find('.editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.content', container)), 23);
       });
@@ -201,7 +201,7 @@ test('change ilm due date', function(assert) {
       assert.equal(interactor.selectedYear(), moment(ilmSession.dueDate).format('YYYY'));
       var newDate = moment(ilmSession.dueDate).add(1, 'year').add(1, 'month');
       interactor.selectDate(newDate.toDate());
-      click(find('.editinplace .actions .save', container));
+      click(find('.editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('div', container)), newDate.format('MM/DD/YY'));
       });
@@ -223,7 +223,7 @@ test('change title', function(assert) {
       var input = find('.editinplace input', container);
       assert.equal(getText(input.val()), getText('session 0'));
       fillIn(input, 'test new title');
-      click(find('.editinplace .actions .save', container));
+      click(find('.editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(container), getText('test new title'));
       });
@@ -247,7 +247,7 @@ test('change type', function(assert) {
       assert.equal(getElementText(options.eq(0)), getText('session type 0'));
       assert.equal(getElementText(options.eq(1)), getText('session type 1'));
       pickOption(find('.sessiontype select', container), 'session type 1', assert);
-      click(find('.sessiontype .actions .save', container));
+      click(find('.sessiontype .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 1'));
       });
@@ -319,7 +319,7 @@ test('change description', function(assert) {
       var input = find('.editinplace textarea', container);
       assert.equal(getText(input.val()), description);
       fillIn(input, 'test new description');
-      click(find('.editinplace .actions .save', container));
+      click(find('.editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.content', container)), getText('test new description'));
       });
@@ -341,7 +341,7 @@ test('add description', function(assert) {
       var input = find('.editinplace textarea', container);
       assert.equal(getText(input.val()), '');
       fillIn(input, 'test new description');
-      click(find('.editinplace .actions .save', container));
+      click(find('.editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.content', container)), getText('test new description'));
       });

--- a/tests/acceptance/course/session/topics-test.js
+++ b/tests/acceptance/course/session/topics-test.js
@@ -57,7 +57,7 @@ test('manage topics', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       assert.equal(getElementText(find('.removable-list li', container)), getText('topic 0'));
       assert.equal(getElementText(find('.selectable-list li', container)), getText('topic 1'));
@@ -70,7 +70,7 @@ test('save topic chages', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       click(find('.removable-list li:eq(0)', container)).then(function(){
         click(find('.selectable-list li:eq(1)', container)).then(function(){
@@ -89,7 +89,7 @@ test('cancel topic chages', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       click(find('.removable-list li:eq(0)', container)).then(function(){
         click(find('.selectable-list li:eq(1)', container)).then(function(){

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -174,7 +174,7 @@ test('new session goes away when we navigate #643', function(assert) {
   let newTitle = 'new session title, woohoo';
   andThen(function() {
     let container = find('.sessions-list');
-    click('.detail-actions .add', container).then(()=> {
+    click('.detail-actions button', container).then(()=> {
       fillIn('.sessions-list .new-session input:eq(0)', newTitle);
       click('.new-session .done', container).then(()=>{
         click('.savedsession a', container).then(()=> {

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -153,7 +153,7 @@ test('new session', function(assert) {
   let newTitle = 'new session title, woohoo';
   andThen(function() {
     let container = find('.sessions-list');
-    click('.detail-actions .add', container);
+    click('.detail-actions button', container);
     andThen(function(){
       fillIn('.sessions-list .new-session input:eq(0)', newTitle);
       click('.new-session .done', container);

--- a/tests/acceptance/course/topics-test.js
+++ b/tests/acceptance/course/topics-test.js
@@ -54,7 +54,7 @@ test('manage topics', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       assert.equal(getElementText(find('.removable-list li', container)), getText('topic 0'));
       assert.equal(getElementText(find('.selectable-list li', container)), getText('topic 1'));
@@ -67,7 +67,7 @@ test('save topic chages', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       click(find('.removable-list li:eq(0)', container)).then(function(){
         click(find('.selectable-list li:eq(1)', container)).then(function(){
@@ -86,7 +86,7 @@ test('cancel topic chages', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       click(find('.removable-list li:eq(0)', container)).then(function(){
         click(find('.selectable-list li:eq(1)', container)).then(function(){

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -169,7 +169,7 @@ test('new course', function(assert) {
   let newTitle = 'new course title, woohoo';
   andThen(function() {
     let container = find('.resultslist');
-    click('.resultslist-actions .add', container);
+    click('.resultslist-actions button', container);
     andThen(function(){
       fillIn('.new-course input:eq(0)', newTitle);
       click('.new-course .done', container);
@@ -190,7 +190,7 @@ test('new course in another year does not display in list', function(assert) {
   let newTitle = 'new course title, woohoo';
   andThen(function() {
     let container = find('.resultslist');
-    click('.resultslist-actions .add', container);
+    click('.resultslist-actions button', container);
     andThen(function(){
       fillIn('.new-course input:eq(0)', newTitle);
       click('.new-course-year button').then(function(){

--- a/tests/acceptance/instructorgroups-test.js
+++ b/tests/acceptance/instructorgroups-test.js
@@ -145,7 +145,7 @@ test('add new instructorgroup', function(assert) {
   assert.expect(1);
   visit('/instructorgroups');
   andThen(function() {
-    click('.resultslist-actions .add');
+    click('.resultslist-actions button');
     fillIn('.newinstructorgroup-title', 'new test tile');
     click('.newinstructorgroup .done');
   });
@@ -167,7 +167,7 @@ test('cancel adding new instructorgroup', function(assert) {
   andThen(function() {
     assert.equal(1, find('.resultslist-list tbody tr').length);
     assert.equal(getElementText(find('.resultslist-list tbody tr:eq(0) td:eq(0)')),getText('instructorgroup 0'));
-    click('.resultslist-actions .add').then(function(){
+    click('.resultslist-actions button').then(function(){
       assert.equal(find('.newinstructorgroup').length, 1);
       click('.newinstructorgroup .cancel');
     });

--- a/tests/acceptance/instructorgroups-test.js
+++ b/tests/acceptance/instructorgroups-test.js
@@ -218,7 +218,7 @@ test('cancel remove instructorgroup', function(assert) {
     assert.equal(getElementText(find('.resultslist-list tbody tr:eq(0) td:eq(0)')),getText('instructorgroup 0'));
     click('.resultslist-list tbody tr:eq(0) td:eq(3) button').then(function(){
       click('.resultslist-list tbody tr:eq(0) td:eq(3) li:eq(1)').then(function(){
-        click('.confirm-buttons .cancel');
+        click('.confirm-buttons .done');
       });
     });
   });

--- a/tests/acceptance/learnergroup/membership-test.js
+++ b/tests/acceptance/learnergroup/membership-test.js
@@ -112,7 +112,7 @@ test('top level group members', function(assert) {
       assert.equal(getElementText(options.eq(5)), getText('Switch Learner to learner group 0 -> learner group 2'));
 
       pickOption(find('.learnergroup-group-membership:eq(0) select', container), 'Switch Learner to learner group 0 -> learner group 1', assert);
-      click(find('.learnergroup-group-membership:eq(0) .actions .save', container));
+      click(find('.learnergroup-group-membership:eq( 0) .actions .done', container));
       andThen(function(){
         let container = find('.detail-overview');
         assert.equal(getElementText(find('.detail-header .info')),getText('Members: 3'));
@@ -144,7 +144,7 @@ test('cohort members', function(assert) {
       assert.equal(getElementText(options.eq(4)), getText('Switch Learner to learner group 0 -> learner group 2'));
 
       pickOption(find('.learnergroup-group-membership:eq(0) select', container), 'Switch Learner to learner group 0 -> learner group 1', assert);
-      click(find('.learnergroup-group-membership:eq(0) .actions .save', container));
+      click(find('.learnergroup-group-membership:eq( 0) .actions .done', container));
       andThen(function(){
         let container = find('.detail-overview');
         assert.equal(getElementText(find('.detail-header .info')),getText('Members: 3'));
@@ -163,7 +163,7 @@ test('move group member to another subgroup', function(assert) {
     let container = find('.detail-overview');
     click('.learnergroup-group-membership:eq(0) .editable').then(function(){
       pickOption(find('.learnergroup-group-membership:eq(0) select', container), 'Switch Learner to learner group 0 -> learner group 2', assert);
-      click(find('.learnergroup-group-membership:eq(0) .actions .save', container));
+      click(find('.learnergroup-group-membership:eq( 0) .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.detail-header .info')),getText('Members: 1'));
         assert.equal(getElementText(find('.detail-overview .detail-title')), getText('learner group 1 Members (1)'));
@@ -183,7 +183,7 @@ test('remove group member back to cohort', function(assert) {
     let container = find('.detail-overview');
     click('.learnergroup-group-membership:eq(0) .editable').then(function(){
       pickOption(find('.learnergroup-group-membership:eq(0) select', container), 'Remove Learner to cohort 0', assert);
-      click(find('.learnergroup-group-membership:eq(0) .actions .save', container));
+      click(find('.learnergroup-group-membership:eq( 0) .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.detail-header .info')),getText('Members: 1'));
         assert.equal(getElementText(find('.detail-overview .detail-title')), getText('learner group 1 Members (1)'));

--- a/tests/acceptance/learnergroup/overview-test.js
+++ b/tests/acceptance/learnergroup/overview-test.js
@@ -104,7 +104,7 @@ test('change title', function(assert) {
       var input = find('.title .editinplace input', container);
       assert.equal(getText(input.val()), getText('learner group 1'));
       fillIn(input, 'test new title');
-      click(find('.title .editinplace .actions .save', container));
+      click(find('.title .editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.title h2', container)), getText('cohort 0 -> learner group 0 -> test new title'));
       });
@@ -180,7 +180,7 @@ test('change location', function(assert) {
       var input = find('.learnergrouplocation .editinplace input', container);
       assert.equal(getText(input.val()), getText('room 101'));
       fillIn(input, 'test new location');
-      click(find('.learnergrouplocation .editinplace .actions .save', container));
+      click(find('.learnergrouplocation .editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.learnergrouplocation div', container)), getText('test new location'));
       });

--- a/tests/acceptance/learnergroup/subgroups-test.js
+++ b/tests/acceptance/learnergroup/subgroups-test.js
@@ -66,7 +66,7 @@ test('add new learnergroup', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.learnergroup-subgroup-list');
-    click('.add', container);
+    click('button', container);
     fillIn('.newlearnergroup input', 'a new test title');
     click('.newlearnergroup .done');
   });
@@ -89,7 +89,7 @@ test('cancel adding new learnergroup', function(assert) {
     assert.equal(find('.resultslist-list tbody tr', container).length, 2);
     assert.equal(getElementText(find('.resultslist-list tbody tr:eq(0) td:eq(0)', container)),getText('learnergroup 1'));
     assert.equal(getElementText(find('.resultslist-list tbody tr:eq(1) td:eq(0)', container)),getText('learnergroup 2'));
-    click('.add', container).then(function(){
+    click('button', container).then(function(){
       assert.equal(find('.newlearnergroup').length, 1);
       click('.newlearnergroup .cancel');
     });

--- a/tests/acceptance/learnergroup/subgroups-test.js
+++ b/tests/acceptance/learnergroup/subgroups-test.js
@@ -128,7 +128,7 @@ test('cancel remove learnergroup', function(assert) {
     assert.equal(find('.resultslist-list tbody tr', container).length, 2);
     assert.equal(getElementText(find('.resultslist-list tbody tr:eq(0) td:eq(0)', container)),getText('learnergroup 1'));
     click('.resultslist-list tbody tr:eq(0) td:eq(2) span').then(function(){
-      click('.confirm-buttons .cancel').then(() => {
+      click('.confirm-buttons .done').then(() => {
           assert.equal(find('.resultslist-list tbody tr').length, 2);
           assert.equal(getElementText(find('.resultslist-list tbody tr:eq(0) td:eq(0)', container)),getText('learnergroup 1'));
           assert.equal(getElementText(find('.resultslist-list tbody tr:eq(1) td:eq(0)', container)),getText('learnergroup 2'));

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -297,7 +297,7 @@ test('add new learnergroup', function(assert) {
   assert.expect(1);
   visit('/learnergroups');
   andThen(function() {
-    click('.resultslist-actions .add');
+    click('.resultslist-actions button');
     fillIn('.newlearnergroup-title', 'new test tile');
     click('.newlearnergroup .done');
   });
@@ -332,7 +332,7 @@ test('cancel adding new learnergroup', function(assert) {
   andThen(function() {
     assert.equal(1, find('.resultslist-list tbody tr').length);
     assert.equal(getElementText(find('.resultslist-list tbody tr:eq(0) td:eq(0)')),getText('learnergroup 0'));
-    click('.resultslist-actions .add').then(function(){
+    click('.resultslist-actions button').then(function(){
       assert.equal(find('.newlearnergroup').length, 1);
       click('.newlearnergroup .cancel');
     });

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -407,7 +407,7 @@ test('cancel remove learnergroup', function(assert) {
     assert.equal(getElementText(find('.resultslist-list tbody tr:eq(0) td:eq(0)')),getText('learnergroup 0'));
     click('.resultslist-list tbody tr:eq(0) td:eq(3) button').then(function(){
       click('.resultslist-list tbody tr:eq(0) td:eq(3) li:eq(1)').then(function(){
-        click('.confirm-buttons .cancel');
+        click('.confirm-buttons .done');
       });
     });
   });

--- a/tests/acceptance/program/overview-test.js
+++ b/tests/acceptance/program/overview-test.js
@@ -48,7 +48,7 @@ test('change title', function(assert) {
       var input = find('.title .editinplace input', container);
       assert.equal(getText(input.val()), getText('program 0'));
       fillIn(input, 'test new title');
-      click(find('.title .editinplace .actions .save', container));
+      click(find('.title .editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.title h2', container)), getText('test new title'));
       });
@@ -69,7 +69,7 @@ test('change short title', function(assert) {
       var input = find('.programtitleshort .editinplace input', container);
       assert.equal(getText(input.val()), getText(program.shortTitle));
       fillIn(input, 'test new short title');
-      click(find('.programtitleshort .editinplace .actions .save', container));
+      click(find('.programtitleshort .editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.programtitleshort div', container)), getText('test new short title'));
       });
@@ -93,7 +93,7 @@ test('change duration', function(assert) {
         assert.equal(getElementText(options.eq(i)), i+1);
       }
       pickOption(find('.programduration select', container), '9', assert);
-      click(find('.programduration .editinplace .actions .save', container));
+      click(find('.programduration .editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.programduration div', container)), 9);
       });
@@ -111,7 +111,7 @@ test('leave duration at 1', function(assert) {
     var container = find('.detail-overview');
     click(find('.programduration .editable', container));
     andThen(function(){
-      click(find('.programduration .editinplace .actions .save', container));
+      click(find('.programduration .editinplace .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.programduration div', container)), 1);
       });

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -207,7 +207,7 @@ test('new program year', function(assert) {
   var newAcademicYear = currentYear+1 + ' - ' + (currentYear+2);
   andThen(function() {
     var container = find('.programyear-list');
-    click('.detail-actions .add', container);
+    click('.detail-actions button', container);
     andThen(function(){
       let items = find('.newprogramyear option');
       assert.equal(items.length, 9);

--- a/tests/acceptance/program/programyear/competencies-test.js
+++ b/tests/acceptance/program/programyear/competencies-test.js
@@ -66,7 +66,7 @@ test('manager', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.programyear-competencies');
-    click('.add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       assert.equal(getElementText(find('.tree-list.selectable', container)), getText('competency3competency4competency5'));
       assert.equal(getElementText(find('.tree-list.removable', container)), getText('competency0competency1competency2'));
 

--- a/tests/acceptance/program/programyear/stewards-test.js
+++ b/tests/acceptance/program/programyear/stewards-test.js
@@ -88,7 +88,7 @@ test('save', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-stewards');
-    click('.add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       assert.equal(getElementText(find('.tree-list.selectable', container)), getText('school 0 department 1 department 4 department 5 department 6 department 7 department 8 school 1 school 2 department 3'));
       assert.equal(getElementText(find('.tree-list.removable', container)), getText('school 0 department 0 school 1 department 2 school 2'));
       click('.tree-list.selectable li:eq(0) ul li:eq(0)', container);
@@ -112,7 +112,7 @@ test('select school and all departments', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-stewards');
-    click('.add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       click('.tree-list.selectable li:eq(0)', container);
       andThen(function(){
         assert.equal(getElementText(find('.tree-list.selectable', container)), getText('school 1 school 2 department 3'));
@@ -134,7 +134,7 @@ test('select all departments but not school', function(assert) {
   andThen(function() {
     var container = find('.detail-stewards');
     //click and then wait for each department in the list
-    click('.add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       click('.tree-list.selectable li:eq(0) li', container).then(()=>{
         click('.tree-list.selectable li:eq(0) li', container).then(()=>{
           click('.tree-list.selectable li:eq(0) li', container).then(()=>{
@@ -166,7 +166,7 @@ test('remove solo school with no departments', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-stewards');
-    click('.add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       click('.tree-list.removable>li:eq(2) span', container);
       andThen(function(){
         assert.equal(getElementText(find('.tree-list.selectable', container)), getText('school 0 department 1 department 4 department 5 department 6 department 7 department 8 school 1 school 2 department 3'));
@@ -187,7 +187,7 @@ test('cancel', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-stewards');
-    click('.add', container).then(function(){
+    click('.detail-actions button', container).then(function(){
       assert.equal(getElementText(find('.tree-list.selectable', container)), getText('school 0 department 1 department 4 department 5 department 6 department 7 department 8 school 1 school 2 department 3'));
       assert.equal(getElementText(find('.tree-list.removable', container)), getText('school 0 department 0 school 1 department 2 school 2'));
       click('.tree-list.selectable li:eq(0) ul li:eq(0)', container);

--- a/tests/acceptance/program/programyear/topics-test.js
+++ b/tests/acceptance/program/programyear/topics-test.js
@@ -52,7 +52,7 @@ test('manage topics', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       assert.equal(getElementText(find('.removable-list li', container)), getText('topic 0'));
       assert.equal(getElementText(find('.selectable-list li', container)), getText('topic 1'));
@@ -65,7 +65,7 @@ test('save topic chages', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       click(find('.removable-list li:eq(0)', container)).then(function(){
         click(find('.selectable-list li:eq(1)', container)).then(function(){
@@ -84,7 +84,7 @@ test('cancel topic chages', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    click(find('.detail-actions .add', container));
+    click(find('.detail-actions button', container));
     andThen(function(){
       click(find('.removable-list li:eq(0)', container)).then(function(){
         click(find('.selectable-list li:eq(1)', container)).then(function(){

--- a/tests/acceptance/programs-test.js
+++ b/tests/acceptance/programs-test.js
@@ -167,7 +167,7 @@ test('cancel remove program', function(assert) {
     assert.equal(getElementText(find('.resultslist-list tbody tr:eq(0) td:eq(0)')),getText('program 0'));
     click('.resultslist-list tbody tr:eq(0) td:eq(3) button').then(function(){
       click('.resultslist-list tbody tr:eq(0) td:eq(3) li:eq(1)').then(function(){
-        click('.confirm-buttons .cancel');
+        click('.confirm-buttons .done');
       });
     });
   });

--- a/tests/acceptance/programs-test.js
+++ b/tests/acceptance/programs-test.js
@@ -92,7 +92,7 @@ test('add new program', function(assert) {
   assert.expect(3);
   visit('/programs');
   andThen(function() {
-    click('.resultslist-actions .add');
+    click('.resultslist-actions button');
     fillIn('.newprogram input', 'new test title');
     click('.newprogram .done');
   });
@@ -116,7 +116,7 @@ test('cancel adding new program', function(assert) {
   andThen(function() {
     assert.equal(1, find('.resultslist-list tbody tr').length);
     assert.equal(getElementText(find('.resultslist-list tbody tr:eq(0) td:eq(0)')),getText('program 0'));
-    click('.resultslist-actions .add').then(function(){
+    click('.resultslist-actions button').then(function(){
       assert.equal(find('.newprogram').length, 1);
       click('.newprogram .cancel');
     });


### PR DESCRIPTION
Removed all the ‘add’ classes from detail buttons - that wasn’t really
doing anything.  Added hover state to inplace edit buttons.  Changed
the inline edit buttons from .save to .done which lets us reuse the
style.

I believe this Fixes #316 