### PR TITLE
Specify API info as environmental variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ npm-debug.log
 testem.log
 lcov.dat
 sauce-example.log
+.env

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,15 +1,16 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import AjaxServiceSupport from 'ember-ajax/mixins/ajax-support';
+import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 
 const { inject, computed } = Ember;
 const { service } = inject;
 const { reads } = computed;
 const { RESTAdapter } = DS;
 
-export default RESTAdapter.extend(AjaxServiceSupport, {
+export default RESTAdapter.extend(DataAdapterMixin, {
   serverVariables: service(),
 
+  host: reads('serverVariables.apiHost'),
   namespace: reads('serverVariables.apiNameSpace'),
 
   coalesceFindRequests: true,

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,17 +1,16 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
+import AjaxServiceSupport from 'ember-ajax/mixins/ajax-support';
 
 const { inject, computed } = Ember;
 const { service } = inject;
 const { reads } = computed;
 const { RESTAdapter } = DS;
 
-export default RESTAdapter.extend(DataAdapterMixin, {
+export default RESTAdapter.extend(AjaxServiceSupport, {
   serverVariables: service(),
 
   namespace: reads('serverVariables.apiNameSpace'),
-  host: reads('serverVariables.apiHost'),
 
   coalesceFindRequests: true,
 

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -3,16 +3,21 @@ import AjaxService from 'ember-ajax/services/ajax';
 
 const { inject, computed } = Ember;
 const { service } = inject;
+const { reads } = computed;
 
 export default AjaxService.extend({
+  serverVariables: service(),
   session: service(),
+
+  host: reads('serverVariables.apiHost'),
+
   headers: computed('session.isAuthenticated', function(){
     let headers = {};
     this.get('session').authorize('authorizer:token', (headerName, headerValue) => {
       headers[headerName] = headerValue;
     });
-    
+
     return headers;
   }),
-  
+
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -87,7 +87,8 @@ module.exports = function(environment) {
       tagPrefix: 'iliosconfig',
       vars: ['api-host', 'api-name-space'],
       defaults: {
-        'api-name-space': 'api/v1'
+        'api-name-space': process.env.ILIOS_FRONTEND_API_NAMESPACE || 'api/v1',
+        'api-host': process.env.ILIOS_FRONTEND_API_HOST || null,
       }
     },
     EmberENV: {
@@ -121,7 +122,11 @@ module.exports = function(environment) {
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV.contentSecurityPolicy['script-src'].push("'unsafe-inline'");
     ENV.redirectAfterShibLogin = false;
-    ENV.serverVariables.defaults['api-name-space'] = 'api';
+
+    //Remove mirage in developemnt, we only use it in testing
+    ENV['ember-cli-mirage'] = {
+      enabled: false
+    };
   }
 
   if (environment === 'test') {
@@ -137,21 +142,6 @@ module.exports = function(environment) {
     ENV.flashMessageDefaults.timeout = 100;
     ENV.flashMessageDefaults.extendedTimeout = 100;
     ENV.serverVariables.defaults['api-name-space'] = 'api';
-  }
-
-  if (environment === 'heroku') {
-    ENV['ember-cli-mirage'] = {
-      enabled: true
-    };
-  }
-
-  //Just like dev except we can use proxy to get data from the API
-  // Example for vagrant ember serve --env=proxy --proxy='http://10.10.10.10'
-  if (environment === 'proxy') {
-    ENV['ember-cli-mirage'] = {
-      enabled: false
-    };
-    ENV.contentSecurityPolicy['script-src'].push("'unsafe-inline'");
   }
 
 /*

--- a/config/environment.js
+++ b/config/environment.js
@@ -152,5 +152,9 @@ module.exports = function(environment) {
   }
 */
 
+  //add our API host to the list of acceptable data sources
+  ENV.contentSecurityPolicy['connect-src'].push(ENV.serverVariables.defaults['api-host']);
+
+
   return ENV;
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -142,6 +142,7 @@ module.exports = function(environment) {
     ENV.flashMessageDefaults.timeout = 100;
     ENV.flashMessageDefaults.extendedTimeout = 100;
     ENV.serverVariables.defaults['api-name-space'] = 'api';
+    ENV.serverVariables.defaults['api-host'] = '';
   }
 
 /*

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ember-cli-deploy-s3": "0.3.2",
     "ember-cli-deploy-s3-index": "0.5.0",
     "ember-cli-deprecation-workflow": "0.2.3",
+    "ember-cli-dotenv": "1.2.0",
     "ember-cli-flash": "1.3.16",
     "ember-cli-htmlbars": "^1.0.11",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",


### PR DESCRIPTION
By using environmental variables here we are able to override them in various places.  For example we can build in netlify or heroku with a connection to the demo data API.  This obviates our need for using a proxy command in development you can just add a .env file to your ilios project with data like:
`ILIOS_FRONTEND_API_HOST="https://ilios3-demo.ucsf.edu"` and be permanently connected to demo whenever `ember serve` is run.