### PR TITLE
Prevent mistake when bulk editing learner groups

### DIFF
--- a/app/templates/components/learnergroup-cohort-user-manager.hbs
+++ b/app/templates/components/learnergroup-cohort-user-manager.hbs
@@ -58,12 +58,14 @@
                 {{#if (contains user usersBeingMoved)}}
                   {{fa-icon 'spinner' spin=true}}
                 {{else}}
-                  {{fa-icon
-                    'plus'
-                    class='yes clickable'
-                    title=(t 'learnerGroups.moveToGroup' groupTitle=learnerGroupTitle count=1)
-                    click=(perform addSingleUser user)
-                  }}
+                  {{#if (eq selectedUsers.length 0)}}
+                    {{fa-icon
+                      'plus'
+                      class='yes clickable'
+                      title=(t 'learnerGroups.moveToGroup' groupTitle=learnerGroupTitle count=1)
+                      click=(perform addSingleUser user)
+                    }}
+                  {{/if}}
                 {{/if}}
               {{/if}}
             </td>

--- a/app/templates/components/learnergroup-user-manager.hbs
+++ b/app/templates/components/learnergroup-user-manager.hbs
@@ -91,12 +91,14 @@
                   {{#if (contains user.content usersBeingMoved)}}
                     {{fa-icon 'spinner' spin=true}}
                   {{else if user.enabled}}
-                    {{fa-icon
-                      'minus'
-                      class='no clickable'
-                      title=(t 'learnerGroups.removeLearnerToCohort' cohort=cohortTitle count=1)
-                      click=(perform removeSingleUser user.content)
-                    }}
+                    {{#if (eq selectedUsers.length 0)}}
+                      {{fa-icon
+                        'minus'
+                        class='no clickable'
+                        title=(t 'learnerGroups.removeLearnerToCohort' cohort=cohortTitle count=1)
+                        click=(perform removeSingleUser user.content)
+                      }}
+                    {{/if}}
                   {{/if}}
                 </td>
               {{/if}}
@@ -145,12 +147,14 @@
                     {{#if (contains user.content usersBeingMoved)}}
                       {{fa-icon 'spinner' spin=true}}
                     {{else if user.enabled}}
-                      {{fa-icon
-                        'plus'
-                        class='yes clickable'
-                        title=(t 'learnerGroups.moveToGroup' groupTitle=learnerGroupTitle)
-                        click=(perform addSingleUser user.content)
-                      }}
+                      {{#if (eq selectedUsers.length 0)}}
+                        {{fa-icon
+                          'plus'
+                          class='yes clickable'
+                          title=(t 'learnerGroups.moveToGroup' groupTitle=learnerGroupTitle)
+                          click=(perform addSingleUser user.content)
+                        }}
+                      {{/if}}
                     {{/if}}
                   </td>
                 {{/if}}

--- a/tests/integration/components/learnergroup-cohort-user-manager-test.js
+++ b/tests/integration/components/learnergroup-cohort-user-manager-test.js
@@ -157,6 +157,33 @@ test('add single user', function(assert) {
 
 });
 
+test('when users are selected single action is disabled', function(assert) {
+  assert.expect(1);
+  const user1CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
+  const action = 'tbody tr:eq(0) td:eq(5) .clickable';
+
+  let user1 = Object.create({
+    enabled: true,
+  });
+
+  this.set('users', [user1]);
+  this.on('nothing', parseInt);
+
+  this.render(hbs`{{learnergroup-cohort-user-manager
+    users=users
+    learnerGroupTitle='this group'
+    topLevelGroupTitle='top level group'
+    sortBy='firstName'
+    setSortBy=(action 'nothing')
+    addUserToGroup=(action 'nothing')
+    addUsersToGroup=(action 'nothing')
+  }}`);
+
+  this.$(user1CheckBox).click();
+  assert.equal(this.$(action).length, 0);
+
+});
+
 test('checkall', function(assert) {
   assert.expect(5);
   const checkAllBox = 'thead tr:eq(0) th:eq(0) input[type=checkbox]';

--- a/tests/integration/components/learnergroup-user-manager-test.js
+++ b/tests/integration/components/learnergroup-user-manager-test.js
@@ -331,6 +331,50 @@ test('add single user', function(assert) {
 
 });
 
+test('when users are selected single action is disabled', function(assert) {
+  assert.expect(2);
+  const user1CheckBox = 'table:eq(1) tbody tr:eq(0) td:eq(0) input[type=checkbox]';
+  const action1 = 'table:eq(1) tbody tr:eq(0) td:eq(6) .clickable';
+  const action2 = 'table:eq(2) tbody tr:eq(0) td:eq(6) .clickable';
+
+  let user1 = Object.create({
+    enabled: true,
+    lowestGroupInTree: Object.create({
+      id: 1
+    }),
+  });
+
+  let user2 = Object.create({
+    enabled: true,
+    lowestGroupInTree: Object.create({
+      id: 2
+    }),
+  });
+
+  this.set('users', [ObjectProxy.create({content: user1}), ObjectProxy.create({content: user2})]);
+  this.set('nothing', parseInt);
+
+  this.render(hbs`{{learnergroup-user-manager
+    learnerGroupId=1
+    learnerGroupTitle='this group'
+    topLevelGroupTitle='top group'
+    cohortTitle='this cohort'
+    users=users
+    sortBy='lastName'
+    setSortBy=(action nothing)
+    isEditing=true
+    addUserToGroup=(action nothing)
+    removeUserFromGroup=(action nothing)
+    addUsersToGroup=(action nothing)
+    removeUsersFromGroup=(action nothing)
+  }}`);
+
+  this.$(user1CheckBox).click();
+  assert.equal(this.$(action1).length, 0);
+  assert.equal(this.$(action2).length, 0);
+
+});
+
 test('checkall', function(assert) {
   assert.expect(5);
   const checkAllBox = 'thead tr:eq(0) th:eq(0) input[type=checkbox]';


### PR DESCRIPTION
Once a user is bulk managing learner groups by choosing one of the checkboxes disabled the ability to move a single learner.

Fixes #1724