### PR TITLE
Learner Group Inprovements

### DIFF
--- a/app/styles/components/_breadcrumbs.scss
+++ b/app/styles/components/_breadcrumbs.scss
@@ -11,6 +11,7 @@
 
   display: inline-block;
   margin-bottom: $base-spacing;
+  margin-top: $base-spacing / 2;
   text-align: left;
 
   span {
@@ -35,11 +36,13 @@
       padding-left: $breadcrumb-height / 2;
     }
 
-    &:last-child {
+    &:last-child,
+    &:last-child:hover {
       background-color: $breadcrumb-background;
       border-bottom-right-radius: $base-border-radius;
       border-top-right-radius: $base-border-radius;
       color: $breadcrumb-color-active;
+      cursor: default;
       padding-right: $breadcrumb-height / 2;
     }
 
@@ -71,7 +74,7 @@
       margin-left: 1px;
       z-index: 1;
     }
-    
+
     &:after {
       border-left-color: $breadcrumb-background;
     }

--- a/app/styles/components/_breadcrumbs.scss
+++ b/app/styles/components/_breadcrumbs.scss
@@ -10,8 +10,7 @@
   $breadcrumb-color-active: $breadcrumb-color;
 
   display: inline-block;
-  margin-bottom: $base-spacing;
-  margin-top: $base-spacing / 2;
+  margin: $base-spacing / 2;
   text-align: left;
 
   span {

--- a/app/templates/components/learnergroup-header.hbs
+++ b/app/templates/components/learnergroup-header.hbs
@@ -1,8 +1,6 @@
 <div class='detail-header'>
   <span class='title'>
     <h2>
-      {{learnerGroup.cohort.displayTitle}} {{fa-icon 'angle-right'}}
-      {{separated-list icon='angle-right' list=learnerGroup.allParentTitles}}
       {{inplace-text tagName='span' value=learnerGroup.title save='changeTitle'}}
     </h2>
   </span>
@@ -10,3 +8,16 @@
     {{t 'learnerGroups.members'}}: {{learnerGroup.users.length}}
   </span>
 </div>
+{{#if (is-fulfilled learnerGroup.allParents)}}
+  <div class='breadcrumbs'>
+    <span>{{#link-to 'learnerGroups'}}{{t 'general.learnerGroups'}}{{/link-to}}</span>
+    {{#each (await learnerGroup.allParents) as |parent|}}
+      <span>
+        {{#link-to 'learnerGroup' parent}}
+          {{parent.title}}
+        {{/link-to}}
+      </span>
+    {{/each}}
+    <span>{{learnerGroup.title}}</span>
+  </div>
+{{/if}}

--- a/app/templates/components/learnergroup-members-multiedit.hbs
+++ b/app/templates/components/learnergroup-members-multiedit.hbs
@@ -6,7 +6,7 @@
   <div class="learnergroup-list-top">
     {{#each proxiedMembers as |userProxy|}}
       <div class="form-col-12">
-        <label class="form-label learnergroup-username">
+        <label class="form-label learnergroup-username" title="{{userProxy.email}} {{userProxy.campusId}}">
           {{userProxy.fullName}}
           {{#unless userProxy.enabled}}
             <em>({{t 'general.disabled'}})</em>

--- a/app/templates/components/learnergroup-members-multiedit.hbs
+++ b/app/templates/components/learnergroup-members-multiedit.hbs
@@ -6,7 +6,7 @@
   <div class="learnergroup-list-top">
     {{#each proxiedMembers as |userProxy|}}
       <div class="form-col-12">
-        <label class="form-label learnergroup-username" title="{{userProxy.email}} {{userProxy.campusId}}">
+        <label class="form-label learnergroup-username" title="{{userProxy.email}} |  {{userProxy.campusId}}">
           {{userProxy.fullName}}
           {{#unless userProxy.enabled}}
             <em>({{t 'general.disabled'}})</em>

--- a/app/templates/components/learnergroup-members.hbs
+++ b/app/templates/components/learnergroup-members.hbs
@@ -7,7 +7,7 @@
     {{#if members.isFulfilled}}
       {{#each proxiedMembers as |userProxy|}}
         <div class="form-col-12">
-          <label class="form-label learnergroup-username">
+          <label class="form-label learnergroup-username" title="{{userProxy.email}} {{userProxy.campusId}}">
             {{userProxy.fullName}}
             {{#unless userProxy.enabled}}
               <em>({{t 'general.disabled'}})</em>

--- a/app/templates/components/learnergroup-members.hbs
+++ b/app/templates/components/learnergroup-members.hbs
@@ -7,7 +7,7 @@
     {{#if members.isFulfilled}}
       {{#each proxiedMembers as |userProxy|}}
         <div class="form-col-12">
-          <label class="form-label learnergroup-username" title="{{userProxy.email}} {{userProxy.campusId}}">
+          <label class="form-label learnergroup-username" title="{{userProxy.email}}  |  {{userProxy.campusId}}">
             {{userProxy.fullName}}
             {{#unless userProxy.enabled}}
               <em>({{t 'general.disabled'}})</em>

--- a/tests/acceptance/learnergroup/overview-test.js
+++ b/tests/acceptance/learnergroup/overview-test.js
@@ -80,7 +80,7 @@ test('check fields', function(assert) {
   visit(url);
   andThen(function() {
     assert.equal(currentPath(), 'learnerGroup');
-    assert.equal(getElementText(find('.detail-header .title h2')),getText('cohort 0  learner group 0  learner group 1'));
+    assert.equal(getElementText(find('.detail-header .title h2')),getText('learner group 1'));
     assert.equal(getElementText(find('.detail-header .info')),getText('Members: 2'));
     assert.equal(getElementText(find('.detail-overview .detail-title')), getText('learner group 1 Members (2)'));
     assert.equal(getElementText(find('.detail-overview .learnergrouplocation')), getText('DefaultLocation:room101'));
@@ -97,7 +97,7 @@ test('change title', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.detail-header');
-    assert.equal(getElementText(find('.title h2', container)), getText('cohort 0  learner group 0  learner group 1'));
+    assert.equal(getElementText(find('.title h2', container)), getText('learner group 1'));
     click(find('.title h2 .editable', container));
     andThen(function(){
       var input = find('.title .editinplace input', container);
@@ -105,7 +105,7 @@ test('change title', function(assert) {
       fillIn(input, 'test new title');
       click(find('.title .editinplace .actions .done', container));
       andThen(function(){
-        assert.equal(getElementText(find('.title h2', container)), getText('cohort 0  learner group 0  test new title'));
+        assert.equal(getElementText(find('.title h2', container)), getText('test new title'));
       });
     });
   });
@@ -191,7 +191,7 @@ test('change location', function(assert) {
 test('no associated courses', function(assert) {
   visit('/learnergroups/3');
   andThen(function() {
-    assert.equal(getElementText(find('.detail-header .title h2')),getText('cohort 0 learnergroup 0 learnergroup 2'));
+    assert.equal(getElementText(find('.detail-header .title h2')),getText('learnergroup 2'));
     assert.equal(getElementText(find('.detail-overview .learnergroupcourses')), getText('Associated Courses: None'));
   });
 });


### PR DESCRIPTION
Addressed a few simple pieces of #1506 before tackling a larger refactoring.

Added breadcrumbs to the top of the page.

Added a title attribute with email and campusId in it to make it easier
to figure out which user was which when there are duplicate names in a
cohort.