### PR TITLE
replaced eyeball icon from edit links in finalized reports.

### DIFF
--- a/app/templates/components/curriculum-inventory-report-list.hbs
+++ b/app/templates/components/curriculum-inventory-report-list.hbs
@@ -49,16 +49,12 @@
         }}
       </td>
       <td class='text-center' colspan=1>
-        {{#if report.isFinalized}}
-          {{#link-to 'curriculumInventoryReport' report.content class='edit'}}
-            {{fa-icon 'eye'}}
-          {{/link-to}}
-        {{else}}
-          {{#link-to 'curriculumInventoryReport' report.content class='edit'}}
-            {{fa-icon 'edit'}}
-          {{/link-to}}
+        {{#link-to 'curriculumInventoryReport' report.content class='edit'}}
+          {{fa-icon 'edit'}}
+        {{/link-to}}
+        {{#unless report.isFinalized}}
           <span class='clickable remove' {{action 'confirmRemove' report}}>{{fa-icon 'trash'}}</span>
-        {{/if}}
+        {{/unless}}
         <span>
           <a href="{{report.content.absoluteFileUri}}" download="report.xml" target="_blank">{{fa-icon 'download'}}</a>
         </span>

--- a/app/templates/components/curriculum-inventory-sequence-block-list.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-list.hbs
@@ -81,16 +81,12 @@
                   {{/if}}
                 </td>
                 <td class='text-center' colspan=1>
-                  {{#if block.isFinalized}}
-                    {{#link-to 'curriculumInventorySequenceBlock' block.content class='edit'}}
-                      {{fa-icon 'eye'}}
-                    {{/link-to}}
-                  {{ else }}
-                    {{#link-to 'curriculumInventorySequenceBlock' block.content class='edit'}}
-                      {{fa-icon 'edit'}}
-                    {{/link-to}}
+                  {{#link-to 'curriculumInventorySequenceBlock' block.content class='edit'}}
+                    {{fa-icon 'edit'}}
+                  {{/link-to}}
+                  {{#unless report.isFinalized}}
                     <span class='clickable remove' {{action 'confirmRemove' block}}>{{fa-icon 'trash'}}</span>
-                  {{/if}}
+                  {{/unless}}
                 </td>
               </tr>
               {{#if block.showRemoveConfirmation}}


### PR DESCRIPTION
as discussed, use the edit icon everywhere - even if the linked-to entity cannot be edited.