### PR TITLE
Make session filter name a query parameter

### DIFF
--- a/app/components/ilios-sessions-list.js
+++ b/app/components/ilios-sessions-list.js
@@ -1,11 +1,9 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import { translationMacro as t } from "ember-i18n";
 
-const { Component, computed, inject, observer, RSVP, run, ObjectProxy } = Ember;
+const { Component, computed, inject, RSVP, ObjectProxy } = Ember;
 const { PromiseArray, PromiseObject } = DS;
 const { service } = inject;
-const { debounce } = run;
 const { sort, not, alias, collect } = computed;
 const { Promise } = RSVP;
 
@@ -49,21 +47,8 @@ export default Component.extend({
   offset: 0,
   limit: 25,
 
-  filter: '',
+  filterBy: null,
   course: null,
-
-  placeholderValue: t('sessions.titleFilterPlaceholder'),
-
-  //in order to delay rendering until a user is done typing debounce the title filter
-  debouncedFilter: '',
-
-  watchFilter: observer('filter', function() {
-    debounce(this, this.setFilter, 500);
-  }),
-
-  setFilter() {
-    this.set('debouncedFilter', this.get('filter'));
-  },
 
   proxiedSessions: computed('sessions.[]', function() {
     return new Promise( resolve => {
@@ -91,10 +76,10 @@ export default Component.extend({
     });
   }),
 
-  filteredContent: computed('proxiedSessions.[]', 'debouncedFilter', function(){
+  filteredContent: computed('proxiedSessions.[]', 'filterBy', function(){
     let defer = RSVP.defer();
     this.get('proxiedSessions').then(sessions => {
-      let filter = this.get('debouncedFilter');
+      let filter = this.get('filterBy');
       let filterExpressions = filter.split(' ').map(function(string){
         return new RegExp(string, 'gi');
       });

--- a/app/controllers/course/index.js
+++ b/app/controllers/course/index.js
@@ -5,8 +5,10 @@ export default Ember.Controller.extend({
     sessionOffset: 'offset',
     sessionLimit: 'limit',
     sortSessionsBy: 'sortBy',
+    filterSessionsBy: 'filterBy',
   },
   sessionOffset: 0,
   sessionLimit: 25,
   sortSessionsBy: 'title',
+  filterSessionsBy: '',
 });

--- a/app/templates/components/ilios-sessions-list.hbs
+++ b/app/templates/components/ilios-sessions-list.hbs
@@ -5,7 +5,11 @@
   {{#if (is-fulfilled proxiedSessions)}}
     <div class="filter-tools">
       <div id='titlefilter' class="filter">
-        {{input type='text' value=filter placeholder=placeholderValue}}
+        {{one-way-input
+          value=filterBy
+          update=this.attrs.setFilterBy
+          placeholder=(t 'sessions.titleFilterPlaceholder')
+        }}
       </div>
     </div>
     <div class='detail-actions'>

--- a/app/templates/course/index.hbs
+++ b/app/templates/course/index.hbs
@@ -6,4 +6,6 @@
   setOffset=(action (mut sessionOffset))
   sortBy=sortSessionsBy
   setSortBy=(action (mut sortSessionsBy))
+  filterBy=filterSessionsBy
+  setFilterBy=(action (mut filterSessionsBy))
 }}


### PR DESCRIPTION
This results in the filter being sticky while navigating between
sessions.

Fixes #1675