### PR TITLE
Ensure courses can be added when none exist

### DIFF
--- a/app/components/new-course.js
+++ b/app/components/new-course.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
+import moment from 'moment';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 
-const { Component, inject } = Ember;
+const { Component, inject, isPresent } = Ember;
 const { service } = inject;
 
 const Validations = buildValidations({
@@ -24,7 +25,25 @@ const Validations = buildValidations({
 export default Component.extend(Validations, ValidationErrorDisplay, {
   didReceiveAttrs(){
     this._super(...arguments);
-    this.set('selectedYear', this.get('currentYear'));
+
+    //build a list of years to seelct from
+    let thisYear = parseInt(moment().format('YYYY'));
+    let years = [
+      thisYear-2,
+      thisYear-1,
+      thisYear,
+      thisYear+1,
+      thisYear+2
+    ];
+
+    this.set('years', years);
+
+    const currentYear = this.get('currentYear');
+    if (isPresent(currentYear) && years.contains(parseInt(currentYear.get('title')))) {
+      this.set('selectedYear', currentYear.get('title'));
+    } else {
+      this.set('selectedYear', thisYear);
+    }
   },
   tagName: 'section',
   classNames: ['new-course', 'new-result', 'form-container'],
@@ -41,12 +60,8 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   isSaving: false,
 
   actions: {
-    setYear(yearTitle) {
-      let selectedYear = this.get('years').find((year) => {
-        return year.get('title') === parseInt(yearTitle);
-      });
-
-      this.set('selectedYear', selectedYear);
+    setYear(year) {
+      this.set('selectedYear', year);
     },
     save() {
       this.set('isSaving', true);
@@ -57,7 +72,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
           let course = this.get('store').createRecord('course', {
             title: this.get('title'),
             school: this.get('currentSchool'),
-            year: this.get('selectedYear').get('title'),
+            year: this.get('selectedYear'),
             level: 1,
           });
 

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -33,11 +33,13 @@ export default Controller.extend({
   newCourses: [],
   courses: computed('selectedSchool', 'selectedYear', function(){
     let defer = RSVP.defer();
-    let schoolId = this.get('selectedSchool').get('id');
-    let yearTitle = this.get('selectedYear').get('title');
-    if(isEmpty(schoolId) || isEmpty(yearTitle)){
+    const selectedSchool = this.get('selectedSchool');
+    const selectedYear = this.get('selectedYear');
+    if (isEmpty(selectedSchool) || isEmpty(selectedYear)) {
       defer.resolve([]);
     } else {
+      let schoolId = selectedSchool.get('id');
+      let yearTitle = selectedYear.get('title');
       this.get('store').query('course', {
         filters: {
           school: schoolId,
@@ -58,11 +60,15 @@ export default Controller.extend({
     this.get('courses').then(courses => {
       let all = [];
       all.pushObjects(courses.toArray());
-      let selectedYearTitle = this.get('selectedYear').get('title');
-      let newCourses = this.get('newCourses').filter(course => {
-        return course.get('year') === selectedYearTitle && !all.contains(course);
-      });
-      all.pushObjects(newCourses.toArray());
+      const selectedYear = this.get('selectedYear');
+      if (isPresent(selectedYear)) {
+        let selectedYearTitle = selectedYear.get('title');
+        let newCourses = this.get('newCourses').filter(course => {
+          return course.get('year') === selectedYearTitle && !all.contains(course);
+        });
+        all.pushObjects(newCourses.toArray());
+      }
+      
       defer.resolve(all);
     });
 

--- a/app/templates/components/new-course.hbs
+++ b/app/templates/components/new-course.hbs
@@ -26,8 +26,8 @@
     <div class="form-data form-data-select form-input-row new-course-year">
       <select onchange={{action "setYear" value="target.value"}}>
         {{#each years as |year|}}
-          <option value={{year.title}} selected={{is-equal year selectedYear}}>
-            {{year.academicYearTitle}}
+          <option value={{year}} selected={{is-equal year selectedYear}}>
+            {{year}} - {{inc year}}
           </option>
         {{/each}}
       </select>

--- a/app/templates/courses.hbs
+++ b/app/templates/courses.hbs
@@ -50,7 +50,6 @@
         {{new-course
           currentSchool=selectedSchool
           currentYear=selectedYear
-          years=model.years
           save=(action 'saveNewCourse')
           cancel='toggleNewCourseForm'
         }}


### PR DESCRIPTION
Academic years are not real things, they come from the `year` on a
course.  When no courses have been created there are no academic years in the system and new courses can not be created.  Instead of relying on
the API for academic year this builds the years based on the two years
before and after the current year.

Fixes #1457