### PR TITLE
Preliminary installation of a styleguide

### DIFF
--- a/app/styles/components/_navigation.scss
+++ b/app/styles/components/_navigation.scss
@@ -1,3 +1,7 @@
+/**
+ * Component name:
+ * `.sliding-navigation` - slide out navigation and menu items
+ */
 $sliding-menu-border-color: $base-border-color;
 $sliding-menu-background: $background-grey;
 $sliding-menu-color: $ilios-orange;

--- a/app/styles/styledown_config.md
+++ b/app/styles/styledown_config.md
@@ -1,0 +1,12 @@
+# Styleguide options
+
+### Head
+
+    <meta name='viewport' content='width=device-width, initial-scale=1' />
+    <script src='https://cdn.rawgit.com/styledown/styledown/v1.0.2/data/styledown.js'></script>
+    <link rel='stylesheet' href='https://cdn.rawgit.com/styledown/styledown/v1.0.2/data/styledown.css' />
+    <link rel='stylesheet' href='assets/ilios.css' />
+
+### Body
+
+    <div class='sg-container' sg-content></div>

--- a/public/styleguide.html
+++ b/public/styleguide.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html class="sg">
+
+<head>
+  <meta charset="utf-8">
+  <title>Styledown</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="https://cdn.rawgit.com/styledown/styledown/v1.0.2/data/styledown.js"></script>
+  <link rel="stylesheet" href="https://cdn.rawgit.com/styledown/styledown/v1.0.2/data/styledown.css">
+  <link rel="stylesheet" href="assets/ilios.css">
+</head>
+
+<body class="sg">
+  <div class="sg-container">
+    <section class="sg-block sg-section-component-name">
+      <h3 id="component-name" class="sg">Component name</h3>
+      <p class="sg">
+        <code class="sg">.sliding-navigation</code>- slide out navigation and menu items</p>
+    </section>
+
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
There are a lot of opportunities for automation here, but this is a
start.
You can access the file by running ember server and visiting
http://localhost:4200/styleguide.html
Running the command
```styledown app/styles/**/*.scss app/styles/styledown_config.md >
public/styleguide.html```  generates a new file.

I added a basic style definition to the navigation component as an example.

I think we will probably want to make generating the guide a pre-commit hook.

Also, I may write an ember add-on to better handle generating the guide and configuration file.