### PR TITLE
Remove deprecated box-sizing mixin

### DIFF
--- a/app/styles/components/_progress-bar.scss
+++ b/app/styles/components/_progress-bar.scss
@@ -16,7 +16,6 @@
   width: 100%;
 
   > .meter {
-    @include box-sizing(border-box);
     background-color: $progress-meter-color;
     background-repeat: repeat-x;
     background-size: 40px 40px;
@@ -24,6 +23,7 @@
     border-bottom-right-radius: 0;
     border-radius: $base-border-radius / 1.5;
     border-top-right-radius: 0;
+    box-sizing: border-box;
     display: block;
     height: 100%;
     width: 60%;


### PR DESCRIPTION
Bourbon deprecated the mixin because it is supported as is in all
browsers now.

Fixes #2155