### PR TITLE
Hide unpublished programs in learner groups list

### DIFF
--- a/app/controllers/learner-groups.js
+++ b/app/controllers/learner-groups.js
@@ -44,13 +44,20 @@ export default Controller.extend({
   sortedSchools: sort('schools', 'sortByTitle'),
   hasMoreThanOneSchool: gt('schools.length', 1),
 
-  programs: computed('selectedSchool.programs.[]', function(){
+  programs: computed('selectedSchool', function(){
     let defer = RSVP.defer();
     this.get('selectedSchool').then(school => {
       if(isEmpty(school)){
         defer.resolve([]);
       } else {
-        defer.resolve(school.get('programs'));
+        this.get('store').query('program', {
+          filters: {
+            school: school.get('id'),
+            published: true
+          }
+        }).then(programs => {
+          defer.resolve(programs);
+        });
       }
     });
 
@@ -67,7 +74,14 @@ export default Controller.extend({
       if(isEmpty(program)){
         defer.resolve([]);
       } else {
-        defer.resolve(program.get('programYears'));
+        this.get('store').query('programYear', {
+          filters: {
+            program: program.get('id'),
+            published: true
+          }
+        }).then(programs => {
+          defer.resolve(programs);
+        });
       }
     });
 
@@ -131,7 +145,11 @@ export default Controller.extend({
       }
     }
     return PromiseObject.create({
-      promise: RSVP.resolve(schools.sortBy('title').get('firstObject'))
+      promise: this.get('currentUser').get('model').then(user => {
+        return user.get('school').then(school => {
+          return school
+        });
+      })
     });
   }),
 

--- a/app/mirage/factories/program.js
+++ b/app/mirage/factories/program.js
@@ -5,5 +5,6 @@ export default Mirage.Factory.extend({
   shortTitle: (i) => `short_${i}`,
   school: (i) => (i+1),
   duration: 4,
-  publishedAsTbd: false
+  published: true,
+  publishedAsTbd: false,
 });

--- a/app/mirage/factories/programYear.js
+++ b/app/mirage/factories/programYear.js
@@ -3,4 +3,6 @@ import Mirage from 'ember-cli-mirage';
 export default Mirage.Factory.extend({
   startYear: (i) => 2012 + i,
   program: (i) => (i+1),
+  published: true,
+  publishedAsTbd: false,
 });

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -61,12 +61,128 @@ test('single option filters', function(assert) {
   });
 });
 
+test('multi-option filters', function(assert) {
+  const schoolsFilter = '.filter:eq(0) option';
+  const programsFilter = '.filter:eq(1) option';
+  const yearsFilter = '.filter:eq(2) option';
+  assert.expect(6);
+  server.create('permission', {
+    user: 4136,
+    tableName: 'school',
+    tableRowId: 2,
+    canRead: true
+  });
+  server.create('user', {id: 4136, permissions: [1]});
+  server.create('school', {
+    programs: [1]
+  });
+  server.create('school');
+  server.create('program', {
+    school: 1,
+    programYears: [1, 2]
+  });
+  server.create('program', {
+    school: 1,
+  });
+  server.create('programYear', {
+    program: 1,
+    cohort: 1
+  });
+  server.create('programYear', {
+    program: 1,
+    cohort: 2
+  });
+  server.create('cohort', {
+    programYear: 1,
+  });
+  server.create('cohort', {
+    programYear: 2,
+  });
+  visit('/learnergroups');
+  andThen(function() {
+    assert.equal(find(schoolsFilter).length, 2);
+    assert.equal(getElementText(find(schoolsFilter)), getText('school 0 school 1'));
+    assert.equal(find(programsFilter).length, 3);
+    assert.equal(getElementText(find(programsFilter)), getText('Select a Program program 0 program 1'));
+    assert.equal(find(yearsFilter).length, 2);
+    assert.equal(getElementText(find(yearsFilter)), getText('cohort 1 cohort 0'));
+  });
+});
+
+test('primary school is selected by default', function(assert) {
+  const schoolsFilter = '.filter:eq(0) option:selected';
+  assert.expect(1);
+  server.create('permission', {
+    user: 4136,
+    tableName: 'school',
+    tableRowId: 1,
+    canRead: true
+  });
+  server.create('user', {id: 4136, permissions: [1], school: 2});
+  server.create('school', {users: []});
+  server.create('school', {
+    users: [1]
+  });
+  visit('/learnergroups');
+  andThen(function() {
+    assert.equal(getElementText(find(schoolsFilter)), getText('school 1'));
+  });
+});
+
+test('multi-option filters', function(assert) {
+  const schoolsFilter = '.filter:eq(0) option';
+  const programsFilter = '.filter:eq(1) option';
+  const yearsFilter = '.filter:eq(2) option';
+  assert.expect(6);
+  server.create('permission', {
+    user: 4136,
+    tableName: 'school',
+    tableRowId: 2,
+    canRead: true
+  });
+  server.create('user', {id: 4136, permissions: [1]});
+  server.create('school', {
+    programs: [1]
+  });
+  server.create('school');
+  server.create('program', {
+    school: 1,
+    programYears: [1, 2]
+  });
+  server.create('program', {
+    school: 1,
+  });
+  server.create('programYear', {
+    program: 1,
+    cohort: 1
+  });
+  server.create('programYear', {
+    program: 1,
+    cohort: 2
+  });
+  server.create('cohort', {
+    programYear: 1,
+  });
+  server.create('cohort', {
+    programYear: 2,
+  });
+  visit('/learnergroups');
+  andThen(function() {
+    assert.equal(find(schoolsFilter).length, 2);
+    assert.equal(getElementText(find(schoolsFilter)), getText('school 0 school 1'));
+    assert.equal(find(programsFilter).length, 3);
+    assert.equal(getElementText(find(programsFilter)), getText('Select a Program program 0 program 1'));
+    assert.equal(find(yearsFilter).length, 2);
+    assert.equal(getElementText(find(yearsFilter)), getText('cohort 1 cohort 0'));
+  });
+});
+
 test('multiple programs filter', function(assert) {
   const selectedProgram = '.filter:eq(1) select option:selected';
   const programOptions = '.filter:eq(1) select option';
   const programSelectList = '.filter:eq(1) select';
   const firstListedLearnerGroup = '.resultslist-list tbody tr td:eq(0)';
-  assert.expect(10);
+  assert.expect(8);
   server.create('user', {id: 4136});
   server.create('school', {
     programs: [1,2]
@@ -103,9 +219,7 @@ test('multiple programs filter', function(assert) {
   });
   visit('/learnergroups');
   andThen(function() {
-    assert.equal(getElementText(find(selectedProgram)), getText('Select a Program'));
-    assert.equal(find(firstListedLearnerGroup).length, 0);
-    pickOption(programSelectList, 'program 0', assert);
+    assert.equal(getElementText(find(selectedProgram)), getText('program 0'));
     andThen(function(){
       assert.equal(getElementText(find(firstListedLearnerGroup)),getText(firstLearnergroup.title));
       var options = find(programOptions);

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -269,7 +269,7 @@ test('can add a program-year (with no pre-existing program-years)', function(ass
     const thisYear = new Date().getFullYear();
     const academicYear = `${thisYear.toString()} - ${(thisYear + 1).toString()}`;
     const classOfYear = `Class of ${(thisYear + 4).toString()}`;
-    
+
     assert.equal(getTableDataText(0, 0).text().trim(), academicYear, 'academic year shown');
     assert.equal(getTableDataText(0, 1).text().trim(), classOfYear, 'cohort class year shown');
     assert.ok(getTableDataText(0, 2, 'i').hasClass('fa-warning'), 'warning label shown');
@@ -321,6 +321,7 @@ test('can add a program-year (with pre-existing program-year)', function(assert)
     terms: [1,2,3],
     objectives: [1,2,3],
     stewards: [1],
+    published: false
   });
   server.create('cohort', {
     programYear: 1

--- a/tests/acceptance/program/programyear/publish-test.js
+++ b/tests/acceptance/program/programyear/publish-test.js
@@ -20,15 +20,15 @@ module('Acceptance: Program Year - Publish' + testgroup, {
     });
     fixtures.published = server.create('programYear', {
       program: 1,
-      published: true,
     });
     fixtures.scheduled = server.create('programYear', {
       program: 1,
-      published: true,
       publishedAsTbd: true
     });
     fixtures.draft = server.create('programYear', {
       program: 1,
+      published: false,
+      publishedAsTbd: false
     });
   },
 

--- a/tests/acceptance/program/publish-test.js
+++ b/tests/acceptance/program/publish-test.js
@@ -18,17 +18,16 @@ module('Acceptance: Program - Publish' + testgroup, {
     fixtures.published = server.create('program', {
       startYear: 2013,
       school: 1,
-      published: true,
     });
     fixtures.scheduled = server.create('program', {
       startYear: 2013,
       school: 1,
-      published: true,
       publishedAsTbd: true
     });
     fixtures.draft = server.create('program', {
       startYear: 2013,
       school: 1,
+      published: false,
     });
   },
 


### PR DESCRIPTION
Programs and program years which are in draft status should not be shown in these lists.

Fixes #1403

Also changed the users primary school to be selected by default.

