### PR TITLE
Remove mixin for display(flex)

### DIFF
--- a/app/styles/components/_pulseloader.scss
+++ b/app/styles/components/_pulseloader.scss
@@ -20,7 +20,7 @@
 
   &.is-full-size {
     @include align-items(center);
-    @include display(flex);
+    display: flex;
     min-height: 100px;
   }
 

--- a/app/styles/components/_waveloader.scss
+++ b/app/styles/components/_waveloader.scss
@@ -1,7 +1,7 @@
 .waveloader {
   &.is-full-size {
     @include align-items(center);
-    @include display(flex);
+    display: flex;
     min-height: 100px;
   }
 


### PR DESCRIPTION
This is a pre-fix mixin and we do not need it.  Autoprefixer will add
any needed additional markup.

Fixes #2157