### PR TITLE
Add sort to CI sequence block overview

### DIFF
--- a/app/components/curriculum-inventory-sequence-block-overview.js
+++ b/app/components/curriculum-inventory-sequence-block-overview.js
@@ -14,6 +14,7 @@ export default Component.extend({
   sequenceBlock: null,
   parent: null,
   report: null,
+  sortBy: 'title',
   linkableCourses: [],
   linkedSessions: [],
   minimum: 0,
@@ -32,6 +33,7 @@ export default Component.extend({
   academicLevels: [],
   childSequenceOrderOptions: [],
   requiredOptions: [],
+
 
   didReceiveAttrs(){
     this._super(...arguments);
@@ -128,6 +130,11 @@ export default Component.extend({
     });
   }),
 
+  sortedAscending: computed('sortBy', function(){
+    const sortBy = this.get('sortBy');
+    return sortBy.search(/desc/) === -1;
+  }),
+
   actions: {
     changeRequired: function(value){
       let block = this.get('sequenceBlock');
@@ -222,6 +229,13 @@ export default Component.extend({
         block.get('sessions').addObject(session);
       }
       block.save();
+    },
+    sortBy(what){
+      const sortBy = this.get('sortBy');
+      if(sortBy === what){
+        what += ':desc';
+      }
+      this.get('setSortBy')(what);
     },
   }
 });

--- a/app/controllers/curriculum-inventory-sequence-block.js
+++ b/app/controllers/curriculum-inventory-sequence-block.js
@@ -3,6 +3,10 @@ import Ember from 'ember';
 const { Controller } = Ember;
 
 export default Controller.extend({
+  queryParams: [
+    'sortSessionsBy',
+  ],
+  sortSessionsBy: 'title',
   actions: {
     removeChildSequenceBlock(block) {
       let parent = this.get('model');

--- a/app/templates/components/curriculum-inventory-sequence-block-details.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-details.hbs
@@ -16,6 +16,6 @@
     </div>
   {{/if}}
   <div class='detail-view-details'>
-    {{curriculum-inventory-sequence-block-overview sequenceBlock=sequenceBlock}}
+    {{curriculum-inventory-sequence-block-overview sequenceBlock=sequenceBlock sortBy=sortSessionsBy setSortBy=setSortSessionBy}}
   </div>
 </div>

--- a/app/templates/components/curriculum-inventory-sequence-block-overview.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-overview.hbs
@@ -207,14 +207,30 @@
               <thead>
                 <tr>
                   <th class='text-center' colspan=2>{{t 'curriculumInventory.countAsOneOffering'}}</th>
-                  <th class='text-left' colspan=3>{{t 'sessions.title'}}</th>
-                  <th class='text-left' colspan=3>{{t 'general.sessionType'}}</th>
+                  {{#sortable-th
+                    colspan=3
+                    click=(action 'sortBy' 'title')
+                    sortedBy=(or (eq sortBy 'title') (eq sortBy 'title:desc'))
+                    sortedAscending=sortedAscending
+                  }}{{t 'sessions.title'}}{{/sortable-th}}
+                  {{#sortable-th
+                    colspan=3
+                    click=(action 'sortBy' 'sessionType.title')
+                    sortedBy=(or (eq sortBy 'sessionType.title') (eq sortBy 'sessionType.title:desc'))
+                    sortedAscending=sortedAscending
+                  }}{{t 'general.sessionType'}}{{/sortable-th}}
                   <th class='text-center' colspan=1>{{t 'curriculumInventory.totalTime'}}</th>
-                  <th class='text-center' colspan=1># {{t 'general.offerings'}}</th>
+                  {{#sortable-th
+                    colspan=1
+                    click=(action 'sortBy' 'offerings.length')
+                    sortedBy=(or (eq sortBy 'offerings.length') (eq sortBy 'offerings.length:desc'))
+                    sortedAscending=sortedAscending
+                    sortType='numeric'
+                  }}{{t 'general.offerings'}}{{/sortable-th}}
                 </tr>
               </thead>
               <tbody>
-                {{#each (sort-by 'title' linkableSessions) as |session|}}
+                {{#each (sort-by sortBy linkableSessions) as |session|}}
                   <tr>
                     <td class='text-center' colspan=2>
                       {{#if isFinalized}}

--- a/app/templates/curriculum-inventory-sequence-block.hbs
+++ b/app/templates/curriculum-inventory-sequence-block.hbs
@@ -1,7 +1,5 @@
-{{curriculum-inventory-sequence-block-details sequenceBlock=model}}
+{{curriculum-inventory-sequence-block-details sequenceBlock=model sortSessionsBy=sortSessionsBy setSortSessionBy=(action (mut sortSessionsBy))}}
 {{curriculum-inventory-sequence-block-list
   parent=model
   remove='removeChildSequenceBlock'
 }}
-
-


### PR DESCRIPTION
Allows sessions to be sorted by title, type, and offering count.

Wasn't able to sort by count offerings once or by the total as those are complex properties and difficult to serialize into the URL.  We would need to do a lot more work to get that working correctly.
Fixes #1968