### PR TITLE
Add the ability to lock and unlock courses

### DIFF
--- a/app/components/ilios-course-list.js
+++ b/app/components/ilios-course-list.js
@@ -26,7 +26,7 @@ const CourseProxy = ObjectProxy.extend({
 
     return i18n.t(translation).string;
   }),
-  userCanDelete: computed('content', 'currentUser.model.directedCourses.[]', function(){
+  userCanDelete: computed('content', 'currentUser.userIsDeveloper', 'currentUser.model.directedCourses.[]', function(){
     return new Promise(resolve => {
       const course = this.get('content');
       const currentUser = this.get('currentUser');
@@ -47,7 +47,7 @@ const CourseProxy = ObjectProxy.extend({
       }
     });
   }),
-  userCanLock: computed('content', 'currentUser.model.directedCourses.[]', function(){
+  userCanLock: computed('content', 'currentUser.userIsDeveloper', 'currentUser.model.directedCourses.[]', function(){
     return new Promise(resolve => {
       const course = this.get('content');
       const currentUser = this.get('currentUser');
@@ -61,6 +61,14 @@ const CourseProxy = ObjectProxy.extend({
             });
           });
         }
+      });
+    });
+  }),
+  userCanUnLock: computed('content', 'currentUser.userIsDeveloper', function(){
+    return new Promise(resolve => {
+      const currentUser = this.get('currentUser');
+      currentUser.get('userIsDeveloper').then(isDeveloper => {
+        resolve(isDeveloper);
       });
     });
   }),
