### PR TITLE
Allow 255 characters in course external id

### DIFF
--- a/app/components/course-overview.js
+++ b/app/components/course-overview.js
@@ -13,7 +13,7 @@ const Validations = buildValidations({
     validator('length', {
       allowBlank: true,
       min: 2,
-      max: 18
+      max: 255
     }),
   ],
 });

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 
 module.exports = function(deployTarget) {
-  const API_VERSION = 'v1.10';
+  const API_VERSION = 'v1.11';
   var ENV = {
     build: {},
     exclude: ['.DS_Store', '*-test.js']

--- a/tests/integration/components/course-overview-test.js
+++ b/tests/integration/components/course-overview-test.js
@@ -84,7 +84,7 @@ test('course external id validation fails if value is too long', function(assert
   this.$(open).click();
   return wait().then(()=>{
     assert.equal(this.$(error).length, 0, 'No validation errors shown initially.');
-    this.$(input).val('this exernal id is longer than eighteen characters').change();
+    this.$(input).val('tooLong'.repeat(50)).change();
     this.$(save).click();
     wait().then(() => {
       assert.equal(this.$(error).length, 1, 'Validation failed, error message shows.');


### PR DESCRIPTION
This field is expanded in size in v1.11 of the API

Fixes #2146