### PR TITLE
prevent session objective modifications if owning course is locked.

### DIFF
--- a/app/templates/components/session-objective-list.hbs
+++ b/app/templates/components/session-objective-list.hbs
@@ -12,6 +12,7 @@
       {{#each sortedObjectives as |objective|}}
         {{session-objective-list-item
           objective=objective
+          editable=editable
           session=session
           showRemoveConfirmation=(is-in objectivesForRemovalConfirmation objective.id)
           remove=(action 'confirmRemoval')


### PR DESCRIPTION
fixes #2131 