### PR TITLE
Handle user middle name correctly

### DIFF
--- a/app/mirage/factories/user.js
+++ b/app/mirage/factories/user.js
@@ -3,7 +3,7 @@ import Mirage from 'ember-cli-mirage';
 export default Mirage.Factory.extend({
   firstName: (i) => `${i} guy`,
   lastName: (i) => `Mc${i}son`,
-  middleName: 'm,',
+  middleName: 'M,',
   enabled: true,
   school: 1,
   roles: []

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -102,7 +102,7 @@ var User = DS.Model.extend({
         return '';
       }
 
-      const middleInitial = middleName.charAt(0).toUpperCase();
+      const middleInitial = middleName?middleName.charAt(0):false;
 
       if (middleInitial) {
         return `${firstName} ${middleInitial}. ${lastName}`;

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -16,6 +16,25 @@ test('it exists', function(assert) {
   assert.ok(!!model);
 });
 
+test('full name', function(assert) {
+  let model = this.subject();
+  Ember.run(()=>{
+    model.set('firstName', 'first');
+    model.set('lastName', 'last');
+    model.set('middleName', 'middle');
+    assert.equal(model.get('fullName'), 'first m. last');
+  });
+});
+
+test('full name no middle name', function(assert) {
+  let model = this.subject();
+  Ember.run(()=>{
+    model.set('firstName', 'first');
+    model.set('lastName', 'last');
+    assert.equal(model.get('fullName'), 'first last');
+  });
+});
+
 test('gets all directed courses', function(assert) {
   let model = this.subject();
   let store = this.store();


### PR DESCRIPTION
Don’t capitalize it automatically
Don’t break when it is missing.

Fixes #1225