### PR TITLE
Fix Shibboleth Logout

### DIFF
--- a/app/routes/logout.js
+++ b/app/routes/logout.js
@@ -15,11 +15,7 @@ export default Ember.Route.extend(UnauthenticatedRouteMixin, {
         session.invalidate();
       }
       if(response.status === 'redirect'){
-        let currentPath = window.location.href;
-        let loginPath = currentPath.replace('logout', 'login');
-        let loginRoute = encodeURIComponent(loginPath);
-        let logoutUrl = response.logoutUrl + '?url=' + loginRoute;
-        window.location.replace(logoutUrl);
+        window.location.replace(response.logoutUrl);
       } else {
         this.get('flashMessages').success('auth.confirmLogout');
         this.transitionTo('login');


### PR DESCRIPTION
Shibboleth logout is local so redirecting back to the login page just sends people back to the IDP and ends up logging them in again.  We need to leave them on the ugly shibboleth logout page.

Fixes ilios/ilios#1164