### PR TITLE
Fix pager for unassigned students to show the right total

### DIFF
--- a/app/components/assign-students.js
+++ b/app/components/assign-students.js
@@ -11,11 +11,15 @@ export default Component.extend({
   store: service(),
   flashMessages: service(),
 
+  init(){
+    this._super(...arguments);
+    this.set('selectedUserIds', []);
+    this.set('savedUserIds', []);
+  },
+
   didReceiveAttrs(){
     this._super(...arguments);
     this.get('loadCohorts').perform();
-    this.set('selectedUserIds', []);
-    this.set('savedUserIds', []);
   },
   students: [],
   school: null,
@@ -123,6 +127,13 @@ export default Component.extend({
     this.get('flashMessages').success('general.savedSuccessfully');
 
   }).drop(),
+
+  totalUnassignedStudents: computed('students.length', 'savedUserIds.length', function(){
+    const students = this.get('students.length');
+    const saved = this.get('savedUserIds.length');
+
+    return students - saved;
+  }),
 
   actions: {
     toggleCheck(){

--- a/app/templates/components/assign-students.hbs
+++ b/app/templates/components/assign-students.hbs
@@ -37,7 +37,7 @@
     {{pagedlist-controls
       offset=offset
       limit=limit
-      total=(get students 'length')
+      total=totalUnassignedStudents
       setOffset=(action this.attrs.setOffset)
       setLimit=(action this.attrs.setLimit)
     }}
@@ -77,7 +77,7 @@
     {{pagedlist-controls
       offset=offset
       limit=limit
-      total=(get students 'length')
+      total=totalUnassignedStudents
       setOffset=(action this.attrs.setOffset)
       setLimit=(action this.attrs.setLimit)
     }}


### PR DESCRIPTION
We were not counting students who had been saved so the total count was
always wrong once any action had been taken.

Fixes #1475