### PR TITLE
Improve hover for results lists

### DIFF
--- a/app/styles/components/_resultslist.scss
+++ b/app/styles/components/_resultslist.scss
@@ -25,15 +25,20 @@
   .resultslist-list {
     @include span-columns(12 of 12);
     @include pad();
-    tbody tr {
 
-      &:hover {
-        background-color: rgba(239, 251, 255, .8);
+    tbody tr {
+      border-bottom: 1px solid transparent;
+      border-top: 1px solid transparent;
+
+      &:hover,
+      &:hover td {
+        border-bottom: 1px solid $hover-border;
+        border-top: 1px solid $hover-border;
       }
 
-      &.active-background,
-      &.active-background:hover {
-        background-color: rgba(239, 251, 255, .8);
+      &.donthover {
+        border-bottom: 0;
+        border-top: 0;
       }
     }
 
@@ -45,21 +50,17 @@
       border: 0;
     }
 
-    &.sessions {
+    .active-background {
+      tbody tr {
+        background-color: rgba(239, 251, 255, .8);
+      }
+
       thead tr {
         background-color: $text-blue;
       }
 
       thead th {
         color: $white;
-      }
-
-      tbody tr {
-        cursor: pointer;
-
-        &:hover {
-          background-color: rgba(203, 231, 240, .9);
-        }
       }
     }
   }

--- a/app/styles/components/_variables.scss
+++ b/app/styles/components/_variables.scss
@@ -45,6 +45,7 @@ $ilios-publish-color: $ilios-green;
 $ilios-remove-color: #aa443e;
 $remove-background-color: #f1dedd;
 $active-background-color: #effbff;
+$hover-border: #bce3ef;
 
 $success-color: $ilios-green;
 $warning-color: #ffc339;

--- a/app/templates/components/ilios-sessions-list.hbs
+++ b/app/templates/components/ilios-sessions-list.hbs
@@ -32,8 +32,8 @@
         {{/each}}
       </section>
     {{/if}}
-    <div class='sessions resultslist-list'>
-      <table>
+    <div class='resultslist-list'>
+      <table class='active-background'>
         <thead>
           <tr>
             <th class='text-left' colspan=2>{{t 'general.title'}}</th>
@@ -76,13 +76,13 @@
               </td>
             </tr>
             {{#if session.expandOfferings}}
-              <tr class='active-background'>
+              <tr class='donthover'>
                 <td colspan=8 class='text-right' {{action 'toggleExpandedOffering' session}}>
                   {{t 'general.close'}}
                   {{fa-icon 'times'}}
                 </td>
               </tr>
-              <tr class='active-background'>
+              <tr>
                 <td colspan=8>
                   {{#if session.offerings.length}}
                     {{session-offerings-list session=session.content editable=false}}


### PR DESCRIPTION
Instead of applying a background color indicate hover by changing the
borders on the table row.  This provides focus without indicating a
click will trigger an action.

I also consolidated the session highlighting and active-background
class.

I applied this state to all the results list (courses, sessions, learner groups, programs, etc...) so give it a look and see if thats an improvement or it this should just apply to the sessions list.

Fixes #607 
Replaces #656 