### PR TITLE
No global jquery

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,8 +3,7 @@
     "server",
     "document",
     "window",
-    "-Promise",
-    "$"
+    "-Promise"
   ],
   "browser": true,
   "boss": true,

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -13,7 +13,7 @@ export default Ember.Controller.extend({
       this.get('session').authenticate(authenticator, credentials).then(() => {
         let jwt = this.get('session').get('secure.jwt');
         let js = atob(jwt.split('.')[1]);
-        let obj = $.parseJSON(js);
+        let obj = Ember.$.parseJSON(js);
         this.get('currentUser').set('currentUserId', obj.user_id);
       }, response => {
         let mappedErrors = response.errors.map(str => {

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -45,7 +45,7 @@ export default Ember.Route.extend(UnauthenticatedRouteMixin, {
             this.get('session').authenticate(authenticator, {jwt: response.jwt}).then(() => {
               let jwt = this.get('session').get('secure.jwt');
               let js = atob(jwt.split('.')[1]);
-              let obj = $.parseJSON(js);
+              let obj = Ember.$.parseJSON(js);
               this.get('currentUser').set('currentUserId', obj.user_id);
             });
           }

--- a/app/utils/scroll-to.js
+++ b/app/utils/scroll-to.js
@@ -5,8 +5,8 @@ export default function scrollTo(elementQuery, time) {
 
   var promise = new Ember.RSVP.Promise(function(resolve) {
     Ember.run.next(()=>{
-      $('html, body').animate({
-        scrollTop: $(elementQuery).offset().top
+      Ember.$('html, body').animate({
+        scrollTop: Ember.$(elementQuery).offset().top
       }, time, function(){
         resolve();
       });

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ember-try": "0.0.8",
     "emberx-select": "2.0.1",
     "ilios-calendar": "ilios/calendar#v1.1.0",
-    "liquid-fire": "0.21.2",
+    "liquid-fire": "0.21.3",
     "liquid-tether": "pzuraq/liquid-tether#v0.1.4",
     "pluralize": "^1.1.6",
     "ui-select": "firefly-ui/ui-select#v0.0.9"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-deploy-s3": "0.0.5",
     "ember-deploy-s3-index": "^0.4.0",
     "ember-disable-proxy-controllers": "^1.0.0",
-    "ember-i18n": "^4.1.2",
+    "ember-i18n": "4.1.3",
     "ember-legacy-views": "0.2.0",
     "ember-load": "0.0.2",
     "ember-modal-dialog": "0.7.7",


### PR DESCRIPTION
This is a quick fix for an issue with ember jshint parsing included libraries (in this case liquid-fire) and throwing some errors that are breaking our build.  More better work on remediation being done elsewhere, but this is a pretty easy win and should harm nothing on our end.