### PR TITLE
Load a limited set of sessions on the course view

### DIFF
--- a/app/components/ilios-sessions-list.js
+++ b/app/components/ilios-sessions-list.js
@@ -200,7 +200,7 @@ export default Component.extend({
       sessionProxy.set('showRemoveConfirmation', false);
     },
     loadAllSessions(){
-      this.set('forceFullSessionList', true);
+      this.sendAction('setForceFullSessionsList', true);
     },
     sortBy(item){
       this.set('forceFullSessionList', true);

--- a/app/components/pagedlist-controls.js
+++ b/app/components/pagedlist-controls.js
@@ -1,0 +1,73 @@
+import Ember from 'ember';
+
+const { computed } = Ember;
+const { lte } = computed;
+
+export default Ember.Component.extend({
+  classNames: ['pagedlist-controls'],
+  tagName: 'div',
+  offset: null,
+  limit: null,
+  total: null,
+  start: computed('offset', function(){
+    return parseInt(this.get('offset')) + 1;
+  }),
+  end: computed('offset', 'limit', function(){
+    const total = this.get('total');
+    let end = parseInt(this.get('offset')) + parseInt(this.get('limit'));
+    if(end > total) {
+      end = total;
+    }
+
+    return end;
+  }),
+  offsetOptions: computed('total', function(){
+    const total = this.get('total');
+    const available = [10, 25, 50, 100, 200, 400, 1000];
+    let options = available.filter(option => {
+      return option < total;
+    });
+    options.pushObject(available[options.length]);
+
+    return options;
+  }),
+  lastPage: computed('total', 'limit', 'offset', function(){
+    const total = parseInt(this.get('total'));
+    const limit = parseInt(this.get('limit'));
+    const offset = parseInt(this.get('offset'));
+
+    return (offset + limit) >= total;
+  }),
+  firstPage: lte('offset', 0),
+
+
+  actions: {
+    goForward(){
+      const offset = this.get('offset');
+      const limit = this.get('limit');
+      this.sendAction('setOffset', offset+limit);
+    },
+    goBack(){
+      const offset = this.get('offset');
+      const limit = this.get('limit');
+      this.sendAction('setOffset', offset-limit);
+    },
+    setOffset(offset){
+      const limit = this.get('limit');
+      const total = this.get('total');
+      const largestOffset = total - limit;
+      if (offset < 0) {
+        offset = 0;
+      }
+      if (offset > largestOffset) {
+        offset = largestOffset;
+      }
+
+      this.sendAction('setOffset', offset);
+    },
+    setLimit(limit){
+      this.sendAction('setLimit', parseInt(limit));
+      this.sendAction('setOffset', 0);
+    }
+  }
+});

--- a/app/controllers/course/index.js
+++ b/app/controllers/course/index.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: {
+    forceFullSessionList: 'showAllSessions'
+  },
+  forceFullSessionList: false,
+  actions: {
+    setForceFullSessionsList(value){
+      this.set('forceFullSessionList', value);
+    }
+  }
+});

--- a/app/controllers/course/index.js
+++ b/app/controllers/course/index.js
@@ -2,12 +2,17 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   queryParams: {
-    forceFullSessionList: 'showAllSessions'
+    sessionOffset: 'offset',
+    sessionLimit: 'limit'
   },
