### PR TITLE
Improved session sorting

### DIFF
--- a/app/components/ilios-sessions-list.js
+++ b/app/components/ilios-sessions-list.js
@@ -73,7 +73,7 @@ export default Component.extend({
             sessionType: session.get('sessionType'),
             firstOfferingDate: session.get('firstOfferingDate'),
             associatedLearnerGroups: session.get('associatedLearnerGroups'),
-            offerings: session.get('offerings'),
+            offerings: session.hasMany('offerings').ids(),
           }).then(({sessionType, firstOfferingDate, associatedLearnerGroups, offerings})=> {
             return SessionProxy.create({
               content: session,
@@ -141,6 +141,17 @@ export default Component.extend({
   saved: false,
   savedSession: null,
   isSaving: null,
+
+  sessionTypes: computed('course.school.sessionTypes.[]', function(){
+    return new Promise( resolve => {
+      const course = this.get('course');
+      course.get('school').then(school => {
+        school.get('sessionTypes').then(sessionTypes => {
+          resolve(sessionTypes);
+        });
+      });
+    });
+  }),
 
   actions: {
     toggleEditor() {

--- a/app/components/new-session.js
+++ b/app/components/new-session.js
@@ -2,9 +2,9 @@ import Ember from 'ember';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 
-const { computed, Component, inject, isEmpty, isPresent } = Ember;
-const { sort } = computed;
+const { computed, Component, inject, isEmpty, isPresent, RSVP } = Ember;
 const { service } = inject;
+const { Promise } = RSVP;
 
 const Validations = buildValidations({
   title: [
@@ -21,31 +21,36 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   store: service(),
   classNames: ['new-session', 'resultslist-new', 'form-container'],
 
-  sessionTypes: [],
-  sortSessionsBy: ['title'],
-  sortedSessionTypes: sort('sessionTypes', 'sortSessionsBy'),
+  sessionTypes: null,
 
   title: null,
   selectedSessionTypeId: null,
   isSaving: false,
 
-
   selectedSessionType: computed('sessionTypes.[]', 'selectedSessionTypeId', function(){
-    let sessionTypes = this.get('sessionTypes');
-    const selectedSessionTypeId = this.get('selectedSessionTypeId');
-    if(isPresent(selectedSessionTypeId)){
-      return sessionTypes.find(sessionType => {
-        return parseInt(sessionType.get('id')) === parseInt(selectedSessionTypeId);
+    return new Promise(resolve => {
+      let selectedSessionType;
+      this.get('sessionTypes').then(sessionTypes => {
+        const selectedSessionTypeId = this.get('selectedSessionTypeId');
+        if(isPresent(selectedSessionTypeId)){
+          selectedSessionType = sessionTypes.find(sessionType => {
+            return parseInt(sessionType.get('id')) === parseInt(selectedSessionTypeId);
+          });
+        }
+
+        if (isEmpty(selectedSessionType)){
+          //try and default to a type names 'Lecture';
+          selectedSessionType = sessionTypes.find(sessionType => sessionType.get('title') === 'Lecture');
+        }
+
+        if(isEmpty(selectedSessionType)){
+          selectedSessionType = sessionTypes.get('firstObject');
+        }
+
+        resolve(selectedSessionType);
+
       });
-    }
-
-    //try and default to a type names 'Lecture';
-    let lectureType = sessionTypes.find(sessionType => sessionType.get('title') === 'Lecture');
-    if(isEmpty(lectureType)){
-      lectureType = sessionTypes.get('firstObject');
-    }
-
-    return lectureType;
+    });
   }),
 
   actions: {
@@ -54,12 +59,14 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
       this.send('addErrorDisplayFor', 'title');
       this.validate().then(({validations}) => {
         if (validations.get('isValid')) {
-          let session = this.get('store').createRecord('session', {
-            title: this.get('title'),
-            sessionType: this.get('selectedSessionType')
-          });
-          this.get('save')(session).finally(()=>{
-            this.sendAction('cancel');
+          this.get('selectedSessionType').then(sessionType => {
+            let session = this.get('store').createRecord('session', {
+              title: this.get('title'),
+              sessionType
+            });
+            this.get('save')(session).finally(()=>{
+              this.sendAction('cancel');
+            });
           });
         }
       });

--- a/app/controllers/course/index.js
+++ b/app/controllers/course/index.js
@@ -3,16 +3,10 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   queryParams: {
     sessionOffset: 'offset',
-    sessionLimit: 'limit'
+    sessionLimit: 'limit',
+    sortSessionsBy: 'sortBy',
   },
   sessionOffset: 0,
   sessionLimit: 25,
-  actions: {
-    setSessionOffset(offset){
-      this.set('sessionOffset', offset);
-    },
-    setSessionLimit(limit){
-      this.set('sessionLimit', limit);
-    }
-  }
+  sortSessionsBy: 'title',
 });

--- a/app/templates/components/ilios-sessions-list.hbs
+++ b/app/templates/components/ilios-sessions-list.hbs
@@ -29,7 +29,7 @@
 
       {{#liquid-if editorOn class='vertical'}}
         {{new-session
-          sessionTypes=course.school.sessionTypes
+          sessionTypes=sessionTypes
           save=(action 'save')
           cancel=(action 'cancel')
         }}

--- a/app/templates/components/ilios-sessions-list.hbs
+++ b/app/templates/components/ilios-sessions-list.hbs
@@ -2,7 +2,7 @@
   <div class='sessions detail-title'>
     {{t 'general.sessions'}} ({{sessionsCount}})
   </div>
-  {{#if proxiedSessions.isFulfilled}}
+  {{#if (is-fulfilled proxiedSessions)}}
     <div class="filter-tools">
       <div id='titlefilter' class="filter">
         {{input type='text' value=filter placeholder=placeholderValue}}
@@ -81,8 +81,8 @@
               }}{{t 'courses.firstOffering'}}{{/sortable-th}}
               {{#sortable-th
                 align='center'
-                click=(action 'sortBy' 'offerings')
-                sortedBy=(is-equal sortItem 'offerings')
+                click=(action 'sortBy' 'offeringCount')
+                sortedBy=(is-equal sortItem 'offeringCount')
                 sortedAscending=sortAscending
                 sortType='numeric'
               }}{{t 'general.offerings'}}{{/sortable-th}}
@@ -99,28 +99,20 @@
                   {{/link-to}}
                 </td>
                 <td class='text-left'>
-                  {{#liquid-if sessionProxy.sessionType.isFulfilled class='crossFade'}}
-                    {{sessionProxy.sessionType.title}}
-                  {{else}}
-                    {{fa-icon 'spinner' spin=true}}
-                  {{/liquid-if}}
+                  {{sessionProxy.sessionType}}
                 </td>
                 <td class='text-center'>{{sessionProxy.learnerGroupCount}}</td>
                 <td class='text-left' colspan=2>
-                  {{#liquid-if sessionProxy.firstOfferingDate.isFulfilled class='crossFade'}}
-                    {{#if sessionProxy.firstOfferingDate}}
-                      {{#if sessionProxy.ilmSession}}
-                        <strong>ILM: {{t 'sessions.dueBy'}}</strong> {{moment-format sessionProxy.firstOfferingDate.content 'MM/DD/YYYY'}}
-                      {{else}}
-                        {{moment-format sessionProxy.firstOfferingDate.content 'MM/DD/YYYY h:mma'}}
-                      {{/if}}
+                  {{#if sessionProxy.firstOfferingDate}}
+                    {{#if sessionProxy.ilmSession}}
+                      <strong>ILM: {{t 'sessions.dueBy'}}</strong> {{moment-format sessionProxy.firstOfferingDate 'MM/DD/YYYY'}}
+                    {{else}}
+                      {{moment-format sessionProxy.firstOfferingDate 'MM/DD/YYYY h:mma'}}
                     {{/if}}
-                  {{else}}
-                    {{fa-icon 'spinner' spin=true}}
-                  {{/liquid-if}}
+                  {{/if}}
                 </td>
                 <td class='text-center clickable editable' {{action 'toggleExpandedOffering' sessionProxy}}>
-                  {{sessionProxy.offerings.length}}
+                  {{sessionProxy.offeringCount}}
                   {{#if sessionProxy.expandOfferings}}
                     {{fa-icon 'caret-down'}}
                   {{else}}

--- a/app/templates/components/ilios-sessions-list.hbs
+++ b/app/templates/components/ilios-sessions-list.hbs
@@ -47,8 +47,8 @@
         offset=offset
         limit=limit
         total=sessionsCount
-        setOffset='setOffset'
-        setLimit='setLimit'
+        setOffset=this.attrs.setOffset
+        setLimit=this.attrs.setLimit
       }}
       <div class='resultslist-list'>
         <table class='active-background'>
@@ -57,33 +57,33 @@
               {{#sortable-th
                 colspan=3
                 click=(action 'sortBy' 'title')
-                sortedBy=(is-equal sortItem 'title')
-                sortedAscending=sortAscending
+                sortedBy=(or (eq sortBy 'title') (eq sortBy 'title:desc'))
+                sortedAscending=sortedAscending
               }}{{t 'general.title'}}{{/sortable-th}}
               {{#sortable-th
                 click=(action 'sortBy' 'sessionType')
-                sortedBy=(is-equal sortItem 'sessionType')
-                sortedAscending=sortAscending
+                sortedBy=(or (eq sortBy 'sessionType') (eq sortBy 'sessionType:desc'))
+                sortedAscending=sortedAscending
               }}{{t 'general.type'}}{{/sortable-th}}
               {{#sortable-th
                 click=(action 'sortBy' 'learnerGroupCount')
-                sortedBy=(is-equal sortItem 'learnerGroupCount')
+                sortedBy=(or (eq sortBy 'learnerGroupCount') (eq sortBy 'learnerGroupCount:desc'))
                 align='center'
                 sortType='numeric'
-                sortedAscending=sortAscending
+                sortedAscending=sortedAscending
               }}{{t 'general.groups'}}{{/sortable-th}}
               {{#sortable-th
                 colspan=2
                 click=(action 'sortBy' 'firstOfferingDate')
-                sortedBy=(is-equal sortItem 'firstOfferingDate')
-                sortedAscending=sortAscending
+                sortedBy=(or (eq sortBy 'firstOfferingDate') (eq sortBy 'firstOfferingDate:desc'))
+                sortedAscending=sortedAscending
                 sortType='numeric'
               }}{{t 'courses.firstOffering'}}{{/sortable-th}}
               {{#sortable-th
                 align='center'
                 click=(action 'sortBy' 'offeringCount')
-                sortedBy=(is-equal sortItem 'offeringCount')
-                sortedAscending=sortAscending
+                sortedBy=(or (eq sortBy 'offeringCount') (eq sortBy 'offeringCount:desc'))
+                sortedAscending=sortedAscending
                 sortType='numeric'
               }}{{t 'general.offerings'}}{{/sortable-th}}
               <th class='text-center' >{{t 'general.status'}}</th>
@@ -168,8 +168,8 @@
       offset=offset
       limit=limit
       total=sessionsCount
-      setOffset='setOffset'
-      setLimit='setLimit'
+      setOffset=this.attrs.setOffset
+      setLimit=this.attrs.setLimit
     }}
   {{else}}
     <br /><h1>{{fa-icon 'spinner' spin=true}}</h1>

--- a/app/templates/components/new-session.hbs
+++ b/app/templates/components/new-session.hbs
@@ -23,19 +23,17 @@
     <div class="form-label">{{t "sessions.type"}}:</div>
 
     <div class="form-data form-data-select form-input-row">
-    {{#if sortedSessionTypes}}
-      <select onchange={{action (mut selectedSessionTypeId) value="target.value"}}>
-        {{#each sortedSessionTypes as |sessionType|}}
-          <option value="{{sessionType.id}}" selected={{is-equal sessionType.id selectedSessionType.id}}>
-            {{sessionType.title}}
-          </option>
-        {{/each}}
-      </select>
-    {{else}}
-      <select>
-        <option selected>{{t 'sessions.loadingSessionTypes'}}</option>
-      </select>
-    {{/if}}
+      {{#if (is-fulfilled sessionTypes)}}
+        <select onchange={{action (mut selectedSessionTypeId) value="target.value"}}>
+          {{#each (sort-by 'title' (await sessionTypes)) as |sessionType|}}
+            <option value="{{sessionType.id}}" selected={{eq sessionType.id (get (await selectedSessionType) 'id')}}>
+              {{sessionType.title}}
+            </option>
+          {{/each}}
+        </select>
+      {{else}}
+        {{fa-icon 'spinner' spin=true}}
+      {{/if}}
     </div>
   </label>
 

--- a/app/templates/course/index.hbs
+++ b/app/templates/course/index.hbs
@@ -2,6 +2,8 @@
   course=model
   offset=sessionOffset
   limit=sessionLimit
-  setLimit='setSessionLimit'
-  setOffset='setSessionOffset'
+  setLimit=(action (mut sessionLimit))
+  setOffset=(action (mut sessionOffset))
+  sortBy=sortSessionsBy
+  setSortBy=(action (mut sortSessionsBy))
 }}

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -16,12 +16,15 @@ module('Acceptance: Course - Session List' + testgroup, {
   beforeEach: function() {
     application = startApp();
     setupAuthentication(application, {id: 4136, directedCourses: [1]});
-    server.create('school');
+    server.create('school', {
+      sessionTypes: [1]
+    });
     fixtures.sessionTypes = server.createList('sessionType', 1, {
-      sessions: [1,2,3,4]
+      sessions: [1,2,3,4],
     });
     server.create('course', {
-      sessions: [1,2,3,4]
+      sessions: [1,2,3,4],
+      school: 1
     });
     fixtures.sessions = [];
     fixtures.sessions.pushObject(server.create('session', {


### PR DESCRIPTION
Pre-load session details for sorting This slows down the initial load, but it is the only way to get sorting
to work for first offering, group count, and offering count. Fixes #1571

Make session sorting sticky
Used url query parameters to make the choice for session sorting sticky.
Which allows the user to go back and forth to individual sessions and
maintain their place. Fixes #1444