### PR TITLE
fixes sticky toggles

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -9,3 +9,5 @@ linters:
     max_depth: 4
   Comment:
     allowed: '^[/*]*'
+  QualifyingElement:
+    allow_element_with_attribute: true

--- a/app/styles/components/_editinplace.scss
+++ b/app/styles/components/_editinplace.scss
@@ -11,7 +11,13 @@
   }
 
   .editor {
-    input {
+    input
+    &[type="text"]
+    &[type="url"]
+    &[type="tel"]
+    &[type="number"]
+    &[type="color"]
+    &[type="email"] {
       background: $white;
       border: 1px solid $header-grey;
       border-radius: $base-border-radius;

--- a/app/styles/components/_editinplace.scss
+++ b/app/styles/components/_editinplace.scss
@@ -11,13 +11,12 @@
   }
 
   .editor {
-    input
-    &[type="text"]
-    &[type="url"]
-    &[type="tel"]
-    &[type="number"]
-    &[type="color"]
-    &[type="email"] {
+    input[type="text"],
+    input[type="url"],
+    input[type="tel"],
+    input[type="number"],
+    input[type="color"],
+    input[type="email"] {
       background: $white;
       border: 1px solid $header-grey;
       border-radius: $base-border-radius;

--- a/app/styles/components/_toggles.scss
+++ b/app/styles/components/_toggles.scss
@@ -29,6 +29,7 @@ $offering-switch-blue: #009ccc;
 }
 
 .switch-input {
+  display: none;
   left: 0;
   opacity: 0;
   position: absolute;

--- a/app/styles/components/_toggles.scss
+++ b/app/styles/components/_toggles.scss
@@ -36,9 +36,9 @@ $offering-switch-blue: #009ccc;
 }
 
 .switch-label {
-  @include transition-property(opacity background);
-  @include transition-duration(.15s);
-  @include transition-timing-function(ease-out);
+  //@include transition-property(opacity background);
+  //@include transition-duration(.15s);
+  //@include transition-timing-function(ease-out);
   background: $switch-label-blue;
   border-radius: inherit;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, .12), inset 0 0 2px rgba(0, 0, 0, .15);
@@ -52,7 +52,7 @@ $offering-switch-blue: #009ccc;
 
 .switch-label:before,
 .switch-label:after {
-  @include transition(inherit);
+  //@include transition(inherit);
   line-height: 1;
   margin-top: -.5em;
   position: absolute;
@@ -89,7 +89,7 @@ $offering-switch-blue: #009ccc;
 
 .switch-handle {
   @include background-image(linear-gradient(top , $white 40%, $toggle-background-grey));
-  @include transition(left .15s ease-out);
+  //@include transition(left .15s ease-out);
   background: $white;
   border-radius: 10px;
   box-shadow: 1px 1px 5px rgba(0, 0, 0, .2);

--- a/app/styles/components/_toggles.scss
+++ b/app/styles/components/_toggles.scss
@@ -37,9 +37,9 @@ $offering-switch-blue: #009ccc;
 }
 
 .switch-label {
-  //@include transition-property(opacity background);
-  //@include transition-duration(.15s);
-  //@include transition-timing-function(ease-out);
+  @include transition-property(opacity background);
+  @include transition-duration(.15s);
+  @include transition-timing-function(ease-out);
   background: $switch-label-blue;
   border-radius: inherit;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, .12), inset 0 0 2px rgba(0, 0, 0, .15);
@@ -53,7 +53,7 @@ $offering-switch-blue: #009ccc;
 
 .switch-label:before,
 .switch-label:after {
-  //@include transition(inherit);
+  @include transition(inherit);
   line-height: 1;
   margin-top: -.5em;
   position: absolute;
@@ -90,7 +90,7 @@ $offering-switch-blue: #009ccc;
 
 .switch-handle {
   @include background-image(linear-gradient(top , $white 40%, $toggle-background-grey));
-  //@include transition(left .15s ease-out);
+  @include transition(left .15s ease-out);
   background: $white;
   border-radius: 10px;
   box-shadow: 1px 1px 5px rgba(0, 0, 0, .2);

--- a/app/templates/components/inplace-boolean.hbs
+++ b/app/templates/components/inplace-boolean.hbs
@@ -1,7 +1,7 @@
 <span class='content'>
   <span class='editor'>
     <span {{action 'toggleValue'}} class='control form-data switch yes-no switch-green'>
-      <input checked={{value}} type='checkbox' class="switch-input" />
+      <input checked={{value}} type='checkbox' class="switch-input" disabled="disabled"/>
       <span class="switch-label" data-on='{{t 'general.yes'}}' data-off='{{t 'general.no'}}'></span>
       <span class="switch-handle"></span>
     </span>

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -427,8 +427,8 @@ test('edit learning material', function(assert) {
     andThen(function(){
       let container = $('.learningmaterial-manager');
       assert.ok(isEmpty(find(searchBox)), 'learner-gorup search box is hidden while in edit mode');
-      click(find('.required input', container));
-      click(find('.publicnotes input', container));
+      click(find('.required .switch-handle', container));
+      click(find('.publicnotes .switch-handle', container));
       click(find('.status .editable', container)).then(function(){
         pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
         click(find('.status .done', container));
@@ -468,8 +468,8 @@ test('cancel editing learning material', function(assert) {
     click('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(0)');
     andThen(function(){
       var container = $('.learningmaterial-manager');
-      click(find('.required input', container));
-      click(find('.publicnotes input', container));
+      click(find('.required .switch-handle', container));
+      click(find('.publicnotes .switch-handle', container));
       click(find('.status .editable', container)).then(function(){
         pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
         click(find('.status .done', container));

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -415,8 +415,8 @@ test('edit learning material', function(assert) {
     andThen(function(){
       let container = $('.learningmaterial-manager');
       assert.ok(isEmpty(find(searchBox)), 'learner-gorup search box is hidden while in edit mode');
-      click(find('.required input', container));
-      click(find('.publicnotes input', container));
+      click(find('.required .switch-handle', container));
+      click(find('.publicnotes .switch-handle', container));
       click(find('.status .editable', container)).then(function(){
         pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
         click(find('.status .done', container));
@@ -456,8 +456,8 @@ test('cancel editing learning material', function(assert) {
     click('.detail-learning-materials .detail-content tbody tr:eq(0) td:eq(0)');
     andThen(function(){
       var container = $('.learningmaterial-manager');
-      click(find('.required input', container));
-      click(find('.publicnotes input', container));
+      click(find('.required .switch-handle', container));
+      click(find('.publicnotes .switch-handle', container));
       click(find('.status .editable', container)).then(function(){
         pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
         click(find('.status .done', container));

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -69,7 +69,7 @@ test('check remove ilm', function(assert) {
     var dueDate = moment(ilmSession.dueDate).format('MM/DD/YY');
     assert.equal(getElementText(find('.sessionilmhours .content', container)), ilmSession.hours);
     assert.equal(getElementText(find('.sessionilmduedate .editable', container)), dueDate);
-    click(find('.independentlearningcontrol input', container));
+    click(find('.independentlearningcontrol .switch-handle', container));
     andThen(function(){
       assert.equal(find('.sessionilmhours', container).length, 0);
       assert.equal(find('.sessionilmduedate', container).length, 0);
@@ -89,7 +89,7 @@ test('check add ilm', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
     var container = find('.session-overview');
-    click(find('.independentlearningcontrol input', container));
+    click(find('.independentlearningcontrol .switch-handle', container));
     andThen(function(){
       assert.equal(find('.sessionilmhours', container).length, 1);
       assert.equal(find('.sessionilmduedate', container).length, 1);

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -122,7 +122,7 @@ test('check remove ilm', function(assert) {
     var dueDate = moment(ilmSession.dueDate).format('MM/DD/YY');
     assert.equal(getElementText(find('.sessionilmhours .content', container)), ilmSession.hours);
     assert.equal(getElementText(find('.sessionilmduedate .editable', container)), dueDate);
-    click(find('.independentlearningcontrol input', container));
+    click(find('.independentlearningcontrol .switch-handle', container));
     andThen(function(){
       assert.equal(find('.sessionilmhours', container).length, 0);
       assert.equal(find('.sessionilmduedate', container).length, 0);
@@ -142,7 +142,7 @@ test('check add ilm', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.session.publicationCheck');
     var container = find('.session-overview');
-    click(find('.independentlearningcontrol input', container));
+    click(find('.independentlearningcontrol .switch-handle', container));
     andThen(function(){
       assert.equal(find('.sessionilmhours', container).length, 1);
       assert.equal(find('.sessionilmduedate', container).length, 1);


### PR DESCRIPTION
fixes #1394.

turns out that disabling the toggle checkbox element and yanking it from display was the solution. 
reverse engineered the [ember-cli-toggle examples](http://knownasilya.github.io/ember-cli-toggle/).

tested with much success in latest FF and chrome.

please test thoroughly, rage-click away.



