### PR TITLE
Handle multiple users moving around in learner groups better

### DIFF
--- a/app/components/learnergroup-cohort-user-manager.js
+++ b/app/components/learnergroup-cohort-user-manager.js
@@ -4,7 +4,7 @@ import { task, timeout } from 'ember-concurrency';
 const { Component, computed, isEmpty } = Ember;
 
 export default Component.extend({
-  didReceiveAttrs(){
+  init(){
     this._super(...arguments);
     this.set('usersBeingMoved', []);
     this.set('selectedUsers', []);

--- a/app/components/learnergroup-summary.js
+++ b/app/components/learnergroup-summary.js
@@ -163,7 +163,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
       this.set('showUserManagerLoader', false);
       return users;
     }
-  }).restartable(),
+  }).enqueue(),
   usersToPassToCohortManager: task(function * () {
     const learnerGroup = this.get('learnerGroup');
     const cohort = yield learnerGroup.get('cohort');
@@ -177,7 +177,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
 
     this.set('showCohortManagerLoader', false);
     return filteredUsers;
-  }).restartable(),
+  }).enqueue(),
   actions: {
     changeLocation() {
       const newLocation = this.get('location');

--- a/app/components/learnergroup-user-manager.js
+++ b/app/components/learnergroup-user-manager.js
@@ -4,7 +4,7 @@ import { task, timeout } from 'ember-concurrency';
 const { Component, computed, isEmpty } = Ember;
 
 export default Component.extend({
-  didReceiveAttrs(){
+  init(){
     this._super(...arguments);
     this.set('usersBeingMoved', []);
     this.set('selectedUsers', []);


### PR DESCRIPTION
We were killing the spinners to often and updating the saved data out of
order.  Instead we should finish each transaction in queue correctly and
keep the list of users being managed open while the component exists.

Fixes #2172