### PR TITLE
Edit user biographical information

### DIFF
--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend({
+const { Route } = Ember;
+
+export default Route.extend(AuthenticatedRouteMixin, {
 });

--- a/app/styles/components/_user-profile.scss
+++ b/app/styles/components/_user-profile.scss
@@ -19,18 +19,19 @@
     right: 0;
   }
 
-  .user-profile {
+  .user-profile-details {
+    @include span-columns(12 of 12);
+
     margin-top: 2em;
 
     .user-permissions {
+      @include span-columns(3 of 12);
       background: $header-grey;
       border-radius: 1em;
-      display: inline-block;
       min-height: 300px;
       padding: 1em;
       text-align: center;
       vertical-align: top;
-      width: 250px;
 
       .user-permissions-header {
         font-size: 1.5em;
@@ -54,27 +55,17 @@
     }
 
     .user-info {
-      display: inline-block;
+      @include shift(1 of 12);
+      @include span-columns(8 of 12);
+    }
 
-      .form-label {
-        display: inline-block;
-        margin-right: 1em;
-        text-align: right;
-        vertical-align: top;
-        width: 200px;
-      }
+    //override form styles since we are in smaller space
+    .form-col-6 {
+      @include span-columns(6 of 8);
 
-      .form-data {
-        display: inline-block;
-        width: 400px;
-      }
-
-      .secondary-cohort {
-        font-size: 12px;
-      }
-
-      .learner-group {
-        font-size: 12px;
+      &.form-data-submit {
+        @include shift(1);
+        @include span-columns(5 of 8);
       }
     }
   }

--- a/app/templates/components/user-profile.hbs
+++ b/app/templates/components/user-profile.hbs
@@ -1,13 +1,18 @@
 {{global-search}}
+<h1 class="user-display-name">
+  {{user.fullName}}
+  {{#if (await currentUser.userIsDeveloper)}}
+    {{fa-icon 'pencil' class='clickable link' click=(action (toggle "isEditing" this))}}
+  {{/if}}
+</h1>
 
-<h1 class="user-display-name">{{user.fullName}}</h1>
 {{#if user.isStudent.content}}
   <span class="user-is-student">{{t 'general.student'}}</span>
 {{/if}}
 
 {{pending-single-user-update user=user}}
 
-<div class="user-profile">
+<div class="user-profile-details">
   <section class="user-permissions">
     <h4 class="user-permissions-header">{{t 'user.userRoles'}}</h4>
 
@@ -67,68 +72,183 @@
   </section>
 
   <section class="user-info">
-    <div class="user-info-row">
-      <label class="form-label">{{t 'general.campusId'}}:</label>
-      <div class="form-data">{{user.campusId}}</div>
+    <div class="detail-content form-container">
+      {{#liquid-if isEditing}}
+        <div class="form-col-6 multi-row">
+          <label class="form-label">{{t "user.firstName"}}:</label>
+          <div class="form-data">
+            {{one-way-input
+              value=firstName
+              update=(action (mut firstName))
+              onenter=(perform save)
+              onescape=(action (toggle 'isEditing' this))
+              focusOut=(action 'addErrorDisplayFor' 'firstName')
+            }}
+            {{#if (and (v-get this 'firstName' 'isInvalid') (is-in showErrorsFor 'firstName'))}}
+              <span class="validation-error-message">{{v-get this 'firstName' 'message'}}</span>
+            {{/if}}
+          </div>
+          <label class="form-label">{{t "user.middleName"}}:</label>
+          <div class="form-data">
+            {{one-way-input
+              value=middleName
+              update=(action (mut middleName))
+              onenter=(perform save)
+              onescape=(action (toggle 'isEditing' this))
+              focusOut=(action 'addErrorDisplayFor' 'middleName')
+            }}
+            {{#if (and (v-get this 'middleName' 'isInvalid') (is-in showErrorsFor 'middleName'))}}
+              <span class="validation-error-message">{{v-get this 'middleName' 'message'}}</span>
+            {{/if}}
+          </div>
+
+          <label class="form-label">{{t "user.lastName"}}:</label>
+          <div class="form-data">
+            {{one-way-input
+              value=lastName
+              update=(action (mut lastName))
+              onenter=(perform save)
+              onescape=(action (toggle 'isEditing' this))
+              focusOut=(action 'addErrorDisplayFor' 'lastName')
+            }}
+            {{#if (and (v-get this 'lastName' 'isInvalid') (is-in showErrorsFor 'lastName'))}}
+              <span class="validation-error-message">{{v-get this 'lastName' 'message'}}</span>
+            {{/if}}
+          </div>
+          <label class="form-label">{{t "general.campusId"}}:</label>
+          <div class="form-data">
+            {{one-way-input
+              value=campusId
+              update=(action (mut campusId))
+              onenter=(perform save)
+              onescape=(action (toggle 'isEditing' this))
+              focusOut=(action 'addErrorDisplayFor' 'campusId')
+            }}
+            {{#if (and (v-get this 'campusId' 'isInvalid') (is-in showErrorsFor 'campusId'))}}
+              <span class="validation-error-message">{{v-get this 'campusId' 'message'}}</span>
+            {{/if}}
+          </div>
+          <label class="form-label">{{t "user.otherId"}}:</label>
+          <div class="form-data">
+            {{one-way-input
+              value=otherId
+              update=(action (mut otherId))
+              onenter=(perform save)
+              onescape=(action (toggle 'isEditing' this))
+              focusOut=(action 'addErrorDisplayFor' 'otherId')
+            }}
+            {{#if (and (v-get this 'otherId' 'isInvalid') (is-in showErrorsFor 'otherId'))}}
+              <span class="validation-error-message">{{v-get this 'otherId' 'message'}}</span>
+            {{/if}}
+          </div>
+          <label class="form-label">{{t "general.email"}}:</label>
+          <div class="form-data">
+            {{one-way-input
+              value=email
+              update=(action (mut email))
+              onenter=(perform save)
+              onescape=(action (toggle 'isEditing' this))
+              focusOut=(action 'addErrorDisplayFor' 'email')
+            }}
+            {{#if (and (v-get this 'email' 'isInvalid') (is-in showErrorsFor 'email'))}}
+              <span class="validation-error-message">{{v-get this 'email' 'message'}}</span>
+            {{/if}}
+          </div>
+          <label class="form-label">{{t "general.phone"}}:</label>
+          <div class="form-data">
+            {{one-way-input
+              value=phone
+              update=(action (mut phone))
+              onenter=(perform save)
+              onescape=(action (toggle 'isEditing' this))
+              focusOut=(action 'addErrorDisplayFor' 'phone')
+            }}
+            {{#if (and (v-get this 'phone' 'isInvalid') (is-in showErrorsFor 'phone'))}}
+              <span class="validation-error-message">{{v-get this 'phone' 'message'}}</span>
+            {{/if}}
+          </div>
+        </div>
+        <div class="form-col-6 form-data-submit">
+          <button class='done text' {{action (perform save)}} disabled={{or isSaving (is-pending bestSelectedSchool)}}>
+            {{#if isSaving}}
+              {{fa-icon 'spinner' spin=true}}
+            {{else}}
+              {{t 'general.done'}}
+            {{/if}}
+          </button>
+          <button class='cancel text' {{action (toggle 'isEditing' this)}}>{{t 'general.cancel'}}</button>
+        </div>
+
+      {{else}}
+        <div class="form-col-6 multi-row">
+          <div class="user-info-row">
+            <label class="form-label">{{t 'general.campusId'}}:</label>
+            <div class="form-data">{{user.campusId}}</div>
+          </div>
+
+          <div class="user-info-row">
+            <label class="form-label">{{t 'general.email'}}:</label>
+            <div class="form-data">{{user.email}}</div>
+          </div>
+
+          <div class="user-info-row">
+            <label class="form-label">{{t 'general.phone'}}:</label>
+            <div class="form-data">{{user.phone}}</div>
+          </div>
+        </div>
+      {{/liquid-if}}
     </div>
 
-    <div class="user-info-row">
-      <label class="form-label">{{t 'general.email'}}:</label>
-      <div class="form-data">{{user.email}}</div>
-    </div>
+    <div class="detail-content form-container">
+      <div class="form-col-6 multi-row">
+        <div class="user-info-row">
+          <label class="form-label">{{t 'general.primarySchool'}}:</label>
+          <div class="form-data">{{get (await user.school) 'title'}}&nbsp;</div>
+        </div>
+        <div class="user-info-row">
+          <label class="form-label">{{t 'general.primaryCohort'}}:</label>
+          <div class="form-data">
+            {{#liquid-if user.primaryCohort.isFulfilled}}
+              {{#if user.primaryCohort.title}}
+                {{user.primaryCohort.programYear.program.title}} {{user.primaryCohort.title}}
+              {{else}}
+                {{t 'general.unassigned'}}
+              {{/if}}
+            {{/liquid-if}}
+          </div>
+        </div>
 
-    <div class="user-info-row">
-      <label class="form-label">{{t 'general.phone'}}:</label>
-      <div class="form-data">{{user.phone}}</div>
-    </div>
+        <div class="user-info-row">
+          <label class="form-label">{{t 'general.secondaryCohorts'}}:</label>
+          <div class="form-data">
+            {{#liquid-if secondaryCohorts.isFulfilled}}
+              {{#if secondaryCohorts.length}}
+                <ul class="secondary-cohorts">
+                  {{#each secondaryCohorts as |cohort|}}
+                    <li class="secondary-cohort">{{cohort.programYear.program.title}} {{cohort.title}}</li>
+                  {{/each}}
+                </ul>
+              {{else}}
+                {{t 'general.unassigned'}}
+              {{/if}}
+            {{/liquid-if}}
+          </div>
+        </div>
 
-    <div class="user-info-row">
-      <label class="form-label">{{t 'general.primarySchool'}}:</label>
-      <div class="form-data">{{user.school.title}}</div>
-    </div>
-
-    <div class="user-info-row">
-      <label class="form-label">{{t 'general.primaryCohort'}}:</label>
-      <div class="form-data">
-        {{#liquid-if user.primaryCohort.isFulfilled}}
-          {{#if user.primaryCohort.title}}
-            {{user.primaryCohort.programYear.program.title}} {{user.primaryCohort.title}}
-          {{else}}
-            {{t 'general.unassigned'}}
-          {{/if}}
-        {{/liquid-if}}
-      </div>
-    </div>
-
-    <div class="user-info-row">
-      <label class="form-label">{{t 'general.secondaryCohorts'}}:</label>
-      <div class="form-data">
-        {{#liquid-if secondaryCohorts.isFulfilled}}
-          {{#if secondaryCohorts.length}}
-            <ul class="secondary-cohorts">
-              {{#each secondaryCohorts as |cohort|}}
-                <li class="secondary-cohort">{{cohort.programYear.program.title}} {{cohort.title}}</li>
-              {{/each}}
-            </ul>
-          {{else}}
-            {{t 'general.unassigned'}}
-          {{/if}}
-        {{/liquid-if}}
-      </div>
-    </div>
-
-    <div class="user-info-row">
-      <label class="form-label">{{t 'general.learnerGroups'}}:</label>
-      <div class="form-data">
-        {{#if user.learnerGroups}}
-          <ul class="learner-groups">
-            {{#each user.learnerGroups as |group|}}
-              <li class="learner-group">{{group.title}}</li>
-            {{/each}}
-          </ul>
-        {{else}}
-          {{t 'general.noLearnerGroups'}}
-        {{/if}}
+        <div class="user-info-row">
+          <label class="form-label">{{t 'general.learnerGroups'}}:</label>
+          <div class="form-data">
+            {{#if user.learnerGroups}}
+              <ul class="learner-groups">
+                {{#each user.learnerGroups as |group|}}
+                  <li class="learner-group">{{group.title}}</li>
+                {{/each}}
+              </ul>
+            {{else}}
+              {{t 'general.noLearnerGroups'}}
+            {{/if}}
+          </div>
+        </div>
       </div>
     </div>
   </section>

--- a/tests/acceptance/admin-test.js
+++ b/tests/acceptance/admin-test.js
@@ -50,6 +50,6 @@ test('can search for users', function(assert) {
   click(secondResultUsername);
   andThen(() => {
     assert.equal(currentURL(), '/users/2', 'new user profile is shown');
-    assert.equal(find(name).text(), '1 guy M. Mc1son', 'user name is shown');
+    assert.equal(find(name).text().trim(), '1 guy M. Mc1son', 'user name is shown');
   });
 });

--- a/tests/acceptance/user-test.js
+++ b/tests/acceptance/user-test.js
@@ -79,7 +79,7 @@ test('can search for users', function(assert) {
   click(secondResultUsername);
   andThen(() => {
     assert.equal(currentURL(), '/users/2', 'new user profile is shown');
-    assert.equal(find(name).text(), '1 guy M. Mc1son', 'user name is shown');
+    assert.equal(find(name).text().trim(), '1 guy M. Mc1son', 'user name is shown');
   });
 });
 

--- a/tests/integration/components/user-profile-test.js
+++ b/tests/integration/components/user-profile-test.js
@@ -2,6 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import initializer from "ilios/instance-initializers/ember-i18n";
 import Ember from 'ember';
+import wait from 'ember-test-helpers/wait';
 
 const { RSVP, Object } = Ember;
 const { resolve } = RSVP;
@@ -11,6 +12,10 @@ moduleForComponent('user-profile', 'Integration | Component | user profile', {
   setup(){
     initializer.initialize(this);
   },
+});
+
+let currentUserMock = Ember.Service.extend({
+  userIsDeveloper: resolve(true)
 });
 
 test('it renders', function(assert) {
@@ -45,4 +50,43 @@ test('does not break when a user has secondry, but no primary cohorts', function
 
   assert.equal(this.$().text().trim().search(/Test Person Name Thing/), 0);
   assert.notEqual(this.$().text().trim().search(/awesome cohort/), -1);
+});
+
+test('can edit user bio', function(assert) {
+  let flashmessagesMock = Ember.Service.extend({
+    success(message){
+      assert.equal(message, 'general.savedSuccessfully');
+    }
+  });
+  this.register('service:currentUser', currentUserMock);
+  this.register('service:flashMessages', flashmessagesMock);
+  let user = Object.create({
+    fullName: 'Test Person Name Thing',
+    firstName: 'Test Person',
+    middleName: 'Name',
+    lastName: 'Thing',
+    roles: resolve([]),
+    cohorts: resolve([]),
+    primaryCohort: resolve(null),
+    save(){
+      const user = this;
+      assert.equal(user.firstName, 'New first Name');
+    }
+  });
+
+  this.set('user', user);
+
+  this.render(hbs`{{user-profile user=user}}`);
+  this.$('.fa-pencil').click();
+  return wait().then(() => {
+    let inputs = this.$('.user-info input');
+    assert.equal(inputs.length, 7);
+    assert.equal(inputs.eq(0).val().trim(), 'Test Person');
+    assert.equal(inputs.eq(1).val().trim(), 'Name');
+    assert.equal(inputs.eq(2).val().trim(), 'Thing');
+    inputs.eq(0).val('New first Name');
+    inputs.eq(0).trigger('change');
+    this.$('.user-info button.done').click();
+  });
+
 });

--- a/tests/unit/components/user-profile-test.js
+++ b/tests/unit/components/user-profile-test.js
@@ -8,7 +8,8 @@ moduleForComponent('user-profile', 'Unit | Component | user profile ', {
 test('properties have default values', function(assert) {
   assert.expect(1);
 
-  const component = this.subject();
+  const user = Ember.Object.create();
+  const component = this.subject({ user });
 
   assert.ok(!component.get('inProgress'), 'false by default');
 });


### PR DESCRIPTION
Clicking the pencil icon by the user name will open an edit form where name and other biographical information can be changed.

This was mainly a result of trying to figure out a way to edit the name in place since it is actually three values (first, middle, last) but only displays as a single value on the page.

Fixes #1549