### PR TITLE
Use isoWeekday for rolling over course

### DIFF
--- a/app/components/course-rollover.js
+++ b/app/components/course-rollover.js
@@ -113,13 +113,13 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     yield timeout(100); //let max/min cp's recalculate
 
     const date = moment(this.get('course.startDate'));
-    const day = date.day();
+    const day = date.isoWeekday();
     const week = date.isoWeek();
 
-    let startDate = moment().year(selectedYear).isoWeek(week).day(day).toDate();
+    let startDate = moment().year(selectedYear).isoWeek(week).isoWeekday(day).toDate();
     this.setProperties({startDate});
   }).restartable(),
-  
+
   /**
    * "disableDayFn" callback function pikaday.
    * @link https://github.com/dbushell/Pikaday#configuration


### PR DESCRIPTION
Set the and week both using the iso standard to avoid conflicts between
the standards.  Specifically Sunday is 7 in the ISO standard and 0 in
javascript.

Fixes #1871