### PR TITLE
Separate learning material mesh management

### DIFF
--- a/app/components/learningmaterial-manager.js
+++ b/app/components/learningmaterial-manager.js
@@ -5,6 +5,7 @@ export default Ember.Component.extend({
   layout: layout,
   classNames: ['learningmaterial-manager'],
   learningMaterial: null,
+  valueBuffer: null,
   isCourse: false,
   isSession: Ember.computed.not('isCourse'),
   learningMaterialStatuses: [],
@@ -28,49 +29,16 @@ export default Ember.Component.extend({
   actions: {
     changeStatus: function(statusId){
       var newStatus = this.get('learningMaterialStatuses').findBy('id', statusId);
-      this.get('learningMaterial.learningMaterial').then(function(lm){
-        lm.set('status', newStatus);
-      });
-    },
-    addMeshTerm: function(descriptor){
-      var subject = this.get('learningMaterial');
-      subject.get('meshDescriptors').addObject(descriptor);
-      if(this.get('isCourse')){
-        descriptor.get('courseLearningMaterials').addObject(subject);
-      }
-      if(this.get('isSession')){
-        descriptor.get('sessionLearningMaterials').addObject(subject);
-      }
-    },
-    removeMeshTerm: function(descriptor){
-      var self = this;
-      var subject = this.get('learningMaterial');
-
-      subject.get('meshDescriptors').then(function(descriptors){
-        var promise;
-        descriptors.removeObject(descriptor);
-        if(self.get('isCourse')){
-          promise = descriptor.get('courseLearningMaterials');
-        }
-        if(self.get('isSession')){
-          promise = descriptor.get('sessionLearningMaterials');
-        }
-        promise.then(function(materials){
-          materials.removeObject(subject);
-        });
-      });
+      this.sendAction('changeStatus', newStatus);
     },
     changeRequired: function(value){
-      this.get('learningMaterial').set('required', value);
-      this.get('learningMaterial').save();
+      this.sendAction('changeRequired', value);
     },
     changePublicNotes: function(value){
-      this.get('learningMaterial').set('publicNotes', value);
-      this.get('learningMaterial').save();
+      this.sendAction('changePublicNotes', value);
     },
     changeNotes: function(value){
-      this.get('learningMaterial').set('notes', value);
-      this.get('learningMaterial').save();
+      this.sendAction('changeNotes', value);
     },
   }
 });

--- a/app/components/mesh-manager.js
+++ b/app/components/mesh-manager.js
@@ -14,6 +14,7 @@ export default Ember.Component.extend(Ember.I18n.TranslateableProperties, {
   placeholderTranslation: 'courses.meshSearchPlaceholder',
   terms: [],
   searchResults: [],
+  targetItemTitle: '',
   searching: false,
   searchReturned: false,
   sortTerms: ['title'],

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -1,11 +1,17 @@
 <section class='detail-block'>
   <div class='detail-title'>
-    {{#if isManaging}}
+    {{#unless isManaging}}
+      {{t 'general.learningMaterials'}} ({{materials.length}})
+    {{/unless}}
+    {{#if isManagingMaterial}}
       <span class='detail-specific-title'>
         {{t 'courses.learningMaterialManageTitle'}}
       </span>
-    {{else}}
-      {{t 'general.learningMaterials'}} ({{materials.length}})
+    {{/if}}
+    {{#if isManagingMesh}}
+      <span class='detail-specific-title'>
+        {{t 'courses.objectiveDescriptorTitle'}}
+      </span>
     {{/if}}
   </div>
   <div class='detail-actions'>
@@ -22,11 +28,26 @@
   </div>
   <div class='detail-content'>
     {{#liquid-if isManaging class="horizontal"}}
-      {{learningmaterial-manager
-        learningMaterial=managingMaterial
-        learningMaterialStatuses=learningMaterialStatuses
-        isCourse=isCourse
-      }}
+      {{#if isManagingMaterial}}
+        {{learningmaterial-manager
+          learningMaterial=managingMaterial
+          valueBuffer=bufferMaterial
+          learningMaterialStatuses=learningMaterialStatuses
+          isCourse=isCourse
+          changeStatus='changeStatus'
+          changeNotes='changeNotes'
+          changeRequired='changeRequired'
+          changePublicNotes='changePublicNotes'
+        }}
+      {{/if}}
+      {{#if isManagingMesh}}
+        {{mesh-manager
+          terms=bufferTerms
+          add='addTermToBuffer'
+          remove='removeTermFromBuffer'
+          targetItemTitle=meshMaterial.learningMaterial.title
+        }}
+      {{/if}}
     {{else}}
       {{#if newLearningMaterials.length}}
         {{#each lm in newLearningMaterials}}
@@ -52,36 +73,42 @@
             </tr>
           </thead>
           <tbody>
-            {{#each lm in materials}}
+            {{#each lmProxy in proxyMaterials}}
               <tr>
-                <td class='text-left clickable link' colspan=2 {{action 'manage' lm}}>
-                  {{fa-icon 'external-link-square'}} {{lm.learningMaterial.title}}
+                <td class='text-left clickable link' colspan=2 {{action 'manageMaterial' lmProxy.content}}>
+                  {{fa-icon 'external-link-square'}} {{lmProxy.learningMaterial.title}}
                 </td>
-                <td class='text-center'>{{lm.learningMaterial.type}}</td>
-                <td class='text-center'>{{lm.learningMaterial.originalAuthor}}</td>
+                <td class='text-center'>{{lmProxy.learningMaterial.type}}</td>
+                <td class='text-center'>{{lmProxy.learningMaterial.originalAuthor}}</td>
                 <td class='text-center'>
-        	        {{#if lm.required}}
+        	        {{#if lmProxy.required}}
         	          <span class='add'>{{t 'general.yes'}}</span>
         	        {{else}}
         	          <span class='remove'>{{t 'general.no'}}</span>
         	        {{/if}}
                 </td>
                 <td class='text-center'>
-        	        {{#if lm.publicNotes}}
+        	        {{#if lmProxy.publicNotes}}
         	          <span class='add'>{{t 'general.yes'}}</span>
         	        {{else}}
         	          <span class='remove'>{{t 'general.no'}}</span>
         	        {{/if}}
                 </td>
                 <td class='text-center'>
-                  <ul>
-                    {{#each descriptor in lm.meshDescriptors}}
-                      <li>{{descriptor.title}}</li>
-                    {{/each}}
-                  </ul>
+                  {{#if lmProxy.sortedDescriptors.length}}
+                    <ul>
+                      <a href='#' {{action 'manageDescriptors' lmProxy.content}}>
+                        {{#each descriptor in lmProxy.sortedDescriptors}}
+                          <li>{{descriptor.title}}</li>
+                        {{/each}}
+                      </a>
+                    </ul>
+                  {{else}}
+                    <button {{action 'manageDescriptors' lmProxy.content}}>{{t 'general.addNew'}}</button>
+                  {{/if}}
                 </td>
                 <td class='text-center'>
-                  {{lm.learningMaterial.status.title}}
+                  {{lmProxy.learningMaterial.status.title}}
                 </td>
               </tr>
             {{/each}}

--- a/app/templates/components/learningmaterial-manager.hbs
+++ b/app/templates/components/learningmaterial-manager.hbs
@@ -7,7 +7,7 @@
     <label class="form-label">{{t 'learningMaterials.status'}}:</label>
     <div class="form-data status">
     {{inplace-select
-      value=learningMaterial.learningMaterial.status.id
+      value=valueBuffer.status.id
       options=statusOptions
       save='changeStatus'
     }}
@@ -16,19 +16,19 @@
   <div class="form-col-12">
     <label class="form-label">{{t 'general.required'}}:</label>
     <div class="form-data required">
-      {{inplace-boolean value=learningMaterial.required save='changeRequired'}}
+      {{inplace-boolean value=valueBuffer.required save='changeRequired'}}
     </div>
   </div>
   <div class="form-col-12">
     <label class="form-label">{{t 'learningMaterials.instructionalNotes'}}:</label>
     <div class="form-data notes">
-      {{inplace-textarea value=learningMaterial.notes save='changeNotes'}}
+      {{inplace-textarea value=valueBuffer.notes save='changeNotes'}}
     </div>
   </div>
   <div class="form-col-12">
     <label class="form-label">{{t 'learningMaterials.showNotesToStudents'}}:</label>
     <div class="form-data publicnotes">
-      {{inplace-boolean value=learningMaterial.publicNotes save='changePublicNotes'}}
+      {{inplace-boolean value=valueBuffer.publicNotes save='changePublicNotes'}}
     </div>
   </div>
   <div class="form-col-12">
@@ -93,10 +93,4 @@
     </div>
   </div>
   {{/if}}
-  <div class="form-col-12">
-    <label class="search-widget-label">{{t 'general.mesh'}}:</label>
-    <div class="search-widget">
-      {{mesh-manager add='addMeshTerm' remove='removeMeshTerm' terms=learningMaterial.meshDescriptors}}
-    </div>
-  </div>
 </div> <!-- /.form-container -->

--- a/app/templates/components/mesh-manager.hbs
+++ b/app/templates/components/mesh-manager.hbs
@@ -1,3 +1,6 @@
+{{#if targetItemTitle}}
+  <h2>{{t 'mesh.targetItemTitle' title=targetItemTitle}}</h2>
+{{/if}}
 <ul class='removable-list'>
   {{#each term in sortedTerms}}
     <li {{action 'remove' term}}>{{term.title}} {{fa-icon 'remove'}}</li>

--- a/app/translations/en.js
+++ b/app/translations/en.js
@@ -132,6 +132,7 @@ var mesh = {
   'available': 'Available MeSH Terms',
   'search': 'Search MeSH Terms',
   'noResults': 'Your seach returned no results.',
+  'targetItemTitle': 'Select MeSH for: {{title}}',
 };
 translations.mesh = mesh;
 


### PR DESCRIPTION
Instead of attempting to manage the mesh terms associated with a
learning material on the edit screen this creates a separate area for
managing mesh terms.

Fixes #470