### PR TITLE
Specify prototype extension explicitly

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -94,6 +94,12 @@ module.exports = function(environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        String: true,
+        Array: true,
+        Function: false,
+        Date: false,
       }
     },
 


### PR DESCRIPTION
We were getting nasty deprecation notices about Ember extending date,
and we haven't used the function extensions in a while so those are both turned off.  We still need Array and String though and likely will for a
long time.