### PR TITLE
Scope reports by school

### DIFF
--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -59,21 +59,25 @@ export default Component.extend({
     let defer = RSVP.defer();
     let model = type.dasherize();
     const store = this.get('store');
+    const school = this.get('currentSchool');
     let query = {
       limit: 1000,
       filters: {}
     };
-    let schoolScopedModels = [
-      'topic',
-      'session',
-      'program',
-      'session-type',
-      'instructor-group',
-      'competency',
-    ];
-    if(schoolScopedModels.contains(model)){
-      query.filters.school = this.get('currentSchool').get('id');
+    if(isPresent(school)){
+      let schoolScopedModels = [
+        'topic',
+        'session',
+        'program',
+        'session-type',
+        'instructor-group',
+        'competency',
+      ];
+      if(schoolScopedModels.contains(model)){
+        query.filters.school = this.get('currentSchool').get('id');
+      }
     }
+    
     store.query(model, query).then(objects => {
       let label = type === 'mesh term'?'name':'title';
       let values = objects.map(object => {

--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -139,6 +139,8 @@ export default Component.extend({
     },
     changeSubject(subject){
       this.set('currentSubject', subject);
+      this.set('currentPrepositionalObject', null);
+      this.set('currentPrepositionalObjectId', null);
     },
     changePrepositionalObject(object){
       this.set('currentPrepositionalObject', object);

--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -12,6 +12,7 @@ export default Component.extend({
   flashMessages: service(),
   classNames: ['form-container', 'detail-view', 'new-myreport', 'mesh-manager'],
   title: null,
+  currentSchool: null,
   currentSubject: 'course',
   currentPrepositionalObject: null,
   currentPrepositionalObjectId: null,
@@ -104,7 +105,22 @@ export default Component.extend({
       return null;
     }
   }),
+  schoolList: computed('currentUser.schools.[]',function(){
+    let defer = RSVP.defer();
+    this.get('currentUser').get('model').then(user => {
+      user.get('schools').then(schools => {
+        defer.resolve(schools.sortBy('title'));
+      });
+    });
+    return PromiseArray.create({
+      promise: defer.promise
+    });
+  }),
   actions: {
+    changeSchool(schoolId){
+      let school = this.get('schoolList').find(school =>  school.get('id') === schoolId);
+      this.set('currentSchool', school);
+    },
     changeSubject(subject){
       this.set('currentSubject', subject);
     },
@@ -157,14 +173,15 @@ export default Component.extend({
         let subject = this.get('currentSubject');
         let prepositionalObject = this.get('currentPrepositionalObject');
         let prepositionalObjectTableRowId = this.get('currentPrepositionalObjectId');
+        let school = this.get('currentSchool');
         let report = store.createRecord('report', {
           title,
           user,
           subject,
           prepositionalObject,
-          prepositionalObjectTableRowId
+          prepositionalObjectTableRowId,
+          school
         });
-
         report.save().then(() => {
           this.sendAction('close');
         });

--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -51,7 +51,7 @@ export default Component.extend({
 
     return list.filter(item =>item.subjects.contains(subject));
   }),
-  prepositionalObjectIdList: computed('currentPrepositionalObject', function(){
+  prepositionalObjectIdList: computed('currentPrepositionalObject', 'currentSchool', function(){
     const type = this.get('currentPrepositionalObject');
     if(isEmpty(type) || type === 'instructor'){
       return [];
@@ -60,8 +60,20 @@ export default Component.extend({
     let model = type.dasherize();
     const store = this.get('store');
     let query = {
-      limit: 1000
+      limit: 1000,
+      filters: {}
     };
+    let schoolScopedModels = [
+      'topic',
+      'session',
+      'program',
+      'session-type',
+      'instructor-group',
+      'competency',
+    ];
+    if(schoolScopedModels.contains(model)){
+      query.filters.school = this.get('currentSchool').get('id');
+    }
     store.query(model, query).then(objects => {
       let label = type === 'mesh term'?'name':'title';
       let values = objects.map(object => {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -404,8 +404,8 @@ export default {
     'myReports': 'My Reports',
     'newReport': 'New Report',
     'reportTitle': 'Report Title',
-    'reportDisplayTitleWithObject': 'All {{subject}} for {{object}}',
-    'reportDisplayTitleWithoutObject': 'All {{subject}}',
+    'reportDisplayTitleWithObject': 'All {{subject}} for {{object}} in {{school}}',
+    'reportDisplayTitleWithoutObject': 'All {{subject}} in {{school}}',
     'associatedWith': 'Associated with',
     'whichIs': 'which is',
     'reportMissingMeshTerm': 'MeSH Term is Required',
@@ -418,7 +418,8 @@ export default {
     'topicOrDetail': 'Topic/Detail',
     'courseOrType': 'Course/Type',
     'usersCalendar': "{{name}}'s Calendar",
-    'myCalendar': 'My Calendar'
+    'myCalendar': 'My Calendar',
+    'allSchools': 'All Schools',
   },
   'errors': {
     'inclusion': "is not included in the list",

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -16,6 +16,7 @@ export default {
     'add': 'Add',
     'addNew': 'Add New',
     'all': 'All',
+    'for': 'For',
     'anything': 'Anything',
     'none': 'None',
     'close': 'Close',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -404,8 +404,8 @@ export default {
     'myReports': 'Mis Reportes',
     'newReport': 'Nuevo Reporte',
     'reportTitle': 'Rítulo de Reporte',
-    'reportDisplayTitleWithObject': 'Todos {{subject}} para {{object}}',
-    'reportDisplayTitleWithoutObject': 'Todos {{subject}}',
+    'reportDisplayTitleWithObject': 'Todos {{subject}} para {{object}} en {{school}}',
+    'reportDisplayTitleWithoutObject': 'Todos {{subject}} en {{school}}',
     'associatedWith': 'Ssociado con',
     'whichIs': 'cuál es',
     'reportMissingMeshTerm': 'Término de MeSH es Necesario',
@@ -418,7 +418,8 @@ export default {
     'topicOrDetail': 'Topico/Detalle',
     'courseOrType': 'Curso/Tipo',
     'usersCalendar': "Calendario de{{name}}",
-    'myCalendar': 'Mi Calendario'
+    'myCalendar': 'Mi Calendario',
+    'allSchools': 'Todas las Escuelas',
   },
   'errors': {
     'inclusion': "no está incluido en la lista",

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -16,6 +16,7 @@ export default {
     'add': 'Agregue',
     'addNew': 'Agregue Nuevo',
     'all': 'Todos',
+    'for': 'Para',
     'anything': 'Caulquier Cosa',
     'none': 'Ningún',
     'close': 'Cerrar',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -404,8 +404,8 @@ export default {
     'myReports': "Mes Rapports",
     'newReport': "nouveau rapport",
     'reportTitle': "Titre du Rapport",
-    'reportDisplayTitleWithObject': "tous {{subject}} pour {{object}}",
-    'reportDisplayTitleWithoutObject': "tous {{subject}}",
+    'reportDisplayTitleWithObject': "tous {{subject}} pour {{object}} en {{school}}",
+    'reportDisplayTitleWithoutObject': "tous {{subject}} en {{school}}",
     'associatedWith': "associée de",
     'whichIs': "qui est",
     'reportMissingMeshTerm': "terme de MeSH requis",
@@ -419,6 +419,7 @@ export default {
     'courseOrType': "Cours/Type",
     'usersCalendar': "Calendrier de {{name}}",
     'myCalendar': "Mon Calendrier",
+    'allSchools': 'Toutes les écoles',
   },
   'errors': {
     'inclusion': "ne figure pas dans la liste",

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -16,6 +16,7 @@ export default {
     'add': "Ajouté",
     'addNew': "Ajouté Neuf",
     'all': "Tous",
+    'for': 'Pour',
     'anything': "Quelque chose",
     'none': "Nul",
     'close': "Fermé",

--- a/app/models/report.js
+++ b/app/models/report.js
@@ -13,7 +13,8 @@ export default DS.Model.extend({
   prepositionalObject: DS.attr('string'),
   prepositionalObjectTableRowId: DS.attr('string'),
   user: DS.belongsTo('user', {async: true}),
-  displayTitle: computed('title', 'i18n.locale', function(){
+  school: DS.belongsTo('school', {async: true}),
+  displayTitle: computed('title', 'i18n.locale', 'school', function(){
     let defer = RSVP.defer();
     if(isPresent(this.get('title'))){
       defer.resolve(this.get('title'));
@@ -37,13 +38,23 @@ export default DS.Model.extend({
         } else {
           object = record.get('title');
         }
-        
-        let displayTitle = this.get('i18n').t('dashboard.reportDisplayTitleWithObject', {
-          subject,
-          object
+        this.get('school').then(schoolObj => {
+          let school;
+          if(schoolObj){
+             school = schoolObj.get('title');
+          } else {
+            school = this.get('i18n').t('dashboard.allSchools');
+          }
+          let displayTitle = this.get('i18n').t('dashboard.reportDisplayTitleWithObject', {
+            subject,
+            object,
+            school
+          });
+          
+          defer.resolve(displayTitle);
         });
         
-        defer.resolve(displayTitle);
+        
       });
     } else {
       let displayTitle = this.get('i18n').t('dashboard.reportDisplayTitleWithoutObject', {

--- a/app/models/report.js
+++ b/app/models/report.js
@@ -21,48 +21,49 @@ export default DS.Model.extend({
     }
     let subject = this.get('subject');
     let prepositionalObject = this.get('prepositionalObject');
-    if(isPresent(prepositionalObject)){
-      let model = prepositionalObject.dasherize();
-      if(model === 'instructor'){
-        model = 'user';
-      }
-      if(model === 'mesh-term'){
-        model = 'mesh-descriptor';
-      }
-      this.store.findRecord(model, this.get('prepositionalObjectTableRowId')).then(record => {
-        let object;
-        if(model === 'user'){
-          object = record.get('fullName');
-        } else if(model === 'mesh-descriptor'){
-          object = record.get('name');
-        } else {
-          object = record.get('title');
-        }
-        this.get('school').then(schoolObj => {
-          let school;
-          if(schoolObj){
-             school = schoolObj.get('title');
-          } else {
-            school = this.get('i18n').t('dashboard.allSchools');
-          }
-          let displayTitle = this.get('i18n').t('dashboard.reportDisplayTitleWithObject', {
-            subject,
-            object,
-            school
-          });
-          
-          defer.resolve(displayTitle);
-        });
-        
-        
-      });
-    } else {
-      let displayTitle = this.get('i18n').t('dashboard.reportDisplayTitleWithoutObject', {
-        subject
-      });
-      defer.resolve(displayTitle);
-    }
     
+    this.get('school').then(schoolObj => {
+      let school;
+      if(schoolObj){
+         school = schoolObj.get('title');
+      } else {
+        school = this.get('i18n').t('dashboard.allSchools');
+      }
+      if(isPresent(prepositionalObject)){
+        let model = prepositionalObject.dasherize();
+        if(model === 'instructor'){
+          model = 'user';
+        }
+        if(model === 'mesh-term'){
+          model = 'mesh-descriptor';
+        }
+        this.store.findRecord(model, this.get('prepositionalObjectTableRowId')).then(record => {
+          let object;
+          if(model === 'user'){
+            object = record.get('fullName');
+          } else if(model === 'mesh-descriptor'){
+            object = record.get('name');
+          } else {
+            object = record.get('title');
+          }
+            let displayTitle = this.get('i18n').t('dashboard.reportDisplayTitleWithObject', {
+              subject,
+              object,
+              school
+            });
+            
+            defer.resolve(displayTitle);
+          
+          
+        });
+      } else {
+        let displayTitle = this.get('i18n').t('dashboard.reportDisplayTitleWithoutObject', {
+          subject,
+          school
+        });
+        defer.resolve(displayTitle);
+      }
+    });
     return PromiseObject.create({
       promise: defer.promise
     });

--- a/app/templates/components/new-myreport.hbs
+++ b/app/templates/components/new-myreport.hbs
@@ -2,7 +2,19 @@
 <div class="detail-content">
     <label class="form-label">{{t 'dashboard.reportTitle'}}:</label>
     <div class="form-data">{{input value=title}}</div>
-    
+    <p>
+      {{t 'general.for'}}
+      <select onchange={{action "changeSchool" value="target.value"}}>
+        <option value=null selected={{is-equal null currentSchool}}>
+          {{t 'dashboard.allSchools'}}
+        </option>
+        {{#each schoolList as |school|}}
+          <option value={{school.id}} selected={{is-equal school currentSchool}}>
+            {{school.title}}
+          </option>
+        {{/each}}
+      </select>
+    </p>
     <p>
       {{t 'general.all'}}
       <select onchange={{action "changeSubject" value="target.value"}}>


### PR DESCRIPTION
Add a school selector to the reports builder.  When a school is picked then:
- only display objects related to the school to be selected
- Limit report results by that school
- Show the school name in the default report title

Fixes #1138 
Fixes #1214
Fixes #1219

Work in progress: This needs ilios/ilios#1180 and ilios/ilios#1183 to be fixed before it will work and can be tested.