### PR TITLE
Clone objectives when creating a new program year

### DIFF
--- a/app/components/new-programyear.js
+++ b/app/components/new-programyear.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { task } from 'ember-concurrency';
 
 const { Component, isEmpty } = Ember;
 
@@ -8,25 +9,15 @@ export default Component.extend({
   selectedYear: null,
   availableAcademicYears: null,
 
-  actions: {
-    setYear(year) {
-      this.set('selectedYear', year);
-    },
-    save() {
-      this.set('isSaving', true);
-      let startYear = this.get('selectedYear');
-      if (isEmpty(startYear)) {
-        const availableAcademicYears = this.get('availableAcademicYears');
-        startYear = availableAcademicYears.get('firstObject.value');
-      }
-
-      if (isEmpty(startYear)) {
-        return false;
-      }
-
-      this.get('save')(parseInt(startYear)).finally(() =>{
-        this.set('isSaving', false);
-      });
-    },
-  }
+  saveNewYear: task(function * (){
+    let startYear = this.get('selectedYear');
+    if (isEmpty(startYear)) {
+      const availableAcademicYears = this.get('availableAcademicYears');
+      startYear = availableAcademicYears.get('firstObject.value');
+    }
+    if (isEmpty(startYear)) {
+      return false;
+    }
+    yield this.get('save')(parseInt(startYear));
+  }).drop(),
 });

--- a/app/templates/components/new-programyear.hbs
+++ b/app/templates/components/new-programyear.hbs
@@ -3,7 +3,7 @@
 <div class='form'>
   <div class="startyear-select">
     <label>{{t 'general.academicYear'}}:</label>
-    <select onchange={{action "setYear" value="target.value"}}>
+    <select onchange={{action (mut selectedYear) value="target.value"}}>
       {{#each (sort-by 'value' availableAcademicYears) as |obj|}}
         <option value={{obj.value}} selected={{eq obj.value selectedYear}}>
           {{obj.label}}
@@ -13,8 +13,8 @@
   </div>
 
   <div class='buttons'>
-    <button class='done text' {{action 'save'}}>
-      {{#if isSaving}}
+    <button class='done text' {{action (perform saveNewYear)}}>
+      {{#if saveNewYear.isRunning}}
         {{fa-icon 'spinner' spin=true}}
       {{else}}
         {{t 'general.done'}}

--- a/app/templates/components/programyear-list.hbs
+++ b/app/templates/components/programyear-list.hbs
@@ -7,7 +7,7 @@
   </div>
   <section class='new'>
     {{#if editorOn}}
-      {{new-programyear availableAcademicYears=availableAcademicYears save=(action 'save') cancel=(action 'cancel')}}
+      {{new-programyear availableAcademicYears=availableAcademicYears save=(perform save) cancel=(action 'cancel')}}
     {{/if}}
 
     {{#if saved}}

--- a/app/templates/components/programyear-list.hbs
+++ b/app/templates/components/programyear-list.hbs
@@ -102,4 +102,7 @@
       <span class="default-message">{{t 'general.noProgramYears'}}</span>
     {{/if}}
   </div>
+  {{#liquid-if save.isRunning class='crossFade'}}
+    {{wait-saving}}
+  {{/liquid-if}}
 </section>

--- a/app/templates/components/programyear-list.hbs
+++ b/app/templates/components/programyear-list.hbs
@@ -103,6 +103,10 @@
     {{/if}}
   </div>
   {{#liquid-if save.isRunning class='crossFade'}}
-    {{wait-saving}}
+    {{wait-saving
+      showProgress=true
+      totalProgress=itemsToSave
+      currentProgress=savedItems
+    }}
   {{/liquid-if}}
 </section>


### PR DESCRIPTION
We were incorrectly linking to the existing objectives, we needed to
create new ones and attach them to the new program year.  Otherwise we will have problems with the audit trail when objective titles are changed in a new program year.

Fixes #2074