### PR TITLE
Fix some ILM Timezone Madness

### DIFF
--- a/app/components/dashboard-agenda.js
+++ b/app/components/dashboard-agenda.js
@@ -10,8 +10,8 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    const fromTimeStamp = moment().hour(0).minute(0).unix();
-    const toTimeStamp = moment().hour(23).minute(59).add(30, 'days').unix();
+    const fromTimeStamp = moment.utc().hour(0).minute(0).unix();
+    const toTimeStamp = moment.utc().hour(23).minute(59).add(30, 'days').unix();
 
     this.setProperties({ fromTimeStamp, toTimeStamp });
   },

--- a/app/components/dashboard-calendar.js
+++ b/app/components/dashboard-calendar.js
@@ -44,10 +44,10 @@ export default Component.extend({
     this.set('selectedCourses', []);
   }),
   fromTimeStamp: computed('selectedDate', 'selectedView', function(){
-    return moment(this.get('selectedDate')).startOf(this.get('selectedView')).unix();
+    return moment.utc(this.get('selectedDate')).startOf(this.get('selectedView')).unix();
   }),
   toTimeStamp: computed('selectedDate', 'selectedView', function(){
-    return moment(this.get('selectedDate')).endOf(this.get('selectedView')).unix();
+    return moment.utc(this.get('selectedDate')).endOf(this.get('selectedView')).unix();
   }),
   calendarDate: momentFormat('selectedDate', 'YYYY-MM-DD'),
   ourEvents: computed('mySchedule', 'fromTimeStamp', 'toTimeStamp', 'selectedSchool', 'selectedView', function(){

--- a/app/serializers/ilm-session.js
+++ b/app/serializers/ilm-session.js
@@ -1,0 +1,25 @@
+import DS from 'ember-data';
+import moment from 'moment';
+
+const { RESTSerializer } = DS;
+
+export default RESTSerializer.extend({
+  isNewSerializerAPI: true,
+  serialize(snapshot, options) {
+    let json = this._super(snapshot, options);
+    let dueDate = moment(json.dueDate);
+    json.dueDate = dueDate.format('YYYY-MM-DD');
+    
+    //don't persist this, it is handled by the server
+    delete json.updatedAt;
+
+    return json;
+  },
+  normalize(modelClass, resourceHash, prop){
+    let dueDate = moment.utc(resourceHash.dueDate).format('YYYY-MM-DD');
+    let localDueDate = moment(dueDate, 'YYYY-MM-DD');
+    resourceHash.dueDate = localDueDate.format();
+    
+    return this._super(modelClass, resourceHash, prop);
+  }
+});

--- a/app/services/school-events.js
+++ b/app/services/school-events.js
@@ -12,11 +12,18 @@ export default Ember.Service.extend(EventMixin, {
     var url = '/' + config.adapterNamespace + '/schoolevents/' +
     schoolId + '?from=' + from + '&to=' + to;
     ajax(url).then(data => {
-      let events = data.events.sortBy('startDate').map(event => {
+      let events = data.events.map(event => {
         event.slug = this.getSlugForEvent(event);
+        if (event.ilmSession) {
+          let startDate = moment(moment.utc(event.startDate).format('YYYYMMDD'), 'YYYYMMDD').hour(17).minute(0).second(0);
+          let endDate = moment(moment.utc(event.endDate).format('YYYYMMDD'), 'YYYYMMDD').hour(17).minute(15).second(0);
+          event.startDate = startDate.format();
+          event.endDate = endDate.format();
+          
+        }
         
         return event;
-      });
+      }).sortBy('startDate');
       
       deferred.resolve(events);
     });

--- a/app/services/user-events.js
+++ b/app/services/user-events.js
@@ -14,11 +14,18 @@ export default Ember.Service.extend(EventMixin, {
         var url = '/' + config.adapterNamespace + '/userevents/' +
         user.get('id') + '?from=' + from + '&to=' + to;
         ajax(url).then(data => {
-          let events = data.userEvents.sortBy('startDate').map(event => {
+          let events = data.userEvents.map(event => {
             event.slug = this.getSlugForEvent(event);
+            if (event.ilmSession) {
+              let startDate = moment(moment.utc(event.startDate).format('YYYYMMDD'), 'YYYYMMDD').hour(17).minute(0).second(0);
+              let endDate = moment(moment.utc(event.endDate).format('YYYYMMDD'), 'YYYYMMDD').hour(17).minute(15).second(0);
+              event.startDate = startDate.format();
+              event.endDate = endDate.format();
+              
+            }
             
             return event;
-          });
+          }).sortBy('startDate');
           
           deferred.resolve(events);
         });

--- a/tests/unit/serializers/ilm-session-test.js
+++ b/tests/unit/serializers/ilm-session-test.js
@@ -2,7 +2,13 @@ import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('ilm-session', 'Unit | Serializer | ilm session', {
   // Specify the other units that are required for this test.
-  needs: ['serializer:ilm-session']
+  needs: [
+    'model:session',
+    'model:learner-group',
+    'model:instructor-group',
+    'model:user',
+    'serializer:ilm-session'
+  ]
 });
 
 // Replace this with your real tests.

--- a/tests/unit/serializers/ilm-session-test.js
+++ b/tests/unit/serializers/ilm-session-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('ilm-session', 'Unit | Serializer | ilm session', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:ilm-session']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});


### PR DESCRIPTION
ILM Sessions are coming from the API with a UTC time, but that isn’t
really true.  They have no real timestamp.  This forces them to be saved and to appear at 5pm on the correct date.