### PR TITLE
Provide ability for user to generate a token

### DIFF
--- a/app/components/my-profile.js
+++ b/app/components/my-profile.js
@@ -1,9 +1,39 @@
 import Ember from 'ember';
+import moment from 'moment';
+import { task, timeout } from 'ember-concurrency';
+import { padStart } from 'ember-pad/utils/pad';
 
-const { computed, RSVP } = Ember;
+const { computed, RSVP, inject } = Ember;
 const { Promise } = RSVP;
+const { service } = inject;
+const { reads } = computed;
+
 
 export default Ember.Component.extend({
+  init(){
+    this._super(...arguments);
+    this.reset();
+  },
+  reset(){
+    let midnightToday = moment().hour(23).minute(59).second(59);
+    let twoWeeksFromNow = midnightToday.clone().add(2, 'weeks');
+    let oneYearFromNow = midnightToday.clone().add(1, 'year');
+    this.set('minDate', midnightToday.toDate());
+    this.set('maxDate', oneYearFromNow.toDate());
+    this.set('expiresAt', twoWeeksFromNow.toDate());
+    this.set('generatedJwt', null);
+  },
+  serverVariables: service(),
+  ajax: service(),
+  flashMessages: service(),
+
+  host: reads('serverVariables.apiHost'),
+  namespace: reads('serverVariables.apiNameSpace'),
+  expiresAt: null,
+  maxDate: null,
+  minDate: null,
+  generatedJwt: null,
+
   classNames: ['my-profile'],
   user: null,
   roles: computed('user.roles.[]', function(){
@@ -14,4 +44,39 @@ export default Ember.Component.extend({
       });
     })
   }),
+  apiDocsUrl: computed('host', 'namespace', function(){
+    let apiPath = '/' + this.get('namespace');
+    let host = this.get('host')?this.get('host'):window.location.protocol + '//' + window.location.host;
+    let docPath = host + apiPath.replace('v1', 'doc');
+
+    return docPath;
+  }),
+  createNewToken: task(function * (){
+    yield timeout(10); //small delay to allow rendering the spinner
+    let selection = this.get('expiresAt');
+    let expiresAt = moment(selection).hour(23).minute(59).second(59);
+    const now = moment();
+    const days = padStart(expiresAt.diff(now, 'days'), 2, '0');
+
+    const hours = padStart(moment().hours(23).diff(now, 'hours'), 2, '0');
+    const minutes = padStart(moment().minutes(59).diff(now, 'minutes'), 2, '0');
+    const seconds = padStart(moment().seconds(59).diff(now, 'seconds'), 2, '0');
+
+    let interval = `P${days}DT${hours}H${minutes}M${seconds}S`;
+
+    const ajax = this.get('ajax');
+    let url = '/auth/token?ttl=' + interval;
+    let data = yield ajax.request(url);
+
+    this.set('generatedJwt', data.jwt);
+  }),
+  actions: {
+    tokenCopied(){
+      const flashMessages = this.get('flashMessages');
+      flashMessages.success('general.copiedSuccessfully');
+    },
+    reset(){
+      this.reset();
+    }
+  }
 });

--- a/app/controllers/myprofile.js
+++ b/app/controllers/myprofile.js
@@ -4,7 +4,9 @@ const { Controller } = Ember;
 
 export default Controller.extend({
   queryParams: {
-    createNewToken: 'newtoken',
+    showCreateNewToken: 'newtoken',
+    showInvalidateTokens: 'invalidatetokens'
   },
-  createNewToken: false,
+  showCreateNewToken: false,
+  showInvalidateTokens: false,
 });

