### PR TITLE
Fix order of learner group breadcrumbs

### DIFF
--- a/app/templates/components/learnergroup-header.hbs
+++ b/app/templates/components/learnergroup-header.hbs
@@ -22,7 +22,7 @@
         )
       }}{{t 'general.learnerGroups'}}{{/link-to}}
     </span>
-    {{#each (await learnerGroup.allParents) as |parent|}}
+    {{#each (reverse (await learnerGroup.allParents)) as |parent|}}
       <span>
         {{#link-to
           'learnerGroup' parent

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -244,3 +244,24 @@ test('check allinstructors', function(assert) {
     });
   });
 });
+
+test('check allParents', function(assert) {
+  assert.expect(5);
+  let learnerGroup = this.subject();
+  let store = this.store();
+
+  return learnerGroup.get('allParents').then(groups => {
+    assert.equal(groups.length, 0);
+
+    let subGroup1 = store.createRecord('learner-group', {parent: learnerGroup});
+    let subGroup2 = store.createRecord('learner-group', {parent: subGroup1});
+    let subGroup3 = store.createRecord('learner-group', {parent: subGroup2});
+
+    return subGroup3.get('allParents').then(groups => {
+      assert.equal(groups.length, 3);
+      assert.equal(groups[0], subGroup2);
+      assert.equal(groups[1], subGroup1);
+      assert.equal(groups[2], learnerGroup);
+    });
+  });
+});


### PR DESCRIPTION
Parents were arriving and being displayed in the wrong ordered.  Needed
to reverse the sort order to get the correctly sorted.

Fixes #1723