### PR TITLE
Fix adding new file learning material

### DIFF
--- a/app/serializers/learning-material.js
+++ b/app/serializers/learning-material.js
@@ -1,9 +1,19 @@
+import Ember from 'ember';
 import DS from 'ember-data';
+
+const { get } = Ember;
 
 export default DS.RESTSerializer.extend({
   isNewSerializerAPI: true,
   serialize: function(snapshot, options) {
     var json = this._super(snapshot, options);
+
+    //When POSTing new file learningMaterials we need to include the file hash
+    const fileHash = get(snapshot.record, 'fileHash');
+    if (fileHash) {
+      json.fileHash = fileHash;
+    }
+    
     //don't persist this, it is handled by the server
     delete json.absoluteFileUri;
     delete json.uploadDate;

--- a/tests/unit/serializers/learning-material-test.js
+++ b/tests/unit/serializers/learning-material-test.js
@@ -21,3 +21,20 @@ test('it removes all non postable fields', function(assert) {
   assert.ok(!("uploadDate" in serializedRecord));
   assert.ok(!("absoluteFileUri" in serializedRecord));
 });
+
+test('no filehash usually', function(assert) {
+  var record = this.subject();
+
+  var serializedRecord = record.serialize();
+  
+  assert.ok(!("fileHash" in serializedRecord));
+});
+
+test('filehash when it is added', function(assert) {
+  var record = this.subject();
+  record.set('fileHash', 'BigPhatBass');
+  var serializedRecord = record.serialize();
+  
+  assert.ok(("fileHash" in serializedRecord));
+  assert.equal(serializedRecord.fileHash, 'BigPhatBass');
+});


### PR DESCRIPTION
We were not sending enough information to attach the file to the record.
This sends the fileHash with new learning materials

Fixes #1230