### PR TITLE
Display Topics list as columns

### DIFF
--- a/app/styles/components/_detailview.scss
+++ b/app/styles/components/_detailview.scss
@@ -192,6 +192,16 @@ $collapse-control-shadow-grey: #e2e2e2;
     }
   }
 
+  .columnar-list {
+    @include media($medium-screen) {
+      @include column-count(3);
+    }
+
+    @include media($large-screen) {
+      @include column-count(4);
+    }
+  }
+
   .removex {
     display: inline;
     margin: 0;
@@ -252,7 +262,7 @@ $collapse-control-shadow-grey: #e2e2e2;
       h4 {
         display: inline;
       }
-      
+
       input {
         @include span-columns(6 of 8);
       }

--- a/app/templates/components/detail-topic-list.hbs
+++ b/app/templates/components/detail-topic-list.hbs
@@ -1,4 +1,4 @@
-<ul class='inline-list'>
+<ul class='columnar-list'>
   {{#each topic in sortedTopics}}
     <li>{{topic.title}}</li>
   {{/each}}

--- a/tests/acceptance/course/session/topics-test.js
+++ b/tests/acceptance/course/session/topics-test.js
@@ -46,7 +46,7 @@ test('list topics', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    var items = find('ul.inline-list li', container);
+    var items = find('ul.columnar-list li', container);
     assert.equal(items.length, fixtures.session.disciplines.length);
     assert.equal(getElementText(items.eq(0)), getText('topic 0'));
   });
@@ -78,7 +78,7 @@ test('save topic chages', function(assert) {
         });
       });
       andThen(function(){
-        assert.equal(getElementText(find('ul.inline-list li', container)), getText('topic 1'));
+        assert.equal(getElementText(find('ul.columnar-list li', container)), getText('topic 1'));
       });
     });
   });
@@ -97,7 +97,7 @@ test('cancel topic chages', function(assert) {
         });
       });
       andThen(function(){
-        assert.equal(getElementText(find('ul.inline-list li', container)), getText('topic 0'));
+        assert.equal(getElementText(find('ul.columnar-list li', container)), getText('topic 0'));
       });
     });
   });

--- a/tests/acceptance/course/topics-test.js
+++ b/tests/acceptance/course/topics-test.js
@@ -43,7 +43,7 @@ test('list topics', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    var items = find('ul.inline-list li', container);
+    var items = find('ul.columnar-list li', container);
     assert.equal(items.length, fixtures.course.disciplines.length);
     assert.equal(getElementText(items.eq(0)), getText('topic 0'));
   });
@@ -75,7 +75,7 @@ test('save topic chages', function(assert) {
         });
       });
       andThen(function(){
-        assert.equal(getElementText(find('ul.inline-list li', container)), getText('topic 1'));
+        assert.equal(getElementText(find('ul.columnar-list li', container)), getText('topic 1'));
       });
     });
   });
@@ -94,7 +94,7 @@ test('cancel topic chages', function(assert) {
         });
       });
       andThen(function(){
-        assert.equal(getElementText(find('ul.inline-list li', container)), getText('topic 0'));
+        assert.equal(getElementText(find('ul.columnar-list li', container)), getText('topic 0'));
       });
     });
   });

--- a/tests/acceptance/program/programyear/topics-test.js
+++ b/tests/acceptance/program/programyear/topics-test.js
@@ -41,7 +41,7 @@ test('list topics', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-topics');
-    var items = find('ul.inline-list li', container);
+    var items = find('ul.columnar-list li', container);
     assert.equal(items.length, 1);
     assert.equal(getElementText(items.eq(0)), getText('topic 0'));
   });
@@ -73,7 +73,7 @@ test('save topic chages', function(assert) {
         });
       });
       andThen(function(){
-        assert.equal(getElementText(find('ul.inline-list li', container)), getText('topic 1'));
+        assert.equal(getElementText(find('ul.columnar-list li', container)), getText('topic 1'));
       });
     });
   });
@@ -92,7 +92,7 @@ test('cancel topic chages', function(assert) {
         });
       });
       andThen(function(){
-        assert.equal(getElementText(find('ul.inline-list li', container)), getText('topic 0'));
+        assert.equal(getElementText(find('ul.columnar-list li', container)), getText('topic 0'));
       });
     });
   });


### PR DESCRIPTION
4 columns on big screens, 3 columns on small screens, one column on mobile.

It looks awesome on big lists, can we live with it when there are only 3 topics?

Fixes #514