### PR TITLE
Don't send unused rollover parameters

### DIFF
--- a/app/components/course-rollover.js
+++ b/app/components/course-rollover.js
@@ -38,13 +38,18 @@ export default Component.extend({
     const ajax = this.get('ajax');
     const courseId = this.get('course.id');
     const expandAdvancedOptions = this.get('expandAdvancedOptions');
-    const selectedYear = this.get('selectedYear');
-    let newStartDate = null;
-    let skipOfferings = false;
+    const year = this.get('selectedYear');
+    let newStartDate = moment(this.get('startDate')).format('YYYY-MM-DD');
+    let skipOfferings = this.get('skipOfferings');
 
-    if (expandAdvancedOptions) {
-      newStartDate = moment(this.get('startDate')).format('YYYY-MM-DD');
-      skipOfferings = this.get('skipOfferings');
+    let data = {
+      year
+    };
+    if (expandAdvancedOptions && newStartDate) {
+      data.newStartDate = newStartDate;
+    }
+    if (expandAdvancedOptions && skipOfferings) {
+      data.skipOfferings = true;
     }
     const host = this.get('host')?this.get('host'):'/';
     const namespace = this.get('namespace');
@@ -52,11 +57,7 @@ export default Component.extend({
     let url = host + namespace + `/courses/${courseId}/rollover`;
     const newCoursesObj = yield ajax.request(url, {
       method: 'POST',
-      data: {
-        year: selectedYear,
-        newStartDate,
-        skipOfferings,
-      }
+      data
     });
 
     const flashMessages = this.get('flashMessages');

--- a/tests/integration/components/course-rollover-test.js
+++ b/tests/integration/components/course-rollover-test.js
@@ -35,7 +35,7 @@ test('it renders', function(assert) {
 });
 
 test('rollover course', function(assert) {
-  assert.expect(15);
+  assert.expect(13);
   let course = Object.create({
     id: 1,
     startDate: moment().hour(0).minute(0).second(0).toDate()
@@ -48,10 +48,8 @@ test('rollover course', function(assert) {
       assert.equal(method, 'POST');
       assert.ok('year' in data);
       assert.equal(data.year, thisYear);
-      assert.ok('newStartDate' in data);
-      assert.equal(data.newStartDate, null);
-      assert.ok('skipOfferings' in data);
-      assert.equal(data.skipOfferings, false);
+      assert.notOk('newStartDate' in data);
+      assert.notOk('skipOfferings' in data);
 
       return resolve({
         courses: [


### PR DESCRIPTION
The API will accept these set to false, but it just seems better to send
a clean request for exactly what we want.

Fixes #1821