### PR TITLE
Remove two deprecations notices

### DIFF
--- a/app/instance-initializers/error.js
+++ b/app/instance-initializers/error.js
@@ -11,7 +11,7 @@ export function initialize(instance) {
   if (currentEnv !== 'test') {
     const controller = instance.container.lookup('controller:application');
     const ajax = instance.container.lookup('service:ajax');
-    
+
     // Global error handler in Ember run loop
     Ember.onerror = (error) => {
       if (error) {
@@ -42,7 +42,7 @@ export function initialize(instance) {
       }
     });
   }
-  
+
 }
 
 
@@ -73,7 +73,7 @@ export default {
 
     return errorData;
   },
-  
+
   incrementLastErrorSent(){
     this.lastErrorSent = moment().unix();
   },

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -1,18 +1,14 @@
 window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
   workflow: [
-    
+
     // These are all from Addons
 
     // Caused by ember-validations PR in as https://github.com/dockyard/ember-validations/pull/380
     { handler: "silence", matchMessage: "Ember.keys is deprecated in favor of Object.keys" },
-    
+
     //elemental calendar formatted-date helper
     { handler: "silence", matchMessage: "Using `Ember.HTMLBars.makeBoundHelper` is deprecated. Please refactor to using `Ember.Helper` or `Ember.Helper.helper`." },
-    
-    { handler: "silence", matchMessage: /A property (.*) was modified inside the didInsertElement hook(.*)/ },
-    { handler: "silence", matchMessage: "Usage of Ember.computed.any is deprecated, use `Ember.computed.or` instead." },
-
 
     // Going with 2.0's default behavior
     { handler: "silence", matchMessage: "The default behavior of `shouldBackgroundReloadRecord` will change in Ember Data 2.0 to always return true. If you would like to preserve the current behavior please override `shouldBackgroundReloadRecord` in your adapter:application and return false." },


### PR DESCRIPTION
didInsertElement deprecation is no longer valid - or at least could not
be triggered any more.
Ember.computed.any deprecation has a PR in calendar.