### PR TITLE
Lock mirage version at 0.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-mirage": "^0.1.11",
+    "ember-cli-mirage": "0.1.11",
     "ember-cli-moment-shim": "1.1.0",
     "ember-cli-neat": "0.0.5",
     "ember-cli-qunit": "^1.4.0",


### PR DESCRIPTION
0.1.12 is not compatible with NPM v3.