### PR TITLE
Fixing code coverage

### DIFF
--- a/app/mirage/config.js
+++ b/app/mirage/config.js
@@ -4,7 +4,8 @@ import Mirage from 'ember-cli-mirage';
 
 export default function() {
     this.timing = 100;
-
+    
+    this.pretender.post.call(this.pretender, '/write-blanket-coverage', this.pretender.passthrough);
     this.get('/api/aamcmethods', getAll);
     this.get('/api/aamcmethods/:id', 'aamcMethod');
     this.put('/api/aamcmethods/:id', 'aamcMethod');

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "loader.js": "ember-cli/loader.js#3.2.0",
     "neat": "~1.7.1",
     "normalize.css": "~3.0.2",
-    "pretender": "~0.6.0",
+    "pretender": "pretender#master",
     "qunit": "~1.17.1",
     "pikaday": "1.3.2",
     "moment": "~2.10.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli": "0.2.7",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-blanket": "sglanzer/ember-cli-blanket#master",
+    "ember-cli-blanket": "0.5.3",
     "ember-cli-bourbon": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",


### PR DESCRIPTION
Needed to passthrough the blanket-coverage post request to trigger
creating the report.  Also went to the master branch of pretender to
fix and issue with phantoms and locked the version of ember-cli-blanket as it has a new release.