### PR TITLE
Update ember-cp-validations to v3

### DIFF
--- a/app/components/bulk-new-users.js
+++ b/app/components/bulk-new-users.js
@@ -7,7 +7,7 @@ import PapaParse from 'papaparse';
 const { Component, RSVP, inject, isPresent, computed, getOwner } = Ember;
 const { service } = inject;
 const { Promise, filter } = RSVP;
-const { reads } = computed;
+const { reads, not } = computed;
 
 const UserValidations = buildValidations({
   firstName: [
@@ -34,17 +34,15 @@ const UserValidations = buildValidations({
       ignoreBlank: true,
     }),
     validator('exclusion', {
-      dependentKeys: ['existingUsernames.[]'],
-      in(){
-        return this.get('model.existingUsernames');
-      }
+      dependentKeys: ['model.existingUsernames.[]'],
+      in: reads('model.existingUsernames')
     })
   ],
   password: [
     validator('presence', {
       presence: true,
-      dependentKeys: ['username'],
-      disabled(model) { return !isPresent(model.get('username')) }
+      dependentKeys: ['model.username'],
+      disabled: not('model.username'),
     })
   ],
   campusId: [

--- a/app/components/curriculum-inventory-sequence-block-dates-duration-editor.js
+++ b/app/components/curriculum-inventory-sequence-block-dates-duration-editor.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 
-const { Component } = Ember;
+const { Component, computed } = Ember;
+const { gt, reads } = computed;
 
 const Validations = buildValidations({
 
@@ -17,28 +18,24 @@ const Validations = buildValidations({
   startDate: [
     validator('presence', {
       presence: true,
-      dependentKeys: ['duration'],
-      disabled(){
-        return this.get('model.duration') > 0;
-      }
+      dependentKeys: ['model.duration'],
+      disabled: gt('model.duration', 0)
     }),
   ],
   endDate: [
     validator('date', {
-      dependentKeys: ['startDate', 'duration'],
-      after: function () {
-        return this.get('model.startDate');
-      },
-      disabled(){
+      dependentKeys: ['model.startDate', 'model.duration'],
+      after: reads('model.startDate'),
+      disabled: computed('model.duration', 'model.startDate', function(){
         return this.get('model.duration') > 0 && !this.get('model.startDate');
-      }
+      })
     }),
     validator('presence', {
       presence: true,
-      dependentKeys: ['startDate', 'duration'],
-      disabled(){
+      dependentKeys: ['model.startDate', 'model.duration'],
+      disabled: computed('model.duration', 'model.startDate', function(){
         return this.get('model.duration') > 0 && !this.get('model.startDate');
-      }
+      })
     }),
   ]
 });

--- a/app/components/curriculum-inventory-sequence-block-min-max-editor.js
+++ b/app/components/curriculum-inventory-sequence-block-min-max-editor.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 
-const { Component } = Ember;
+const { Component, computed } = Ember;
 
 const Validations = buildValidations({
   minimum: [
@@ -14,13 +14,13 @@ const Validations = buildValidations({
   ],
   maximum: [
     validator('number', {
-      dependentKeys: ['minimum'],
+      dependentKeys: ['model.minimum'],
       allowString: true,
       integer: true,
-      gte: function() {
+      gte: computed('model.minimum', function() {
         const min = this.get('model.minimum') || 0;
         return Math.max(0, min);
-      }
+      })
     }),
   ],
 });

--- a/app/components/new-curriculum-inventory-sequence-block.js
+++ b/app/components/new-curriculum-inventory-sequence-block.js
@@ -3,8 +3,9 @@ import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 import { task } from 'ember-concurrency';
 
-const { inject, Component, isPresent } = Ember;
+const { inject, Component, isPresent, computed } = Ember;
 const { service } = inject;
+const { gt, reads } = computed;
 
 const Validations = buildValidations({
   title: [
@@ -25,28 +26,25 @@ const Validations = buildValidations({
   startDate: [
     validator('presence', {
       presence: true,
-      dependentKeys: ['duration'],
-      disabled(){
-        return this.get('model.duration') > 0;
-      }
+      dependentKeys: ['model.duration'],
+      disabled: gt('model.duration', 0)
     }),
   ],
   endDate: [
     validator('date', {
-      dependentKeys: ['startDate', 'duration'],
-      after: function () {
-        return this.get('model.startDate');
-      },
-      disabled(){
+      dependentKeys: ['model.startDate', 'model.duration'],
+      after: reads('model.startDate'),
+      disabled: computed('model.duration', 'model.startDate', function(){
         return this.get('model.duration') > 0 && !this.get('model.startDate');
-      }
+      })
     }),
     validator('presence', {
       presence: true,
-      dependentKeys: ['startDate', 'duration'],
-      disabled(){
+      dependentKeys: ['model.startDate', 'model.duration'],
+      after: reads('model.startDate'),
+      disabled: computed('model.duration', 'model.startDate', function(){
         return this.get('model.duration') > 0 && !this.get('model.startDate');
-      }
+      })
     }),
   ],
   minimum: [
@@ -61,10 +59,10 @@ const Validations = buildValidations({
       dependentKeys: ['minimum'],
       allowString: true,
       integer: true,
-      gte: function() {
+      gte: computed('model.minimum', function() {
         const min = this.get('model.minimum') || 0;
         return Math.max(0, min);
-      }
+      })
     }),
   ],
 });

--- a/app/components/new-directory-user.js
+++ b/app/components/new-directory-user.js
@@ -11,10 +11,12 @@ const Validations = buildValidations({
   username: [
     validator('presence', {
       presence: true,
-      dependentKeys: 'allowCustomUserName.content',
-      disabled(){
-        return !this.get('model.allowCustomUserName.content');
-      }
+      dependentKeys: ['model.allowCustomUserName'],
+      disabled: computed('model.allowCustomUserName', function(){
+        return this.get('model.allowCustomUserName').then(allowCustomUserName => {
+          return allowCustomUserName;
+        });
+      })
     }),
     validator('length', {
       max: 100
@@ -23,10 +25,12 @@ const Validations = buildValidations({
   password: [
     validator('presence', {
       presence: true,
-      dependentKeys: 'allowCustomUserName.content',
-      disabled(){
-        return !this.get('model.allowCustomUserName.content');
-      }
+      dependentKeys: ['model.allowCustomUserName'],
+      disabled: computed('model.allowCustomUserName', function(){
+        return this.get('model.allowCustomUserName').then(allowCustomUserName => {
+          return allowCustomUserName;
+        });
+      })
     })
   ],
   otherId: [

--- a/app/components/new-learningmaterial.js
+++ b/app/components/new-learningmaterial.js
@@ -4,7 +4,7 @@ import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 
 const { Component, computed, inject, set } = Ember;
-const { equal } = computed;
+const { equal, not } = computed;
 const { service } = inject;
 
 const Validations = buildValidations({
@@ -25,46 +25,38 @@ const Validations = buildValidations({
   fileHash: [
     validator('presence', {
       presence: true,
-      dependentKeys: ['isFile'],
-      disabled(){
-        return !this.get('model.isFile');
-      }
+      dependentKeys: ['model.isFile'],
+      disabled: not('model.isFile')
     }),
   ],
   filename: [
     validator('presence', {
       presence: true,
-      dependentKeys: ['isFile'],
-      disabled(){
-        return !this.get('model.isFile');
-      }
+      dependentKeys: ['model.isFile'],
+      disabled: not('model.isFile')
     }),
   ],
   link: [
     validator('presence', {
       presence: true,
-      dependentKeys: ['isLink'],
-      disabled(){
-        return !this.get('model.isLink');
-      }
+      dependentKeys: ['model.isLink'],
+      disabled: not('model.isLink')
     }),
   ],
   citation: [
     validator('presence', {
       presence: true,
-      dependentKeys: ['isCitation'],
-      disabled(){
-        return !this.get('model.isCitation');
-      }
+      dependentKeys: ['model.isCitation'],
+      disabled: not('model.isCitation')
     }),
   ],
   copyrightRationale: [
     validator('presence', {
       presence: true,
-      dependentKeys: ['copyrightPermission'],
-      disabled(){
+      dependentKeys: ['model.copyrightPermission'],
+      disabled: computed('model.isFile', 'model.copyrightPermission', function(){
         return !this.get('model.isFile') || this.get('model.copyrightPermission');
-      }
+      })
     }),
     validator('length', {
       min: 2,

--- a/app/components/offering-form.js
+++ b/app/components/offering-form.js
@@ -7,6 +7,7 @@ import { task, timeout } from 'ember-concurrency';
 const { Component, inject, computed, RSVP, isPresent, isEmpty } = Ember;
 const { service } = inject;
 const { Promise, map, filter, hash } = RSVP;
+const { not } = computed;
 
 const Validations = buildValidations({
   room: [
@@ -18,10 +19,8 @@ const Validations = buildValidations({
     }),
   ],
   numberOfWeeks: {
-    dependentKeys: ['makeRecurring'],
-    disabled(){
-      return !this.get('model.makeRecurring');
-    },
+    dependentKeys: ['model.makeRecurring'],
+    disabled: not('model.makeRecurring'),
     validators: [
       validator('presence', {
         presence: true
@@ -49,10 +48,8 @@ const Validations = buildValidations({
     })
   ],
   learnerGroups: {
-    dependentKeys: ['smallGroupMode'],
-    disabled(){
-      return !this.get('model.smallGroupMode');
-    },
+    dependentKeys: ['model.smallGroupMode'],
+    disabled: not('model.smallGroupMode'),
     validators: [
       validator('length', {
         min: 1,

--- a/app/components/school-vocabulary-manager.js
+++ b/app/components/school-vocabulary-manager.js
@@ -14,8 +14,8 @@ const Validations = buildValidations({
       max: 200
     }),
     validator('async-exclusion', {
-      dependentKeys: ['vocabulary.topLevelTerms.@each.title'],
-      in(){
+      dependentKeys: ['model.vocabulary.terms.@each.title'],
+      in: computed('model.vocabulary.terms.@each.title', function(){
         return new Promise(resolve => {
           const vocabulary = this.get('model.vocabulary');
           if (isPresent(vocabulary)) {
@@ -23,11 +23,10 @@ const Validations = buildValidations({
               resolve(terms.filterBy('isTopLevel', true).mapBy('title'));
             });
           }
-
           resolve([]);
         });
 
-      },
+      }),
       descriptionKey: 'general.term',
     })
   ],

--- a/app/components/school-vocabulary-term-manager.js
+++ b/app/components/school-vocabulary-term-manager.js
@@ -14,8 +14,8 @@ const Validations = buildValidations({
       max: 200
     }),
     validator('async-exclusion', {
-      dependentKeys: ['term.children.@each.title'],
-      in(){
+      dependentKeys: ['model.term.children.@each.title'],
+      in: computed('model.term.@each.title', function(){
         return new Promise(resolve => {
           const term = this.get('model.term');
           if (isPresent(term)) {
@@ -26,8 +26,7 @@ const Validations = buildValidations({
             resolve([]);
           }
         });
-
-      },
+      }),
       descriptionKey: 'general.term',
     })
   ],

--- a/app/components/user-profile-bio.js
+++ b/app/components/user-profile-bio.js
@@ -61,10 +61,10 @@ const Validations = buildValidations({
     ]
   },
   password: {
-    dependentKeys: ['canEditUsernameAndPassword', 'changeUserPassword'],
-    disabled(){
+    dependentKeys: ['model.canEditUsernameAndPassword', 'model.changeUserPassword'],
+    disabled: computed('model.canEditUsernameAndPassword', 'model.changeUserPassword', function(){
       return this.get('model.canEditUsernameAndPassword') && !this.get('model.changeUserPassword');
-    },
+    }),
     validators: [
       validator('presence', true),
       validator('length', {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-composable-helpers": "1.1.2",
     "ember-concurrency": "0.7.9",
-    "ember-cp-validations": "2.9.7",
+    "ember-cp-validations": "3.0.1",
     "ember-cryptojs-shim": "^1.0.0",
     "ember-data": "^2.8.0",
     "ember-exam": "0.5.0",


### PR DESCRIPTION
This update uses CPs instead of private functions to define properties
for validations.  This necessitated changing some of our validations to
match.

Fixes #2041

Needs: 
- [x] Tests to pass
- [x] Click test of some untested validations