### PR TITLE
Display correct learning material owner in course print view

### DIFF
--- a/app/templates/components/print-course.hbs
+++ b/app/templates/components/print-course.hbs
@@ -232,7 +232,7 @@
                     {{lm.learningMaterial.title}}
                   </td>
                   <td class='text-center'>{{lm.learningMaterial.type}}</td>
-                  <td class='text-center'>{{lm.learningMaterial.originalAuthor}}</td>
+                  <td class='text-center'>{{lm.learningMaterial.owningUser.fullName}}</td>
                   <td class='text-center'>
                   {{#if lm.required}}
                     <span class='add'>{{t 'general.yes'}}</span>

--- a/app/templates/components/print-course.hbs
+++ b/app/templates/components/print-course.hbs
@@ -122,7 +122,7 @@
                     {{lm.learningMaterial.title}}
                   </td>
                   <td class='text-center'>{{lm.learningMaterial.type}}</td>
-                  <td class='text-center'>{{lm.learningMaterial.originalAuthor}}</td>
+                  <td class='text-center'>{{lm.learningMaterial.owningUser.fullName}}</td>
                   <td class='text-center'>
         	        {{#if lm.required}}
         	          <span class='add'>{{t 'general.yes'}}</span>


### PR DESCRIPTION
owner field in print summary should display owner name rather than original author name.  no tests currently exist for this page.

fixes #1339.