### PR TITLE
made language keys configurable.

### DIFF
--- a/app/components/publication-status.js
+++ b/app/components/publication-status.js
@@ -4,6 +4,10 @@ const { Component, computed } = Ember;
 const { alias } = computed;
 
 export default Component.extend({
+  publishedLangKey: 'general.published',
+  scheduledLangKey: 'general.scheduled',
+  notPublishedLangKey: 'general.notPublished',
+
   showIcon: true,
   tagName: 'span',
   classNameBindings: [

--- a/app/templates/components/publication-status.hbs
+++ b/app/templates/components/publication-status.hbs
@@ -11,11 +11,11 @@
 {{/if}}
 
 {{#if isScheduled}}
-  {{t 'general.scheduled'}}
+  {{t scheduledLangKey}}
 {{else}}
   {{#if isPublished}}
-    {{t 'general.published'}}
+    {{t publishedLangKey}}
   {{else}}
-    {{t 'general.notPublished'}}
+    {{t notPublishedLangKey}}
   {{/if}}
 {{/if}}


### PR DESCRIPTION
i'd like to reuse this component for the Curriculum Inventory UI.
there, the verbiage is slightly different, so i'd like to switch out the language keys.

![selection_012](https://cloud.githubusercontent.com/assets/1410427/15724369/9520f4fe-27fb-11e6-885f-cd50e6471ac0.png)
