### PR TITLE
Added an option to course printing to see unpublished sessions

### DIFF
--- a/app/components/print-course.js
+++ b/app/components/print-course.js
@@ -8,6 +8,7 @@ const { service } = inject;
 export default Component.extend({
   store: service(),
   course: null,
+  includeUnpublishedSessions: false,
   tagName: 'section',
   classNames: ['printable course'],
   sortTitle: ['title'],
@@ -34,9 +35,11 @@ export default Component.extend({
         });
       })
     });
-    course.get('sessions').then(function(sessions){
-      let noDraftSessions = sessions.filterBy('isPublishedOrScheduled');
-      let proxiedSessions = noDraftSessions.map(function(session){
+    course.get('sessions').then(sessions => {
+      if (!this.get('includeUnpublishedSessions')) {
+        sessions = sessions.filterBy('isPublishedOrScheduled');
+      }
+      let proxiedSessions = sessions.map(function(session){
         return SessionProxy.create({
           content: session
         });
@@ -50,7 +53,7 @@ export default Component.extend({
     });
 
   }),
-  
+
   courseLearningMaterials: computed('course', function(){
     let course = this.get('course').get('id');
     return this.get('store').query('courseLearningMaterial', {
@@ -59,5 +62,5 @@ export default Component.extend({
       }
     });
   }),
-  
+
 });

--- a/app/controllers/print-course.js
+++ b/app/controllers/print-course.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+const { Controller, computed, inject } = Ember;
+const { service } = inject;
+
+export default Controller.extend({
+  currentUser: service(),
+  queryParams: ['unpublished'],
+  unpublished: false,
+  includeUnpublishedSessions: computed('unpublished', 'currentUser.canPrintUnpublishedCourse', function(){
+    const unpublished = this.get('unpublished');
+    const canPrintUnpublishedCourse = this.get('currentUser.canPrintUnpublishedCourse');
+
+    return unpublished && canPrintUnpublishedCourse;
+  })
+});

--- a/app/routes/print-course.js
+++ b/app/routes/print-course.js
@@ -1,12 +1,37 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin, {
-  beforeModel: function(){
+const { Route, inject, RSVP } = Ember;
+const { service } = inject;
+const { Promise, all } = RSVP;
+
+export default Route.extend(AuthenticatedRouteMixin, {
+  currentUser: service(),
+  beforeModel(){
     this.controllerFor('application').set('showHeader', false);
     this.controllerFor('application').set('showNavigation', false);
   },
-  renderTemplate: function() {
+  // only allow priviligeds users to view unpublished courses
+  afterModel(course, transition){
+    if (course.get('isPublishedOrScheduled')) {
+      return true;
+    }
+    return new Promise(resolve => {
+      const currentUser = this.get('currentUser');
+      all([
+        currentUser.get('userIsCourseDirector'),
+        currentUser.get('userIsFaculty'),
+        currentUser.get('userIsDeveloper')
+      ]).then(hasRole => {
+        if (!hasRole.contains(true)) {
+          transition.abort();
+        } else {
+          resolve(true);
+        }
+      });
+    });
+  },
+  renderTemplate() {
     this.render({ outlet: 'fullscreen' });
   }
 });

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -14,7 +14,7 @@ export default Ember.Service.extend({
     if(isEmpty(session)){
       return null;
     }
-    
+
     const jwt = session.get('data.authenticated.jwt');
 
     if(isEmpty(jwt)){
@@ -22,7 +22,7 @@ export default Ember.Service.extend({
     }
     const js = atob(jwt.split('.')[1]);
     const obj = Ember.$.parseJSON(js);
-    
+
     return get(obj, 'user_id');
   }),
 
@@ -179,6 +179,7 @@ export default Ember.Service.extend({
   }),
   canViewCourses: false,
   canEditCourses: false,
+  canPrintUnpublishedCourse: false,
   coursesPrivilegesObserver: on('init', observer('privileges',
     function(){
       Ember.RSVP.all([
@@ -188,6 +189,7 @@ export default Ember.Service.extend({
       ]).then(hasRole => {
         this.set('canViewCourses', hasRole.contains(true));
         this.set('canEditCourses', hasRole.contains(true));
+        this.set('canPrintUnpublishedCourse', hasRole.contains(true));
       });
     }
   )),

--- a/app/templates/components/course-overview.hbs
+++ b/app/templates/components/course-overview.hbs
@@ -3,11 +3,9 @@
     {{t 'general.overview'}}
   </div>
   <div class='detail-actions'>
-    {{#if course.isPublishedOrScheduled}}
-      {{#link-to 'printCourse' course}}
-        <button>{{t 'general.printSummary'}}</button>
-      {{/link-to}}
-    {{/if}}
+    {{#link-to 'printCourse' course (query-params unpublished=true)}}
+      <button>{{t 'general.printSummary'}}</button>
+    {{/link-to}}
   </div>
   <div class='detail-content form-container'>
       <div class="form-col-6 multi-row">

--- a/app/templates/print-course.hbs
+++ b/app/templates/print-course.hbs
@@ -1,5 +1,1 @@
-{{#if model.isPublishedOrScheduled}}
-  {{print-course course=model}}
-{{else}}
-  {{t 'courses.noPrintDraft'}}
-{{/if}}
+{{print-course course=model includeUnpublishedSessions=includeUnpublishedSessions}}

--- a/tests/unit/controllers/print-course-test.js
+++ b/tests/unit/controllers/print-course-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:print-course', 'Unit | Controller | print course', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});


### PR DESCRIPTION
This allows privileged users to print the course with all unpublished
sessions.  The default is still to show only published sessions.

Unpublished courses and sessions cannot be viewed by unprivileged users
even if they want to.

Fixes #1419