### PR TITLE
Fix for issue dispelling users with no primary cohort

### DIFF
--- a/app/components/user-profile.js
+++ b/app/components/user-profile.js
@@ -23,6 +23,9 @@ export default Component.extend({
 
       let promise = user.get('cohorts').then((cohorts) => {
         return user.get('primaryCohort').then((primaryCohort) => {
+          if (!primaryCohort) {
+            return cohorts;
+          }
           return cohorts.filter(cohort => {
             return cohort.get('id') !== primaryCohort.get('id');
           });

--- a/tests/integration/components/user-profile-test.js
+++ b/tests/integration/components/user-profile-test.js
@@ -1,0 +1,48 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import initializer from "ilios/instance-initializers/ember-i18n";
+import Ember from 'ember';
+
+const { RSVP, Object } = Ember;
+const { resolve } = RSVP;
+
+moduleForComponent('user-profile', 'Integration | Component | user profile', {
+  integration: true,
+  setup(){
+    initializer.initialize(this);
+  },
+});
+
+test('it renders', function(assert) {
+  let user = Object.create({
+    fullName: 'Test Person Name Thing',
+    roles: resolve([]),
+    cohorts: resolve([]),
+    primaryCohort: resolve(null)
+  });
+
+  this.set('user', user);
+
+  this.render(hbs`{{user-profile user=user}}`);
+
+  assert.equal(this.$().text().trim().search(/Test Person Name Thing/), 0);
+});
+
+test('does not break when a user has secondry, but no primary cohorts', function(assert) {
+  let cohort = Object.create({
+    title: "awesome cohort"
+  });
+  let user = Object.create({
+    fullName: 'Test Person Name Thing',
+    roles: resolve([]),
+    cohorts: resolve([cohort]),
+    primaryCohort: resolve(null)
+  });
+
+  this.set('user', user);
+
+  this.render(hbs`{{user-profile user=user}}`);
+
+  assert.equal(this.$().text().trim().search(/Test Person Name Thing/), 0);
+  assert.notEqual(this.$().text().trim().search(/awesome cohort/), -1);
+});


### PR DESCRIPTION
Users who ONLY have a secondary cohort should still display correctly
in the profile view.

Fixes #1417