@@ -97,7 +105,7 @@ export default Component.extend({
       courseProxy.set('showRemoveConfirmation', true);
     },
     unlockCourse(courseProxy){
-      courseProxy.get('userCanLock').then(permission => {
+      courseProxy.get('userCanUnLock').then(permission => {
         if (permission) {
           courseProxy.set('isSaving', true);
           this.get('unlock')(courseProxy.get('content')).then(()=>{

--- a/app/components/programyear-list.js
+++ b/app/components/programyear-list.js
@@ -157,7 +157,7 @@ export default Component.extend({
       programYearProxy.set('showRemoveConfirmation', false);
     },
     unlockProgramYear(programYearProxy){
-      programYearProxy.get('userCanLock').then(permission => {
+      programYearProxy.get('userCanUnLock').then(permission => {
         if (permission) {
           run(()=>{
             programYearProxy.set('isSaving', true);
@@ -189,7 +189,7 @@ const ProgramYearProxy = ObjectProxy.extend({
   currentUser: null,
   showRemoveConfirmation: false,
   isSaving: false,
-  userCanDelete: computed('content', 'currentUser.model.programYears.[]', function(){
+  userCanDelete: computed('content', 'currentUser.userIsDeveloper', 'currentUser.model.programYears.[]', function(){
     return new Promise(resolve => {
       const programYear = this.get('content');
       const currentUser = this.get('currentUser');
@@ -202,7 +202,15 @@ const ProgramYearProxy = ObjectProxy.extend({
       }
     });
   }),
-  userCanLock: computed('content', 'currentUser.model.programYears.[]', function(){
+  userCanLock: computed('content', 'currentUser.userIsDeveloper', 'currentUser.model.programYears.[]', function(){
+    return new Promise(resolve => {
+      const currentUser = this.get('currentUser');
+      currentUser.get('userIsDeveloper').then(isDeveloper => {
+        resolve(isDeveloper);
+      });
+    });
+  }),
+  userCanUnLock: computed('content', 'currentUser.userIsDeveloper', 'currentUser.model.programYears.[]', function(){
     return new Promise(resolve => {
       const currentUser = this.get('currentUser');
       currentUser.get('userIsDeveloper').then(isDeveloper => {

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -201,6 +201,14 @@ export default Controller.extend({
     },
     toggleNewCourseForm: function(){
       this.set('showNewCourseForm', !this.get('showNewCourseForm'));
-    }
+    },
+    lockCourse: function(course){
+      course.set('locked', true);
+      return course.save();
+    },
+    unlockCourse: function(course){
+      course.set('locked', false);
+      return course.save();
+    },
   },
 });

--- a/app/controllers/program/index.js
+++ b/app/controllers/program/index.js
@@ -7,5 +7,15 @@ const { alias } = computed;
 export default Controller.extend({
   programController: controller('program'),
 
-  program: alias('programController.model')
+  program: alias('programController.model'),
+  actions: {
+    lockProgramYear: function(programYear){
+      programYear.set('locked', true);
+      return programYear.save();
+    },
+    unlockProgramYear: function(programYear){
+      programYear.set('locked', false);
+      return programYear.save();
+    },
+  }
 });

--- a/app/styles/components/_global.scss
+++ b/app/styles/components/_global.scss
@@ -12,10 +12,6 @@ a,
     color: $hover-link-color;
     outline: none;
   }
-
-  &.edit {
-    margin-right: 7px;
-  }
 }
 
 button {

--- a/app/styles/newcomponents/courses-list.scss
+++ b/app/styles/newcomponents/courses-list.scss
@@ -41,5 +41,9 @@
 
   .list {
     @include main-list-box-table;
+
+    i {
+      margin-left: .5em;
+    }
   }
 }

--- a/app/templates/components/ilios-course-list.hbs
+++ b/app/templates/components/ilios-course-list.hbs
@@ -37,13 +37,11 @@
         hideFromSmallScreen=true
       }}{{t 'general.endDate'}}{{/sortable-th}}
       {{#sortable-th
-        colspan=2
+        colspan=3
         click=(action 'sortBy' 'status')
         sortedBy=(or (eq sortBy 'status') (eq sortBy 'status:desc'))
         sortedAscending=sortedAscending
-        hideFromSmallScreen=true
       }}{{t 'general.status'}}{{/sortable-th}}
-      <th class='text-left' colspan=1>{{t 'general.actions'}}</th>
     </tr>
   </thead>
   <tbody>
@@ -62,16 +60,19 @@
         <td class='text-center hide-from-small-screen' colspan=1>{{course.level}}</td>
         <td class='text-center hide-from-small-screen' colspan=2>{{moment-format course.startDate 'MM/DD/YY'}}</td>
         <td class='text-center hide-from-small-screen' colspan=2>{{moment-format course.endDate 'MM/DD/YY'}}</td>
-        <td class='text-left hide-from-small-screen' colspan=2>
-          {{#if course.locked}}{{fa-icon 'lock'}}{{/if}}
-          {{publication-status item=course showIcon=false}}
-        </td>
-        <td class='text-left' colspan=1>
-          {{#link-to 'course' course.content class='edit'}}
-            {{fa-icon 'edit'}}
-          {{/link-to}}
-          {{#if course.userCanDelete}}
-            <span class='clickable remove' {{action 'confirmRemove' course}}>{{fa-icon 'trash'}}</span>
+        <td class='text-left' colspan=3>
+          {{#if course.isSaving}}
+            {{fa-icon 'spinner' spin=true}}
+          {{else}}
+            {{publication-status item=course showIcon=false}}
+            {{#if course.locked}}
+              <span class={{if (await course.userCanLock) 'clickable'}} {{action 'unlockCourse' course}}>{{fa-icon 'lock'}}</span>
+            {{else}}
+              <span class={{if (await course.userCanLock) 'clickable'}} {{action 'lockCourse' course}}>{{fa-icon 'unlock'}}</span>
+            {{/if}}
+            {{#if (await course.userCanDelete)}}
+              <span class='clickable remove' {{action 'confirmRemove' course}}>{{fa-icon 'trash'}}</span>
+            {{/if}}
           {{/if}}
         </td>
       </tr>

--- a/app/templates/components/ilios-course-list.hbs
+++ b/app/templates/components/ilios-course-list.hbs
@@ -66,7 +66,7 @@
           {{else}}
             {{publication-status item=course showIcon=false}}
             {{#if course.locked}}
-               {{fa-icon 'lock' class=(if (await course.userCanLock) 'clickable') click=(action 'unlockCourse' course)}}
+               {{fa-icon 'lock' class=(if (await course.userCanUnLock) 'clickable') click=(action 'unlockCourse' course)}}
              {{else}}
               {{fa-icon 'unlock' class=(if (await course.userCanLock) 'clickable') click=(action 'lockCourse' course)}}
              {{/if}}

--- a/app/templates/components/ilios-course-list.hbs
+++ b/app/templates/components/ilios-course-list.hbs
@@ -66,10 +66,10 @@
           {{else}}
             {{publication-status item=course showIcon=false}}
             {{#if course.locked}}
-              <span class={{if (await course.userCanLock) 'clickable'}} {{action 'unlockCourse' course}}>{{fa-icon 'lock'}}</span>
-            {{else}}
-              <span class={{if (await course.userCanLock) 'clickable'}} {{action 'lockCourse' course}}>{{fa-icon 'unlock'}}</span>
-            {{/if}}
+               {{fa-icon 'lock' class=(if (await course.userCanLock) 'clickable') click=(action 'unlockCourse' course)}}
+             {{else}}
+              {{fa-icon 'unlock' class=(if (await course.userCanLock) 'clickable') click=(action 'lockCourse' course)}}
+             {{/if}}
             {{#if (await course.userCanDelete)}}
               <span class='clickable remove' {{action 'confirmRemove' course}}>{{fa-icon 'trash'}}</span>
             {{/if}}

--- a/app/templates/components/programyear-list.hbs
+++ b/app/templates/components/programyear-list.hbs
@@ -79,7 +79,7 @@
                   {{else}}
                     {{publication-status item=programYearProxy.content showIcon=false}}
                     {{#if programYearProxy.locked}}
-                       {{fa-icon 'lock' class=(if (await programYearProxy.userCanLock) 'clickable') click=(action 'unlockProgramYear' programYearProxy)}}
+                       {{fa-icon 'lock' class=(if (await programYearProxy.userCanUnLock) 'clickable') click=(action 'unlockProgramYear' programYearProxy)}}
                      {{else}}
                       {{fa-icon 'unlock' class=(if (await programYearProxy.userCanLock) 'clickable') click=(action 'lockProgramYear' programYearProxy)}}
                      {{/if}}

--- a/app/templates/components/programyear-list.hbs
+++ b/app/templates/components/programyear-list.hbs
@@ -25,13 +25,12 @@
         <thead>
           <tr>
             <th class='text-left'>{{t 'general.matriculationYear'}}</th>
-            <th class='text-left' >{{t 'general.cohort'}}</th>
-            <th class='text-left' >{{t 'general.competencies'}}</th>
-            <th class='text-left' >{{t 'general.objectives'}}</th>
-            <th class='text-left' >{{t 'general.directors'}}</th>
-            <th class='text-left' >{{t 'general.terms'}}</th>
-            <th class='text-center' >{{t 'general.status'}}</th>
-            <th class='text-center' >{{t 'general.actions'}}</th>
+            <th class='text-left'>{{t 'general.cohort'}}</th>
+            <th class='text-left'>{{t 'general.competencies'}}</th>
+            <th class='text-left'>{{t 'general.objectives'}}</th>
+            <th class='text-left'>{{t 'general.directors'}}</th>
+            <th class='text-left'>{{t 'general.terms'}}</th>
+            <th class='text-center' colspan=2>{{t 'general.status'}}</th>
           </tr>
         </thead>
         <tbody>
@@ -74,10 +73,20 @@
                   {{/if}}
                 </td>
 
-                <td class='text-center'>{{publication-status item=programYearProxy.content showIcon=false}}</td>
-                <td class='text-center'>
-                  {{#link-to 'programYear.index' program programYearProxy.content class="program-year-link edit"}}{{fa-icon 'edit'}}{{/link-to}}
-                  <span class="clickable remove {{if programYearProxy.showRemoveConfirmation 'confirm-removal'}}" {{action 'remove' programYearProxy}}>{{fa-icon 'trash'}}</span>
+                <td class='text-center' colspan=2>
+                  {{#if programYearProxy.isSaving}}
+                    {{fa-icon 'spinner' spin=true}}
+                  {{else}}
+                    {{publication-status item=programYearProxy.content showIcon=false}}
+                    {{#if programYearProxy.locked}}
+                       {{fa-icon 'lock' class=(if (await programYearProxy.userCanLock) 'clickable') click=(action 'unlockProgramYear' programYearProxy)}}
+                     {{else}}
+                      {{fa-icon 'unlock' class=(if (await programYearProxy.userCanLock) 'clickable') click=(action 'lockProgramYear' programYearProxy)}}
+                     {{/if}}
+                    {{#if (await programYearProxy.userCanDelete)}}
+                      {{fa-icon 'trash' class='remove clickable' click=(action 'remove' programYearProxy)}}
+                    {{/if}}
+                  {{/if}}
                 </td>
               </tr>
 

--- a/app/templates/courses.hbs
+++ b/app/templates/courses.hbs
@@ -65,6 +65,8 @@
           remove='removeCourse'
           sortBy=sortCoursesBy
           setSortBy=(action (mut sortCoursesBy))
+          lock=(action 'lockCourse')
+          unlock=(action 'unlockCourse')
         }}
       {{else}}
         {{pulse-loader}}

--- a/app/templates/program/index.hbs
+++ b/app/templates/program/index.hbs
@@ -1,1 +1,1 @@
-{{programyear-list programYears=model program=program}}
+{{programyear-list programYears=model program=program lock=(action 'lockProgramYear') unlock=(action 'unlockProgramYear')}}

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -567,7 +567,7 @@ test('sort by status', function(assert) {
 });
 
 test('privileged users can lock and unlock course', function(assert) {
-  assert.expect(4);
+  assert.expect(6);
   const firstCourseRow = '.list tbody tr:eq(0)';
   const secondCourseRow = '.list tbody tr:eq(1)';
   const firstCourseLockedIcon = `${firstCourseRow} td:eq(6) i:eq(0)`;
@@ -592,7 +592,9 @@ test('privileged users can lock and unlock course', function(assert) {
   visit('/courses');
   andThen(function() {
     assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
+    assert.ok(find(firstCourseLockedIcon).hasClass('clickable'), 'first course is clickable');
     assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
+    assert.ok(find(secondCourseLockedIcon).hasClass('clickable'), 'second course is clickable');
     click(find(firstCourseLockedIcon));
     click(find(secondCourseLockedIcon));
     andThen(()=>{
@@ -603,7 +605,7 @@ test('privileged users can lock and unlock course', function(assert) {
 });
 
 test('non-privileged users cannot lock and unlock course but can see the icon', function(assert) {
-  assert.expect(4);
+  assert.expect(6);
   const firstCourseRow = '.list tbody tr:eq(0)';
   const secondCourseRow = '.list tbody tr:eq(1)';
   const firstCourseLockedIcon = `${firstCourseRow} td:eq(6) i:eq(0)`;
@@ -626,7 +628,9 @@ test('non-privileged users cannot lock and unlock course but can see the icon', 
   visit('/courses');
   andThen(function() {
     assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
+    assert.notOk(find(firstCourseLockedIcon).hasClass('clickable'), 'first course is clickable');
     assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
+    assert.notOk(find(secondCourseLockedIcon).hasClass('clickable'), 'second course is clickable');
     click(find(firstCourseLockedIcon));
     click(find(secondCourseLockedIcon));
     andThen(()=>{

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -566,7 +566,47 @@ test('sort by status', function(assert) {
   });
 });
 
-test('privileged users can lock and unlock course', function(assert) {
+test('developer users can lock and unlock course', function(assert) {
+  assert.expect(6);
+  const firstCourseRow = '.list tbody tr:eq(0)';
+  const secondCourseRow = '.list tbody tr:eq(1)';
+  const firstCourseLockedIcon = `${firstCourseRow} td:eq(6) i:eq(0)`;
+  const secondCourseLockedIcon = `${secondCourseRow} td:eq(6) i:eq(0)`;
+  server.create('academicYear', {id: 2014});
+  server.create('userRole', {
+    title: 'Developer'
+  });
+  server.db.users.update(4136, {roles: [1]})
+  server.create('course', {
+    year: 2014,
+    school: 1,
+    published: true,
+    publishedAsTbd: false,
+    locked: true,
+  });
+  server.create('course', {
+    year: 2014,
+    school: 1,
+    published: true,
+    publishedAsTbd: true,
+    locked: false,
+  });
+  visit('/courses');
+  andThen(function() {
+    assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
+    assert.ok(find(firstCourseLockedIcon).hasClass('clickable'), 'first course is clickable');
+    assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
+    assert.ok(find(secondCourseLockedIcon).hasClass('clickable'), 'second course is clickable');
+    click(find(firstCourseLockedIcon));
+    click(find(secondCourseLockedIcon));
+    andThen(()=>{
+      assert.ok(find(firstCourseLockedIcon).hasClass('fa-unlock'), 'first course is now unlocked');
+      assert.ok(find(secondCourseLockedIcon).hasClass('fa-lock'), 'second course is now locked');
+    });
+  });
+});
+
+test('course directors users can lock but not unlock course', function(assert) {
   assert.expect(6);
   const firstCourseRow = '.list tbody tr:eq(0)';
   const secondCourseRow = '.list tbody tr:eq(1)';
@@ -592,13 +632,13 @@ test('privileged users can lock and unlock course', function(assert) {
   visit('/courses');
   andThen(function() {
     assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
-    assert.ok(find(firstCourseLockedIcon).hasClass('clickable'), 'first course is clickable');
+    assert.notOk(find(firstCourseLockedIcon).hasClass('clickable'), 'first course is not clickable');
     assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
     assert.ok(find(secondCourseLockedIcon).hasClass('clickable'), 'second course is clickable');
     click(find(firstCourseLockedIcon));
     click(find(secondCourseLockedIcon));
     andThen(()=>{
-      assert.ok(find(firstCourseLockedIcon).hasClass('fa-unlock'), 'first course is now unlocked');
+      assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is still locked');
       assert.ok(find(secondCourseLockedIcon).hasClass('fa-lock'), 'second course is now locked');
     });
   });

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -12,7 +12,6 @@ module('Acceptance: Courses', {
   beforeEach: function() {
     application = startApp();
     setupAuthentication(application);
-
     server.createList('school', 2)
   },
 
@@ -41,12 +40,12 @@ test('filters by title', function(assert) {
     year: 2014,
     school: 1
   });
-  var regularCourse = server.create('course', {
+  let regularCourse = server.create('course', {
     title: 'regularcourse',
     year: 2014,
     school: 1
   });
-  var lastCourse = server.create('course', {
+  let lastCourse = server.create('course', {
     title: 'aaLastcourse',
     year: 2014,
     school: 1
@@ -228,12 +227,18 @@ test('user can only delete non-published courses with proper privileges', functi
     published: false,
     directors: [4136]
   });
+  const courses = '.list tbody tr';
+  const remove = 'td:eq(6) .remove';
+  const firstCourseRemove = `${courses}:eq(0) ${remove}`;
+  const secondCourseRemove = `${courses}:eq(1) ${remove}`;
+  const thirdCourseRemove = `${courses}:eq(2) ${remove}`;
+  const fourthCourseRemove = `${courses}:eq(3) ${remove}`;
   visit('/courses');
   andThen(function() {
-    assert.equal(find('.list tbody tr:eq(0) td:eq(7) .remove').length, 0, 'non-privileged user cannot delete published course');
-    assert.equal(find('.list tbody tr:eq(1) td:eq(7) .remove').length, 0, 'non-privileged user cannot delete unpublished course');
-    assert.equal(find('.list tbody tr:eq(2) td:eq(7) .remove').length, 0, 'privileged user cannot delete published course');
-    assert.equal(find('.list tbody tr:eq(3) td:eq(7) .remove').length, 1, 'privileged user can delete published course');
+    assert.equal(find(firstCourseRemove).length, 0, 'non-privileged user cannot delete published course');
+    assert.equal(find(secondCourseRemove).length, 0, 'non-privileged user cannot delete unpublished course');
+    assert.equal(find(thirdCourseRemove).length, 0, 'privileged user cannot delete published course');
+    assert.equal(find(fourthCourseRemove).length, 1, 'privileged user can delete unpublished course');
   });
 });
 
@@ -557,6 +562,76 @@ test('sort by status', function(assert) {
       assert.equal(getElementText(find(firstCourseTitle)), getText(secondCourse.title));
       assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
       assert.equal(getElementText(find(thirdCourseTitle)), getText(thirdCourse.title));
+    });
+  });
+});
+
+test('privileged users can lock and unlock course', function(assert) {
+  assert.expect(4);
+  const firstCourseRow = '.list tbody tr:eq(0)';
+  const secondCourseRow = '.list tbody tr:eq(1)';
+  const firstCourseLockedIcon = `${firstCourseRow} td:eq(6) i:eq(0)`;
+  const secondCourseLockedIcon = `${secondCourseRow} td:eq(6) i:eq(0)`;
+  server.create('academicYear', {id: 2014});
+  server.create('course', {
+    year: 2014,
+    school: 1,
+    published: true,
+    publishedAsTbd: false,
+    locked: true,
+    directors: [4136],
+  });
+  server.create('course', {
+    year: 2014,
+    school: 1,
+    published: true,
+    publishedAsTbd: true,
+    locked: false,
+    directors: [4136],
+  });
+  visit('/courses');
+  andThen(function() {
+    assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
+    assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
+    click(find(firstCourseLockedIcon));
+    click(find(secondCourseLockedIcon));
+    andThen(()=>{
+      assert.ok(find(firstCourseLockedIcon).hasClass('fa-unlock'), 'first course is now unlocked');
+      assert.ok(find(secondCourseLockedIcon).hasClass('fa-lock'), 'second course is now locked');
+    });
+  });
+});
+
+test('non-privileged users cannot lock and unlock course but can see the icon', function(assert) {
+  assert.expect(4);
+  const firstCourseRow = '.list tbody tr:eq(0)';
+  const secondCourseRow = '.list tbody tr:eq(1)';
+  const firstCourseLockedIcon = `${firstCourseRow} td:eq(6) i:eq(0)`;
+  const secondCourseLockedIcon = `${secondCourseRow} td:eq(6) i:eq(0)`;
+  server.create('academicYear', {id: 2014});
+  server.create('course', {
+    year: 2014,
+    school: 1,
+    published: true,
+    publishedAsTbd: false,
+    locked: true,
+  });
+  server.create('course', {
+    year: 2014,
+    school: 1,
+    published: true,
+    publishedAsTbd: true,
+    locked: false,
+  });
+  visit('/courses');
+  andThen(function() {
+    assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
+    assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
+    click(find(firstCourseLockedIcon));
+    click(find(secondCourseLockedIcon));
+    andThen(()=>{
+      assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is still locked');
+      assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is still unlocked');
     });
   });
 });


### PR DESCRIPTION
On the course list clicking the lock icon locks or unlocks the course if
the user has permission to do so.

Removed the edit icon in order to make space (also it doesn’t do anything)
Moved lock and delete into the status column along with publish for a little bit nicer visual picture.

WIP:
- [x] Needs API change to allow course unlock
- [x] Needs tests for lock /unlock on course list
- [x] Add lock to program year list
- [x] Only developers can unlock - need to enforce this in the UI