### PR TITLE
Add the session when creating a new session description

### DIFF
--- a/app/components/session-overview.js
+++ b/app/components/session-overview.js
@@ -176,9 +176,10 @@ export default Ember.Component.extend({
     },
     changeDescription: function(value){
       var self = this;
-      this.get('session.sessionDescription').then(function(sessionDescription){
+      this.get('session.sessionDescription').then(sessionDescription => {
         if(!sessionDescription){
           sessionDescription = self.get('store').createRecord('session-description');
+          sessionDescription.set('session', this.get('session'));
         }
         sessionDescription.set('description', value);
         sessionDescription.save().then(function(returnedDescription){


### PR DESCRIPTION
This allows session descriptions to be saved correctly against the API.