### PR TITLE
Bump the API to v1.8 for CI endpoint changes

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 
 module.exports = function(deployTarget) {
-  const API_VERSION = 'v1.7';
+  const API_VERSION = 'v1.8';
   var ENV = {
     build: {},
     exclude: ['.DS_Store', '*-test.js']


### PR DESCRIPTION
Several changes since the last release require an API version bump to work correctly.