### PR TITLE
Course Rollover

### DIFF
--- a/app/components/course-rollover.js
+++ b/app/components/course-rollover.js
@@ -1,0 +1,71 @@
+import Ember from 'ember';
+import moment from 'moment';
+import { task, timeout } from 'ember-concurrency';
+
+const { Component, inject, computed, isEmpty } = Ember;
+const { service } = inject;
+const { reads } = computed;
+
+export default Component.extend({
+  ajax: service(),
+  store: service(),
+  flashMessages: service(),
+  serverVariables: service(),
+  didReceiveAttrs(){
+    this._super(...arguments);
+    this.get('loadUnavailableYears').perform();
+    let thisYear = parseInt(moment().format('YYYY'));
+    let years = [];
+    for (let i = 0; i < 10; i++) {
+      years.push(thisYear + i);
+    }
+    this.set('years', years);
+    this.set('selectedYear', thisYear);
+  },
+  host: reads('serverVariables.apiHost'),
+  namespace: reads('serverVariables.apiNameSpace'),
+  classNames: ['course-rollover'],
+  years: [],
+  selectedYear: null,
+  course: null,
+  expandAdvancedOptions: false,
+
+  save: task(function * (){
+    yield timeout(10);
+    const ajax = this.get('ajax');
+    const courseId = this.get('course.id');
+    const selectedYear = this.get('selectedYear');
+
+    if (isEmpty(selectedYear)) {
+      throw new Error("no year selected");
+    }
+    const host = this.get('host')?this.get('host'):'/';
+    const namespace = this.get('namespace');
+
+    let url = host + namespace + `/courses/${courseId}/rollover`;
+    const newCoursesObj = yield ajax.request(url, {
+      method: 'POST',
+      data: {
+        year: selectedYear
+      }
+    });
+
+    const flashMessages = this.get('flashMessages');
+    const store = this.get('store');
+    flashMessages.success('courses.rolloverSuccess');
+    store.pushPayload(newCoursesObj);
+    let newCourse = store.peekRecord('course', newCoursesObj.courses[0].id);
+
+    return this.get('visit')(newCourse);
+  }).drop(),
+
+  loadUnavailableYears: task(function * (){
+    const course = this.get('course');
+    const store = this.get('store');
+    let existingCoursesWithTitle = yield store.query('course', {
+      filters: {title: course.get('title')}
+    });
+
+    return existingCoursesWithTitle.mapBy('year');
+  }).drop(),
+});

