### PR TITLE
Improved user search

### DIFF
--- a/app/components/global-search.js
+++ b/app/components/global-search.js
@@ -48,7 +48,8 @@ export default Component.extend({
         const searchResults = store.query('user', {
           q,
           'order_by[lastName]': 'ASC',
-          'order_by[firstName]': 'ASC'
+          'order_by[firstName]': 'ASC',
+          limit: 100
         }).then((users) => {
           return users;
         });

--- a/app/components/user-search.js
+++ b/app/components/user-search.js
@@ -60,7 +60,8 @@ export default Component.extend({
         sortTerm: oneWay('content.title'),
       });
       let query = {
-        q: searchTerms
+        q: searchTerms,
+        limit: 100
       };
       if (this.get('roles')) {
         query.filters = {

--- a/app/styles/components/_global-search.scss
+++ b/app/styles/components/_global-search.scss
@@ -37,6 +37,11 @@
         color: darken($header-grey, 20);
         font-style: italic;
       }
+      
+      &.results-count {
+        color: $ilios-green;
+        cursor: default;
+      }
 
       div {
         font-size: 14px;

--- a/app/styles/components/_livesearch.scss
+++ b/app/styles/components/_livesearch.scss
@@ -30,6 +30,11 @@
         color: darken($header-grey, 20);
         font-style: italic;
       }
+      
+      &.results-count {
+        color: $ilios-green;
+        cursor: default;
+      }
     }
   }
 }

