### PR TITLE
Remove most browser tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,8 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    # IE10 builds allowed to fail until https://github.com/edgycircle/ember-pikaday/issues/21 is fixed
-    - env: "TESTEM_LAUNCHER='SL_internet_explorer_10' START_SAUCE_CONNECT=true JS_TESTS=true SEND_COVERAGE=false"
-    - env: "TESTEM_LAUNCHER='SL_internet_explorer_11' START_SAUCE_CONNECT=true JS_TESTS=true SEND_COVERAGE=false"
   include:
     - env: "TESTEM_LAUNCHER='SL_chrome' START_SAUCE_CONNECT=true JS_TESTS=true SEND_COVERAGE=false"
-    - env: "TESTEM_LAUNCHER='SL_firefox' START_SAUCE_CONNECT=true JS_TESTS=true SEND_COVERAGE=false"
-    - env: "TESTEM_LAUNCHER='SL_internet_explorer_10' START_SAUCE_CONNECT=true JS_TESTS=true SEND_COVERAGE=false"
-    - env: "TESTEM_LAUNCHER='SL_internet_explorer_11' START_SAUCE_CONNECT=true JS_TESTS=true SEND_COVERAGE=false"
-    - env: "TESTEM_LAUNCHER='SL_safari_7' START_SAUCE_CONNECT=true JS_TESTS=true SEND_COVERAGE=false"
     - env: "JS_TESTS=false SCSS_LINT=true SEND_COVERAGE=false"
 
 


### PR DESCRIPTION
We have yet to hit a browser specific issue and these tests take forever
and are unreliable.  I’ve paired it down to just chrome and phantomJS.