### PR TITLE
Separate Learner Groups by a nice icon where possible

### DIFF
--- a/app/components/separated-list.js
+++ b/app/components/separated-list.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'span',
+  list: [],
+  icon: 'angle-right',
+});

--- a/app/models/learner-group.js
+++ b/app/models/learner-group.js
@@ -135,16 +135,24 @@ export default DS.Model.extend({
     });
   },
   allParentsTitle: function(){
-    var title = '';
-    if(this.get('parent.content')){
-      if(this.get('parent.allParentsTitle')){
-        title += this.get('parent.allParentsTitle');
-      }
-      title += this.get('parent.title') + ' -> ';
-    }
+    let title = '';
+    this.get('allParentTitles').forEach(str => {
+      title += str + ' > ';
+    });
 
     return title;
-  }.property('parent.{title,allParentsTitle}'),
+  }.property('allParentTitles'),
+  allParentTitles: function(){
+    let titles = [];
+    if(this.get('parent.content')){
+      if(this.get('parent.allParentTitles')){
+        titles.pushObjects(this.get('parent.allParentTitles'));
+      }
+      titles.pushObject(this.get('parent.title'));
+    }
+
+    return titles;
+  }.property('parent.{title,allParentTitles}'),
   sortTitle: function(){
     var title = this.get('allParentsTitle') + this.get('title');
     return title.replace(/([\s->]+)/ig,"");

--- a/app/templates/components/detail-learnergroups-list.hbs
+++ b/app/templates/components/detail-learnergroups-list.hbs
@@ -2,7 +2,7 @@
   {{#each learnerGroup in sortedLearnerGroups}}
     <li>
       <em>
-        {{learnerGroup.allParentsTitle}}
+        {{separated-list icon='angle-right' list=learnerGroup.allParentTitles}}
       </em>
       <strong>
         {{learnerGroup.title}}

--- a/app/templates/components/learnergroup-header.hbs
+++ b/app/templates/components/learnergroup-header.hbs
@@ -1,8 +1,9 @@
 <div class='detail-header'>
   <span class='title'>
     <h2>
-      {{learnerGroup.cohort.displayTitle}} ->
-      {{learnerGroup.allParentsTitle}}
+
+      {{learnerGroup.cohort.displayTitle}} {{fa-icon 'angle-right'}}
+      {{separated-list icon='angle-right' list=learnerGroup.allParentTitles}}
       {{inplace-text tagName='span' value=learnerGroup.title save='changeTitle'}}
     </h2>
   </span>

--- a/app/templates/components/learnergroup-selection-manager.hbs
+++ b/app/templates/components/learnergroup-selection-manager.hbs
@@ -2,7 +2,7 @@
   {{#each learnerGroup in sortedLearnerGroups}}
     <li {{action 'remove' learnerGroup}}>
       <em>
-        {{learnerGroup.allParentsTitle}}
+        {{separated-list icon='angle-right' list=learnerGroup.allParentTitles}}
       </em>
       <strong>
         {{learnerGroup.title}}
@@ -21,7 +21,7 @@
           {{#each learnerGroup in cohort.filteredAvailableLearnerGroups}}
             <li {{action 'add' learnerGroup}}>
               <em>
-                {{learnerGroup.allParentsTitle}}
+                {{separated-list icon='angle-right' list=learnerGroup.allParentTitles}}
               </em>
               <strong>
                 {{learnerGroup.title}}

--- a/app/templates/components/separated-list.hbs
+++ b/app/templates/components/separated-list.hbs
@@ -1,0 +1,3 @@
+{{#each list as |item|}}
+  {{item}} {{fa-icon icon}}
+{{/each}}

--- a/tests/acceptance/course/session/ilm-test.js
+++ b/tests/acceptance/course/session/ilm-test.js
@@ -129,7 +129,7 @@ test('check learner groups', function(assert) {
     andThen(function(){
       var cohorts = find('.selectable-list li.static');
       assert.equal(cohorts.length, fixtures.course.cohorts.length);
-      assert.equal(getElementText(cohorts.eq(0)), getText('cohort0learnergroup1learnergroup1->learnergroup4learnergroup1->learnergroup5learnergroup1->learnergroup5->learnergroup6'));
+      assert.equal(getElementText(cohorts.eq(0)), getText('cohort0 learnergroup1 learnergroup1 learnergroup4 learnergroup1 learnergroup5 learnergroup1 learnergroup5 learnergroup6'));
     });
 
   });
@@ -143,7 +143,7 @@ test('filter learner groups', function(assert) {
     click('.detail-actions button', container);
     andThen(function(){
       fillIn(find('input', container), 'group 5').then(function(){
-        assert.equal(getElementText(find('.selectable-list li.static').eq(0)), getText('cohort0learnergroup1->learnergroup5learnergroup1->learnergroup5->learnergroup6'));
+        assert.equal(getElementText(find('.selectable-list li.static').eq(0)), getText('cohort0learnergroup1 learnergroup5learnergroup1 learnergroup5 learnergroup6'));
       });
     });
   });
@@ -159,7 +159,7 @@ test('add learner group', function(assert) {
     });
     andThen(function(){
       assert.equal(getElementText(find('.removable-list', container)), 'learnergroup0learnergroup2');
-      assert.equal(getElementText(find('.selectable-list li.static').eq(0)), getText('cohort0learnergroup1learnergroup1->learnergroup4learnergroup1->learnergroup5learnergroup1->learnergroup5->learnergroup6'));
+      assert.equal(getElementText(find('.selectable-list li.static').eq(0)), getText('cohort0learnergroup1learnergroup1 learnergroup4learnergroup1 learnergroup5learnergroup1 learnergroup5 learnergroup6'));
       assert.equal(getElementText(find('.selectable-list li.static').eq(1)), getText('cohort1learnergroup3'));
       click('.bigadd', container);
     });
@@ -179,14 +179,14 @@ test('add learner sub group', function(assert) {
       click('.selectable-list ul li.static:eq(0) ul li:eq(1)', container);
     });
     andThen(function(){
-      assert.equal(getElementText(find('.removable-list', container)), 'learnergroup0learnergroup1->learnergroup4');
-      assert.equal(getElementText(find('.selectable-list li.static').eq(0)), getText('cohort0learnergroup1learnergroup1->learnergroup5learnergroup1->learnergroup5->learnergroup6'));
+      assert.equal(getElementText(find('.removable-list', container)), getText('learnergroup0 learnergroup1 learnergroup4'));
+      assert.equal(getElementText(find('.selectable-list li.static').eq(0)), getText('cohort0learnergroup1learnergroup1 learnergroup5learnergroup1 learnergroup5 learnergroup6'));
       assert.equal(getElementText(find('.selectable-list li.static').eq(1)), getText('cohort1learnergroup2learnergroup3'));
       click('.bigadd', container);
     });
     andThen(function(){
       var selectedGroups = find('.inline-list li', container);
-      assert.equal(getElementText(selectedGroups), 'learnergroup0learnergroup1->learnergroup4');
+      assert.equal(getElementText(selectedGroups), getText('learnergroup0 learnergroup1 learnergroup4'));
     });
   });
 });
@@ -203,7 +203,7 @@ test('add learner group with children', function(assert) {
     });
     andThen(function(){
       var selectedGroups = find('.inline-list li', container);
-      assert.equal(getElementText(selectedGroups), 'learnergroup0learnergroup1learnergroup1->learnergroup4learnergroup1->learnergroup5learnergroup1->learnergroup5->learnergroup6');
+      assert.equal(getElementText(selectedGroups), getText('learnergroup0 learnergroup1 learnergroup1 learnergroup4 learnergroup1 learnergroup5 learnergroup1 learnergroup5 learnergroup6'));
     });
   });
 });
@@ -218,14 +218,14 @@ test('add learner group with children and remove one child', function(assert) {
       click('.selectable-list ul li.static:eq(0) ul li:eq(0)', container);
       click('.removable-list li:eq(2)', container);
       andThen(function(){
-        assert.equal(getElementText(find('.removable-list', container)), 'learnergroup0learnergroup1learnergroup1->learnergroup5learnergroup1->learnergroup5->learnergroup6');
-        assert.equal(getElementText(find('.selectable-list li.static').eq(0)), getText('cohort0learnergroup1->learnergroup4'));
+        assert.equal(getElementText(find('.removable-list', container)), getText('learnergroup0 learnergroup1 learnergroup1 learnergroup5 learnergroup1 learnergroup5 learnergroup6'));
+        assert.equal(getElementText(find('.selectable-list li.static').eq(0)), getText('cohort0learnergroup1 learnergroup4'));
         click('.bigadd', container);
       });
     });
     andThen(function(){
       var selectedGroups = find('.inline-list li', container);
-      assert.equal(getElementText(selectedGroups), 'learnergroup0learnergroup1learnergroup1->learnergroup5learnergroup1->learnergroup5->learnergroup6');
+      assert.equal(getElementText(selectedGroups), getText('learnergroup0 learnergroup1 learnergroup1 learnergroup5 learnergroup1 learnergroup5 learnergroup6'));
     });
   });
 });

