### PR TITLE
Improved Logout

### DIFF
--- a/app/components/ilios-header.js
+++ b/app/components/ilios-header.js
@@ -14,9 +14,6 @@ export default Ember.Component.extend({
     }).filter(locale => locale.id !== this.get('i18n.locale'));
   }),
   actions: {
-    logout(){
-      this.get('session').invalidate();
-    },
     changeLocale(newLocale){
       this.get('i18n').set('locale', newLocale);
     }

--- a/app/router.js
+++ b/app/router.js
@@ -37,6 +37,7 @@ Router.map(function() {
   this.route('users', {});
   this.route('user', {path: '/users/:user_id'});
   this.route('fourOhFour', { path: "*path"});
+  this.route('logout');
 });
 
 export default Router;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -8,11 +8,6 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
   flashMessages: service(),
 
   actions: {
-    sessionInvalidationSucceeded(){
-      this.get('flashMessages').success('auth.confirmLogout');
-      this.transitionTo('login');
-    },
-
     error(error, transition) {
       transition.abort();
 

--- a/app/routes/logout.js
+++ b/app/routes/logout.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+import ajax from 'ic-ajax';
+import UnauthenticatedRouteMixin from 'simple-auth/mixins/unauthenticated-route-mixin';
+
+const { inject } = Ember;
+const { service } = inject;
+
+export default Ember.Route.extend(UnauthenticatedRouteMixin, {
+  flashMessages: service(),
+  beforeModel(){
+    let logoutUrl = '/auth/logout';
+    return ajax(logoutUrl).then(response => {
+      const session = this.get('session');
+      if(session.isAuthenticated){
+        session.invalidate();
+      }
+      if(response.status === 'redirect'){
+        let currentPath = window.location.href;
+        let loginPath = currentPath.replace('logout', 'login');
+        let loginRoute = encodeURIComponent(loginPath);
+        let logoutUrl = response.logoutUrl + '?url=' + loginRoute;
+        window.location.replace(logoutUrl);
+      } else {
+        this.get('flashMessages').success('auth.confirmLogout');
+        this.transitionTo('login');
+      }
+      return false;
+    });
+  }
+});

--- a/app/templates/components/ilios-header.hbs
+++ b/app/templates/components/ilios-header.hbs
@@ -9,7 +9,9 @@
     {{#if session.isAuthenticated}}
       <div class='user'>
         {{#action-menu title=userName icon='user' classNameBindings=':user-menu'}}
-          <li {{action 'logout'}}>{{t "auth.logout"}}</li>
+          {{#link-to 'logout'}}
+            <li>{{t "auth.logout"}}</li>
+          {{/link-to}}
           {{#each locales as |loc|}}
             <li {{action 'changeLocale' loc.id}}>{{loc.text}}</li>
           {{/each}}

--- a/tests/unit/routes/logout-test.js
+++ b/tests/unit/routes/logout-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:logout', 'Unit | Route | logout', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  var route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
Get info from the server during logout in case we want to do something else.  Specifically redirecting to s shibboleth logout endpoint.

fixes #1054 (with corresponding API changes in ilios/ilios#1097)