### PR TITLE
rm hardwired 1000 records limit when reporting on mesh terms and instructors.

### DIFF
--- a/app/services/reporting.js
+++ b/app/services/reporting.js
@@ -57,9 +57,21 @@ export default Service.extend({
   },
   getQuery(subject, object, objectId, school){
     let query = {
-      limit: 1000,
       filters: {}
     };
+
+    /**
+     * EXTRAWURST!
+     * For reports targeting users and MeSH terms as their primary subjects,
+     * explicitly do not limit on the returned result record.
+     * Otherwise, unintentional truncation will occur due to query construction on the server side.
+     * [ST 2016/03/31]
+     */
+    if (subject === 'instructor' || subject === 'mesh term') {
+      query.limit = 0;
+    } else {
+      query.limit = 1000;
+    }
 
     if(object && objectId){
       let what = pluralize(object.camelize());


### PR DESCRIPTION
fixes #1533.