### PR TITLE
universal spacing between edit and trash icons

### DIFF
--- a/app/styles/components/_global.scss
+++ b/app/styles/components/_global.scss
@@ -12,6 +12,10 @@ a,
     color: $hover-link-color;
     outline: none;
   }
+
+  &.edit {
+    margin-right: 7px;
+  }
 }
 
 button {
@@ -344,5 +348,11 @@ select:hover {
 
   p {
     margin: 0;
+  }
+}
+
+span {
+  &.edit {
+    margin-right: 7px;
   }
 }

--- a/app/templates/components/offering-manager.hbs
+++ b/app/templates/components/offering-manager.hbs
@@ -102,7 +102,7 @@
     </span>
     {{#if editable}}
       <span class='offering-block-time-offering-actions offering-detail-box'>
-        <span class='clickable' {{action 'edit'}}>{{fa-icon 'edit'}}</span>
+        <span class='clickable edit' {{action 'edit'}}>{{fa-icon 'edit'}}</span>
         <span class='clickable remove' {{action 'confirmRemove'}}>{{fa-icon 'trash'}}</span>
       </span>
     {{/if}}


### PR DESCRIPTION
Two locations where edit and remove are next to each other so far
- `/programs/1` (Note: #964 needs to be merged in order to see them)
- `/courses/595/sessions/16523`

Fixes #973 
