### PR TITLE
Removed deprecated Ember.Select views

### DIFF
--- a/app/components/new-learningmaterial.js
+++ b/app/components/new-learningmaterial.js
@@ -24,5 +24,19 @@ export default Ember.Component.extend({
     remove: function(){
       this.sendAction('remove', this.get('learningMaterial'));
     },
+    changeSelectedStatus(){
+      let selectedEl = this.$('select')[0];
+      let selectedIndex = selectedEl.selectedIndex;
+      let learningMaterialStatuses = this.get('learningMaterialStatuses');
+      let status = learningMaterialStatuses.toArray()[selectedIndex];
+      this.set('learningMaterial.status', status);
+    },
+    changeSelectedRole(){
+      let selectedEl = this.$('select')[1];
+      let selectedIndex = selectedEl.selectedIndex;
+      let learningMaterialUserRoles = this.get('learningMaterialUserRoles');
+      let role = learningMaterialUserRoles.toArray()[selectedIndex];
+      this.set('learningMaterial.userRole', role);
+    },
   }
 });

--- a/app/components/new-programyear.js
+++ b/app/components/new-programyear.js
@@ -7,10 +7,7 @@ export default Ember.Component.extend({
   academicYears: function(){
     return this.get('availableProgramStartYears').map(
       startYear => {
-        return {
-          id: startYear,
-          title: startYear + ' - ' + (startYear+1)
-        };
+        return startYear + ' - ' + (startYear+1);
       }
     );
   }.property('availableProgramStartYears.@each'),
@@ -20,6 +17,13 @@ export default Ember.Component.extend({
     },
     cancel: function(){
       this.sendAction('cancel', this.get('programYear'));
-    }
+    },
+    changeSelectedYear(){
+      let selectedEl = this.$('select')[0];
+      let selectedIndex = selectedEl.selectedIndex;
+      let availableProgramStartYears = this.get('availableProgramStartYears');
+      let year = availableProgramStartYears.toArray()[selectedIndex];
+      this.set('programYear.startYear', year);
+    },
   }
 });

--- a/app/components/new-session.js
+++ b/app/components/new-session.js
@@ -8,43 +8,21 @@ export default Ember.Component.extend({
   placeholder: t('sessions.sessionTitlePlaceholder'),
   session: null,
   sessionTypes: [],
-  sortedSessionTypes: [],
-  selectedSessionTypeId: null,
-  watchSessionTypes: function(){
-    var self = this;
-    var session = this.get('session');
-    var sessionTypes = this.get('sessionTypes');
-    if(sessionTypes.length){
-      this.set('sortedSessionTypes', sessionTypes.sortBy('title'));
-      if(!session){
-        this.set('selectedSessionTypeId', null);
-      } else {
-        session.get('sessionType').then(function(sessionType){
-          if(sessionType){
-            self.set('selectedSessionTypeId', sessionType.get('id'));
-          } else {
-            self.set('selectedSessionTypeId', self.get('defaultSessionType.id'));
-          }
-        });
-      }
-    }
-  }.observes('sessionTypes.@each').on('init'),
-  defaultSessionType: function(){
-    var sessionTypes = this.get('sessionTypes');
-    //we attempt to load a type with the title of lecture as its the default
-    var lectureType = sessionTypes.findBy('title', 'Lecture');
-    var defaultType = lectureType?lectureType:sessionTypes.get('firstObject');
-
-    return defaultType;
-  }.property('sessionTypes.@each'),
+  sortSessionsBy: ['title'],
+  sortedSessionTypes: Ember.computed.sort('sessionTypes', 'sortSessionsBy'),
   actions: {
     save: function(){
-      var sessionType = this.get('sortedSessionTypes').findBy('id', this.get('selectedSessionTypeId'));
-      this.set('session.sessionType', sessionType);
       this.sendAction('save', this.get('session'));
     },
     cancel: function(){
       this.sendAction('cancel', this.get('session'));
+    },
+    changeSessionType(){
+      let selectedEl = this.$('select')[0];
+      let selectedIndex = selectedEl.selectedIndex;
+      let sortedSessionTypes = this.get('sortedSessionTypes');
+      let sessionType = sortedSessionTypes.toArray()[selectedIndex];
+      this.set('session.sessionType', sessionType);
     }
   }
 });