--- a/app/components/course-rollover.js
+++ b/app/components/course-rollover.js
@@ -31,6 +31,7 @@ export default Component.extend({
   course: null,
   expandAdvancedOptions: false,
   startDate: null,
+  skipOfferings: false,
 
   save: task(function * (){
     yield timeout(10);
@@ -39,9 +40,11 @@ export default Component.extend({
     const expandAdvancedOptions = this.get('expandAdvancedOptions');
     const selectedYear = this.get('selectedYear');
     let newStartDate = null;
+    let skipOfferings = false;
 
     if (expandAdvancedOptions) {
       newStartDate = moment(this.get('startDate')).format('YYYY-MM-DD');
+      skipOfferings = this.get('skipOfferings');
     }
     const host = this.get('host')?this.get('host'):'/';
     const namespace = this.get('namespace');
@@ -51,7 +54,8 @@ export default Component.extend({
       method: 'POST',
       data: {
         year: selectedYear,
-        newStartDate
+        newStartDate,
+        skipOfferings,
       }
     });
 

--- a/app/components/course-rollover.js
+++ b/app/components/course-rollover.js
@@ -16,7 +16,7 @@ export default Component.extend({
     this.get('loadUnavailableYears').perform();
     let thisYear = parseInt(moment().format('YYYY'));
     let years = [];
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 5; i++) {
       years.push(thisYear + i);
     }
     this.set('years', years);

--- a/app/components/course-rollover.js
+++ b/app/components/course-rollover.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import moment from 'moment';
 import { task, timeout } from 'ember-concurrency';
 
-const { Component, inject, computed, isEmpty } = Ember;
+const { Component, inject, computed, isPresent } = Ember;
 const { service } = inject;
 const { reads } = computed;
 
@@ -20,7 +20,8 @@ export default Component.extend({
       years.push(thisYear + i);
     }
     this.set('years', years);
-    this.set('selectedYear', thisYear);
+
+    this.get('changeSelectedYear').perform(thisYear);
   },
   host: reads('serverVariables.apiHost'),
   namespace: reads('serverVariables.apiNameSpace'),
@@ -29,15 +30,18 @@ export default Component.extend({
   selectedYear: null,
   course: null,
   expandAdvancedOptions: false,
+  startDate: null,
 
   save: task(function * (){
     yield timeout(10);
     const ajax = this.get('ajax');
     const courseId = this.get('course.id');
+    const expandAdvancedOptions = this.get('expandAdvancedOptions');
     const selectedYear = this.get('selectedYear');
+    let newStartDate = null;
 
-    if (isEmpty(selectedYear)) {
-      throw new Error("no year selected");
+    if (expandAdvancedOptions) {
+      newStartDate = moment(this.get('startDate')).format('YYYY-MM-DD');
     }
     const host = this.get('host')?this.get('host'):'/';
     const namespace = this.get('namespace');
@@ -46,7 +50,8 @@ export default Component.extend({
     const newCoursesObj = yield ajax.request(url, {
       method: 'POST',
       data: {
-        year: selectedYear
+        year: selectedYear,
+        newStartDate
       }
     });
 
@@ -68,4 +73,34 @@ export default Component.extend({
 
     return existingCoursesWithTitle.mapBy('year');
   }).drop(),
+
+  changeSelectedYear: task(function * (selectedYear){
+    this.setProperties({selectedYear});
+    yield timeout(100); //let max/min cp's recalculate
+
+    const date = moment(this.get('course.startDate'));
+    const day = date.day();
+    const week = date.isoWeek();
+
+    let startDate = moment().year(selectedYear).isoWeek(week).day(day).toDate();
+    this.setProperties({startDate});
+  }).restartable(),
+
+  minDate: computed('selectedYear', function(){
+    const selectedYear = this.get('selectedYear');
+    let today = moment();
+    if (isPresent(selectedYear)) {
+      today.year(selectedYear);
+    }
+    return today.dayOfYear(1).toDate();
+  }),
+
+  maxDate: computed('selectedYear', function(){
+    const selectedYear = this.get('selectedYear');
+    let today = moment();
+    if (isPresent(selectedYear)) {
+      today.year(selectedYear+1);
+    }
+    return today.dayOfYear(365).toDate();
+  }),
 });

--- a/app/controllers/course/rollover.js
+++ b/app/controllers/course/rollover.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+const { Controller } = Ember;
+
+export default Controller.extend({
+  actions: {
+    loadCourse(newCourse){
+      this.transitionToRoute('course', newCourse);
+    }
+  }
+});

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -330,7 +330,8 @@ export default {
     'noPrintDraft': 'Courses which are in draft status cannot be printed',
     'rollover': 'Rollover Course',
     'rolloverSuccess': 'Rollover Completed Successfully',
-    'rolloverYearUnavailable': 'Course Already Exists'
+    'rolloverYearUnavailable': 'Course Already Exists',
+    'rolloverSummary': 'You are about to roll over this course into the selected academic year, along with all selected options. To continue, click “done”. To return to your current course, click “cancel”',
   },
   'sessions': {
     'specialAttireRequired': 'Special Attire Required',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -145,6 +145,7 @@ export default {
     'copiedSuccessfully': 'Copied Successfully',
     'unsupportedBrowserFailure': 'Your browser is not officially supported by Ilios and cannot complete this action. Please try again using an up-to-date browser.',
     'viewAll': 'View All',
+    'advancedOptions': 'Advanced Options',
   },
   'programs': {
     'programTitle': 'Program Title',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -326,6 +326,9 @@ export default {
     'confirmObjectiveRemoval': 'Are you sure you want to delete this objective?',
     'confirmSessionRemoval': 'Are you sure you want to delete this session?',
     'noPrintDraft': 'Courses which are in draft status cannot be printed',
+    'rollover': 'Rollover Course',
+    'rolloverSuccess': 'Rollover Completed Successfully',
+    'rolloverYearUnavailable': 'Course Already Exists'
   },
   'sessions': {
     'specialAttireRequired': 'Special Attire Required',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -146,6 +146,7 @@ export default {
     'unsupportedBrowserFailure': 'Your browser is not officially supported by Ilios and cannot complete this action. Please try again using an up-to-date browser.',
     'viewAll': 'View All',
     'advancedOptions': 'Advanced Options',
+    'include': 'Include',
   },
   'programs': {
     'programTitle': 'Program Title',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -145,6 +145,8 @@ export default {
     'copiedSuccessfully': 'Copiado con Éxito',
     'unsupportedBrowserFailure': 'Su navegador no está soportado oficialmente por Ilios y no puede completar esta acción.  Por favor inténtalo de nuevo utilizando un navegador actualizado.',
     'viewAll': 'View All',
+    'advancedOptions': 'Opciones Avanzadas',
+    'include': 'Incluir',
   },
   'programs': {
     'programTitle': 'Titulo de Programa',
@@ -326,6 +328,10 @@ export default {
     'confirmObjectiveRemoval': "¿Está seguro que desea eliminar este objetivo?",
     'confirmSessionRemoval': "¿Está seguro que desea eliminar este sessión?",
     'noPrintDraft': 'Cursos que se encuentran en estado borrador no se puede imprimir',
+    'rollover': 'Copiar Curso',
+    'rolloverSuccess': 'Curso Copiado con Éxito',
+    'rolloverYearUnavailable': 'El Curso Ya Existe',
+    'rolloverSummary': 'Va a rodar este curso en el seleccionado año académico, junto con todas las opciones seleccionadas.. Para continuar, haga clic en "done". Para volver a su curso corriente, haga clic en "cancel"',
   },
   'sessions': {
     'specialAttireRequired': 'Vestimenta Especial Requerido',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -145,6 +145,8 @@ export default {
     'copiedSuccessfully': 'Copied Successfully',
     'unsupportedBrowserFailure': "Votre navigateur n'est pas officiellement soutenu par Ilios et ne peut pas compléter cette action. Essayez S'il vous plaît d'utiliser de nouveau un navigateur à jour.",
     'viewAll': 'Voir Tous',
+    'advancedOptions': 'Options avancées',
+    'include': 'Inclure',
   },
   'programs': {
     'programTitle': "Titre de Diplôme",
@@ -326,6 +328,9 @@ export default {
     'confirmObjectiveRemoval': "Êtes vous sûr de vouloir supprimer cet objectif?",
     'confirmSessionRemoval': "Êtes vous sûr de vouloir supprimer cette séance?",
     'noPrintDraft': "Cours qui sont au stade de projet ne peuvent pas étre imprimés",
+    'rollover': 'Roulement Cours',
+    'rolloverSuccess': 'Roulement achevée avec succès',
+    'rolloverYearUnavailable': 'Cours déja existant',
   },
   'sessions': {
     'specialAttireRequired': "Vêtements particuliers requis",

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -331,6 +331,7 @@ export default {
     'rollover': 'Roulement Cours',
     'rolloverSuccess': 'Roulement achevée avec succès',
     'rolloverYearUnavailable': 'Cours déja existant',
+    'rolloverSummary': "Vous êtes sur le point le roulement ce cours dans l'année universitaire choisie, avec toutes les options choisies. Continuer, cliquer \"done\". Pour retourner à votre cours actuel, le clic \"annul\"",
   },
   'sessions': {
     'specialAttireRequired': "Vêtements particuliers requis",

--- a/app/router.js
+++ b/app/router.js
@@ -16,6 +16,7 @@ Router.map(function() {
   }, function(){
     this.route('publicationCheck', { path: '/publicationcheck'});
     this.route('publishall', { path: '/publishall'});
+    this.route('rollover', { path: '/rollover'});
     this.route("session", {
       path: '/sessions/:session_id',
       resetNamespace: true
@@ -57,6 +58,7 @@ Router.map(function() {
   this.route('school', { path: 'schools/:school_id'});
   this.route('assign-students', {path: '/admin/assignstudents'});
   this.route('myprofile');
+  this.route('course-rollover');
 });
 
 export default Router;

--- a/app/styles/newcomponents.scss
+++ b/app/styles/newcomponents.scss
@@ -26,3 +26,4 @@
 @import 'newcomponents/programs-list';
 @import 'newcomponents/bulk-new-users';
 @import 'newcomponents/admin-dashboard';
+@import 'newcomponents/course-rollover';

--- a/app/styles/newcomponents/course-overview.scss
+++ b/app/styles/newcomponents/course-overview.scss
@@ -7,10 +7,25 @@
 
   .title {
     @include ilios-overview-title;
+    @include span-columns(5 of 12);
   }
 
-  .print {
+  .course-overview-actions {
     @include ilios-overview-actions;
+    @include span-columns(6 of 12);
+    @include shift(1);
+    @include omega;
+    text-align: right;
+
+    a {
+      color: $header-blue;
+      font-size: 1.2 * $base-font-size;
+      margin-right: .5em;
+
+      &.print {
+        margin-right: 1em;
+      }
+    }
   }
 
   .block {

--- a/app/styles/newcomponents/course-rollover.scss
+++ b/app/styles/newcomponents/course-rollover.scss
@@ -20,4 +20,22 @@
       @include ilios-form-buttons;
     }
   }
+
+  .advanced-options {
+    @include fill-parent;
+    clear: both;
+
+    .title {
+      @include fill-parent;
+      cursor: pointer;
+
+      &.collapsed::after {
+        content: ' \25BA';
+      }
+
+      &.expanded::after {
+        content: ' \25BC';
+      }
+    }
+  }
 }

--- a/app/styles/newcomponents/course-rollover.scss
+++ b/app/styles/newcomponents/course-rollover.scss
@@ -21,6 +21,15 @@
     }
   }
 
+  .rollover-summary {
+    font-weight: 400;
+    margin: 0 1em 2em;
+
+    @include media($large-screen) {
+      padding: .5em 6em 0 4em;
+    }
+  }
+
   .advanced-options-title {
     @include fill-parent;
     clear: both;

--- a/app/styles/newcomponents/course-rollover.scss
+++ b/app/styles/newcomponents/course-rollover.scss
@@ -21,20 +21,42 @@
     }
   }
 
+  .advanced-options-title {
+    @include fill-parent;
+    cursor: pointer;
+
+    &.collapsed::after {
+      content: ' \25BA';
+    }
+
+    &.expanded::after {
+      content: ' \25BC';
+    }
+  }
+
   .advanced-options {
     @include fill-parent;
     clear: both;
+    padding-left: 1em;
+  }
+
+  .included {
 
     .title {
       @include fill-parent;
-      cursor: pointer;
+      display: block;
+      font-weight: bold;
+      margin-bottom: .5em;
+    }
 
-      &.collapsed::after {
-        content: ' \25BA';
-      }
+    .include {
+      line-height: 1em;
+      margin-left: 1em;
 
-      &.expanded::after {
-        content: ' \25BC';
+      input {
+        display: inline;
+        margin: 0;
+        width: 1em;
       }
     }
   }

--- a/app/styles/newcomponents/course-rollover.scss
+++ b/app/styles/newcomponents/course-rollover.scss
@@ -23,7 +23,9 @@
 
   .advanced-options-title {
     @include fill-parent;
+    clear: both;
     cursor: pointer;
+    display: block;
 
     &.collapsed::after {
       content: ' \25BA';

--- a/app/styles/newcomponents/course-rollover.scss
+++ b/app/styles/newcomponents/course-rollover.scss
@@ -1,0 +1,23 @@
+.course-rollover {
+  h3 {
+    @include ilios-heading-h3;
+    margin-bottom: 1em;
+  }
+
+  .rollover-form {
+    @include ilios-form;
+    @include fill-parent;
+    border: 1px solid $ilios-blue;
+    display: block;
+    margin-top: 1em;
+    padding: 1em;
+
+    .item {
+      @include ilios-form-item;
+    }
+
+    .buttons {
+      @include ilios-form-buttons;
+    }
+  }
+}

--- a/app/templates/components/course-overview.hbs
+++ b/app/templates/components/course-overview.hbs
@@ -1,10 +1,15 @@
 <div class='title'>
   {{t 'general.overview'}}
 </div>
-<div class='print'>
-  {{#link-to 'printCourse' course (query-params unpublished=true)}}
-    <button>{{t 'general.printSummary'}}</button>
+<div class='course-overview-actions'>
+  {{#link-to 'printCourse' course (query-params unpublished=true) class='print'}}
+    {{fa-icon 'print' title=(t 'general.printSummary') fixedWidth=true}}
   {{/link-to}}
+  {{#if (and (is-fulfilled showRollover) (await showRollover))}}
+    {{#link-to 'course.rollover' course class='rollover'}}
+      {{fa-icon 'random' title=(t 'courses.rollover') fixedWidth=true}}
+    {{/link-to}}
+  {{/if}}
 </div>
 <div class='course-overview-content'>
   <div class="block courseexternalid">
@@ -118,4 +123,5 @@
       <span>{{fa-icon 'spinner' spin=true}}</span>
     {{/unless}}
   </div>
+
 </div>

--- a/app/templates/components/course-rollover.hbs
+++ b/app/templates/components/course-rollover.hbs
@@ -3,6 +3,9 @@
 
 <div class='rollover-form'>
   <h3 class="title">{{t 'courses.rollover'}}</h3>
+
+  <p class='rollover-summary'>{{t 'courses.rolloverSummary'}}</p>
+
   <div class='item'>
     <label>{{t "general.year"}}:</label>
     {{#if loadAvailableYears.isRunning}}

--- a/app/templates/components/course-rollover.hbs
+++ b/app/templates/components/course-rollover.hbs
@@ -1,0 +1,37 @@
+{{#link-to 'course' course}}{{t 'general.backToTitle' title=course.title}}{{/link-to}}
+
+
+<div class='rollover-form'>
+  <h3 class="title">{{t 'courses.rollover'}}</h3>
+  <div class='item'>
+    <label>{{t "general.year"}}:</label>
+    {{#if loadAvailableYears.isRunning}}
+      {{fa-icon 'spinner' spin=true}}
+    {{else}}
+      <select onchange={{action (mut selectedYear) value="target.value"}}>
+        {{#each years as |year|}}
+          <option disabled={{contains year loadUnavailableYears.lastSuccessful.value}} value={{year}} selected={{is-equal year selectedYear}}>
+            {{year}} - {{inc year}}
+            {{#if (contains year loadUnavailableYears.lastSuccessful.value)}}
+              ({{t 'courses.rolloverYearUnavailable'}})
+            {{/if}}
+          </option>
+        {{/each}}
+      </select>
+    {{/if}}
+
+  </div>
+
+  <div class='buttons'>
+    <button disabled={{if (or save.isRunning (not selectedYear) (contains selectedYear loadUnavailableYears.lastSuccessful.value)) true}} class='done text' {{action (perform save)}}>
+      {{#if save.isRunning}}
+        {{fa-icon 'spinner' spin=true}}
+      {{else}}
+        {{t 'general.done'}}
+      {{/if}}
+    </button>
+    {{#link-to 'course' course}}
+      <button class='cancel text'>{{t 'general.cancel'}}</button>
+    {{/link-to}}
+  </div>
+</div>

--- a/app/templates/components/course-rollover.hbs
+++ b/app/templates/components/course-rollover.hbs
@@ -8,7 +8,7 @@
     {{#if loadAvailableYears.isRunning}}
       {{fa-icon 'spinner' spin=true}}
     {{else}}
-      <select onchange={{action (mut selectedYear) value="target.value"}}>
+      <select onchange={{action (perform changeSelectedYear) value="target.value"}}>
         {{#each years as |year|}}
           <option disabled={{contains year loadUnavailableYears.lastSuccessful.value}} value={{year}} selected={{is-equal year selectedYear}}>
             {{year}} - {{inc year}}
@@ -20,6 +20,16 @@
       </select>
     {{/if}}
 
+  </div>
+
+  <div class='advanced-options'>
+    <span onclick={{toggle-action 'expandAdvancedOptions' this}} class="title {{if expandAdvancedOptions 'expanded' 'collapsed'}}">{{t 'general.advancedOptions'}}</span>
+    {{#liquid-if expandAdvancedOptions class='vertical'}}
+      <div class='item'>
+        <label>{{t "general.startDate"}}:</label>
+        {{pikaday-input size=10 value=startDate maxDate=maxDate minDate=minDate format='YYYY-MM-DD'}}
+      </div>
+    {{/liquid-if}}
   </div>
 
   <div class='buttons'>

--- a/app/templates/components/course-rollover.hbs
+++ b/app/templates/components/course-rollover.hbs
@@ -22,12 +22,23 @@
 
   </div>
 
+  <span onclick={{toggle-action 'expandAdvancedOptions' this}} class="advanced-options-title {{if expandAdvancedOptions 'expanded' 'collapsed'}}">{{t 'general.advancedOptions'}}</span>
   <div class='advanced-options'>
-    <span onclick={{toggle-action 'expandAdvancedOptions' this}} class="title {{if expandAdvancedOptions 'expanded' 'collapsed'}}">{{t 'general.advancedOptions'}}</span>
     {{#liquid-if expandAdvancedOptions class='vertical'}}
       <div class='item'>
         <label>{{t "general.startDate"}}:</label>
         {{pikaday-input size=10 value=startDate maxDate=maxDate minDate=minDate format='YYYY-MM-DD'}}
+      </div>
+
+      <div class='included'>
+        <span class='title'>{{t 'general.include'}}:</span>
+        <div class='include'>
+          {{one-way-checkbox
+            checked=(not skipOfferings)
+            update=(toggle 'skipOfferings' this)
+          }}
+          <span>{{t 'general.offerings'}}</span>
+        </div>
       </div>
     {{/liquid-if}}
   </div>

--- a/app/templates/course/rollover.hbs
+++ b/app/templates/course/rollover.hbs
@@ -1,0 +1,1 @@
+{{course-rollover course=model visit=(action 'loadCourse')}}

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -28,7 +28,12 @@ module('Acceptance: Course - Overview' + testgroup, {
 
 test('check fields', function(assert) {
   server.create('user', {
-    id: 4136
+    id: 4136,
+    roles: [1],
+  });
+  server.create('userRole', {
+    users: [4136],
+    title: 'course director'
   });
   server.create('user', {
     directedCourses: [1],
@@ -60,6 +65,7 @@ test('check fields', function(assert) {
     assert.equal(getElementText(find('.universallocator', container)), 'ILIOS' + course.id);
     assert.equal(getElementText(find('.clerkshiptype', container)), getText('Clerkship Type:' + clerkshipType.title));
     assert.equal(getElementText(find('.coursedirectors', container)), getText('Directors: A M. Director'));
+    assert.ok(find('a.rollover', container).prop('href').search(/courses\/1\/rollover/) > -1);
 
   });
 });
@@ -488,5 +494,119 @@ test('search twice and list should be correct', function(assert) {
         });
       });
     });
+  });
+});
+
+test('click rollover', function(assert) {
+  server.create('user', {
+    id: 4136,
+    roles: [1],
+  });
+  server.create('userRole', {
+    users: [4136],
+    title: 'course director'
+  });
+  server.create('course', {
+    year: 2013,
+    school: 1,
+  });
+  const rollover = '.course-overview a.rollover';
+  visit(url);
+  click(rollover);
+
+  andThen(function() {
+    assert.equal(currentPath(), 'course.rollover');
+  });
+});
+
+test('rollover hidden from instructors', function(assert) {
+  server.create('user', {
+    id: 4136,
+    roles: [1],
+  });
+  server.create('userRole', {
+    users: [4136],
+    title: 'instructor'
+  });
+  server.create('course', {
+    year: 2013,
+    school: 1,
+  });
+  visit(url);
+  const container = '.course-overview';
+  const rollover = `${container} a.rollover`;
+
+  andThen(function() {
+    assert.equal(currentPath(), 'course.index');
+    assert.equal(find(rollover).length, 0)
+  });
+});
+
+test('rollover visible to developers', function(assert) {
+  server.create('user', {
+    id: 4136,
+    roles: [1],
+  });
+  server.create('userRole', {
+    users: [4136],
+    title: 'developer'
+  });
+  server.create('course', {
+    year: 2013,
+    school: 1,
+  });
+  visit(url);
+  const container = '.course-overview';
+  const rollover = `${container} a.rollover`;
+
+  andThen(function() {
+    assert.equal(currentPath(), 'course.index');
+    assert.equal(find(rollover).length, 1)
+  });
+});
+
+test('rollover visible to course directors', function(assert) {
+  server.create('user', {
+    id: 4136,
+    roles: [1],
+  });
+  server.create('userRole', {
+    users: [4136],
+    title: 'course director'
+  });
+  server.create('course', {
+    year: 2013,
+    school: 1,
+  });
+  visit(url);
+  const container = '.course-overview';
+  const rollover = `${container} a.rollover`;
+
+  andThen(function() {
+    assert.equal(currentPath(), 'course.index');
+    assert.equal(find(rollover).length, 1)
+  });
+});
+
+test('rollover hidden on rollover route', function(assert) {
+  server.create('user', {
+    id: 4136,
+    roles: [1],
+  });
+  server.create('userRole', {
+    users: [4136],
+    title: 'course director'
+  });
+  server.create('course', {
+    year: 2013,
+    school: 1,
+  });
+  visit(`${url}/rollover`);
+  const container = '.course-overview';
+  const rollover = `${container} a.rollover`;
+
+  andThen(function() {
+    assert.equal(currentPath(), 'course.rollover');
+    assert.equal(find(rollover).length, 0)
   });
 });

--- a/tests/integration/components/course-rollover-test.js
+++ b/tests/integration/components/course-rollover-test.js
@@ -29,7 +29,7 @@ test('it renders', function(assert) {
 
   let thisYear = parseInt(moment().format('YYYY'));
 
-  for (let i=0; i<6; i++){
+  for (let i=0; i<5; i++){
     assert.equal(this.$(`select:eq(0) option:eq(${i})`).text().trim(), `${thisYear + i} - ${thisYear + 1 + i}`);
   }
 });
@@ -139,11 +139,6 @@ test('disable years when title already exists', function(assert) {
   assert.ok(options.eq(2).prop('disabled'));
   assert.notOk(options.eq(3).prop('disabled'));
   assert.notOk(options.eq(4).prop('disabled'));
-  assert.notOk(options.eq(5).prop('disabled'));
-  assert.notOk(options.eq(6).prop('disabled'));
-  assert.notOk(options.eq(7).prop('disabled'));
-  assert.notOk(options.eq(8).prop('disabled'));
-  assert.notOk(options.eq(9).prop('disabled'));
 });
 
 test('rollover course with new start date', function(assert) {

--- a/tests/integration/components/course-rollover-test.js
+++ b/tests/integration/components/course-rollover-test.js
@@ -97,6 +97,8 @@ test('rollover course', function(assert) {
   });
   this.render(hbs`{{course-rollover course=course visit=(action visit)}}`);
   this.$('.done').click();
+
+  return wait();
 });
 
 test('disable years when title already exists', function(assert) {

--- a/tests/integration/components/course-rollover-test.js
+++ b/tests/integration/components/course-rollover-test.js
@@ -1,0 +1,137 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
+import Ember from 'ember';
+
+const { Service, RSVP, Object } = Ember;
+const { resolve } = RSVP;
+
+moduleForComponent('course-rollover', 'Integration | Component | course rollover', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  let storeMock = Service.extend({
+    query(){
+      return [];
+    }
+  });
+  this.register('service:store', storeMock);
+
+  let course = Object.create({
+    id: 1
+  });
+  this.set('course', course);
+
+  this.render(hbs`{{course-rollover course=course}}`);
+
+  let thisYear = parseInt(moment().format('YYYY'));
+
+  for (let i=0; i<6; i++){
+    assert.equal(this.$(`select:eq(0) option:eq(${i})`).text().trim(), `${thisYear + i} - ${thisYear + 1 + i}`);
+  }
+});
+
+test('rollover course', function(assert) {
+  assert.expect(10);
+  let ajaxMock = Service.extend({
+    request(url, {method, data}){
+      let thisYear = parseInt(moment().format('YYYY'));
+      assert.equal(url.trim(), '/api/courses/1/rollover');
+      assert.equal(method, 'POST');
+      assert.equal(data.year, thisYear);
+
+      return resolve({
+        courses: [
+          {
+            id: 14
+          }
+        ]
+      });
+    }
+  });
+  this.register('service:ajax', ajaxMock);
+
+  let storeMock = Service.extend({
+    pushPayload(obj){
+      assert.ok('courses' in obj);
+      assert.ok(obj.courses.length, 1);
+      assert.equal(obj.courses[0].id, 14);
+    },
+    peekRecord(what, id){
+      assert.equal(what, 'course');
+      assert.equal(id, 14);
+
+      return Object.create({
+        id: 14
+      });
+    },
+    query(){
+      return [];
+    }
+  });
+  this.register('service:store', storeMock);
+  let flashmessagesMock = Ember.Service.extend({
+    success(message){
+      assert.equal(message, 'courses.rolloverSuccess');
+    }
+  });
+  this.register('service:flashMessages', flashmessagesMock);
+
+  let course = Object.create({
+    id: 1
+  });
+  this.set('course', course);
+  this.set('visit', (newCourse) => {
+    assert.equal(newCourse.id, 14);
+  });
+  this.render(hbs`{{course-rollover course=course visit=(action visit)}}`);
+  this.$('.done').click();
+});
+
+
+
+test('disable years when title already exists', function(assert) {
+  assert.expect(13);
+  const thisYear = parseInt(moment().format('YYYY'));
+
+  let storeMock = Service.extend({
+    query(what, {filters}){
+      assert.equal(what, 'course');
+      assert.ok('title' in filters);
+      assert.equal(filters.title, 'to be rolled');
+
+      return [
+        {
+          id: 2,
+          year: thisYear
+        },
+        {
+          id: 3,
+          year: thisYear+2
+        },
+      ];
+    }
+  });
+  this.register('service:store', storeMock);
+
+  let course = Object.create({
+    id: 1,
+    title: 'to be rolled',
+  });
+  this.set('course', course);
+  this.set('nothing', parseInt);
+  this.render(hbs`{{course-rollover course=course visit=(action nothing)}}`);
+
+  let options = this.$('select:eq(0) option');
+  assert.ok(options.eq(0).prop('disabled'));
+  assert.notOk(options.eq(1).prop('disabled'));
+  assert.ok(options.eq(2).prop('disabled'));
+  assert.notOk(options.eq(3).prop('disabled'));
+  assert.notOk(options.eq(4).prop('disabled'));
+  assert.notOk(options.eq(5).prop('disabled'));
+  assert.notOk(options.eq(6).prop('disabled'));
+  assert.notOk(options.eq(7).prop('disabled'));
+  assert.notOk(options.eq(8).prop('disabled'));
+  assert.notOk(options.eq(9).prop('disabled'));
+});

--- a/tests/integration/components/course-rollover-test.js
+++ b/tests/integration/components/course-rollover-test.js
@@ -102,7 +102,7 @@ test('rollover course', function(assert) {
 });
 
 test('disable years when title already exists', function(assert) {
-  assert.expect(13);
+  assert.expect(8);
   const thisYear = parseInt(moment().format('YYYY'));
 
   let storeMock = Service.extend({

--- a/tests/unit/controllers/course/rollover-test.js
+++ b/tests/unit/controllers/course/rollover-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:course/rollover', 'Unit | Controller | course/rollover', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});


### PR DESCRIPTION
Added option to rollover a course.  User has to select a year and can optionally select a new start date and to skip offerings.

Fixes #686

Requires ilios/ilios#1475

todo:
- [x] Decide what should happen after a course is rolled over?  Right now it transitions to that course with a success message.