### PR TITLE
fixed issue #1117

### DIFF
--- a/app/templates/components/learningmaterial-search.hbs
+++ b/app/templates/components/learningmaterial-search.hbs
@@ -20,7 +20,7 @@
     {{#each results as |learningMaterial|}}
       <li {{action 'add' learningMaterial}}>
         <h4 class="learning-material-title">{{learningMaterial.title}}</h4>
-        <span class="learning-material-description">{{learningMaterial.description}}</span>
+        <span class="learning-material-description">{{{learningMaterial.description}}}</span>
         {{#if learningMaterial.status.title}}
           <span class="learning-material-status">{{learningMaterial.status.title}}</span>
         {{/if}}


### PR DESCRIPTION
@jrjohnson Can we remove the rule in SCSS linter, where one cannot use `!important`? I need to override the inline styles and I wouldn't have to spend time finding ways around previously defined CSS.

Without override:
<img width="722" alt="screen shot 2015-11-14 at 6 15 29 pm" src="https://cloud.githubusercontent.com/assets/7553764/11166831/54c2dd0a-8afd-11e5-88ff-54e181f56760.png">

With override:
<img width="715" alt="screen shot 2015-11-14 at 6 23 21 pm" src="https://cloud.githubusercontent.com/assets/7553764/11166834/5f034c6e-8afd-11e5-9902-b3762e803d4d.png">

Fixes #1117 