### PR TITLE
Courses list filter improvement

### DIFF
--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import { translationMacro as t } from "ember-i18n";
+import moment from 'moment';
 
 const { computed, RSVP, isEmpty, isPresent } = Ember;
 const { gt, sort } = computed;
@@ -142,8 +143,17 @@ export default Ember.Controller.extend({
         return year.get('title') === parseInt(this.get('yearTitle'));
       });
     }
-
-    return years.get('lastObject');
+    let currentYear = moment().format('YYYY');
+    const currentMonth = parseInt(moment().format('M'));
+    if(currentMonth < 6){
+      currentYear--;
+    }
+    let defaultYear = years.find(year => year.get('id') === currentYear);
+    if(isEmpty(defaultYear)){
+      defaultYear = years.get('lastObject');
+    }
+    
+    return defaultYear;
   }),
   actions: {
     editCourse: function(course){

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -3,7 +3,7 @@ import DS from 'ember-data';
 import { translationMacro as t } from "ember-i18n";
 
 const { computed, RSVP, isEmpty, isPresent } = Ember;
-const { gt } = computed;
+const { gt, sort } = computed;
 const { PromiseArray } = DS;
 
 export default Ember.Controller.extend({
@@ -21,6 +21,10 @@ export default Ember.Controller.extend({
   titleFilter: null,
   userCoursesOnly: false,
   showNewCourseForm: false,
+  sortSchoolsBy:['title'],
+  sortedSchools: sort('model.schools', 'sortSchoolsBy'),
+  sortYearsBy:['title:desc'],
+  sortedYears: sort('model.years', 'sortYearsBy'),
   newCourses: [],
   courses: computed('selectedSchool', 'selectedYear', function(){
     let defer = RSVP.defer();
@@ -162,11 +166,11 @@ export default Ember.Controller.extend({
       });
       this.get('newCourses').removeObject(courseProxy);
     },
-    changeSelectedYear: function(year){
-      this.set('yearTitle', year.get('title'));
+    changeSelectedYear: function(yearTitle){
+      this.set('yearTitle', yearTitle);
     },
-    changeSelectedSchool: function(school){
-      this.set('schoolId', school.get('id'));
+    changeSelectedSchool: function(schoolId){
+      this.set('schoolId', schoolId);
     },
     //called by the 'toggle-mycourses' component
     toggleMyCourses: function(){

--- a/app/templates/courses.hbs
+++ b/app/templates/courses.hbs
@@ -3,26 +3,33 @@
     {{toggle-mycourses isChecked=userCoursesOnly toggleMyCourses='toggleMyCourses'}}
     <div id='schoolsfilter' class="filter">
       <label class="inline-label">
-        {{t 'general.school'}}:
+        {{fa-icon 'university'}}
       </label>
       <div id="school-selection" class="inline-data">
         {{#if hasMoreThanOneSchool}}
-          {{#action-menu title=selectedSchool.title icon=false}}
-            {{#each model.schools as |school|}}
-              <li {{action 'changeSelectedSchool' school}}>{{school.title}}</li>
+          <select onchange={{action "changeSelectedSchool" value="target.value"}}>
+            {{#each sortedSchools as |school|}}
+              <option value={{school.id}} selected={{is-equal school selectedSchool}}>
+                {{school.title}}
+              </option>
             {{/each}}
-          {{/action-menu}}
+          </select>
         {{else}}
           {{selectedSchool.title}}
         {{/if}}
       </div>
     </div>
     <div id='yearsfilter' class="filter">
-      {{#action-menu title=selectedYear.academicYearTitle icon=false}}
-        {{#each model.years as |year|}}
-          <li {{action 'changeSelectedYear' year}}>{{year.academicYearTitle}}</li>
+      <label class="inline-label">
+        {{fa-icon 'calendar'}}
+      </label>
+      <select onchange={{action "changeSelectedYear" value="target.value"}}>
+        {{#each sortedYears as |year|}}
+          <option value={{year.year}} selected={{is-equal year selectedYear}}>
+            {{year.academicYearTitle}}
+          </option>
         {{/each}}
-      {{/action-menu}}
+      </select>
     </div>
 
     <div id='titlefilter' class="filter">

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -111,7 +111,7 @@ test('filters by title', function(assert) {
 });
 
 test('filters by year', function(assert) {
-  assert.expect(2);
+  assert.expect(4);
   var firstCourse = server.create('course', {
     year: 2013,
     school: 1,
@@ -122,19 +122,13 @@ test('filters by year', function(assert) {
   });
   visit('/courses');
   andThen(function() {
-    click('#yearsfilter button').then(function(){
-      var yearOptions = find('#yearsfilter ul.dropdown-menu li');
-      click(yearOptions.eq(0));
-    });
+    pickOption('#yearsfilter select', '2013 - 2014', assert);
     andThen(function(){
       assert.equal(getElementText(find('.resultslist-list tbody tr:eq(0) td:eq(0)')),getText(firstCourse.title));
     });
   });
   andThen(function() {
-    click('#yearsfilter button').then(function(){
-      var yearOptions = find('#yearsfilter ul.dropdown-menu li');
-      click(yearOptions.eq(1));
-    });
+    pickOption('#yearsfilter select', '2014 - 2015', assert);
     andThen(function(){
       assert.equal(getElementText(find('.resultslist-list tbody tr:eq(0) td:eq(0)')),getText(secondCourse.title));
     });
@@ -195,14 +189,11 @@ test('filters options', function(assert) {
     var filters = find('#courses .filter');
     assert.equal(filters.length, 4);
     assert.equal(find('#school-selection').eq(0).text().trim(), fixtures.schools[0].title);
-    click('#yearsfilter button');
-    andThen(function(){
-      var yearOptions = find('#yearsfilter ul.dropdown-menu li');
-      assert.equal(yearOptions.length, fixtures.academicYears.length);
-      for(let i = 0; i < fixtures.academicYears.length; i++){
-        assert.equal(getElementText(yearOptions.eq(i)).substring(0,4), fixtures.academicYears[i].title);
-      }
-    });
+    var yearOptions = find('#yearsfilter select option');
+    assert.equal(yearOptions.length, fixtures.academicYears.length);
+    assert.equal(getElementText(yearOptions.eq(0)).substring(0,4), 2014);
+    assert.equal(getElementText(yearOptions.eq(1)).substring(0,4), 2013);
+
   });
 });
 


### PR DESCRIPTION
- Prevent the lists from being cut off
- Sort school by title 
- sort year by date in reverse order
- default the selected year to the current academic year

Fixes #846
Fixes #804
Refs #707

Can be reviewed at http://56555bfad6865d4276000005.ilios-frontend.netlify.com/login