### PR TITLE
Don't show new learner group form when there are no cohorts

### DIFF
--- a/app/templates/learner-groups.hbs
+++ b/app/templates/learner-groups.hbs
@@ -67,7 +67,9 @@
         <h2>{{t 'general.learnerGroups'}}</h2>
       </div>
       <div class='actions'>
-        {{expand-collapse-button value=showNewLearnerGroupForm action="toggleNewLearnerGroupForm"}}
+        {{#if selectedProgramYear}}
+          {{expand-collapse-button value=showNewLearnerGroupForm action="toggleNewLearnerGroupForm"}}
+        {{/if}}
       </div>
     </div>
 

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -681,3 +681,15 @@ test('add new learnergroup with full cohort', function(assert) {
     assert.equal(getCellData(0, 1), 5, 'member count is correct');
   });
 });
+
+test('no add button when there is no cohort', function(assert) {
+  server.create('user', {id: 4136});
+  server.create('school');
+  visit('/learnergroups');
+  const expandNewButton = '.actions .expand-button';
+
+  andThen(function() {
+    assert.equal(currentPath(), 'learnerGroups');
+    assert.equal(find(expandNewButton).length, 0);
+  });
+});


### PR DESCRIPTION
This prevents attempting to create an invalid learner group.

@saschaben do we need to do something here besides hiding the button to make it clear WHY this isn’t possible?

Fixes #1846