### PR TITLE
Use indeterminate state learner group select all

### DIFF
--- a/app/components/learnergroup-cohort-user-manager.js
+++ b/app/components/learnergroup-cohort-user-manager.js
@@ -9,6 +9,10 @@ export default Component.extend({
     this.set('usersBeingMoved', []);
     this.set('selectedUsers', []);
   },
+  didRender(){
+    this._super(...arguments);
+    this.setCheckAllState();
+  },
   classNames: ['learnergroup-user-list'],
   sortBy: 'firstName',
   users: [],
@@ -53,6 +57,22 @@ export default Component.extend({
     yield this.get('addUsersToGroup')(users);
     this.get('usersBeingMoved').removeObjects(users);
   }),
+
+  setCheckAllState(){
+    const selectedUsers = this.get('selectedUsers').get('length');
+    const filteredUsers = this.get('filteredUsers').get('length');
+    let el = this.$('th:eq(0) input');
+    if (selectedUsers === 0) {
+      el.prop('indeterminate', false);
+      el.prop('checked', false);
+    } else if (selectedUsers < filteredUsers) {
+      el.prop('indeterminate', true);
+      el.prop('checked', false);
+    } else {
+      el.prop('indeterminate', false);
+      el.prop('checked', true);
+    }
+  },
   actions: {
     sortBy(what){
       const sortBy = this.get('sortBy');
@@ -69,13 +89,17 @@ export default Component.extend({
       }
     },
     toggleUserSelectionAllOrNone() {
-      const selectedUsers = this.get('selectedUsers');
-      if (selectedUsers.length) {
-        selectedUsers.clear();
+      const selectedUsers = this.get('selectedUsers').get('length');
+      const filteredUsers = this.get('filteredUsers').get('length');
+
+      if (selectedUsers >= filteredUsers) {
+        this.get('selectedUsers').clear();
       } else {
-        const users = this.get('users');
-        selectedUsers.pushObjects(users);
+        const users = this.get('filteredUsers');
+        this.get('selectedUsers').pushObjects(users);
       }
+
+      this.setCheckAllState();
     },
   }
 });

--- a/app/components/learnergroup-user-manager.js
+++ b/app/components/learnergroup-user-manager.js
@@ -28,7 +28,7 @@ export default Component.extend({
   }),
   filter: '',
   filteredUsers: computed('filter', 'users.[]', function() {
-    let users = this.get('users');
+    let users = this.get('users')?this.get('users'):[];
     const filter = this.get('filter');
 
     if (isEmpty(filter)){

--- a/app/components/learnergroup-user-manager.js
+++ b/app/components/learnergroup-user-manager.js
@@ -9,6 +9,10 @@ export default Component.extend({
     this.set('usersBeingMoved', []);
     this.set('selectedUsers', []);
   },
+  didRender(){
+    this._super(...arguments);
+    this.setCheckAllState();
+  },
   learnerGroupId: null,
   learnerGroupTitle: null,
   cohortTitle: null,
@@ -87,6 +91,22 @@ export default Component.extend({
     yield this.get('removeUsersFromGroup')(users);
     this.get('usersBeingMoved').removeObjects(users);
   }),
+
+  setCheckAllState(){
+    const selectedUsers = this.get('selectedUsers').get('length');
+    const filteredUsers = this.get('filteredUsers').get('length');
+    let el = this.$('th:eq(0) input');
+    if (selectedUsers === 0) {
+      el.prop('indeterminate', false);
+      el.prop('checked', false);
+    } else if (selectedUsers < filteredUsers) {
+      el.prop('indeterminate', true);
+      el.prop('checked', false);
+    } else {
+      el.prop('indeterminate', false);
+      el.prop('checked', true);
+    }
+  },
   actions: {
     sortBy(what){
       const sortBy = this.get('sortBy');
@@ -103,13 +123,17 @@ export default Component.extend({
       }
     },
     toggleUserSelectionAllOrNone() {
-      const selectedUsers = this.get('selectedUsers');
-      if (selectedUsers.length) {
-        selectedUsers.clear();
+      const selectedUsers = this.get('selectedUsers').get('length');
+      const filteredUsers = this.get('filteredUsers').get('length');
+
+      if (selectedUsers >= filteredUsers) {
+        this.get('selectedUsers').clear();
       } else {
-        const users = this.get('users').mapBy('content');
-        selectedUsers.pushObjects(users);
+        const users = this.get('filteredUsers');
+        this.get('selectedUsers').pushObjects(users.mapBy('content'));
       }
+
+      this.setCheckAllState();
     },
   }
 });

--- a/app/templates/components/learnergroup-cohort-user-manager.hbs
+++ b/app/templates/components/learnergroup-cohort-user-manager.hbs
@@ -14,10 +14,7 @@
       <thead>
         <tr>
           <th class='text-left' colspan=1>
-            {{one-way-checkbox
-              update=(action 'toggleUserSelectionAllOrNone')
-              checked=(gt selectedUsers.length 0)
-            }}
+            <input type='checkbox' onclick={{action 'toggleUserSelectionAllOrNone'}} />
           </th>
           {{#sortable-th
             colspan=2
@@ -37,7 +34,7 @@
         </tr>
       </thead>
       <tbody>
-        {{#each (sort-by sortBy (await filteredUsers)) as |user|}}
+        {{#each (sort-by sortBy filteredUsers) as |user|}}
           <tr class="{{unless user.enabled 'disabled-user-account'}}">
             <td class='text-left' colspan=1>
               {{#if user.enabled}}

--- a/app/templates/components/learnergroup-user-manager.hbs
+++ b/app/templates/components/learnergroup-user-manager.hbs
@@ -18,10 +18,7 @@
           <tr>
             <th class='text-left' colspan=1>
               {{#if isEditing}}
-                {{one-way-checkbox
-                  update=(action 'toggleUserSelectionAllOrNone')
-                  checked=(gt selectedUsers.length 0)
-                }}
+                <input type='checkbox' onclick={{action 'toggleUserSelectionAllOrNone'}} />
               {{/if}}
             </th>
             {{#sortable-th

--- a/tests/integration/components/learnergroup-cohort-user-manager-test.js
+++ b/tests/integration/components/learnergroup-cohort-user-manager-test.js
@@ -161,7 +161,7 @@ test('checkall', function(assert) {
   assert.expect(5);
   const checkAllBox = 'thead tr:eq(0) th:eq(0) input[type=checkbox]';
   const user1CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
-  const user2CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
+  const user2CheckBox = 'tbody tr:eq(1) td:eq(0) input[type=checkbox]';
   const button = 'button.done';
 
   let user1 = Object.create({
@@ -194,4 +194,39 @@ test('checkall', function(assert) {
   assert.equal(this.$(button).text().trim(), 'Move 2 learners to this group');
   return wait(this.$(button).click());
 
+});
+
+test('checking one puts checkall box into indeterminate state', function(assert) {
+  assert.expect(4);
+  const checkAllBox = 'thead tr:eq(0) th:eq(0) input[type=checkbox]';
+  const user1CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
+  const user2CheckBox = 'tbody tr:eq(1) td:eq(0) input[type=checkbox]';
+
+  let user1 = Object.create({
+    enabled: true,
+  });
+  let user2 = Object.create({
+    enabled: true,
+  });
+
+  this.set('users', [user1, user2]);
+  this.on('nothing', parseInt);
+
+  this.render(hbs`{{learnergroup-cohort-user-manager
+    users=users
+    learnerGroupTitle='this group'
+    topLevelGroupTitle='top level group'
+    sortBy='firstName'
+    setSortBy=(action 'nothing')
+    addUserToGroup=(action 'nothing')
+    addUsersToGroup=(action 'nothing')
+  }}`);
+
+  this.$(user1CheckBox).click();
+  assert.ok(this.$(checkAllBox).prop('indeterminate'));
+  this.$(user2CheckBox).click();
+  assert.ok(this.$(checkAllBox).prop('checked'));
+  this.$(checkAllBox).click();
+  assert.notOk(this.$(user1CheckBox).prop('checked'));
+  assert.notOk(this.$(user2CheckBox).prop('checked'));
 });

--- a/tests/integration/components/learnergroup-user-manager-test.js
+++ b/tests/integration/components/learnergroup-user-manager-test.js
@@ -335,7 +335,7 @@ test('checkall', function(assert) {
   assert.expect(5);
   const checkAllBox = 'thead tr:eq(0) th:eq(0) input[type=checkbox]';
   const user1CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
-  const user2CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
+  const user2CheckBox = 'tbody tr:eq(1) td:eq(0) input[type=checkbox]';
   const button = 'button.done';
 
   let user1 = Object.create({
@@ -379,4 +379,50 @@ test('checkall', function(assert) {
   assert.equal(this.$(button).text().trim(), 'Move 2 learners to this group');
   return wait(this.$(button).click());
 
+});
+
+test('checking one puts checkall box into indeterminate state', function(assert) {
+  assert.expect(4);
+  const checkAllBox = 'thead tr:eq(0) th:eq(0) input[type=checkbox]';
+  const user1CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
+  const user2CheckBox = 'tbody tr:eq(1) td:eq(0) input[type=checkbox]';
+
+  let user1 = Object.create({
+    enabled: true,
+    lowestGroupInTree: Object.create({
+      id: 1
+    }),
+  });
+  let user2 = Object.create({
+    enabled: true,
+    lowestGroupInTree: Object.create({
+      id: 1
+    }),
+  });
+
+  this.set('users', [ObjectProxy.create({content: user1}), ObjectProxy.create({content: user2})]);
+  this.set('nothing', parseInt);
+
+  this.render(hbs`{{learnergroup-user-manager
+    learnerGroupId=1
+    learnerGroupTitle='this group'
+    topLevelGroupTitle='top group'
+    cohortTitle='this cohort'
+    users=users
+    sortBy='lastName'
+    setSortBy=(action nothing)
+    isEditing=true
+    addUserToGroup=(action nothing)
+    removeUserFromGroup=(action nothing)
+    addUsersToGroup=(action nothing)
+    removeUsersFromGroup=(action nothing)
+  }}`);
+
+  this.$(user1CheckBox).click();
+  assert.ok(this.$(checkAllBox).prop('indeterminate'));
+  this.$(user2CheckBox).click();
+  assert.ok(this.$(checkAllBox).prop('checked'));
+  this.$(checkAllBox).click();
+  assert.notOk(this.$(user1CheckBox).prop('checked'));
+  assert.notOk(this.$(user2CheckBox).prop('checked'));
 });


### PR DESCRIPTION
Presents a better UX for selecting all / none learner groups.

Fixes #1722