### PR TITLE
stack trace to the console

### DIFF
--- a/app/initializers/error.js
+++ b/app/initializers/error.js
@@ -20,6 +20,7 @@ export default {
       // Global error handler in Ember run loop
       Ember.onerror = (error) => {
         console.log(error);
+        console.error(error.stack);
 
         if (error) {
           controller.addError(error);
@@ -30,6 +31,7 @@ export default {
       // Global error handler for promises
       Ember.RSVP.on('error', (error) => {
         console.log(error);
+        console.error(error.stack);
 
         if (error) {
           controller.addError(error);

--- a/app/styles/components/_error-display.scss
+++ b/app/styles/components/_error-display.scss
@@ -9,6 +9,7 @@
 
 .error-detail {
   border: 1px solid $ilios-orange;
+  overflow: auto;
   padding: 25px;
 
   .error-total {


### PR DESCRIPTION
@jrjohnson Let me know if this solves the issue. I made it so it logs the error object itself and the stack trace. If not, I may need to use [`console.trace()`](https://developer.mozilla.org/en-US/docs/Web/API/Console/trace).

Fixes #913