### PR TITLE
Fix user profile

### DIFF
--- a/app/components/user-profile.js
+++ b/app/components/user-profile.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import DS from 'ember-data';
 
 const { computed, Component, inject } = Ember;
-const { PromiseObject } = DS;
+const { PromiseObject, PromiseArray } = DS;
 const { service } = inject;
 
 export default Component.extend({
@@ -21,13 +21,15 @@ export default Component.extend({
     get() {
       const user = this.get('user');
 
-      const cohorts = user.get('cohorts').then((cohorts) => {
+      let promise = user.get('cohorts').then((cohorts) => {
         return user.get('primaryCohort').then((primaryCohort) => {
-          return cohorts.removeObject(primaryCohort);
+          return cohorts.filter(cohort => {
+            return cohort.get('id') !== primaryCohort.get('id');
+          });
         });
       });
 
-      return PromiseObject.create({ promise: cohorts });
+      return PromiseArray.create({ promise });
     }
   }).readOnly(),
 

--- a/app/templates/components/user-profile.hbs
+++ b/app/templates/components/user-profile.hbs
@@ -88,26 +88,30 @@
     <div class="user-info-row">
       <label class="form-label">{{t 'general.primaryCohort'}}:</label>
       <div class="form-data">
-        {{#if user.primaryCohort.title}}
-          {{user.primaryCohort.title}}
-        {{else}}
-          {{t 'general.unassigned'}}
-        {{/if}}
+        {{#liquid-if user.primaryCohort.isFulfilled}}
+          {{#if user.primaryCohort.title}}
+            {{user.primaryCohort.programYear.program.title}} {{user.primaryCohort.title}}
+          {{else}}
+            {{t 'general.unassigned'}}
+          {{/if}}
+        {{/liquid-if}}
       </div>
     </div>
 
     <div class="user-info-row">
       <label class="form-label">{{t 'general.secondaryCohorts'}}:</label>
       <div class="form-data">
-        {{#if secondaryCohorts.content}}
-          <ul class="secondary-cohorts">
-            {{#each secondaryCohorts.content as |cohort|}}
-              <li class="secondary-cohort">{{cohort.title}}</li>
-            {{/each}}
-          </ul>
-        {{else}}
-          {{t 'general.unassigned'}}
-        {{/if}}
+        {{#liquid-if secondaryCohorts.isFulfilled}}
+          {{#if secondaryCohorts.length}}
+            <ul class="secondary-cohorts">
+              {{#each secondaryCohorts as |cohort|}}
+                <li class="secondary-cohort">{{cohort.programYear.program.title}} {{cohort.title}}</li>
+              {{/each}}
+            </ul>
+          {{else}}
+            {{t 'general.unassigned'}}
+          {{/if}}
+        {{/liquid-if}}
       </div>
     </div>
 

--- a/tests/acceptance/user-test.js
+++ b/tests/acceptance/user-test.js
@@ -21,8 +21,10 @@ module('Acceptance: User', {
       learnerGroups: [3, 5]
     };
     setupAuthentication(application, userObject);
-    
-    server.create('school');
+
+    server.create('school', { programs: [1]});
+    server.create('program', {programYears: [1, 2, 3]});
+    server.createList('programYear', 3, { program: 1});
     server.create('cohort', { title: 'Medicine', users: [ 4136 ] });
     server.createList('cohort', 2, {  users: [ 4136 ] });
     server.createList('learnerGroup', 5, { title: 'Group 1', users: [ 4136 ] });
@@ -49,9 +51,9 @@ test('can see user profile', function(assert) {
     assert.equal(getUserContent(1), 'user@example.edu', 'email is shown');
     assert.equal(getUserContent(2), '111-111-1111', 'phone is shown');
     assert.equal(getUserContent(3), 'school 0', 'primary school is shown');
-    assert.equal(getUserContent(4), 'Medicine', 'primary cohort is shown');
-    assert.equal(find(`${secondaryCohorts}:first`).text(), 'cohort 1', 'secondary cohort is shown');
-    assert.equal(find(`${secondaryCohorts}:last`).text(), 'cohort 2', 'secondary cohort is shown');
+    assert.equal(getUserContent(4), 'program 0 Medicine', 'primary cohort is shown');
+    assert.equal(find(`${secondaryCohorts}:first`).text(), 'program 0 cohort 1', 'secondary cohort is shown');
+    assert.equal(find(`${secondaryCohorts}:last`).text(), 'program 0 cohort 2', 'secondary cohort is shown');
     assert.equal(find(`${learnerGroups}:first`).text(), 'Group 1', 'learner group is shown');
     assert.equal(find(`${learnerGroups}:last`).text(), 'Group 1', 'learner group is shown');
   });


### PR DESCRIPTION
Don't destroy cohorts list when displaying students 
We were mutating the original list of cohorts and removing the primary cohort.  Thus when a user was saved they got removed from that cohort, which is obviously bad.

Also updated the display of cohort information to be a bit cleaner.