--- a/tests/acceptance/learnergroup/membership-test.js
+++ b/tests/acceptance/learnergroup/membership-test.js
@@ -71,19 +71,19 @@ test('this group members', function(assert) {
     assert.equal(currentPath(), 'learnerGroup');
     assert.equal(getElementText(find('.detail-title', container)), getText('learner group 1 Members (2)'));
     assert.equal(getElementText(find('.detail-content .learnergroup-username:eq(0)'), container), getText('1 guy Mc1son'));
-    assert.equal(getElementText(find('.detail-content .learnergroup-group-membership:eq(0)'), container), getText('learner group 0 -> learner group 1'));
+    assert.equal(getElementText(find('.detail-content .learnergroup-group-membership:eq(0)'), container), getText('learner group 0 > learner group 1'));
     assert.equal(getElementText(find('.detail-content .learnergroup-username:eq(1)'), container), getText('2 guy Mc2son'));
-    assert.equal(getElementText(find('.detail-content .learnergroup-group-membership:eq(1)'), container), getText('learner group 0 -> learner group 1'));
+    assert.equal(getElementText(find('.detail-content .learnergroup-group-membership:eq(1)'), container), getText('learner group 0 > learner group 1'));
 
     click('.learnergroup-group-membership:eq(0) .editable').then(function(){
       let options = find('.learnergroup-group-membership:eq(0) select option', container);
       assert.equal(options.length, 6);
       assert.equal(getElementText(options.eq(0)), getText('Remove Learner to cohort 0'));
       assert.equal(getElementText(options.eq(1)), getText('Switch Learner to learner group 0'));
-      assert.equal(getElementText(options.eq(2)), getText('Switch Learner to learner group 0 -> learner group 1'));
-      assert.equal(getElementText(options.eq(3)), getText('Switch Learner to learner group 0 -> learner group 1 -> learner group 3'));
-      assert.equal(getElementText(options.eq(4)), getText('Switch Learner to learner group 0 -> learner group 1 -> learner group 4'));
-      assert.equal(getElementText(options.eq(5)), getText('Switch Learner to learner group 0 -> learner group 2'));
+      assert.equal(getElementText(options.eq(2)), getText('Switch Learner to learner group 0 > learner group 1'));
+      assert.equal(getElementText(options.eq(3)), getText('Switch Learner to learner group 0 > learner group 1 > learner group 3'));
+      assert.equal(getElementText(options.eq(4)), getText('Switch Learner to learner group 0 > learner group 1 > learner group 4'));
+      assert.equal(getElementText(options.eq(5)), getText('Switch Learner to learner group 0 > learner group 2'));
     });
   });
 });
