### PR TITLE
Add our real froala key

### DIFF
--- a/app/initializers/froala.js
+++ b/app/initializers/froala.js
@@ -1,0 +1,13 @@
+/* global $ */
+export function initialize() {
+  //version 1 key
+  $.Editable.DEFAULTS.key = 'vD1Ua1Mf1e1VSYKa1EPYD==';
+  
+  //version 2 key (currently not in use)
+  //$.FroalaEditor.DEFAULTS.key = 'vD1Ua1Mf1e1VSYKa1EPYD==';
+}
+
+export default {
+  name: 'froala',
+  initialize: initialize
+};

--- a/tests/unit/initializers/froala-test.js
+++ b/tests/unit/initializers/froala-test.js
@@ -1,0 +1,24 @@
+/* global $ */
+import Ember from 'ember';
+import { initialize } from '../../../initializers/froala';
+import { module, test } from 'qunit';
+
+var registry, application;
+
+module('Unit | Initializer | froala', {
+  beforeEach: function() {
+    Ember.run(function() {
+      application = Ember.Application.create();
+      registry = application.registry;
+      application.deferReadiness();
+    });
+  }
+});
+
+test('froala key is in the jquery global', function(assert) {
+  initialize(registry, application);
+  
+  let key = $.Editable.DEFAULTS.key;
+  assert.ok(key);
+  assert.ok(key.length > 10);
+});


### PR DESCRIPTION
Maybe a little bit overboard to stick this in an initializer, but it
had to go somewhere.  This kind of leaves the key open in the wild, but
I don’t know how else we would distribute it to partners.