### PR TITLE
ember watson:replace-needs-with-injection app

### DIFF
--- a/app/components/live-search.js
+++ b/app/components/live-search.js
@@ -20,6 +20,7 @@ export default Component.extend({
   sortedSearchResults: computed('results.@each', function(){
     return this.get('results').sortBy('sortTerm');
   }),
+
   searchResults: computed(function(key, values){
     if (arguments.length > 1) {
       values.forEach(function(obj){
@@ -31,6 +32,7 @@ export default Component.extend({
     }
     return this.get('results');
   }),
+
   watchSeatchTerms: observer('searchTerms', function(){
     this.send('search');
   }),

--- a/app/controllers/program-year.js
+++ b/app/controllers/program-year.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 
-const { computed, Controller } = Ember;
+const { computed, Controller, inject } = Ember;
+const { controller } = inject;
 const { alias } = computed;
 
 export default Controller.extend({
-  needs: "program",
-  program: alias("controllers.program.model"),
+  programController: controller('program'),
+
+  program: alias('programController.model'),
 });

--- a/app/controllers/program-year/publication-check.js
+++ b/app/controllers/program-year/publication-check.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
 
-const { computed, Controller } = Ember;
+const { computed, Controller, inject } = Ember;
+const { controller } = inject;
 const { alias } = computed;
 
 export default Controller.extend({
-  needs: ["program", "programYear"],
-  program: alias("controllers.program.model"),
-  programYear: alias("controllers.programYear.model"),
+  programYearController: controller('programYear'),
+  programController: controller('program'),
+
+  program: alias('programController.model'),
+  programYear: alias('programYearController.model')
 });

--- a/app/controllers/program/index.js
+++ b/app/controllers/program/index.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 
-const { computed, Controller } = Ember;
+const { computed, Controller, inject } = Ember;
 const { alias } = computed;
+const { controller } = inject;
 
 export default Controller.extend({
-  needs: "program",
-  program: alias("controllers.program.model"),
+  programController: controller('program'),
+
+  program: alias('programController.model'),
 });

--- a/app/controllers/session/index.js
+++ b/app/controllers/session/index.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
 
-const { computed, Controller } = Ember;
+const { computed, Controller, inject } = Ember;
+const { controller } = inject;
 const { alias } = computed;
 
 export default Controller.extend({
-  needs: ["course", "session"],
-  courseController: alias("controllers.course"),
-  sessionController: alias("controllers.session"),
+  sessionController: controller('session'),
+  courseController: controller('course'),
+
+  courseController: alias('courseController'),
+  sessionController: alias('sessionController')
 });

--- a/app/controllers/session/publication-check.js
+++ b/app/controllers/session/publication-check.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
 
-const { computed, Controller } = Ember;
+const { computed, Controller, inject } = Ember;
+const { controller } = inject;
 const { alias } = computed;
 
 export default Controller.extend({
-  needs: ["course", "session"],
-  courseController: alias("controllers.course"),
-  sessionController: alias("controllers.session"),
+  sessionController: controller('session'),
+  courseController: controller('course'),
+
+  courseController: alias('courseController'),
+  sessionController: alias('sessionController')
 });

--- a/tests/acceptance/admin-test.js
+++ b/tests/acceptance/admin-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 

--- a/tests/acceptance/course/cohorts-test.js
+++ b/tests/acceptance/course/cohorts-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -60,7 +60,7 @@ module('Acceptance: Course - Cohorts' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -106,7 +106,7 @@ module('Acceptance: Course - Learning Materials' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/mesh-test.js
+++ b/tests/acceptance/course/mesh-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -49,7 +49,7 @@ module('Acceptance: Course - Mesh Terms' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/objectivecreate-test.js
+++ b/tests/acceptance/course/objectivecreate-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -30,7 +30,7 @@ module('Acceptance: Course - Objective Create' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/objectivelist-test.js
+++ b/tests/acceptance/course/objectivelist-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -23,7 +23,7 @@ module('Acceptance: Course - Objective List' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/objectivemesh-test.js
+++ b/tests/acceptance/course/objectivemesh-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -53,7 +53,7 @@ module('Acceptance: Course - Objective Mesh Descriptors' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -93,7 +93,7 @@ module('Acceptance: Course with multiple Cohorts - Objective Parents' + testgrou
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/objectiveparents-test.js
+++ b/tests/acceptance/course/objectiveparents-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -69,7 +69,7 @@ module('Acceptance: Course - Objective Parents' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -21,7 +21,7 @@ module('Acceptance: Course - Overview' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/publicationcheck-test.js
+++ b/tests/acceptance/course/publicationcheck-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -41,7 +41,7 @@ module('Acceptance: Course - Publication Check' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/publish-test.js
+++ b/tests/acceptance/course/publish-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -20,7 +20,7 @@ module('Acceptance: Course - Publish' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/ilm-test.js
+++ b/tests/acceptance/course/session/ilm-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -102,7 +102,7 @@ module('Acceptance: Session - Independent Learning' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -109,7 +109,7 @@ module('Acceptance: Session - Learning Materials' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/mesh-test.js
+++ b/tests/acceptance/course/session/mesh-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -32,7 +32,7 @@ module('Acceptance: Session - Mesh Terms' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/objectivecreate-test.js
+++ b/tests/acceptance/course/session/objectivecreate-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -27,7 +27,7 @@ module('Acceptance: Session - Objective Create' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/objectivelist-test.js
+++ b/tests/acceptance/course/session/objectivelist-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -22,7 +22,7 @@ module('Acceptance: Session - Objective List' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/objectivemesh-test.js
+++ b/tests/acceptance/course/session/objectivemesh-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -59,7 +59,7 @@ module('Acceptance: Session - Objective Mesh Descriptors' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/objectiveparents-test.js
+++ b/tests/acceptance/course/session/objectiveparents-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -52,7 +52,7 @@ module('Acceptance: Session - Objective Parents' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -124,7 +124,7 @@ module('Acceptance: Session - Offerings' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -28,7 +28,7 @@ module('Acceptance: Session - Overview' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -41,7 +41,7 @@ module('Acceptance: Session - Publication Check' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/publish-test.js
+++ b/tests/acceptance/course/session/publish-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -49,7 +49,7 @@ module('Acceptance: Session - Publish' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/session/topics-test.js
+++ b/tests/acceptance/course/session/topics-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -39,7 +39,7 @@ module('Acceptance: Session - Topics' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -60,7 +60,7 @@ module('Acceptance: Course - Session List' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/course/topics-test.js
+++ b/tests/acceptance/course/topics-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -36,7 +36,7 @@ module('Acceptance: Course - Topics' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -23,7 +23,7 @@ module('Acceptance: Courses' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -107,7 +107,7 @@ module('Acceptance: Dashboard Calendar' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/four-oh-four-test.js
+++ b/tests/acceptance/four-oh-four-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -20,7 +20,7 @@ module('Acceptance: FourOhFour' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/instructorgroup-test.js
+++ b/tests/acceptance/instructorgroup-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -62,7 +62,7 @@ module('Acceptance: Instructor Group Details' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/instructorgroups-test.js
+++ b/tests/acceptance/instructorgroups-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -15,7 +15,7 @@ module('Acceptance: Instructor Groups' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/learnergroup/membership-test.js
+++ b/tests/acceptance/learnergroup/membership-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -59,7 +59,7 @@ module('Acceptance: Learner Group - Membership' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/learnergroup/overview-test.js
+++ b/tests/acceptance/learnergroup/overview-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -74,7 +74,7 @@ module('Acceptance: Learner Group - Overview' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/learnergroup/subgroups-test.js
+++ b/tests/acceptance/learnergroup/subgroups-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -44,7 +44,7 @@ module('Acceptance: Learner Group - Subgroups' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -18,7 +18,7 @@ module('Acceptance: Learner Groups' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/overview-test.js
+++ b/tests/acceptance/program/overview-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -17,7 +17,7 @@ module('Acceptance: Program - Overview' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -1,5 +1,5 @@
+import destroyApp from '../helpers/destroy-app';
 import moment from 'moment';
-import Ember from 'ember';
 import {
   module,
   test
@@ -20,7 +20,7 @@ module('Acceptance: Program - ProgramYear List' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/competencies-test.js
+++ b/tests/acceptance/program/programyear/competencies-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -46,7 +46,7 @@ module('Acceptance: Program Year - Competencies' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/objectives-test.js
+++ b/tests/acceptance/program/programyear/objectives-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -58,7 +58,7 @@ module('Acceptance: Program Year - Objectives' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/overview-test.js
+++ b/tests/acceptance/program/programyear/overview-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -28,7 +28,7 @@ module('Acceptance: Program Year - Overview' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/publicationcheck-test.js
+++ b/tests/acceptance/program/programyear/publicationcheck-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -27,7 +27,7 @@ module('Acceptance: Program - Publication Check' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/publish-test.js
+++ b/tests/acceptance/program/programyear/publish-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -37,7 +37,7 @@ module('Acceptance: Program Year - Publish' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/stewards-test.js
+++ b/tests/acceptance/program/programyear/stewards-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -69,7 +69,7 @@ module('Acceptance: Program Year - Stewards' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/programyear/topics-test.js
+++ b/tests/acceptance/program/programyear/topics-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -33,7 +33,7 @@ module('Acceptance: Program Year - Topics' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/publicationcheck-test.js
+++ b/tests/acceptance/program/publicationcheck-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -37,7 +37,7 @@ module('Acceptance: Program Year - Publication Check' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/program/publish-test.js
+++ b/tests/acceptance/program/publish-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -37,7 +37,7 @@ module('Acceptance: Program - Publish' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/programs-test.js
+++ b/tests/acceptance/programs-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import destroyApp from '../helpers/destroy-app';
 import {
   module,
   test
@@ -15,7 +15,7 @@ module('Acceptance: Programs' + testgroup, {
   },
 
   afterEach: function() {
-    Ember.run(application, 'destroy');
+    destroyApp(application);
   }
 });
 

--- a/tests/acceptance/user-test.js
+++ b/tests/acceptance/user-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 

--- a/tests/acceptance/users-test.js
+++ b/tests/acceptance/users-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 

--- a/tests/integration/components/dashboard-agenda-test.js
+++ b/tests/integration/components/dashboard-agenda-test.js
@@ -1,6 +1,5 @@
 import moment from 'moment';
 import { moduleForComponent, test } from 'ember-qunit';
-import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';

--- a/tests/integration/components/dashboard-calendar-test.js
+++ b/tests/integration/components/dashboard-calendar-test.js
@@ -1,7 +1,5 @@
 import moment from 'moment';
 import { moduleForComponent, test } from 'ember-qunit';
-// import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
 import tHelper from "ember-i18n/helper";
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 

--- a/tests/integration/components/dashboard-mycourses-test.js
+++ b/tests/integration/components/dashboard-mycourses-test.js
@@ -1,5 +1,4 @@
 import { moduleForComponent, test } from 'ember-qunit';
-import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';

--- a/tests/integration/components/dashboard-myreports-test.js
+++ b/tests/integration/components/dashboard-myreports-test.js
@@ -1,5 +1,4 @@
 import { moduleForComponent, test } from 'ember-qunit';
-import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
 

--- a/tests/integration/components/offering-editor-learnergroups-test.js
+++ b/tests/integration/components/offering-editor-learnergroups-test.js
@@ -1,7 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
-import Ember from 'ember';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
 moduleForComponent('offering-editor-learnergroups', 'Integration | Component | offering editor learnergroups' + testgroup, {

--- a/tests/integration/components/offering-editor-test.js
+++ b/tests/integration/components/offering-editor-test.js
@@ -1,6 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import Ember from 'ember';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
 const { isEmpty, isPresent } = Ember;

--- a/tests/integration/components/publish-all-sessions-test.js
+++ b/tests/integration/components/publish-all-sessions-test.js
@@ -1,7 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
-import Ember from 'ember';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 
 const {RSVP} = Ember;

--- a/tests/unit/components/expand-collapse-button-test.js
+++ b/tests/unit/components/expand-collapse-button-test.js
@@ -1,6 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
-import Ember from 'ember';
 
 const { run } = Ember;
 

--- a/tests/unit/components/learnergroup-overview-test.js
+++ b/tests/unit/components/learnergroup-overview-test.js
@@ -1,6 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
-import Ember from 'ember';
 
 const { run } = Ember;
 const { next } = run;

--- a/tests/unit/components/offering-editor-learnergroups-test.js
+++ b/tests/unit/components/offering-editor-learnergroups-test.js
@@ -1,6 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
-import Ember from 'ember';
 
 moduleForComponent('offering-editor-learnergroups', 'Unit | Component | offering editor learnergroups ' + testgroup, {
   unit: true

--- a/tests/unit/components/offering-editor-test.js
+++ b/tests/unit/components/offering-editor-test.js
@@ -1,7 +1,6 @@
 /* global moment */
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
-import Ember from 'ember';
 
 const { isEmpty, RSVP, run } = Ember;
 const { Promise } = RSVP;

--- a/tests/unit/components/session-offerings-test.js
+++ b/tests/unit/components/session-offerings-test.js
@@ -1,6 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
-import Ember from 'ember';
 
 const { run } = Ember;
 const { next } = run;

--- a/tests/unit/components/user-profile-test.js
+++ b/tests/unit/components/user-profile-test.js
@@ -1,5 +1,4 @@
 import { moduleForComponent, test } from 'ember-qunit';
-import Ember from 'ember';
 
 moduleForComponent('user-profile', 'Unit | Component | user profile ', {
   unit: true
@@ -25,18 +24,6 @@ test('`isDisabled` computed property works', function(assert) {
   assert.ok(component.get('isDisabled'), 'isDisabled is true');
 });
 
-test('`removeFromSync` computed property works', function(assert) {
-  assert.expect(2);
-
-  const user = Ember.Object.create({ userSyncIgnore: true });
-  const component = this.subject({ user });
-
-  assert.ok(component.get('removeFromSync'), 'removeFromSync is true');
-
-  user.set('userSyncIgnore', false);
-  assert.ok(!component.get('removeFromSync'), 'removeFromSync is false');
-});
-
 // Couldn't get this one to pass:
 // test('`isCourseDirector` computed property works', function(assert) {
 //   assert.expect(1);
@@ -53,3 +40,14 @@ test('`removeFromSync` computed property works', function(assert) {
 //     assert.ok(component.get('isCourseDirector.content'), 'true');
 //   });
 // });
+test('`removeFromSync` computed property works', function(assert) {
+  assert.expect(2);
+
+  const user = Ember.Object.create({ userSyncIgnore: true });
+  const component = this.subject({ user });
+
+  assert.ok(component.get('removeFromSync'), 'removeFromSync is true');
+
+  user.set('userSyncIgnore', false);
+  assert.ok(!component.get('removeFromSync'), 'removeFromSync is false');
+});

--- a/tests/unit/mixins/events-test.js
+++ b/tests/unit/mixins/events-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import EventMixin from '../../../mixins/events';
 import { module, test } from 'qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';

--- a/tests/unit/mixins/inplace-test.js
+++ b/tests/unit/mixins/inplace-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import InplaceMixin from '../../../mixins/inplace';
 import { module, test } from 'qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';

--- a/tests/unit/mixins/live-search-item-test.js
+++ b/tests/unit/mixins/live-search-item-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import LiveSearchItemMixin from 'ilios/mixins/live-search-item';
 import { module, test } from 'qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';

--- a/tests/unit/mixins/publishable-model-test.js
+++ b/tests/unit/mixins/publishable-model-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import PublishableModelMixin from '../../../mixins/publishable-model';
 import { module, test } from 'qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';

--- a/tests/unit/mixins/publishable-test.js
+++ b/tests/unit/mixins/publishable-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import PublishableMixin from '../../../mixins/publishable';
 import { module, test } from 'qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';

--- a/tests/unit/models/objective-test.js
+++ b/tests/unit/models/objective-test.js
@@ -4,7 +4,6 @@ import {
 } from 'ember-qunit';
 import {a as testgroup} from 'ilios/tests/helpers/test-groups';
 import modelList from '../../helpers/model-list';
-import Ember from 'ember';
 let {run} = Ember;
 
 moduleForModel('objective', 'Unit | Model | Objective' + testgroup, {


### PR DESCRIPTION
Convert `needs` declarations the individual properties using the new `Ember.inject.controller()` feature. Also convert any uses of the `controllers` hash to use the newly defined properties.