### PR TITLE
Fix courses list default year

### DIFF
--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -153,7 +153,7 @@ export default Controller.extend({
     if(currentMonth < 6){
       currentYear--;
     }
-    let defaultYear = years.find(year => year.get('id') === currentYear);
+    let defaultYear = years.find(year => parseInt(year.get('id')) === currentYear);
     if(isEmpty(defaultYear)){
       defaultYear = years.get('lastObject');
     }


### PR DESCRIPTION
Bad comparison operator was causing us to pick the latest year all the time.

Fixes #707