### PR TITLE
Group tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ install:
 
 script:
   - if [ "$SCSS_LINT" = true ]; then scss-lint; fi
+  #ensure that all tests contain a reference to 'helpers/test-groups' hopefully means they are in at least one group
+  - if [ $(grep -rL  'helpers/test-groups' tests/acceptance tests/integration tests/unit) ]; then echo 'One of the test files is not in a group so will not be run'; return 1; else return 0; fi
   - node_modules/.bin/ember test --filter=${TEST_GROUP} --launch=${TESTEM_LAUNCHER};
 
 #encrypted the slack token to post to #info so that it doesn't run on pull requests or forks

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,16 @@ cache:
 
 env:
   global:
-    #set these here becuase they get pulled out by testem saucie
-    - JS_TESTS=true
-    - SCSS_LINT=false
+    - TEST_GROUP='(itga)'
+    - SCSS_LINT=true
     - TESTEM_LAUNCHER='PhantomJS'
-    - SEND_COVERAGE=true
 
 matrix:
   fast_finish: true
   allow_failures:
   include:
-    - env: "JS_TESTS=false SCSS_LINT=true SEND_COVERAGE=false"
+    - env: "TEST_GROUP='(itgb)' SCSS_LINT=false"
+    - env: "TEST_GROUP='(itgc)' SCSS_LINT=false"
 
 
 before_install:
@@ -33,19 +32,14 @@ before_install:
   - "npm install -g npm@^2"
 
 install:
-  - if [ "$JS_TESTS" = true ]; then npm install -g bower; fi
-  - if [ "$JS_TESTS" = true ]; then travis_retry npm install --no-optional; fi
-  - if [ "$JS_TESTS" = true ]; then travis_retry bower install; fi
+  - npm install -g bower;
+  - travis_retry npm install --no-optional;
+  - travis_retry bower install;
   - if [ "$SCSS_LINT" = true ]; then travis_retry gem install scss-lint; fi
 
 script:
   - if [ "$SCSS_LINT" = true ]; then scss-lint; fi
-  - if [ "$JS_TESTS" = true ] && [ "$SEND_COVERAGE" = false ]; then node_modules/.bin/ember test --launch=${TESTEM_LAUNCHER}; fi
-  - if [ "$JS_TESTS" = true ] && [ "$SEND_COVERAGE" = true ]; then node_modules/.bin/ember test --test-page='tests/index.html?hidepassed&coverage' --launch=${TESTEM_LAUNCHER}; fi
-
-after_script:
-  # Destroy the sauce tunnel
-  - if [ "$SEND_COVERAGE" = true ]; then CODECLIMATE_REPO_TOKEN=8c510ad3aa4b1a2a3d504dfdbcc5605e7966c019dc1e9b68a815de50b946ebc6 node_modules/.bin/codeclimate-test-reporter < lcov.dat; fi
+  - node_modules/.bin/ember test --filter=${TEST_GROUP} --launch=${TESTEM_LAUNCHER};
 
 #encrypted the slack token to post to #info so that it doesn't run on pull requests or forks
 notifications:

