### PR TITLE
Reset new vocabularies when navigating

### DIFF
--- a/app/components/school-vocabularies-list.js
+++ b/app/components/school-vocabularies-list.js
@@ -18,6 +18,10 @@ const Validations = buildValidations({
 
 export default Component.extend(Validations, ValidationErrorDisplay, {
   store: service(),
+  didReceiveAttrs(){
+    this._super(...arguments);
+    this.set('newVocabularies', []);
+  },
   school: null,
   newVocabularies: [],
   sortedVocabularies: computed('school.vocabularies', function(){


### PR DESCRIPTION
When a new vocabulary is saved and then the users goes somewhere and comes back it should not longer appear in the 'new' section.

Fixes #1568