--- a/app/templates/components/global-search.hbs
+++ b/app/templates/components/global-search.hbs
@@ -17,6 +17,7 @@
         <li>{{t 'general.currentlySearchingPrompt'}}</li>
       {{else}}
         {{#if searchResults.content}}
+          <li class='results-count'>{{searchResults.content.length}} {{t 'general.results'}}</li>
           {{#each searchResults.content as |proxy|}}
             <li>
               {{#link-to 'user' proxy}}

--- a/app/templates/components/user-search.hbs
+++ b/app/templates/components/user-search.hbs
@@ -12,6 +12,7 @@
     {{else}}
       {{#if results.length}}
         <ul class='results'>
+          <li class='results-count'>{{results.length}} {{t 'general.results'}}</li>
           {{#each results as |proxy|}}
             {{#if proxy.isUser}}
               {{#if proxy.isActive}}

--- a/tests/acceptance/admin-test.js
+++ b/tests/acceptance/admin-test.js
@@ -36,7 +36,7 @@ test('can search for users', function(assert) {
   server.createList('user', 20, { email: 'user@example.edu' });
 
   const userSearch = '.global-search input';
-  const secondResult = '.global-search .results li:eq(1)';
+  const secondResult = '.global-search .results li:eq(2)';
   const secondResultUsername = `${secondResult} a .livesearch-user-name`;
   const secondResultEmail = `${secondResult} a .livesearch-user-email`;
   const name = '.user-display-name';

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -413,17 +413,18 @@ test('manage directors', function(assert) {
       click('span.search-icon', searchBox);
       andThen(function(){
         let searchResults = find('.live-search li', directors);
-        assert.equal(searchResults.length, 3);
-        assert.equal(getElementText($(searchResults[0])), getText('0 guy M. Mc0son'));
-        assert.ok(!$(searchResults[0]).hasClass('inactive'));
-        assert.equal(getElementText($(searchResults[1])), getText('Added M. Guy'));
-        assert.ok($(searchResults[1]).hasClass('inactive'));
-        assert.equal(getElementText($(searchResults[2])), getText('Disabled M. Guy'));
+        assert.equal(searchResults.length, 4);
+        assert.equal(getElementText($(searchResults[0])), getText('3 Results'));
+        assert.equal(getElementText($(searchResults[1])), getText('0 guy M. Mc0son'));
+        assert.ok(!$(searchResults[1]).hasClass('inactive'));
+        assert.equal(getElementText($(searchResults[2])), getText('Added M. Guy'));
         assert.ok($(searchResults[2]).hasClass('inactive'));
+        assert.equal(getElementText($(searchResults[3])), getText('Disabled M. Guy'));
+        assert.ok($(searchResults[3]).hasClass('inactive'));
 
         click('.removable-list li:eq(0)', directors).then(function(){
-          assert.ok(!$(find('.live-search li:eq(1)', directors)).hasClass('inactive'));
-          click(searchResults[0]);
+          assert.ok(!$(find('.live-search li:eq(2)', directors)).hasClass('inactive'));
+          click(searchResults[1]);
         });
         andThen(function(){
           assert.equal(getElementText(find('.coursedirectors .removable-list')), getText('0 guy M. Mc0son'));
@@ -465,18 +466,20 @@ test('search twice and list should be correct', function(assert) {
       click('span.search-icon', searchBox);
       andThen(function(){
         let searchResults = find('.live-search li', directors);
-        assert.equal(searchResults.length, 2);
-        assert.equal(getElementText($(searchResults[0])), getText('0 guy M. Mc0son'));
-        assert.equal(getElementText($(searchResults[1])), getText('Added M. Guy'));
-        click(searchResults[0]).then(function(){
+        assert.equal(searchResults.length, 3);
+        assert.equal(getElementText($(searchResults[0])), getText('2 Results'));
+        assert.equal(getElementText($(searchResults[1])), getText('0 guy M. Mc0son'));
+        assert.equal(getElementText($(searchResults[2])), getText('Added M. Guy'));
+        click(searchResults[1]).then(function(){
           let searchBoxInput = find('input', searchBox);
           fillIn(searchBoxInput, 'guy');
           click('span.search-icon', searchBox);
           andThen(function(){
             let searchResults = find('.live-search li', directors);
-            assert.equal(searchResults.length, 2);
-            assert.equal(getElementText($(searchResults[0])), getText('0 guy M. Mc0son'));
-            assert.equal(getElementText($(searchResults[1])), getText('Added M. Guy'));
+            assert.equal(searchResults.length, 3);
+            assert.equal(getElementText($(searchResults[0])), getText('2 Results'));
+            assert.equal(getElementText($(searchResults[1])), getText('0 guy M. Mc0son'));
+            assert.equal(getElementText($(searchResults[2])), getText('Added M. Guy'));
           });
         });
     });

--- a/tests/acceptance/course/session/ilm-test.js
+++ b/tests/acceptance/course/session/ilm-test.js
@@ -319,8 +319,8 @@ test('manage instructors search users', function(assert) {
       fillIn(searchBoxInput, 'guy');
       click('span.search-icon', searchBox).then(()=>{
         let searchResults = find('.live-search .results li', container);
-        assert.equal(searchResults.length, 7);
-        let expectedResults = '0 guy M. Mc0son 1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son 4 guy M. Mc4son 5 guy M. Mc5son 6 guy M. Mc6son';
+        assert.equal(searchResults.length, 8);
+        let expectedResults = '7 Results 0 guy M. Mc0son 1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son 4 guy M. Mc4son 5 guy M. Mc5son 6 guy M. Mc6son';
         assert.equal(getElementText(searchResults), getText(expectedResults));
 
         let activeResults = find('.live-search .results li.active', container);
@@ -349,8 +349,8 @@ test('manage instructors search groups', function(assert) {
       fillIn(searchBoxInput, 'group');
       click('span.search-icon', searchBox).then(()=>{
         let searchResults = find('.live-search .results li', container);
-        assert.equal(searchResults.length, 5);
-        let expectedResults = 'instructorgroup 0 instructorgroup 1 instructorgroup 2 instructorgroup 3 instructorgroup 4';
+        assert.equal(searchResults.length, 6);
+        let expectedResults = '5 Results instructorgroup 0 instructorgroup 1 instructorgroup 2 instructorgroup 3 instructorgroup 4';
         assert.equal(getElementText(searchResults), getText(expectedResults));
 
         let activeResults = find('.live-search .results li.active', container);
@@ -372,7 +372,7 @@ test('add instructor group', function(assert) {
       let input = find('.search-box input', container);
       fillIn(input, 'group');
       click('span.search-icon', container).then(()=>{
-        click('.live-search .results li:eq(3)');
+        click('.live-search .results li:eq(4)');
       });
     });
     andThen(function(){
@@ -406,7 +406,7 @@ test('add instructor', function(assert) {
       let input = find('.search-box input', container);
       fillIn(input, 'guy');
       click('span.search-icon', container).then(()=>{
-        click('.live-search .results li:eq(4)');
+        click('.live-search .results li:eq(5)');
       });
     });
     andThen(function(){

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -391,7 +391,7 @@ test('users can edit existing offerings (single & multi-day)', function(assert) 
 
   const learnerGroupOne = '.selectable li:first';
   const searchBox = '.search-box:last input';
-  const searchBoxOption = '.live-search li:first';
+  const searchBoxOption = '.live-search li:contains("instructor group 0")';
   const createButton = '.done';
 
   const dayOfWeek = '.offering-block-date-dayofweek:first';
@@ -470,6 +470,7 @@ test('users can edit existing offerings (single & multi-day)', function(assert) 
   click(searchBoxOption);
   click(createButton);
   andThen(() => {
+    
     assert.equal(find(multiDayDesc).text().trim(), 'Multiday', 'multi-day statement is correct');
     assert.equal(find(multiDayStarts).text().trim(), 'Starts Wednesday October 5th @ 11:45 AM', 'multi-day statement is correct');
     assert.equal(find(multiDayEnds).text().trim(), 'Ends Sunday December 25th @ 7:30 PM', 'multi-day statement is correct');

--- a/tests/acceptance/instructorgroup-test.js
+++ b/tests/acceptance/instructorgroup-test.js
@@ -109,17 +109,18 @@ test('search instructors', function(assert) {
     var container = find('.instructorgroup-overview').eq(0);
     fillIn(find('.search-box input', container), 'guy').then(function(){
       var searchResults = find('.results li', container);
-      assert.equal(searchResults.length, 5);
-      assert.equal(getElementText(searchResults.eq(0)), getText('0 guy M. Mc0son'));
-      assert.ok(searchResults.eq(0).hasClass('active'));
-      assert.equal(getElementText(searchResults.eq(1)), getText('1 guy M. Mc1son'));
-      assert.ok(!searchResults.eq(1).hasClass('active'));
-      assert.equal(getElementText(searchResults.eq(2)), getText('2 guy M. Mc2son'));
+      assert.equal(searchResults.length, 6);
+      assert.equal(getElementText(searchResults.eq(0)), getText('5 Results'));
+      assert.equal(getElementText(searchResults.eq(1)), getText('0 guy M. Mc0son'));
+      assert.ok(searchResults.eq(1).hasClass('active'));
+      assert.equal(getElementText(searchResults.eq(2)), getText('1 guy M. Mc1son'));
       assert.ok(!searchResults.eq(2).hasClass('active'));
-      assert.equal(getElementText(searchResults.eq(3)), getText('3 guy M. Mc3son'));
-      assert.ok(searchResults.eq(3).hasClass('active'));
-      assert.equal(getElementText(searchResults.eq(4)), getText('4 guy M. Mc4son'));
+      assert.equal(getElementText(searchResults.eq(3)), getText('2 guy M. Mc2son'));
+      assert.ok(!searchResults.eq(3).hasClass('active'));
+      assert.equal(getElementText(searchResults.eq(4)), getText('3 guy M. Mc3son'));
       assert.ok(searchResults.eq(4).hasClass('active'));
+      assert.equal(getElementText(searchResults.eq(5)), getText('4 guy M. Mc4son'));
+      assert.ok(searchResults.eq(5).hasClass('active'));
     });
   });
 });
@@ -135,7 +136,7 @@ test('add instructor', function(assert) {
     assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
 
     fillIn(find('.search-box input', container), 'guy').then(function(){
-      click('.results li:eq(3)', container).then(function(){
+      click('.results li:eq(4)', container).then(function(){
         var items = find('.removable-list li', container);
         assert.equal(items.length, 3);
         assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));

--- a/tests/acceptance/learnergroup/overview-test.js
+++ b/tests/acceptance/learnergroup/overview-test.js
@@ -121,17 +121,18 @@ test('search default instructors', function(assert) {
     var container = find('.learnergroup-overview').eq(0);
     fillIn(find('.search-box input', container), 'guy').then(function(){
       var searchResults = find('.results li', container);
-      assert.equal(searchResults.length, 5);
-      assert.equal(getElementText(searchResults.eq(0)), getText('0 guy M. Mc0son'));
-      assert.ok(searchResults.eq(0).hasClass('active'));
-      assert.equal(getElementText(searchResults.eq(1)), getText('1 guy M. Mc1son'));
+      assert.equal(searchResults.length, 6);
+      assert.equal(getElementText(searchResults.eq(0)), getText('5 Results'));
+      assert.equal(getElementText(searchResults.eq(1)), getText('0 guy M. Mc0son'));
       assert.ok(searchResults.eq(1).hasClass('active'));
-      assert.equal(getElementText(searchResults.eq(2)), getText('2 guy M. Mc2son'));
+      assert.equal(getElementText(searchResults.eq(2)), getText('1 guy M. Mc1son'));
       assert.ok(searchResults.eq(2).hasClass('active'));
-      assert.equal(getElementText(searchResults.eq(3)), getText('3 guy M. Mc3son'));
-      assert.ok(searchResults.eq(3).hasClass('inactive'));
-      assert.equal(getElementText(searchResults.eq(4)), getText('4 guy M. Mc4son'));
+      assert.equal(getElementText(searchResults.eq(3)), getText('2 guy M. Mc2son'));
+      assert.ok(searchResults.eq(3).hasClass('active'));
+      assert.equal(getElementText(searchResults.eq(4)), getText('3 guy M. Mc3son'));
       assert.ok(searchResults.eq(4).hasClass('inactive'));
+      assert.equal(getElementText(searchResults.eq(5)), getText('4 guy M. Mc4son'));
+      assert.ok(searchResults.eq(5).hasClass('inactive'));
     });
   });
 });
@@ -147,7 +148,7 @@ test('add default instructor', function(assert) {
     assert.equal(getElementText(items.eq(1)), getText('4 guy M. Mc4son'));
 
     fillIn(find('.search-box input', container), 'guy').then(function(){
-      click('.results li:eq(1)', container).then(function(){
+      click('.results li:eq(2)', container).then(function(){
         var items = find('.removable-list li', container);
         assert.equal(items.length, 3);
         assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));

--- a/tests/acceptance/program/programyear/overview-test.js
+++ b/tests/acceptance/program/programyear/overview-test.js
@@ -54,19 +54,20 @@ test('search directors', function(assert) {
     var container = find('.programyear-overview').eq(0);
     fillIn(find('.search-box input', container), 'guy').then(function(){
       var searchResults = find('.results li', container);
-      assert.equal(searchResults.length, 6);
-      assert.equal(getElementText(searchResults.eq(0)), getText('0 guy M. Mc0son'));
-      assert.ok(searchResults.eq(0).hasClass('active'));
-      assert.equal(getElementText(searchResults.eq(1)), getText('1 guy M. Mc1son'));
-      assert.ok(searchResults.eq(1).hasClass('inactive'));
-      assert.equal(getElementText(searchResults.eq(2)), getText('2 guy M. Mc2son'));
+      assert.equal(searchResults.length, 7);
+      assert.equal(getElementText(searchResults.eq(0)), getText('6 Results'));
+      assert.equal(getElementText(searchResults.eq(1)), getText('0 guy M. Mc0son'));
+      assert.ok(searchResults.eq(1).hasClass('active'));
+      assert.equal(getElementText(searchResults.eq(2)), getText('1 guy M. Mc1son'));
       assert.ok(searchResults.eq(2).hasClass('inactive'));
-      assert.equal(getElementText(searchResults.eq(3)), getText('3 guy M. Mc3son'));
+      assert.equal(getElementText(searchResults.eq(3)), getText('2 guy M. Mc2son'));
       assert.ok(searchResults.eq(3).hasClass('inactive'));
-      assert.equal(getElementText(searchResults.eq(4)), getText('4 guy M. Mc4son'));
-      assert.ok(searchResults.eq(4).hasClass('active'));
-      assert.equal(getElementText(searchResults.eq(5)), getText('5 guy M. Mc5son'));
+      assert.equal(getElementText(searchResults.eq(4)), getText('3 guy M. Mc3son'));
+      assert.ok(searchResults.eq(4).hasClass('inactive'));
+      assert.equal(getElementText(searchResults.eq(5)), getText('4 guy M. Mc4son'));
       assert.ok(searchResults.eq(5).hasClass('active'));
+      assert.equal(getElementText(searchResults.eq(6)), getText('5 guy M. Mc5son'));
+      assert.ok(searchResults.eq(6).hasClass('active'));
     });
   });
 });
@@ -84,7 +85,7 @@ test('add director', function(assert) {
     assert.equal(getElementText(items.eq(2)), getText('3 guy M. Mc3son'));
 
     fillIn(find('.search-box input', container), 'guy').then(function(){
-      click('.results li:eq(5)', container).then(function(){
+      click('.results li:eq(6)', container).then(function(){
         var items = find('.removable-list li', container);
         assert.equal(items.length, 4);
         assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));

--- a/tests/acceptance/user-test.js
+++ b/tests/acceptance/user-test.js
@@ -61,7 +61,7 @@ test('can search for users', function(assert) {
   server.createList('user', 20, { email: 'user@example.edu' });
 
   const userSearch = '.global-search input';
-  const secondResult = '.global-search .results li:eq(1)';
+  const secondResult = '.global-search .results li:eq(2)';
   const secondResultUsername = `${secondResult} a .livesearch-user-name`;
   const secondResultEmail = `${secondResult} a .livesearch-user-email`;
   const name = '.user-display-name';


### PR DESCRIPTION
Increased the query limit to 100 and added a count to the top of the results.  The count should let the know they need to add more terms without us explicitly saying that, but we can add that later if necessary.  For now this fixes #1228.