--- a/tests/acceptance/course/cohorts-test.js
+++ b/tests/acceptance/course/cohorts-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 var url = '/courses/1?details=true';
-module('Acceptance: Course - Cohorts', {
+module('Acceptance: Course - Cohorts' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -4,13 +4,14 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 const {run} = Ember;
 const {later} = run;
 
 var application;
 var fixtures = {};
 var url = '/courses/1?details=true';
-module('Acceptance: Course - Learning Materials', {
+module('Acceptance: Course - Learning Materials' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/mesh-test.js
+++ b/tests/acceptance/course/mesh-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/courses/1?details=true';
-module('Acceptance: Course - Mesh Terms', {
+module('Acceptance: Course - Mesh Terms' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/objectivecreate-test.js
+++ b/tests/acceptance/course/objectivecreate-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 var url = '/courses/1?details=true';
-module('Acceptance: Course - Objective Create', {
+module('Acceptance: Course - Objective Create' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/objectivelist-test.js
+++ b/tests/acceptance/course/objectivelist-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 var url = '/courses/1?details=true';
-module('Acceptance: Course - Objective List', {
+module('Acceptance: Course - Objective List' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/objectivemesh-test.js
+++ b/tests/acceptance/course/objectivemesh-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/courses/1?details=true';
 var fixtures = {};
-module('Acceptance: Course - Objective Mesh Descriptors', {
+module('Acceptance: Course - Objective Mesh Descriptors' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/courses/1?details=true';
 var fixtures = {};
-module('Acceptance: Course with multiple Cohorts - Objective Parents', {
+module('Acceptance: Course with multiple Cohorts - Objective Parents' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/objectiveparents-test.js
+++ b/tests/acceptance/course/objectiveparents-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/courses/1?details=true';
 var fixtures = {};
-module('Acceptance: Course - Objective Parents', {
+module('Acceptance: Course - Objective Parents' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -5,12 +5,13 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 
 var application;
 var fixtures = {};
 var url = '/courses/1';
-module('Acceptance: Course - Overview', {
+module('Acceptance: Course - Overview' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/publicationcheck-test.js
+++ b/tests/acceptance/course/publicationcheck-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
-module('Acceptance: Course - Publication Check', {
+module('Acceptance: Course - Publication Check' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/publish-test.js
+++ b/tests/acceptance/course/publish-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 
-module('Acceptance: Course - Publish', {
+module('Acceptance: Course - Publish' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/ilm-test.js
+++ b/tests/acceptance/course/session/ilm-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 var url = '/courses/1/sessions/1';
-module('Acceptance: Session - Independent Learning', {
+module('Acceptance: Session - Independent Learning' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -4,13 +4,14 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 const {run} = Ember;
 const {later} = run;
 
 var application;
 var fixtures = {};
 var url = '/courses/1/sessions/1';
-module('Acceptance: Session - Learning Materials', {
+module('Acceptance: Session - Learning Materials' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/mesh-test.js
+++ b/tests/acceptance/course/session/mesh-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/courses/1/sessions/1';
-module('Acceptance: Session - Mesh Terms', {
+module('Acceptance: Session - Mesh Terms' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/objectivecreate-test.js
+++ b/tests/acceptance/course/session/objectivecreate-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 var url = '/courses/1/sessions/1';
-module('Acceptance: Session - Objective Create', {
+module('Acceptance: Session - Objective Create' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/objectivelist-test.js
+++ b/tests/acceptance/course/session/objectivelist-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 var url = '/courses/1/sessions/1';
-module('Acceptance: Session - Objective List', {
+module('Acceptance: Session - Objective List' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/objectivemesh-test.js
+++ b/tests/acceptance/course/session/objectivemesh-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/courses/1/sessions/1';
 var fixtures = {};
-module('Acceptance: Session - Objective Mesh Descriptors', {
+module('Acceptance: Session - Objective Mesh Descriptors' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/objectiveparents-test.js
+++ b/tests/acceptance/course/session/objectiveparents-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/courses/1/sessions/1';
 var fixtures = {};
-module('Acceptance: Session - Objective Parents', {
+module('Acceptance: Session - Objective Parents' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -5,13 +5,14 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 
 var application;
 var fixtures = {};
 var url = '/courses/1/sessions/1';
 
-module('Acceptance: Session - Offerings', {
+module('Acceptance: Session - Offerings' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -5,12 +5,13 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 
 var application;
 var fixtures = {};
 var url = '/courses/1/sessions/1';
-module('Acceptance: Session - Overview', {
+module('Acceptance: Session - Overview' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -5,10 +5,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 
 var application;
-module('Acceptance: Session - Publication Check', {
+module('Acceptance: Session - Publication Check' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/publish-test.js
+++ b/tests/acceptance/course/session/publish-test.js
@@ -5,11 +5,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 
-module('Acceptance: Session - Publish', {
+module('Acceptance: Session - Publish' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/session/topics-test.js
+++ b/tests/acceptance/course/session/topics-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 var url = '/courses/1/sessions/1';
-module('Acceptance: Session - Topics', {
+module('Acceptance: Session - Topics' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -5,11 +5,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 var url = '/courses/1';
-module('Acceptance: Course - Session List', {
+module('Acceptance: Course - Session List' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/course/topics-test.js
+++ b/tests/acceptance/course/topics-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 var url = '/courses/1?details=true';
-module('Acceptance: Course - Topics', {
+module('Acceptance: Course - Topics' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 
-module('Acceptance: Courses', {
+module('Acceptance: Courses' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -5,10 +5,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 
-module('Acceptance: Dashboard Calendar', {
+module('Acceptance: Dashboard Calendar' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/four-oh-four-test.js
+++ b/tests/acceptance/four-oh-four-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 
-module('Acceptance: FourOhFour', {
+module('Acceptance: FourOhFour' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/instructorgroup-test.js
+++ b/tests/acceptance/instructorgroup-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/instructorgroups/1';
-module('Acceptance: Instructor Group Details', {
+module('Acceptance: Instructor Group Details' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/instructorgroups-test.js
+++ b/tests/acceptance/instructorgroups-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 
-module('Acceptance: Instructor Groups', {
+module('Acceptance: Instructor Groups' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/learnergroup/membership-test.js
+++ b/tests/acceptance/learnergroup/membership-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/learnergroups/2';
-module('Acceptance: Learner Group - Membership', {
+module('Acceptance: Learner Group - Membership' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/learnergroup/overview-test.js
+++ b/tests/acceptance/learnergroup/overview-test.js
@@ -4,12 +4,13 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 const { isEmpty } = Ember;
 
 var application;
 var url = '/learnergroups/2';
-module('Acceptance: Learner Group - Overview', {
+module('Acceptance: Learner Group - Overview' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/learnergroup/subgroups-test.js
+++ b/tests/acceptance/learnergroup/subgroups-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/learnergroups/1';
-module('Acceptance: Learner Group - Subgroups', {
+module('Acceptance: Learner Group - Subgroups' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 
-module('Acceptance: Learner Groups', {
+module('Acceptance: Learner Groups' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/program/overview-test.js
+++ b/tests/acceptance/program/overview-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/programs/1';
-module('Acceptance: Program - Overview', {
+module('Acceptance: Program - Overview' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -5,10 +5,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/programs/1';
-module('Acceptance: Program - ProgramYear List', {
+module('Acceptance: Program - ProgramYear List' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/program/programyear/competencies-test.js
+++ b/tests/acceptance/program/programyear/competencies-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/programs/1/programyears/1';
-module('Acceptance: Program Year - Competencies', {
+module('Acceptance: Program Year - Competencies' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/program/programyear/objectives-test.js
+++ b/tests/acceptance/program/programyear/objectives-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/programs/1/programyears/1';
-module('Acceptance: Program Year - Objectives', {
+module('Acceptance: Program Year - Objectives' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/program/programyear/overview-test.js
+++ b/tests/acceptance/program/programyear/overview-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/programs/1/programyears/1';
-module('Acceptance: Program Year - Overview', {
+module('Acceptance: Program Year - Overview' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/program/programyear/publicationcheck-test.js
+++ b/tests/acceptance/program/programyear/publicationcheck-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
-module('Acceptance: Program - Publication Check', {
+module('Acceptance: Program - Publication Check' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/program/programyear/publish-test.js
+++ b/tests/acceptance/program/programyear/publish-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 
-module('Acceptance: Program Year - Publish', {
+module('Acceptance: Program Year - Publish' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/program/programyear/stewards-test.js
+++ b/tests/acceptance/program/programyear/stewards-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/programs/1/programyears/1';
-module('Acceptance: Program Year - Stewards', {
+module('Acceptance: Program Year - Stewards' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/program/programyear/topics-test.js
+++ b/tests/acceptance/program/programyear/topics-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/programs/1/programyears/1';
-module('Acceptance: Program Year - Topics', {
+module('Acceptance: Program Year - Topics' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/program/publicationcheck-test.js
+++ b/tests/acceptance/program/publicationcheck-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
-module('Acceptance: Program Year - Publication Check', {
+module('Acceptance: Program Year - Publication Check' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/program/publish-test.js
+++ b/tests/acceptance/program/publish-test.js
@@ -4,11 +4,12 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};
 
-module('Acceptance: Program - Publish', {
+module('Acceptance: Program - Publish' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/acceptance/programs-test.js
+++ b/tests/acceptance/programs-test.js
@@ -4,10 +4,11 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 
-module('Acceptance: Programs', {
+module('Acceptance: Programs' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();

--- a/tests/helpers/test-groups.js
+++ b/tests/helpers/test-groups.js
@@ -1,0 +1,5 @@
+const testGroupPrefix = ' (itg';
+const testGroupSuffix = ')';
+export const a = testGroupPrefix + 'a' + testGroupSuffix;
+export const b = testGroupPrefix + 'b' + testGroupSuffix;
+export const c = testGroupPrefix + 'c' + testGroupSuffix;

--- a/tests/integration/components/dashboard-agenda-test.js
+++ b/tests/integration/components/dashboard-agenda-test.js
@@ -3,6 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
 let today = moment();
 let mockEvents = [
@@ -21,7 +22,7 @@ let blankEventsMock = Ember.Service.extend({
   }
 });
 
-moduleForComponent('dashboard-agenda', 'Integration | Component | dashboard agenda', {
+moduleForComponent('dashboard-agenda', 'Integration | Component | dashboard agenda' + testgroup, {
   integration: true,
   beforeEach: function() {
     this.container.lookup('service:i18n').set('locale', 'en');

--- a/tests/integration/components/dashboard-calendar-test.js
+++ b/tests/integration/components/dashboard-calendar-test.js
@@ -3,6 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 // import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import tHelper from "ember-i18n/helper";
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
 let today = moment();
 let mockEvents = [
@@ -16,7 +17,7 @@ let userEventsMock = Ember.Service.extend({
   }
 });
 
-moduleForComponent('dashboard-calendar', 'Integration | Component | dashboard calendar', {
+moduleForComponent('dashboard-calendar', 'Integration | Component | dashboard calendar' + testgroup, {
   integration: true,
   beforeEach: function() {
     this.container.register('service:mockuserevents', userEventsMock);

--- a/tests/integration/components/dashboard-mycourses-test.js
+++ b/tests/integration/components/dashboard-mycourses-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
-
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
 let mockCourses = [
   Ember.Object.create({title: 'first', level: 4, academicYear: '2012-2013', locked: false, archived: false}),
@@ -36,7 +36,7 @@ let currentUserMockNoCourses = Ember.Service.extend({
 
 
 
-moduleForComponent('dashboard-mycourses', 'Integration | Component | dashboard mycourses', {
+moduleForComponent('dashboard-mycourses', 'Integration | Component | dashboard mycourses' + testgroup, {
   integration: true,
   beforeEach: function() {
     this.container.lookup('service:i18n').set('locale', 'en');

--- a/tests/integration/components/error-display-test.js
+++ b/tests/integration/components/error-display-test.js
@@ -1,8 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('error-display', 'Integration | Component | error display', {
+moduleForComponent('error-display', 'Integration | Component | error display' + testgroup, {
   integration: true,
 
   beforeEach() {

--- a/tests/integration/components/global-search-test.js
+++ b/tests/integration/components/global-search-test.js
@@ -1,8 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('global-search', 'Integration | Component | global search', {
+moduleForComponent('global-search', 'Integration | Component | global search' + testgroup, {
   integration: true,
   beforeEach: function() {
     this.container.lookup('service:i18n').set('locale', 'en');

--- a/tests/integration/components/inplace-html-test.js
+++ b/tests/integration/components/inplace-html-test.js
@@ -1,8 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('inplace-html', 'Integration | Component | inplace html', {
+moduleForComponent('inplace-html', 'Integration | Component | inplace html' + testgroup, {
   integration: true,
 
   beforeEach() {

--- a/tests/integration/components/learningmaterial-search-test.js
+++ b/tests/integration/components/learningmaterial-search-test.js
@@ -1,8 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('learningmaterial-search', 'Integration | Component | learningmaterial search', {
+moduleForComponent('learningmaterial-search', 'Integration | Component | learningmaterial search' + testgroup, {
   integration: true,
   beforeEach: function() {
     this.container.lookup('service:i18n').set('locale', 'en');

--- a/tests/integration/components/offering-editor-learnergroups-test.js
+++ b/tests/integration/components/offering-editor-learnergroups-test.js
@@ -2,8 +2,9 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
 import Ember from 'ember';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('offering-editor-learnergroups', 'Integration | Component | offering editor learnergroups', {
+moduleForComponent('offering-editor-learnergroups', 'Integration | Component | offering editor learnergroups' + testgroup, {
   integration: true,
 
   beforeEach() {

--- a/tests/integration/components/offering-editor-test.js
+++ b/tests/integration/components/offering-editor-test.js
@@ -1,10 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
 const { isEmpty, isPresent } = Ember;
 
-moduleForComponent('offering-editor', 'Integration | Component | offering editor', {
+moduleForComponent('offering-editor', 'Integration | Component | offering editor' + testgroup, {
   integration: true,
 
   beforeEach() {

--- a/tests/integration/components/publish-all-sessions-test.js
+++ b/tests/integration/components/publish-all-sessions-test.js
@@ -2,10 +2,11 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
 import Ember from 'ember';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
 const {RSVP} = Ember;
 
-moduleForComponent('publish-all-sessions', 'Integration | Component | publish all sessions', {
+moduleForComponent('publish-all-sessions', 'Integration | Component | publish all sessions' + testgroup, {
   integration: true,
 
   beforeEach() {

--- a/tests/integration/components/toggle-onoff-test.js
+++ b/tests/integration/components/toggle-onoff-test.js
@@ -1,8 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('toggle-onoff', 'Integration | Component | toggle onoff', {
+moduleForComponent('toggle-onoff', 'Integration | Component | toggle onoff' + testgroup, {
   integration: true,
   beforeEach() {
     this.container.lookup('service:i18n').set('locale', 'en');

--- a/tests/integration/components/toggle-wide-test.js
+++ b/tests/integration/components/toggle-wide-test.js
@@ -1,8 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('toggle-wide', 'Integration | Component | toggle wide', {
+moduleForComponent('toggle-wide', 'Integration | Component | toggle wide' + testgroup, {
   integration: true,
   beforeEach: function() {
     this.container.lookup('service:i18n').set('locale', 'en');

--- a/tests/integration/components/toggle-yesno-test.js
+++ b/tests/integration/components/toggle-yesno-test.js
@@ -1,8 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('toggle-yesno', 'Integration | Component | toggle yesno', {
+moduleForComponent('toggle-yesno', 'Integration | Component | toggle yesno' + testgroup, {
   integration: true,
   beforeEach: function() {
     this.container.lookup('service:i18n').set('locale', 'en');

--- a/tests/integration/components/user-list-test.js
+++ b/tests/integration/components/user-list-test.js
@@ -1,8 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('user-list', 'Integration | Component | user list', {
+moduleForComponent('user-list', 'Integration | Component | user list' + testgroup, {
   integration: true,
   beforeEach: function() {
     this.container.lookup('service:i18n').set('locale', 'en');

--- a/tests/integration/components/wait-saving-test.js
+++ b/tests/integration/components/wait-saving-test.js
@@ -1,8 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('wait-saving', 'Integration | Component | wait saving', {
+moduleForComponent('wait-saving', 'Integration | Component | wait saving' + testgroup, {
   integration: true,
   beforeEach: function() {
     this.container.lookup('service:i18n').set('locale', 'en');

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('adapter:application', 'ApplicationAdapter', {
+moduleFor('adapter:application', 'ApplicationAdapter' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['serializer:foo']
 });

--- a/tests/unit/components/boolean-check-test.js
+++ b/tests/unit/components/boolean-check-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('boolean-check', 'Unit | Component | boolean check', {
+moduleForComponent('boolean-check' + testgroup, 'Unit | Component | boolean check', {
   unit: true
 });
 

--- a/tests/unit/components/click-choice-button-test.js
+++ b/tests/unit/components/click-choice-button-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('click-choice-buttons', 'Unit | Component | click choice buttons', {
+moduleForComponent('click-choice-buttons' + testgroup, 'Unit | Component | click choice buttons', {
   unit: true
 });
 

--- a/tests/unit/components/error-display-test.js
+++ b/tests/unit/components/error-display-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('error-display', 'Unit | Component | error display', {
+moduleForComponent('error-display' + testgroup, 'Unit | Component | error display', {
   unit: true
 });
 

--- a/tests/unit/components/expand-collapse-button-test.js
+++ b/tests/unit/components/expand-collapse-button-test.js
@@ -1,10 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import Ember from 'ember';
 
 const { run } = Ember;
 const { next } = run;
 
-moduleForComponent('expand-collapse-button', 'Unit | Component | expand collapse button', {
+moduleForComponent('expand-collapse-button' + testgroup, 'Unit | Component | expand collapse button', {
   needs: ['helper:fa-icon'],
   unit: true
 });

--- a/tests/unit/components/file-upload-test.js
+++ b/tests/unit/components/file-upload-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('file-upload', 'Unit | Component | file upload', {
+moduleForComponent('file-upload' + testgroup, 'Unit | Component | file upload', {
   // Specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar'],
   unit: true

--- a/tests/unit/components/learnergroup-members-multiedit-test.js
+++ b/tests/unit/components/learnergroup-members-multiedit-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('learnergroup-members-multiedit', 'Unit | Component | learnergroup members multiedit', {
+moduleForComponent('learnergroup-members-multiedit' + testgroup, 'Unit | Component | learnergroup members multiedit', {
   unit: true
 });
 

--- a/tests/unit/components/learnergroup-overview-test.js
+++ b/tests/unit/components/learnergroup-overview-test.js
@@ -1,10 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import Ember from 'ember';
 
 const { run } = Ember;
 const { next } = run;
 
-moduleForComponent('learnergroup-overview', 'Unit | Component | learnergroup overview', {
+moduleForComponent('learnergroup-overview' + testgroup, 'Unit | Component | learnergroup overview', {
   unit: true
 });
 

--- a/tests/unit/components/multiedit-select-test.js
+++ b/tests/unit/components/multiedit-select-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('multiedit-select', 'Unit | Component | multiedit select', {
+moduleForComponent('multiedit-select' + testgroup, 'Unit | Component | multiedit select', {
   needs: ['component:boolean-check'],
   unit: true
 });

--- a/tests/unit/components/offering-editor-learnergroups-test.js
+++ b/tests/unit/components/offering-editor-learnergroups-test.js
@@ -1,7 +1,8 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import Ember from 'ember';
 
-moduleForComponent('offering-editor-learnergroups', 'Unit | Component | offering editor learnergroups', {
+moduleForComponent('offering-editor-learnergroups' + testgroup, 'Unit | Component | offering editor learnergroups', {
   unit: true
 });
 

--- a/tests/unit/components/offering-editor-test.js
+++ b/tests/unit/components/offering-editor-test.js
@@ -1,12 +1,13 @@
 /* global moment */
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import Ember from 'ember';
 
 const { isEmpty, RSVP, run } = Ember;
 const { Promise } = RSVP;
 const { next } = run;
 
-moduleForComponent('offering-editor', 'Unit | Component | offering editor', {
+moduleForComponent('offering-editor' + testgroup, 'Unit | Component | offering editor', {
   unit: true
 });
 

--- a/tests/unit/components/session-offerings-test.js
+++ b/tests/unit/components/session-offerings-test.js
@@ -1,10 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import Ember from 'ember';
 
 const { run } = Ember;
 const { next } = run;
 
-moduleForComponent('session-offerings', 'Unit | Component | session offerings', {
+moduleForComponent('session-offerings' + testgroup, 'Unit | Component | session offerings', {
   unit: true
 });
 

--- a/tests/unit/components/toggle-onoff-test.js
+++ b/tests/unit/components/toggle-onoff-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('toggle-onoff', 'Unit | Component | toggle onoff', {
+moduleForComponent('toggle-onoff' + testgroup, 'Unit | Component | toggle onoff', {
   unit: true
 });
 

--- a/tests/unit/controllers/admin-dashboard-test.js
+++ b/tests/unit/controllers/admin-dashboard-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:admin-dashboard', {
+moduleFor('controller:admin-dashboard', 'Unit | Controller | AdminDashboard ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/application-test.js
+++ b/tests/unit/controllers/application-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:application', 'ApplicationController', {
+moduleFor('controller:application', 'ApplicationController' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/course-test.js
+++ b/tests/unit/controllers/course-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:course', 'CourseController', {
+moduleFor('controller:course', 'CourseController' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/courses-test.js
+++ b/tests/unit/controllers/courses-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:courses', 'CoursesController', {
+moduleFor('controller:courses', 'CoursesController' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/dashboard-test.js
+++ b/tests/unit/controllers/dashboard-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:dashboard', {
+moduleFor('controller:dashboard', 'Unit | Controller | Dashboad ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/instructor-groups-test.js
+++ b/tests/unit/controllers/instructor-groups-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:instructorGroups', {
+moduleFor('controller:instructorGroups', 'Unit | Controller | InstructorGroups ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/learner-groups-test.js
+++ b/tests/unit/controllers/learner-groups-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:learnerGroups', {
+moduleFor('controller:learnerGroups', 'Unit | Controller | LearnerGroups ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/login-test.js
+++ b/tests/unit/controllers/login-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:login', {
+moduleFor('controller:login', 'Unit | Controller | Login ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/navigation-test.js
+++ b/tests/unit/controllers/navigation-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:navigation', 'NavigationController', {
+moduleFor('controller:navigation', 'NavigationController' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/program-test.js
+++ b/tests/unit/controllers/program-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:program', {
+moduleFor('controller:program', 'Unit | Controller | Program ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/program-year-test.js
+++ b/tests/unit/controllers/program-year-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:program-year', {
+moduleFor('controller:program-year', 'Unit | Controller | ProgramYear ' + testgroup, {
   // Specify the other units that are required for this test.
   needs: ['controller:program']
 });

--- a/tests/unit/controllers/program-year/publication-check-test.js
+++ b/tests/unit/controllers/program-year/publication-check-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:program-year/publication-check', {
+moduleFor('controller:program-year/publication-check', 'Unit | Controller | ProgramYearPublicationCheck' + testgroup, {
   // Specify the other units that are required for this test.
   needs: ['controller:program', 'controller:programYear']
 });

--- a/tests/unit/controllers/program/index-test.js
+++ b/tests/unit/controllers/program/index-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:program/index', {
+moduleFor('controller:program/index', 'Unit | Controller | Program / Index ' + testgroup, {
   // Specify the other units that are required for this test.
   needs: ['controller:program']
 });

--- a/tests/unit/controllers/programs-test.js
+++ b/tests/unit/controllers/programs-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:programs', {
+moduleFor('controller:programs', 'Unit | Controller | Programs ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/session-test.js
+++ b/tests/unit/controllers/session-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:session', {
+moduleFor('controller:session', 'Unit | Controller | Session ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/controllers/session/index-test.js
+++ b/tests/unit/controllers/session/index-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:session/index', {
+moduleFor('controller:session/index', 'Unit | Controller | Session / Index ' + testgroup, {
   // Specify the other units that are required for this test.
   needs: ['controller:course', 'controller:session']
 });

--- a/tests/unit/controllers/session/publication-check-test.js
+++ b/tests/unit/controllers/session/publication-check-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:session/publicationCheck', {
+moduleFor('controller:session/publicationCheck', 'Unit | Controller | PublicationCheck ' + testgroup, {
   // Specify the other units that are required for this test.
   needs: ['controller:course', 'controller:session']
 });

--- a/tests/unit/controllers/users-test.js
+++ b/tests/unit/controllers/users-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('controller:users', {
+moduleFor('controller:users', 'Unit | Controller | Users ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/helpers/is-equal-test.js
+++ b/tests/unit/helpers/is-equal-test.js
@@ -1,7 +1,8 @@
 import { isEqual } from '../../../helpers/is-equal';
 import { module, test } from 'qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-module('Unit | Helper | is equal');
+module('Unit | Helper | is equal' + testgroup);
 
 test('correctly compares values', function(assert) {
   var result = isEqual([42, 42]);

--- a/tests/unit/helpers/is-in-test.js
+++ b/tests/unit/helpers/is-in-test.js
@@ -1,7 +1,8 @@
 import { isIn } from '../../../helpers/is-in';
 import { module, test } from 'qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-module('Unit | Helper | is in');
+module('Unit | Helper | is in' + testgroup);
 
 test('correctly calculates if a value is in an array', function(assert) {
   var result = isIn([[42], 42]);

--- a/tests/unit/helpers/not-in-test.js
+++ b/tests/unit/helpers/not-in-test.js
@@ -1,7 +1,8 @@
 import { notIn } from '../../../helpers/not-in';
 import { module, test } from 'qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-module('Unit | Helper | not in');
+module('Unit | Helper | not in' + testgroup);
 
 
 test('correctly calculates if a value is not in an array', function(assert) {

--- a/tests/unit/initializers/froala-test.js
+++ b/tests/unit/initializers/froala-test.js
@@ -2,10 +2,11 @@
 import Ember from 'ember';
 import { initialize } from '../../../initializers/froala';
 import { module, test } from 'qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var registry, application;
 
-module('Unit | Initializer | froala', {
+module('Unit | Initializer | froala' + testgroup, {
   beforeEach: function() {
     Ember.run(function() {
       application = Ember.Application.create();

--- a/tests/unit/mixins/events-test.js
+++ b/tests/unit/mixins/events-test.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import EventMixin from '../../../mixins/events';
 import { module, test } from 'qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-module('Unit | Mixin | events');
+module('Unit | Mixin | events' + testgroup);
 
 // Replace this with your real tests.
 test('it works', function(assert) {

--- a/tests/unit/mixins/inplace-test.js
+++ b/tests/unit/mixins/inplace-test.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import InplaceMixin from '../../../mixins/inplace';
 import { module, test } from 'qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-module('InplaceMixin');
+module('InplaceMixin' + testgroup);
 
 // Replace this with your real tests.
 test('it works', function(assert) {

--- a/tests/unit/mixins/live-search-item-test.js
+++ b/tests/unit/mixins/live-search-item-test.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import LiveSearchItemMixin from 'ilios/mixins/live-search-item';
 import { module, test } from 'qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-module('LiveSearchItemMixin');
+module('LiveSearchItemMixin' + testgroup);
 
 // Replace this with your real tests.
 test('it works', function(assert) {

--- a/tests/unit/mixins/publishable-model-test.js
+++ b/tests/unit/mixins/publishable-model-test.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import PublishableModelMixin from '../../../mixins/publishable-model';
 import { module, test } from 'qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-module('Unit | Mixin | publishable model');
+module('Unit | Mixin | publishable model' + testgroup);
 
 // Replace this with your real tests.
 test('it works', function(assert) {

--- a/tests/unit/mixins/publishable-test.js
+++ b/tests/unit/mixins/publishable-test.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import PublishableMixin from '../../../mixins/publishable';
 import { module, test } from 'qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-module('Unit | Mixin | publishable');
+module('Unit | Mixin | publishable' + testgroup);
 
 // Replace this with your real tests.
 test('it works', function(assert) {

--- a/tests/unit/models/aamc-method-test.js
+++ b/tests/unit/models/aamc-method-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('aamc-method', 'AamcMethod', {
+moduleForModel('aamc-method', 'Unit | Model | AamcMethod' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/aamc-pcrs-test.js
+++ b/tests/unit/models/aamc-pcrs-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('aamc-pcrs', 'AamcPcrs', {
+moduleForModel('aamc-pcrs', 'Unit | Model | AamcPcrs' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/academic-year-test.js
+++ b/tests/unit/models/academic-year-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('academic-year', 'AcademicYear', {
+moduleForModel('academic-year', 'Unit | Model | AcademicYear' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/alert-change-type-test.js
+++ b/tests/unit/models/alert-change-type-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('alert-change-type', 'AlertChangeType', {
+moduleForModel('alert-change-type', 'Unit | Model | AlertChangeType' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/alert-test.js
+++ b/tests/unit/models/alert-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('alert', 'Alert', {
+moduleForModel('alert', 'Unit | Model | Alert' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/assessment-option-test.js
+++ b/tests/unit/models/assessment-option-test.js
@@ -1,7 +1,8 @@
 import { moduleForModel, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('assessment-option', 'Unit | Model | assessment option', {
+moduleForModel('assessment-option' + testgroup, 'Unit | Model | assessment option', {
   needs: modelList
 });
 

--- a/tests/unit/models/cohort-test.js
+++ b/tests/unit/models/cohort-test.js
@@ -2,6 +2,7 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 import Ember from 'ember';
 
@@ -9,7 +10,7 @@ let needs = modelList;
 needs.pushObject('service:i18n');
 needs.pushObject('locale:en/translations');
 
-moduleForModel('cohort', 'Cohort', {
+moduleForModel('cohort', 'Unit | Model | Cohort' + testgroup, {
   needs
 });
 

--- a/tests/unit/models/competency-test.js
+++ b/tests/unit/models/competency-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('competency', 'Competency', {
+moduleForModel('competency', 'Unit | Model | Competency' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/course-clerkship-type-test.js
+++ b/tests/unit/models/course-clerkship-type-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('course-clerkship-type', {
+moduleForModel('course-clerkship-type', 'Unit | Model | course-clerkship-type' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/course-learning-material-test.js
+++ b/tests/unit/models/course-learning-material-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('course-learning-material', 'CourseLearningMaterial', {
+moduleForModel('course-learning-material', 'Unit | Model | CourseLearningMaterial' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('course', 'Course', {
+moduleForModel('course', 'Unit | Model | Course' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/curriculum-inventory-academic-level-test.js
+++ b/tests/unit/models/curriculum-inventory-academic-level-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('curriculum-inventory-academic-level', 'CurriculumInventoryAcademicLevel', {
+moduleForModel('curriculum-inventory-academic-level', 'Unit | Model | CurriculumInventoryAcademicLevel' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/curriculum-inventory-export-test.js
+++ b/tests/unit/models/curriculum-inventory-export-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('curriculum-inventory-export', 'CurriculumInventoryExport', {
+moduleForModel('curriculum-inventory-export', 'Unit | Model | CurriculumInventoryExport' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/curriculum-inventory-institution-test.js
+++ b/tests/unit/models/curriculum-inventory-institution-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('curriculum-inventory-institution', 'CurriculumInventoryInstitution', {
+moduleForModel('curriculum-inventory-institution', 'Unit | Model | CurriculumInventoryInstitution' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/curriculum-inventory-report-test.js
+++ b/tests/unit/models/curriculum-inventory-report-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('curriculum-inventory-report', 'CurriculumInventoryReport', {
+moduleForModel('curriculum-inventory-report', 'Unit | Model | CurriculumInventoryReport' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/curriculum-inventory-sequence-block-session-test.js
+++ b/tests/unit/models/curriculum-inventory-sequence-block-session-test.js
@@ -1,7 +1,8 @@
 import { moduleForModel, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('curriculum-inventory-sequence-block-session', 'Unit | Model | curriculum inventory sequence block session', {
+moduleForModel('curriculum-inventory-sequence-block-session' + testgroup, 'Unit | Model | curriculum inventory sequence block session', {
   needs: modelList
 });
 

--- a/tests/unit/models/curriculum-inventory-sequence-block-test.js
+++ b/tests/unit/models/curriculum-inventory-sequence-block-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('curriculum-inventory-sequence-block', 'CurriculumInventorySequenceBlock', {
+moduleForModel('curriculum-inventory-sequence-block', 'Unit | Model | CurriculumInventorySequenceBlock' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/curriculum-inventory-sequence-test.js
+++ b/tests/unit/models/curriculum-inventory-sequence-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('curriculum-inventory-sequence', 'CurriculumInventorySequence', {
+moduleForModel('curriculum-inventory-sequence', 'Unit | Model | CurriculumInventorySequence' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/department-test.js
+++ b/tests/unit/models/department-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('department', 'Department', {
+moduleForModel('department', 'Unit | Model | Department' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/ilm-session-test.js
+++ b/tests/unit/models/ilm-session-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('ilm-session', 'IlmSession', {
+moduleForModel('ilm-session', 'Unit | Model | IlmSession' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/ingestion-exception-test.js
+++ b/tests/unit/models/ingestion-exception-test.js
@@ -1,7 +1,8 @@
 import { moduleForModel, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('ingestion-exception', 'Unit | Model | ingestion exception', {
+moduleForModel('ingestion-exception' + testgroup, 'Unit | Model | ingestion exception', {
   needs: modelList
 });
 

--- a/tests/unit/models/instructor-group-test.js
+++ b/tests/unit/models/instructor-group-test.js
@@ -2,10 +2,11 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import Ember from 'ember';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('instructor-group', 'InstructorGroup', {
+moduleForModel('instructor-group', 'Unit | Model | InstructorGroup' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -2,10 +2,11 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 import Ember from 'ember';
 
-moduleForModel('learner-group', 'LearnerGroup', {
+moduleForModel('learner-group', 'Unit | Model | LearnerGroup' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/learning-material-status-test.js
+++ b/tests/unit/models/learning-material-status-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('learning-material-status', 'LearningMaterialStatus', {
+moduleForModel('learning-material-status', 'Unit | Model | LearningMaterialStatus' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/learning-material-test.js
+++ b/tests/unit/models/learning-material-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('learning-material', 'LearningMaterial', {
+moduleForModel('learning-material', 'Unit | Model | LearningMaterial' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/learning-material-user-role-test.js
+++ b/tests/unit/models/learning-material-user-role-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('learning-material-user-role', 'LearningMaterialUserRole', {
+moduleForModel('learning-material-user-role', 'Unit | Model | LearningMaterialUserRole' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/mesh-concept-test.js
+++ b/tests/unit/models/mesh-concept-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('mesh-concept', 'MeshConcept', {
+moduleForModel('mesh-concept', 'Unit | Model | MeshConcept' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/mesh-descriptor-test.js
+++ b/tests/unit/models/mesh-descriptor-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('mesh-descriptor', 'MeshDescriptor', {
+moduleForModel('mesh-descriptor', 'Unit | Model | MeshDescriptor' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/mesh-previous-indexing-test.js
+++ b/tests/unit/models/mesh-previous-indexing-test.js
@@ -1,7 +1,8 @@
 import { moduleForModel, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('mesh-previous-indexing', 'Unit | Model | mesh previous indexing', {
+moduleForModel('mesh-previous-indexing' + testgroup, 'Unit | Model | mesh previous indexing', {
   needs: modelList
 });
 

--- a/tests/unit/models/mesh-qualifier-test.js
+++ b/tests/unit/models/mesh-qualifier-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('mesh-qualifier', 'MeshQualifier', {
+moduleForModel('mesh-qualifier', 'Unit | Model | MeshQualifier' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/mesh-tree-test.js
+++ b/tests/unit/models/mesh-tree-test.js
@@ -1,7 +1,8 @@
 import { moduleForModel, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('mesh-tree', 'Unit | Model | mesh tree', {
+moduleForModel('mesh-tree' + testgroup, 'Unit | Model | mesh tree', {
   needs: modelList
 });
 

--- a/tests/unit/models/objective-test.js
+++ b/tests/unit/models/objective-test.js
@@ -2,11 +2,12 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 import Ember from 'ember';
 let {run} = Ember;
 
-moduleForModel('objective', 'Objective', {
+moduleForModel('objective', 'Unit | Model | Objective' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/offering-test.js
+++ b/tests/unit/models/offering-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('offering', 'Offering', {
+moduleForModel('offering', 'Unit | Model | Offering' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/program-test.js
+++ b/tests/unit/models/program-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('program', 'Program', {
+moduleForModel('program', 'Unit | Model | Program' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/program-year-steward-test.js
+++ b/tests/unit/models/program-year-steward-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('program-year-steward', {
+moduleForModel('program-year-steward', 'Unit | Model | program-year-steward' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/program-year-test.js
+++ b/tests/unit/models/program-year-test.js
@@ -3,9 +3,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('program-year', 'ProgramYear', {
+moduleForModel('program-year', 'Unit | Model | ProgramYear' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/publish-event-test.js
+++ b/tests/unit/models/publish-event-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('publish-event', 'PublishEvent', {
+moduleForModel('publish-event', 'Unit | Model | PublishEvent' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/report-test.js
+++ b/tests/unit/models/report-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('report', 'Report', {
+moduleForModel('report', 'Unit | Model | Report' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/school-test.js
+++ b/tests/unit/models/school-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('school', 'School', {
+moduleForModel('school', 'Unit | Model | School' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/session-description-test.js
+++ b/tests/unit/models/session-description-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('session-description', 'SessionDescription', {
+moduleForModel('session-description', 'Unit | Model | SessionDescription' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/session-learning-material-test.js
+++ b/tests/unit/models/session-learning-material-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('session-learning-material', 'SessionLearningMaterial', {
+moduleForModel('session-learning-material', 'Unit | Model | SessionLearningMaterial' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -2,10 +2,11 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import Ember from 'ember';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('session', 'Session', {
+moduleForModel('session', 'Unit | Model | Session' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/session-type-test.js
+++ b/tests/unit/models/session-type-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('session-type', 'SessionType', {
+moduleForModel('session-type', 'Unit | Model | SessionType' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/topic-test.js
+++ b/tests/unit/models/topic-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('topic', 'Topic', {
+moduleForModel('topic', 'Unit | Model | Topic' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/user-role-test.js
+++ b/tests/unit/models/user-role-test.js
@@ -2,9 +2,10 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('user-role', 'UserRole', {
+moduleForModel('user-role', 'Unit | Model | UserRole' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -2,10 +2,11 @@ import {
   moduleForModel,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import Ember from 'ember';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('user', 'User', {
+moduleForModel('user', 'Unit | Model | User' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/routes/admin-dashboard-test.js
+++ b/tests/unit/routes/admin-dashboard-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:admin-dashboard', 'Unit | Route | admin dashboard', {
+moduleFor('route:admin-dashboard' + testgroup, 'Unit | Route | admin dashboard', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:application', 'Unit | Route | application', {
+moduleFor('route:application' + testgroup, 'Unit | Route | application', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/course-test.js
+++ b/tests/unit/routes/course-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:course', 'CourseRoute', {
+moduleFor('route:course', 'CourseRoute' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/course/index-test.js
+++ b/tests/unit/routes/course/index-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:course/index', {
+moduleFor('route:course/index', 'Unit | Controller | Course/Index ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/courses-test.js
+++ b/tests/unit/routes/courses-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:courses', 'CoursesRoute', {
+moduleFor('route:courses', 'CoursesRoute' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/dashboard-test.js
+++ b/tests/unit/routes/dashboard-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:dashboard', 'DashboardRoute', {
+moduleFor('route:dashboard', 'DashboardRoute' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/events-test.js
+++ b/tests/unit/routes/events-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:events', 'Unit | Route | events', {
+moduleFor('route:events' + testgroup, 'Unit | Route | events', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/index-test.js
+++ b/tests/unit/routes/index-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:index', 'IndexRoute', {
+moduleFor('route:index', 'IndexRoute' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/instructor-group-test.js
+++ b/tests/unit/routes/instructor-group-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:instructor-group', 'Unit | Route | instructor group', {
+moduleFor('route:instructor-group' + testgroup, 'Unit | Route | instructor group', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/instructor-groups-test.js
+++ b/tests/unit/routes/instructor-groups-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:instructorGroups', 'InstructorGroupsRoute', {
+moduleFor('route:instructorGroups', 'InstructorGroupsRoute' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/learner-group-test.js
+++ b/tests/unit/routes/learner-group-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:learner-group', {
+moduleFor('route:learner-group', 'Unit | Controller | LearnerGroup ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/learner-groups-test.js
+++ b/tests/unit/routes/learner-groups-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:learnerGroups', {
+moduleFor('route:learnerGroups', 'Unit | Controller | LearnerGroups ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/loading-test.js
+++ b/tests/unit/routes/loading-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:loading', 'LoadingRoute', {
+moduleFor('route:loading', 'LoadingRoute' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/login-test.js
+++ b/tests/unit/routes/login-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:login', 'Unit | Route | login', {
+moduleFor('route:login' + testgroup, 'Unit | Route | login', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/print-course-test.js
+++ b/tests/unit/routes/print-course-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:print-course', {
+moduleFor('route:print-course', 'Unit | Controller | PrintCourse ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/program-test.js
+++ b/tests/unit/routes/program-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:program', {
+moduleFor('route:program', 'Unit | Route | Program ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/program/index-test.js
+++ b/tests/unit/routes/program/index-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:program/index', {
+moduleFor('route:program/index', 'Unit | Route | Program/Index ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/program/publication-check-test.js
+++ b/tests/unit/routes/program/publication-check-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:program/publicationCheck', {
+moduleFor('route:program/publicationCheck', 'Unit | Route | PublicationCheck ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/programs-test.js
+++ b/tests/unit/routes/programs-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:programs', {
+moduleFor('route:programs', 'Unit | Route | Programs ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/session-test.js
+++ b/tests/unit/routes/session-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:session', {
+moduleFor('route:session', 'Unit | Route | Session ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/session/publication-check-test.js
+++ b/tests/unit/routes/session/publication-check-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:session/publicationCheck', {
+moduleFor('route:session/publicationCheck', 'Unit | Route | Session/PublicationCheck ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/test-models-test.js
+++ b/tests/unit/routes/test-models-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:test-models', 'TestmodelsRoute', {
+moduleFor('route:test-models' + testgroup, 'TestmodelsRoute', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/user-test.js
+++ b/tests/unit/routes/user-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:user', 'Unit | Route | user', {
+moduleFor('route:user' + testgroup, 'Unit | Route | user', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/users-test.js
+++ b/tests/unit/routes/users-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:users', 'Unit | Route | users', {
+moduleFor('route:users' + testgroup, 'Unit | Route | users', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/serializers/publish-event-test.js
+++ b/tests/unit/serializers/publish-event-test.js
@@ -1,6 +1,7 @@
 import { moduleForModel, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForModel('publish-event', 'Unit | Serializer | publish event', {
+moduleForModel('publish-event' + testgroup, 'Unit | Serializer | publish event', {
   needs: [
     'serializer:publish-event',
     'model:course',

--- a/tests/unit/serializers/session-test.js
+++ b/tests/unit/serializers/session-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('serializer:session', {
+moduleFor('serializer:session', 'Unit | Serializer | Session ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['serializer:foo']
 });

--- a/tests/unit/services/current-user-test.js
+++ b/tests/unit/services/current-user-test.js
@@ -2,8 +2,9 @@ import {
   moduleFor,
   test
 } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('service:current-user', 'CurrentUserService', {
+moduleFor('service:current-user', 'CurrentUserService' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['service:foo']
 });

--- a/tests/unit/services/school-events-test.js
+++ b/tests/unit/services/school-events-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('service:school-events', 'Unit | Service | school events', {
+moduleFor('service:school-events', 'Unit | Service | school events' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['service:foo']
 });

--- a/tests/unit/services/user-events-test.js
+++ b/tests/unit/services/user-events-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('service:user-events', 'Unit | Service | user events', {
+moduleFor('service:user-events', 'Unit | Service | user events' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['service:foo']
 });

--- a/tests/unit/translations-test.js
+++ b/tests/unit/translations-test.js
@@ -1,9 +1,10 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import {default as en} from 'ilios/locales/en/translations';
 import {default as es} from 'ilios/locales/es/translations';
 import {default as fr} from 'ilios/locales/fr/translations';
 
-moduleForComponent('ilios-header', 'Unit | Translations', {
+moduleForComponent('ilios-header', 'Unit | Translations' + testgroup, {
   integration: true
 });
 


### PR DESCRIPTION
This is my response to our failing tests.  Hopefully it is temporary and phantom js 2 will become more stable.  I created 2 test groups (itga, itgb, itgc) - stands for Ilios Test Group - and placed our tests in one of those groups.  Even if tests fail they should be easier and faster to restart.

The grouping is done by appending the test group name to the test description and then using the testem filter option to only run those that match the group name.

I added a grep test as well which checks to see that the test-groups helper is imported into each test file.  This is the best I could come up with for a way to check that each set of tests was in at least one group.