### PR TITLE
select options update on subgroup creation

### DIFF
--- a/app/components/learnergroup-members-multiedit.js
+++ b/app/components/learnergroup-members-multiedit.js
@@ -21,7 +21,7 @@ export default Component.extend(MembersMixin, {
   optionLabelPath: 'title',
   optionValuePath: 'id',
 
-  proxiedOptions: computed('learnerGroupOptions.@each', 'optionLabelPath', 'optionValuePath', function() {
+  proxiedOptions: computed('learnerGroupOptions.[]', 'optionLabelPath', 'optionValuePath', function() {
     let options = this.get('learnerGroupOptions');
 
     let objectProxy = ObjectProxy.extend({

--- a/app/mixins/members.js
+++ b/app/mixins/members.js
@@ -19,7 +19,7 @@ export default Mixin.create({
   overrideCurrentGroupDisplay: false,
   saving: false,
 
-  learnerGroupOptions: computed('cohort', 'topLevelGroup', 'topLevelGroup.allTreeGroups.[]', 'showMoveToCohortOption', 'showMoveToTopLevelGroupOption', function() {
+  learnerGroupOptions: computed('cohort', 'topLevelGroup', 'topLevelGroup.allTreeGroups.[]', 'showMoveToCohortOption', 'showMoveToTopLevelGroupOption', 'cohort.learnerGroups.[]', function() {
     let defer = RSVP.defer();
 
     this.get('cohort').then((cohort) => {


### PR DESCRIPTION
Select options now updates themselves on sub-group creation. No more page refreshing necessary.

Fixes #730 