### PR TITLE
Replace styles on new-user form

### DIFF
--- a/app/components/click-choice-buttons.js
+++ b/app/components/click-choice-buttons.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 const { $, Component, on } = Ember;
 
 export default Component.extend({
+  classNames: ['click-choice-buttons'],
   firstChoicePicked: true,
 
   buttonContent1: null,

--- a/app/components/new-user.js
+++ b/app/components/new-user.js
@@ -58,5 +58,5 @@ const Validations = buildValidations({
 });
 
 export default Component.extend(NewUser, Validations, {
-
+  classNames: ['new-user'],
 });

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -74,6 +74,7 @@ $base-link-color: $base-accent-color;
 $hover-link-color: darken($base-accent-color, 15);
 
 // Neat Breakpoints
+$small-screen: em(320);
 $medium-screen: em(640);
 $large-screen: em(860);
 $giant-screen: em(1480);

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -60,4 +60,6 @@
 @import 'components/school-manager';
 @import 'components/assign-students';
 @import 'components/pre-fill';
+@import 'mixins';
+@import 'newcomponents';
 @import 'layout/layout';

--- a/app/styles/components/_global.scss
+++ b/app/styles/components/_global.scss
@@ -307,29 +307,6 @@ select:hover {
   width: 1px;
 }
 
-//scrollbar style */
-::-webkit-scrollbar {
-  width: 9px;
-}
-
-::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, .02);
-  border-radius: 5px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, .2);
-  border-radius: 5px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, .4);
-}
-
-::-webkit-scrollbar-thumb:window-inactive {
-  background: rgba(0, 0, 0, .05);
-}
-
 .list-reset {
   ul {
     list-style-position: inside;

--- a/app/styles/mixins.scss
+++ b/app/styles/mixins.scss
@@ -1,0 +1,1 @@
+@import 'mixins/ilios-form';

--- a/app/styles/mixins/ilios-form.scss
+++ b/app/styles/mixins/ilios-form.scss
@@ -1,0 +1,53 @@
+@mixin ilios-form () {
+  label {
+    @include fill-parent;
+    display: block;
+    font-weight: bold;
+    margin-top: 1em;
+  }
+
+  input[type=text],
+  input[type=password],
+  select {
+    @include fill-parent;
+    background-position: right 4px bottom .75em;
+    height: 2.5em;
+  }
+
+  input {
+    @include fill-parent;
+    background: $white;
+    border: 1px solid $input-box-grey;
+    border-radius: $base-border-radius;
+  }
+}
+
+@mixin ilios-form-item () {
+  @include fill-parent;
+  height: 6em;
+
+  @include media($large-screen) {
+    @include span-columns(4);
+  }
+
+}
+
+@mixin ilios-form-last-item () {
+  @include fill-parent;
+
+  @include media($large-screen) {
+    @include span-columns(8);
+  }
+}
+
+@mixin ilios-form-buttons () {
+  @include fill-parent;
+  clear: both;
+  margin-top: 2em;
+  padding: 1em 0;
+
+  button {
+    margin-right: 1em;
+  }
+
+}

--- a/app/styles/newcomponents.scss
+++ b/app/styles/newcomponents.scss
@@ -1,0 +1,1 @@
+@import 'newcomponents/new-user';

--- a/app/styles/newcomponents/new-user.scss
+++ b/app/styles/newcomponents/new-user.scss
@@ -1,0 +1,27 @@
+.new-user {
+  .new-user-form {
+    @include ilios-form;
+    @include fill-parent;
+    display: block;
+
+    .click-choice-buttons {
+      @include fill-parent;
+      @include clearfix;
+      display: block;
+      margin-bottom: .5em;
+      min-height: 1em;
+    }
+
+    .item {
+      @include ilios-form-item;
+
+      &.last {
+        @include ilios-form-last-item;
+      }
+    }
+
+    .buttons {
+      @include ilios-form-buttons;
+    }
+  }
+}

--- a/app/templates/components/new-directory-user.hbs
+++ b/app/templates/components/new-directory-user.hbs
@@ -128,9 +128,9 @@
   <div id='new-directory-user-search-tools'>
     {{one-way-input
       value=searchTerms
-      update=(action attrs.setSearchTerms)
+      update=this.attrs.setSearchTerms
       onenter=(action "findUsersInDirectory")
-      onescape=(action attrs.setSearchTerms '')
+      onescape=(action this.attrs.setSearchTerms '')
     }}
     <button type='search' {{action 'findUsersInDirectory'}}>{{t 'user.searchDirectory'}}</button>
   </div>

--- a/app/templates/components/new-user.hbs
+++ b/app/templates/components/new-user.hbs
@@ -1,166 +1,164 @@
 <div class="new-result-title">{{t 'user.new'}}</div>
 
-<div class="detail-content form-container">
-  <div class="form-col-12 multi-row">
-    <label class="form-label">{{t 'general.createNew'}}:</label>
-    <div class="form-data">
-      {{click-choice-buttons
-        buttonContent1=(t 'general.nonStudent')
-        buttonContent2=(t 'general.student')
-        firstChoicePicked=nonStudentMode
-        action='setNonStudentMode'
-      }}
-    </div>
-    <label class="form-label">{{t "user.firstName"}}:</label>
-    <div class="form-data">
-      {{one-way-input
-        value=firstName
-        update=(action (mut firstName))
-        onenter=(action "save")
-        onescape=(action this.attrs.close)
-        focusOut=(action 'addErrorDisplayFor' 'firstName')
-      }}
-      {{#if (and (v-get this 'firstName' 'isInvalid') (is-in showErrorsFor 'firstName'))}}
-        <span class="validation-error-message">{{v-get this 'firstName' 'message'}}</span>
-      {{/if}}
-    </div>
-    <label class="form-label">{{t "user.middleName"}}:</label>
-    <div class="form-data">
-      {{one-way-input
-        value=middleName
-        update=(action (mut middleName))
-        onenter=(action "save")
-        onescape=(action this.attrs.close)
-        focusOut=(action 'addErrorDisplayFor' 'middleName')
-      }}
-      {{#if (and (v-get this 'middleName' 'isInvalid') (is-in showErrorsFor 'middleName'))}}
-        <span class="validation-error-message">{{v-get this 'middleName' 'message'}}</span>
-      {{/if}}
-    </div>
-    <label class="form-label">{{t "user.lastName"}}:</label>
-    <div class="form-data">
-      {{one-way-input
-        value=lastName
-        update=(action (mut lastName))
-        onenter=(action "save")
-        onescape=(action this.attrs.close)
-        focusOut=(action 'addErrorDisplayFor' 'lastName')
-      }}
-      {{#if (and (v-get this 'lastName' 'isInvalid') (is-in showErrorsFor 'lastName'))}}
-        <span class="validation-error-message">{{v-get this 'lastName' 'message'}}</span>
-      {{/if}}
-    </div>
-    <label class="form-label">{{t "general.campusId"}}:</label>
-    <div class="form-data">
-      {{one-way-input
-        value=campusId
-        update=(action (mut campusId))
-        onenter=(action "save")
-        onescape=(action this.attrs.close)
-        focusOut=(action 'addErrorDisplayFor' 'campusId')
-      }}
-      {{#if (and (v-get this 'campusId' 'isInvalid') (is-in showErrorsFor 'campusId'))}}
-        <span class="validation-error-message">{{v-get this 'campusId' 'message'}}</span>
-      {{/if}}
-    </div>
-    <label class="form-label">{{t "user.otherId"}}:</label>
-    <div class="form-data">
-      {{one-way-input
-        value=otherId
-        update=(action (mut otherId))
-        onenter=(action "save")
-        onescape=(action this.attrs.close)
-        focusOut=(action 'addErrorDisplayFor' 'otherId')
-      }}
-      {{#if (and (v-get this 'otherId' 'isInvalid') (is-in showErrorsFor 'otherId'))}}
-        <span class="validation-error-message">{{v-get this 'otherId' 'message'}}</span>
-      {{/if}}
-    </div>
-    <label class="form-label">{{t "general.email"}}:</label>
-    <div class="form-data">
-      {{one-way-input
-        value=email
-        update=(action (mut email))
-        onenter=(action "save")
-        onescape=(action this.attrs.close)
-        focusOut=(action 'addErrorDisplayFor' 'email')
-      }}
-      {{#if (and (v-get this 'email' 'isInvalid') (is-in showErrorsFor 'email'))}}
-        <span class="validation-error-message">{{v-get this 'email' 'message'}}</span>
-      {{/if}}
-    </div>
-    <label class="form-label">{{t "general.phone"}}:</label>
-    <div class="form-data">
-      {{one-way-input
-        value=phone
-        update=(action (mut phone))
-        onenter=(action "save")
-        onescape=(action this.attrs.close)
-        focusOut=(action 'addErrorDisplayFor' 'phone')
-      }}
-      {{#if (and (v-get this 'phone' 'isInvalid') (is-in showErrorsFor 'phone'))}}
-        <span class="validation-error-message">{{v-get this 'phone' 'message'}}</span>
-      {{/if}}
-    </div>
-    <label class="form-label">{{t "user.username"}}:</label>
-    <div class="form-data">
-      {{one-way-input
-        value=username
-        update=(action (mut username))
-        onenter=(action "save")
-        onescape=(action this.attrs.close)
-        focusOut=(action 'addErrorDisplayFor' 'username')
-      }}
-      {{#if (and (v-get this 'username' 'isInvalid') (is-in showErrorsFor 'username'))}}
-        <span class="validation-error-message">{{v-get this 'username' 'message'}}</span>
-      {{/if}}
-    </div>
-    <label class="form-label">{{t "user.password"}}:</label>
-    <div class="form-data">
-      {{one-way-input
-        value=password
-        update=(action (mut password))
-        onenter=(action "save")
-        onescape=(action this.attrs.close)
-        focusOut=(action 'addErrorDisplayFor' 'password')
-      }}
-      {{#if (and (v-get this 'password' 'isInvalid') (is-in showErrorsFor 'password'))}}
-        <span class="validation-error-message">{{v-get this 'password' 'message'}}</span>
-      {{/if}}
-    </div>
-    <label class="form-label">{{t "general.primarySchool"}}:</label>
+<div class='new-user-form'>
+  <div class='choose-form-type'>
+    <label>{{t 'general.createNew'}}:</label>
+    {{click-choice-buttons
+      buttonContent1=(t 'general.nonStudent')
+      buttonContent2=(t 'general.student')
+      firstChoicePicked=nonStudentMode
+      action='setNonStudentMode'
+    }}
+  </div>
+  <div class='item'>
+    <label>{{t "user.firstName"}}:</label>
+    {{one-way-input
+      value=firstName
+      update=(action (mut firstName))
+      onenter=(action "save")
+      onescape=(action this.attrs.close)
+      focusOut=(action 'addErrorDisplayFor' 'firstName')
+    }}
+    {{#if (and (v-get this 'firstName' 'isInvalid') (is-in showErrorsFor 'firstName'))}}
+      <span class="message error">{{v-get this 'firstName' 'message'}}</span>
+    {{/if}}
+  </div>
+  <div class='item'>
+    <label>{{t "user.middleName"}}:</label>
+    {{one-way-input
+      value=middleName
+      update=(action (mut middleName))
+      onenter=(action "save")
+      onescape=(action this.attrs.close)
+      focusOut=(action 'addErrorDisplayFor' 'middleName')
+    }}
+    {{#if (and (v-get this 'middleName' 'isInvalid') (is-in showErrorsFor 'middleName'))}}
+      <span class="message error">{{v-get this 'middleName' 'message'}}</span>
+    {{/if}}
+  </div>
+  <div class='item'>
+    <label>{{t "user.lastName"}}:</label>
+    {{one-way-input
+      value=lastName
+      update=(action (mut lastName))
+      onenter=(action "save")
+      onescape=(action this.attrs.close)
+      focusOut=(action 'addErrorDisplayFor' 'lastName')
+    }}
+    {{#if (and (v-get this 'lastName' 'isInvalid') (is-in showErrorsFor 'lastName'))}}
+      <span class="message error">{{v-get this 'lastName' 'message'}}</span>
+    {{/if}}
+  </div>
+  <div class='item'>
+    <label>{{t "general.campusId"}}:</label>
+    {{one-way-input
+      value=campusId
+      update=(action (mut campusId))
+      onenter=(action "save")
+      onescape=(action this.attrs.close)
+      focusOut=(action 'addErrorDisplayFor' 'campusId')
+    }}
+    {{#if (and (v-get this 'campusId' 'isInvalid') (is-in showErrorsFor 'campusId'))}}
+      <span class="message error">{{v-get this 'campusId' 'message'}}</span>
+    {{/if}}
+  </div>
+  <div class='item'>
+    <label>{{t "user.otherId"}}:</label>
+    {{one-way-input
+      value=otherId
+      update=(action (mut otherId))
+      onenter=(action "save")
+      onescape=(action this.attrs.close)
+      focusOut=(action 'addErrorDisplayFor' 'otherId')
+    }}
+    {{#if (and (v-get this 'otherId' 'isInvalid') (is-in showErrorsFor 'otherId'))}}
+      <span class="message error">{{v-get this 'otherId' 'message'}}</span>
+    {{/if}}
+  </div>
+  <div class='item'>
+    <label>{{t "general.email"}}:</label>
+    {{one-way-input
+      value=email
+      update=(action (mut email))
+      onenter=(action "save")
+      onescape=(action this.attrs.close)
+      focusOut=(action 'addErrorDisplayFor' 'email')
+    }}
+    {{#if (and (v-get this 'email' 'isInvalid') (is-in showErrorsFor 'email'))}}
+      <span class="message error">{{v-get this 'email' 'message'}}</span>
+    {{/if}}
+  </div>
+  <div class='item'>
+    <label>{{t "general.phone"}}:</label>
+    {{one-way-input
+      value=phone
+      update=(action (mut phone))
+      onenter=(action "save")
+      onescape=(action this.attrs.close)
+      focusOut=(action 'addErrorDisplayFor' 'phone')
+    }}
+    {{#if (and (v-get this 'phone' 'isInvalid') (is-in showErrorsFor 'phone'))}}
+      <span class="message error">{{v-get this 'phone' 'message'}}</span>
+    {{/if}}
+  </div>
+  <div class='item'>
+    <label>{{t "user.username"}}:</label>
+    {{one-way-input
+      value=username
+      update=(action (mut username))
+      onenter=(action "save")
+      onescape=(action this.attrs.close)
+      focusOut=(action 'addErrorDisplayFor' 'username')
+    }}
+    {{#if (and (v-get this 'username' 'isInvalid') (is-in showErrorsFor 'username'))}}
+      <span class="message error">{{v-get this 'username' 'message'}}</span>
+    {{/if}}
+  </div>
+  <div class='item'>
+    <label>{{t "user.password"}}:</label>
+    {{one-way-input
+      value=password
+      update=(action (mut password))
+      onenter=(action "save")
+      onescape=(action this.attrs.close)
+      focusOut=(action 'addErrorDisplayFor' 'password')
+    }}
+    {{#if (and (v-get this 'password' 'isInvalid') (is-in showErrorsFor 'password'))}}
+      <span class="message error">{{v-get this 'password' 'message'}}</span>
+    {{/if}}
+  </div>
+  <div class='item'>
+    <label>{{t "general.primarySchool"}}:</label>
     {{#if (and (is-fulfilled schools) (is-fulfilled bestSelectedSchool))}}
-      <div class="form-data form-data-select">
-        <select onchange={{action "setSchool" value="target.value"}}>
-          {{#each (sort-by 'title' (await schools)) as |school|}}
-            <option value={{school.id}} selected={{eq school (await bestSelectedSchool)}}>
-              {{school.title}}
-            </option>
-          {{/each}}
-        </select>
-      </div>
+      <select onchange={{action "setSchool" value="target.value"}}>
+        {{#each (sort-by 'title' (await schools)) as |school|}}
+          <option value={{school.id}} selected={{eq school (await bestSelectedSchool)}}>
+            {{school.title}}
+          </option>
+        {{/each}}
+      </select>
     {{else}}
       {{fa-icon 'spinner' spin=true}}
     {{/if}}
-    {{#if (and (not nonStudentMode) (is-fulfilled bestSelectedSchool)) class='vertical'}}
-      <label class="form-label">{{t "general.primaryCohort"}}:</label>
+  </div>
+  {{#if (and (not nonStudentMode) (is-fulfilled bestSelectedSchool)) class='vertical'}}
+    <div class='item last'>
+      <label>{{t "general.primaryCohort"}}:</label>
       {{#if (and loadCohorts.isIdle (is-fulfilled bestSelectedCohort))}}
-        <div class="form-data form-data-select">
-          <select onchange={{action "setPrimaryCohort" value="target.value"}}>
-            {{#each (sort-by 'title' cohorts) as |cohort|}}
-              <option value={{cohort.id}} selected={{eq cohort.id (get (await bestSelectedCohort) 'id')}}>
-                {{cohort.title}}
-              </option>
-            {{/each}}
-          </select>
-        </div>
+        <select onchange={{action "setPrimaryCohort" value="target.value"}}>
+          {{#each (sort-by 'title' cohorts) as |cohort|}}
+            <option value={{cohort.id}} selected={{eq cohort.id (get (await bestSelectedCohort) 'id')}}>
+              {{cohort.title}}
+            </option>
+          {{/each}}
+        </select>
       {{else}}
         {{fa-icon 'spinner' spin=true}}
       {{/if}}
-    {{/if}}
-  </div>
+    </div>
+  {{/if}}
 
-  <div class="form-col-6 form-data-submit">
+  <div class='buttons'>
     <button class='done text' {{action 'save'}} disabled={{or isSaving (is-pending bestSelectedCohort)  (and (not nonStudentMode) (is-pending bestSelectedSchool))}}>
       {{#if isSaving}}
         {{fa-icon 'spinner' spin=true}}

--- a/tests/integration/components/new-directory-user-test.js
+++ b/tests/integration/components/new-directory-user-test.js
@@ -33,60 +33,22 @@ moduleForComponent('new-directory-user', 'Integration | Component | new director
 });
 
 test('it renders', function(assert) {
-  this.set('close', () => {});
 
-  this.render(hbs`{{new-user close=(action close)}}`);
+  let storeMock = Service.extend({
+    query(what, {filters}){
+
+      assert.equal('cohort', what);
+      assert.equal(filters.schools[0], 2);
+      return resolve([]);
+    }
+  });
+  this.register('service:store', storeMock);
+  this.set('nothing', () => {});
+
+  this.render(hbs`{{new-directory-user close=(action nothing) setSearchTerms=(action nothing)}}`);
 
   return wait().then(() => {
     let content = this.$().text().trim();
-    assert.notEqual(content.search(/New User/), -1);
-    assert.notEqual(content.search(/First Name/), -1);
-    assert.notEqual(content.search(/Last Name/), -1);
-    assert.notEqual(content.search(/Middle Name/), -1);
-    assert.notEqual(content.search(/Campus ID/), -1);
-    assert.notEqual(content.search(/Other ID/), -1);
-    assert.notEqual(content.search(/Email/), -1);
-    assert.notEqual(content.search(/Phone/), -1);
-    assert.notEqual(content.search(/Username/), -1);
-    assert.notEqual(content.search(/Password/), -1);
-    assert.notEqual(content.search(/Primary School/), -1);
-
-    let options = this.$('option');
-    assert.equal(options.length, mockSchools.length);
-    assert.equal(options.eq(0).text().trim(), 'first');
-    assert.equal(options.eq(1).text().trim(), 'second');
-    assert.equal(options.eq(2).text().trim(), 'third');
-  });
-});
-
-test('errors do not show up initially', function(assert) {
-  this.set('close', () => {
-    assert.ok(false); //shouldn't be called
-  });
-  this.render(hbs`{{new-user close=(action close)}}`);
-
-  return wait().then(() => {
-    assert.equal(this.$('.validation-error-message').length, 0);
-
-  });
-});
-
-test('errors show up', function(assert) {
-  this.set('close', () => {
-    assert.ok(false); //shouldn't be called
-  });
-  this.render(hbs`{{new-user close=(action close)}}`);
-
-  return wait().then(() => {
-    this.$('.done').click();
-    return wait().then(() => {
-      let boxes = this.$('.form-data');
-      assert.ok(boxes.eq(1).text().search(/blank/) > -1);
-      assert.ok(boxes.eq(3).text().search(/blank/) > -1);
-      assert.ok(boxes.eq(6).text().search(/blank/) > -1);
-      assert.ok(boxes.eq(8).text().search(/blank/) > -1);
-      assert.ok(boxes.eq(9).text().search(/blank/) > -1);
-    });
-
+    assert.notEqual(content.search(/Search directory for new users/), -1);
   });
 });

--- a/tests/integration/components/new-user-test.js
+++ b/tests/integration/components/new-user-test.js
@@ -28,13 +28,22 @@ moduleForComponent('new-user', 'Integration | Component | new users', {
   },
   beforeEach(){
     this.register('service:current-user', currentUserMock);
-    this.inject.service('current-user', { as: 'current-user' });
   }
 });
 
 
 test('it renders', function(assert) {
   this.set('close', () => {});
+
+  let storeMock = Service.extend({
+    query(what, {filters}){
+
+      assert.equal('cohort', what);
+      assert.equal(filters.schools[0], 2);
+      return resolve([]);
+    }
+  });
+  this.register('service:store', storeMock);
 
   this.render(hbs`{{new-user close=(action close)}}`);
 
@@ -52,7 +61,8 @@ test('it renders', function(assert) {
     assert.notEqual(content.search(/Password/), -1);
     assert.notEqual(content.search(/Primary School/), -1);
 
-    let options = this.$('option');
+    const schools = 'select:eq(0) option';
+    let options = this.$(schools);
     assert.equal(options.length, mockSchools.length);
     assert.equal(options.eq(0).text().trim(), 'first');
     assert.equal(options.eq(1).text().trim(), 'second');
@@ -61,6 +71,16 @@ test('it renders', function(assert) {
 });
 
 test('errors do not show up initially', function(assert) {
+
+  let storeMock = Service.extend({
+    query(what, {filters}){
+
+      assert.equal('cohort', what);
+      assert.equal(filters.schools[0], 2);
+      return resolve([]);
+    }
+  });
+  this.register('service:store', storeMock);
   this.set('close', () => {
     assert.ok(false); //shouldn't be called
   });
@@ -73,6 +93,15 @@ test('errors do not show up initially', function(assert) {
 });
 
 test('errors show up', function(assert) {
+  let storeMock = Service.extend({
+    query(what, {filters}){
+
+      assert.equal('cohort', what);
+      assert.equal(filters.schools[0], 2);
+      return resolve([]);
+    }
+  });
+  this.register('service:store', storeMock);
   this.set('close', () => {
     assert.ok(false); //shouldn't be called
   });
@@ -82,11 +111,11 @@ test('errors show up', function(assert) {
     this.$('.done').click();
     return wait().then(() => {
       let boxes = this.$('.item');
-      assert.ok(boxes.eq(1).text().search(/blank/) > -1);
-      assert.ok(boxes.eq(3).text().search(/blank/) > -1);
-      assert.ok(boxes.eq(6).text().search(/blank/) > -1);
+      assert.ok(boxes.eq(0).text().search(/blank/) > -1);
+      assert.ok(boxes.eq(2).text().search(/blank/) > -1);
+      assert.ok(boxes.eq(5).text().search(/blank/) > -1);
+      assert.ok(boxes.eq(7).text().search(/blank/) > -1);
       assert.ok(boxes.eq(8).text().search(/blank/) > -1);
-      assert.ok(boxes.eq(9).text().search(/blank/) > -1);
     });
 
   });

--- a/tests/integration/components/new-user-test.js
+++ b/tests/integration/components/new-user-test.js
@@ -67,7 +67,7 @@ test('errors do not show up initially', function(assert) {
   this.render(hbs`{{new-user close=(action close)}}`);
 
   return wait().then(() => {
-    assert.equal(this.$('.validation-error-message').length, 0);
+    assert.equal(this.$('.messagee').length, 0);
 
   });
 });
@@ -81,7 +81,7 @@ test('errors show up', function(assert) {
   return wait().then(() => {
     this.$('.done').click();
     return wait().then(() => {
-      let boxes = this.$('.form-data');
+      let boxes = this.$('.item');
       assert.ok(boxes.eq(1).text().search(/blank/) > -1);
       assert.ok(boxes.eq(3).text().search(/blank/) > -1);
       assert.ok(boxes.eq(6).text().search(/blank/) > -1);


### PR DESCRIPTION
This is a new structured approach to styling components.  For now I'm
placing the files in newcomponents/ directory but once we have replaced
styles on the rest of the site the components/ directors will be
removed.

Individual ember components get a class and then we use mixins as
functions to apply the actual styles to the page.  Hopefully this gives
us a bunch of re-uability without needing to put things in a global
style space at all.

Refs #1705