### PR TITLE
Use tasks to prevent multiple user additions

### DIFF
--- a/app/templates/components/new-directory-user.hbs
+++ b/app/templates/components/new-directory-user.hbs
@@ -39,7 +39,7 @@
         {{one-way-input
           value=otherId
           update=(action (mut otherId))
-          onenter=(action "save")
+          onenter=(perform save)
           onescape=(action this.attrs.close)
           focusOut=(action 'addErrorDisplayFor' 'otherId')
         }}
@@ -53,7 +53,7 @@
             {{one-way-input
               value=username
               update=(action (mut username))
-              onenter=(action "save")
+              onenter=(perform save)
               onescape=(action this.attrs.close)
               focusOut=(action 'addErrorDisplayFor' 'username')
             }}
@@ -71,7 +71,7 @@
           {{one-way-input
             value=password
             update=(action (mut password))
-            onenter=(action "save")
+            onenter=(perform save)
             onescape=(action this.attrs.close)
             focusOut=(action 'addErrorDisplayFor' 'password')
           }}
@@ -113,8 +113,8 @@
     </div>
 
     <div class="form-col-6 form-data-submit">
-      <button class='done text' {{action 'save'}} disabled={{or isSaving (is-pending bestSelectedCohort)  (and (not nonStudentMode) (is-pending bestSelectedSchool))}}>
-        {{#if isSaving}}
+      <button class='done text' {{action (perform save)}} disabled={{or save.isRunning (is-pending bestSelectedCohort)  (and (not nonStudentMode) (is-pending bestSelectedSchool))}}>
+        {{#if save.isRunning}}
           {{fa-icon 'spinner' spin=true}}
         {{else}}
           {{t 'general.done'}}
@@ -125,14 +125,14 @@
   </div>
 {{else}}
   <div class="new-result-title">{{t 'general.newUser'}}</div>
-  <div id='new-directory-user-search-tools'>
+  <div class='new-directory-user-search-tools'>
     {{one-way-input
       value=searchTerms
-      update=this.attrs.setSearchTerms
-      onenter=(action "findUsersInDirectory")
-      onescape=(action this.attrs.setSearchTerms '')
+      update=setSearchTerms
+      onenter=(perform findUsersInDirectory searchTerms)
+      onescape=(action setSearchTerms '')
     }}
-    <button type='search' {{action 'findUsersInDirectory'}}>{{t 'general.searchDirectory'}}</button>
+    <button type='search' {{action (perform findUsersInDirectory) searchTerms}}>{{t 'general.searchDirectory'}}</button>
   </div>
   {{#liquid-if isSearching class='crossFade'}}
     {{fa-icon 'spinner' spin=true}} {{t 'general.currentlySearchingPrompt'}}

--- a/app/templates/components/new-user.hbs
+++ b/app/templates/components/new-user.hbs
@@ -15,7 +15,7 @@
     {{one-way-input
       value=firstName
       update=(action (mut firstName))
-      onenter=(action "save")
+      onenter=(perform save)
       onescape=(action this.attrs.close)
       focusOut=(action 'addErrorDisplayFor' 'firstName')
     }}
@@ -28,7 +28,7 @@
     {{one-way-input
       value=middleName
       update=(action (mut middleName))
-      onenter=(action "save")
+      onenter=(perform save)
       onescape=(action this.attrs.close)
       focusOut=(action 'addErrorDisplayFor' 'middleName')
     }}
@@ -41,7 +41,7 @@
     {{one-way-input
       value=lastName
       update=(action (mut lastName))
-      onenter=(action "save")
+      onenter=(perform save)
       onescape=(action this.attrs.close)
       focusOut=(action 'addErrorDisplayFor' 'lastName')
     }}
@@ -54,7 +54,7 @@
     {{one-way-input
       value=campusId
       update=(action (mut campusId))
-      onenter=(action "save")
+      onenter=(perform save)
       onescape=(action this.attrs.close)
       focusOut=(action 'addErrorDisplayFor' 'campusId')
     }}
@@ -67,7 +67,7 @@
     {{one-way-input
       value=otherId
       update=(action (mut otherId))
-      onenter=(action "save")
+      onenter=(perform save)
       onescape=(action this.attrs.close)
       focusOut=(action 'addErrorDisplayFor' 'otherId')
     }}
@@ -80,7 +80,7 @@
     {{one-way-input
       value=email
       update=(action (mut email))
-      onenter=(action "save")
+      onenter=(perform save)
       onescape=(action this.attrs.close)
       focusOut=(action 'addErrorDisplayFor' 'email')
     }}
@@ -93,7 +93,7 @@
     {{one-way-input
       value=phone
       update=(action (mut phone))
-      onenter=(action "save")
+      onenter=(perform save)
       onescape=(action this.attrs.close)
       focusOut=(action 'addErrorDisplayFor' 'phone')
     }}
@@ -106,7 +106,7 @@
     {{one-way-input
       value=username
       update=(action (mut username))
-      onenter=(action "save")
+      onenter=(perform save)
       onescape=(action this.attrs.close)
       focusOut=(action 'addErrorDisplayFor' 'username')
     }}
@@ -119,7 +119,7 @@
     {{one-way-input
       value=password
       update=(action (mut password))
-      onenter=(action "save")
+      onenter=(perform save)
       onescape=(action this.attrs.close)
       focusOut=(action 'addErrorDisplayFor' 'password')
     }}
@@ -159,8 +159,8 @@
   {{/if}}
 
   <div class='buttons'>
-    <button class='done text' {{action 'save'}} disabled={{or isSaving (is-pending bestSelectedCohort)  (and (not nonStudentMode) (is-pending bestSelectedSchool))}}>
-      {{#if isSaving}}
+    <button class='done text' {{action (perform save)}} disabled={{or save.isRunning (is-pending bestSelectedCohort)  (and (not nonStudentMode) (is-pending bestSelectedSchool))}}>
+      {{#if save.isRunning}}
         {{fa-icon 'spinner' spin=true}}
       {{else}}
         {{t 'general.done'}}

--- a/tests/integration/components/new-directory-user-test.js
+++ b/tests/integration/components/new-directory-user-test.js
@@ -52,3 +52,240 @@ test('it renders', function(assert) {
     assert.notEqual(content.search(/Search directory for new users/), -1);
   });
 });
+
+test('input into the search field fires action', function(assert) {
+  assert.expect(1);
+  let storeMock = Service.extend({
+    query(){
+      return resolve([]);
+    },
+  });
+  this.register('service:store', storeMock);
+  const searchTerm = 'search for me!';
+  this.set('nothing', parseInt);
+  this.set('setSearchTerms', (val)=>{
+    assert.equal(val, searchTerm, 'changes to search get sent as action');
+  });
+  this.render(hbs`{{new-directory-user close=(action nothing) setSearchTerms=(action setSearchTerms) searchTerms=startingSearchTerms}}`);
+  const searchBox = '.new-directory-user-search-tools';
+  const searchInput = `${searchBox} input`;
+  this.$(searchInput).val(searchTerm).change();
+
+});
+
+test('initial search input fires search and fills input', function(assert) {
+  assert.expect(2);
+  const startingSearchTerms = 'start here';
+
+  let ajaxMock = Service.extend({
+    request(url){
+      assert.equal(url.trim(), `/application/directory/search?limit=51&searchTerms=${startingSearchTerms}`);
+      return resolve({
+        results: []
+      });
+    }
+  });
+  this.register('service:ajax', ajaxMock);
+  let storeMock = Service.extend({
+    query(){
+      return resolve([]);
+    },
+  });
+  this.register('service:store', storeMock);
+  this.set('nothing', parseInt);
+  this.set('startingSearchTerms', startingSearchTerms);
+  this.render(hbs`{{new-directory-user close=(action nothing) setSearchTerms=(action nothing) searchTerms=startingSearchTerms}}`);
+  const searchBox = '.new-directory-user-search-tools';
+  const searchInput = `${searchBox} input`;
+  assert.equal(this.$(searchInput).val(), startingSearchTerms, 'passed value is in the box');
+
+});
+
+test('create new user', function(assert) {
+  assert.expect(42);
+  let facultyRole = Object.create({
+    id: 3,
+    title: 'Faculty'
+  });
+  let studentRole = Object.create({
+    id: 4,
+    title: 'Student'
+  });
+  let user1 = Object.create({
+    firstName: 'user1-first',
+    lastName: 'user1-last',
+    campusId: 'user1-campus',
+    email: 'user1@test.com',
+    telephoneNumber: 'user11234',
+    user: null,
+    username: 'user1-username',
+  });
+  let user2 = Object.create({
+    firstName: 'user2-first',
+    lastName: 'user2-last',
+    campusId: 'user2-campus',
+    email: 'user2@test.com',
+    telephoneNumber: 'user21234',
+    user: 4136,
+    username: 'user2-username',
+  });
+  let user3 = Object.create({
+    firstName: 'user3-first',
+    lastName: 'user3-last',
+    campusId: null,
+    email: null,
+    telephoneNumber: 'user31234',
+    user: null,
+    username: null,
+  });
+  let ajaxRequestCalled = 0;
+
+  let ajaxMock = Service.extend({
+    request(url){
+      ajaxRequestCalled++;
+      if (ajaxRequestCalled === 1){
+        assert.equal(url.trim(), '/application/directory/search?limit=51&searchTerms=searchterm', 'search for user request is correct');
+        return resolve({
+          results: [user1, user2, user3]
+        });
+      }
+      if (ajaxRequestCalled === 2){
+        assert.equal(url.trim(), '/application/config', 'config request is correct');
+        return resolve({config: {
+          locale: 'en',
+          type: 'ladp',
+          userSearchType: 'ldap',
+        }});
+      }
+
+    }
+  });
+  this.register('service:ajax', ajaxMock);
+  let createRecordCalled = 0;
+  let storeMock = Service.extend({
+    query(what, {filters}){
+      assert.equal('cohort', what, 'looking for a cohort');
+      assert.equal(filters.schools[0], 2, 'for school 2');
+      return resolve([]);
+    },
+    findAll(what){
+      assert.equal(what, 'user-role', 'looking for user roles');
+      return resolve([facultyRole, studentRole]);
+    },
+    createRecord(what, properties){
+      createRecordCalled++;
+
+      if (createRecordCalled === 1) {
+        const {firstName, middleName, lastName, campusId, otherId, phone, email} = properties;
+        assert.equal(what, 'user', 'creating a user record');
+        assert.equal(firstName, user1.get('firstName'), 'record created with correct value for firstName');
+        assert.equal(middleName, null, 'record created with correct value for middleName');
+        assert.equal(lastName, user1.get('lastName'), 'record created with correct value for lastName');
+        assert.equal(campusId, user1.get('campusId'), 'record created with correct value for campusId');
+        assert.equal(otherId, null, 'record created with correct value for otherId');
+        assert.equal(phone, user1.get('telephoneNumber'), 'record created with correct value for phone');
+        assert.equal(email, user1.get('email'), 'record created with correct value for email');
+
+        return new Object({
+          save(){
+            const roles = this.get('roles');
+            assert.equal(roles.length, 1, 'Only one new role was added');
+            assert.ok(roles.contains(facultyRole), 'The faculty role was added');
+            assert.ok(true, 'save gets called');
+
+            return Object.create({
+              id: '13'
+            });
+          }
+        });
+      }
+
+      if (createRecordCalled === 2) {
+        const {user, username, password} = properties;
+        assert.equal(what, 'authentication', 'creating an authentication record');
+        assert.equal(username, user1.get('username'), 'record has correct username');
+        assert.equal(password, null, 'record has no password');
+        assert.equal(user.get('id'), '13', 'we are linking to the expected user');
+
+        return new Object({
+          save(){
+            assert.ok(true, 'save gets called');
+          }
+        });
+      }
+
+      assert.ok(false, 'create record called too many times');
+
+    },
+  });
+  this.register('service:store', storeMock);
+  let flashmessagesMock = Ember.Service.extend({
+    success(message){
+      assert.equal(message, 'general.saved', 'we display a saved message');
+    }
+  });
+  this.register('service:flashMessages', flashmessagesMock);
+
+  this.set('nothing', parseInt);
+  this.set('transitionToUser', (userId)=>{
+    assert.equal(userId, 13, 'after saving we transition to the right user');
+  });
+  this.render(hbs`{{new-directory-user
+    close=(action nothing)
+    setSearchTerms=(action nothing)
+    transitionToUser=(action transitionToUser)
+    searchTerms='searchterm'
+  }}`);
+
+  const results = '.new-directory-user-search-results';
+  const firstResultValues = `${results} tbody tr:eq(0) td`;
+  const secondResultValues = `${results} tbody tr:eq(1) td`;
+  const thirdResultValues = `${results} tbody tr:eq(2) td`;
+  const firstIcon = `${firstResultValues}:eq(0) i`;
+  const secondIcon = `${secondResultValues}:eq(0) i`;
+  const thirdIcon = `${thirdResultValues}:eq(0) i`;
+
+  const firstName = '.form-data:eq(1)';
+  const lastName = '.form-data:eq(2)';
+  const campusId = '.form-data:eq(3)';
+  const email = '.form-data:eq(4)';
+  const phone = '.form-data:eq(5)';
+  const otherId = '.form-data:eq(6)';
+  const username = '.form-data:eq(7)';
+
+  const save = '.done';
+
+  return wait().then(()=>{
+    assert.ok(this.$(firstIcon).hasClass('fa-plus'), 'this user can be added');
+    assert.equal(this.$(firstResultValues).eq(1).text().trim(), user1.get('firstName') + ' ' + user1.get('lastName'), 'correct display for name');
+    assert.equal(this.$(firstResultValues).eq(2).text().trim(), user1.get('campusId'), 'correct display for campusId');
+    assert.equal(this.$(firstResultValues).eq(3).text().trim(), user1.get('email'), 'correct display for email');
+
+    assert.ok(this.$(secondIcon).hasClass('fa-sun-o'), 'correct display for things');
+    assert.equal(this.$(secondResultValues).eq(1).text().trim(), user2.get('firstName') + ' ' + user2.get('lastName'), 'correct display for name');
+    assert.equal(this.$(secondResultValues).eq(2).text().trim(), user2.get('campusId'), 'correct display for campusId');
+    assert.equal(this.$(secondResultValues).eq(3).text().trim(), user2.get('email'), 'correct display for email');
+
+    assert.ok(this.$(thirdIcon).hasClass('fa-ambulance'), 'correct display for things');
+    assert.equal(this.$(thirdResultValues).eq(1).text().trim(), user3.get('firstName') + ' ' + user3.get('lastName'), 'correct display for name');
+    assert.equal(this.$(thirdResultValues).eq(2).text().trim(), '', 'campus id is empty');
+    assert.equal(this.$(thirdResultValues).eq(3).text().trim(), '', 'email is empty');
+
+    this.$(firstIcon).click();
+
+    return wait().then(()=>{
+      assert.equal(this.$(firstName).text().trim(), user1.get('firstName'), 'firstName is correct in form');
+      assert.equal(this.$(lastName).text().trim(), user1.get('lastName'), 'lastName is correct in form');
+      assert.equal(this.$(campusId).text().trim(), user1.get('campusId'), 'campusId is correct in form');
+      assert.equal(this.$(email).text().trim(), user1.get('email'), 'email is correct in form');
+      assert.equal(this.$(phone).text().trim(), user1.get('telephoneNumber'), 'phone is correct in form');
+      assert.equal(this.$(otherId).text().trim(), '', 'otherId is blank in form');
+      assert.equal(this.$(username).text().trim(), user1.get('username'), 'username is correct in form');
+
+      this.$(save).click();
+
+      return wait();
+    });
+
+  });
+});

--- a/tests/integration/components/new-user-test.js
+++ b/tests/integration/components/new-user-test.js
@@ -21,7 +21,7 @@ const currentUserMock = Service.extend({
   model: resolve(mockUser)
 });
 
-moduleForComponent('new-user', 'Integration | Component | new users', {
+moduleForComponent('new-user', 'Integration | Component | new user', {
   integration: true,
   setup(){
     initializer.initialize(this);
@@ -117,6 +117,113 @@ test('errors show up', function(assert) {
       assert.ok(boxes.eq(7).text().search(/blank/) > -1);
       assert.ok(boxes.eq(8).text().search(/blank/) > -1);
     });
+
+  });
+});
+
+test('create new user', function(assert) {
+  assert.expect(21);
+  let facultyRole = Object.create({
+    id: 3,
+    title: 'Faculty'
+  });
+  let studentRole = Object.create({
+    id: 4,
+    title: 'Student'
+  });
+  let createRecordCalled = 0;
+  let storeMock = Service.extend({
+    query(what, {filters}){
+      assert.equal('cohort', what, 'we are lookign for cohorts');
+      assert.equal(filters.schools[0], 2, 'in the correct school');
+      return resolve([]);
+    },
+    findAll(what){
+      assert.equal(what, 'user-role');
+      return resolve([facultyRole, studentRole]);
+    },
+    createRecord(what, properties){
+      createRecordCalled++;
+
+      if (createRecordCalled === 1) {
+        const {firstName, middleName, lastName, campusId, otherId, phone, email} = properties;
+        assert.equal(what, 'user', 'creating a user record');
+        assert.equal(firstName, 'first', 'with the correct firstName');
+        assert.equal(middleName, 'middle', 'with the correct middleName');
+        assert.equal(lastName, 'last', 'with the correct lastName');
+        assert.equal(campusId, 'campusid', 'with the correct campusId');
+        assert.equal(otherId, 'otherid', 'with the correct otherId');
+        assert.equal(phone, 'phone', 'with the correct phone');
+        assert.equal(email, 'test@test.com', 'with the correct email');
+
+        return new Object({
+          save(){
+            const roles = this.get('roles');
+            assert.equal(roles.length, 1, 'Only one new role was added');
+            assert.ok(roles.contains(facultyRole), 'The faculty role was added');
+            assert.ok(true, 'save gets called');
+
+            return Object.create({
+              id: '13'
+            });
+          }
+        });
+      }
+
+      if (createRecordCalled === 2) {
+        const {user, username, password} = properties;
+        assert.equal(what, 'authentication', 'creating an authentication record');
+        assert.equal(username, 'user123', 'with the correct username');
+        assert.equal(password, 'password123', 'with the correct password');
+        assert.equal(user.get('id'), '13', 'with the correct userId');
+
+        return new Object({
+          save(){
+            assert.ok(true, 'save gets called');
+          }
+        });
+      }
+
+      assert.ok(false, 'create record called too many times');
+
+    },
+  });
+  this.register('service:store', storeMock);
+  let flashmessagesMock = Ember.Service.extend({
+    success(message){
+      assert.equal(message, 'general.saved', 'success message is displayed');
+    }
+  });
+  this.register('service:flashMessages', flashmessagesMock);
+
+  this.set('nothing', parseInt);
+  this.set('transitionToUser', (userId)=>{
+    assert.equal(userId, 13);
+  });
+  this.render(hbs`{{new-user close=(action nothing) transitionToUser=(action transitionToUser)}}`);
+  const firstName = '.item:eq(0) input';
+  const middleName = '.item:eq(1) input';
+  const lastName = '.item:eq(2) input';
+  const campusId = '.item:eq(3) input';
+  const otherId = '.item:eq(4) input';
+  const email = '.item:eq(5) input';
+  const phone = '.item:eq(6) input';
+  const username = '.item:eq(7) input';
+  const password = '.item:eq(8) input';
+
+  return wait().then(() => {
+    this.$(firstName).val('first').change();
+    this.$(middleName).val('middle').change();
+    this.$(lastName).val('last').change();
+    this.$(campusId).val('campusid').change();
+    this.$(otherId).val('otherid').change();
+    this.$(phone).val('phone').change();
+    this.$(email).val('test@test.com').change();
+    this.$(username).val('user123').change();
+    this.$(password).val('password123').change();
+
+    this.$('.done').click();
+    return wait();
 
   });
 });


### PR DESCRIPTION
Before this change it was possible to double or quintuple click the add
user button and create a bunch of bad accounts.  Using a dropable task
this is no longer possible.  Only the first click will be counted.

Fixes #2059