### PR TITLE
Fix recently updated agenda itesm

### DIFF
--- a/app/components/recently-updated-display.js
+++ b/app/components/recently-updated-display.js
@@ -1,19 +1,24 @@
 import Ember from 'ember';
 import moment from 'moment';
 
-const { Component, computed } = Ember;
+const { Component, computed, isEmpty } = Ember;
 
 export default Component.extend({
   tagName: 'span',
+  lastModified: null,
 
   classNames: ['recently-updated-display'],
 
-  recentlyUpdated: computed('attrs.lastModified', {
+  recentlyUpdated: computed('lastModified', {
     get() {
-      const lastModifiedDate = moment(this.attrs.lastModified);
+      const lastModified = this.get('lastModified');
+      if (isEmpty(lastModified)) {
+        return false;
+      }
+
+      const lastModifiedDate = moment(lastModified);
       const today = moment();
       const daysSinceLastUpdate = today.diff(lastModifiedDate, 'days');
-
       return daysSinceLastUpdate < 6 ? true : false;
     }
   }).readOnly(),

--- a/app/templates/components/dashboard-agenda.hbs
+++ b/app/templates/components/dashboard-agenda.hbs
@@ -1,26 +1,30 @@
-{{#if weeksEvents.length}}
-  <table>
-    <tbody>
-      {{#each weeksEvents as |event|}}
-        {{#if event.isBlanked}}
-          <tr>
-            <td class='event-date'>{{moment-format event.startDate 'dddd, MMMM Do, YYYY h:mma'}}</td>
-            <td>{{event.name}}</td>
-            <td>{{event.location}}</td>
-            <td>{{recently-updated-display lastModified=event.lastModified}}</td>
-          </tr>
-        {{/if}}
-        {{#unless event.isBlanked}}
-            <tr class='clickable'>
-              <td class='event-date'>{{fa-icon 'external-link-square'}} {{#link-to 'events' event.slug}}{{moment-format event.startDate 'dddd, MMMM Do, YYYY h:mma'}}{{/link-to}}</td>
-              <td>{{#link-to 'events' event.slug}}{{event.name}}{{/link-to}}</td>
-              <td>{{#link-to 'events' event.slug}}{{event.location}}{{/link-to}}</td>
+{{#liquid-if weeksEvents.isFulfilled}}
+  {{#if weeksEvents.length}}
+    <table>
+      <tbody>
+        {{#each weeksEvents as |event|}}
+          {{#if event.isBlanked}}
+            <tr>
+              <td class='event-date'>{{moment-format event.startDate 'dddd, MMMM Do, YYYY h:mma'}}</td>
+              <td>{{event.name}}</td>
+              <td>{{event.location}}</td>
               <td>{{recently-updated-display lastModified=event.lastModified}}</td>
             </tr>
-        {{/unless}}
-      {{/each}}
-    </tbody>
-  </table>
+          {{/if}}
+          {{#unless event.isBlanked}}
+              <tr class='clickable'>
+                <td class='event-date'>{{fa-icon 'external-link-square'}} {{#link-to 'events' event.slug}}{{moment-format event.startDate 'dddd, MMMM Do, YYYY h:mma'}}{{/link-to}}</td>
+                <td>{{#link-to 'events' event.slug}}{{event.name}}{{/link-to}}</td>
+                <td>{{#link-to 'events' event.slug}}{{event.location}}{{/link-to}}</td>
+                <td>{{recently-updated-display lastModified=event.lastModified}}</td>
+              </tr>
+          {{/unless}}
+        {{/each}}
+      </tbody>
+    </table>
+  {{else}}
+    {{t 'dashboard.noEvents'}}
+  {{/if}}
 {{else}}
-  {{t 'dashboard.noEvents'}}
-{{/if}}
+  <p>{{fa-icon 'spinner' spin=true}} {{t 'calendar.loadingEvents'}}</p>
+{{/liquid-if}}

--- a/tests/unit/components/recently-updated-display-test.js
+++ b/tests/unit/components/recently-updated-display-test.js
@@ -7,11 +7,10 @@ moduleForComponent('recently-updated-display', 'Unit | Component | recently upda
 
 test('`recentlyUpdated` computed property works', function(assert) {
   const lastModified = moment().subtract(5, 'day');
-  const attrs = { lastModified };
-  const component = this.subject({ attrs });
+  const component = this.subject({ lastModified });
 
   assert.ok(component.get('recentlyUpdated'), 'last modified within 5 days');
 
-  component.set('attrs.lastModified', moment().subtract(7, 'day'));
+  component.set('lastModified', moment().subtract(7, 'day'));
   assert.notOk(component.get('recentlyUpdated'), 'last modified more than 5 days');
 });


### PR DESCRIPTION
Users logging into Ilios will no longer see every single event as recently updated.  

I also add a loading indicator so it does not just say none until it loads.

Fixes #1383