### PR TITLE
force ruby v2.2.0 on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ before_install:
   - npm set progress=false
   - npm config set spin false
   - npm install -g bower
+  - rvm install 2.2.0
   - travis_retry gem install scss_lint --no-ri --no-rdoc
+
 
 install:
   - travis_retry npm install --no-optional


### PR DESCRIPTION
this should fix the `scss-lint` warnings that travis emits on each build.

```
DEPRECATION WARNING:
Sass 3.5 will no longer support Ruby 1.9.3.
Please upgrade to Ruby 2.0.0 or greater as soon as possible.
```

see http://stackoverflow.com/a/31373752/307333