### PR TITLE
UI guides user to correct dates

### DIFF
--- a/app/components/course-overview.js
+++ b/app/components/course-overview.js
@@ -1,8 +1,13 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-export default Ember.Component.extend({
-  store: Ember.inject.service(),
+const { Component, inject } = Ember;
+const { service } = inject;
+
+export default Component.extend({
+  store: service(),
+  flashMessages: service(),
+
   editable: true,
   course: null,
   directorsSort: ['lastName', 'firstName'],
@@ -44,6 +49,8 @@ export default Ember.Component.extend({
     const endDate = this.get('course.endDate');
 
     if (endDate <= startDate) {
+      this.get('flashMessages').warning('courses.courseDateMessage');
+
       if (whichDate === 'start') {
         this.set('startDateFlag', true);
       } else {

--- a/app/components/course-overview.js
+++ b/app/components/course-overview.js
@@ -36,6 +36,24 @@ export default Ember.Component.extend({
     }
   },
 
+  startDateFlag: false,
+  endDateFlag: false,
+
+  checkDate(whichDate) {
+    const startDate = this.get('course.startDate');
+    const endDate = this.get('course.endDate');
+
+    if (endDate <= startDate) {
+      if (whichDate === 'start') {
+        this.set('startDateFlag', true);
+      } else {
+        this.set('endDateFlag', true);
+      }
+    } else {
+      this.setProperties({ startDateFlag: false, endDateFlag: false });
+    }
+  },
+
   actions: {
     addDirector: function(user){
       var course = this.get('course');
@@ -62,14 +80,19 @@ export default Ember.Component.extend({
         course.save();
       }
     },
+
     changeStartDate: function(newDate){
       this.get('course').set('startDate', newDate);
       this.get('course').save();
+      this.checkDate('end');
     },
+
     changeEndDate: function(newDate){
       this.get('course').set('endDate', newDate);
       this.get('course').save();
+      this.checkDate('start');
     },
+
     changeExternalId: function(value){
       this.get('course').set('externalId', value);
       this.get('course').save();

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -245,6 +245,7 @@ export default {
     'confirmObjectiveRemoval': 'Are you sure you want to delete this objective?',
     'confirmSessionRemoval': 'Are you sure you want to delete this session?',
     'noPrintDraft': 'Courses which are in draft status cannot be printed',
+    'courseDateMessage': 'Course start-date should be before course-end date'
   },
   'sessions': {
     'specialAttireRequired': 'Special Attire Required',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -245,6 +245,7 @@ export default {
     'confirmObjectiveRemoval': "¿Está seguro que desea eliminar este objetivo?",
     'confirmSessionRemoval': "¿Está seguro que desea eliminar este sessión?",
     'noPrintDraft': 'Cursos que se encuentran en estado borrador no se puede imprimir',
+    'courseDateMessage': 'Fecha de inicio de curso debe ser antes de la fecha de fin de curso'
   },
   'sessions': {
     'specialAttireRequired': 'Vestimenta Especial Requerido',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -245,6 +245,7 @@ export default {
     'confirmObjectiveRemoval': "Êtes vous sûr de vouloir supprimer cet objectif?",
     'confirmSessionRemoval': 'Êtes vous sûr de vouloir supprimer cette séance?',
     'noPrintDraft': 'Cours qui sont au stade de projet ne peuvent pas étre imprimés',
+    'courseDateMessage': 'La date de début du cours doit être avant la date de fin'
   },
   'sessions': {
     'specialAttireRequired': "Vêtements particuliers requis",

--- a/app/templates/components/course-overview.hbs
+++ b/app/templates/components/course-overview.hbs
@@ -31,24 +31,33 @@
 
       <div class="form-col-6 multi-row">
         <label class='form-label'>{{t "general.start"}}:</label>
-        <div class="form-data coursestartdate">{{inplace-date value=course.startDate save='changeStartDate'}}</div>
+
+        <div class="form-data coursestartdate">
+          {{inplace-date value=course.startDate save='changeStartDate' isEditing=startDateFlag}}
+        </div>
+
         <label class="form-label">{{t "general.end"}}:</label>
-        <div class="form-data courseenddate">{{inplace-date value=course.endDate save='changeEndDate'}}</div>
+
+        <div class="form-data courseenddate">
+          {{inplace-date value=course.endDate save='changeEndDate' isEditing=endDateFlag}}
+        </div>
       </div>
+
       <div class="form-col-12 coursedirectors">
         <label>{{t "general.directors"}}:</label>
-          <span>
-            <ul class='removable-list'>
-              {{#each sortedDirectors as |user|}}
-              <li {{action 'removeDirector' user}}>{{user.fullName}}{{fa-icon 'remove' classNames='removex'}}</li>
-              {{/each}}
-            </ul>
-          </span>
-          {{user-search
-            addUser='addDirector'
-            roles='1'
-            currentlyActiveUsers=course.directors
-          }}
+
+        <span>
+          <ul class='removable-list'>
+            {{#each sortedDirectors as |user|}}
+            <li {{action 'removeDirector' user}}>{{user.fullName}}{{fa-icon 'remove' classNames='removex'}}</li>
+            {{/each}}
+          </ul>
+        </span>
+        {{user-search
+          addUser='addDirector'
+          roles='1'
+          currentlyActiveUsers=course.directors
+        }}
       </div>
   </div>
 </section>

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -278,6 +278,43 @@ test('change end date', function(assert) {
   });
 });
 
+test('invalid date combination triggers edit mode', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
+  const course = server.create('course', {
+    year: 2013,
+    school: 1,
+  });
+
+  const startDate = '.coursestartdate .editable';
+  const startDateInput = '.coursestartdate input';
+  const endDateInput = '.courseenddate input';
+  const startDateDone = '.coursestartdate .done';
+  const endDateDone = '.courseenddate .done';
+
+  visit(url);
+  click(startDate);
+  andThen(() => {
+    const interactor = openDatepicker(find(startDateInput));
+    const newDate = moment(course.endDate).add(5, 'year');
+    interactor.selectDate(newDate.toDate());
+  });
+
+  click(startDateDone);
+  andThen(() => {
+    assert.ok(find(endDateInput).is(':visible'), 'invalid date combo triggered end-date in edit mode');
+    const interactor = openDatepicker(find(endDateInput));
+    const newDate = moment(course.endDate).add(2, 'year');
+    interactor.selectDate(newDate.toDate());
+  });
+
+  click(endDateDone);
+  andThen(() => {
+    assert.ok(find(startDateInput).is(':visible'), 'invalid date combo triggered start-date in edit mode');
+  });
+});
+
 test('change externalId', function(assert) {
   server.create('user', {
     id: 4136


### PR DESCRIPTION
This is not like the validation currently on other input areas. It merely guides the user by putting the dat-picker (for both start and end) in edit mode if the end-date is on or before the start-date. If real validation must be used, then I will likely need to use observers within `inplace-date` component.

Fixes #1002 