### PR TITLE
ember watson:convert-prototype-extensions

### DIFF
--- a/app/components/action-menu.js
+++ b/app/components/action-menu.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import DropdownComponentMixin from 'ember-rl-dropdown/mixins/rl-dropdown-component';
 
-export default Ember.Component.extend(DropdownComponentMixin, {
+const { Component } = Ember;
+
+export default Component.extend(DropdownComponentMixin, {
   title: '',
   icon: 'gear',
   classNames: ['action-menu'],

--- a/app/components/big-text.js
+++ b/app/components/big-text.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 
-const { computed, Handlebars } = Ember;
+const { Component, computed, Handlebars } = Ember;
 const { SafeString } = Handlebars;
 const { collect, sum } = computed;
 
-export default Ember.Component.extend({
+export default Component.extend({
   expanded: false,
   classNames: ['big-text'],
   length: 200,

--- a/app/components/boolean-check.js
+++ b/app/components/boolean-check.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   classNames: ['checkbox'],
 
   tagName: 'span',

--- a/app/components/course-editing.js
+++ b/app/components/course-editing.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   actions: {
     save: function(){
       var self = this;

--- a/app/components/course-overview.js
+++ b/app/components/course-overview.js
@@ -1,14 +1,16 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+
+export default Component.extend({
   store: Ember.inject.service(),
   editable: true,
   course: null,
   directorsSort: ['lastName', 'firstName'],
-  directorsWithFullName: Ember.computed.filterBy('course.directors', 'fullName'),
-  sortedDirectors: Ember.computed.sort('directorsWithFullName', 'directorsSort'),
-  levelOptions: function(){
+  directorsWithFullName: computed.filterBy('course.directors', 'fullName'),
+  sortedDirectors: computed.sort('directorsWithFullName', 'directorsSort'),
+  levelOptions: computed(function(){
     var arr = [];
     for(let i=1;i<=5; i++){
       arr.pushObject(Ember.Object.create({
@@ -18,9 +20,9 @@ export default Ember.Component.extend({
     }
 
     return arr;
-  }.property(),
+  }),
   classNames: ['course-overview'],
-  clerkshipTypeOptions: function(){
+  clerkshipTypeOptions: computed(function(){
     var deferred = Ember.RSVP.defer();
     this.get('store').findAll('course-clerkship-type').then(function(clerkshipTypes){
       deferred.resolve(clerkshipTypes.sortBy('title'));
@@ -28,7 +30,7 @@ export default Ember.Component.extend({
     return DS.PromiseArray.create({
       promise: deferred.promise
     });
-  }.property(),
+  }),
 
   externalIdValidations: {
     'validationBuffer': {

--- a/app/components/course-publicationcheck.js
+++ b/app/components/course-publicationcheck.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   classNames: ['course-publication-check', 'detail-view'],
   course: null
 });

--- a/app/components/dashboard-calendar.js
+++ b/app/components/dashboard-calendar.js
@@ -3,11 +3,11 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import momentFormat from 'ember-moment/computeds/format';
 
-const { computed, isPresent, RSVP, inject } = Ember;
+const { Component, computed, isPresent, on, RSVP, inject } = Ember;
 const { PromiseObject } = DS;
 const { service } = inject;
 
-export default Ember.Component.extend({
+export default Component.extend({
   userEvents: service(),
   schoolEvents: service(),
   currentUser: service(),
@@ -16,25 +16,25 @@ export default Ember.Component.extend({
   selectedDate: null,
   selectedView: null,
 
-  dueTranslation: Ember.computed('i18n.locale', function(){
+  dueTranslation: computed('i18n.locale', function(){
     return this.get('i18n').t('calendar.dueThisDay');
   }),
-  dayTranslation: Ember.computed('i18n.locale', function(){
+  dayTranslation: computed('i18n.locale', function(){
     return this.get('i18n').t('calendar.day');
   }),
-  weekTranslation: Ember.computed('i18n.locale', function(){
+  weekTranslation: computed('i18n.locale', function(){
     return this.get('i18n').t('calendar.week');
   }),
-  monthTranslation: Ember.computed('i18n.locale', function(){
+  monthTranslation: computed('i18n.locale', function(){
     return this.get('i18n').t('calendar.month');
   }),
-  loadingEventsTranslation: Ember.computed('i18n.locale', function(){
+  loadingEventsTranslation: computed('i18n.locale', function(){
     return this.get('i18n').t('calendar.loadingEvents');
   }),
   icsInstructionsTranslation: computed('i18n.locale', function(){
     return this.get('i18n').t('calendar.icsInstructions');
   }),
-  setup: Ember.on('init', function() {
+  setup: on('init', function() {
     //do these on setup otherwise tests were failing because
     //the old filter value hung around
     this.set('selectedTopics', []);
@@ -43,14 +43,14 @@ export default Ember.Component.extend({
     this.set('selectedCohorts', []);
     this.set('selectedCourses', []);
   }),
-  fromTimeStamp: Ember.computed('selectedDate', 'selectedView', function(){
+  fromTimeStamp: computed('selectedDate', 'selectedView', function(){
     return moment(this.get('selectedDate')).startOf(this.get('selectedView')).unix();
   }),
-  toTimeStamp: Ember.computed('selectedDate', 'selectedView', function(){
+  toTimeStamp: computed('selectedDate', 'selectedView', function(){
     return moment(this.get('selectedDate')).endOf(this.get('selectedView')).unix();
   }),
   calendarDate: momentFormat('selectedDate', 'YYYY-MM-DD'),
-  ourEvents: Ember.computed('mySchedule', 'fromTimeStamp', 'toTimeStamp', 'selectedSchool', 'selectedView', function(){
+  ourEvents: computed('mySchedule', 'fromTimeStamp', 'toTimeStamp', 'selectedSchool', 'selectedView', function(){
     if(this.get('mySchedule')) {
       return DS.PromiseArray.create({
         promise: this.get('userEvents').getEvents(this.get('fromTimeStamp'), this.get('toTimeStamp'))
@@ -88,7 +88,7 @@ export default Ember.Component.extend({
       });
     }
   }),
-  filteredEvents: Ember.computed(
+  filteredEvents: computed(
     'ourEvents.[]',
     'eventsWithSelectedTopics.[]',
     'eventsWithSelectedSessionTypes.[]',
@@ -129,7 +129,7 @@ export default Ember.Component.extend({
       });
 
   }),
-  eventsWithSelectedTopics: Ember.computed('ourEvents.[]', 'selectedTopics.[]', function(){
+  eventsWithSelectedTopics: computed('ourEvents.[]', 'selectedTopics.[]', function(){
     let selectedTopics = this.get('selectedTopics');
     if(selectedTopics.length === 0) {
       return this.get('ourEvents');
@@ -155,7 +155,7 @@ export default Ember.Component.extend({
       promise: defer.promise
     });
   }),
-  eventsWithSelectedSessionTypes: Ember.computed('ourEvents.[]', 'selectedSessionTypes.[]', function(){
+  eventsWithSelectedSessionTypes: computed('ourEvents.[]', 'selectedSessionTypes.[]', function(){
     let selectedSessionTypes = this.get('selectedSessionTypes').mapBy('id');
     let events = this.get('ourEvents');
     if(selectedSessionTypes.length === 0) {
@@ -179,7 +179,7 @@ export default Ember.Component.extend({
       promise: defer.promise
     });
   }),
-  eventsWithSelectedCourseLevels: Ember.computed('ourEvents.[]', 'selectedCourseLevels.[]', function(){
+  eventsWithSelectedCourseLevels: computed('ourEvents.[]', 'selectedCourseLevels.[]', function(){
     let selectedCourseLevels = this.get('selectedCourseLevels');
     let events = this.get('ourEvents');
     if(selectedCourseLevels.length === 0) {
@@ -203,7 +203,7 @@ export default Ember.Component.extend({
       promise: defer.promise
     });
   }),
-  eventsWithSelectedCohorts: Ember.computed('ourEvents.[]', 'selectedCohorts.[]', function(){
+  eventsWithSelectedCohorts: computed('ourEvents.[]', 'selectedCohorts.[]', function(){
     let selectedCohorts = this.get('selectedCohorts').mapBy('id');
     let events = this.get('ourEvents');
     if(selectedCohorts.length === 0) {
@@ -229,7 +229,7 @@ export default Ember.Component.extend({
       promise: defer.promise
     });
   }),
-  eventsWithSelectedCourses: Ember.computed('ourEvents.[]', 'selectedCourses.[]', function(){
+  eventsWithSelectedCourses: computed('ourEvents.[]', 'selectedCourses.[]', function(){
     let selectedCourses = this.get('selectedCourses').mapBy('id');
     let events = this.get('ourEvents');
     if(selectedCourses.length === 0) {
@@ -254,7 +254,7 @@ export default Ember.Component.extend({
     });
   }),
   selectedTopics: [],
-  topics: Ember.computed('selectedSchool.topics.[]', 'selectedTopics.[]', function(){
+  topics: computed('selectedSchool.topics.[]', 'selectedTopics.[]', function(){
     return DS.PromiseArray.create({
       promise: this.get('selectedSchool').then(school => {
         return school.get('topics').then( topics => {
@@ -264,7 +264,7 @@ export default Ember.Component.extend({
     });
   }),
   selectedSessionTypes: [],
-  sessionTypes: Ember.computed('selectedSchool.sessionTypes.[]', 'selectedSessionTypes.[]', function(){
+  sessionTypes: computed('selectedSchool.sessionTypes.[]', 'selectedSessionTypes.[]', function(){
     return DS.PromiseArray.create({
       promise: this.get('selectedSchool').then(school => {
         return school.get('sessionTypes').then( types => {
@@ -274,7 +274,7 @@ export default Ember.Component.extend({
     });
   }),
   selectedCourseLevels: [],
-  courseLevels: Ember.computed('selectedCourseLevels.[]', function(){
+  courseLevels: computed('selectedCourseLevels.[]', function(){
     let levels = [];
     for(let i =1; i <=5; i++){
       levels.pushObject(i);
@@ -283,7 +283,7 @@ export default Ember.Component.extend({
     return levels;
   }),
   selectedCohorts: [],
-  allCohorts: Ember.computed('selectedSchool', 'selectedAcademicYear', function(){
+  allCohorts: computed('selectedSchool', 'selectedAcademicYear', function(){
     let defer = Ember.RSVP.defer();
     this.get('selectedSchool').then(school => {
       this.get('selectedAcademicYear').then(year => {
@@ -296,11 +296,11 @@ export default Ember.Component.extend({
       promise: defer.promise
     });
   }),
-  cohorts: Ember.computed('allCohorts.[].displayTitle', 'selectedCohorts.[]', function(){
+  cohorts: computed('allCohorts.[].displayTitle', 'selectedCohorts.[]', function(){
     return this.get('allCohorts');
   }),
   selectedCourses: [],
-  allCourses: Ember.computed('selectedSchool', 'selectedAcademicYear', function(){
+  allCourses: computed('selectedSchool', 'selectedAcademicYear', function(){
     let defer = Ember.RSVP.defer();
     this.get('selectedSchool').then((school) => {
       this.get('selectedAcademicYear').then((year) => {
@@ -319,7 +319,7 @@ export default Ember.Component.extend({
       promise: defer.promise
     });
   }),
-  courses: Ember.computed('allCourses.[]', 'selectedCourses.[]', function(){
+  courses: computed('allCourses.[]', 'selectedCourses.[]', function(){
     return this.get('allCourses');
   }),
   selectedSchool: computed('schoolPickedByUser', 'currentUser.model.school', function(){
@@ -339,8 +339,8 @@ export default Ember.Component.extend({
       promise: defer.promise
     });
   }),
-  hasMoreThanOneSchool: Ember.computed.gt('schools.length', 1),
-  allSchools: Ember.computed(function(){
+  hasMoreThanOneSchool: computed.gt('schools.length', 1),
+  allSchools: computed(function(){
     return DS.PromiseArray.create({
       promise: this.get('currentUser.model').then(user => {
         return user.get('schools').then(schools => {
@@ -349,10 +349,10 @@ export default Ember.Component.extend({
       })
     });
   }),
-  schools: Ember.computed('allSchools.[]', 'selectedSchool', function(){
+  schools: computed('allSchools.[]', 'selectedSchool', function(){
     return this.get('allSchools').sortBy('title');
   }),
-  selectedAcademicYear: Ember.computed('academicYearSelectedByUser', function(){
+  selectedAcademicYear: computed('academicYearSelectedByUser', function(){
     if(this.get('academicYearSelectedByUser')){
       //wrap it in a proxy so the is-equal comparison works the same as the promise
       return DS.PromiseObject.create({
@@ -366,10 +366,10 @@ export default Ember.Component.extend({
       })
     });
   }),
-  allAcademicYears: Ember.computed(function(){
+  allAcademicYears: computed(function(){
     return this.get('store').findAll('academic-year');
   }),
-  academicYears: Ember.computed('allAcademicYears.[]', 'academicYearSelectedByUser', function(){
+  academicYears: computed('allAcademicYears.[]', 'academicYearSelectedByUser', function(){
     return DS.PromiseArray.create({
       promise: this.get('allAcademicYears').then(years => {
         return years.sortBy('title');

--- a/app/components/detail-cohort-list.js
+++ b/app/components/detail-cohort-list.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-const {computed, RSVP} = Ember;
-const {PromiseArray} = DS;
+const { Component, computed, RSVP } = Ember;
+const { PromiseArray } = DS;
 
-export default Ember.Component.extend({
+export default Component.extend({
   cohorts: [],
   sortedCohorts: computed('cohorts.@each.{school,displayTitle}', function(){
     let defer = RSVP.defer();
@@ -12,7 +12,7 @@ export default Ember.Component.extend({
     this.get('cohorts').then(cohorts => {
       defer.resolve(cohorts.sortBy(['school', 'displayTitle']));
     });
-    
+
     return PromiseArray.create({
       promise: defer.promise
     });

--- a/app/components/detail-cohort-manager.js
+++ b/app/components/detail-cohort-manager.js
@@ -3,12 +3,12 @@ import DS from 'ember-data';
 
 import { translationMacro as t } from "ember-i18n";
 
-const {computed, inject, RSVP} = Ember;
-const {service} = inject;
-const {PromiseArray} = DS;
-const {sort} = computed;
+const { Component, computed, inject, RSVP} = Ember;
+const { service } = inject;
+const { PromiseArray } = DS;
+const { sort } = computed;
 
-export default Ember.Component.extend({
+export default Component.extend({
   i18n: service(),
   currentUser: service(),
   tagName: 'section',
@@ -45,7 +45,7 @@ export default Ember.Component.extend({
           });
         });
       });
-      
+
       return PromiseArray.create({
         promise: defer.promise
       });
@@ -54,7 +54,7 @@ export default Ember.Component.extend({
   availableCohorts: computed('useableCohorts.[]', 'selectedCohorts.[]', {
     get(){
       let defer = RSVP.defer();
-      
+
       this.get('useableCohorts').then(useableCohorts => {
         let availableCohorts = useableCohorts.filter(cohort => {
           return (
@@ -64,7 +64,7 @@ export default Ember.Component.extend({
         });
         defer.resolve(availableCohorts);
       });
-      
+
       return PromiseArray.create({
         promise: defer.promise
       });

--- a/app/components/detail-cohorts.js
+++ b/app/components/detail-cohorts.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 
-const { RSVP } = Ember;
+const { Component, RSVP } = Ember;
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['detail-cohorts'],
   subject: null,
   isManaging: false,
@@ -28,7 +28,7 @@ export default Ember.Component.extend({
           cohortList.pushObject(cohort);
         });
         RSVP.all(removedCohorts.mapBy('programYear')).then(programYearsToRemove => {
-          course.get('objectives').then(objectives => {  
+          course.get('objectives').then(objectives => {
             RSVP.all(objectives.invoke('removeParentWithProgramYears', programYearsToRemove)).then(()=> {
               course.save().then(()=>{
                 this.set('isManaging', false);
@@ -37,12 +37,12 @@ export default Ember.Component.extend({
               });
             });
           });
-          
-          
+
+
         });
-        
+
       });
-      
+
     },
     cancel(){
       this.set('bufferedCohorts', []);

--- a/app/components/detail-competencies.js
+++ b/app/components/detail-competencies.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   course: null,
 });

--- a/app/components/detail-instructors-list.js
+++ b/app/components/detail-instructors-list.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { sort } = computed;
+
+export default Component.extend({
   instructors: [],
   sortInstructorsBy: ['title'],
-  sortedInstructors: Ember.computed.sort('instructors', 'sortInstructorsBy'),
+  sortedInstructors: sort('instructors', 'sortInstructorsBy'),
   instructorGroups: [],
   sortGroupsBy: ['title'],
-  sortedInstructorGroups: Ember.computed.sort('instructorGroups', 'sortGroupsBy'),
+  sortedInstructorGroups: sort('instructorGroups', 'sortGroupsBy'),
 });

--- a/app/components/detail-instructors.js
+++ b/app/components/detail-instructors.js
@@ -1,13 +1,15 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+
+export default Component.extend({
   currentUser: Ember.inject.service(),
   classNames: ['detail-instructors'],
   ilmSession: null,
   isManaging: false,
   instructorGroupBuffer: [],
   instructorBuffer: [],
-  titleCount: Ember.computed('ilmSession.instructorGroups.length', 'ilmSession.instructors.length', function(){
+  titleCount: computed('ilmSession.instructorGroups.length', 'ilmSession.instructors.length', function(){
     return this.get('ilmSession.instructorGroups.length') +
            this.get('ilmSession.instructors.length');
   }),

--- a/app/components/detail-learnergroups-list.js
+++ b/app/components/detail-learnergroups-list.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { sort } = computed;
+
+export default Component.extend({
   learnerGroups: [],
   sortBy: ['title'],
-  sortedLearnerGroups: Ember.computed.sort('learnerGroups', 'sortBy'),
+  sortedLearnerGroups: sort('learnerGroups', 'sortBy'),
 });

--- a/app/components/detail-learnergroups.js
+++ b/app/components/detail-learnergroups.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   classNames: ['detail-learnergroups'],
   subject: null,
   isIlmSession: false,

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -2,12 +2,12 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import { translationMacro as t } from "ember-i18n";
 
-const {computed, inject, RSVP} = Ember;
-const {notEmpty, or, not} = computed;
-const {service} = inject;
-const {PromiseArray} = DS;
+const { Component, computed, inject, RSVP} = Ember;
+const { notEmpty, or, not } = computed;
+const { service } = inject;
+const { PromiseArray } = DS;
 
-export default Ember.Component.extend({
+export default Component.extend({
   currentUser: service(),
   store: service(),
   i18n: service(),
@@ -38,12 +38,12 @@ export default Ember.Component.extend({
     }
   }).readOnly(),
 
-  learningMaterialStatuses: function(){
+  learningMaterialStatuses: computed(function(){
     var self = this;
     return PromiseArray.create({
       promise: self.get('store').findAll('learning-material-status')
     });
-  }.property(),
+  }),
   learningMaterialUserRoles: computed(function(){
     var self = this;
     return PromiseArray.create({
@@ -54,7 +54,7 @@ export default Ember.Component.extend({
     let materialProxy = Ember.ObjectProxy.extend({
       sortTerms: ['name'],
       confirmRemoval: false,
-      sortedDescriptors: Ember.computed.sort('content.meshDescriptors', 'sortTerms')
+      sortedDescriptors: computed.sort('content.meshDescriptors', 'sortTerms')
     });
     return this.get('subject.learningMaterials').map(material => {
       return materialProxy.create({

--- a/app/components/detail-mesh.js
+++ b/app/components/detail-mesh.js
@@ -1,16 +1,18 @@
 import Ember from 'ember';
 import { translationMacro as t } from "ember-i18n";
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+
+export default Component.extend({
   store: Ember.inject.service(),
   i18n: Ember.inject.service(),
   classNames: ['detail-mesh'],
   placeholder: t('courses.meshSearchPlaceholder'),
   subject: null,
-  terms: Ember.computed.oneWay('subject.meshDescriptors'),
+  terms: computed.oneWay('subject.meshDescriptors'),
   isCourse: false,
   sortTerms: ['title'],
-  sortedTerms: Ember.computed.sort('terms', 'sortTerms'),
+  sortedTerms: computed.sort('terms', 'sortTerms'),
   isSession: false,
   isManaging: false,
   bufferTerms: [],

--- a/app/components/detail-objectives.js
+++ b/app/components/detail-objectives.js
@@ -2,11 +2,11 @@ import Ember from 'ember';
 import scrollTo from '../utils/scroll-to';
 import config from 'ilios/config/environment';
 
-const {computed, inject} = Ember;
-const {service} = inject;
-const {or, notEmpty} = computed;
+const { Component, computed, inject } = Ember;
+const { service } = inject;
+const { or, notEmpty } = computed;
 
-export default Ember.Component.extend({
+export default Component.extend({
   store: service(),
   i18n: service(),
   flashMessages: service(),

--- a/app/components/detail-steward-manager.js
+++ b/app/components/detail-steward-manager.js
@@ -1,30 +1,33 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { filter, mapBy } = computed;
+
+export default Component.extend({
   store: Ember.inject.service(),
   stewards: [],
   tagName: 'section',
   classNames: ['detail-block'],
-  stewardedDepartmentlessSchools: Ember.computed.filter('stewards', function(steward){
+  stewardedDepartmentlessSchools: filter('stewards', function(steward){
     return !steward.get('department.content');
   }),
-  stewardedSchools: Ember.computed.mapBy('stewardedDepartmentlessSchools', 'school'),
-  selectedSchools: Ember.computed.mapBy('stewardedSchools', 'content'),
-  stewardedDepartments: Ember.computed.mapBy('stewards', 'department'),
-  selectedDepartments: Ember.computed.mapBy('stewardedDepartments', 'content'),
-  schools: Ember.computed(function(){
+  stewardedSchools: mapBy('stewardedDepartmentlessSchools', 'school'),
+  selectedSchools: mapBy('stewardedSchools', 'content'),
+  stewardedDepartments: mapBy('stewards', 'department'),
+  selectedDepartments: mapBy('stewardedDepartments', 'content'),
+  schools: computed(function(){
     return DS.PromiseArray.create({
       promise: this.get('store').findAll('school')
     });
   }),
-  availableSchools: Ember.computed('stewardedSchools.@each', 'stewardedDepartments.@each', 'schools.@each', function(){
+  availableSchools: computed('stewardedSchools.@each', 'stewardedDepartments.@each', 'schools.@each', function(){
     let defer = Ember.RSVP.defer();
     let schoolProxy = Ember.ObjectProxy.extend({
       departments: [],
       selectedSchools: [],
       //display those with departments or those who are not already solo-assigned
-      display: Ember.computed('content', 'departments.length', function(){
+      display: computed('content', 'departments.length', function(){
         return this.get('departments').length > 0 ||
                !this.get('selectedSchools').contains(this.get('content'));
       }),
@@ -55,13 +58,13 @@ export default Ember.Component.extend({
       promise: defer.promise
     });
   }),
-  stewardSchools: Ember.computed('selectedSchools.@each', 'selectedDepartments.@each', 'schools.@each', function(){
+  stewardSchools: computed('selectedSchools.@each', 'selectedDepartments.@each', 'schools.@each', function(){
     let defer = Ember.RSVP.defer();
     let schoolProxy = Ember.ObjectProxy.extend({
       departments: [],
       selectedSchools: [],
       //display those with departments or those who are not already solo-assigned
-      display: Ember.computed('content', 'departments.length', function(){
+      display: computed('content', 'departments.length', function(){
         return this.get('departments').length > 0 ||
                this.get('selectedSchools').contains(this.get('content'));
       })

--- a/app/components/detail-stewards.js
+++ b/app/components/detail-stewards.js
@@ -1,13 +1,15 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+
+export default Component.extend({
   store: Ember.inject.service(),
   classNames: ['detail-stewards'],
   programYear: null,
   isManaging: false,
   bufferStewards: [],
-  stewardsBySchool: Ember.computed('programYear.stewards.@each', function(){
+  stewardsBySchool: computed('programYear.stewards.@each', function(){
     let deferred = Ember.RSVP.defer();
     let programYear = this.get('programYear');
 

--- a/app/components/detail-topic-list.js
+++ b/app/components/detail-topic-list.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-const {computed, RSVP} = Ember;
-const {PromiseArray} = DS;
+const { Component, computed, RSVP } = Ember;
+const { PromiseArray } = DS;
 
-export default Ember.Component.extend({
+export default Component.extend({
   topics: [],
   sortedTopics: computed('topics.[]', function(){
     let defer = RSVP.defer();
@@ -12,7 +12,7 @@ export default Ember.Component.extend({
     this.get('topics').then(topics => {
       defer.resolve(topics.sortBy('title'));
     });
-    
+
     return PromiseArray.create({
       promise: defer.promise
     });

--- a/app/components/detail-topic-manager.js
+++ b/app/components/detail-topic-manager.js
@@ -3,12 +3,12 @@ import DS from 'ember-data';
 
 import { translationMacro as t } from "ember-i18n";
 
-const {computed, inject, RSVP} = Ember;
-const {service} = inject;
-const {PromiseArray} = DS;
-const {sort} = computed;
+const { Component, computed, inject, RSVP } = Ember;
+const { service } = inject;
+const { PromiseArray } = DS;
+const { sort } = computed;
 
-export default Ember.Component.extend({
+export default Component.extend({
   i18n: service(),
   tagName: 'section',
   classNames: ['detail-block'],
@@ -21,7 +21,7 @@ export default Ember.Component.extend({
   filteredAvailableTopics: computed('availableTopics.[]', 'selectedTopics.[]', 'filter', function(){
     let defer = RSVP.defer();
     let exp = new RegExp(this.get('filter'), 'gi');
-    
+
     this.get('availableTopics').then(availableTopics => {
       let filteredTopics = availableTopics.filter(topic => {
         return (
@@ -31,10 +31,10 @@ export default Ember.Component.extend({
           !this.get('selectedTopics').contains(topic)
         );
       });
-      
+
       defer.resolve(filteredTopics.sortBy('title'));
     });
-    
+
     return PromiseArray.create({
       promise: defer.promise
     });

--- a/app/components/detail-topics.js
+++ b/app/components/detail-topics.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-const {computed, RSVP} = Ember;
-const {PromiseArray} = DS;
+const { Component, computed, RSVP } = Ember;
+const { PromiseArray } = DS;
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['detail-topics'],
   subject: null,
   isManaging: false,
@@ -15,7 +15,7 @@ export default Ember.Component.extend({
   bufferedTopics: [],
   availableTopics: computed('isCourse', 'isSession', 'isProgramYear', 'subject', function(){
     let defer = RSVP.defer();
-    
+
     if(this.get('isCourse')){
       this.get('subject').get('school').then(school => {
         school.get('topics').then(topics => {
@@ -41,7 +41,7 @@ export default Ember.Component.extend({
     } else {
       throw new Error("detail-topic component called without isCourse, isSession, or isProgramYear context");
     }
-    
+
     return PromiseArray.create({
       promise: defer.promise
     });
@@ -67,7 +67,7 @@ export default Ember.Component.extend({
           this.set('isSaving', false);
         });
       });
-      
+
     },
     cancel(){
       this.set('bufferedTopics', []);

--- a/app/components/file-upload.js
+++ b/app/components/file-upload.js
@@ -1,9 +1,12 @@
 import Ember from 'ember';
 import EmberUploader from 'ember-uploader';
 
-export default EmberUploader.FileField.extend({
+const { observer } = Ember;
+const { FileField } = EmberUploader;
+
+export default FileField.extend({
   url: '',
-  filesDidChange: (function() {
+  filesDidChange: observer('files', function() {
     var uploadUrl = this.get('url');
     var files = this.get('files');
 
@@ -18,5 +21,5 @@ export default EmberUploader.FileField.extend({
     if (!Ember.isEmpty(files)) {
       uploader.upload(files[0]);
     }
-  }).observes('files')
+  })
 });

--- a/app/components/global-search.js
+++ b/app/components/global-search.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 
-const {inject, run, computed} = Ember;
-const {service} = inject;
-const {debounce} = run;
-const {or, notEmpty} = computed;
+const { Component, inject, run, computed } = Ember;
+const { service } = inject;
+const { debounce } = run;
+const { or, notEmpty } = computed;
 
-export default Ember.Component.extend({
+export default Component.extend({
   store: service(),
   i18n: service(),
   classNames: ['global-search'],

--- a/app/components/ilios-course-details.js
+++ b/app/components/ilios-course-details.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
 import scrollTo from '../utils/scroll-to';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { not } = computed;
+
+export default Component.extend({
   course: null,
   collapsed: true,
-  notCollapsed: Ember.computed.not('collapsed'),
+  notCollapsed: not('collapsed'),
   actions: {
     expand: function(){
       this.sendAction('collapsedState', false);

--- a/app/components/ilios-course-list.js
+++ b/app/components/ilios-course-list.js
@@ -23,7 +23,7 @@ const CourseProxy = ObjectProxy.extend({
         });
       }
     });
-    
+
     return PromiseObject.create({
       promise: defer.promise
     });

--- a/app/components/ilios-event.js
+++ b/app/components/ilios-event.js
@@ -2,12 +2,12 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import momentFormat from 'ember-moment/computeds/format';
 
-const {computed, inject, RSVP, isEmpty} = Ember;
-const {PromiseObject, PromiseArray} = DS;
-const {notEmpty} = computed;
+const { Component, computed, inject, RSVP, isEmpty} = Ember;
+const { PromiseObject, PromiseArray } = DS;
+const { notEmpty } = computed;
 const { service } = inject;
 
-export default Ember.Component.extend({
+export default Component.extend({
   store: service(),
   i18n: service(),
   event: null,

--- a/app/components/ilios-header.js
+++ b/app/components/ilios-header.js
@@ -1,14 +1,17 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { oneWay, equal } = computed;
+
+export default Component.extend({
   session: null,
   currentUser: Ember.inject.service(),
   i18n: Ember.inject.service(),
-  userName: Ember.computed.oneWay('currentUser.model.fullName'),
-  inEnglish: Ember.computed.equal('i18n.locale', 'en'),
-  inSpanish: Ember.computed.equal('i18n.locale', 'es'),
-  inFrench: Ember.computed.equal('i18n.locale', 'fr'),
-  locales: Ember.computed('i18n.locales', 'i18n.locale', function() {
+  userName: oneWay('currentUser.model.fullName'),
+  inEnglish: equal('i18n.locale', 'en'),
+  inSpanish: equal('i18n.locale', 'es'),
+  inFrench: equal('i18n.locale', 'fr'),
+  locales: computed('i18n.locales', 'i18n.locale', function() {
     return this.get('i18n.locales').map(locale => {
       return { id: locale, text: this.get('i18n').t('language.select.' + locale) };
     }).filter(locale => locale.id !== this.get('i18n.locale'));

--- a/app/components/ilios-navigation.js
+++ b/app/components/ilios-navigation.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   i18n: Ember.inject.service(),
   isMenuVisible: false,
   actions: {

--- a/app/components/inplace-html.js
+++ b/app/components/inplace-html.js
@@ -2,7 +2,9 @@ import Ember from 'ember';
 import config from 'ilios/config/environment';
 import InPlace from 'ilios/mixins/inplace';
 
-export default Ember.Component.extend(InPlace, {
+const { Component } = Ember;
+
+export default Component.extend(InPlace, {
   classNames: ['editinplace', 'inplace-html'],
   editorParams: config.froalaEditorDefaults,
   willDestroyElement(){
@@ -20,7 +22,7 @@ export default Ember.Component.extend(InPlace, {
           //if all we have is empty html then save null
           if(plainText.length === 0){
             html = null;
-          } 
+          }
           value = html;
         }
         this.sendAction('save', value, this.get('condition'));

--- a/app/components/instructor-selection-manager.js
+++ b/app/components/instructor-selection-manager.js
@@ -1,17 +1,20 @@
 import Ember from 'ember';
 import { translationMacro as t } from "ember-i18n";
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { sort } = computed;
+
+export default Component.extend({
   i18n: Ember.inject.service(),
   instructors: [],
   availableInstructorGroups: [],
   sortInstructorsBy: ['title'],
   classNames: ['detail-block'],
   tagName: 'section',
-  sortedInstructors: Ember.computed.sort('instructors', 'sortInstructorsBy'),
+  sortedInstructors: sort('instructors', 'sortInstructorsBy'),
   instructorGroups: [],
   sortGroupsBy: ['title'],
-  sortedInstructorGroups: Ember.computed.sort('instructorGroups', 'sortGroupsBy'),
+  sortedInstructorGroups: sort('instructorGroups', 'sortGroupsBy'),
   userSearchPlaceholder: t('general.findInstructorOrGroup'),
   actions: {
     addInstructor(user){

--- a/app/components/instructorgroup-details.js
+++ b/app/components/instructorgroup-details.js
@@ -1,12 +1,15 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { filterBy, sort } = computed;
+
+export default Component.extend({
   instructorGroup: null,
   usersSort: ['lastName', 'firstName'],
-  usersWithFullName: Ember.computed.filterBy('instructorGroup.users', 'fullName'),
-  sortedUsers: Ember.computed.sort('usersWithFullName', 'usersSort'),
+  usersWithFullName: filterBy('instructorGroup.users', 'fullName'),
+  sortedUsers: sort('usersWithFullName', 'usersSort'),
   courseSort: ['title'],
-  sortedCourses: Ember.computed.sort('instructorGroup.courses', 'courseSort'),
+  sortedCourses: sort('instructorGroup.courses', 'courseSort'),
   actions: {
     changeTitle: function(newTitle){
       this.get('instructorGroup').set('title', newTitle);

--- a/app/components/instructorgroup-list.js
+++ b/app/components/instructorgroup-list.js
@@ -1,15 +1,17 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+
+export default Component.extend({
   instructorGroups: [],
-  proxiedInstructorGroups: function(){
+  proxiedInstructorGroups: computed('instructorGroups.@each', function(){
     return this.get('instructorGroups').map(function(instructorGroup){
       return Ember.ObjectProxy.create({
         content: instructorGroup,
         showRemoveConfirmation: false
       });
     });
-  }.property('instructorGroups.@each'),
+  }),
   actions: {
     edit: function(instructorGroupProxy){
       this.sendAction('edit', instructorGroupProxy.get('content'));

--- a/app/components/instructorgroup-selection-manager.js
+++ b/app/components/instructorgroup-selection-manager.js
@@ -1,29 +1,37 @@
 import Ember from 'ember';
 import { translationMacro as t } from "ember-i18n";
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { alias, sort } = computed;
+
+export default Component.extend({
   i18n: Ember.inject.service(),
   placeholder: t('general.filterPlaceholder'),
   filter: '',
   sortBy: ['title'],
   subject: null,
   availableInstructorGroups: [],
-  instructorGroups: Ember.computed.alias('subject.instructorGroups'),
-  sortedInstructorGroups: Ember.computed.sort('instructorGroups', 'sortBy'),
-  filteredAvailableInstructorGroups: function(){
-    var self = this;
-    var filter = this.get('filter');
-    var exp = new RegExp(filter, 'gi');
-    var instructorGroups = this.get('availableInstructorGroups')?this.get('availableInstructorGroups'):[];
-    return instructorGroups.filter(function(group) {
-      return (
-        group.get('title') !== undefined &&
-        self.get('instructorGroups') &&
-        exp.test(group.get('title')) &&
-        !self.get('instructorGroups').contains(group)
-      );
-    }).sortBy('title');
-  }.property('instructorGroups.@each', 'filter', 'availableInstructorGroups.@each.title'),
+  instructorGroups: alias('subject.instructorGroups'),
+  sortedInstructorGroups: sort('instructorGroups', 'sortBy'),
+  filteredAvailableInstructorGroups: computed(
+    'instructorGroups.@each',
+    'filter',
+    'availableInstructorGroups.@each.title',
+    function(){
+      var self = this;
+      var filter = this.get('filter');
+      var exp = new RegExp(filter, 'gi');
+      var instructorGroups = this.get('availableInstructorGroups')?this.get('availableInstructorGroups'):[];
+      return instructorGroups.filter(function(group) {
+        return (
+          group.get('title') !== undefined &&
+          self.get('instructorGroups') &&
+          exp.test(group.get('title')) &&
+          !self.get('instructorGroups').contains(group)
+        );
+      }).sortBy('title');
+    }
+  ),
   actions: {
     add: function(instructorGroup){
       var subject = this.get('subject');

--- a/app/components/learnergroup-details.js
+++ b/app/components/learnergroup-details.js
@@ -2,33 +2,20 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import { translationMacro as t } from "ember-i18n";
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+
+export default Component.extend({
   i18n: Ember.inject.service(),
   learnerGroup: null,
   notInThisGroup: t('learnerGroups.notInThisGroup'),
-  topLevelGroupMembersNotInThisGroup: function(){
-    var deferred = Ember.RSVP.defer();
-    this.get('learnerGroup.usersOnlyAtThisLevel').then(currentUsers => {
-      this.get('learnerGroup.topLevelGroup').then(topLevelGroup => {
-        topLevelGroup.get('allDescendantUsers').then(users => {
-          let filteredUsers = users.filter(
-            user => !currentUsers.contains(user)
-          );
-          deferred.resolve(filteredUsers.sortBy('fullName'));
-        });
-      });
-    });
-
-    return DS.PromiseArray.create({
-      promise: deferred.promise
-    });
-  }.property('learnerGroup.topLevelGroup.allDescendantUsers.@each', 'learnerGroup.user.@each'),
-  cohortMembersNotInAnyGroup: function(){
-    var deferred = Ember.RSVP.defer();
-    this.get('learnerGroup.topLevelGroup').then(topLevelGroup => {
-      topLevelGroup.get('allDescendantUsers').then(currentUsers => {
-        this.get('learnerGroup.cohort').then(cohort => {
-          cohort.get('users').then(users => {
+  topLevelGroupMembersNotInThisGroup: computed(
+    'learnerGroup.topLevelGroup.allDescendantUsers.@each',
+    'learnerGroup.user.@each',
+    function(){
+      var deferred = Ember.RSVP.defer();
+      this.get('learnerGroup.usersOnlyAtThisLevel').then(currentUsers => {
+        this.get('learnerGroup.topLevelGroup').then(topLevelGroup => {
+          topLevelGroup.get('allDescendantUsers').then(users => {
             let filteredUsers = users.filter(
               user => !currentUsers.contains(user)
             );
@@ -36,9 +23,33 @@ export default Ember.Component.extend({
           });
         });
       });
-    });
-    return DS.PromiseArray.create({
-      promise: deferred.promise
-    });
-  }.property('learnerGroup.topLevelGroup.allDescendantUsers.@each', 'learnerGroup.user.@each', 'learnerGroup.cohort.users.@each')
+
+      return DS.PromiseArray.create({
+        promise: deferred.promise
+      });
+    }
+  ),
+  cohortMembersNotInAnyGroup: computed(
+    'learnerGroup.topLevelGroup.allDescendantUsers.@each',
+    'learnerGroup.user.@each',
+    'learnerGroup.cohort.users.@each',
+    function(){
+      var deferred = Ember.RSVP.defer();
+      this.get('learnerGroup.topLevelGroup').then(topLevelGroup => {
+        topLevelGroup.get('allDescendantUsers').then(currentUsers => {
+          this.get('learnerGroup.cohort').then(cohort => {
+            cohort.get('users').then(users => {
+              let filteredUsers = users.filter(
+                user => !currentUsers.contains(user)
+              );
+              deferred.resolve(filteredUsers.sortBy('fullName'));
+            });
+          });
+        });
+      });
+      return DS.PromiseArray.create({
+        promise: deferred.promise
+      });
+    }
+  )
 });

--- a/app/components/learnergroup-list.js
+++ b/app/components/learnergroup-list.js
@@ -1,15 +1,17 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+
+export default Component.extend({
   learnerGroups: [],
-  proxiedLearnerGroups: function(){
+  proxiedLearnerGroups: computed('learnerGroups.@each', function(){
     return this.get('learnerGroups').map(function(learnerGroup){
       return Ember.ObjectProxy.create({
         content: learnerGroup,
         showRemoveConfirmation: false
       });
     });
-  }.property('learnerGroups.@each'),
+  }),
   actions: {
     edit: function(learnerGroupProxy){
       this.sendAction('edit', learnerGroupProxy.get('content'));

--- a/app/components/learnergroup-overview.js
+++ b/app/components/learnergroup-overview.js
@@ -1,20 +1,21 @@
 import Ember from 'ember';
 
-const { observer, run } = Ember;
+const { Component, computed, observer, run } = Ember;
+const { filterBy, mapBy, sort } = computed;
 const { once } = run;
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['learnergroup-overview'],
   learnerGroup: null,
   instructorsSort: ['lastName', 'firstName'],
-  instructorsWithFullName: Ember.computed.filterBy('learnerGroup.instructors', 'fullName'),
-  sortedInstructors: Ember.computed.sort('instructorsWithFullName', 'instructorsSort'),
+  instructorsWithFullName: filterBy('learnerGroup.instructors', 'fullName'),
+  sortedInstructors: sort('instructorsWithFullName', 'instructorsSort'),
   courseSort: ['title'],
-  sortedCourses: Ember.computed.sort('learnerGroup.courses', 'courseSort'),
-  associatedCoursesTitles: Ember.computed.mapBy('sortedCourses', 'title'),
-  associatedCoursesString: function(){
+  sortedCourses: sort('learnerGroup.courses', 'courseSort'),
+  associatedCoursesTitles: mapBy('sortedCourses', 'title'),
+  associatedCoursesString: computed('associatedCoursesTitles.@each', function(){
     return this.get('associatedCoursesTitles').join(', ');
-  }.property('associatedCoursesTitles.@each'),
+  }),
 
   multiEditModeOn: false,
   includeAll: false,

--- a/app/components/learnergroup-subgroup-list.js
+++ b/app/components/learnergroup-subgroup-list.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 const { Component, computed, inject, ObjectProxy } = Ember;
 const { service } = inject;
-const { oneWay } = computed;
+const { oneWay, sort } = computed;
 
 export default Component.extend({
   store: service(),
@@ -14,7 +14,7 @@ export default Component.extend({
   learnerGroups: oneWay('parentGroup.children'),
 
   sortBy: ['title'],
-  sortedLearnerGroups: Ember.computed.sort('learnerGroups', 'sortBy'),
+  sortedLearnerGroups: sort('learnerGroups', 'sortBy'),
 
   proxiedLearnerGroups: computed('sortedLearnerGroups.[]', {
     get() {

--- a/app/components/learningmaterial-manager.js
+++ b/app/components/learningmaterial-manager.js
@@ -1,31 +1,34 @@
 import Ember from 'ember';
 import layout from '../templates/components/learningmaterial-manager';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { not } = computed;
+
+export default Component.extend({
   layout: layout,
   classNames: ['learningmaterial-manager'],
   learningMaterial: null,
   valueBuffer: null,
   isCourse: false,
-  isSession: Ember.computed.not('isCourse'),
+  isSession: not('isCourse'),
   learningMaterialStatuses: [],
-  statusOptions: function(){
+  statusOptions: computed('learningMaterialStatuses.@each', function(){
     return this.get('learningMaterialStatuses').map(function(status){
       return Ember.Object.create({
         id: status.get('id'),
         title: status.get('title')
       });
     }).sortBy('title');
-  }.property('learningMaterialStatuses.@each'),
-  isFile: function(){
+  }),
+  isFile: computed('learningMaterial.learningMaterial.type', function(){
     return this.get('learningMaterial.learningMaterial.type') === 'file';
-  }.property('learningMaterial.learningMaterial.type'),
-  isLink: function(){
+  }),
+  isLink: computed('learningMaterial.learningMaterial.type', function(){
     return this.get('learningMaterial.learningMaterial.type') === 'link';
-  }.property('learningMaterial.learningMaterial.type'),
-  isCitation: function(){
+  }),
+  isCitation: computed('learningMaterial.learningMaterial.type', function(){
     return this.get('learningMaterial.learningMaterial.type') === 'citation';
-  }.property('learningMaterial.learningMaterial.type'),
+  }),
   actions: {
     changeStatus: function(statusId){
       var newStatus = this.get('learningMaterialStatuses').findBy('id', statusId);

--- a/app/components/live-search.js
+++ b/app/components/live-search.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import LiveSearchItem from 'ilios/mixins/live-search-item';
 
-export default Ember.Component.extend({
+const { Component, computed, observer } = Ember;
+
+export default Component.extend({
   keyDown: function(event) {
     if (event.which === 27) {
       this.send('clear');  // ESC key
@@ -15,10 +17,10 @@ export default Ember.Component.extend({
   showMoreInputPrompt: false,
   searchReturned: false,
   searching: false,
-  sortedSearchResults: function(){
+  sortedSearchResults: computed('results.@each', function(){
     return this.get('results').sortBy('sortTerm');
-  }.property('results.@each'),
-  searchResults: function(key, values){
+  }),
+  searchResults: computed(function(key, values){
     if (arguments.length > 1) {
       values.forEach(function(obj){
         if(!LiveSearchItem.detect(obj)){
@@ -28,10 +30,10 @@ export default Ember.Component.extend({
       this.set('results', values);
     }
     return this.get('results');
-  }.property(),
-  watchSeatchTerms: function(){
+  }),
+  watchSeatchTerms: observer('searchTerms', function(){
     this.send('search');
-  }.observes('searchTerms'),
+  }),
   actions: {
     add: function(obj) {
       this.sendAction('add', obj);

--- a/app/components/loading-part.js
+++ b/app/components/loading-part.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import layout from '../templates/components/loading-part';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   layout: layout
 });

--- a/app/components/mesh-manager.js
+++ b/app/components/mesh-manager.js
@@ -2,14 +2,16 @@ import Ember from 'ember';
 import layout from '../templates/components/mesh-manager';
 import { translationMacro as t } from "ember-i18n";
 
+const { Component, computed } = Ember;
+
 var ProxiedDescriptors = Ember.ObjectProxy.extend({
   terms: [],
-  isActive: function(){
+  isActive: computed('content', 'terms.@each', function(){
     return !this.get('terms').contains(this.get('content'));
-  }.property('content', 'terms.@each')
+  })
 });
 
-export default Ember.Component.extend({
+export default Component.extend({
   store: Ember.inject.service(),
   i18n: Ember.inject.service(),
   layout: layout,
@@ -25,13 +27,13 @@ export default Ember.Component.extend({
   searching: false,
   searchReturned: false,
   sortTerms: ['name'],
-  sortedTerms: function(){
+  sortedTerms: computed('terms.@each.name', function(){
     var terms = this.get('terms');
     if(!terms || terms.length === 0){
       return [];
     }
     return terms.sortBy('name');
-  }.property('terms.@each.name'),
+  }),
   tagName: 'section',
   actions: {
     search: function(query){

--- a/app/components/new-learningmaterial.js
+++ b/app/components/new-learningmaterial.js
@@ -3,11 +3,11 @@ import config from 'ilios/config/environment';
 import layout from '../templates/components/new-learningmaterial';
 import EmberValidations from 'ember-validations';
 
-const { computed, inject } = Ember;
+const { Component, computed, inject } = Ember;
 const { alias } = computed;
 const { service } = inject;
 
-export default Ember.Component.extend(EmberValidations, {
+export default Component.extend(EmberValidations, {
   init() {
     const type = this.get('type');
 

--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-const { computed, inject, RSVP, isEmpty, isPresent } = Ember;
+const { Component, computed, inject, RSVP, isEmpty, isPresent } = Ember;
 const { service } = inject;
 const { PromiseArray } = DS;
 
-export default Ember.Component.extend({
+export default Component.extend({
   store: service(),
   i18n: service(),
   currentUser: service(),
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
       {value: 'mesh term', label: this.get('i18n').t('general.meshTerms')},
       {value: 'session type', label: this.get('i18n').t('general.sessionTypes')},
     ];
-    
+
     return list;
   }),
   prepositionalObjectList: computed('i18n.locale', 'currentSubject', function(){
@@ -45,9 +45,9 @@ export default Ember.Component.extend({
       {value: 'mesh term', label: this.get('i18n').t('general.meshTerm'), subjects: ['course', 'session', 'learning material', 'topic', 'session type']},
       {value: 'session type', label: this.get('i18n').t('general.sessionType'), subjects: ['session', 'instructor', 'instructor group', 'learning material', 'competency', 'topic', 'mesh term']},
     ];
-    
+
     const subject = this.get('currentSubject');
-    
+
     return list.filter(item =>item.subjects.contains(subject));
   }),
   prepositionalObjectIdList: computed('currentPrepositionalObject', function(){
@@ -69,7 +69,7 @@ export default Ember.Component.extend({
           label: object.get(label)
         };
       }).sortBy('label');
-      
+
       defer.resolve(values);
     });
     return PromiseArray.create({
@@ -81,7 +81,7 @@ export default Ember.Component.extend({
     let currentSubject = this.get('subjectList').find(subject => {
       return subject.value === currentSubjectValue;
     });
-    
+
     return currentSubject.label;
   }),
   selectedUser: computed('currentPrepositionalObject', 'currentPrepositionalObjectId', function(){
@@ -152,7 +152,7 @@ export default Ember.Component.extend({
         return;
       }
       this.get('currentUser.model').then(user => {
-        
+
         let title = this.get('title');
         let subject = this.get('currentSubject');
         let prepositionalObject = this.get('currentPrepositionalObject');
@@ -164,7 +164,7 @@ export default Ember.Component.extend({
           prepositionalObject,
           prepositionalObjectTableRowId
         });
-        
+
         report.save().then(() => {
           this.sendAction('close');
         });

--- a/app/components/objective-manage-competency.js
+++ b/app/components/objective-manage-competency.js
@@ -1,12 +1,15 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { notEmpty, oneWay } = computed;
+
+export default Component.extend({
   objective: null,
-  programYear: Ember.computed.oneWay('objective.programYear'),
-  showCompetencyList: Ember.computed.notEmpty('programYear.competencies'),
+  programYear: oneWay('objective.programYear'),
+  showCompetencyList: notEmpty('programYear.competencies'),
   classNames: ['objective-manager', 'objective-manage-competency'],
-  competencies: function(){
+  competencies: computed('programYear.competencies.@each', 'objective.competency', function(){
     if(!this.get('programYear')){
       return [];
     }
@@ -14,8 +17,8 @@ export default Ember.Component.extend({
     return DS.PromiseArray.create({
       promise: this.get('programYear.competencies')
     });
-  }.property('programYear.competencies.@each', 'objective.competency'),
-  domains: function(){
+  }),
+  domains: computed('competencies.@each.domain', 'objective.competency', function(){
     var defer = Ember.RSVP.defer();
     var domainContainer = {};
     var domainIds = [];
@@ -23,7 +26,7 @@ export default Ember.Component.extend({
     let domainProxy = Ember.ObjectProxy.extend({
       selectedCompetency: null,
       subCompetencies: [],
-      selected: Ember.computed('subCompetencies.@each', 'selectedCompetency', function(){
+      selected: computed('subCompetencies.@each', 'selectedCompetency', function(){
         let selectedSubCompetencies = this.get('subCompetencies').filter(competencyProxy => {
           return competencyProxy.get('id') === this.get('selectedCompetency.id');
         });
@@ -32,7 +35,7 @@ export default Ember.Component.extend({
     });
     let competencyProxy = Ember.ObjectProxy.extend({
       selectedCompetency: null,
-      selected: Ember.computed('content', 'selectedCompetency', function(){
+      selected: computed('content', 'selectedCompetency', function(){
         return this.get('content.id') === this.get('selectedCompetency.id');
       }),
     });
@@ -72,7 +75,7 @@ export default Ember.Component.extend({
     return DS.PromiseArray.create({
       promise: defer.promise
     });
-  }.property('competencies.@each.domain', 'objective.competency'),
+  }),
   actions: {
     changeCompetency: function(competency){
       this.get('objective').set('competency', competency);

--- a/app/components/objective-manage-descriptors.js
+++ b/app/components/objective-manage-descriptors.js
@@ -1,16 +1,18 @@
 import Ember from 'ember';
 import layout from '../templates/components/objective-manage-descriptors';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+
+export default Component.extend({
   layout: layout,
   objective: null,
-  objectiveDescriptors: function(){
+  objectiveDescriptors: computed('objective', 'objective.meshDescriptors.[]', function(){
     var objective = this.get('objective');
     if(!objective){
       return [];
     }
     return objective.get('meshDescriptors');
-  }.property('objective', 'objective.meshDescriptors.[]'),
+  }),
   actions: {
     add: function(descriptor){
       var objective = this.get('objective');

--- a/app/components/offering-block.js
+++ b/app/components/offering-block.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import layout from '../templates/components/offering-block';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   layout: layout,
   block: null,
   actions: {

--- a/app/components/offering-manager.js
+++ b/app/components/offering-manager.js
@@ -2,13 +2,13 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import moment from 'moment';
 
-const { computed, copy, inject, isEmpty, ObjectProxy, RSVP } = Ember;
-const { notEmpty } = computed;
+const { Component, computed, copy, inject, isEmpty, ObjectProxy, RSVP } = Ember;
+const { alias, notEmpty, sort } = computed;
 const { all, Promise } = RSVP;
 const { PromiseArray, PromiseObject } = DS;
 const { service } = inject;
 
-export default Ember.Component.extend({
+export default Component.extend({
   init() {
     this._super(...arguments);
 
@@ -21,13 +21,13 @@ export default Ember.Component.extend({
   editable: true,
   sortBy: ['lastName', 'firstName'],
   classNames: ['offering-manager'],
-  sortedInstructors: Ember.computed.sort('instructors', 'sortBy'),
+  sortedInstructors: sort('instructors', 'sortBy'),
   isMultiDay: false,
-  cohorts: Ember.computed.alias('offering.session.course.cohorts'),
-  availableInstructorGroups: Ember.computed.alias('offering.session.course.school.instructorGroups'),
+  cohorts: alias('offering.session.course.cohorts'),
+  availableInstructorGroups: alias('offering.session.course.school.instructorGroups'),
   showRemoveConfirmation: false,
   buffer: null,
-  allInstructors: function(){
+  allInstructors: computed('instructors.@each', 'instructorGroups.@each.users.@each', function(){
     var self = this;
     var defer = Ember.RSVP.defer();
     var instructorGroups = this.get('instructorGroups');
@@ -43,7 +43,7 @@ export default Ember.Component.extend({
     return DS.PromiseArray.create({
       promise: defer.promise
     });
-  }.property('instructors.@each', 'instructorGroups.@each.users.@each'),
+  }),
 
   learnerGroups: null,
 

--- a/app/components/print-course.js
+++ b/app/components/print-course.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-const { computed, RSVP, ObjectProxy } = Ember;
+const { Component, computed, RSVP, ObjectProxy } = Ember;
 const { PromiseArray } = DS;
 
-export default Ember.Component.extend({
+export default Component.extend({
   course: null,
   tagName: 'section',
   classNames: ['printable course'],

--- a/app/components/program-details.js
+++ b/app/components/program-details.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
 });

--- a/app/components/program-list.js
+++ b/app/components/program-list.js
@@ -1,15 +1,17 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+
+export default Component.extend({
   programs: [],
-  proxiedPrograms: function(){
+  proxiedPrograms: computed('programs.@each', function(){
     return this.get('programs').map(function(program){
       return Ember.ObjectProxy.create({
         content: program,
         showRemoveConfirmation: false
       });
     });
-  }.property('programs.@each'),
+  }),
   actions: {
     edit: function(programProxy){
       this.sendAction('edit', programProxy.get('content'));

--- a/app/components/programyear-competencies.js
+++ b/app/components/programyear-competencies.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   programYear: null,
   classNames: ['programyear-competencies'],
   isManaging: false,

--- a/app/components/programyear-competency-manager.js
+++ b/app/components/programyear-competency-manager.js
@@ -1,20 +1,22 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+
+export default Component.extend({
   filter: '',
   availableCompetencies: [],
   selectedCompetencies: [],
   tagName: 'section',
   classNames: ['detail-block'],
-  filteredCompetencies: function(){
+  filteredCompetencies: computed('availableCompetencies.@each', 'selectedCompetencies.@each', function(){
     return this.get('availableCompetencies').filter(
       competency => {
         return !this.get('selectedCompetencies').contains(competency);
       }
     );
-  }.property('availableCompetencies.@each', 'selectedCompetencies.@each'),
-  filteredDomains: function(){
+  }),
+  filteredDomains: computed('filteredCompetencies.@each.domain', function(){
     var defer = Ember.RSVP.defer();
     var domainContainer = {};
     var domainIds = [];
@@ -51,8 +53,8 @@ export default Ember.Component.extend({
     return DS.PromiseArray.create({
       promise: defer.promise
     });
-  }.property('filteredCompetencies.@each.domain'),
-  selectedDomains: function(){
+  }),
+  selectedDomains: computed('selectedCompetencies.@each.domain', function(){
     var defer = Ember.RSVP.defer();
     var domainContainer = {};
     var domainIds = [];
@@ -87,7 +89,7 @@ export default Ember.Component.extend({
     return DS.PromiseArray.create({
       promise: defer.promise
     });
-  }.property('selectedCompetencies.@each.domain'),
+  }),
   actions: {
     removeCompetency: function(competency){
       this.sendAction('remove', competency);

--- a/app/components/programyear-details.js
+++ b/app/components/programyear-details.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
 });

--- a/app/components/programyear-header.js
+++ b/app/components/programyear-header.js
@@ -1,8 +1,11 @@
 import Ember from 'ember';
 import Publishable from 'ilios/mixins/publishable';
 
-export default Ember.Component.extend(Publishable, {
+const { Component, computed } = Ember;
+const { alias } = computed;
+
+export default Component.extend(Publishable, {
   programYear: null,
-  publishTarget: Ember.computed.alias('programYear'),
+  publishTarget: alias('programYear'),
   publishEventCollectionName: 'programYears',
 });

--- a/app/components/programyear-objective-list.js
+++ b/app/components/programyear-objective-list.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { alias, sort } = computed;
+
+export default Component.extend({
   programYear: null,
   classNames: ['programyear-objective-list'],
-  objectives: Ember.computed.alias('programYear.objectives'),
-  sortedObjectives: Ember.computed.sort('objectives', function(a, b){
+  objectives: alias('programYear.objectives'),
+  sortedObjectives: sort('objectives', function(a, b){
     return parseInt(a.get( 'id' )) - parseInt(b.get( 'id' ));
   }),
   actions: {

--- a/app/components/programyear-overview.js
+++ b/app/components/programyear-overview.js
@@ -1,11 +1,14 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { filterBy, sort } = computed;
+
+export default Component.extend({
   classNames: ['programyear-overview'],
   programYear: null,
   directorsSort: ['lastName', 'firstName'],
-  directorsWithFullName: Ember.computed.filterBy('programYear.directors', 'fullName'),
-  sortedDirectors: Ember.computed.sort('directorsWithFullName', 'directorsSort'),
+  directorsWithFullName: filterBy('programYear.directors', 'fullName'),
+  sortedDirectors: sort('directorsWithFullName', 'directorsSort'),
   actions: {
     addDirector: function(user){
       let programYear = this.get('programYear');

--- a/app/components/publication-status.js
+++ b/app/components/publication-status.js
@@ -1,13 +1,16 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { alias } = computed;
+
+export default Component.extend({
   showIcon: true,
   tagName: 'span',
   classNameBindings: [
     ':status',
     'publicationStatus'
   ],
-  publicationStatus: function(){
+  publicationStatus: computed('isPublished', 'isScheduled', function(){
     if(this.get('isScheduled')){
       return 'scheduled';
     } else if (this.get('isPublished')){
@@ -15,8 +18,8 @@ export default Ember.Component.extend({
     }
 
     return 'notpublished';
-  }.property('isPublished', 'isScheduled'),
+  }),
   item: null,
-  isPublished: Ember.computed.alias('item.isPublished'),
-  isScheduled: Ember.computed.alias('item.publishedAsTbd'),
+  isPublished: alias('item.isPublished'),
+  isScheduled: alias('item.publishedAsTbd')
 });

--- a/app/components/publish-all-sessions.js
+++ b/app/components/publish-all-sessions.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-const {Component, computed, RSVP, inject} = Ember;
-const {PromiseArray} = DS;
-const {equal} = computed;
-const {service} = inject;
+const { Component, computed, RSVP, inject } = Ember;
+const { PromiseArray } = DS;
+const { equal } = computed;
+const { service } = inject;
 
 export default Component.extend({
   store: service(),
@@ -20,37 +20,37 @@ export default Component.extend({
   }),
   publishableSessions: computed('sessions.@each.allPublicationIssuesLength', function(){
     let defer = RSVP.defer();
-    
+
     this.get('sessions').then(sessions=>{
       let filteredSessions = sessions.filter(session => {
         return session.get('allPublicationIssuesLength') === 0;
       });
-      
+
       defer.resolve(filteredSessions);
     });
-    
+
     return PromiseArray.create({
       promise: defer.promise
     });
   }),
   unPublishableSessions: computed('sessions.@each.requiredPublicationIssues', function(){
     let defer = RSVP.defer();
-    
+
     this.get('sessions').then(sessions=>{
       let filteredSessions = sessions.filter(session => {
         return session.get('requiredPublicationIssues').get('length') > 0;
       });
-      
+
       defer.resolve(filteredSessions);
     });
-    
+
     return PromiseArray.create({
       promise: defer.promise
     });
   }),
   overridableSessions: computed('sessions.@each.{requiredPublicationIssues,optionalPublicationIssues}', function(){
     let defer = RSVP.defer();
-    
+
     this.get('sessions').then(sessions=>{
       let filteredSessions = sessions.filter(session => {
         return (
@@ -58,10 +58,10 @@ export default Component.extend({
           session.get('optionalPublicationIssues').get('length') > 0
         );
       });
-      
+
       defer.resolve(filteredSessions);
     });
-    
+
     return PromiseArray.create({
       promise: defer.promise
     });
@@ -130,7 +130,7 @@ export default Component.extend({
           this.get('flashMessages').success('general.savedSuccessfully');
         });
       });
-      
+
     },
     togglePublishableCollapsed(){
       this.set('publishableCollapsed', !this.get('publishableCollapsed'));

--- a/app/components/pulse-loader.js
+++ b/app/components/pulse-loader.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   classNameBindings: [':pulseloader'],
   tagName: 'div',
 });

--- a/app/components/search-box.js
+++ b/app/components/search-box.js
@@ -1,14 +1,16 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, observer } = Ember;
+
+export default Component.extend({
   classNames: ['search-box'],
   value: null,
   liveSearch: true,
-  watchValue: function(){
+  watchValue: observer('value', 'liveSearch', function(){
     if(this.get('liveSearch')){
       this.send('search');
     }
-  }.observes('value', 'liveSearch'),
+  }),
   actions: {
     clear: function() {
       this.set('value', '');

--- a/app/components/selectable-search-result.js
+++ b/app/components/selectable-search-result.js
@@ -1,11 +1,13 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+
+export default Component.extend({
   selectedItems: Ember.A(),
   item: null,
-  selected: function(){
+  selected: computed('item', 'selectedItems.@each', function(){
     return this.get('selectedItems').contains(this.item);
-  }.property('item', 'selectedItems.@each'),
+  }),
   click: function() {
     this.sendAction('action', this.get('item'));
   }

--- a/app/components/separated-list.js
+++ b/app/components/separated-list.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   tagName: 'span',
   list: [],
   icon: 'angle-right',

--- a/app/components/session-details.js
+++ b/app/components/session-details.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import scrollTo from '../utils/scroll-to';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   sessionTypes: [],
   session: null,
   didInsertElement: function(){

--- a/app/components/session-objective-manager.js
+++ b/app/components/session-objective-manager.js
@@ -1,18 +1,20 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
+const { Component, computed, observer, on } = Ember;
+
 var objectiveProxy = Ember.ObjectProxy.extend({
   sessionObjective: null,
-  selected: function(){
+  selected: computed('content', 'sessionObjective.parents.@each', function(){
     return this.get('sessionObjective.parents').contains(this.get('content'));
-  }.property('content', 'sessionObjective.parents.@each'),
+  }),
 });
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['objective-manager'],
   sessionObjective: null,
   showObjectiveList: false,
-  course: function(){
+  course: computed('sessionObjective.courses.@each', function(){
     var sessionObjective = this.get('sessionObjective');
     if(!sessionObjective){
       return null;
@@ -27,8 +29,8 @@ export default Ember.Component.extend({
     return DS.PromiseObject.create({
       promise:deferred.promise
     });
-  }.property('sessionObjective.courses.@each'),
-  proxiedObjectives: function(){
+  }),
+  proxiedObjectives: computed('course', 'course.objectives.@each', function(){
     var sessionObjective = this.get('sessionObjective');
     if(!sessionObjective){
       return [];
@@ -51,8 +53,8 @@ export default Ember.Component.extend({
     return DS.PromiseArray.create({
       promise: deferred.promise
     });
-  }.property('course', 'course.objectives.@each'),
-  watchProxiedObjectives: function(){
+  }),
+  watchProxiedObjectives: on('init', observer('proxiedObjectives.length', function(){
     //debounce setting showObjectiveList to avoid animating changes when
     //a save causes the proxied list to change
     Ember.run.debounce(this, function(){
@@ -60,7 +62,7 @@ export default Ember.Component.extend({
         this.set('showObjectiveList', this.get('proxiedObjectives.length') > 0);
       }
     }, 500);
-  }.observes('proxiedObjectives.length').on('init'),
+  })),
   actions: {
     addParent: function(parentProxy){
       var newParent = parentProxy.get('content');

--- a/app/components/session-offerings-list.js
+++ b/app/components/session-offerings-list.js
@@ -3,40 +3,46 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import momentFormat from 'ember-moment/computeds/format';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { oneWay, sort } = computed;
+
+export default Component.extend({
   store: Ember.inject.service(),
   session: null,
-  offerings: Ember.computed.oneWay('session.offerings'),
+  offerings: oneWay('session.offerings'),
   editable: true,
-  offeringBlocks: function(){
-    var offerings = this.get('offerings');
-    if(offerings == null){
-      return Ember.A();
-    }
-    var deferred = Ember.RSVP.defer();
-    offerings.then(function(offerings){
-      let dateBlocks = {};
-      offerings.forEach(function(offering){
-        let key = offering.get('dateKey');
-        if(!(key in dateBlocks)){
-          dateBlocks[key] = OfferingDateBlock.create({
-            dateKey: key
-          });
-        }
-        dateBlocks[key].addOffering(offering);
-
-      });
-      //convert indexed object to array
-      let dateBlockArray = [];
-      for(let key in dateBlocks){
-        dateBlockArray.pushObject(dateBlocks[key]);
+  offeringBlocks: computed(
+    'offerings.@each.{startDate,endDate,room,instructorGroups.@each}',
+    function(){
+      var offerings = this.get('offerings');
+      if(offerings == null){
+        return Ember.A();
       }
-      deferred.resolve(dateBlockArray.sortBy('dateStamp'));
-    });
-    return DS.PromiseArray.create({
-      promise: deferred.promise
-    });
-  }.property('offerings.@each.{startDate,endDate,room,instructorGroups.@each}'),
+      var deferred = Ember.RSVP.defer();
+      offerings.then(function(offerings){
+        let dateBlocks = {};
+        offerings.forEach(function(offering){
+          let key = offering.get('dateKey');
+          if(!(key in dateBlocks)){
+            dateBlocks[key] = OfferingDateBlock.create({
+              dateKey: key
+            });
+          }
+          dateBlocks[key].addOffering(offering);
+
+        });
+        //convert indexed object to array
+        let dateBlockArray = [];
+        for(let key in dateBlocks){
+          dateBlockArray.pushObject(dateBlocks[key]);
+        }
+        deferred.resolve(dateBlockArray.sortBy('dateStamp'));
+      });
+      return DS.PromiseArray.create({
+        promise: deferred.promise
+      });
+    }
+  ),
   actions: {
     removeOffering: function(offering){
       let session = this.get('session');
@@ -66,16 +72,16 @@ var OfferingBlock = Ember.Object.extend({
 var OfferingDateBlock = OfferingBlock.extend({
   dateKey: null,
   //convert our day of the year key into a date at midnight
-  date: function(){
+  date: computed('dateKey', function(){
     var year = this.get('dateKey').substring(0,4);
     var dayOfYear = this.get('dateKey').substring(4);
     var date = new Date(year, 0);
     return new Date(date.setDate(dayOfYear));
-  }.property('dateKey'),
+  }),
   dateStamp: momentFormat('date', 'X'),
   dayOfWeek: momentFormat('date', 'dddd'),
   dayOfMonth: momentFormat('date', 'MMMM Do'),
-  offeringTimeBlocks: function(){
+  offeringTimeBlocks: computed('offerings.@each.{startDate,endDate}', function(){
     let offeringGroups = {};
     this.get('offerings').forEach(function(offering){
       let key = offering.get('timeKey');
@@ -93,27 +99,27 @@ var OfferingDateBlock = OfferingBlock.extend({
     }
 
     return offeringGroupArray.sortBy('timeKey');
-  }.property('offerings.@each.{startDate,endDate}')
+  })
 });
 
 var OfferingTimeBlock = OfferingBlock.extend({
   timeKey: null,
-  isMultiDay: function(){
+  isMultiDay: computed('startDate', 'endDate', function(){
     return this.get('startDate').format('DDDDYYYY') !== this.get('endDate').format('DDDDYYYY');
-  }.property('startDate', 'endDate'),
+  }),
   //pull our times out of the key
-  startDate: function(){
+  startDate: computed('timeKey', function(){
     let key = this.get('timeKey').substring(0,11);
     return moment(key, 'YYYYDDDHHmm');
-  }.property('timeKey'),
-  endDate: function(){
+  }),
+  endDate: computed('timeKey', function(){
     let key = this.get('timeKey').substring(11);
     return moment(key, 'YYYYDDDHHmm');
-  }.property('timeKey'),
+  }),
   startTime: momentFormat('startDate', 'LT'),
   endTime: momentFormat('endDate', 'LT'),
   longStartText: momentFormat('startDate', 'dddd MMMM Do [@] LT'),
   longEndText: momentFormat('endDate', 'dddd MMMM Do [@] LT'),
   sortOfferingsBy: ['learnerGroups.firstObject.title'],
-  sortedOfferings: Ember.computed.sort('offerings', 'sortOfferingsBy'),
+  sortedOfferings: sort('offerings', 'sortOfferingsBy'),
 });

--- a/app/components/session-overview.js
+++ b/app/components/session-overview.js
@@ -2,15 +2,18 @@ import moment from 'moment';
 import Ember from 'ember';
 import Publishable from 'ilios/mixins/publishable';
 
-export default Ember.Component.extend(Publishable, {
+const { Component, computed } = Ember;
+const { oneWay, sort } = computed;
+
+export default Component.extend(Publishable, {
   session: null,
-  publishTarget: Ember.computed.oneWay('session'),
+  publishTarget: oneWay('session'),
   publishEventCollectionName: 'sessions',
   editable: true,
   classNames: ['session-overview'],
   sortTypes: ['title'],
   sessionTypes: [],
-  sortedSessionTypes: Ember.computed.sort('sessionTypes', 'sortTypes'),
+  sortedSessionTypes: sort('sessionTypes', 'sortTypes'),
   showCheckLink: true,
 
   titleValidations: {

--- a/app/components/session-publicationcheck.js
+++ b/app/components/session-publicationcheck.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   classNames: ['session-publication-check'],
   session: null,
 });

--- a/app/components/toggle-mycourses.js
+++ b/app/components/toggle-mycourses.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import layout from '../templates/components/toggle-mycourses';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   layout: layout,
   actions: {
   	toggleMyCourses: function(){

--- a/app/components/toggle-onoff.js
+++ b/app/components/toggle-onoff.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   classNames: ['toggle-onoff'],
 
   lable: null,

--- a/app/components/toggle-wide.js
+++ b/app/components/toggle-wide.js
@@ -1,16 +1,19 @@
 import Ember from 'ember';
 import randomString from '../utils/random-string';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { oneWay } = computed;
+
+export default Component.extend({
   tagName: 'label',
   classNames: ['switch', 'switch-wide', 'switch-green'],
-  cssId: Ember.computed(function() {
+  cssId: computed(function() {
     return randomString();
   }),
   onLabel: null,
   offLabel: null,
   value: false,
-  switchValue: Ember.computed.oneWay('value'),
+  switchValue: oneWay('value'),
   actions: {
     click(){
       this.sendAction();

--- a/app/components/toggle-yesno.js
+++ b/app/components/toggle-yesno.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
   label: null,
   yes: false,
   click(){

--- a/app/components/user-search.js
+++ b/app/components/user-search.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component, computed } = Ember;
+const { notEmpty, oneWay } = computed;
+
+export default Component.extend({
   store: Ember.inject.service(),
   classNames: ['user-search'],
   results: [],
@@ -14,7 +17,7 @@ export default Ember.Component.extend({
   availableInstructorGroups: [],
   currentlyActiveInstructorGroups: [],
   currentlySearchingForTerm: false,
-  integrateInstructorGroups: Ember.computed.notEmpty('availableInstructorGroups'),
+  integrateInstructorGroups: notEmpty('availableInstructorGroups'),
   actions: {
     search: function(searchTerms){
       if(this.get('currentlySearchingForTerm') === searchTerms){
@@ -37,24 +40,24 @@ export default Ember.Component.extend({
       let userProxy = Ember.ObjectProxy.extend({
         isUser: true,
         currentlyActiveUsers: [],
-        isActive: function(){
+        isActive: computed('content', 'currentlyActiveUsers.@each', function(){
           let user = this.get('content');
           if(!user.get('enabled')){
             return false;
           }
           return !this.get('currentlyActiveUsers').contains(user);
-        }.property('content', 'currentlyActiveUsers.@each'),
-        sortTerm: Ember.computed('content.firstName', 'content.lastName', function(){
+        }),
+        sortTerm: computed('content.firstName', 'content.lastName', function(){
           return this.get('content.lastName')+this.get('content.firstName');
         }),
       });
       let instructorGroupProxy = Ember.ObjectProxy.extend({
         isInstructorGroup: true,
         currentlyActiveInstructorGroups: [],
-        isActive: function(){
+        isActive: computed('content', 'currentlyActiveInstructorGroups.@each', function(){
           return !this.get('currentlyActiveInstructorGroups').contains(this.get('content'));
-        }.property('content', 'currentlyActiveInstructorGroups.@each'),
-        sortTerm: Ember.computed.oneWay('content.title'),
+        }),
+        sortTerm: oneWay('content.title'),
       });
       let query = {
         q: searchTerms

--- a/app/components/wait-saving.js
+++ b/app/components/wait-saving.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const { Component } = Ember;
+
+export default Component.extend({
 });

--- a/app/controllers/admin-dashboard.js
+++ b/app/controllers/admin-dashboard.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const { Controller } = Ember;
+
+export default Controller.extend({
 });

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -3,11 +3,11 @@ import DS from 'ember-data';
 import { translationMacro as t } from "ember-i18n";
 import moment from 'moment';
 
-const { computed, RSVP, isEmpty, isPresent } = Ember;
+const { computed, Controller, RSVP, isEmpty, isPresent, observer } = Ember;
 const { gt, sort } = computed;
 const { PromiseArray } = DS;
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   i18n: Ember.inject.service(),
   currentUser: Ember.inject.service(),
   queryParams: {
@@ -68,9 +68,9 @@ export default Ember.Controller.extend({
   }),
   //in order to delay rendering until a user is done typing debounce the title filter
   debouncedFilter: null,
-  watchFilter: function(){
+  watchFilter: observer('titleFilter', function(){
     Ember.run.debounce(this, this.setFilter, 500);
-  }.observes('titleFilter'),
+  }),
   setFilter: function(){
     this.set('debouncedFilter', this.get('titleFilter'));
   },
@@ -152,7 +152,7 @@ export default Ember.Controller.extend({
     if(isEmpty(defaultYear)){
       defaultYear = years.get('lastObject');
     }
-    
+
     return defaultYear;
   }),
   actions: {

--- a/app/controllers/instructor-groups.js
+++ b/app/controllers/instructor-groups.js
@@ -2,12 +2,12 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import { translationMacro as t } from "ember-i18n";
 
-const { computed, RSVP, isEmpty, isPresent, inject } = Ember;
+const { computed, Controller, RSVP, isEmpty, isPresent, inject, observer } = Ember;
 const { gt } = computed;
 const { service } = inject;
 const { PromiseArray } = DS;
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   i18n: service(),
   currentUser: service(),
   queryParams: {
@@ -34,16 +34,16 @@ export default Ember.Controller.extend({
         defer.resolve(instructorGroups);
       });
     }
-    
+
     return PromiseArray.create({
       promise: defer.promise
     });
   }),
   //in order to delay rendering until a user is done typing debounce the title filter
   debouncedFilter: null,
-  watchFilter: function(){
+  watchFilter: observer('titleFilter', function(){
     Ember.run.debounce(this, this.setFilter, 500);
-  }.observes('titleFilter'),
+  }),
   setFilter: function(){
     this.set('debouncedFilter', this.get('titleFilter'));
   },
@@ -66,8 +66,8 @@ export default Ember.Controller.extend({
         }
         defer.resolve(filteredInstructorGroups.sortBy('title'));
       });
-      
-      
+
+
       return PromiseArray.create({
         promise: defer.promise
       });

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const { Controller } = Ember;
+
+export default Controller.extend({
   currentUser: Ember.inject.service(),
   errors: [],
   noAccountExistsError: false,

--- a/app/controllers/navigation.js
+++ b/app/controllers/navigation.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const { Controller } = Ember;
+
+export default Controller.extend({
 });

--- a/app/controllers/program-year.js
+++ b/app/controllers/program-year.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const { computed, Controller } = Ember;
+const { alias } = computed;
+
+export default Controller.extend({
   needs: "program",
-  program: Ember.computed.alias("controllers.program.model"),
+  program: alias("controllers.program.model"),
 });

--- a/app/controllers/program-year/publication-check.js
+++ b/app/controllers/program-year/publication-check.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const { computed, Controller } = Ember;
+const { alias } = computed;
+
+export default Controller.extend({
   needs: ["program", "programYear"],
-  program: Ember.computed.alias("controllers.program.model"),
-  programYear: Ember.computed.alias("controllers.programYear.model"),
+  program: alias("controllers.program.model"),
+  programYear: alias("controllers.programYear.model"),
 });

--- a/app/controllers/program.js
+++ b/app/controllers/program.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const { Controller } = Ember;
+
+export default Controller.extend({
 });

--- a/app/controllers/program/index.js
+++ b/app/controllers/program/index.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const { computed, Controller } = Ember;
+const { alias } = computed;
+
+export default Controller.extend({
   needs: "program",
-  program: Ember.computed.alias("controllers.program.model"),
+  program: alias("controllers.program.model"),
 });

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const { Controller } = Ember;
+
+export default Controller.extend({
 });

--- a/app/controllers/session/index.js
+++ b/app/controllers/session/index.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const { computed, Controller } = Ember;
+const { alias } = computed;
+
+export default Controller.extend({
   needs: ["course", "session"],
-  courseController: Ember.computed.alias("controllers.course"),
-  sessionController: Ember.computed.alias("controllers.session"),
+  courseController: alias("controllers.course"),
+  sessionController: alias("controllers.session"),
 });

--- a/app/controllers/session/publication-check.js
+++ b/app/controllers/session/publication-check.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const { computed, Controller } = Ember;
+const { alias } = computed;
+
+export default Controller.extend({
   needs: ["course", "session"],
-  courseController: Ember.computed.alias("controllers.course"),
-  sessionController: Ember.computed.alias("controllers.session"),
+  courseController: alias("controllers.course"),
+  sessionController: alias("controllers.session"),
 });

--- a/app/helpers/is-in.js
+++ b/app/helpers/is-in.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const { Helper, observer } = Ember;
+
 export function isIn([values, item]) {
   if(!values){
     return false;
@@ -7,11 +9,11 @@ export function isIn([values, item]) {
   if(!item){
     return false;
   }
-  
+
   return values.contains(item);
 }
 
-export default Ember.Helper.extend({
+export default Helper.extend({
   values: [],
   compute: function([values, item]) {
     this.set('values', values);
@@ -19,7 +21,7 @@ export default Ember.Helper.extend({
     return isIn([values, item]);
   },
 
-  recomputeOnArrayChange: Ember.observer('values.[]', function() {
+  recomputeOnArrayChange: observer('values.[]', function() {
     this.recompute();
   })
 });

--- a/app/helpers/not-in.js
+++ b/app/helpers/not-in.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const { Helper, observer } = Ember;
+
 export function notIn([values, item]) {
   if(!values){
     return false;
@@ -10,7 +12,7 @@ export function notIn([values, item]) {
   return !values.contains(item);
 }
 
-export default Ember.Helper.extend({
+export default Helper.extend({
   values: [],
   compute: function([values, item]) {
     this.set('values', values);
@@ -18,7 +20,7 @@ export default Ember.Helper.extend({
     return notIn([values, item]);
   },
 
-  recomputeOnArrayChange: Ember.observer('values.[]', function() {
+  recomputeOnArrayChange: observer('values.[]', function() {
     this.recompute();
   })
 });

--- a/app/models/academic-year.js
+++ b/app/models/academic-year.js
@@ -1,8 +1,11 @@
+import Ember from 'ember';
 import DS from 'ember-data';
+
+const { computed } = Ember;
 
 export default DS.Model.extend({
   title: DS.attr('number'),
-  academicYearTitle: function(){
+  academicYearTitle: computed('title', function(){
     return this.get('title') + ' - ' + (parseInt(this.get('title')) + 1);
-  }.property('title'),
+  }),
 });

--- a/app/models/cohort.js
+++ b/app/models/cohort.js
@@ -2,6 +2,8 @@ import moment from 'moment';
 import Ember from 'ember';
 import DS from 'ember-data';
 
+const { computed, observer } = Ember;
+
 export default DS.Model.extend({
   i18n: Ember.inject.service(),
   title: DS.attr('string'),
@@ -10,7 +12,7 @@ export default DS.Model.extend({
   learnerGroups: DS.hasMany('learner-group', {async: true}),
   users: DS.hasMany('user', {async: true}),
   displayTitle: '',
-  competencies: function(){
+  competencies: computed('programYear.competencies.@each', function(){
     var self = this;
     return new Ember.RSVP.Promise(function(resolve) {
       self.get('programYear').then(function(programYear){
@@ -21,8 +23,8 @@ export default DS.Model.extend({
         }
       });
     });
-  }.property('programYear.competencies.@each'),
-  objectives: function(){
+  }),
+  objectives: computed('programYear.objectives.@each', function(){
     var self = this;
     return new Ember.RSVP.Promise(function(resolve) {
       self.get('programYear').then(function(programYear){
@@ -33,8 +35,8 @@ export default DS.Model.extend({
         }
       });
     });
-  }.property('programYear.objectives.@each'),
-  topLevelLearnerGroups: function(){
+  }),
+  topLevelLearnerGroups: computed('learnerGroups.@each', function(){
     let defer = Ember.RSVP.defer();
     this.get('learnerGroups').then(groups => {
       let topLevelGroups = Ember.A();
@@ -52,8 +54,8 @@ export default DS.Model.extend({
     return DS.PromiseArray.create({
       promise: defer.promise
     });
-  }.property('learnerGroups.@each'),
-  displayTitleObserver: function(){
+  }),
+  displayTitleObserver: observer('title', 'programYear.classOfYear', function(){
     var self = this;
     if(this.get('title.length') > 0){
       this.set('displayTitle', this.get('title'));
@@ -65,12 +67,12 @@ export default DS.Model.extend({
         self.set('displayTitle', title);
       });
     }
-  }.observes('title', 'programYear.classOfYear'),
-  currentLevel: function(){
+  }),
+  currentLevel: computed('programYear.startYear', function(){
     var startYear = this.get('programYear.startYear');
     if(startYear){
       return Math.abs(moment().year(startYear).diff(moment(), 'years'));
     }
     return '';
-  }.property('programYear.startYear')
+  })
 });

--- a/app/models/competency.js
+++ b/app/models/competency.js
@@ -1,6 +1,9 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 
+const { computed } = Ember;
+const { empty } = computed;
+
 export default DS.Model.extend({
   title: DS.attr('string'),
   school: DS.belongsTo('school'),
@@ -9,8 +12,8 @@ export default DS.Model.extend({
   children: DS.hasMany('competency', {async: true, inverse: 'parent'}),
   aamcPcrses: DS.hasMany('aamc-pcrs',  {async: true}),
   programYears: DS.hasMany('program-year',  {async: true}),
-  isDomain: Ember.computed.empty('parent.content'),
-  domain: function(){
+  isDomain: empty('parent.content'),
+  domain: computed('parent', 'parent.domain', function(){
     let promise = new Ember.RSVP.Promise(
       resolve => {
         this.get('parent').then(
@@ -29,5 +32,5 @@ export default DS.Model.extend({
     return DS.PromiseObject.create({
       promise: promise
     });
-  }.property('parent','parent.domain'),
+  }),
 });

--- a/app/models/instructor-group.js
+++ b/app/models/instructor-group.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
+const { computed } = Ember;
+
 export default DS.Model.extend({
   title: DS.attr('string'),
   school: DS.belongsTo('school', {async: true}),
@@ -8,7 +10,7 @@ export default DS.Model.extend({
   ilmSessions: DS.hasMany('ilm-session', {async: true}),
   users: DS.hasMany('user', {async: true}),
   offerings: DS.hasMany('offering', {async: true}),
-  courses: Ember.computed('offerings.[]', 'ilmSessions.[]', function(){
+  courses: computed('offerings.[]', 'ilmSessions.[]', function(){
     var defer = Ember.RSVP.defer();
     let promises = [];
     let allCourses = [];

--- a/app/models/mesh-concept.js
+++ b/app/models/mesh-concept.js
@@ -1,4 +1,7 @@
+import Ember from 'ember';
 import DS from 'ember-data';
+
+const { computed } = Ember;
 
 export default DS.Model.extend({
   name: DS.attr('string'),
@@ -12,14 +15,14 @@ export default DS.Model.extend({
   createdAt: DS.attr('date'),
   updatedAt: DS.attr('date'),
   descriptors: DS.hasMany('mesh-descriptor',  {async: true}),
-  truncatedScopeNote: function() {
+  truncatedScopeNote: computed('scopeNote', function() {
     let scopeNote = this.get('scopeNote');
     if (250 < scopeNote.length) {
         scopeNote = scopeNote.substring(0, 250);
     }
     return scopeNote;
-  }.property('scopeNote'),
-  hasTruncatedScopeNote: function() {
+  }),
+  hasTruncatedScopeNote: computed('scopeNote', 'truncatedScopeNote', function() {
     return this.get('scopeNote').length !== this.get('truncatedScopeNote').length;
-  }.property('scopeNote', 'truncatedScopeNote')
+  })
 });

--- a/app/models/objective.js
+++ b/app/models/objective.js
@@ -1,8 +1,8 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 
-let {computed, RSVP, isEmpty} =  Ember;
-let {alias, gt, gte} = computed;
+const { computed, RSVP, isEmpty } =  Ember;
+const { alias, gt, gte } = computed;
 
 export default DS.Model.extend({
   title: DS.attr('string'),
@@ -65,7 +65,7 @@ export default DS.Model.extend({
           allTopParents.pushObjects(topParents.toArray());
         }));
       });
-      
+
       RSVP.all(promises).then(()=>{
         defer.resolve(allTopParents);
       });
@@ -74,20 +74,20 @@ export default DS.Model.extend({
       promise: defer.promise
     });
   }),
-  shortTitle: function(){
+  shortTitle: computed('title', function(){
     var title = this.get('title');
     if(title === undefined){
       return '';
     }
     return title.substr(0,200);
-  }.property('title'),
-  textTitle: function(){
+  }),
+  textTitle: computed('title', function(){
     var title = this.get('title');
     if(title === undefined){
       return '';
     }
     return title.replace(/(<([^>]+)>)/ig,"");
-  }.property('title'),
+  }),
   //Remove any parents with a relationship to the cohort
   removeParentWithProgramYears(programYearsToRemove){
     return new RSVP.Promise(resolve => {

--- a/app/models/offering.js
+++ b/app/models/offering.js
@@ -4,6 +4,7 @@ import momentFormat from 'ember-moment/computeds/format';
 
 const { computed, RSVP } = Ember;
 const { PromiseArray } = DS;
+const { not } = computed;
 
 export default DS.Model.extend({
   room: DS.attr('string'),
@@ -31,28 +32,36 @@ export default DS.Model.extend({
   endTime: momentFormat('endDate', 'HHmm'),
   startYearAndDayOfYear: momentFormat('startDate', 'DDDDYYYY'),
   endYearAndDayOfYear: momentFormat('endDate', 'DDDDYYYY'),
-  isSingleDay: function(){
+  isSingleDay: computed('startYearAndDayOfYear', 'endYearAndDayOfYear', function(){
     return this.get('startYearAndDayOfYear') === this.get('endYearAndDayOfYear');
-  }.property('startYearAndDayOfYear', 'endYearAndDayOfYear'),
-  isMultiDay: Ember.computed.not('isSingleDay'),
-  dateKey: function(){
+  }),
+  isMultiDay: not('isSingleDay'),
+  dateKey: computed('startDayOfYear', 'startYear', function(){
     return this.get('startYear') + this.get('startDayOfYear');
-  }.property('startDayOfYear', 'startYear'),
-  timeKey: function(){
-    let properties = [
-      'startYear',
-      'startDayOfYear',
-      'startTime',
-      'endYear',
-      'endDayOfYear',
-      'endTime'
-    ];
-    let key = '';
-    for(let i = 0; i < properties.length; i++){
-      key += this.get(properties[i]);
+  }),
+  timeKey: computed(
+    'startDayOfYear',
+    'startYear',
+    'startTime',
+    'endDayOfYear',
+    'endYear',
+    'endTime',
+    function(){
+      let properties = [
+        'startYear',
+        'startDayOfYear',
+        'startTime',
+        'endYear',
+        'endDayOfYear',
+        'endTime'
+      ];
+      let key = '';
+      for(let i = 0; i < properties.length; i++){
+        key += this.get(properties[i]);
+      }
+      return key;
     }
-    return key;
-  }.property('startDayOfYear', 'startYear', 'startTime', 'endDayOfYear', 'endYear', 'endTime'),
+  ),
   allInstructors: computed('instructors.[]', 'instructorsGroups.@each.users.[]', function(){
     var defer = Ember.RSVP.defer();
     this.get('instructorGroups').then(instructorGroups => {

--- a/app/models/program-year.js
+++ b/app/models/program-year.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import PublishableModel from 'ilios/mixins/publishable-model';
 
+const { computed } = Ember;
+
 export default DS.Model.extend(PublishableModel,{
   startYear: DS.attr('string'),
   locked: DS.attr('boolean'),
@@ -13,30 +15,27 @@ export default DS.Model.extend(PublishableModel,{
   topics: DS.hasMany('topic', {async: true}),
   objectives: DS.hasMany('objective', {async: true}),
   stewards: DS.hasMany('program-year-steward', {async: true}),
-  academicYear: function(){
+  academicYear: computed('startYear', function(){
     return this.get('startYear') + ' - ' + (parseInt(this.get('startYear'))+1);
-  }.property('startYear'),
-  classOfYear: function(){
+  }),
+  classOfYear: computed('startYear', 'program.duration', function(){
     return (parseInt(this.get('startYear'))+parseInt(this.get('program.duration')));
-  }.property('startYear', 'program.duration'),
-  requiredPublicationIssues: function(){
+  }),
+  requiredPublicationIssues: computed('startYear', 'cohort', 'program', function(){
     return this.getRequiredPublicationIssues();
-  }.property(
-    'startYear',
-    'cohort',
-    'program'
-  ),
-  optionalPublicationIssues: function(){
-    return this.getOptionalPublicationIssues();
-  }.property(
+  }),
+  optionalPublicationIssues: computed(
     'directors.length',
     'competencies.length',
     'topics.length',
-    'objectives.length'
+    'objectives.length',
+    function(){
+      return this.getOptionalPublicationIssues();
+    }
   ),
   requiredPublicationSetFields: ['startYear', 'cohort', 'program'],
   optionalPublicationLengthFields: ['directors', 'competencies', 'topics', 'objectives'],
-  domains: function(){
+  domains: computed('competencies.@each.domain', function(){
     var defer = Ember.RSVP.defer();
     var domainContainer = {};
     var domainIds = [];
@@ -71,5 +70,5 @@ export default DS.Model.extend(PublishableModel,{
     return DS.PromiseArray.create({
       promise: defer.promise
     });
-  }.property('competencies.@each.domain'),
+  }),
 });

--- a/app/models/program.js
+++ b/app/models/program.js
@@ -2,6 +2,9 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import PublishableModel from 'ilios/mixins/publishable-model';
 
+const { computed } = Ember;
+const { mapBy, sum } = computed;
+
 export default DS.Model.extend(PublishableModel,{
   title: DS.attr('string'),
   shortTitle: DS.attr('string'),
@@ -12,22 +15,16 @@ export default DS.Model.extend(PublishableModel,{
       inverse: 'program'
   }),
   curriculumInventoryReports: DS.hasMany('curriculum-inventory-report', {async: true}),
-  cohortPromises: Ember.computed.mapBy('programYears', 'cohort'),
-  cohorts: Ember.computed.mapBy('cohortPromises', 'content'),
-  courseCounts: Ember.computed.mapBy('programYears', 'cohort.courses.length'),
-  courseCount: Ember.computed.sum('courseCounts'),
+  cohortPromises: mapBy('programYears', 'cohort'),
+  cohorts: mapBy('cohortPromises', 'content'),
+  courseCounts: mapBy('programYears', 'cohort.courses.length'),
+  courseCount: sum('courseCounts'),
   requiredPublicationSetFields: ['title', 'shortTitle', 'duration'],
   optionalPublicationLengthFields: ['programYears'],
-  requiredPublicationIssues: function(){
+  requiredPublicationIssues: computed('title', 'shortTitle', 'duration', function(){
     return this.getRequiredPublicationIssues();
-  }.property(
-    'title',
-    'shortTitle',
-    'duration'
-  ),
-  optionalPublicationIssues: function(){
+  }),
+  optionalPublicationIssues: computed('programYears.length', function(){
     return this.getOptionalPublicationIssues();
-  }.property(
-    'programYears.length'
-  ),
+  }),
 });

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -1,6 +1,8 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 
+const { computed } = Ember;
+
 export default DS.Model.extend({
   title: DS.attr('string'),
   templatePrefix: DS.attr('string'),
@@ -15,7 +17,7 @@ export default DS.Model.extend({
   curriculumInventoryInsitution: DS.belongsTo('curriculum-inventory-institution', {async: true}),
   sessionTypes: DS.hasMany('session-type', {async: true}),
   stewards: DS.hasMany('program-year-steward', {async: true}),
-  cohorts: function(){
+  cohorts: computed('programs.@each', function(){
     var school = this;
     return new Ember.RSVP.Promise(function(resolve) {
       school.get('programs').then(function(programs){
@@ -41,7 +43,7 @@ export default DS.Model.extend({
         });
       });
     });
-  }.property('programs.@each'),
+  }),
   getCohortsForYear(year){
     let defer = Ember.RSVP.defer();
     this.getProgramYearsForYear(year).then(programYears => {
@@ -56,8 +58,8 @@ export default DS.Model.extend({
         defer.resolve(cohorts);
       });
     });
-    
-    
+
+
     return DS.PromiseArray.create({
       promise: defer.promise
     });

--- a/app/models/session-description.js
+++ b/app/models/session-description.js
@@ -1,13 +1,16 @@
+import Ember from 'ember';
 import DS from 'ember-data';
+
+const { computed } = Ember;
 
 export default DS.Model.extend({
   description: DS.attr('string'),
   session: DS.belongsTo('session', {async: true}),
-  textDescription: function(){
+  textDescription: computed('description', function(){
     var title = this.get('title');
     if(title === undefined){
       return '';
     }
     return title.replace(/(<([^>]+)>)/ig,"");
-  }.property('description')
+  })
 });

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -6,26 +6,26 @@ const { service } = inject;
 const { hash, Promise } = RSVP;
 
 export default Route.extend(AuthenticatedRouteMixin, {
-	i18n: service(),
-	currentUser: service(),
-	store: service(),
-	today: new Date(),
+    i18n: service(),
+    currentUser: service(),
+    store: service(),
+    today: new Date(),
 
-	model() {
-		const store = this.get('store');
-		return new Promise(resolve => {
-			this.get('currentUser.model').then(user => {
-				const schools = user.get('schools');
-				const academicYears = store.findAll('academic-year');
-				resolve(hash({ schools, academicYears }));
-			});
-		});
-		
-	},
+    model() {
+        const store = this.get('store');
+        return new Promise(resolve => {
+            this.get('currentUser.model').then(user => {
+                const schools = user.get('schools');
+                const academicYears = store.findAll('academic-year');
+                resolve(hash({ schools, academicYears }));
+            });
+        });
+        
+    },
 
-	setupController() {
+    setupController() {
     this._super.apply(this, arguments);
 
-		this.controllerFor('application').set('pageTitleTranslation', 'navigation.dashboard');
-	}
+        this.controllerFor('application').set('pageTitleTranslation', 'navigation.dashboard');
+    }
 });

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -37,16 +37,16 @@ export default Ember.Service.extend({
     });
   }),
 
-  availableCohortsObserver: function(){
+  availableCohortsObserver: observer('availableCohorts.@each', function(){
     var self = this;
     this.get('availableCohorts').then(function(cohorts){
       if(!cohorts.contains(self.get('currentCohort'))){
         self.set('currentCohort', null);
       }
     });
-  }.observes('availableCohorts.@each'),
+  }),
   currentCohort: null,
-  availableCohorts: function(){
+  availableCohorts: computed('currentSchool', function(){
     var self = this;
     return new Ember.RSVP.Promise(function(resolve) {
       self.get('currentSchool').then(function(school){
@@ -72,7 +72,7 @@ export default Ember.Service.extend({
         });
       });
     });
-  }.property('currentSchool'),
+  }),
   userRoleTitles: computed('model.roles.[]', function(){
     return new Ember.RSVP.Promise((resolve) => {
       this.get('model').then(user => {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ember-rl-dropdown": "0.7.0",
     "ember-tooltips": "0.4.0",
     "ember-validations": "2.0.0-alpha.4",
+    "ember-watson": "^0.7.0",
     "emberx-select": "2.0.2",
     "ilios-calendar": "ilios/calendar#v2.3.0",
     "liquid-fire": "0.21.3",

--- a/tests/integration/components/dashboard-mycourses-test.js
+++ b/tests/integration/components/dashboard-mycourses-test.js
@@ -4,6 +4,8 @@ import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
+const { computed } = Ember;
+
 let mockCourses = [
   Ember.Object.create({title: 'first', level: 4, academicYear: '2012-2013', locked: false, archived: false}),
   Ember.Object.create({title: 'second', level: 1, academicYear: '2013-2014', locked: false, archived: false}),
@@ -13,21 +15,21 @@ let mockCourses = [
 ];
 
 let currentUserMock = Ember.Service.extend({
-  relatedCourses: Ember.computed(function() {
+  relatedCourses: computed(function() {
     return Ember.RSVP.resolve(mockCourses);
   }),
   canEditCourses: true
 });
 
 let currentUserMockNoCourses = Ember.Service.extend({
-  relatedCourses: Ember.computed(function() {
+  relatedCourses: computed(function() {
     return Ember.RSVP.resolve([]);
   }),
   canEditCourses: true
 });
 
 let currentUserMockUnprivileged = Ember.Service.extend({
-  relatedCourses: Ember.computed(function() {
+  relatedCourses: computed(function() {
     return Ember.RSVP.resolve(mockCourses);
   }),
   canEditCourses: false
@@ -57,7 +59,7 @@ test('list courses for privileged users', function(assert) {
 
     assert.equal(this.$(`table tr`).length, 3);
   });
-  
+
 });
 
 
@@ -66,7 +68,7 @@ test('list courses for un-privileged users', function(assert) {
   this.register('service:currentUser', currentUserMockUnprivileged);
   this.render(hbs`{{dashboard-mycourses}}`);
   assert.equal(this.$('.dashboard-block-header').text().trim(), 'My Courses');
-  
+
   Ember.run.later(()=> {
     for(let i = 0; i < 3; i++){
       let a = this.$(`table a:eq(${i})`);
@@ -78,7 +80,7 @@ test('list courses for un-privileged users', function(assert) {
 
     assert.equal(this.$(`table tr`).length, 3);
   });
-  
+
 });
 
 test('display none when no courses', function(assert) {
@@ -86,7 +88,7 @@ test('display none when no courses', function(assert) {
   this.register('service:currentUser', currentUserMockNoCourses);
   this.render(hbs`{{dashboard-mycourses}}`);
   assert.equal(this.$('.dashboard-block-header').text().trim(), 'My Courses');
-  
+
   assert.equal(this.$('.dashboard-block-body').text().trim(), 'None');
-  
+
 });

--- a/tests/integration/components/dashboard-myreports-test.js
+++ b/tests/integration/components/dashboard-myreports-test.js
@@ -3,19 +3,21 @@ import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
 
+const { computed } = Ember;
+
 let mockReports = [
   Ember.Object.create({displayTitle: {content: 'all courses'}, subject: 'courses', user: 1}),
   Ember.Object.create({displayTitle: {content: 'courses for session'}, subject: 'courses', prepositionalObject: 'session', prepositionalObjectTableRowId: 11, user: 1}),
 ];
 
 let reportingMock = Ember.Service.extend({
-  reportsList: Ember.computed(function(){
+  reportsList: computed(function(){
     return Ember.RSVP.resolve(mockReports);
   })
 });
 
 let reportingMockNoReports = Ember.Service.extend({
-  reportsList: Ember.computed(function(){
+  reportsList: computed(function(){
     return Ember.RSVP.resolve([]);
   })
 });
@@ -32,7 +34,7 @@ test('list reports', function(assert) {
   assert.expect(4);
   this.register('service:reporting', reportingMock);
   this.render(hbs`{{dashboard-myreports}}`);
-  
+
   assert.equal(this.$('.dashboard-block-header').text().trim(), 'My Reports');
   for(let i = 0; i < 2; i++){
     let tds = this.$(`table tr:eq(${i}) td`);
@@ -47,5 +49,5 @@ test('display none when no reports', function(assert) {
   this.render(hbs`{{dashboard-myreports}}`);
   assert.equal(this.$('.dashboard-block-header').text().trim(), 'My Reports');
   assert.equal(this.$('.dashboard-block-body').text().trim(), 'None');
-  
+
 });


### PR DESCRIPTION
Convert computed properties and observers to not use prototype extensions.