### PR TITLE
Add a fourth test group (d)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
   include:
     - env: "TEST_GROUP='(itgb)' SCSS_LINT=false"
     - env: "TEST_GROUP='(itgc)' SCSS_LINT=false"
+    - env: "TEST_GROUP='(itgd)' SCSS_LINT=false"
 
 
 before_install:

--- a/tests/acceptance/course/cohorts-test.js
+++ b/tests/acceptance/course/cohorts-test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};

--- a/tests/acceptance/course/mesh-test.js
+++ b/tests/acceptance/course/mesh-test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/courses/1?details=true';

--- a/tests/acceptance/course/objectivelist-test.js
+++ b/tests/acceptance/course/objectivelist-test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};

--- a/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/courses/1?details=true';

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -5,7 +5,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 
 const { isEmpty } = Ember;

--- a/tests/acceptance/course/publish-test.js
+++ b/tests/acceptance/course/publish-test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 const {run} = Ember;
 const {later} = run;
 

--- a/tests/acceptance/course/session/objectivecreate-test.js
+++ b/tests/acceptance/course/session/objectivecreate-test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};

--- a/tests/acceptance/course/session/objectivemesh-test.js
+++ b/tests/acceptance/course/session/objectivemesh-test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var url = '/courses/1/sessions/1';

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -5,7 +5,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 
 var application;

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -5,7 +5,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 
 var application;

--- a/tests/acceptance/course/session/topics-test.js
+++ b/tests/acceptance/course/session/topics-test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};

--- a/tests/acceptance/course/topics-test.js
+++ b/tests/acceptance/course/topics-test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import {d as testgroup} from 'ilios/tests/helpers/test-groups';
 
 var application;
 var fixtures = {};

--- a/tests/helpers/test-groups.js
+++ b/tests/helpers/test-groups.js
@@ -3,3 +3,4 @@ const testGroupSuffix = ')';
 export const a = testGroupPrefix + 'a' + testGroupSuffix;
 export const b = testGroupPrefix + 'b' + testGroupSuffix;
 export const c = testGroupPrefix + 'c' + testGroupSuffix;
+export const d = testGroupPrefix + 'd' + testGroupSuffix;


### PR DESCRIPTION
Hopefully splitting up test group C into two groups will help with
phantoms crashes.  Or at least make them easier to deal with.