### PR TITLE
ember watson:use-destroy-app-helper tests

### DIFF
--- a/app/components/live-search.js
+++ b/app/components/live-search.js
@@ -20,6 +20,7 @@ export default Component.extend({
   sortedSearchResults: computed('results.@each', function(){
     return this.get('results').sortBy('sortTerm');
   }),
+
   searchResults: computed(function(key, values){
     if (arguments.length > 1) {
       values.forEach(function(obj){
@@ -31,6 +32,7 @@ export default Component.extend({
     }
     return this.get('results');
   }),
+
   watchSeatchTerms: observer('searchTerms', function(){
     this.send('search');
   }),

--- a/tests/acceptance/admin-test.js
+++ b/tests/acceptance/admin-test.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import Ember from 'ember';
 
 const { run } = Ember;
 

--- a/tests/acceptance/course/cohorts-test.js
+++ b/tests/acceptance/course/cohorts-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -60,7 +60,7 @@ module('Acceptance: Course - Cohorts' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 const { isEmpty, isPresent, run } = Ember;
 const { later } = run;
@@ -106,7 +107,7 @@ module('Acceptance: Course - Learning Materials' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/mesh-test.js
+++ b/tests/acceptance/course/mesh-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -49,7 +49,7 @@ module('Acceptance: Course - Mesh Terms' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/objectivecreate-test.js
+++ b/tests/acceptance/course/objectivecreate-test.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 var application;
 var fixtures = {};
@@ -30,7 +31,7 @@ module('Acceptance: Course - Objective Create' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 
@@ -60,7 +61,7 @@ test('save new objective', function(assert) {
       });
     }, 100);
   });
-  
+
 });
 
 test('cancel new objective', function(assert) {

--- a/tests/acceptance/course/objectivelist-test.js
+++ b/tests/acceptance/course/objectivelist-test.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 var application;
 var fixtures = {};
@@ -23,7 +24,7 @@ module('Acceptance: Course - Objective List' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 
@@ -156,7 +157,7 @@ test('edit objective title', function(assert) {
         let editor = find('.froala-box', td);
         let editorContents = editor.editable('getText');
         assert.equal(getText(editorContents), getText(objective.title));
-        
+
         editor.editable('setHTML', 'new title');
         click(find('.actions .done', td));
         andThen(function(){

--- a/tests/acceptance/course/objectivemesh-test.js
+++ b/tests/acceptance/course/objectivemesh-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -53,7 +53,7 @@ module('Acceptance: Course - Objective Mesh Descriptors' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -93,7 +93,7 @@ module('Acceptance: Course with multiple Cohorts - Objective Parents' + testgrou
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/objectiveparents-test.js
+++ b/tests/acceptance/course/objectiveparents-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -69,7 +69,7 @@ module('Acceptance: Course - Objective Parents' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -21,7 +21,7 @@ module('Acceptance: Course - Overview' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/publicationcheck-test.js
+++ b/tests/acceptance/course/publicationcheck-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -41,7 +41,7 @@ module('Acceptance: Course - Publication Check' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/publish-test.js
+++ b/tests/acceptance/course/publish-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -20,7 +20,7 @@ module('Acceptance: Course - Publish' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/ilm-test.js
+++ b/tests/acceptance/course/session/ilm-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -102,7 +102,7 @@ module('Acceptance: Session - Independent Learning' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 const { isEmpty, isPresent, run } = Ember;
 const { later } = run;
@@ -109,7 +110,7 @@ module('Acceptance: Session - Learning Materials' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/mesh-test.js
+++ b/tests/acceptance/course/session/mesh-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -32,7 +32,7 @@ module('Acceptance: Session - Mesh Terms' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/objectivecreate-test.js
+++ b/tests/acceptance/course/session/objectivecreate-test.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 var application;
 var fixtures = {};
@@ -27,7 +28,7 @@ module('Acceptance: Session - Objective Create' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 
@@ -57,7 +58,7 @@ test('save new objective', function(assert) {
       });
     }, 100);
   });
-  
+
 });
 
 test('cancel new objective', function(assert) {

--- a/tests/acceptance/course/session/objectivelist-test.js
+++ b/tests/acceptance/course/session/objectivelist-test.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {c as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 var application;
 var fixtures = {};
@@ -22,7 +23,7 @@ module('Acceptance: Session - Objective List' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 
@@ -139,14 +140,14 @@ test('edit objective title', function(assert) {
     let td = find('tbody tr:eq(0) td:eq(0)', container);
     assert.equal(getElementText(td), getText(objective.title));
     click('.editable span', td);
-    
+
     andThen(function(){
       //wait for the editor to load
       Ember.run.later(()=>{
         let editor = find('.froala-box', td);
         let editorContents = editor.editable('getText');
         assert.equal(getText(editorContents), getText(objective.title));
-        
+
         editor.editable('setHTML', 'new title');
         click(find('.actions .done', td));
         andThen(function(){

--- a/tests/acceptance/course/session/objectivemesh-test.js
+++ b/tests/acceptance/course/session/objectivemesh-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -59,7 +59,7 @@ module('Acceptance: Session - Objective Mesh Descriptors' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/objectiveparents-test.js
+++ b/tests/acceptance/course/session/objectiveparents-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -52,7 +52,7 @@ module('Acceptance: Session - Objective Parents' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../../../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -124,7 +124,7 @@ module('Acceptance: Session - Offerings' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../../../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -7,6 +7,7 @@ import {
 import startApp from 'ilios/tests/helpers/start-app';
 import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
+import Ember from 'ember';
 
 var application;
 var fixtures = {};
@@ -28,7 +29,7 @@ module('Acceptance: Session - Overview' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 
@@ -188,7 +189,7 @@ test('change type', function(assert) {
     assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 0'));
     click(find('.sessiontype .editable', container));
     andThen(function(){
-      
+
       let options = find('.sessiontype select option', container);
       assert.equal(options.length, 2);
       assert.equal(getElementText(options.eq(0)), getText('session type 0'));

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../../../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -7,6 +7,7 @@ import {
 import startApp from 'ilios/tests/helpers/start-app';
 import {c as testgroup} from 'ilios/tests/helpers/test-groups';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
+import Ember from 'ember';
 
 var application;
 module('Acceptance: Session - Publication Check' + testgroup, {
@@ -41,7 +42,7 @@ module('Acceptance: Session - Publication Check' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/publish-test.js
+++ b/tests/acceptance/course/session/publish-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../../../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -49,7 +49,7 @@ module('Acceptance: Session - Publish' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/topics-test.js
+++ b/tests/acceptance/course/session/topics-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -39,7 +39,7 @@ module('Acceptance: Session - Topics' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -60,7 +60,7 @@ module('Acceptance: Course - Session List' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/topics-test.js
+++ b/tests/acceptance/course/topics-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -36,7 +36,7 @@ module('Acceptance: Course - Topics' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
-import {
-  module,
-  test
-} from 'qunit';
+import destroyApp from '../helpers/destroy-app';
+import { module, test } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {b as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 var application;
 var fixtures = {};
@@ -23,7 +21,7 @@ module('Acceptance: Courses' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -1,11 +1,12 @@
+import destroyApp from '../../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {b as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 const { isEmpty } = Ember;
 
@@ -107,7 +108,7 @@ module('Acceptance: Dashboard Calendar' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/four-oh-four-test.js
+++ b/tests/acceptance/four-oh-four-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -20,7 +20,7 @@ module('Acceptance: FourOhFour' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/instructorgroup-test.js
+++ b/tests/acceptance/instructorgroup-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -62,7 +62,7 @@ module('Acceptance: Instructor Group Details' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/instructorgroups-test.js
+++ b/tests/acceptance/instructorgroups-test.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {b as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 var application;
 
@@ -15,7 +16,7 @@ module('Acceptance: Instructor Groups' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/learnergroup/membership-test.js
+++ b/tests/acceptance/learnergroup/membership-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -59,7 +59,7 @@ module('Acceptance: Learner Group - Membership' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/learnergroup/overview-test.js
+++ b/tests/acceptance/learnergroup/overview-test.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {b as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 const { isEmpty } = Ember;
 
@@ -74,7 +75,7 @@ module('Acceptance: Learner Group - Overview' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/learnergroup/subgroups-test.js
+++ b/tests/acceptance/learnergroup/subgroups-test.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {b as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 const { isEmpty, isPresent } = Ember;
 
@@ -44,7 +45,7 @@ module('Acceptance: Learner Group - Subgroups' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {b as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 const { isEmpty, isPresent } = Ember;
 
@@ -18,7 +19,7 @@ module('Acceptance: Learner Groups' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/overview-test.js
+++ b/tests/acceptance/program/overview-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -17,7 +17,7 @@ module('Acceptance: Program - Overview' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -1,11 +1,12 @@
+import destroyApp from '../../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {b as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 const { isEmpty, isPresent } = Ember;
 
@@ -20,7 +21,7 @@ module('Acceptance: Program - ProgramYear List' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/competencies-test.js
+++ b/tests/acceptance/program/programyear/competencies-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -46,7 +46,7 @@ module('Acceptance: Program Year - Competencies' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/objectives-test.js
+++ b/tests/acceptance/program/programyear/objectives-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -58,7 +58,7 @@ module('Acceptance: Program Year - Objectives' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/overview-test.js
+++ b/tests/acceptance/program/programyear/overview-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -28,7 +28,7 @@ module('Acceptance: Program Year - Overview' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/publicationcheck-test.js
+++ b/tests/acceptance/program/programyear/publicationcheck-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -27,7 +27,7 @@ module('Acceptance: Program - Publication Check' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/publish-test.js
+++ b/tests/acceptance/program/programyear/publish-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -37,7 +37,7 @@ module('Acceptance: Program Year - Publish' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/stewards-test.js
+++ b/tests/acceptance/program/programyear/stewards-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -69,7 +69,7 @@ module('Acceptance: Program Year - Stewards' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/topics-test.js
+++ b/tests/acceptance/program/programyear/topics-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
   test
@@ -33,7 +33,7 @@ module('Acceptance: Program Year - Topics' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/publicationcheck-test.js
+++ b/tests/acceptance/program/publicationcheck-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -37,7 +37,7 @@ module('Acceptance: Program Year - Publication Check' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/publish-test.js
+++ b/tests/acceptance/program/publish-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../../helpers/destroy-app';
 import {
   module,
   test
@@ -37,7 +37,7 @@ module('Acceptance: Program - Publish' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/programs-test.js
+++ b/tests/acceptance/programs-test.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {b as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 var application;
 
@@ -15,7 +16,7 @@ module('Acceptance: Programs' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/user-test.js
+++ b/tests/acceptance/user-test.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import Ember from 'ember';
 
 const { run } = Ember;
 

--- a/tests/acceptance/users-test.js
+++ b/tests/acceptance/users-test.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
+import Ember from 'ember';
 
 const { run } = Ember;
 

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const { run } = Ember;
+
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/integration/components/dashboard-agenda-test.js
+++ b/tests/integration/components/dashboard-agenda-test.js
@@ -1,9 +1,9 @@
 import moment from 'moment';
 import { moduleForComponent, test } from 'ember-qunit';
-import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 let today = moment();
 let mockEvents = [
@@ -34,7 +34,7 @@ test('it renders with events', function(assert) {
   this.container.register('service:mockuserevents', userEventsMock);
   this.container.injection('component', 'userEvents', 'service:mockuserevents');
   assert.expect(6);
-  
+
   this.render(hbs`{{dashboard-agenda}}`);
 
   for(let i = 0; i < 3; i++){
@@ -48,7 +48,7 @@ test('it renders blank', function(assert) {
   this.container.register('service:mockuserevents', blankEventsMock);
   this.container.injection('component', 'userEvents', 'service:mockuserevents');
   assert.expect(1);
-  
+
   this.render(hbs`{{dashboard-agenda}}`);
 
   assert.equal(this.$().text().trim(), 'No upcoming events');

--- a/tests/integration/components/dashboard-calendar-test.js
+++ b/tests/integration/components/dashboard-calendar-test.js
@@ -1,9 +1,8 @@
 import moment from 'moment';
 import { moduleForComponent, test } from 'ember-qunit';
-// import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
 import tHelper from "ember-i18n/helper";
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 let today = moment();
 let mockEvents = [
@@ -32,7 +31,7 @@ test('it renders', function(assert) {
 
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
-  
+
   /*
   {{dashboard-calendar
     selectedDate=selectedDate

--- a/tests/integration/components/dashboard-mycourses-test.js
+++ b/tests/integration/components/dashboard-mycourses-test.js
@@ -1,8 +1,8 @@
 import { moduleForComponent, test } from 'ember-qunit';
-import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 const { computed } = Ember;
 

--- a/tests/integration/components/dashboard-myreports-test.js
+++ b/tests/integration/components/dashboard-myreports-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
-import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
+import Ember from 'ember';
 
 const { computed } = Ember;
 

--- a/tests/integration/components/offering-editor-learnergroups-test.js
+++ b/tests/integration/components/offering-editor-learnergroups-test.js
@@ -1,8 +1,8 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
-import Ember from 'ember';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 moduleForComponent('offering-editor-learnergroups', 'Integration | Component | offering editor learnergroups' + testgroup, {
   integration: true,

--- a/tests/integration/components/offering-editor-test.js
+++ b/tests/integration/components/offering-editor-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 const { isEmpty, isPresent } = Ember;
 

--- a/tests/integration/components/publish-all-sessions-test.js
+++ b/tests/integration/components/publish-all-sessions-test.js
@@ -1,8 +1,8 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
-import Ember from 'ember';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 const {RSVP} = Ember;
 
@@ -21,7 +21,7 @@ test('it renders', function(assert) {
   this.set('sessions', RSVP.resolve(sessions));
 
   this.render(hbs`{{publish-all-sessions sessions=sessions}}`);
-  
+
   assert.ok(this.$().text().search(/Sessions Incomplete: cannot publish \(0\)/) !== -1);
   assert.ok(this.$().text().search(/Sessions Complete: ready to publish \(0\)/) !== -1);
   assert.ok(this.$().text().search(/Sessions Requiring Review \(0\)/) !== -1);

--- a/tests/unit/components/user-profile-test.js
+++ b/tests/unit/components/user-profile-test.js
@@ -25,18 +25,6 @@ test('`isDisabled` computed property works', function(assert) {
   assert.ok(component.get('isDisabled'), 'isDisabled is true');
 });
 
-test('`removeFromSync` computed property works', function(assert) {
-  assert.expect(2);
-
-  const user = Ember.Object.create({ userSyncIgnore: true });
-  const component = this.subject({ user });
-
-  assert.ok(component.get('removeFromSync'), 'removeFromSync is true');
-
-  user.set('userSyncIgnore', false);
-  assert.ok(!component.get('removeFromSync'), 'removeFromSync is false');
-});
-
 // Couldn't get this one to pass:
 // test('`isCourseDirector` computed property works', function(assert) {
 //   assert.expect(1);
@@ -53,3 +41,14 @@ test('`removeFromSync` computed property works', function(assert) {
 //     assert.ok(component.get('isCourseDirector.content'), 'true');
 //   });
 // });
+test('`removeFromSync` computed property works', function(assert) {
+  assert.expect(2);
+
+  const user = Ember.Object.create({ userSyncIgnore: true });
+  const component = this.subject({ user });
+
+  assert.ok(component.get('removeFromSync'), 'removeFromSync is true');
+
+  user.set('userSyncIgnore', false);
+  assert.ok(!component.get('removeFromSync'), 'removeFromSync is false');
+});

--- a/tests/unit/mixins/events-test.js
+++ b/tests/unit/mixins/events-test.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
 import EventMixin from '../../../mixins/events';
 import { module, test } from 'qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 module('Unit | Mixin | events' + testgroup);
 

--- a/tests/unit/mixins/inplace-test.js
+++ b/tests/unit/mixins/inplace-test.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
 import InplaceMixin from '../../../mixins/inplace';
 import { module, test } from 'qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 module('InplaceMixin' + testgroup);
 

--- a/tests/unit/mixins/live-search-item-test.js
+++ b/tests/unit/mixins/live-search-item-test.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
 import LiveSearchItemMixin from 'ilios/mixins/live-search-item';
 import { module, test } from 'qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 module('LiveSearchItemMixin' + testgroup);
 

--- a/tests/unit/mixins/publishable-model-test.js
+++ b/tests/unit/mixins/publishable-model-test.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
 import PublishableModelMixin from '../../../mixins/publishable-model';
 import { module, test } from 'qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 module('Unit | Mixin | publishable model' + testgroup);
 

--- a/tests/unit/mixins/publishable-test.js
+++ b/tests/unit/mixins/publishable-test.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
 import PublishableMixin from '../../../mixins/publishable';
 import { module, test } from 'qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import Ember from 'ember';
 
 module('Unit | Mixin | publishable' + testgroup);
 

--- a/tests/unit/models/objective-test.js
+++ b/tests/unit/models/objective-test.js
@@ -5,7 +5,8 @@ import {
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
 import Ember from 'ember';
-let {run} = Ember;
+
+const { run } = Ember;
 
 moduleForModel('objective', 'Unit | Model | Objective' + testgroup, {
   needs: modelList
@@ -19,7 +20,7 @@ test('it exists', function(assert) {
 
 test('top parent with no parents should be self', function(assert) {
   assert.expect(2);
-  
+
   var model = this.subject();
   model.get('topParents').then(topParents => {
     assert.ok(topParents.get('length') === 1);
@@ -38,13 +39,13 @@ test('corrent top parents with single parent tree', function(assert) {
     let parent2 = store.createRecord('objective', {
       children: [parent1]
     });
-    
+
     model.get('topParents').then(topParents => {
       assert.ok(topParents.get('length') === 1);
       assert.equal(topParents.get('firstObject'), parent2);
     });
   });
-  
+
 });
 
 test('corrent top parents with multi parent tree', function(assert) {
@@ -64,12 +65,12 @@ test('corrent top parents with multi parent tree', function(assert) {
     let parent4 = store.createRecord('objective', {
       children: [parent2]
     });
-    
+
     model.get('topParents').then(topParents => {
       assert.ok(topParents.get('length') === 2);
       assert.ok(topParents.contains(parent3));
       assert.ok(topParents.contains(parent4));
     });
   });
-  
+
 });


### PR DESCRIPTION
Convert (qunit or mocha flavored) acceptance tests to utilize the destroyApp helper introduced in Ember CLI 1.13.9.