### PR TITLE
removed max-date constraint on date picker for rollover start date

### DIFF
--- a/app/components/course-rollover.js
+++ b/app/components/course-rollover.js
@@ -117,16 +117,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     let startDate = moment().year(selectedYear).isoWeek(week).day(day).toDate();
     this.setProperties({startDate});
   }).restartable(),
-
-  minDate: computed('selectedYear', function(){
-    const selectedYear = this.get('selectedYear');
-    let today = moment();
-    if (isPresent(selectedYear)) {
-      today.year(selectedYear);
-    }
-    return today.dayOfYear(1).toDate();
-  }),
-
+  
   /**
    * "disableDayFn" callback function pikaday.
    * @link https://github.com/dbushell/Pikaday#configuration

--- a/app/components/course-rollover.js
+++ b/app/components/course-rollover.js
@@ -127,15 +127,6 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     return today.dayOfYear(1).toDate();
   }),
 
-  maxDate: computed('selectedYear', function(){
-    const selectedYear = this.get('selectedYear');
-    let today = moment();
-    if (isPresent(selectedYear)) {
-      today.year(selectedYear+1);
-    }
-    return today.dayOfYear(365).toDate();
-  }),
-
   /**
    * "disableDayFn" callback function pikaday.
    * @link https://github.com/dbushell/Pikaday#configuration

--- a/app/templates/components/course-rollover.hbs
+++ b/app/templates/components/course-rollover.hbs
@@ -51,7 +51,7 @@
         {{pikaday-input
           size=10
           value=startDate
-          minDate=startDate
+          minDate=course.startDate
           format='YYYY-MM-DD'
           onSelection=(action (mut startDate))
           options=(hash disableDayFn=disableDayFn course=course)

--- a/app/templates/components/course-rollover.hbs
+++ b/app/templates/components/course-rollover.hbs
@@ -51,7 +51,7 @@
         {{pikaday-input
           size=10
           value=startDate
-          minDate=minDate
+          minDate=startDate
           format='YYYY-MM-DD'
           onSelection=(action (mut startDate))
           options=(hash disableDayFn=disableDayFn course=course)

--- a/app/templates/components/course-rollover.hbs
+++ b/app/templates/components/course-rollover.hbs
@@ -51,7 +51,6 @@
         {{pikaday-input
           size=10
           value=startDate
-          maxDate=maxDate
           minDate=minDate
           format='YYYY-MM-DD'
           onSelection=(action (mut startDate))


### PR DESCRIPTION
changing the academic year selection will result in a max date recalculation. however, the date picker does not pick up on that, it will continue to operate on the originally set min/max date ranges.

the same applies to the min date of that range, the recalculated date does not get applied in the date picker. the base-line requirement is that the rollover  date cannot come before the course's original start date, which can be enforced. updated the date picker component to take the course start date as min date instead.