### PR TITLE
Remove draft learning materials from print view

### DIFF
--- a/app/components/print-course.js
+++ b/app/components/print-course.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-const { Component, computed, RSVP, ObjectProxy } = Ember;
+const { Component, computed, RSVP, ObjectProxy, inject } = Ember;
 const { PromiseArray } = DS;
+const { service } = inject;
 
 export default Component.extend({
+  store: service(),
   course: null,
   tagName: 'section',
   classNames: ['printable course'],
@@ -23,6 +25,14 @@ export default Component.extend({
       sortTitle: ['title'],
       sortedTopics: computed.sort('content.topics', 'sortTitle'),
       sortedMeshDescriptors: computed.sort('content.meshDescriptors', 'sortTitle'),
+      sessionLearningMaterials: computed('content', function(){
+        let session = this.get('content').get('id');
+        return this.get('store').query('sessionLearningMaterial', {
+          filters: {
+            session
+          }
+        });
+      })
     });
     course.get('sessions').then(function(sessions){
       let noDraftSessions = sessions.filterBy('isPublishedOrScheduled');
@@ -40,4 +50,14 @@ export default Component.extend({
     });
 
   }),
+  
+  courseLearningMaterials: computed('course', function(){
+    let course = this.get('course').get('id');
+    return this.get('store').query('courseLearningMaterial', {
+      filters: {
+        course
+      }
+    });
+  }),
+  
 });

--- a/app/templates/components/print-course.hbs
+++ b/app/templates/components/print-course.hbs
@@ -101,10 +101,10 @@
 
       <section class='detail-block'>
         <div class='detail-title'>
-          {{t 'general.learningMaterials'}} ({{course.learningMaterials.length}})
+          {{t 'general.learningMaterials'}} ({{courseLearningMaterials.length}})
         </div>
         <div class='detail-content'>
-         {{#if course.learningMaterials.length}}
+         {{#if courseLearningMaterials.length}}
          <table>
             <thead>
               <tr>
@@ -116,7 +116,7 @@
               </tr>
             </thead>
             <tbody>
-              {{#each course.learningMaterials as |lm|}}
+              {{#each courseLearningMaterials as |lm|}}
                 <tr>
                   <td class='text-left' colspan=2>
                     {{lm.learningMaterial.title}}
@@ -211,10 +211,10 @@
 
       <section class='detail-block'>
         <div class='detail-title'>
-          {{t 'general.learningMaterials'}} ({{session.learningMaterials.length}})
+          {{t 'general.learningMaterials'}} ({{session.sessionLearningMaterials.length}})
         </div>
         <div class='detail-content'>
-         {{#if session.learningMaterials.length}}
+         {{#if session.sessionLearningMaterials.length}}
          <table>
             <thead>
               <tr>
@@ -226,7 +226,7 @@
               </tr>
             </thead>
             <tbody>
-              {{#each session.learningMaterials as |lm|}}
+              {{#each session.sessionLearningMaterials as |lm|}}
                 <tr>
                   <td class='text-left' colspan=2>
                     {{lm.learningMaterial.title}}

--- a/app/templates/components/print-course.hbs
+++ b/app/templates/components/print-course.hbs
@@ -110,7 +110,6 @@
               <tr>
                 <th class='text-left' colspan=2>{{t 'learningMaterials.displayName'}}</th>
                 <th class='text-center'>{{t 'general.type'}}</th>
-                <th class='text-center'>{{t 'learningMaterials.owner'}}</th>
                 <th class='text-center'>{{t 'general.required'}}</th>
                 <th class='text-left'>{{t 'learningMaterials.notes'}}</th>
               </tr>
@@ -122,7 +121,6 @@
                     {{lm.learningMaterial.title}}
                   </td>
                   <td class='text-center'>{{lm.learningMaterial.type}}</td>
-                  <td class='text-center'>{{lm.learningMaterial.owningUser.fullName}}</td>
                   <td class='text-center'>
         	        {{#if lm.required}}
         	          <span class='add'>{{t 'general.yes'}}</span>
@@ -220,7 +218,6 @@
               <tr>
                 <th class='text-left' colspan=2>{{t 'learningMaterials.displayName'}}</th>
                 <th class='text-center'>{{t 'general.type'}}</th>
-                <th class='text-center'>{{t 'learningMaterials.owner'}}</th>
                 <th class='text-center'>{{t 'general.required'}}</th>
                 <th class='text-left'>{{t 'learningMaterials.notes'}}</th>
               </tr>
@@ -232,7 +229,6 @@
                     {{lm.learningMaterial.title}}
                   </td>
                   <td class='text-center'>{{lm.learningMaterial.type}}</td>
-                  <td class='text-center'>{{lm.learningMaterial.owningUser.fullName}}</td>
                   <td class='text-center'>
                   {{#if lm.required}}
                     <span class='add'>{{t 'general.yes'}}</span>


### PR DESCRIPTION
Students only have access to those learning materials that are final or revised.  By querying for them manually we ensure that we only get the ones the user has access to.

Fixes #1350