### PR TITLE
Improved Topic Management

### DIFF
--- a/app/components/course-editing.js
+++ b/app/components/course-editing.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  availableTopics: [],
   actions: {
     save: function(){
       var self = this;

--- a/app/components/detail-topic-list.js
+++ b/app/components/detail-topic-list.js
@@ -1,7 +1,20 @@
 import Ember from 'ember';
+import DS from 'ember-data';
+
+const {computed, RSVP} = Ember;
+const {PromiseArray} = DS;
 
 export default Ember.Component.extend({
   topics: [],
-  sortBy: ['title'],
-  sortedTopics: Ember.computed.sort('topics', 'sortBy'),
+  sortedTopics: computed('topics.[]', function(){
+    let defer = RSVP.defer();
+
+    this.get('topics').then(topics => {
+      defer.resolve(topics.sortBy('title'));
+    });
+    
+    return PromiseArray.create({
+      promise: defer.promise
+    });
+  }),
 });

--- a/app/components/detail-topic-manager.js
+++ b/app/components/detail-topic-manager.js
@@ -4,31 +4,21 @@ import DS from 'ember-data';
 import { translationMacro as t } from "ember-i18n";
 
 const {computed, inject, RSVP} = Ember;
-const {alias} = computed;
 const {service} = inject;
 const {PromiseArray} = DS;
+const {sort} = computed;
 
 export default Ember.Component.extend({
   i18n: service(),
-  placeholder: t('general.filterPlaceholder'),
-  filter: '',
-  subject: null,
-  topics: alias('subject.topics'),
-  sortedTopics: computed('topics.[]', function(){
-    let defer = RSVP.defer();
-
-    this.get('topics').then(topics => {
-      defer.resolve(topics.sortBy('title'));
-    });
-    
-    return PromiseArray.create({
-      promise: defer.promise
-    });
-  }),
-  availableTopics: [],
   tagName: 'section',
   classNames: ['detail-block'],
-  filteredAvailableTopics: computed('availableTopics.[]', 'topics.[]', 'filter', function(){
+  placeholder: t('general.filterPlaceholder'),
+  filter: '',
+  selectedTopics: [],
+  sortBy: ['title'],
+  sortedTopics: sort('selectedTopics', 'sortBy'),
+  availableTopics: [],
+  filteredAvailableTopics: computed('availableTopics.[]', 'selectedTopics.[]', 'filter', function(){
     let defer = RSVP.defer();
     let exp = new RegExp(this.get('filter'), 'gi');
     
@@ -36,9 +26,9 @@ export default Ember.Component.extend({
       let filteredTopics = availableTopics.filter(topic => {
         return (
           topic.get('title') !== undefined &&
-          this.get('topics') &&
+          this.get('selectedTopics') &&
           topic.get('title').match(exp) &&
-          !this.get('topics').contains(topic)
+          !this.get('selectedTopics').contains(topic)
         );
       });
       
@@ -52,12 +42,10 @@ export default Ember.Component.extend({
   }),
   actions: {
     add: function(topic){
-      var subject = this.get('subject');
-      subject.get('topics').addObject(topic);
+      this.sendAction('add', topic);
     },
     remove: function(topic){
-      var subject = this.get('subject');
-      subject.get('topics').removeObject(topic);
+      this.sendAction('remove', topic);
     }
   }
 });

--- a/app/components/detail-topics.js
+++ b/app/components/detail-topics.js
@@ -22,9 +22,7 @@ export default Ember.Component.extend({
           defer.resolve(topics);
         });
       });
-    }
-    
-    if(this.get('isSession')){
+    } else if(this.get('isSession')){
       this.get('subject').get('course').then(course => {
         course.get('school').then(school => {
           school.get('topics').then(topics => {
@@ -32,9 +30,7 @@ export default Ember.Component.extend({
           });
         });
       });
-    }
-    
-    if(this.get('isProgramYear')){
+    } else if(this.get('isProgramYear')){
       this.get('subject').get('program').then(program => {
         program.get('school').then(school => {
           school.get('topics').then(topics => {
@@ -42,6 +38,8 @@ export default Ember.Component.extend({
           });
         });
       });
+    } else {
+      throw new Error("detail-topic component called without isCourse, isSession, or isProgramYear context");
     }
     
     return PromiseArray.create({

--- a/app/components/detail-topics.js
+++ b/app/components/detail-topics.js
@@ -1,11 +1,53 @@
 import Ember from 'ember';
+import DS from 'ember-data';
+
+const {computed, RSVP} = Ember;
+const {PromiseArray} = DS;
 
 export default Ember.Component.extend({
   classNames: ['detail-topics'],
   subject: null,
   isManaging: false,
+  isCourse: false,
+  isSession: false,
+  isProgramYear: false,
   //keep track of our initial state so we can roll back
   initialTopics: [],
+  availableTopics: computed('isCourse', 'isSession', 'isProgramYear', 'subject', function(){
+    let defer = RSVP.defer();
+    
+    if(this.get('isCourse')){
+      this.get('subject').get('school').then(school => {
+        school.get('topics').then(topics => {
+          defer.resolve(topics);
+        });
+      });
+    }
+    
+    if(this.get('isSession')){
+      this.get('subject').get('course').then(course => {
+        course.get('school').then(school => {
+          school.get('topics').then(topics => {
+            defer.resolve(topics);
+          });
+        });
+      });
+    }
+    
+    if(this.get('isProgramYear')){
+      this.get('subject').get('program').then(program => {
+        program.get('school').then(school => {
+          school.get('topics').then(topics => {
+            defer.resolve(topics);
+          });
+        });
+      });
+    }
+    
+    return PromiseArray.create({
+      promise: defer.promise
+    });
+  }),
   actions: {
     manage: function(){
       var self = this;

--- a/app/components/session-details.js
+++ b/app/components/session-details.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import scrollTo from '../utils/scroll-to';
 
 export default Ember.Component.extend({
-  availableTopics: [],
   sessionTypes: [],
   session: null,
   didInsertElement: function(){

--- a/app/controllers/course.js
+++ b/app/controllers/course.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   queryParams: ['details'],
-  availableTopics: [],
   details: false,
   showBackToCourseListLink: true,
   //pass the state var that ilios-course-details expects

--- a/app/routes/course.js
+++ b/app/routes/course.js
@@ -2,31 +2,8 @@ import Ember from 'ember';
 import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
-  i18n: Ember.inject.service(),
-  availableTopics: [],
-  afterModel: function(course){
-    var self = this;
-    var deferred = Ember.RSVP.defer();
-    Ember.run.later(deferred.resolve, function() {
-      var resolve = this;
-      course.get('school').then(function(school){
-        var promises = {
-          'availableTopics': school.get('topics')
-        };
-        Ember.RSVP.hash(promises).then(function(hash){
-          if(!self.get('isDestroyed')){
-            self.set('availableTopics', hash.availableTopics);
-          }
-          resolve();
-        });
-      });
-
-    }, 500);
-    return deferred.promise;
-  },
   setupController: function(controller, model){
     controller.set('model', model);
-    controller.set('availableTopics', this.get('availableTopics'));
     this.controllerFor('application').set('pageTitleTranslation', 'navigation.courses');
     this.controllerFor('course').set('showBackToCourseListLink', true);
   }

--- a/app/templates/components/course-editing.hbs
+++ b/app/templates/components/course-editing.hbs
@@ -2,8 +2,8 @@
 {{detail-learning-materials subject=course isCourse=true}}
 {{detail-competencies course=course}}
 {{detail-topics
-  availableTopics=availableTopics
   subject=course
+  isCourse=true
 }}
 {{detail-mesh
   subject=course

--- a/app/templates/components/detail-topic-list.hbs
+++ b/app/templates/components/detail-topic-list.hbs
@@ -1,5 +1,9 @@
 <ul class='columnar-list'>
-  {{#each sortedTopics as |topic|}}
-    <li>{{topic.title}}</li>
-  {{/each}}
+  {{#if sortedTopics.isFulfilled}}
+    {{#each sortedTopics as |topic|}}
+      <li>{{topic.title}}</li>
+    {{/each}}
+  {{else}}
+    <li>{{fa-icon 'spinner' spin=true}}</li>
+  {{/if}}
 </ul>

--- a/app/templates/components/detail-topic-manager.hbs
+++ b/app/templates/components/detail-topic-manager.hbs
@@ -1,11 +1,7 @@
 <ul class='removable-list'>
-  {{#if sortedTopics.isFulfilled}}
-    {{#each sortedTopics as |topic|}}
-      <li {{action 'remove' topic}}>{{topic.title}} {{fa-icon 'remove'}}</li>
-    {{/each}}
-  {{else}}
-    <li>{{fa-icon 'spinner' spin=true}}</li>
-  {{/if}}
+  {{#each sortedTopics as |topic|}}
+    <li {{action 'remove' topic}}>{{topic.title}} {{fa-icon 'remove'}}</li>
+  {{/each}}
 </ul>
 {{search-box value=filter placeholder=placeholder}}
 <div class='selectable-list'>

--- a/app/templates/components/detail-topic-manager.hbs
+++ b/app/templates/components/detail-topic-manager.hbs
@@ -1,13 +1,21 @@
 <ul class='removable-list'>
-  {{#each sortedTopics as |topic|}}
-  <li {{action 'remove' topic}}>{{topic.title}} {{fa-icon 'remove'}}</li>
-  {{/each}}
+  {{#if sortedTopics.isFulfilled}}
+    {{#each sortedTopics as |topic|}}
+      <li {{action 'remove' topic}}>{{topic.title}} {{fa-icon 'remove'}}</li>
+    {{/each}}
+  {{else}}
+    <li>{{fa-icon 'spinner' spin=true}}</li>
+  {{/if}}
 </ul>
 {{search-box value=filter placeholder=placeholder}}
 <div class='selectable-list'>
   <ul>
-    {{#each filteredAvailableTopics as |topic|}}
-      <li {{action 'add' topic}}>{{topic.title}}</li>
-    {{/each}}
+    {{#if filteredAvailableTopics.isFulfilled}}
+      {{#each filteredAvailableTopics as |topic|}}
+        <li {{action 'add' topic}}>{{topic.title}}</li>
+      {{/each}}
+    {{else}}
+      <li>{{fa-icon 'spinner' spin=true}}</li>
+    {{/if}}
   </ul>
 </div>

--- a/app/templates/components/detail-topics.hbs
+++ b/app/templates/components/detail-topics.hbs
@@ -11,7 +11,9 @@
 
   <div class='detail-actions'>
     {{#if isManaging}}
-        <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
+        <button class='bigadd' {{action 'save'}}>
+          {{fa-icon (if isSaving 'spinner' 'check') spin=(if isSaving true false)}}
+        </button>
         <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
     {{else}}
       <button {{action 'manage'}}>{{t 'courses.topicsManageTitle'}}</button>
@@ -21,7 +23,9 @@
     {{#liquid-if isManaging class="horizontal"}}
         {{detail-topic-manager
           availableTopics=availableTopics
-          subject=subject
+          selectedTopics=bufferedTopics
+          add='addTopicToBuffer'
+          remove='removeTopicFromBuffer'
         }}
     {{else}}
       {{detail-topic-list

--- a/app/templates/components/ilios-course-details.hbs
+++ b/app/templates/components/ilios-course-details.hbs
@@ -7,7 +7,7 @@
       {{#if collapsed}}
         <div {{action 'expand'}} class='detail-collapsed-control'><span>{{t 'courses.expandDetail'}}{{fa-icon "fa-plus-square"}}</span></div>
       {{else}}
-        {{course-editing course=course availableTopics=availableTopics programs=programs}}
+        {{course-editing course=course}}
         <div {{action 'collapse'}} class='detail-collapsed-control'><span class='is-expanded'>{{t 'courses.collapseDetail'}}{{fa-icon "fa-minus-square"}}</span></div>
       {{/if}}
     </div>

--- a/app/templates/components/programyear-details.hbs
+++ b/app/templates/components/programyear-details.hbs
@@ -1,7 +1,7 @@
 {{programyear-competencies programYear=programYear}}
 {{detail-objectives subject=programYear isProgramYear=true}}
 {{detail-topics
-  availableTopics=programYear.program.school.topics
   subject=programYear
+  isProgramYear=true
 }}
 {{detail-stewards programYear=programYear}}

--- a/app/templates/components/session-details.hbs
+++ b/app/templates/components/session-details.hbs
@@ -19,7 +19,7 @@
     {{detail-learning-materials subject=session isCourse=false}}
     {{detail-topics
       subject=session
-      availableTopics=availableTopics
+      isSession=true
     }}
     {{detail-mesh
       subject=session

--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -4,7 +4,6 @@
 <section id='course-details' class='full-width course-details'>
   {{ilios-course-details
     course=model
-    availableTopics=availableTopics
     collapsed=collapsed
     collapsedState='collapsedState'
   }}

--- a/app/templates/session/index.hbs
+++ b/app/templates/session/index.hbs
@@ -3,7 +3,6 @@
   {{session-details
     session=model
     course=courseController.model
-    availableTopics=courseController.availableTopics
     programs=courseController.programs
     sessionTypes=sessionController.sessionTypes
   }}


### PR DESCRIPTION
Course and Program Year now load much faster since the list of available topics is not loaded until it is needed.
Fixes #820

The topic manager now works with a buffer instead of on the subject directly.  So when you pick new topics, but do not save them they don’t show up other places on the page.

I also added a spinner to icon when topics are being saved.  I think we can use this on all the managers, see what you think.

Fixes #629

Review link: http://56249ae971e20a33b200001d.zoo-keeper-levels-51188.netlify.com