### PR TITLE
Replace bad chars with a space when cleaning up queries

### DIFF
--- a/app/utils/query-utils.js
+++ b/app/utils/query-utils.js
@@ -3,5 +3,5 @@ import Ember from 'ember';
 const { trim } = Ember.$;
 
 export function cleanQuery(query) {
-  return trim(query).replace(/[\-,?~!@#$%&*+\-'="]/, '');
+  return trim(query).replace(/[\-,?~!@#$%&*+\-'="]/, ' ');
 }


### PR DESCRIPTION
This makes searches which contain these characters still work.  We
could probably just remove this cleanQuery entirely, but that requires
more investigation

Fixes #1450