@@ -94,9 +94,9 @@ test('top level group members', function(assert) {
     let container = find('.toplevelgroupmembers');
     assert.equal(getElementText(find('.detail-title', container)), getText('learner group 0 Members NOT in this Subgroup'));
     assert.equal(getElementText(find('.learnergroup-username:eq(0)', container)), getText('3 guy Mc3son'));
-    assert.equal(getElementText(find('.learnergroup-group-membership:eq(0)', container)), getText('learner group 0 -> learner group 1 -> learner group 3'));
+    assert.equal(getElementText(find('.learnergroup-group-membership:eq(0)', container)), getText('learner group 0 > learner group 1 > learner group 3'));
     assert.equal(getElementText(find('.learnergroup-username:eq(1)', container)), getText('4 guy Mc4son'));
-    assert.equal(getElementText(find('.learnergroup-group-membership:eq(1)', container)), getText('learner group 0 -> learner group 1  -> learner group 3'));
+    assert.equal(getElementText(find('.learnergroup-group-membership:eq(1)', container)), getText('learner group 0 > learner group 1  > learner group 3'));
     assert.equal(getElementText(find('.learnergroup-username:eq(2)', container)), getText('5 guy Mc5son'));
     assert.equal(getElementText(find('.learnergroup-group-membership:eq(2)', container)), getText('learner group 0'));
     assert.equal(getElementText(find('.learnergroup-username:eq(3)', container)), getText('6 guy Mc6son'));
@@ -106,12 +106,12 @@ test('top level group members', function(assert) {
       assert.equal(options.length, 6);
       assert.equal(getElementText(options.eq(0)), getText('Remove Learner to cohort 0'));
       assert.equal(getElementText(options.eq(1)), getText('Switch Learner to learner group 0'));
-      assert.equal(getElementText(options.eq(2)), getText('Switch Learner to learner group 0 -> learner group 1'));
-      assert.equal(getElementText(options.eq(3)), getText('Switch Learner to learner group 0 -> learner group 1 -> learner group 3'));
-      assert.equal(getElementText(options.eq(4)), getText('Switch Learner to learner group 0 -> learner group 1 -> learner group 4'));
-      assert.equal(getElementText(options.eq(5)), getText('Switch Learner to learner group 0 -> learner group 2'));
+      assert.equal(getElementText(options.eq(2)), getText('Switch Learner to learner group 0 > learner group 1'));
+      assert.equal(getElementText(options.eq(3)), getText('Switch Learner to learner group 0 > learner group 1 > learner group 3'));
+      assert.equal(getElementText(options.eq(4)), getText('Switch Learner to learner group 0 > learner group 1 > learner group 4'));
+      assert.equal(getElementText(options.eq(5)), getText('Switch Learner to learner group 0 > learner group 2'));
 
-      pickOption(find('.learnergroup-group-membership:eq(0) select', container), 'Switch Learner to learner group 0 -> learner group 1', assert);
+      pickOption(find('.learnergroup-group-membership:eq(0) select', container), 'Switch Learner to learner group 0 > learner group 1', assert);
       click(find('.learnergroup-group-membership:eq( 0) .actions .done', container));
       andThen(function(){
         let container = find('.detail-overview');
@@ -138,12 +138,12 @@ test('cohort members', function(assert) {
       let options = find('.learnergroup-group-membership:eq(0) select option', container);
       assert.equal(options.length, 5);
       assert.equal(getElementText(options.eq(0)), getText('Switch Learner to learner group 0'));
-      assert.equal(getElementText(options.eq(1)), getText('Switch Learner to learner group 0 -> learner group 1'));
-      assert.equal(getElementText(options.eq(2)), getText('Switch Learner to learner group 0 -> learner group 1 -> learner group 3'));
-      assert.equal(getElementText(options.eq(3)), getText('Switch Learner to learner group 0 -> learner group 1 -> learner group 4'));
-      assert.equal(getElementText(options.eq(4)), getText('Switch Learner to learner group 0 -> learner group 2'));
+      assert.equal(getElementText(options.eq(1)), getText('Switch Learner to learner group 0 > learner group 1'));
+      assert.equal(getElementText(options.eq(2)), getText('Switch Learner to learner group 0 > learner group 1 > learner group 3'));
+      assert.equal(getElementText(options.eq(3)), getText('Switch Learner to learner group 0 > learner group 1 > learner group 4'));
+      assert.equal(getElementText(options.eq(4)), getText('Switch Learner to learner group 0 > learner group 2'));
 
-      pickOption(find('.learnergroup-group-membership:eq(0) select', container), 'Switch Learner to learner group 0 -> learner group 1', assert);
+      pickOption(find('.learnergroup-group-membership:eq(0) select', container), 'Switch Learner to learner group 0 > learner group 1', assert);
       click(find('.learnergroup-group-membership:eq( 0) .actions .done', container));
       andThen(function(){
         let container = find('.detail-overview');
@@ -162,16 +162,16 @@ test('move group member to another subgroup', function(assert) {
   andThen(function() {
     let container = find('.detail-overview');
     click('.learnergroup-group-membership:eq(0) .editable').then(function(){
-      pickOption(find('.learnergroup-group-membership:eq(0) select', container), 'Switch Learner to learner group 0 -> learner group 2', assert);
+      pickOption(find('.learnergroup-group-membership:eq(0) select', container), 'Switch Learner to learner group 0 > learner group 2', assert);
       click(find('.learnergroup-group-membership:eq( 0) .actions .done', container));
       andThen(function(){
         assert.equal(getElementText(find('.detail-header .info')),getText('Members: 1'));
         assert.equal(getElementText(find('.detail-overview .detail-title')), getText('learner group 1 Members (1)'));
         assert.equal(getElementText(find('.detail-content .learnergroup-username:eq(0)'), container), getText('2 guy Mc2son'));
-        assert.equal(getElementText(find('.detail-content .learnergroup-group-membership:eq(0)'), container), getText('learner group 0 -> learner group 1'));
+        assert.equal(getElementText(find('.detail-content .learnergroup-group-membership:eq(0)'), container), getText('learner group 0 > learner group 1'));
 
         assert.equal(getElementText(find('.toplevelgroupmembers .learnergroup-username:eq(0)')), getText('1 guy Mc1son'));
-        assert.equal(getElementText(find('.toplevelgroupmembers .learnergroup-group-membership:eq(0)')), getText('learner group 0 -> learner group 2'));
+        assert.equal(getElementText(find('.toplevelgroupmembers .learnergroup-group-membership:eq(0)')), getText('learner group 0 > learner group 2'));
       });
     });
   });
@@ -188,7 +188,7 @@ test('remove group member back to cohort', function(assert) {
         assert.equal(getElementText(find('.detail-header .info')),getText('Members: 1'));
         assert.equal(getElementText(find('.detail-overview .detail-title')), getText('learner group 1 Members (1)'));
         assert.equal(getElementText(find('.detail-content .learnergroup-username:eq(0)'), container), getText('2 guy Mc2son'));
-        assert.equal(getElementText(find('.detail-content .learnergroup-group-membership:eq(0)'), container), getText('learner group 0 -> learner group 1'));
+        assert.equal(getElementText(find('.detail-content .learnergroup-group-membership:eq(0)'), container), getText('learner group 0 > learner group 1'));
 
         assert.equal(getElementText(find('.cohortmembers .learnergroup-username:eq(0)')), getText('1 guy Mc1son'));
         assert.equal(getElementText(find('.cohortmembers .learnergroup-group-membership:eq(0)')), getText('Not in this group'));

--- a/tests/acceptance/learnergroup/overview-test.js
+++ b/tests/acceptance/learnergroup/overview-test.js
@@ -81,7 +81,7 @@ test('check fields', function(assert) {
   visit(url);
   andThen(function() {
     assert.equal(currentPath(), 'learnerGroup');
-    assert.equal(getElementText(find('.detail-header .title h2')),getText('cohort 0 -> learner group 0 -> learner group 1'));
+    assert.equal(getElementText(find('.detail-header .title h2')),getText('cohort 0  learner group 0  learner group 1'));
     assert.equal(getElementText(find('.detail-header .info')),getText('Members: 2'));
     assert.equal(getElementText(find('.detail-overview .detail-title')), getText('learner group 1 Members (2)'));
     assert.equal(getElementText(find('.detail-overview .learnergrouplocation')), getText('DefaultLocation:room101'));
@@ -98,7 +98,7 @@ test('change title', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-header');
-    assert.equal(getElementText(find('.title h2', container)), getText('cohort 0 -> learner group 0 -> learner group 1'));
+    assert.equal(getElementText(find('.title h2', container)), getText('cohort 0  learner group 0  learner group 1'));
     click(find('.title h2 .editable', container));
     andThen(function(){
       var input = find('.title .editinplace input', container);
@@ -106,7 +106,7 @@ test('change title', function(assert) {
       fillIn(input, 'test new title');
       click(find('.title .editinplace .actions .done', container));
       andThen(function(){
-        assert.equal(getElementText(find('.title h2', container)), getText('cohort 0 -> learner group 0 -> test new title'));
+        assert.equal(getElementText(find('.title h2', container)), getText('cohort 0  learner group 0  test new title'));
       });
     });
   });
@@ -191,7 +191,7 @@ test('change location', function(assert) {
 test('no associated courses', function(assert) {
   visit('/learnergroups/3');
   andThen(function() {
-    assert.equal(getElementText(find('.detail-header .title h2')),getText('cohort 0 -> learnergroup 0 -> learnergroup 2'));
+    assert.equal(getElementText(find('.detail-header .title h2')),getText('cohort 0 learnergroup 0 learnergroup 2'));
     assert.equal(getElementText(find('.detail-overview .learnergroupcourses')), getText('Associated Courses: None'));
   });
 });

--- a/tests/unit/components/separated-list-test.js
+++ b/tests/unit/components/separated-list-test.js
@@ -1,11 +1,9 @@
-import {
-  moduleForComponent,
-  test
-} from 'ember-qunit';
+import { moduleForComponent, test } from 'ember-qunit';
 
-moduleForComponent('learnergroup-header', {
+moduleForComponent('separated-list', 'Unit | Component | separated list', {
   // Specify the other units that are required for this test
-  needs: ['component:inplace-text', 'helper:fa-icon', 'component:separated-list']
+  // needs: ['component:foo', 'helper:bar'],
+  unit: true
 });
 
 test('it renders', function(assert) {


### PR DESCRIPTION
In some places the group list has to be a string so I used a plain >
character to separate group levels there.

Fixes #664