### PR TITLE
Fix issue with new CI sequence block creation

### DIFF
--- a/app/components/new-curriculum-inventory-sequence-block.js
+++ b/app/components/new-curriculum-inventory-sequence-block.js
@@ -93,6 +93,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   maximum: 0,
   orderInSequenceOptions: [],
   isSaving: false,
+  isLoaded: false,
   academicLevels: [],
   childSequenceOrderOptions: [],
   requiredOptions: [],
@@ -105,6 +106,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   },
 
   loadAttr: task(function * (report, parent) {
+    this.set('isLoaded', false);
     let academicLevels = yield report.get('academicLevels');
     academicLevels = academicLevels.toArray();
 
@@ -147,7 +149,9 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
       required,
       childSequenceOrder,
     });
-  }),
+
+    this.set('isLoaded', true);
+  }).restartable(),
 
   actions: {
     save: function(){

--- a/app/mirage/factories/curriculumInventoryReport.js
+++ b/app/mirage/factories/curriculumInventoryReport.js
@@ -1,0 +1,14 @@
+import moment from 'moment';
+import Mirage from 'ember-cli-mirage';
+
+export default Mirage.Factory.extend({
+  name: (i) => `report ${i} `,
+  description: (i) => `descirption for report ${i} `,
+  year: 2013,
+  startDate: () => moment().format(),
+  endDate: () => moment().add(7, 'weeks').format(),
+  sequence: (i) => (i+1),
+  program: (i) => (i+1),
+  sequenceBlocks: [],
+  academicLevels: [],
+});

--- a/app/mirage/factories/curriculumInventorySequence.js
+++ b/app/mirage/factories/curriculumInventorySequence.js
@@ -1,0 +1,6 @@
+import Mirage from 'ember-cli-mirage';
+
+export default Mirage.Factory.extend({
+  description: (i) => `descirption for sequence ${i} `,
+  report: (i) => (i+1),
+});

--- a/app/templates/components/new-curriculum-inventory-sequence-block.hbs
+++ b/app/templates/components/new-curriculum-inventory-sequence-block.hbs
@@ -1,5 +1,5 @@
 <div class="new-result-title">{{t 'general.newSequenceBlock'}}</div>
-{{#unless loadAttr.isRunning}}
+{{#if isLoaded}}
   <div class="item title">
     <label>{{t 'general.title'}}:</label>
     {{one-way-input
@@ -175,4 +175,4 @@
     </button>
     <button class='cancel text' {{action 'cancel'}}>{{t 'general.cancel'}}</button>
   </div>
-{{/unless}}
+{{/if}}

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ilios",
   "dependencies": {
-    "ember": "~2.8.0",
+    "ember": "~2.8.1",
     "ember-cli-shims": "0.1.1",
     "ember-uploader": "0.3.11",
     "neat": "~1.7.2",

--- a/tests/acceptance/curriculum-inventory/report-test.js
+++ b/tests/acceptance/curriculum-inventory/report-test.js
@@ -1,0 +1,43 @@
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from 'ilios/tests/helpers/start-app';
+import destroyApp from 'ilios/tests/helpers/destroy-app';
+import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+
+var application;
+var url = '/curriculum-inventory-reports/1';
+module('Acceptance: Curriculum Inventory: Report', {
+  beforeEach: function() {
+    application = startApp();
+    setupAuthentication(application);
+  },
+
+  afterEach: function() {
+    destroyApp(application);
+  }
+});
+
+test('create new sequence block Issue #2108', function(assert) {
+  server.create('program');
+  server.create('curriculumInventoryReport');
+  server.create('curriculumInventorySequence');
+
+  const sequenceBlockList = '.curriculum-inventory-sequence-block-list';
+  const addSequenceBlock = `${sequenceBlockList} .expand-button`;
+  const newBlockForm = '.new-curriculum-inventory-sequence-block';
+  const newFormTitle = `${newBlockForm} .new-result-title`;
+
+  visit(url);
+  andThen(function() {
+    assert.equal(currentPath(), 'curriculumInventoryReport');
+    assert.equal(find(newBlockForm).length, 0);
+    assert.equal(find(newFormTitle).length, 0);
+    click(addSequenceBlock).then(()=>{
+      assert.equal(find(newBlockForm).length, 1);
+      assert.equal(find(newFormTitle).length, 1);
+      assert.equal(getElementText(newFormTitle), getText('New Sequence Block'));
+    });
+  });
+});


### PR DESCRIPTION
The form to build new sequence blocks was being rendered any time the
load task was not running.  However the load task might get called
multiple times initially causing the form to be rendered and destroyed
rapidly.  This in turn caused problems with one-way-input component
tearing itself down.

Fixes #2108