### PR TITLE
notes and publicNotes display straightened out

### DIFF
--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -95,11 +95,15 @@
         	        {{/if}}
                 </td>
                 <td class='text-center' colspan=2>
-        	        {{#if lmProxy.publicNotes}}
+                  {{#if lmProxy.notes}}
         	          <span class='add'>{{t 'general.yes'}}</span>
+
+                    {{#if lmProxy.publicNotes}}
+                      {{fa-icon 'eye'}}
+                    {{/if}}
         	        {{else}}
         	          <span class='remove'>{{t 'general.no'}}</span>
-        	        {{/if}}
+        	        {{/if}}  
                 </td>
                 <td class='text-center' colspan=2>
                   {{#if lmProxy.sortedDescriptors.length}}

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -128,8 +128,11 @@ test('list learning materials', function(assert) {
       assert.equal(getElementText(find('td:eq(2)', row)), getText(lm.originalAuthor));
       let required = courseLm.required?'Yes':'No';
       assert.equal(getElementText(find('td:eq(3)', row)), getText(required));
-      let publicNotes = courseLm.publicNotes?'Yes':'No';
-      assert.equal(getElementText(find('td:eq(4)', row)), getText(publicNotes));
+      let notes = courseLm.notes? 'Yes' : 'No';
+      assert.equal(getElementText(find('td:eq(4)', row)), getText(notes));
+      let notesBool = courseLm.notes? true : false;
+      let publicNotes = courseLm.publicNotes ? true : false;
+      assert.equal(find('td:eq(4) i', row).hasClass('fa-eye'), publicNotes && notesBool);
       let meshTerms = find('td:eq(5) li', row);
       if('meshDescriptors' in courseLm){
         assert.equal(meshTerms.length, courseLm.meshDescriptors.length);
@@ -422,7 +425,8 @@ test('edit learning material', function(assert) {
           click('.detail-learning-materials button.bigadd');
           andThen(function(){
             assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(3)')), getText('Yes'));
-            assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4)')), getText('No'));
+            assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4)')), getText('Yes'), 'there is content in notes');
+            assert.ok(isEmpty(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is false and `eye` icon is not visible');
             assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[2].title));
 
             click('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(0)');
@@ -453,7 +457,8 @@ test('cancel editing learning material', function(assert) {
       click('.detail-learning-materials button.bigcancel');
       andThen(function(){
         assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(3)')), getText('No'));
-        assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4)')), getText('Yes'));
+        assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4)')), getText('No'), 'no content is available under notes');
+        assert.ok(isEmpty(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is true but notes are blank so `eye` icon is not visible');
         assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[0].title));
       });
     });

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -130,8 +130,11 @@ test('list learning materials', function(assert) {
       //assert.equal(getElementText(find('td:eq(1)', row)), getText(lm.type));assert.equal(getElementText(find('td:eq(2)', row)), getText(lm.originalAuthor));
       let required = sessionLm.required?'Yes':'No';
       assert.equal(getElementText(find('td:eq(3)', row)), getText(required));
-      let publicNotes = sessionLm.publicNotes?'Yes':'No';
-      assert.equal(getElementText(find('td:eq(4)', row)), getText(publicNotes));
+      let notes = sessionLm.notes? 'Yes' : 'No';
+      assert.equal(getElementText(find('td:eq(4)', row)), getText(notes));
+      let notesBool = sessionLm.notes? true : false;
+      let publicNotes = sessionLm.publicNotes ? true : false;
+      assert.equal(find('td:eq(4) i', row).hasClass('fa-eye'), publicNotes && notesBool);
       let meshTerms = find('td:eq(5) li', row);
       if('meshDescriptors' in sessionLm){
         assert.equal(meshTerms.length, sessionLm.meshDescriptors.length);
@@ -407,7 +410,8 @@ test('edit learning material', function(assert) {
           click('.detail-learning-materials button.bigadd');
           andThen(function(){
             assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(3)')), getText('Yes'));
-            assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4)')), getText('No'));
+            assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4)')), getText('Yes'), 'there is content in notes');
+            assert.ok(isEmpty(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is false and `eye` icon is not visible');
             assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[2].title));
 
             click('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(0)');
@@ -438,7 +442,8 @@ test('cancel editing learning material', function(assert) {
       click('.detail-learning-materials button.bigcancel');
       andThen(function(){
         assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(3)')), getText('No'));
-        assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4)')), getText('Yes'));
+        assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4)')), getText('No'), 'no content is available under notes');
+        assert.ok(isEmpty(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is true but notes are blank so `eye` icon is not visible');
         assert.equal(getElementText(find('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[0].title));
       });
     });


### PR DESCRIPTION
Fixes #1083 

Notes: `undefined`, publicNotes: `true`

<img width="116" alt="screen shot 2015-11-13 at 3 15 59 pm" src="https://cloud.githubusercontent.com/assets/7553764/11159975/7a818eb8-8a19-11e5-93f6-06564042006f.png">

Notes: `a`, publicNotes: `false`

<img width="95" alt="screen shot 2015-11-13 at 3 17 08 pm" src="https://cloud.githubusercontent.com/assets/7553764/11159992/b04b50ce-8a19-11e5-9b46-19c1df7f514d.png">
