### PR TITLE
Add Authorization and limit access to navigation items

### DIFF
--- a/app/abilities/admin-dashboard.js
+++ b/app/abilities/admin-dashboard.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import { Ability } from 'ember-can';
+
+const { inject, computed } = Ember;
+const { service } = inject;
+const { alias } = computed;
+
+export default Ability.extend({
+  currentUser: service(),
+  canView: alias('currentUser.canViewAdminDashboard'),
+});

--- a/app/abilities/courses.js
+++ b/app/abilities/courses.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import { Ability } from 'ember-can';
+
+const { inject, computed } = Ember;
+const { service } = inject;
+const { alias } = computed;
+
+export default Ability.extend({
+  currentUser: service(),
+  canView: alias('currentUser.canViewCourses'),
+});

--- a/app/abilities/courses.js
+++ b/app/abilities/courses.js
@@ -8,4 +8,5 @@ const { alias } = computed;
 export default Ability.extend({
   currentUser: service(),
   canView: alias('currentUser.canViewCourses'),
+  canEdit: alias('currentUser.canEditCourses'),
 });

--- a/app/abilities/instructor-groups.js
+++ b/app/abilities/instructor-groups.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import { Ability } from 'ember-can';
+
+const { inject, computed } = Ember;
+const { service } = inject;
+const { alias } = computed;
+
+export default Ability.extend({
+  currentUser: service(),
+  canView: alias('currentUser.canViewInstructorGroups'),
+});

--- a/app/abilities/instructor-groups.js
+++ b/app/abilities/instructor-groups.js
@@ -8,4 +8,5 @@ const { alias } = computed;
 export default Ability.extend({
   currentUser: service(),
   canView: alias('currentUser.canViewInstructorGroups'),
+  canEdit: alias('currentUser.canEditInstructorGroups'),
 });

--- a/app/abilities/learner-groups.js
+++ b/app/abilities/learner-groups.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import { Ability } from 'ember-can';
+
+const { inject, computed } = Ember;
+const { service } = inject;
+const { alias } = computed;
+
+export default Ability.extend({
+  currentUser: service(),
+  canView: alias('currentUser.canViewLearnerGroups'),
+});

--- a/app/abilities/learner-groups.js
+++ b/app/abilities/learner-groups.js
@@ -8,4 +8,5 @@ const { alias } = computed;
 export default Ability.extend({
   currentUser: service(),
   canView: alias('currentUser.canViewLearnerGroups'),
+  canEdit: alias('currentUser.canEditLearnerGroups'),
 });

--- a/app/abilities/programs.js
+++ b/app/abilities/programs.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import { Ability } from 'ember-can';
+
+const { inject, computed } = Ember;
+const { service } = inject;
+const { alias } = computed;
+
+export default Ability.extend({
+  currentUser: service(),
+  canView: alias('currentUser.canViewPrograms'),
+});

--- a/app/abilities/programs.js
+++ b/app/abilities/programs.js
@@ -8,4 +8,5 @@ const { alias } = computed;
 export default Ability.extend({
   currentUser: service(),
   canView: alias('currentUser.canViewPrograms'),
+  canEdit: alias('currentUser.canEditPrograms'),
 });

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -157,13 +157,15 @@ export default Ember.Component.extend({
             if(!defaultStatus){
               defaultStatus = statuses.get('firstObject');
             }
-            var lm = self.get('store').createRecord('learning-material', {
-              type: type,
-              owningUser: self.get('currentUser.model'),
-              status: defaultStatus,
-              userRole: roles.get('firstObject'),
+            self.get('currentUser').get('model').then(user => {
+              var lm = self.get('store').createRecord('learning-material', {
+                type: type,
+                owningUser: user,
+                status: defaultStatus,
+                userRole: roles.get('firstObject'),
+              });
+              self.get('newLearningMaterials').addObject(lm);
             });
-            self.get('newLearningMaterials').addObject(lm);
           });
         });
       }

