### PR TITLE
Fix instructor group loading

### DIFF
--- a/app/routes/instructor-groups.js
+++ b/app/routes/instructor-groups.js
@@ -13,8 +13,7 @@ export default Ember.Route.extend({
         self.store.find('school', schoolId).then(function(school){
           self.store.find('instructorGroup', {
             filters: {
-              school: school.get('id'),
-              deleted: false
+              school: school.get('id')
             },
             limit: 500
           }).then(function(instructorGroups){


### PR DESCRIPTION
We don’t need to filter for not deleted instructor groups.

This is a fix for https://github.com/ilios/ilios/issues/833