### PR TITLE
Add search to add course / session learning material

### DIFF
--- a/app/components/learningmaterial-search.js
+++ b/app/components/learningmaterial-search.js
@@ -1,0 +1,78 @@
+import Ember from 'ember';
+
+const {inject, run, computed} = Ember;
+const {service} = inject;
+const {debounce} = run;
+const {or, notEmpty} = computed;
+
+export default Ember.Component.extend({
+  store: service(),
+  i18n: service(),
+  classNames: ['learningmaterial-search'],
+  results: [],
+  currentMaterials: [],
+  searching: false,
+  showMoreInputPrompt: false,
+  showNoResultsMessage: false,
+  currentlySearchingForTerm: false,
+  hasResults: notEmpty('results'),
+  showList: or('searching', 'showMoreInputPrompt', 'showNoResultsMessage', 'hasResults'),
+  actions: {
+    clear() {
+      let input = this.$('input')[0];
+      input.value = '';
+      this.setProperties({
+        searchTerms: '',
+        showMoreInputPrompt: false,
+        showNoResultsMessage: false,
+        searching: false,
+        results: [],
+        showClearButton: false,
+      });
+    },
+    inputValueChanged(){
+      let input = this.$('input')[0];
+      let searchTerms = input.value;
+      if(this.get('currentlySearchingForTerm') === searchTerms){
+        return;
+      }
+      this.setProperties({
+        currentlySearchingForTerm: searchTerms,
+        showMoreInputPrompt: false,
+        showNoResultsMessage: false,
+        searching: false,
+      });
+      let noWhiteSpaceTerm = searchTerms.replace(/ /g,'');
+      if(noWhiteSpaceTerm.length === 0){
+        this.send('clear');
+        return;
+      } else if(noWhiteSpaceTerm.length < 3){
+        this.setProperties({
+          results: [],
+          showMoreInputPrompt: true,
+        });
+        return;
+      }
+      this.set('searching', true);
+      debounce(this, function(){
+        this.send('search', searchTerms);
+      }, 1000);
+    },
+    search(searchTerms){
+      this.set('searching', true);
+      this.get('store').query('learningMaterial', {q: searchTerms}).then(learningMaterials => {
+        let results = learningMaterials.filter(learningMaterial => {
+          return !this.get('currentMaterials').contains(learningMaterial);
+        });
+        this.set('searching', false);
+        if(results.get('length') === 0){
+          this.set('showNoResultsMessage', true);
+        }
+        this.set('results', results.sortBy('title'));
+      });
+    },
+    add(lm){
+      this.sendAction('add', lm);
+    },
+  }
+});

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -267,7 +267,7 @@ export default {
     'copyrightPermission': 'Copyright Permission',
     'copyrightAgreement': "The file I am attempting to upload is my own or I have express permission to reproduce and/or distribute this item and does not contain any protected health information. My use of this file is in compliance with Government and University policies on copyright and information security and my educational program's guidelines for professional conduct. This file also adheres to the Terms and Conditions for this application.",
     'copyrightRationale':'Copyright Rationale',
-
+    'searchPlaceholder': 'Find Learning Material',
   },
   'groupMembers': {
     'filterPlaceholder': 'Filter by name or email',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -267,7 +267,7 @@ export default {
     'copyrightPermission': 'Permisos de Derechos de Autor',
     'copyrightAgreement': "El archivo yo estoy tratando a subir es mi pripio o yo la tengo la autorización expresa a reproducir y/o distribuir esta información y que no contiene ninguna información de la salud protegida. Mi uso de este archivo conforme a Políticas del gobierno y a la Universidad según a la seguridad de copyright e información y las reglas de mi program de estudio a cerca de conducto profesional. Este archivo también adhiere a los Terminos y Condiciones para esta aplicación.",
     'copyrightRationale':'Justificación para Derechos de Autor',
-
+    'searchPlaceholder': 'encontrar material de aprendizaje',
   },
   'groupMembers': {
     'filterPlaceholder': 'Aplicar un Filtro por nombre o email',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -267,7 +267,7 @@ export default {
     'copyrightPermission': "Droit d'auteur",
     'copyrightAgreement': "Le fichier que je tente de télécharger est ma propre ou je avoir la permission expresse à reproduire et / ou distribuer cet article et ne contient pas d'informations de santé protégées . Mon utilisation de ce fichier est en conformité avec les politiques gouvernementales et universitaires sur le droit d'auteur et de la sécurité de l'information et les directives de mon programme d'enseignement de conduite professionnelle . Ce fichier respecte également les Termes et Conditions pour cette application .",
     'copyrightRationale': "Raison du droit d'auteur",
-
+    'searchPlaceholder': "Trouver matières d'étude",
   },
   'groupMembers': {
     'filterPlaceholder': "Filtre par nom ou email",

--- a/app/mirage/config.js
+++ b/app/mirage/config.js
@@ -58,7 +58,17 @@ export default function() {
     this.get('/api/courselearningmaterials/:id', 'courseLearningMaterial');
     this.put('/api/courselearningmaterials/:id', 'courseLearningMaterial');
     this.delete('/api/courselearningmaterials/:id', 'courseLearningMaterial');
-    this.post('/api/courselearningmaterials', 'courseLearningMaterial');
+    this.post('/api/courselearningmaterials', function(db, request) {
+      let attrs = JSON.parse(request.requestBody);
+      let record = db.courseLearningMaterials.insert(attrs);
+      let lm = db.learningMaterials.find(record.learningMaterial);
+      if(lm){
+        lm.courseLearningMaterials.pushObject(record);
+      }
+      return {
+        courseLearningMaterial: record
+      };
+    });
 
     this.get('/api/courses', getAll);
     this.get('/api/courses/:id', 'course');
@@ -232,7 +242,19 @@ export default function() {
     this.get('/api/sessionlearningmaterials/:id', 'sessionLearningMaterial');
     this.put('/api/sessionlearningmaterials/:id', 'sessionLearningMaterial');
     this.delete('/api/sessionlearningmaterials/:id', 'sessionLearningMaterial');
-    this.post('/api/sessionlearningmaterials', 'sessionLearningMaterial');
+    
+    this.post('/api/sessionlearningmaterials', function(db, request) {
+      let attrs = JSON.parse(request.requestBody);
+      let record = db.sessionLearningMaterial.insert(attrs);
+      let lm = db.learningMaterials.find(record.learningMaterial);
+      
+      if(lm){
+        lm.sessionLearningMaterials.pushObject(record);
+      }
+      return {
+        sessionLearningMaterial: record
+      };
+    });
 
     this.get('/api/sessiontypes', getAll);
     this.get('/api/sessiontypes/:id', 'sessionType');

--- a/app/mirage/helpers/get-all.js
+++ b/app/mirage/helpers/get-all.js
@@ -77,6 +77,9 @@ export default function getAll(db, request){
           case 'meshDescriptors':
             comparisonString = (obj.name + obj.annotation).toLowerCase();
             break;
+          case 'learningMaterials':
+            comparisonString = (obj.title).toLowerCase();
+            break;
           default:
             console.log('No Q comparison defined for ' + modelName);
             return false;

--- a/app/styles/components/_detailview.scss
+++ b/app/styles/components/_detailview.scss
@@ -347,3 +347,57 @@ $collapse-control-shadow-grey: #e2e2e2;
     list-style-type: disc;
   }
 }
+
+.learningmaterial-search {
+  display: inline-block;
+  float: right;
+  margin-top: 1em;
+  position: relative;
+  
+  input {
+    height: 2em;
+    width: 200px;
+  }
+
+  .results {
+    @include transition (all .2s ease-in-out);
+    background: $white;
+    border: 1px solid $background-grey;
+    border-radius: $base-border-radius;
+    box-shadow: 0 2px 2px transparentize($black, .8);
+    color: $base-font-color;
+    cursor: pointer;
+    left: 0;
+    max-height: 400px;
+    overflow-x: visible;
+    overflow-y: auto;
+    //this should be absolute, but first we have to move the .global-search
+    //out of the grid.
+    position: relative;
+    top: 0;
+    width: 300px;
+    z-index: 100;
+
+    li {
+      border-bottom: 1px solid $base-border-color;
+      padding: $base-font-size * .6;
+      padding-left: 1em;
+
+      &.active:hover {
+        background-color: $background-grey;
+        cursor: pointer;
+      }
+
+      &.inactive {
+        color: darken($header-grey, 20);
+        font-style: italic;
+      }
+    }
+  }
+  
+  .livesearch-user-email {
+    color: $medium-grey;
+    font-style: italic;
+    padding-right: .2em;
+  }
+}

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -1,7 +1,7 @@
-<section class='detail-block'>
+<section class='detail-block filter-detail-block'>
   <div class='detail-title'>
     {{#unless isManaging}}
-      {{t 'general.learningMaterials'}} ({{materials.length}})
+      {{t 'general.learningMaterials'}} ({{proxyMaterials.length}})
     {{/unless}}
     {{#if isManagingMaterial}}
       <span class='detail-specific-title'>
@@ -13,6 +13,9 @@
         {{t 'courses.objectiveDescriptorTitle'}}
       </span>
     {{/if}}
+  </div>
+  <div class="filter-tools">
+    {{learningmaterial-search add='addLearningMaterial' currentMaterials=parentMaterials}}
   </div>
   <div class='detail-actions'>
     {{#if isManaging}}
@@ -59,7 +62,7 @@
             remove='removeNewLearningMaterial'}}
         {{/each}}
       {{/if}}
-      {{#if materials.length}}
+      {{#if proxyMaterials.length}}
         <table>
           <thead>
             <tr>

--- a/app/templates/components/learningmaterial-search.hbs
+++ b/app/templates/components/learningmaterial-search.hbs
@@ -1,0 +1,24 @@
+<input
+  type="search"
+  placeholder={{t 'learningMaterials.searchPlaceholder'}}
+  incremental=true
+  onsearch={{action "inputValueChanged"}}
+  onkeyup={{action "inputValueChanged"}}
+  results=5
+  autosave='ilios-global-search'
+/>
+<ul class="results {{unless showList 'hidden'}}" {{action 'clear'}}>
+  {{#if searching}}
+    <li>{{t 'general.currentlySearchingPrompt'}}</li>
+  {{else if showMoreInputPrompt}}
+    <li>{{t 'general.moreInputRequiredPrompt'}}</li>
+  {{else if showNoResultsMessage}}
+    <li>{{t 'general.noSearchResultsPrompt'}}</li>
+  {{else}}
+    {{#each results as |learningMaterial|}}
+      <li {{action 'add' learningMaterial}}>
+        {{learningMaterial.title}}
+      </li>
+    {{/each}}
+  {{/if}}
+</ul>

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -4,6 +4,8 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+const {run} = Ember;
+const {later} = run;
 
 var application;
 var fixtures = {};
@@ -60,6 +62,15 @@ module('Acceptance: Course - Learning Materials', {
       citation: 'a citation',
       status: 1,
       courseLearningMaterials: [4],
+    }));
+    fixtures.learningMaterials.pushObject(server.create('learningMaterial',{
+      title: 'Letter to Doc Brown',
+      originalAuthor: 'Marty McFly',
+      owningUser: 4136,
+      status: 1,
+      userRole: 1,
+      copyrightPermission: true,
+      courseLearningMaterials: [],
     }));
     fixtures.courseLearningMaterials = [];
     fixtures.courseLearningMaterials.pushObject(server.create('courseLearningMaterial',{
@@ -543,6 +554,33 @@ test('cancel term changes', function(assert) {
           assert.equal(getElementText(tds.eq(5)), getText(expectedMesh));
         });
       });
+    });
+  });
+});
+
+test('find and add learning material', function(assert) {
+  visit(url);
+  andThen(function() {
+    assert.equal(currentPath(), 'course.index');
+    let container = find('.detail-learning-materials');
+    let rows = find('.detail-content tbody tr', container);
+    assert.equal(rows.length, fixtures.course.learningMaterials.length);
+    
+    let searchBoxInput = find('input', container);
+    fillIn(searchBoxInput, 'doc');
+    triggerEvent(searchBoxInput, 'search');
+    andThen(function(){
+      later(function(){
+        let searchResults = find('.results li', container);
+        assert.equal(searchResults.length, 1);
+        assert.equal(getElementText($(searchResults[0])), getText('Letter to Doc Brown'));
+        click(searchResults[0]);
+        
+        andThen(function(){
+          let rows = find('.detail-content tbody tr', container);
+          assert.equal(rows.length, fixtures.course.learningMaterials.length + 1);
+        });
+      }, 1000);
     });
   });
 });

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -4,6 +4,8 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+const {run} = Ember;
+const {later} = run;
 
 var application;
 var fixtures = {};
@@ -67,6 +69,15 @@ module('Acceptance: Session - Learning Materials', {
       citation: 'a citation',
       status: 1,
       sessionLearningMaterials: [4],
+    }));
+    fixtures.learningMaterials.pushObject(server.create('learningMaterial',{
+      title: 'Letter to Doc Brown',
+      originalAuthor: 'Marty McFly',
+      owningUser: 4136,
+      status: 1,
+      userRole: 1,
+      copyrightPermission: true,
+      courseLearningMaterials: [],
     }));
     fixtures.sessionLearningMaterials = [];
     fixtures.sessionLearningMaterials.pushObject(server.create('sessionLearningMaterial',{
@@ -549,6 +560,33 @@ test('cancel term changes', function(assert) {
           assert.equal(getElementText(tds.eq(5)), getText(expectedMesh));
         });
       });
+    });
+  });
+});
+
+test('find and add learning material', function(assert) {
+  visit(url);
+  andThen(function() {
+    assert.equal(currentPath(), 'course.session.index');
+    let container = find('.detail-learning-materials');
+    let rows = find('.detail-content tbody tr', container);
+    assert.equal(rows.length, fixtures.session.learningMaterials.length);
+    
+    let searchBoxInput = find('input', container);
+    fillIn(searchBoxInput, 'doc');
+    triggerEvent(searchBoxInput, 'search');
+    andThen(function(){
+      later(function(){
+        let searchResults = find('.results li', container);
+        assert.equal(searchResults.length, 1);
+        assert.equal(getElementText($(searchResults[0])), getText('Letter to Doc Brown'));
+        click(searchResults[0]);
+        
+        andThen(function(){
+          let rows = find('.detail-content tbody tr', container);
+          assert.equal(rows.length, fixtures.session.learningMaterials.length + 1);
+        });
+      }, 1000);
     });
   });
 });

--- a/tests/integration/components/learningmaterial-search-test.js
+++ b/tests/integration/components/learningmaterial-search-test.js
@@ -1,0 +1,18 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import tHelper from "ember-i18n/helper";
+
+moduleForComponent('learningmaterial-search', 'Integration | Component | learningmaterial search', {
+  integration: true,
+  beforeEach: function() {
+    this.container.lookup('service:i18n').set('locale', 'en');
+    this.registry.register('helper:t', tHelper);
+  }
+});
+
+test('it renders', function(assert) {
+  assert.expect(1);
+  this.render(hbs`{{learningmaterial-search}}`);
+
+  assert.equal(this.$().text().trim(), '');
+});


### PR DESCRIPTION
Allows the user to find an already created learning material and then
add it to a course or session.  Any LMs that have already been added
are excluded from the results.

We probably need to add some ore context to the results, that can be done later though.

Requires https://github.com/ilios/ilios/pull/1055 to work with the API.  I did add the required endpoints to the dev data so it will work without a proxy for limited testing.  The keywords 'internal' and 'dev' produce results.

Fixes #389