### PR TITLE
Better Expiration time

### DIFF
--- a/app/mirage/config.js
+++ b/app/mirage/config.js
@@ -1,3 +1,4 @@
+/* global moment */
 import getAll from './helpers/get-all';
 import Mirage from 'ember-cli-mirage';
 
@@ -280,8 +281,10 @@ export default function() {
       let username = attrs.username.toLowerCase();
       if(errors.length === 0){
         if(username === 'demo' && attrs.password === 'demo'){
+          let now = moment();
+          let nextWeek = now.clone().add(1, 'week');
           let header = '{"alg":"none"}';
-          let body = '{"iss": "ilios","aud": "ilios","iat": "1435288723","exp": "1435317523","user_id": 4136}';
+          let body = `{"iss": "ilios","aud": "ilios","iat": "${now.format('X')}","exp": "${nextWeek.format('X')}","user_id": 4136}`;
 
           let encodedData =  window.btoa(header) + '.' +  window.btoa(body) + '.';
           return {
@@ -315,9 +318,10 @@ export default function() {
       // return {
       //   jwt: null
       // };
-
+      let now = moment();
+      let nextWeek = now.clone().add(1, 'week');
       let header = '{"alg":"none"}';
-      let body = '{"iss": "ilios","aud": "ilios","iat": "1435288723","exp": "1435317523","user_id": 4136}';
+      let body = `{"iss": "ilios","aud": "ilios","iat": "${now.format('X')}","exp": "${nextWeek.format('X')}","user_id": 4136}`;
 
       let encodedData =  window.btoa(header) + '.' +  window.btoa(body) + '.';
       return {

--- a/config/environment.js
+++ b/config/environment.js
@@ -33,6 +33,7 @@ module.exports = function(environment) {
       tokenPropertyName: 'jwt',
       authorizationHeaderName: 'X-JWT-Authorization',
       authorizationPrefix: 'Token ',
+      timeFactor: 1000
     },
     EmberENV: {
       FEATURES: {

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -116,7 +116,10 @@ test('click month day number and go to day', function(assert) {
   visit('/dashboard?view=month');
   andThen(function() {
     let dayOfMonth = today.date();
-    click(find('.day a').eq(dayOfMonth)).then(()=>{
+    let link = find('.day a').filter(function(){
+      return parseInt($(this).text()) === dayOfMonth;
+    }).eq(0);
+    click(link).then(()=>{
       assert.equal(currentURL(), '/dashboard?date=' + today.format('YYYY-MM-DD') + '&view=day');
     });
   });


### PR DESCRIPTION
Use a time factor to go between php’s unix time in seconds and
javascript’s unix time in milliseconds.
Set the expire token correctly in demo.

Also fixed an issue with the month calendar test.