### PR TITLE
ember watson:replace-needs-with-injection app

### DIFF
--- a/app/controllers/program-year.js
+++ b/app/controllers/program-year.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 
-const { computed, Controller } = Ember;
+const { computed, Controller, inject } = Ember;
+const { controller } = inject;
 const { alias } = computed;
 
 export default Controller.extend({
-  needs: "program",
-  program: alias("controllers.program.model"),
+  programController: controller('program'),
+
+  program: alias('programController.model')
 });

--- a/app/controllers/program-year/publication-check.js
+++ b/app/controllers/program-year/publication-check.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
 
-const { computed, Controller } = Ember;
+const { computed, Controller, inject } = Ember;
+const { controller } = inject;
 const { alias } = computed;
 
 export default Controller.extend({
-  needs: ["program", "programYear"],
-  program: alias("controllers.program.model"),
-  programYear: alias("controllers.programYear.model"),
+  programYearController: controller('programYear'),
+  programController: controller('program'),
+
+  program: alias('programController.model'),
+  programYear: alias('programYearController.model')
 });

--- a/app/controllers/program/index.js
+++ b/app/controllers/program/index.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 
-const { computed, Controller } = Ember;
+const { computed, Controller, inject } = Ember;
+const { controller } = inject;
 const { alias } = computed;
 
 export default Controller.extend({
-  needs: "program",
-  program: alias("controllers.program.model"),
+  programController: controller('program'),
+
+  program: alias('programController.model')
 });

--- a/app/controllers/session/index.js
+++ b/app/controllers/session/index.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
 
-const { computed, Controller } = Ember;
-const { alias } = computed;
+const { Controller, inject } = Ember;
+const { controller } = inject;
 
 export default Controller.extend({
-  needs: ["course", "session"],
-  courseController: alias("controllers.course"),
-  sessionController: alias("controllers.session"),
+  sessionController: controller('session'),
+  courseController: controller('course')
 });

--- a/app/controllers/session/publication-check.js
+++ b/app/controllers/session/publication-check.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
 
-const { computed, Controller } = Ember;
-const { alias } = computed;
+const { Controller, inject } = Ember;
+const { controller } = inject;
 
 export default Controller.extend({
-  needs: ["course", "session"],
-  courseController: alias("controllers.course"),
-  sessionController: alias("controllers.session"),
+  sessionController: controller('session'),
+  courseController: controller('course')
 });


### PR DESCRIPTION
Convert `needs` declarations the individual properties using the new `Ember.inject.controller()` feature. Also convert any uses of the `controllers` hash to use the newly defined properties.