--- a/app/controllers/myprofile.js
+++ b/app/controllers/myprofile.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+const { Controller } = Ember;
+
+export default Controller.extend({
+  queryParams: {
+    createNewToken: 'newtoken',
+  },
+  createNewToken: false,
+});

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -138,6 +138,7 @@ export default {
     'schools': 'Schools',
     'universalLocator': 'Universal Locator',
     'removeAll': 'Remove All',
+    'copiedSuccessfully': 'Copied Successfully',
   },
   'programs': {
     'programTitle': 'Program Title',
@@ -466,6 +467,12 @@ export default {
     'username': 'Username',
     'password': 'Password',
     'myProfile': 'My Profile',
+    'manageAPITokens': 'Manage API Tokens',
+    'tokenInfo': 'API Tokens are used to programatically accesss Ilios data.  Your token is like a password - anyone who has it can make changes on your behlaf.  Read more in the documentation at <a href="{{apiDocsUrl}}">{{apiDocsUrl}}</a>',
+    'validUntil': 'When should this token stop working?',
+    'newToken': 'New Token',
+    'expireTokens': 'Expire All Tokens',
+    'expireTokensConfirmation': 'This will invalidate all existing API tokens and you will need to generate new ones for any applications you have.  Are you sure you want to do this?',
   },
   'language': {
     'select': {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -471,8 +471,9 @@ export default {
     'tokenInfo': 'API Tokens are used to programatically accesss Ilios data.  Your token is like a password - anyone who has it can make changes on your behlaf.  Read more in the documentation at <a href="{{apiDocsUrl}}">{{apiDocsUrl}}</a>',
     'validUntil': 'When should this token stop working?',
     'newToken': 'New Token',
-    'expireTokens': 'Expire All Tokens',
-    'expireTokensConfirmation': 'This will invalidate all existing API tokens and you will need to generate new ones for any applications you have.  Are you sure you want to do this?',
+    'invalidateTokens': 'Invalidate All Tokens',
+    'invalidateTokensConfirmation': 'This will invalidate all existing API tokens and you will need to generate new ones for any applications you have.  Are you sure you want to do this?',
+    'successfullyInvalidatedTokens': 'All existing tokens were successfully invalidated',
   },
   'language': {
     'select': {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -468,7 +468,7 @@ export default {
     'password': 'Password',
     'myProfile': 'My Profile',
     'manageAPITokens': 'Manage API Tokens',
-    'tokenInfo': 'API Tokens are used to programatically accesss Ilios data.  Your token is like a password - anyone who has it can make changes on your behlaf.  Read more in the documentation at <a href="{{apiDocsUrl}}">{{apiDocsUrl}}</a>',
+    'tokenInfo': 'API Tokens are used to programatically accesss Ilios data.  Your token is like a password - anyone who has it can make changes on your behalf.  Read more in the documentation at <a href="{{apiDocsUrl}}">{{apiDocsUrl}}</a>',
     'validUntil': 'When should this token stop working?',
     'newToken': 'New Token',
     'invalidateTokens': 'Invalidate All Tokens',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -468,7 +468,7 @@ export default {
     'password': 'Password',
     'myProfile': 'My Profile',
     'manageAPITokens': 'Manage API Tokens',
-    'tokenInfo': 'API Tokens are used to programmatically access Ilios data.  Your token is like a password - anyone who has it can make changes on your behalf.  Read more in the documentation at <a href="{{apiDocsUrl}}">{{apiDocsUrl}}</a>',
+    'tokenInfo': 'API Tokens are used to programmatically access Ilios data.  Your token is like a password - anyone who has it can make changes on your behalf.  Read more in the documentation at <a href="{{apiDocsUrl}}">{{apiDocsUrl}}</a>.',
     'validUntil': 'When should this token stop working?',
     'newToken': 'New Token',
     'invalidateTokens': 'Invalidate All Tokens',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -468,7 +468,7 @@ export default {
     'password': 'Password',
     'myProfile': 'My Profile',
     'manageAPITokens': 'Manage API Tokens',
-    'tokenInfo': 'API Tokens are used to programatically accesss Ilios data.  Your token is like a password - anyone who has it can make changes on your behalf.  Read more in the documentation at <a href="{{apiDocsUrl}}">{{apiDocsUrl}}</a>',
+    'tokenInfo': 'API Tokens are used to programmatically access Ilios data.  Your token is like a password - anyone who has it can make changes on your behalf.  Read more in the documentation at <a href="{{apiDocsUrl}}">{{apiDocsUrl}}</a>',
     'validUntil': 'When should this token stop working?',
     'newToken': 'New Token',
     'invalidateTokens': 'Invalidate All Tokens',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -468,7 +468,7 @@ export default {
     'password': 'Contraseña',
     'myProfile': 'Mi Perfil',
     'manageAPITokens': 'Maneje Tokens de la API',
-    'tokenInfo': 'Tokens de la API se utilizan para obtener acceso a datos de Ilios. Su símbolo (token) es como una contraseña. - cualquier persona que lo tiene puede hacer cambios en su nombre. Lea más en la documentación en <a href="{{apiDocsUrl}}">{{apiDocsUrl}}</a>',
+    'tokenInfo': 'Tokens de la API se utilizan para obtener acceso a datos de Ilios. Su símbolo (token) es como una contraseña. - cualquier persona que lo tiene puede hacer cambios en su nombre. Lea más en la documentación en <a href="{{apiDocsUrl}}">{{apiDocsUrl}}</a>.',
     'validUntil': '¿Cuándo debe este símbolo (token) deje de funcionar??',
     'newToken': 'Nuevo Símbolo (Token)',
     'invalidateTokens': 'Invalida Todos los Tokens',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -138,6 +138,7 @@ export default {
     'schools': 'Escuelas',
     'universalLocator': 'Localizador universal de',
     'removeAll': 'Quitar Todos',
+    'copiedSuccessfully': 'Copiado con Éxito',
   },
   'programs': {
     'programTitle': 'Titulo de Programa',
@@ -466,6 +467,13 @@ export default {
     'username': 'Nombre de Usuario',
     'password': 'Contraseña',
     'myProfile': 'Mi Perfil',
+    'manageAPITokens': 'Maneje Tokens de la API',
+    'tokenInfo': 'Tokens de la API se utilizan para obtener acceso a datos de Ilios. Su símbolo (token) es como una contraseña. - cualquier persona que lo tiene puede hacer cambios en su nombre. Lea más en la documentación en <a href="{{apiDocsUrl}}">{{apiDocsUrl}}</a>',
+    'validUntil': '¿Cuándo debe este símbolo (token) deje de funcionar??',
+    'newToken': 'Nuevo Símbolo (Token)',
+    'invalidateTokens': 'Invalida Todos los Tokens',
+    'invalidateTokensConfirmation': 'Esto invalidará todas los tokens de API existentes y ustedes tendrán que generar nuevos tokens para cualquier aplicación que tengan. ¿Está seguro que desea hacer esto?',
+    'successfullyInvalidatedTokens': 'Todas los tokens existentes fueron con éxito invalidadas',
   },
   'language': {
     'select': {

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -468,7 +468,7 @@ export default {
     'password': 'Mot de passe',
     'myProfile': 'Mon profil',
     'manageAPITokens': "Gérer des jetons de l’API",
-    'tokenInfo': "Jetons de l’API sont utilisés d’y accèder les données de Ilios.  Votre jeton comme un mot de passe: quiconque l’obtenu pouvent apporter des modifications en votre nom.  Lire plus dans les documentation à <a href=\"{{apiDocsUrl}}\">{{apiDocsUrl}}</a>",
+    'tokenInfo': "Jetons de l’API sont utilisés d’y accèder les données de Ilios.  Votre jeton comme un mot de passe: quiconque l’obtenu pouvent apporter des modifications en votre nom.  Lire plus dans les documentation à <a href=\"{{apiDocsUrl}}\">{{apiDocsUrl}}</a>.",
     'validUntil': "Quand ce jeton devrais arrêter de travailler?",
     'newToken': 'Nouveau jeton',
     'invalidateTokens': 'Invalider tous les jetons',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -138,6 +138,7 @@ export default {
     'schools': 'Écoles',
     'universalLocator': 'Localisateur universel',
     'removeAll': 'Supprimer Tous',
+    'copiedSuccessfully': 'Copied Successfully',
   },
   'programs': {
     'programTitle': "Titre de Diplôme",
@@ -466,6 +467,13 @@ export default {
     'username': 'Nom d’utilisateur',
     'password': 'Mot de passe',
     'myProfile': 'Mon profil',
+    'manageAPITokens': "Gérer des jetons de l’API",
+    'tokenInfo': "Jetons de l’API sont utilisés d’y accèder les données de Ilios.  Votre jeton comme un mot de passe: quiconque l’obtenu pouvent apporter des modifications en votre nom.  Lire plus dans les documentation à <a href=\"{{apiDocsUrl}}\">{{apiDocsUrl}}</a>",
+    'validUntil': "Quand ce jeton devrais arrêter de travailler?",
+    'newToken': 'Nouveau jeton',
+    'invalidateTokens': 'Invalider tous les jetons',
+    'invalidateTokensConfirmation': "Cette action va effacer tous les jetons de l’API. Vouz devrez générer nouveaux jetons pour toutes des vos applications.  Êtes vous sûr de vouloir le faire?",
+    'successfullyInvalidatedTokens': 'Tous les jetons existant ont été invalidés avec succès.',
   },
   'language': {
     'select': {

--- a/app/styles/newcomponents/my-profile.scss
+++ b/app/styles/newcomponents/my-profile.scss
@@ -1,3 +1,40 @@
 .my-profile {
   @include profile;
+
+  .token-maintenance {
+    @include shift(1);
+    @include span-columns(7);
+
+    border-top: 1px dotted $ilios-orange;
+    margin-top: 1em;
+    padding: 1em;
+
+    h2 {
+      margin: 0;
+      padding: 0;
+    }
+
+    label {
+      @include ilios-label;
+    }
+
+    .new-token-form {
+      input {
+        min-width: 0;
+        width: 7em;
+      }
+    }
+
+    .new-token-result {
+      h3 {
+        display: inline;
+        margin-right: .5em;
+      }
+
+      input {
+        height: 2em;
+        width: 15em;
+      }
+    }
+  }
 }

--- a/app/styles/newcomponents/my-profile.scss
+++ b/app/styles/newcomponents/my-profile.scss
@@ -6,10 +6,11 @@
     @include span-columns(7);
 
     border-top: 1px dotted $ilios-orange;
+    font-size: .8 * $base-font-size;
     margin-top: 1em;
     padding: 1em;
 
-    h2 {
+    h3 {
       margin: 0;
       padding: 0;
     }

--- a/app/templates/components/my-profile.hbs
+++ b/app/templates/components/my-profile.hbs
@@ -102,3 +102,36 @@
     </div>
   </section>
 </div>
+
+<section class='token-maintenance'>
+  <h2>{{t 'user.manageAPITokens'}}</h2>
+  <p>{{t 'user.tokenInfo' apiDocsUrl=apiDocsUrl}}</p>
+  {{#unless showCreateNewToken}}
+    <button class='new-token' onclick={{action toggleShowCreateNewToken}}>{{t 'general.createNew'}}</button>
+  {{else}}
+      {{#if generatedJwt}}
+        <div class='new-token-result'>
+          <h3>{{t 'user.newToken'}}:</h3>
+          <input readonly value={{generatedJwt}} />
+          {{#copy-button success='tokenCopied' clipboardText=generatedJwt}}
+            {{fa-icon 'copy'}}
+          {{/copy-button}}
+          <button class='bigcancel' {{action (pipe toggleShowCreateNewToken (action 'reset'))}}>{{fa-icon 'times'}}</button>
+        </div>
+      {{else}}
+        <div class='new-token-form'>
+          <label>{{t 'user.validUntil'}}</label>
+          {{pikaday-input size=10 value=expiresAt maxDate=maxDate minDate=minDate format='YYYY-MM-DD'}}
+          <button class='bigadd' {{action (perform createNewToken)}}>
+            {{#if createNewToken.isRunning}}
+              {{fa-icon 'spinner' spin=true}}
+            {{else}}
+              {{fa-icon 'check'}}
+            {{/if}}
+          </button>
+          <button class='bigcancel' {{action (pipe toggleShowCreateNewToken (action 'reset'))}}>{{fa-icon 'times'}}</button>
+        </div>
+      {{/if}}
+
+  {{/unless}}
+</section>

--- a/app/templates/components/my-profile.hbs
+++ b/app/templates/components/my-profile.hbs
@@ -106,9 +106,11 @@
 <section class='token-maintenance'>
   <h2>{{t 'user.manageAPITokens'}}</h2>
   <p>{{t 'user.tokenInfo' apiDocsUrl=apiDocsUrl}}</p>
-  {{#unless showCreateNewToken}}
+  {{#unless (or showInvalidateTokens showCreateNewToken)}}
     <button class='new-token' onclick={{action toggleShowCreateNewToken}}>{{t 'general.createNew'}}</button>
+    <button class='invalidate-tokens no' onclick={{action toggleShowInvalidateTokens}}>{{t 'user.invalidateTokens'}}</button>
   {{else}}
+    {{#if showCreateNewToken}}
       {{#if generatedJwt}}
         <div class='new-token-result'>
           <h3>{{t 'user.newToken'}}:</h3>
@@ -132,6 +134,20 @@
           <button class='bigcancel' {{action (pipe toggleShowCreateNewToken (action 'reset'))}}>{{fa-icon 'times'}}</button>
         </div>
       {{/if}}
-
+    {{/if}}
+    {{#if showInvalidateTokens}}
+      <div class='invalidate-tokens-form'>
+        <h3>{{t 'user.invalidateTokens'}}</h3>
+        <p>{{t 'user.invalidateTokensConfirmation'}}</p>
+        <button class='done text' {{action (perform invalidateTokens)}}>
+          {{#if invalidateTokens.isRunning}}
+            {{fa-icon 'spinner' spin=true}}
+          {{else}}
+            {{t 'general.yes'}}
+          {{/if}}
+        </button>
+        <button class='cancel text' {{action toggleShowInvalidateTokens}}>{{t 'general.cancel'}}</button>
+      </div>
+    {{/if}}
   {{/unless}}
 </section>

--- a/app/templates/components/my-profile.hbs
+++ b/app/templates/components/my-profile.hbs
@@ -104,11 +104,11 @@
 </div>
 
 <section class='token-maintenance'>
-  <h2>{{t 'user.manageAPITokens'}}</h2>
+  <h3>{{t 'user.manageAPITokens'}}</h3>
   <p>{{t 'user.tokenInfo' apiDocsUrl=apiDocsUrl}}</p>
   {{#unless (or showInvalidateTokens showCreateNewToken)}}
-    <button class='new-token' onclick={{action toggleShowCreateNewToken}}>{{t 'general.createNew'}}</button>
-    <button class='invalidate-tokens no' onclick={{action toggleShowInvalidateTokens}}>{{t 'user.invalidateTokens'}}</button>
+    <button class='new-token done text' onclick={{action toggleShowCreateNewToken}}>{{t 'general.createNew'}}</button>
+    <button class='invalidate-tokens cancel text' onclick={{action toggleShowInvalidateTokens}}>{{t 'user.invalidateTokens'}}</button>
   {{else}}
     {{#if showCreateNewToken}}
       {{#if generatedJwt}}

--- a/app/templates/myprofile.hbs
+++ b/app/templates/myprofile.hbs
@@ -1,1 +1,5 @@
-{{my-profile user=model}}
+{{my-profile
+  user=model
+  showCreateNewToken=createNewToken
+  toggleShowCreateNewToken=(toggle-action 'createNewToken' this)
+}}

--- a/app/templates/myprofile.hbs
+++ b/app/templates/myprofile.hbs
@@ -1,5 +1,7 @@
 {{my-profile
   user=model
-  showCreateNewToken=createNewToken
-  toggleShowCreateNewToken=(toggle-action 'createNewToken' this)
+  showCreateNewToken=showCreateNewToken
+  toggleShowCreateNewToken=(toggle-action 'showCreateNewToken' this)
+  showInvalidateTokens=showInvalidateTokens
+  toggleShowInvalidateTokens=(toggle-action 'showInvalidateTokens' this)
 }}

--- a/tests/unit/controllers/myprofile-test.js
+++ b/tests/unit/controllers/myprofile-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:myprofile', 'Unit | Controller | myprofile', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});


### PR DESCRIPTION
Allows users to create their own API tokens which can expire up to one
year from now.

Fixes #1746 

Needs:
- [x] token expiration
- [x] translations
- [x] fix spelling of behalf in tokenInfo