-  forceFullSessionList: false,
+  sessionOffset: 0,
+  sessionLimit: 25,
   actions: {
-    setForceFullSessionsList(value){
-      this.set('forceFullSessionList', value);
+    setSessionOffset(offset){
+      this.set('sessionOffset', offset);
+    },
+    setSessionLimit(limit){
+      this.set('sessionLimit', limit);
     }
   }
 });

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -259,6 +259,7 @@ export default {
     'confirmObjectiveRemoval': 'Are you sure you want to delete this objective?',
     'confirmSessionRemoval': 'Are you sure you want to delete this session?',
     'noPrintDraft': 'Courses which are in draft status cannot be printed',
+    'expandSessions': 'Show More Sessions',
   },
   'sessions': {
     'specialAttireRequired': 'Special Attire Required',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -124,7 +124,9 @@ export default {
     'campusId': 'Campus ID',
     'prev': 'Prev',
     'next': 'Next',
-    'disabled': 'disabled'
+    'disabled': 'disabled',
+    'pagedResultsCount': 'Showing {{start}} - {{end}} of {{total}}',
+    'perPage': 'Per Page',
   },
   'programs': {
     'programTitle': 'Program Title',
@@ -259,7 +261,6 @@ export default {
     'confirmObjectiveRemoval': 'Are you sure you want to delete this objective?',
     'confirmSessionRemoval': 'Are you sure you want to delete this session?',
     'noPrintDraft': 'Courses which are in draft status cannot be printed',
-    'expandSessions': 'Show More Sessions',
   },
   'sessions': {
     'specialAttireRequired': 'Special Attire Required',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -259,6 +259,7 @@ export default {
     'confirmObjectiveRemoval': "¿Está seguro que desea eliminar este objetivo?",
     'confirmSessionRemoval': "¿Está seguro que desea eliminar este sessión?",
     'noPrintDraft': 'Cursos que se encuentran en estado borrador no se puede imprimir',
+    'expandSessions': 'Mostrar Más Sesiones',
   },
   'sessions': {
     'specialAttireRequired': 'Vestimenta Especial Requerido',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -124,7 +124,9 @@ export default {
     'campusId': 'Campus ID',
     'prev': 'Anterior',
     'next': 'Siguiente',
-    'disabled': 'desactivado'
+    'disabled': 'desactivado',
+    'pagedResultsCount': 'Mostrando {{start}} - {{end}} de {{total}}',
+    'perPage': 'Por Página',
   },
   'programs': {
     'programTitle': 'Titulo de Programa',
@@ -259,7 +261,6 @@ export default {
     'confirmObjectiveRemoval': "¿Está seguro que desea eliminar este objetivo?",
     'confirmSessionRemoval': "¿Está seguro que desea eliminar este sessión?",
     'noPrintDraft': 'Cursos que se encuentran en estado borrador no se puede imprimir',
-    'expandSessions': 'Mostrar Más Sesiones',
   },
   'sessions': {
     'specialAttireRequired': 'Vestimenta Especial Requerido',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -259,6 +259,7 @@ export default {
     'confirmObjectiveRemoval': "Êtes vous sûr de vouloir supprimer cet objectif?",
     'confirmSessionRemoval': "Êtes vous sûr de vouloir supprimer cette séance?",
     'noPrintDraft': "Cours qui sont au stade de projet ne peuvent pas étre imprimés",
+    'expandSessions': 'Voir plus de séances',
   },
   'sessions': {
     'specialAttireRequired': "Vêtements particuliers requis",

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -125,6 +125,8 @@ export default {
     'prev': "Précéd.",
     'next': "Proch.",
     'disabled': "désactivée",
+    'pagedResultsCount': 'Montrant {{start}} - {{end}} de {{total}}',
+    'perPage': 'Par Page',
   },
   'programs': {
     'programTitle': "Titre de Diplôme",
@@ -259,7 +261,6 @@ export default {
     'confirmObjectiveRemoval': "Êtes vous sûr de vouloir supprimer cet objectif?",
     'confirmSessionRemoval': "Êtes vous sûr de vouloir supprimer cette séance?",
     'noPrintDraft': "Cours qui sont au stade de projet ne peuvent pas étre imprimés",
-    'expandSessions': 'Voir plus de séances',
   },
   'sessions': {
     'specialAttireRequired': "Vêtements particuliers requis",

--- a/app/templates/components/ilios-sessions-list.hbs
+++ b/app/templates/components/ilios-sessions-list.hbs
@@ -1,13 +1,6 @@
 <section id='sessions' class='detail-block filter-detail-block'>
   <div class='sessions detail-title'>
-    {{t 'general.sessions'}}
-    {{#if proxiedSessions.isFulfilled}}
-      {{#if allSessionsLoaded}}
-        ({{sessionsCount}})
-      {{else}}
-        ({{proxiedSessions.length}} / {{sessionsCount}})
-      {{/if}}
-    {{/if}}
+    {{t 'general.sessions'}} ({{sessionsCount}})
   </div>
   {{#if filteredContent.isFulfilled}}
     <div class="filter-tools">
@@ -22,7 +15,7 @@
         {{/if}}
       </div>
 
-      {{#if (and proxiedSessions.length editable)}}
+      {{#if (and sessions.length editable)}}
         {{#link-to 'course.publishall' course}}
           <button>{{t 'publish.all' sessionCount=sessionsCount}}</button>
         {{/link-to}}
@@ -33,7 +26,7 @@
       {{#liquid-if isSaving}}
         <h1 class='text-center'>{{fa-icon 'spinner' spin=true}}</h1>
       {{/liquid-if}}
-      
+
       {{#liquid-if editorOn class='vertical'}}
         {{new-session
           sessionTypes=course.school.sessionTypes
@@ -50,7 +43,13 @@
           {{t 'general.savedSuccessfully'}}
         </div>
       {{/liquid-if}}
-
+      {{pagedlist-controls
+        offset=offset
+        limit=limit
+        total=sessionsCount
+        setOffset='setOffset'
+        setLimit='setLimit'
+      }}
       <div class='resultslist-list'>
         <table class='active-background'>
           <thead>
@@ -92,7 +91,7 @@
             </tr>
           </thead>
           <tbody>
-            {{#each sortedSessionList as |sessionProxy|}}
+            {{#each displayedSessions as |sessionProxy|}}
               <tr class="{{if sessionProxy.showRemoveConfirmation 'confirm-removal'}}">
                 <td class='text-left' colspan=3>
                   {{#link-to 'session.index' course sessionProxy.content}}
@@ -173,9 +172,13 @@
         </table>
       </div>
     </section>
-    {{#unless allSessionsLoaded}}
-      <div {{action 'loadAllSessions'}} class='detail-collapsed-control'><span>{{t 'courses.expandSessions'}}{{fa-icon "fa-plus-square"}}</span></div>
-    {{/unless}}
+    {{pagedlist-controls
+      offset=offset
+      limit=limit
+      total=sessionsCount
+      setOffset='setOffset'
+      setLimit='setLimit'
+    }}
   {{else}}
     <br /><h1>{{fa-icon 'spinner' spin=true}}</h1>
   {{/if}}

--- a/app/templates/components/ilios-sessions-list.hbs
+++ b/app/templates/components/ilios-sessions-list.hbs
@@ -1,6 +1,13 @@
 <section id='sessions' class='detail-block filter-detail-block'>
   <div class='sessions detail-title'>
-    {{t 'general.sessions'}} ({{course.sessions.length}})
+    {{t 'general.sessions'}}
+    {{#if proxiedSessions.isFulfilled}}
+      {{#if allSessionsLoaded}}
+        ({{sessionsCount}})
+      {{else}}
+        ({{proxiedSessions.length}} / {{sessionsCount}})
+      {{/if}}
+    {{/if}}
   </div>
   {{#if filteredContent.isFulfilled}}
     <div class="filter-tools">
@@ -17,7 +24,7 @@
 
       {{#if (and proxiedSessions.length editable)}}
         {{#link-to 'course.publishall' course}}
-          <button>{{t 'publish.all' sessionCount=course.sessions.length}}</button>
+          <button>{{t 'publish.all' sessionCount=sessionsCount}}</button>
         {{/link-to}}
       {{/if}}
     </div>
@@ -166,6 +173,9 @@
         </table>
       </div>
     </section>
+    {{#unless allSessionsLoaded}}
+      <div {{action 'loadAllSessions'}} class='detail-collapsed-control'><span>{{t 'courses.expandSessions'}}{{fa-icon "fa-plus-square"}}</span></div>
+    {{/unless}}
   {{else}}
     <br /><h1>{{fa-icon 'spinner' spin=true}}</h1>
   {{/if}}

--- a/app/templates/components/pagedlist-controls.hbs
+++ b/app/templates/components/pagedlist-controls.hbs
@@ -1,0 +1,18 @@
+{{#unless firstPage}}
+  <span class='clickable link' {{action 'goBack'}}>{{fa-icon 'backward'}}</span>
+{{/unless}}
+
+{{t 'general.pagedResultsCount' start=start end=end total=total}}
+
+{{#unless lastPage}}
+  <span class='clickable link' {{action 'goForward'}}>{{fa-icon 'forward'}}</span>
+{{/unless}}
+
+<select onchange={{action "setLimit" value="target.value"}}>
+  {{#each offsetOptions as |option|}}
+    <option value={{option}} selected={{is-equal option limit}}>
+      {{option}}
+    </option>
+  {{/each}}
+</select>
+{{t 'general.perPage'}}

--- a/app/templates/course/index.hbs
+++ b/app/templates/course/index.hbs
@@ -1,1 +1,1 @@
-{{ilios-sessions-list course=model}}
+{{ilios-sessions-list course=model forceFullSessionList=forceFullSessionList setForceFullSessionsList='setForceFullSessionsList'}}

--- a/app/templates/course/index.hbs
+++ b/app/templates/course/index.hbs
@@ -1,1 +1,7 @@
-{{ilios-sessions-list course=model forceFullSessionList=forceFullSessionList setForceFullSessionsList='setForceFullSessionsList'}}
+{{ilios-sessions-list
+  course=model
+  offset=sessionOffset
+  limit=sessionLimit
+  setLimit='setSessionLimit'
+  setOffset='setSessionOffset'
+}}

--- a/tests/integration/components/pagedlist-controls-test.js
+++ b/tests/integration/components/pagedlist-controls-test.js
@@ -1,0 +1,16 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('pagedlist-controls', 'Integration | Component | pagedlist controls', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
+
+  this.render(hbs`{{pagedlist-controls limit=4 offset=11 total=33}}`);
+
+  assert.equal(this.$().text().replace(/[\t\n\s]+/g, ""), 'Showing12-15of33102550PerPage');
+});

--- a/tests/unit/controllers/course/index-test.js
+++ b/tests/unit/controllers/course/index-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:course/index', 'Unit | Controller | course/index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});


### PR DESCRIPTION
Instead of loading all sessions load only 50 of them.  This speeds up rendering of the sessions list on the course page substantially.

Fixes #1317

WIP: Still needs some translations