### PR TITLE
Disable the password validator when it is not needed

### DIFF
--- a/app/components/new-directory-user.js
+++ b/app/components/new-directory-user.js
@@ -20,7 +20,13 @@ const Validations = buildValidations({
     }),
   ],
   password: [
-    validator('presence', true)
+    validator('presence', {
+      presence: true,
+      dependentKeys: 'allowCustomUserName.content',
+      disabled(){
+        return !this.get('model.allowCustomUserName.content');
+      }
+    })
   ],
   otherId: [
     validator('length', {


### PR DESCRIPTION
When creating a new user for a shibboleth or ldap install a password is not required.

Fixes #1561