### PR TITLE
Deal with empty HTML correctly

### DIFF
--- a/app/components/editable-field.js
+++ b/app/components/editable-field.js
@@ -7,7 +7,7 @@ export default Component.extend({
   value: null,
   isEditing: false,
   isSaving: false,
-  isSaveDisabled: true,
+  isSaveDisabled: false,
   renderHtml: false,
   classNames: ['editinplace'],
   clickPrompt: null,

--- a/app/components/editable-field.js
+++ b/app/components/editable-field.js
@@ -1,15 +1,24 @@
 import Ember from 'ember';
 import { timeout, task } from 'ember-concurrency';
 
-const { Component } = Ember;
+const { Component, computed, isEmpty } = Ember;
 
 export default Component.extend({
+  value: null,
   isEditing: false,
   isSaving: false,
   isSaveDisabled: true,
   renderHtml: false,
   classNames: ['editinplace'],
   clickPrompt: null,
+  looksEmpty: computed('value', function(){
+    let value = this.get('value') || '';
+    let text = value.toString();
+    let noTagsText = text.replace(/(<([^>]+)>)/ig,"");
+    let strippedText = noTagsText.replace(/&nbsp;/ig,"").replace(/\s/g, "");
+
+    return isEmpty(strippedText);
+  }),
 
   saveData: task(function * () {
     yield timeout(1);

--- a/app/components/editable-field.js
+++ b/app/components/editable-field.js
@@ -6,6 +6,7 @@ const { Component } = Ember;
 export default Component.extend({
   isEditing: false,
   isSaving: false,
+  isSaveDisabled: true,
   renderHtml: false,
   classNames: ['editinplace'],
   clickPrompt: null,

--- a/app/components/inplace-html.js
+++ b/app/components/inplace-html.js
@@ -18,9 +18,11 @@ export default Component.extend(InPlace, {
         let value;
         if(editor){
           let html = editor.froalaEditor('html.get', true);
-          let plainText = html.replace(/(<([^>]+)>)/ig,"");
+          let noTagsText = html.replace(/(<([^>]+)>)/ig,"");
+          let strippedText = noTagsText.replace(/&nbsp;/ig,"").replace(/\s/g, "");
+
           //if all we have is empty html then save null
-          if(plainText.length === 0){
+          if(strippedText.length === 0){
             html = null;
           }
           value = html;

--- a/app/components/new-learningmaterial.js
+++ b/app/components/new-learningmaterial.js
@@ -200,7 +200,15 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
 
     changeDescription(event, editor) {
       if (editor) {
-        this.set('description', editor.html.get());
+        let html = editor.html.get();
+        let noTagsText = html.replace(/(<([^>]+)>)/ig,"");
+        let strippedText = noTagsText.replace(/&nbsp;/ig,"").replace(/\s/g, "");
+
+        //if all we have is empty html then save null
+        if(strippedText.length === 0){
+          html = null;
+        }
+        this.set('description', html);
       }
     },
 

--- a/app/components/new-objective.js
+++ b/app/components/new-objective.js
@@ -7,7 +7,7 @@ const { Component } = Ember;
 
 const Validations = buildValidations({
   title: [
-    validator('presence', true),
+    validator('html-presence', true),
     validator('length', {
       min: 3,
       max: 65000
@@ -39,6 +39,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
       });
     },
     changeTitle(event, editor){
+      this.send('addErrorDisplayFor', 'title');
       if(editor){
         const contents = editor.html.get();
         this.set('title', contents);

--- a/app/components/session-overview.js
+++ b/app/components/session-overview.js
@@ -225,9 +225,11 @@ export default Component.extend(Publishable, Validations, ValidationErrorDisplay
     changeDescription(event, editor){
       this.send('addErrorDisplayFor', 'description');
       let html = editor.html.get();
-      let plainText = html.replace(/(<([^>]+)>)/ig,"");
+      let noTagsText = html.replace(/(<([^>]+)>)/ig,"");
+      let strippedText = noTagsText.replace(/&nbsp;/ig,"").replace(/\s/g, "");
+
       //if all we have is empty html then save null
-      if(plainText.length === 0){
+      if(strippedText.length === 0){
         html = null;
       }
 

--- a/app/mixins/objective-list-item.js
+++ b/app/mixins/objective-list-item.js
@@ -8,7 +8,7 @@ const { Promise } = RSVP;
 
 const Validations = buildValidations({
   title: [
-    validator('presence', true),
+    validator('html-presence', true),
     validator('length', {
       min: 3,
       max: 65000

--- a/app/templates/components/course-objective-list-item.hbs
+++ b/app/templates/components/course-objective-list-item.hbs
@@ -3,7 +3,7 @@
       {{#editable-field
         value=title
         renderHtml=true
-        isSaveDisabled=(v-get this 'title' 'isInvalid')
+        isSaveDisabled=(and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))
         save=(action 'saveTitleChanges' )
         close=(action 'revertTitleChanges')
         as |isSaving save close|

--- a/app/templates/components/course-objective-list-item.hbs
+++ b/app/templates/components/course-objective-list-item.hbs
@@ -3,6 +3,7 @@
       {{#editable-field
         value=title
         renderHtml=true
+        isSaveDisabled=(v-get this 'title' 'isInvalid')
         save=(action 'saveTitleChanges' )
         close=(action 'revertTitleChanges')
         as |isSaving save close|

--- a/app/templates/components/editable-field.hbs
+++ b/app/templates/components/editable-field.hbs
@@ -11,7 +11,7 @@
     <span class='editor'>
       {{yield saveData.isRunning (perform saveData) (perform closeEditor)}}
       <span class='actions'>
-        <button class='done icon' title='{{t 'general.save'}}' {{action (perform saveData)}}>
+        <button disabled={{isSaveDisabled}} class='done icon' title='{{t 'general.save'}}' {{action (perform saveData)}}>
           {{fa-icon (if saveData.isRunning 'spinner' 'check') spin=saveData.isRunning}}
         </button>
         <button class='cancel icon' title='{{t 'general.cancel'}}' {{action (perform closeEditor)}}>{{fa-icon 'times'}}</button>

--- a/app/templates/components/editable-field.hbs
+++ b/app/templates/components/editable-field.hbs
@@ -2,7 +2,11 @@
   {{#unless isEditing}}
     <span onclick={{action (mut isEditing) true}} class='editable'>
       {{#if value}}
-        {{big-text text=value renderHtml=renderHtml}}
+        {{#if looksEmpty}}
+          {{fa-icon 'edit'}}
+        {{else}}
+          {{big-text text=value renderHtml=renderHtml}}
+        {{/if}}
       {{else}}
         {{clickPrompt}}
       {{/if}}

--- a/app/templates/components/new-objective.hbs
+++ b/app/templates/components/new-objective.hbs
@@ -17,7 +17,7 @@
   </label>
 
   <div class="form-col-6 form-data-submit">
-    <button class='done text' {{action 'save'}}>
+    <button disabled={{or isSaving (v-get this 'title' 'isInvalid')}} class='done text' {{action 'save'}}>
       {{#if isSaving}}
         {{fa-icon 'spinner' spin=true}}
       {{else}}

--- a/app/templates/components/new-objective.hbs
+++ b/app/templates/components/new-objective.hbs
@@ -17,7 +17,7 @@
   </label>
 
   <div class="form-col-6 form-data-submit">
-    <button disabled={{or isSaving (v-get this 'title' 'isInvalid')}} class='done text' {{action 'save'}}>
+    <button disabled={{or isSaving (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}} class='done text' {{action 'save'}}>
       {{#if isSaving}}
         {{fa-icon 'spinner' spin=true}}
       {{else}}

--- a/app/templates/components/programyear-objective-list-item.hbs
+++ b/app/templates/components/programyear-objective-list-item.hbs
@@ -2,7 +2,7 @@
   {{#editable-field
     value=title
     renderHtml=true
-    isSavingDisabled=(v-get this 'title' 'isInvalid')
+    isSaveDisabled=(and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))
     save=(action 'saveTitleChanges' )
     close=(action 'revertTitleChanges')
     as |isSaving save close|

--- a/app/templates/components/programyear-objective-list-item.hbs
+++ b/app/templates/components/programyear-objective-list-item.hbs
@@ -2,6 +2,7 @@
   {{#editable-field
     value=title
     renderHtml=true
+    isSavingDisabled=(v-get this 'title' 'isInvalid')
     save=(action 'saveTitleChanges' )
     close=(action 'revertTitleChanges')
     as |isSaving save close|

--- a/app/templates/components/session-objective-list-item.hbs
+++ b/app/templates/components/session-objective-list-item.hbs
@@ -3,6 +3,7 @@
     {{#editable-field
       value=title
       renderHtml=true
+      isSaveDisabled=(and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))
       save=(action 'saveTitleChanges' )
       close=(action 'revertTitleChanges')
       as |isSaving save close|

--- a/app/templates/components/session-overview.hbs
+++ b/app/templates/components/session-overview.hbs
@@ -186,7 +186,7 @@
             save=(action 'saveDescription')
             close=(action 'revertDescriptionChanges')
             renderHtml=true
-            isSaveDisabled=(v-get this 'description' 'isInvalid')
+            isSaveDisabled=(and (v-get this 'description' 'isInvalid') (is-in showErrorsFor 'description'))
             clickPrompt=(t 'general.clickToEdit')
             as |isSaving save close|
           }}

--- a/app/templates/components/session-overview.hbs
+++ b/app/templates/components/session-overview.hbs
@@ -186,6 +186,7 @@
             save=(action 'saveDescription')
             close=(action 'revertDescriptionChanges')
             renderHtml=true
+            isSaveDisabled=(v-get this 'description' 'isInvalid')
             clickPrompt=(t 'general.clickToEdit')
             as |isSaving save close|
           }}

--- a/app/validators/html-presence.js
+++ b/app/validators/html-presence.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+import BaseValidator from 'ember-cp-validations/validators/base';
+
+const { isEmpty } = Ember;
+
+export default BaseValidator.extend({
+  validate(value, options) {
+    let text = value || '';
+    let noTagsText = text.replace(/(<([^>]+)>)/ig,"");
+    let strippedText = noTagsText.replace(/&nbsp;/ig,"").replace(/\s/g, "");
+    if (isEmpty(strippedText)) {
+      return this.createErrorMessage('blank', value, options);
+    }
+
+    return true;
+  }
+});

--- a/tests/acceptance/course/objectivecreate-test.js
+++ b/tests/acceptance/course/objectivecreate-test.js
@@ -46,19 +46,21 @@ test('save new objective', function(assert) {
     Ember.run.later(()=>{
       find('.detail-objectives .newobjective .froalaEditor').froalaEditor('html.set', newObjectiveTitle);
       find('.detail-objectives .newobjective .froalaEditor').froalaEditor('events.trigger', 'contentChanged');
-      click('.detail-objectives .newobjective button.done');
-      andThen(function(){
-        let objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
-        assert.equal(objectiveRows.length, fixtures.course.objectives.length + 1);
-        let tds = find('td', objectiveRows.eq(0));
-        assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
-        assert.equal(getElementText(tds.eq(1)), getText('Add New'));
-        assert.equal(getElementText(tds.eq(2)), getText('Add New'));
-        tds = find('td', objectiveRows.eq(1));
-        assert.equal(getElementText(tds.eq(0)), getText(newObjectiveTitle));
-        assert.equal(getElementText(tds.eq(1)), getText('Add New'));
-        assert.equal(getElementText(tds.eq(2)), getText('Add New'));
-      });
+      Ember.run.later(()=>{
+        click('.detail-objectives .newobjective button.done');
+        andThen(function(){
+          let objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
+          assert.equal(objectiveRows.length, fixtures.course.objectives.length + 1);
+          let tds = find('td', objectiveRows.eq(0));
+          assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
+          assert.equal(getElementText(tds.eq(1)), getText('Add New'));
+          assert.equal(getElementText(tds.eq(2)), getText('Add New'));
+          tds = find('td', objectiveRows.eq(1));
+          assert.equal(getElementText(tds.eq(0)), getText(newObjectiveTitle));
+          assert.equal(getElementText(tds.eq(1)), getText('Add New'));
+          assert.equal(getElementText(tds.eq(2)), getText('Add New'));
+        });
+      }, 100);
     }, 100);
   });
 
@@ -80,5 +82,32 @@ test('cancel new objective', function(assert) {
     assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
     assert.equal(getElementText(tds.eq(1)), getText('Add New'));
     assert.equal(getElementText(tds.eq(2)), getText('Add New'));
+  });
+});
+
+test('empty objective title can not be created', function(assert) {
+  assert.expect(3);
+  const container = '.detail-objectives:eq(0)';
+  const expandNewObjective = `${container} .detail-objectives-actions button`;
+  const newObjective = `${container} .newobjective`;
+  const editor = `${newObjective} .froalaEditor`;
+  const save = `${newObjective} .done`;
+  const errorMessage = `${newObjective} .validation-error-message`;
+  visit(url);
+  click(expandNewObjective);
+
+  andThen(function() {
+    //wait for the editor to load
+    Ember.run.later(()=>{
+      let editorContents = find(editor).data('froala.editor').$el.text();
+      assert.equal(getText(editorContents), '');
+
+      find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
+      find(editor).froalaEditor('events.trigger', 'contentChanged');
+      Ember.run.later(()=>{
+        assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
+        assert.ok(find(save).is(':disabled'));
+      }, 100);
+    }, 100);
   });
 });

--- a/tests/acceptance/course/objectivelist-test.js
+++ b/tests/acceptance/course/objectivelist-test.js
@@ -167,3 +167,44 @@ test('edit objective title', function(assert) {
     });
   });
 });
+
+test('empty objective title can not be saved', function(assert) {
+  assert.expect(4);
+  server.create('objective', {
+    courses: [1],
+  });
+
+  server.create('course', {
+    year: 2013,
+    school: 1,
+    objectives: [1]
+  });
+  visit(url);
+  const container = '.course-objective-list';
+  const title = `${container} tbody tr:eq(0) td:eq(0)`;
+  const edit = `${title} .editable span`;
+  const editor = `${title} .froalaEditor`;
+  const initialObjectiveTitle = 'objective 0';
+  const save = `${title} .done`;
+  const errorMessage = `${title} .validation-error-message`;
+
+  andThen(function() {
+    assert.equal(getElementText(title), getText(initialObjectiveTitle));
+    click(edit);
+    andThen(function(){
+      //wait for the editor to load
+      Ember.run.later(()=>{
+
+        let editorContents = find(editor).data('froala.editor').$el.text();
+        assert.equal(getText(editorContents), getText(initialObjectiveTitle));
+
+        find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
+        find(editor).froalaEditor('events.trigger', 'contentChanged');
+        Ember.run.later(()=>{
+          assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
+          assert.ok(find(save).is(':disabled'));
+        }, 100);
+      }, 100);
+    });
+  });
+});

--- a/tests/acceptance/course/session/objectivecreate-test.js
+++ b/tests/acceptance/course/session/objectivecreate-test.js
@@ -37,25 +37,27 @@ test('save new objective', function(assert) {
   var newObjectiveTitle = 'Test junk 123';
   andThen(function() {
     let objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
-    assert.equal(objectiveRows.length, fixtures.session.objectives.length);
+    assert.equal(objectiveRows.length, fixtures.session.objectives.length, 'correct number ob initial objectives');
     click('.detail-objectives .detail-objectives-actions button');
     //wait for the editor to load
     Ember.run.later(()=>{
       find('.detail-objectives .newobjective .froalaEditor').froalaEditor('html.set', newObjectiveTitle);
       find('.detail-objectives .newobjective .froalaEditor').froalaEditor('events.trigger', 'contentChanged');
-      click('.detail-objectives .newobjective button.done');
-      andThen(function(){
-        let objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
-        assert.equal(objectiveRows.length, fixtures.session.objectives.length + 1);
-        let tds = find('td', objectiveRows.eq(0));
-        assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
-        assert.equal(getElementText(tds.eq(1)), getText('Add New'));
-        assert.equal(getElementText(tds.eq(2)), getText('Add New'));
-        tds = find('td', objectiveRows.eq(1));
-        assert.equal(getElementText(tds.eq(0)), getText(newObjectiveTitle));
-        assert.equal(getElementText(tds.eq(1)), getText('Add New'));
-        assert.equal(getElementText(tds.eq(2)), getText('Add New'));
-      });
+      Ember.run.later(()=>{
+        click('.detail-objectives .newobjective button.done');
+        andThen(function(){
+          let objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
+          assert.equal(objectiveRows.length, fixtures.session.objectives.length + 1);
+          let tds = find('td', objectiveRows.eq(0));
+          assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
+          assert.equal(getElementText(tds.eq(1)), getText('Add New'));
+          assert.equal(getElementText(tds.eq(2)), getText('Add New'));
+          tds = find('td', objectiveRows.eq(1));
+          assert.equal(getElementText(tds.eq(0)), getText(newObjectiveTitle));
+          assert.equal(getElementText(tds.eq(1)), getText('Add New'));
+          assert.equal(getElementText(tds.eq(2)), getText('Add New'));
+        });
+      }, 100)
     }, 100);
   });
 
@@ -77,5 +79,32 @@ test('cancel new objective', function(assert) {
     assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
     assert.equal(getElementText(tds.eq(1)), getText('Add New'));
     assert.equal(getElementText(tds.eq(2)), getText('Add New'));
+  });
+});
+
+test('empty objective title can not be created', function(assert) {
+  assert.expect(3);
+  const container = '.detail-objectives:eq(0)';
+  const expandNewObjective = `${container} .detail-objectives-actions button`;
+  const newObjective = `${container} .newobjective`;
+  const editor = `${newObjective} .froalaEditor`;
+  const save = `${newObjective} .done`;
+  const errorMessage = `${newObjective} .validation-error-message`;
+  visit(url);
+  click(expandNewObjective);
+
+  andThen(function() {
+    //wait for the editor to load
+    Ember.run.later(()=>{
+      let editorContents = find(editor).data('froala.editor').$el.text();
+      assert.equal(getText(editorContents), '');
+
+      find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
+      find(editor).froalaEditor('events.trigger', 'contentChanged');
+      Ember.run.later(()=>{
+        assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
+        assert.ok(find(save).is(':disabled'));
+      }, 100);
+    }, 100);
   });
 });

--- a/tests/acceptance/course/session/objectivelist-test.js
+++ b/tests/acceptance/course/session/objectivelist-test.js
@@ -157,3 +157,43 @@ test('edit objective title', function(assert) {
     });
   });
 });
+
+test('empty objective title can not be saved', function(assert) {
+  assert.expect(4);
+  server.create('objective', {
+    sessions: [1],
+  });
+
+  server.create('session', {
+    course: 1,
+    objectives: [1]
+  });
+  visit(url);
+  const container = '.session-objective-list';
+  const title = `${container} tbody tr:eq(0) td:eq(0)`;
+  const edit = `${title} .editable span`;
+  const editor = `${title} .froalaEditor`;
+  const initialObjectiveTitle = 'objective 0';
+  const save = `${title} .done`;
+  const errorMessage = `${title} .validation-error-message`;
+
+  andThen(function() {
+    assert.equal(getElementText(title), getText(initialObjectiveTitle));
+    click(edit);
+    andThen(function(){
+      //wait for the editor to load
+      Ember.run.later(()=>{
+
+        let editorContents = find(editor).data('froala.editor').$el.text();
+        assert.equal(getText(editorContents), getText(initialObjectiveTitle));
+
+        find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
+        find(editor).froalaEditor('events.trigger', 'contentChanged');
+        Ember.run.later(()=>{
+          assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
+          assert.ok(find(save).is(':disabled'));
+        }, 100);
+      }, 100);
+    });
+  });
+});

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -346,6 +346,77 @@ test('add description', function(assert) {
   });
 });
 
+test('empty description removes description', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
+  server.create('session', {
+    course: 1,
+    sessionType: 1
+  });
+  const container = '.sessiondescription';
+  const description = `${container} .content`;
+  const editorElement = `${container} .froalaEditor`;
+  const edit = `${container} .editable`;
+  const save = `${container} .done`;
+
+  visit(url);
+  andThen(function() {
+    assert.equal(getElementText(description), getText('Click to edit'));
+    click(edit);
+    andThen(function(){
+      //wait for the editor to load
+      Ember.run.later(()=>{
+        let editor = find(editorElement);
+        assert.equal(editor.data('froala.editor').$el.text(), '');
+        editor.froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
+        editor.froalaEditor('events.trigger', 'contentChanged');
+        click(save);
+        andThen(function(){
+          assert.equal(getElementText(description), getText('Click to edit'));
+        });
+      }, 100);
+    });
+  });
+});
+
+test('remove description', function(assert) {
+  server.create('user', {
+    id: 4136
+  });
+  server.create('session', {
+    course: 1,
+    sessionType: 1,
+    sessionDescription: 1
+  });
+  const container = '.sessiondescription';
+  const description = `${container} .content`;
+  const editorElement = `${container} .froalaEditor`;
+  const edit = `${container} .editable`;
+  const save = `${container} .done`;
+
+  visit(url);
+  andThen(function() {
+    assert.equal(getElementText(description), 'sessiondescription0');
+    click(edit);
+    andThen(function(){
+      //wait for the editor to load
+      Ember.run.later(()=>{
+        let editor = find(editorElement);
+        let editorContents = editor.data('froala.editor').$el.text();
+        assert.equal(getText(editorContents), 'sessiondescription0');
+        editor.froalaEditor('html.set', '');
+        editor.froalaEditor('events.trigger', 'contentChanged');
+        click(save);
+        andThen(function(){
+          assert.equal(getElementText(description), getText('Click to edit'));
+        });
+      }, 100);
+    });
+  });
+});
+
+
 test('click copy', function(assert) {
   server.create('user', {
     id: 4136,

--- a/tests/acceptance/program/programyear/objectives-test.js
+++ b/tests/acceptance/program/programyear/objectives-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import destroyApp from '../../../helpers/destroy-app';
 import {
   module,
@@ -318,6 +319,38 @@ test('add competency', function(assert) {
       andThen(function(){
         assert.equal(getElementText(find('.programyear-objective-list tbody tr:eq(2) td:eq(1)')), getText('competency 2 (competency 0)'));
       });
+    });
+  });
+});
+
+test('empty objective title can not be saved', function(assert) {
+  assert.expect(4);
+  visit(url);
+  const container = '.programyear-objective-list';
+  const title = `${container} tbody tr:eq(0) td:eq(0)`;
+  const edit = `${title} .editable span`;
+  const editor = `${title} .froalaEditor`;
+  const initialObjectiveTitle = 'objective 0';
+  const save = `${title} .done`;
+  const errorMessage = `${title} .validation-error-message`;
+
+  andThen(function() {
+    assert.equal(getElementText(title), getText(initialObjectiveTitle));
+    click(edit);
+    andThen(function(){
+      //wait for the editor to load
+      Ember.run.later(()=>{
+
+        let editorContents = find(editor).data('froala.editor').$el.text();
+        assert.equal(getText(editorContents), getText(initialObjectiveTitle));
+
+        find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
+        find(editor).froalaEditor('events.trigger', 'contentChanged');
+        Ember.run.later(()=>{
+          assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
+          assert.ok(find(save).is(':disabled'));
+        }, 100);
+      }, 100);
     });
   });
 });

--- a/tests/integration/components/editable-field-test.js
+++ b/tests/integration/components/editable-field-test.js
@@ -6,26 +6,18 @@ moduleForComponent('editable-field', 'Integration | Component | editable field',
 });
 
 test('it renders value', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
   this.render(hbs`{{editable-field value='woot!'}}`);
 
   assert.equal(this.$().text().trim(), 'woot!');
 });
 
 test('it renders clickPrompt', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
   this.render(hbs`{{editable-field clickPrompt='click me!'}}`);
 
   assert.equal(this.$().text().trim(), 'click me!');
 });
 
 test('it renders content', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
   this.render(hbs`
     {{#editable-field value='text'}}
        template block text
@@ -37,4 +29,13 @@ test('it renders content', function(assert) {
   assert.equal(this.$().text().trim(), 'template block text');
 
 
+});
+
+test('it renders an edit icon when it looks empty', function(assert) {
+  const icon = 'i.fa-edit';
+  this.set('value', '<p>&nbsp;</p>');
+  this.render(hbs`{{editable-field value=value}}`);
+
+  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$(icon).length, 1);
 });


### PR DESCRIPTION
In Session Description, Objective title, learning material description, and anywhere else HTML is being saved we need to account for a blank set of input.  If a user just enters a space or some new lines this is technically blank, but the display result is the same.

Fixes #2072
Fixes #1438