### PR TITLE
Add 'preview' environment

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,15 +1,15 @@
 /* eslint-env node */
-/* global require, module */
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   var env = EmberApp.env() || 'development';
-  var isProductionLikeBuild = ['production', 'staging', 'heroku'].indexOf(env) > -1;
+  var isProductionLikeBuild = ['production', 'staging', 'preview'].indexOf(env) > -1;
+  var prependCloudfrontUrl = ['production', 'staging'].indexOf(env) > -1;
 
   var app = new EmberApp(defaults, {
     fingerprint: {
       enabled: isProductionLikeBuild,
-      prepend: 'https://d26vzvixg52o0d.cloudfront.net/'
+      prepend: prependCloudfrontUrl?'https://d26vzvixg52o0d.cloudfront.net/':null
     },
     sourcemaps: {
       enabled: !isProductionLikeBuild,


### PR DESCRIPTION
When --environment=preview is specified we get a production like build
but with no prepending of assets with AWS cloud front domain.

Fixes #2144