### PR TITLE
ember watson:convert-ember-data-async-false-relationships

### DIFF
--- a/app/models/competency.js
+++ b/app/models/competency.js
@@ -6,8 +6,8 @@ const { empty } = computed;
 
 export default DS.Model.extend({
   title: DS.attr('string'),
-  school: DS.belongsTo('school'),
-  objectives: DS.hasMany('objective',  {async: true}),
+  school: DS.belongsTo('school', {async: true}),
+  objectives: DS.hasMany('objective', {async: true}),
   parent: DS.belongsTo('competency', {async: true, inverse: 'children'}),
   children: DS.hasMany('competency', {async: true, inverse: 'parent'}),
   aamcPcrses: DS.hasMany('aamc-pcrs',  {async: true}),


### PR DESCRIPTION
This task adds an explicit `async: false` options to all `belongsTo` and `hasMany` that either have no options or its options does not contain an explicit async value.