### PR TITLE
Make link to view users more precise

### DIFF
--- a/app/templates/components/manage-users-summary.hbs
+++ b/app/templates/components/manage-users-summary.hbs
@@ -1,5 +1,5 @@
 <h2 class='title'>
-  {{t 'general.manageUsersSummaryTitle'}} ({{#link-to 'users'}}{{t 'general.viewAll'}}{{/link-to}})
+  {{t 'general.manageUsersSummaryTitle'}} ({{#link-to 'users' (query-params showBulkNewUserForm=false showNewUserForm=false)}}{{t 'general.viewAll'}}{{/link-to}})
 </h2>
 <div class='actions'>
   {{#link-to 'users' (query-params showNewUserForm=true showBulkNewUserForm=false)}}


### PR DESCRIPTION
If we don't include the query param information then whatever was open
the last time a user visited the page will remain open.  This is
confusing.

Fixes #2104