### PR TITLE
Reset the selected course when changing years

### DIFF
--- a/app/components/session-copy.js
+++ b/app/components/session-copy.js
@@ -152,6 +152,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
 
   actions: {
     changeSelectedYear(newYear){
+      this.set('selectedCourse', null);
       this.set('selectedYear', newYear);
       this.get('loadCourses').perform();
     },


### PR DESCRIPTION
If we don't reset the course then loading the new years doesn't change
the default course selected.  If a user then clicks done without
changing the course selection an invalid course is chosen.

Fixes #2130