--- a/app/components/error-display.js
+++ b/app/components/error-display.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { Component, computed, isPresent } = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend({
   classNames: ['error-display'],

--- a/app/components/ilios-navigation.js
+++ b/app/components/ilios-navigation.js
@@ -3,40 +3,6 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   i18n: Ember.inject.service(),
   isMenuVisible: false,
-  menuItems: Ember.computed('i18n.locale', function(){
-    return [
-      {
-        'icon': 'home',
-        'route': 'dashboard',
-        'name': this.get('i18n').t('navigation.dashboard')
-      },
-      {
-        'icon': 'book',
-        'route': 'courses',
-        'name': this.get('i18n').t('navigation.courses')
-      },
-      {
-        'icon': 'mortar-board',
-        'route': 'learnerGroups',
-        'name': this.get('i18n').t('navigation.learnerGroups')
-      },
-      {
-        'icon': 'user-md',
-        'route': 'instructorGroups',
-        'name': this.get('i18n').t('navigation.instructorGroups')
-      },
-      {
-        'icon': 'list-alt',
-        'route': 'programs',
-        'name': this.get('i18n').t('navigation.programs')
-      },
-      {
-        'icon': 'cogs',
-        'route': 'admin-dashboard',
-        'name': this.get('i18n').t('navigation.admin')
-      },
-    ];
-  }),
   actions: {
     toggleMenuVisibility: function(){
       this.toggleProperty('isMenuVisible');

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -21,6 +21,8 @@ export default Ember.Service.extend({
         } else {
           deferred.resolve(null);
         }
+      }, () => {
+        deferred.resolve(null);
       });
     } else {
       this.get('store').find('user', currentUserId).then(function(user){

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -70,39 +70,51 @@ export default Ember.Service.extend({
   }.property('currentSchool'),
   //will be customizable
   preferredDashboard: 'dashboard.week',
+  //Program
   canViewProgram: computed('model', function(){
     return false;
   }),
+  //Programs
   canViewPrograms: computed('model', function(){
     return false;
   }),
+  //Course
   canViewCourse: computed('model', function(){
     return false;
   }),
+  //Courses
   canViewCourses: computed('model', function(){
     return false;
   }),
+  //Instructor Group
   canViewInstructorGroup: computed('model', function(){
     return false;
   }),
+  //Instructor Groups
   canViewInstructorGroups: computed('model', function(){
     return false;
   }),
+  //Learner Group
   canViewLearnerGroup: computed('model', function(){
     return false;
   }),
+  //Learner Groups
   canViewLearnerGroups: computed('model', function(){
     return false;
   }),
+  //Curriculum Inventory
   canViewCurriculumInventory: computed('model', function(){
     return false;
   }),
+  //Report
   canViewReport: computed('model', function(){
     return false;
   }),
+  //Reports
   canViewReports: computed('model', function(){
     return false;
   }),
+  //Admin Dashboard
   canViewAdminDashboard: computed('model', function(){
     return false;
   }),

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -71,10 +71,14 @@ export default Ember.Service.extend({
   userRoleTitles: computed('model.roles.[]', function(){
     return new Ember.RSVP.Promise((resolve) => {
       this.get('model').then(user => {
-        user.get('roles').then(roles => {
-          let roleTitles = roles.map(role => role.get('title').toLowerCase());
-          resolve(roleTitles);
-        });
+        if(!user){
+          resolve([]);
+        } else {
+          user.get('roles').then(roles => {
+            let roleTitles = roles.map(role => role.get('title').toLowerCase());
+            resolve(roleTitles);
+          });
+        }
       });
     });
   }),

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import ajax from 'ic-ajax';
 
+const { computed } = Ember;
+
 export default Ember.Service.extend({
   store: Ember.inject.service(),
   currentUserId: null,
@@ -68,4 +70,7 @@ export default Ember.Service.extend({
   }.property('currentSchool'),
   //will be customizable
   preferredDashboard: 'dashboard.week',
+  canViewCourses: computed('model', function(){
+    return false;
+  })
 });

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -70,7 +70,40 @@ export default Ember.Service.extend({
   }.property('currentSchool'),
   //will be customizable
   preferredDashboard: 'dashboard.week',
+  canViewProgram: computed('model', function(){
+    return false;
+  }),
+  canViewPrograms: computed('model', function(){
+    return false;
+  }),
+  canViewCourse: computed('model', function(){
+    return false;
+  }),
   canViewCourses: computed('model', function(){
     return false;
-  })
+  }),
+  canViewInstructorGroup: computed('model', function(){
+    return false;
+  }),
+  canViewInstructorGroups: computed('model', function(){
+    return false;
+  }),
+  canViewLearnerGroup: computed('model', function(){
+    return false;
+  }),
+  canViewLearnerGroups: computed('model', function(){
+    return false;
+  }),
+  canViewCurriculumInventory: computed('model', function(){
+    return false;
+  }),
+  canViewReport: computed('model', function(){
+    return false;
+  }),
+  canViewReports: computed('model', function(){
+    return false;
+  }),
+  canViewAdminDashboard: computed('model', function(){
+    return false;
+  }),
 });

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -147,13 +147,15 @@ export default Ember.Service.extend({
     return false;
   }),
   canViewPrograms: false,
-  canViewProgramsObserver: on('init', observer('privileges',
+  canEditPrograms: false,
+  programsPrivilegesObserver: on('init', observer('privileges',
     function(){
       Ember.RSVP.all([
         this.get('userIsCourseDirector'),
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         this.set('canViewPrograms', hasRole.contains(true));
+        this.set('canEditPrograms', hasRole.contains(true));
       });
   })),
   //Course
@@ -161,7 +163,8 @@ export default Ember.Service.extend({
     return false;
   }),
   canViewCourses: false,
-  canViewCoursesObserver: on('init', observer('privileges',
+  canEditCourses: false,
+  coursesPrivilegesObserver: on('init', observer('privileges',
     function(){
       Ember.RSVP.all([
         this.get('userIsCourseDirector'),
@@ -169,16 +172,19 @@ export default Ember.Service.extend({
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         this.set('canViewCourses', hasRole.contains(true));
+        this.set('canEditCourses', hasRole.contains(true));
       });
   })),
   canViewInstructorGroups: false,
-  canViewInstructorGroupsObserver: on('init', observer('privileges',
+  canEditInstructorGroups: false,
+  instructorGroupsPrivilegesObserver: on('init', observer('privileges',
     function(){
       Ember.RSVP.all([
         this.get('userIsCourseDirector'),
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         this.set('canViewInstructorGroups', hasRole.contains(true));
+        this.set('canEditInstructorGroups', hasRole.contains(true));
       });
   })),
   //Instructor Group
@@ -186,13 +192,15 @@ export default Ember.Service.extend({
     return false;
   }),
   canViewLearnerGroups: false,
-  canViewLearnerGroupObserver: on('init', observer('privileges',
+  canEditLearnerGroups: false,
+  learnerGroupsPrivilegesObserver: on('init', observer('privileges',
     function(){
       Ember.RSVP.all([
         this.get('userIsCourseDirector'),
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         this.set('canViewLearnerGroups', hasRole.contains(true));
+        this.set('canEditLearnerGroups', hasRole.contains(true));
       });
   })),
   //Learner Group

--- a/app/templates/components/ilios-navigation.hbs
+++ b/app/templates/components/ilios-navigation.hbs
@@ -5,16 +5,16 @@
 	<nav {{action 'toggleMenuVisibility'}} class="sliding-menu-content {{if isMenuVisible 'is-menu-visible'}}">
 		<ul>
 			<li>{{#link-to 'dashboard'}}{{fa-icon 'home'}} {{t 'navigation.dashboard'}}{{/link-to}}</li>
-			{{#if (can 'view courses')}}
+			{{#if (can 'edit courses')}}
 				<li>{{#link-to 'courses'}}{{fa-icon 'book'}} {{t 'navigation.courses'}}{{/link-to}}</li>
 			{{/if}}
-			{{#if (can 'view learnerGroups')}}
+			{{#if (can 'edit learnerGroups')}}
 				<li>{{#link-to 'learnerGroups'}}{{fa-icon 'mortar-board'}} {{t 'navigation.learnerGroups'}}{{/link-to}}</li>
 			{{/if}}
-			{{#if (can 'view instructorGroups')}}
+			{{#if (can 'edit instructorGroups')}}
 				<li>{{#link-to 'instructorGroups'}}{{fa-icon 'user-md'}} {{t 'navigation.instructorGroups'}}{{/link-to}}</li>
 			{{/if}}
-			{{#if (can 'view programs')}}
+			{{#if (can 'edit programs')}}
 				<li>{{#link-to 'programs'}}{{fa-icon 'list-alt'}} {{t 'navigation.programs'}}{{/link-to}}</li>
 			{{/if}}
 			{{#if (can 'view adminDashboard')}}

--- a/app/templates/components/ilios-navigation.hbs
+++ b/app/templates/components/ilios-navigation.hbs
@@ -4,9 +4,12 @@
 	</a>
 	<nav {{action 'toggleMenuVisibility'}} class="sliding-menu-content {{if isMenuVisible 'is-menu-visible'}}">
 		<ul>
-      {{#each menuItems as |item|}}
-        <li>{{#link-to item.route}}{{fa-icon item.icon}} {{item.name}}{{/link-to}}</li>
-      {{/each}}
+			<li>{{#link-to 'dashboard'}}{{fa-icon 'home'}} {{t 'navigation.dashboard'}}{{/link-to}}</li>
+			<li>{{#link-to 'courses'}}{{fa-icon 'book'}} {{t 'navigation.courses'}}{{/link-to}}</li>
+			<li>{{#link-to 'learnerGroups'}}{{fa-icon 'mortar-board'}} {{t 'navigation.learnerGroups'}}{{/link-to}}</li>
+			<li>{{#link-to 'instructorGroups'}}{{fa-icon 'user-md'}} {{t 'navigation.instructorGroups'}}{{/link-to}}</li>
+			<li>{{#link-to 'programs'}}{{fa-icon 'list-alt'}} {{t 'navigation.programs'}}{{/link-to}}</li>
+			<li>{{#link-to 'admin-dashboard'}}{{fa-icon 'cogs'}} {{t 'navigation.admin'}}{{/link-to}}</li>
 		</ul>
 	</nav>
 	<div {{action 'toggleMenuVisibility'}} class="menu-screen {{if isMenuVisible 'is-menu-visible'}}"></div>

--- a/app/templates/components/ilios-navigation.hbs
+++ b/app/templates/components/ilios-navigation.hbs
@@ -5,7 +5,9 @@
 	<nav {{action 'toggleMenuVisibility'}} class="sliding-menu-content {{if isMenuVisible 'is-menu-visible'}}">
 		<ul>
 			<li>{{#link-to 'dashboard'}}{{fa-icon 'home'}} {{t 'navigation.dashboard'}}{{/link-to}}</li>
-			<li>{{#link-to 'courses'}}{{fa-icon 'book'}} {{t 'navigation.courses'}}{{/link-to}}</li>
+			{{#if (can 'view courses')}}
+				<li>{{#link-to 'courses'}}{{fa-icon 'book'}} {{t 'navigation.courses'}}{{/link-to}}</li>
+			{{/if}}
 			<li>{{#link-to 'learnerGroups'}}{{fa-icon 'mortar-board'}} {{t 'navigation.learnerGroups'}}{{/link-to}}</li>
 			<li>{{#link-to 'instructorGroups'}}{{fa-icon 'user-md'}} {{t 'navigation.instructorGroups'}}{{/link-to}}</li>
 			<li>{{#link-to 'programs'}}{{fa-icon 'list-alt'}} {{t 'navigation.programs'}}{{/link-to}}</li>

--- a/app/templates/components/ilios-navigation.hbs
+++ b/app/templates/components/ilios-navigation.hbs
@@ -8,10 +8,18 @@
 			{{#if (can 'view courses')}}
 				<li>{{#link-to 'courses'}}{{fa-icon 'book'}} {{t 'navigation.courses'}}{{/link-to}}</li>
 			{{/if}}
-			<li>{{#link-to 'learnerGroups'}}{{fa-icon 'mortar-board'}} {{t 'navigation.learnerGroups'}}{{/link-to}}</li>
-			<li>{{#link-to 'instructorGroups'}}{{fa-icon 'user-md'}} {{t 'navigation.instructorGroups'}}{{/link-to}}</li>
-			<li>{{#link-to 'programs'}}{{fa-icon 'list-alt'}} {{t 'navigation.programs'}}{{/link-to}}</li>
-			<li>{{#link-to 'admin-dashboard'}}{{fa-icon 'cogs'}} {{t 'navigation.admin'}}{{/link-to}}</li>
+			{{#if (can 'view learnerGroups')}}
+				<li>{{#link-to 'learnerGroups'}}{{fa-icon 'mortar-board'}} {{t 'navigation.learnerGroups'}}{{/link-to}}</li>
+			{{/if}}
+			{{#if (can 'view instructorGroups')}}
+				<li>{{#link-to 'instructorGroups'}}{{fa-icon 'user-md'}} {{t 'navigation.instructorGroups'}}{{/link-to}}</li>
+			{{/if}}
+			{{#if (can 'view programs')}}
+				<li>{{#link-to 'programs'}}{{fa-icon 'list-alt'}} {{t 'navigation.programs'}}{{/link-to}}</li>
+			{{/if}}
+			{{#if (can 'view adminDashboard')}}
+				<li>{{#link-to 'admin-dashboard'}}{{fa-icon 'cogs'}} {{t 'navigation.admin'}}{{/link-to}}</li>
+			{{/if}}
 		</ul>
 	</nav>
 	<div {{action 'toggleMenuVisibility'}} class="menu-screen {{if isMenuVisible 'is-menu-visible'}}"></div>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "broccoli-sass": "^0.6.4",
     "codeclimate-test-reporter": "~0.1.0",
     "elemental-calendar": "0.0.7",
+    "ember-can": "0.7.0",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
     "ember-cli-autoprefixer": "0.5.0",

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -17,10 +17,6 @@ module('Acceptance: Course - Overview' + testgroup, {
   beforeEach: function() {
     application = startApp();
     authenticateSession();
-    server.create('user', {
-      id: 4136,
-      roles: [1]
-    });
     server.create('school');
     fixtures.clerkshipTypes = [];
     fixtures.clerkshipTypes.pushObjects(server.createList('courseClerkshipType', 2));
@@ -32,6 +28,9 @@ module('Acceptance: Course - Overview' + testgroup, {
 });
 
 test('check fields', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
   server.create('user', {
     directedCourses: [1],
     firstName: 'A',
@@ -65,6 +64,9 @@ test('check fields', function(assert) {
 });
 
 test('check detail fields', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
   var course = server.create('course', {
     year: 2013,
     school: 1,
@@ -91,6 +93,9 @@ test('check detail fields', function(assert) {
 });
 
 test('pick clerkship type', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
   server.create('course', {
     year: 2013,
     school: 1,
@@ -122,6 +127,9 @@ test('pick clerkship type', function(assert) {
 });
 
 test('remove clerkship type', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
   server.create('course', {
     year: 2013,
     school: 1,
@@ -146,6 +154,9 @@ test('remove clerkship type', function(assert) {
 });
 
 test('open and close details', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
   server.create('course', {
     year: 2013,
     school: 1
@@ -173,6 +184,9 @@ test('open and close details', function(assert) {
 });
 
 test('change title', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
   server.create('course', {
     year: 2013,
     school: 1,
@@ -199,6 +213,9 @@ test('change title', function(assert) {
 });
 
 test('change start date', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
   var course = server.create('course', {
     year: 2013,
     school: 1,
@@ -230,6 +247,9 @@ test('change start date', function(assert) {
 });
 
 test('change end date', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
   var course = server.create('course', {
     year: 2013,
     school: 1,
@@ -261,6 +281,9 @@ test('change end date', function(assert) {
 });
 
 test('change externalId', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
   server.create('course', {
     year: 2013,
     school: 1,
@@ -288,6 +311,9 @@ test('change externalId', function(assert) {
 });
 
 test('change level', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
   server.create('course', {
     year: 2013,
     school: 1,
@@ -318,6 +344,9 @@ test('change level', function(assert) {
 
 test('remove director', function(assert) {
   server.create('user', {
+    id: 4136
+  });
+  server.create('user', {
     directedCourses: [1],
     firstName: 'A',
     lastName: 'Director'
@@ -339,7 +368,13 @@ test('remove director', function(assert) {
 
 
 test('manage directors', function(assert) {
-
+  server.create('user', {
+    id: 4136,
+    roles: [1],
+  });
+  server.create('userRole', {
+    users: [1, 2, 4136]
+  });
   server.create('user', {
     directedCourses: [1],
     firstName: 'Added',
@@ -351,6 +386,10 @@ test('manage directors', function(assert) {
     lastName: 'Guy',
     enabled: false,
     roles: [1]
+  });
+  
+  server.create('userRole', {
+    users: [3]
   });
   server.create('user', {
     firstName: 'Not a director',
@@ -398,6 +437,13 @@ test('manage directors', function(assert) {
 //test for a bug where the search results were not cleared between searches
 test('search twice and list should be correct', function(assert) {
   server.create('user', {
+    id: 4136,
+    roles: [1],
+  });
+  server.create('userRole', {
+    users: [1, 4136]
+  });
+  server.create('user', {
     directedCourses: [1],
     firstName: 'Added',
     lastName: 'Guy',
@@ -440,6 +486,9 @@ test('search twice and list should be correct', function(assert) {
 });
 
 test('validations work properly', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
   assert.expect(5);
 
   server.create('course', {

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -8,4 +8,6 @@ resolver.namespace = {
   podModulePrefix: config.podModulePrefix
 };
 
+resolver.pluralizedTypes.ability = 'abilities';
+
 export default resolver;

--- a/tests/unit/abilities/admin-dashboard-test.js
+++ b/tests/unit/abilities/admin-dashboard-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('ability:adminDashboard', 'Unit | Ability | adminDashboard', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var ability = this.subject();
+  assert.ok(ability);
+});

--- a/tests/unit/abilities/courses-test.js
+++ b/tests/unit/abilities/courses-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('ability:courses', 'Unit | Ability | courses', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var ability = this.subject();
+  assert.ok(ability);
+});

--- a/tests/unit/abilities/instructor-groups-test.js
+++ b/tests/unit/abilities/instructor-groups-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('ability:instructorGroups', 'Unit | Ability | instructorGroups', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var ability = this.subject();
+  assert.ok(ability);
+});

--- a/tests/unit/abilities/learner-groups-test.js
+++ b/tests/unit/abilities/learner-groups-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('ability:learnerGroups', 'Unit | Ability | learnerGroups', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var ability = this.subject();
+  assert.ok(ability);
+});

--- a/tests/unit/abilities/programs-test.js
+++ b/tests/unit/abilities/programs-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('ability:programs', 'Unit | Ability | programs', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  var ability = this.subject();
+  assert.ok(ability);
+});

--- a/tests/unit/components/boolean-check-test.js
+++ b/tests/unit/components/boolean-check-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('boolean-check' + testgroup, 'Unit | Component | boolean check', {
+moduleForComponent('boolean-check', 'Unit | Component | boolean check ' + testgroup, {
   unit: true
 });
 

--- a/tests/unit/components/click-choice-button-test.js
+++ b/tests/unit/components/click-choice-button-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('click-choice-buttons' + testgroup, 'Unit | Component | click choice buttons', {
+moduleForComponent('click-choice-buttons', 'Unit | Component | click choice buttons ' + testgroup, {
   unit: true
 });
 

--- a/tests/unit/components/error-display-test.js
+++ b/tests/unit/components/error-display-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('error-display' + testgroup, 'Unit | Component | error display', {
+moduleForComponent('error-display', 'Unit | Component | error display ' + testgroup, {
   unit: true
 });
 

--- a/tests/unit/components/expand-collapse-button-test.js
+++ b/tests/unit/components/expand-collapse-button-test.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 const { run } = Ember;
 const { next } = run;
 
-moduleForComponent('expand-collapse-button' + testgroup, 'Unit | Component | expand collapse button', {
+moduleForComponent('expand-collapse-button', 'Unit | Component | expand collapse button ' + testgroup, {
   needs: ['helper:fa-icon'],
   unit: true
 });

--- a/tests/unit/components/file-upload-test.js
+++ b/tests/unit/components/file-upload-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('file-upload' + testgroup, 'Unit | Component | file upload', {
+moduleForComponent('file-upload', 'Unit | Component | file upload ' + testgroup, {
   // Specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar'],
   unit: true

--- a/tests/unit/components/learnergroup-members-multiedit-test.js
+++ b/tests/unit/components/learnergroup-members-multiedit-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('learnergroup-members-multiedit' + testgroup, 'Unit | Component | learnergroup members multiedit', {
+moduleForComponent('learnergroup-members-multiedit', 'Unit | Component | learnergroup members multiedit ' + testgroup, {
   unit: true
 });
 

--- a/tests/unit/components/learnergroup-overview-test.js
+++ b/tests/unit/components/learnergroup-overview-test.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 const { run } = Ember;
 const { next } = run;
 
-moduleForComponent('learnergroup-overview' + testgroup, 'Unit | Component | learnergroup overview', {
+moduleForComponent('learnergroup-overview', 'Unit | Component | learnergroup overview ' + testgroup, {
   unit: true
 });
 

--- a/tests/unit/components/multiedit-select-test.js
+++ b/tests/unit/components/multiedit-select-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('multiedit-select' + testgroup, 'Unit | Component | multiedit select', {
+moduleForComponent('multiedit-select', 'Unit | Component | multiedit select ' + testgroup, {
   needs: ['component:boolean-check'],
   unit: true
 });

--- a/tests/unit/components/offering-editor-learnergroups-test.js
+++ b/tests/unit/components/offering-editor-learnergroups-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import Ember from 'ember';
 
-moduleForComponent('offering-editor-learnergroups' + testgroup, 'Unit | Component | offering editor learnergroups', {
+moduleForComponent('offering-editor-learnergroups', 'Unit | Component | offering editor learnergroups ' + testgroup, {
   unit: true
 });
 

--- a/tests/unit/components/offering-editor-test.js
+++ b/tests/unit/components/offering-editor-test.js
@@ -7,7 +7,7 @@ const { isEmpty, RSVP, run } = Ember;
 const { Promise } = RSVP;
 const { next } = run;
 
-moduleForComponent('offering-editor' + testgroup, 'Unit | Component | offering editor', {
+moduleForComponent('offering-editor', 'Unit | Component | offering editor ' + testgroup, {
   unit: true
 });
 

--- a/tests/unit/components/session-offerings-test.js
+++ b/tests/unit/components/session-offerings-test.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 const { run } = Ember;
 const { next } = run;
 
-moduleForComponent('session-offerings' + testgroup, 'Unit | Component | session offerings', {
+moduleForComponent('session-offerings', 'Unit | Component | session offerings ' + testgroup, {
   unit: true
 });
 

--- a/tests/unit/components/toggle-onoff-test.js
+++ b/tests/unit/components/toggle-onoff-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleForComponent('toggle-onoff' + testgroup, 'Unit | Component | toggle onoff', {
+moduleForComponent('toggle-onoff', 'Unit | Component | toggle onoff ' + testgroup, {
   unit: true
 });
 

--- a/tests/unit/models/assessment-option-test.js
+++ b/tests/unit/models/assessment-option-test.js
@@ -2,7 +2,7 @@ import { moduleForModel, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('assessment-option' + testgroup, 'Unit | Model | assessment option', {
+moduleForModel('assessment-option', 'Unit | Model | assessment option ' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/curriculum-inventory-sequence-block-session-test.js
+++ b/tests/unit/models/curriculum-inventory-sequence-block-session-test.js
@@ -2,7 +2,7 @@ import { moduleForModel, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('curriculum-inventory-sequence-block-session' + testgroup, 'Unit | Model | curriculum inventory sequence block session', {
+moduleForModel('curriculum-inventory-sequence-block-session', 'Unit | Model | CurriculumInventorySequenceBlockSession ' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/curriculum-inventory-sequence-block-test.js
+++ b/tests/unit/models/curriculum-inventory-sequence-block-test.js
@@ -5,9 +5,10 @@ import {
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('curriculum-inventory-sequence-block', 'Unit | Model | CurriculumInventorySequenceBlock' + testgroup, {
+moduleForModel('curriculum-inventory-sequence-block', 'Unit | Model | CurriculumInventorySequenceBlock ' + testgroup, {
   needs: modelList
 });
+
 
 test('it exists', function(assert) {
   var model = this.subject();

--- a/tests/unit/models/ingestion-exception-test.js
+++ b/tests/unit/models/ingestion-exception-test.js
@@ -2,7 +2,7 @@ import { moduleForModel, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('ingestion-exception' + testgroup, 'Unit | Model | ingestion exception', {
+moduleForModel('ingestion-exception' , 'Unit | Model | ingestion exception ' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/mesh-previous-indexing-test.js
+++ b/tests/unit/models/mesh-previous-indexing-test.js
@@ -2,7 +2,7 @@ import { moduleForModel, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('mesh-previous-indexing' + testgroup, 'Unit | Model | mesh previous indexing', {
+moduleForModel('mesh-previous-indexing', 'Unit | Model | mesh previous indexing ' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/models/mesh-tree-test.js
+++ b/tests/unit/models/mesh-tree-test.js
@@ -2,7 +2,7 @@ import { moduleForModel, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 
-moduleForModel('mesh-tree' + testgroup, 'Unit | Model | mesh tree', {
+moduleForModel('mesh-tree', 'Unit | Model | mesh tree ' + testgroup, {
   needs: modelList
 });
 

--- a/tests/unit/routes/admin-dashboard-test.js
+++ b/tests/unit/routes/admin-dashboard-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:admin-dashboard' + testgroup, 'Unit | Route | admin dashboard', {
+moduleFor('route:admin-dashboard', 'Unit | Route | admin dashboard ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:application' + testgroup, 'Unit | Route | application', {
+moduleFor('route:application', 'Unit | Route | application ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/events-test.js
+++ b/tests/unit/routes/events-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:events' + testgroup, 'Unit | Route | events', {
+moduleFor('route:events', 'Unit | Route | events ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/instructor-group-test.js
+++ b/tests/unit/routes/instructor-group-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:instructor-group' + testgroup, 'Unit | Route | instructor group', {
+moduleFor('route:instructor-group', 'Unit | Route | instructor group ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/login-test.js
+++ b/tests/unit/routes/login-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:login' + testgroup, 'Unit | Route | login', {
+moduleFor('route:login', 'Unit | Route | login ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/test-models-test.js
+++ b/tests/unit/routes/test-models-test.js
@@ -4,7 +4,7 @@ import {
 } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:test-models' + testgroup, 'TestmodelsRoute', {
+moduleFor('route:test-models', 'TestmodelsRoute ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/user-test.js
+++ b/tests/unit/routes/user-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:user' + testgroup, 'Unit | Route | user', {
+moduleFor('route:user', 'Unit | Route | user ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });

--- a/tests/unit/routes/users-test.js
+++ b/tests/unit/routes/users-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
-moduleFor('route:users' + testgroup, 'Unit | Route | users', {
+moduleFor('route:users', 'Unit | Route | users ' + testgroup, {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });


### PR DESCRIPTION
Authorize basic user actions.  Right now we are just hiding the items from the menu which will prevent most problems.  This is not for security, its for ensuring that the user doesn't get annoyed by having access to things they can't actually do.

Can be tested here:
http://5638561571e20a1a4200001c.ilios-frontend.netlify.com/