### PR TITLE
Enable IE10 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    # IE10 builds allowed to fail until https://github.com/edgycircle/ember-pikaday/issues/21 is fixed
-    - env: "TESTEM_LAUNCHER='SL_internet_explorer_10' START_SAUCE_CONNECT=true JS_TESTS=true SEND_COVERAGE=false"
   include:
     - env: "TESTEM_LAUNCHER='SL_chrome' START_SAUCE_CONNECT=true JS_TESTS=true SEND_COVERAGE=false"
     - env: "TESTEM_LAUNCHER='SL_firefox' START_SAUCE_CONNECT=true JS_TESTS=true SEND_COVERAGE=false"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-moment": "1.1.1",
     "ember-normalize": "0.0.2",
     "ember-noscript": "^1.0.2",
-    "ember-pikaday": "0.6.0",
+    "ember-pikaday": "0.7.1",
     "ember-rl-dropdown": "0.2.0",
     "ember-try": "0.0.5",
     "emberx-select": "1.1.1",


### PR DESCRIPTION
This update to ember-pikaday should allow IE10 tests to pass once again so they should no longer be marked as an allowed failure.