### PR TITLE
Make all Users available as report instructor

### DIFF
--- a/app/templates/components/new-myreport.hbs
+++ b/app/templates/components/new-myreport.hbs
@@ -37,7 +37,6 @@
           {{else}}
             {{user-search
               addUser='chooseInstructor'
-              roles='1'
             }}
           {{/if}}
         {{else if (is-equal currentPrepositionalObject 'mesh term')}}


### PR DESCRIPTION
The instructor role isn’t important here and makes it confusing when
the person you are looking for cannot be found in the list.

Refs #1201