--- a/app/templates/components/ilios-sessions-list.hbs
+++ b/app/templates/components/ilios-sessions-list.hbs
@@ -17,7 +17,7 @@
           {{#liquid-unless sessionProxy.isSaved class='horizontal'}}
             {{new-session
               session=sessionProxy.content
-              sessionTypes=sessionTypes
+              sessionTypes=course.owningSchool.sessionTypes
               save='saveNewSession'
               cancel='removeNewSession'
             }}

--- a/app/templates/components/new-learningmaterial.hbs
+++ b/app/templates/components/new-learningmaterial.hbs
@@ -6,12 +6,13 @@
   <div class="form-col-12">
     <label class="form-label">{{t 'learningMaterials.status'}}:</label>
     <div class="form-data">
-    {{view "select"
-      content=learningMaterialStatuses
-      value=learningMaterial.status.content
-      optionValuePath='content'
-      optionLabelPath='content.title'
-    }}
+      <select {{action 'changeSelectedStatus' on='change'}}>
+        {{#each learningMaterialStatuses as |status|}}
+          <option value="{{status}}" selected={{is-equal status learningMaterial.status}}>
+            {{status.title}}
+          </option>
+        {{/each}}
+      </select>
     </div>
   </div>
   <div class="form-col-12">
@@ -25,12 +26,13 @@
   <div class="form-col-12">
     <label class="form-label">{{t 'learningMaterials.userRole'}}:</label>
     <div class="form-data">
-    {{view "select"
-      content=learningMaterialUserRoles
-      value=learningMaterial.userRole.content
-      optionValuePath='content'
-      optionLabelPath='content.title'
-    }}
+      <select {{action 'changeSelectedRole' on='change'}}>
+        {{#each learningMaterialUserRoles as |role|}}
+          <option value="{{role}}" selected={{is-equal role learningMaterial.userRole}}>
+            {{role.title}}
+          </option>
+        {{/each}}
+      </select>
     </div>
   </div>
   <div class="form-col-12">
@@ -70,4 +72,3 @@
   <button class='cancel text' {{action 'remove'}}>{{t 'general.cancel'}}</button>
 </div>
 </div>
-

--- a/app/templates/components/new-programyear.hbs
+++ b/app/templates/components/new-programyear.hbs
@@ -3,12 +3,13 @@
     <div class="form-col-12">
       <label class="form-label">{{t "general.academicYear"}}:</label>
       <div class="form-data">
-        {{view "select"
-          content=academicYears
-          value=programYear.startYear
-          optionValuePath='content.id'
-          optionLabelPath='content.title'
-        }}
+        <select {{action 'changeSelectedYear' on='change'}}>
+          {{#each academicYears as |year|}}
+            <option value="{{year}}" selected={{is-equal year programYear.startYear}}>
+              {{year}}
+            </option>
+          {{/each}}
+        </select>
       </div>
     </div>
     <div class="form-col-6 form-data-submit">
@@ -17,4 +18,3 @@
     </div>
   </div>
 </section>
-

--- a/app/templates/components/new-session.hbs
+++ b/app/templates/components/new-session.hbs
@@ -8,12 +8,13 @@
     <div class="form-label">{{t "sessions.type"}}:</div>
     <div class="form-data form-data-select form-input-row">
     {{#if sortedSessionTypes}}
-      {{view "select"
-        content=sortedSessionTypes
-        value=selectedSessionTypeId
-        optionValuePath='content.id'
-        optionLabelPath='content.title'
-      }}
+      <select {{action 'changeSessionType' on='change'}}>
+        {{#each sortedSessionTypes as |sessionType|}}
+          <option value="{{sessionType}}" selected={{is-equal sessionType.id session.sessionType.id}}>
+            {{sessionType.title}}
+          </option>
+        {{/each}}
+      </select>
     {{else}}
       <select>
         <option selected>{{t 'sessions.loadingSessionTypes'}}</option>

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ember-rl-dropdown": "0.2.0",
     "ember-try": "0.0.5",
     "emberx-select": "1.1.1",
-    "liquid-fire": "0.20.4",
+    "liquid-fire": "^0.21.0",
     "moment": "^2.10.0",
     "pluralize": "^1.1.2"
   },


### PR DESCRIPTION
Removed the last remaining Ember.Select views from Ilios.  These were deprecated for good reason as removing them made the code a lot easier to understand and removed several observers.