### PR TITLE
Remove un-postable fields from learning materials

### DIFF
--- a/app/components/error-display.js
+++ b/app/components/error-display.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { Component, computed, isPresent } = Ember;
+const { Component, computed } = Ember;
 
 export default Component.extend({
   classNames: ['error-display'],

--- a/app/serializers/learning-material.js
+++ b/app/serializers/learning-material.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend({
+  isNewSerializerAPI: true,
+  serialize: function(snapshot, options) {
+    var json = this._super(snapshot, options);
+    //don't persist this, it is handled by the server
+    delete json.absoluteFileUri;
+    delete json.uploadDate;
+
+    return json;
+  }
+});

--- a/tests/unit/serializers/learning-material-test.js
+++ b/tests/unit/serializers/learning-material-test.js
@@ -1,0 +1,23 @@
+import { moduleForModel, test } from 'ember-qunit';
+import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+
+moduleForModel('learning-material', 'Unit | Serializer | learning material' + testgroup, {
+  // Specify the other units that are required for this test.
+  needs: [
+    'serializer:learning-material',
+    'model:learning-material-user-role',
+    'model:learning-material-status',
+    'model:user',
+    'model:session-learning-material',
+    'model:course-learning-material',
+  ]
+});
+
+test('it removes all non postable fields', function(assert) {
+  var record = this.subject();
+
+  var serializedRecord = record.serialize();
+  
+  assert.ok(!("uploadDate" in serializedRecord));
+  assert.ok(!("absoluteFileUri" in serializedRecord));
+});


### PR DESCRIPTION
This should allow course and session learning materials to be saved.

Fixes #1007
Fixes #957
Fixes #875