### PR TITLE
commented out toggle for release

### DIFF
--- a/app/templates/components/learnergroup-overview.hbs
+++ b/app/templates/components/learnergroup-overview.hbs
@@ -4,7 +4,7 @@
   </div>
   <div class='detail-content'>
     <div class="overview-toggle-container">
-      {{toggle-onoff label="learnerGroups.multiEdit" on=multiEditModeOn action="toggleSwitch"}}
+      {{!toggle-onoff label="learnerGroups.multiEdit" on=multiEditModeOn action="toggleSwitch"}}
     </div>
 
     {{#if multiEditModeOn}}

--- a/tests/acceptance/learnergroup/membership-test.js
+++ b/tests/acceptance/learnergroup/membership-test.js
@@ -1,8 +1,5 @@
 import destroyApp from '../../helpers/destroy-app';
-import {
-  module,
-  test
-} from 'qunit';
+import { module, skip, test } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 
@@ -207,7 +204,7 @@ test('remove group member back to cohort', function(assert) {
   });
 });
 
-test('multi-edit save (bulk-saving) works properly and knows when to trigger', function(assert) {
+skip('multi-edit save (bulk-saving) works properly and knows when to trigger', function(assert) {
   const toggleSwitch = '.switch-label';
   const checkAllBox = '.check-all-input';
   const selectInputField = '.ff-select-field';

--- a/tests/acceptance/learnergroup/overview-test.js
+++ b/tests/acceptance/learnergroup/overview-test.js
@@ -1,8 +1,5 @@
 import destroyApp from '../../helpers/destroy-app';
-import {
-  module,
-  test
-} from 'qunit';
+import { module, skip, test } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import {b as testgroup} from 'ilios/tests/helpers/test-groups';
 import Ember from 'ember';
@@ -198,7 +195,7 @@ test('no associated courses', function(assert) {
   });
 });
 
-test('toggleSwitch for multi-editing works', function(assert) {
+skip('toggleSwitch for multi-editing works', function(assert) {
   const toggleSwitch = '.switch-label';
   const checkBoxLabel = '.check-all-label';
   const checkAllBox = '.check-all-input';
@@ -228,7 +225,7 @@ test('toggleSwitch for multi-editing works', function(assert) {
   });
 });
 
-test('`Check All` checkbox checks all or none', function(assert) {
+skip('`Check All` checkbox checks all or none', function(assert) {
   const toggleSwitch = '.switch-label';
   const checkAllBox = '.check-all-input';
   const checkBoxes = '.learnergroup-list .ember-checkbox';


### PR DESCRIPTION
@jrjohnson The issue with moving learner-groups might need more attention. Even a single-request can lead to the client being not aligned with the server. I used the single-request below.

<img width="643" alt="screen shot 2015-12-10 at 6 56 40 pm" src="https://cloud.githubusercontent.com/assets/7553764/11734944/8df2d59e-9f70-11e5-9520-49a934e3d38d.png">
