### PR TITLE
Directly download travis instead of pulling it from npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ sudo: false
 cache:
   directories:
     - node_modules
+    - travis-phantomjs
 
 matrix:
   fast_finish: true
@@ -17,9 +18,13 @@ before_install:
   - git clone https://github.com/creationix/nvm.git ~/.nvm
   - source ~/.nvm/nvm.sh
   - nvm install 0.12.7
+  - if [ ! -d travis-phantomjs ]; then wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.0.0-macosx.zip -O phantomjs.zip; fi
+  - if [ ! -d travis-phantomjs ]; then unzip phantomjs.zip; fi
+  - if [ ! -d travis-phantomjs ]; then mv phantomjs-2.0.0-macosx travis-phantomjs; fi
+  - export PATH=$PWD/travis-phantomjs/bin:$PATH
+  - phantomjs -v
   - npm config set spin false
   - npm install -g npm@^2
-  - npm install -g phantomjs2
   - npm install -g bower
   - travis_retry gem install scss-lint --no-ri --no-rdoc
 


### PR DESCRIPTION
Hopefully this is a bit more reliable even though it takes more work.