### PR TITLE
Return our version of ember-cli-qunit to the one ember-cli recommends.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ember-cli-mirage": "0.1.13",
     "ember-cli-moment-shim": "2.0.0",
     "ember-cli-neat": "0.0.5",
-    "ember-cli-qunit": "^2.1.0",
+    "ember-cli-qunit": "^1.4.0",
     "ember-cli-release": "0.2.9",
     "ember-cli-sauce": "^1.4.2",
     "ember-cli-server-variables": "2.0.0",


### PR DESCRIPTION
Locking the version appears to mitigate random test failures.  Lets merge and find out!