### PR TITLE
 removed Ember.HTMLBars.makeBoundHelper deprecation

### DIFF
--- a/app/helpers/is-equal.js
+++ b/app/helpers/is-equal.js
@@ -1,11 +1,27 @@
 import Ember from 'ember';
 
-export function isEqual(params) {
-  if(params.length < 2){
-    return false;
-  }
+const { isBlank, Helper, observer, run } = Ember;
+const { once } = run;
 
-  return params[0] === params[1];
+export function isEqual(params) {
+  const validate = isBlank(params) || isBlank(params[0]) || isBlank(params[1]);
+
+  return validate ? false : params[0] === params[1];
 }
 
-export default Ember.HTMLBars.makeBoundHelper(isEqual);
+export default Helper.extend({
+  value1: null,
+  value2: null,
+
+  compute([ value1, value2 ]) {
+    this.setProperties({ value1, value2 });
+
+    return isEqual([ value1, value2 ]);
+  },
+
+  recomputeOnArrayChange: observer('value1', 'value2', function() {
+    once(this, () => {
+      this.recompute();
+    });
+  })
+});

--- a/app/helpers/is-in.js
+++ b/app/helpers/is-in.js
@@ -3,10 +3,11 @@ import Ember from 'ember';
 const { Helper, observer } = Ember;
 
 export function isIn([values, item]) {
-  if(!values){
+  if (!values) {
     return false;
   }
-  if(!item){
+
+  if (!item) {
     return false;
   }
 
@@ -15,7 +16,8 @@ export function isIn([values, item]) {
 
 export default Helper.extend({
   values: [],
-  compute: function([values, item]) {
+
+  compute([values, item]) {
     this.set('values', values);
 
     return isIn([values, item]);

--- a/app/helpers/not-in.js
+++ b/app/helpers/not-in.js
@@ -3,18 +3,21 @@ import Ember from 'ember';
 const { Helper, observer } = Ember;
 
 export function notIn([values, item]) {
-  if(!values){
+  if (!values) {
     return false;
   }
-  if(!item){
+
+  if (!item) {
     return false;
   }
+
   return !values.contains(item);
 }
 
 export default Helper.extend({
   values: [],
-  compute: function([values, item]) {
+
+  compute([values, item]) {
     this.set('values', values);
 
     return notIn([values, item]);

--- a/tests/unit/helpers/is-equal-test.js
+++ b/tests/unit/helpers/is-equal-test.js
@@ -1,14 +1,27 @@
 import { isEqual } from '../../../helpers/is-equal';
 import { module, test } from 'qunit';
-import {a as testgroup} from 'ilios/tests/helpers/test-groups';
+import { a as testgroup } from 'ilios/tests/helpers/test-groups';
 
 module('Unit | Helper | is equal' + testgroup);
 
 test('correctly compares values', function(assert) {
-  var result = isEqual([42, 42]);
+  let result = isEqual([ 42, 42 ]);
   assert.ok(result);
-  result = isEqual([42, '42']);
-  assert.ok(!result);
-  result = isEqual(['42', '42']);
+
+  result = isEqual([ 42, '42' ]);
+  assert.notOk(result);
+
+  result = isEqual([ '42', '42' ]);
   assert.ok(result);
+});
+
+test('returns false when arguments are empty or `isBlank`', function(assert) {
+  let result = isEqual([]);
+  assert.notOk(result);
+
+  result = isEqual([ 42 ]);
+  assert.notOk(result);
+
+  result = isEqual([ undefined, undefined ]);
+  assert.notOk(result);
 });


### PR DESCRIPTION
Deprecation Warning:
- Using `Ember.HTMLBars.makeBoundHelper` is deprecated. Please refactor to using `Ember.Helper` or `Ember.Helper.helper`.