### PR TITLE
error handlers created

### DIFF
--- a/app/components/error-display.js
+++ b/app/components/error-display.js
@@ -29,12 +29,6 @@ export default Component.extend({
 
   showDetails: false,
 
-  showOrHideDetails: computed('showDetails', {
-    get() {
-      return this.get('showDetails') ? 'Hide Details' : 'Show Details';
-    }
-  }).readOnly(),
-
   totalErrors: computed('content.[]', {
     get() {
       const contentLength = this.get('content').length;

--- a/app/components/error-display.js
+++ b/app/components/error-display.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+
+const { Component, computed, isPresent } = Ember;
+
+export default Component.extend({
+  classNames: ['error-display'],
+
+  content: null,
+
+  revisedContent: computed('content.[]', {
+    get() {
+      const content = this.get('content');
+
+      return content.map((error) => {
+        let errorObject = {};
+
+        errorObject.mainMessage = error.message;
+        errorObject.stack = error.stack;
+
+        if (isPresent(error.errors)) {
+          errorObject.statusCode = error.errors[0].status;
+          errorObject.message = error.errors[0].title;
+        }
+
+        return errorObject;
+      });
+    }
+  }).readOnly(),
+
+  showDetails: false,
+
+  showOrHideDetails: computed('showDetails', {
+    get() {
+      return this.get('showDetails') ? 'Hide Details' : 'Show Details';
+    }
+  }).readOnly(),
+
+  totalErrors: computed('content.[]', {
+    get() {
+      const contentLength = this.get('content').length;
+
+      return contentLength > 1 ? `There are ${contentLength} errors` : 'There is 1 error';
+    }
+  }).readOnly(),
+
+  actions: {
+    toggleDetails() {
+      this.set('showDetails', !this.get('showDetails'));
+    }
+  }
+});

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -27,16 +27,16 @@ export default Controller.extend({
     this._super(...arguments);
 
     const showErrorDisplay = false;
-    const error = [];
+    const errors = [];
 
-    this.setProperties({ showErrorDisplay, error });
+    this.setProperties({ showErrorDisplay, errors });
   },
 
   showErrorDisplay: null,
-  error: null,
+  errors: null,
 
-  setError(error) {
-    this.get('error').pushObject(error);
+  addError(error) {
+    this.get('errors').pushObject(error);
     this.set('showErrorDisplay', true);
   }
 });

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,16 +1,42 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
-  currentUser: Ember.inject.service(),
-  i18n: Ember.inject.service(),
+const { computed, Controller, inject } = Ember;
+const { service } = inject;
+
+export default Controller.extend({
+  currentUser: service(),
+
+  i18n: service(),
+
   pageTitleTranslation: null,
-  pageTitle: Ember.computed('pageTitleTranslation', 'i18n.locale', function(){
-    if(this.get('pageTitleTranslation')){
-      return this.get('i18n').t(this.get('pageTitleTranslation'));
+
+  pageTitle: computed('pageTitleTranslation', 'i18n.locale', {
+    get() {
+      if(this.get('pageTitleTranslation')){
+        return this.get('i18n').t(this.get('pageTitleTranslation'));
+      }
+
+      return '';
     }
-    
-    return '';
-  }),
+  }).readOnly(),
+
   showHeader: true,
   showNavigation: true,
+
+  init() {
+    this._super(...arguments);
+
+    const showErrorDisplay = false;
+    const error = [];
+
+    this.setProperties({ showErrorDisplay, error });
+  },
+
+  showErrorDisplay: null,
+  error: null,
+
+  setError(error) {
+    this.get('error').pushObject(error);
+    this.set('showErrorDisplay', true);
+  }
 });

--- a/app/initializers/error.js
+++ b/app/initializers/error.js
@@ -22,7 +22,7 @@ export default {
         console.log(error);
 
         if (error) {
-          controller.setError(error);
+          controller.addError(error);
           this.logError(error);
         }
       };
@@ -32,7 +32,7 @@ export default {
         console.log(error);
 
         if (error) {
-          controller.setError(error);
+          controller.addError(error);
           this.logError(error);
         }
       });

--- a/app/initializers/error.js
+++ b/app/initializers/error.js
@@ -1,0 +1,58 @@
+import Ember from 'ember';
+import config from '../config/environment';
+
+const { isPresent } = Ember;
+
+export default {
+  name: 'error-service',
+  after: ['flash-messages', 'simple-auth'],
+
+  _initializeApplicationController(container) {
+    return container.lookup('controller:application');
+  },
+
+  initialize(container) {
+    let currentEnv = config.environment;
+
+    if (currentEnv !== 'test') {
+      const controller = this._initializeApplicationController(container);
+
+      // Global error handler in Ember run loop
+      Ember.onerror = (error) => {
+        console.log(error);
+
+        if (error) {
+          controller.setError(error);
+          this.logError(error);
+        }
+      };
+
+      // Global error handler for promises
+      Ember.RSVP.on('error', (error) => {
+        console.log(error);
+
+        if (error) {
+          controller.setError(error);
+          this.logError(error);
+        }
+      });
+    }
+  },
+
+  logError(error) {
+    let errorData = {};
+
+    errorData.mainMessage = error.message || '';
+    errorData.stack = error.stack || '';
+
+    if (error.errors && isPresent(error.errors)) {
+      errorData.statusCode = error.errors[0].status || '';
+      errorData.message = error.errors[0].title || '';
+    }
+
+    Ember.$.ajax('/errors', {
+      type: 'POST',
+      data: JSON.stringify(errorData)
+    });
+  }
+};

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -95,6 +95,8 @@ export default {
     'select': 'Select',
     'invalidDatetimes': 'Invalid dates/times',
     'globalSearchPlaceholder': 'Find Users...',
+    'transitionErrorMessage': 'Sorry, we can’t get you where you asked to go: something seems to be broken...',
+    'errorDisplayMessage': 'Sorry! Something went wrong with your request. Please try refreshing or check back later.'
   },
   'programs': {
     'programTitle': 'Program Title',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -96,7 +96,8 @@ export default {
     'invalidDatetimes': 'Invalid dates/times',
     'globalSearchPlaceholder': 'Find Users...',
     'transitionErrorMessage': 'Sorry, we can’t get you where you asked to go: something seems to be broken...',
-    'errorDisplayMessage': 'Sorry! Something went wrong with your request. Please try refreshing or check back later.'
+    'errorDisplayMessage': 'Sorry! Something went wrong with your request. Please try refreshing or check back later.',
+    'backToDashboard': 'Back to Dashboard'
   },
   'programs': {
     'programTitle': 'Program Title',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -95,6 +95,8 @@ export default {
     'select': 'Selecciona',
     'invalidDatetimes': 'Fecha/Hora Inválida',
     'globalSearchPlaceholder': 'Encontrar Usuarios...',
+    'transitionErrorMessage': 'Lo sentimos! No le podemos conseguir donde pidió ir...',
+    'errorDisplayMessage': 'Lo sentimos! Algo salió mal con su pedido. Por favor, trate de actualizar la página o revise de nuevo más tarde.'
   },
   'programs': {
     'programTitle': 'Titulo de Programa',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -96,7 +96,8 @@ export default {
     'invalidDatetimes': 'Fecha/Hora Inválida',
     'globalSearchPlaceholder': 'Encontrar Usuarios...',
     'transitionErrorMessage': 'Lo sentimos! No le podemos conseguir donde pidió ir...',
-    'errorDisplayMessage': 'Lo sentimos! Algo salió mal con su pedido. Por favor, trate de actualizar la página o revise de nuevo más tarde.'
+    'errorDisplayMessage': 'Lo sentimos! Algo salió mal con su pedido. Por favor, trate de actualizar la página o revise de nuevo más tarde.',
+    'backToDashboard': 'Detrás a Tablero'
   },
   'programs': {
     'programTitle': 'Titulo de Programa',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -96,7 +96,8 @@ export default {
     'invalidDatetimes': 'Dates/Heures invalides',
     'globalSearchPlaceholder': 'Trouver des utilisateurs...',
     'transitionErrorMessage': 'Désolé, nous ne pouvons pas vous faire demander où vous aller : quelque chose semble être cassé.',
-    'errorDisplayMessage': "Désolé! Quelque chose s'est passé mal avec votre demande. Essayez S'il vous plaît de rafraîchir ou vérifier en arrière plus tard."
+    'errorDisplayMessage': "Désolé! Quelque chose s'est passé mal avec votre demande. Essayez S'il vous plaît de rafraîchir ou vérifier en arrière plus tard.",
+    'backToDashboard': 'Retour à tableau de bord'
   },
   'programs': {
     'programTitle': "Titre de Diplôme",

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -95,6 +95,8 @@ export default {
     'select': 'Sélectionnez',
     'invalidDatetimes': 'Dates/Heures invalides',
     'globalSearchPlaceholder': 'Trouver des utilisateurs...',
+    'transitionErrorMessage': 'Désolé, nous ne pouvons pas vous faire demander où vous aller : quelque chose semble être cassé.',
+    'errorDisplayMessage': "Désolé! Quelque chose s'est passé mal avec votre demande. Essayez S'il vous plaît de rafraîchir ou vérifier en arrière plus tard."
   },
   'programs': {
     'programTitle': "Titre de Diplôme",

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -18,10 +18,8 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
 
       this.get('flashMessages').alert('general.transitionErrorMessage');
 
-      // Manage route-related errors
-      // Ember.onerror(error);
-
-      // Substate implementation when returning `true` (i.e. error.hbs)
+      // Future Reference:
+      // Uncommented code below would render substate (error.hbs)
       // return true;
     }
   }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,12 +1,28 @@
 import Ember from 'ember';
 import ApplicationRouteMixin from 'simple-auth/mixins/application-route-mixin';
 
+const { inject } = Ember;
+const { service } = inject;
+
 export default Ember.Route.extend(ApplicationRouteMixin, {
-  flashMessages: Ember.inject.service(),
+  flashMessages: service(),
+
   actions: {
     sessionInvalidationSucceeded(){
       this.get('flashMessages').success('auth.confirmLogout');
       this.transitionTo('login');
+    },
+
+    error(error, transition) {
+      transition.abort();
+
+      this.get('flashMessages').alert('general.transitionErrorMessage');
+
+      // Manage route-related errors
+      // Ember.onerror(error);
+
+      // Substate implementation when returning `true` (i.e. error.hbs)
+      // return true;
     }
   }
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -37,4 +37,5 @@
 @import 'components/offering-editor-learnergroups';
 @import 'components/expand-collapse-button';
 @import 'components/global-search';
+@import 'components/error-display';
 @import 'layout/layout';

--- a/app/styles/components/_error-display.scss
+++ b/app/styles/components/_error-display.scss
@@ -1,0 +1,37 @@
+.error-main {
+  margin-bottom: 25px;
+
+  .error-detail-action {
+    color: $text-blue;
+    cursor: pointer;
+  }
+}
+
+.error-detail {
+  border: 1px solid $ilios-orange;
+  padding: 25px;
+
+  .error-total {
+    color: $dark-grey;
+    margin: 0;
+  }
+
+  .error-main-message {
+    color: $ilios-red;
+    margin: 10px 0;
+  }
+
+  .error-status-code {
+    display: block;
+    font-size: 14px;
+  }
+
+  .error-message {
+    display: block;
+    font-size: 14px;
+  }
+
+  .error-stack {
+    font-size: 12px;
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -16,7 +16,7 @@
   </div>
 
   {{#if showErrorDisplay}}
-    {{error-display content=error}}
+    {{error-display content=errors}}
   {{else}}
     {{liquid-outlet}}
   {{/if}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -14,7 +14,12 @@
       {{/flash-message}}
     {{/each}}
   </div>
-  {{liquid-outlet}}
+
+  {{#if showErrorDisplay}}
+    {{error-display content=error}}
+  {{else}}
+    {{liquid-outlet}}
+  {{/if}}
 </div>
 
 {{outlet 'fullscreen'}}

--- a/app/templates/components/error-display.hbs
+++ b/app/templates/components/error-display.hbs
@@ -1,7 +1,11 @@
 <div class="error-main">
   <h2>{{t 'general.errorDisplayMessage'}}</h2>
 
-  <span class="error-detail-action" {{action 'toggleDetails'}}>{{showOrHideDetails}}</span>
+  {{#if showDetails}}
+    <span class="error-detail-action" {{action 'toggleDetails'}}>{{t 'courses.collapseDetail'}}</span>
+  {{else}}
+    <span class="error-detail-action" {{action 'toggleDetails'}}>{{t 'courses.expandDetail'}}</span>
+  {{/if}}
 </div>
 
 {{#if showDetails}}

--- a/app/templates/components/error-display.hbs
+++ b/app/templates/components/error-display.hbs
@@ -1,0 +1,24 @@
+<div class="error-main">
+  <h2>{{t 'general.errorDisplayMessage'}}</h2>
+
+  <span class="error-detail-action" {{action 'toggleDetails'}}>{{showOrHideDetails}}</span>
+</div>
+
+{{#if showDetails}}
+  <div class="error-detail">
+    <h3 class="error-total">{{totalErrors}}</h3>
+
+    {{#each revisedContent as |error|}}
+      <div class="error-details">
+        <h5 class="error-main-message">{{error.mainMessage}}</h5>
+        {{#if error.statusCode}}
+          <span class="error-status-code">Status Code: {{error.statusCode}}</span>
+        {{/if}}
+        {{#if error.message}}
+          <span class="error-message">Message: {{error.message}}</span>
+        {{/if}}
+        <pre class="error-stack">{{error.stack}}</pre>
+      </div>
+    {{/each}}
+  </div>
+{{/if}}

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -1,0 +1,3 @@
+{{#link-to "index"}}Back to Dashboard{{/link-to}}
+
+<h1>Sorry! Something went wrong. Please try refreshing the page or check back later.</h1>

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -1,3 +1,3 @@
-{{#link-to "index"}}Back to Dashboard{{/link-to}}
+{{#link-to "index"}}{{t 'general.backToDashboard'}}{{/link-to}}
 
-<h1>Sorry! Something went wrong. Please try refreshing the page or check back later.</h1>
+<h1>{{t 'general.errorDisplayMessage'}}</h1>

--- a/tests/integration/components/error-display-test.js
+++ b/tests/integration/components/error-display-test.js
@@ -1,0 +1,30 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import tHelper from "ember-i18n/helper";
+
+moduleForComponent('error-display', 'Integration | Component | error display', {
+  integration: true,
+
+  beforeEach() {
+    this.container.lookup('service:i18n').set('locale', 'en');
+    this.registry.register('helper:t', tHelper);
+  }
+});
+
+test('the detail link toggles properly', function(assert) {
+  assert.expect(2);
+
+  const errors = [{
+    message: 'this is an error'
+  }];
+
+  this.set('errors', errors);
+
+  this.render(hbs`{{error-display content=errors}}`);
+
+  assert.equal(this.$('.error-detail-action').text(), 'Show Details');
+
+  this.$('.error-detail-action').click();
+
+  assert.equal(this.$('.error-detail-action').text(), 'Hide Details');
+});

--- a/tests/unit/components/error-display-test.js
+++ b/tests/unit/components/error-display-test.js
@@ -22,23 +22,6 @@ test('properties have default values', function(assert) {
   assert.deepEqual(actual, expected, 'default values are correct');
 });
 
-// test('`toggleDetails` gets triggered on click', function(assert) {
-//   assert.expect(1);
-//
-//   const link = '.error-detail-action';
-//   const component = this.subject({
-//     content: []
-//   });
-//
-//   component.send = (action) => {
-//     assert.equal(action, 'toggleDetails', 'action was called');
-//   };
-//
-//   this.render();
-//
-//   this.$(link).click();
-// });
-
 test('`toggleDetails` action changes `showDetails` property', function(assert) {
   assert.expect(1);
 
@@ -47,18 +30,6 @@ test('`toggleDetails` action changes `showDetails` property', function(assert) {
   component.send('toggleDetails');
 
   assert.equal(component.get('showDetails'), true);
-});
-
-test('`showOrHideDetails` computed property works', function(assert) {
-  assert.expect(2);
-
-  const component = this.subject();
-
-  assert.equal(component.get('showOrHideDetails'), 'Show Details');
-
-  component.set('showDetails', true);
-
-  assert.equal(component.get('showOrHideDetails'), 'Hide Details');
 });
 
 test('`totalErrors` computed property works', function(assert) {

--- a/tests/unit/components/error-display-test.js
+++ b/tests/unit/components/error-display-test.js
@@ -1,0 +1,100 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('error-display', 'Unit | Component | error display', {
+  unit: true
+});
+
+test('properties have default values', function(assert) {
+  assert.expect(1);
+
+  const expected = {
+    content:     null,
+    showDetails: false
+  };
+
+  const component = this.subject();
+
+  const actual = {
+    content:     component.get('content'),
+    showDetails: component.get('showDetails'),
+  };
+
+  assert.deepEqual(actual, expected, 'default values are correct');
+});
+
+// test('`toggleDetails` gets triggered on click', function(assert) {
+//   assert.expect(1);
+//
+//   const link = '.error-detail-action';
+//   const component = this.subject({
+//     content: []
+//   });
+//
+//   component.send = (action) => {
+//     assert.equal(action, 'toggleDetails', 'action was called');
+//   };
+//
+//   this.render();
+//
+//   this.$(link).click();
+// });
+
+test('`toggleDetails` action changes `showDetails` property', function(assert) {
+  assert.expect(1);
+
+  const component = this.subject();
+
+  component.send('toggleDetails');
+
+  assert.equal(component.get('showDetails'), true);
+});
+
+test('`showOrHideDetails` computed property works', function(assert) {
+  assert.expect(2);
+
+  const component = this.subject();
+
+  assert.equal(component.get('showOrHideDetails'), 'Show Details');
+
+  component.set('showDetails', true);
+
+  assert.equal(component.get('showOrHideDetails'), 'Hide Details');
+});
+
+test('`totalErrors` computed property works', function(assert) {
+  assert.expect(2);
+
+  const component = this.subject({
+    content: [1]
+  });
+
+  assert.equal(component.get('totalErrors'), 'There is 1 error');
+
+  component.get('content').pushObject(2);
+
+  assert.equal(component.get('totalErrors'), 'There are 2 errors');
+});
+
+test('`revisedContent` computed property works', function(assert) {
+  assert.expect(1);
+
+  const component = this.subject({
+    content: [{
+      message: 'Adapter operation failed',
+      stack: 'Error: Adapter operation failed...',
+      errors: [{
+        status: '403',
+        title: 'The backend responded with an error'
+      }]
+    }]
+  });
+
+  const expected = [{
+    mainMessage: 'Adapter operation failed',
+    message: 'The backend responded with an error',
+    stack: 'Error: Adapter operation failed...',
+    statusCode: '403'
+  }];
+
+  assert.deepEqual(component.get('revisedContent'), expected, 'revisedContent works');
+});


### PR DESCRIPTION
1. Global Error Handlers
  - Route Rejection Errors: 
    - Abort transition
    - Display message to user (instead of rendering `erros.hbs`)
  - Ember Errors & Promise Errors:
    - Display error substate to user (`error-display.hbs`)
    - Content: status code, messages, stack trace, etc.

2. Error Logging
  - Send error to the server
  - POST to `/errors` route
  - Data to server: `mainMessage`, `message`, `stack`, `statusCode`

fixes #870