### PR TITLE
lock curriculum inventory download button while d/l is in process

### DIFF
--- a/app/components/curriculum-inventory-report-header.js
+++ b/app/components/curriculum-inventory-report-header.js
@@ -23,13 +23,21 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     this._super(...arguments);
     this.set('reportName', this.get('report.name'));
     this.set('isFinalized', this.get('report.isFinalized'));
+
+    // check if the d/l link points at the same domain as the current page is on.
+    let parser = document.createElement('a');
+    parser.href = this.get('report.absoluteFileUri');
+    let backendDomain = parser.hostname;
+    let frontendDomain = window.location.hostname;
+    this.set('downloadFromSameDomain', (backendDomain === frontendDomain));
   },
   classNames: ['curriculum-inventory-report-header'],
   report: null,
   reportName: null,
   publishTarget: alias('report'),
   isFinalized: false,
-  isDownloading:false,
+  isDownloading: false,
+  downloadFromSameDomain: false,
 
   downloadReport: task(function * (report){
     let anchor = document.createElement('a');

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -128,6 +128,7 @@ export default {
     'domain': 'Domain',
     'done': 'Done',
     'download': 'Download',
+    'downloadingCurriculumInventoryReport': 'Report download has started. This may take a while...',
     'draft': 'Draft',
     'dueBy': 'Due By',
     'dueThisDay': 'Due this day',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -128,6 +128,7 @@ export default {
     'domain': 'Dominio',
     'done': 'Acabado',
     'download': 'Descargar',
+    'downloadingCurriculumInventoryReport': 'Informe descarga ha comenzado. Esto puede tardar un rato...',
     'draft': 'Borrador',
     'dueBy': 'Debido Por',
     'dueThisDay': 'Debido por esta fecha',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -128,6 +128,7 @@ export default {
     'domain': 'Domaine',
     'done': "Fini",
     'download': 'Télécharger',
+    'downloadingCurriculumInventoryReport': 'Rapport téléchargement a commencé. Cela peut prendre un peu de temps...',
     'draft': 'Provisoire',
     'dueBy': "Avant",
     'dueThisDay': "Dû ce jour-là",

--- a/app/templates/components/curriculum-inventory-report-header.hbs
+++ b/app/templates/components/curriculum-inventory-report-header.hbs
@@ -25,8 +25,18 @@
   {{/if}}
 </div>
 <div class ='header-actions'>
-  <a href="{{report.absoluteFileUri}}" class="button" download="report.xml" target="_blank">
-    <button>{{fa-icon 'download'}} {{t 'general.download'}}</button></a>
+  <a
+    href="{{report.absoluteFileUri}}"
+    class="button"
+    download="report.xml"
+    target="_blank"
+    {{action (perform downloadReport report)}}
+  >
+    <button>
+      {{fa-icon (if downloadReport.isRunning 'spinner' 'download') spin=(if downloadReport.isRunning true false)}}
+      {{t 'general.download'}}
+    </button>
+  </a>
   {{#unless isFinalized}}
      <button {{action 'finalize'}} >{{t 'general.finalize'}}</button>
   {{/unless}}

--- a/app/templates/components/curriculum-inventory-report-header.hbs
+++ b/app/templates/components/curriculum-inventory-report-header.hbs
@@ -25,18 +25,16 @@
   {{/if}}
 </div>
 <div class ='header-actions'>
-  {{#if downloadFromSameDomain}}
-    <a class="button" {{action (perform downloadReport report)}}>
-      <button>
+  <a class="button" {{action (perform downloadReport report)}}>
+    <button>
+      {{#if downloadFromSameDomain}}
         {{fa-icon (if downloadReport.isRunning 'spinner' 'download') spin=(if downloadReport.isRunning true false)}}
+      {{else}}
+        {{fa-icon 'download'}}
+      {{/if}}
         {{t 'general.download'}}
-      </button>
-    </a>
-  {{else}}
-    <a href="{{report.absoluteFileUri}}" class="button" download="report.xml" target="_blank">
-      <button>{{fa-icon 'download'}} {{t 'general.download'}}</button>
-    </a>
-  {{/if}}
+    </button>
+  </a>
   {{#unless isFinalized}}
     <button {{action 'finalize'}} >{{t 'general.finalize'}}</button>
   {{/unless}}

--- a/app/templates/components/curriculum-inventory-report-header.hbs
+++ b/app/templates/components/curriculum-inventory-report-header.hbs
@@ -25,20 +25,20 @@
   {{/if}}
 </div>
 <div class ='header-actions'>
-  <a
-    href="{{report.absoluteFileUri}}"
-    class="button"
-    download="report.xml"
-    target="_blank"
-    {{action (perform downloadReport report)}}
-  >
-    <button>
-      {{fa-icon (if downloadReport.isRunning 'spinner' 'download') spin=(if downloadReport.isRunning true false)}}
-      {{t 'general.download'}}
-    </button>
-  </a>
+  {{#if downloadFromSameDomain}}
+    <a class="button" {{action (perform downloadReport report)}}>
+      <button>
+        {{fa-icon (if downloadReport.isRunning 'spinner' 'download') spin=(if downloadReport.isRunning true false)}}
+        {{t 'general.download'}}
+      </button>
+    </a>
+  {{else}}
+    <a href="{{report.absoluteFileUri}}" class="button" download="report.xml" target="_blank">
+      <button>{{fa-icon 'download'}} {{t 'general.download'}}</button>
+    </a>
+  {{/if}}
   {{#unless isFinalized}}
-     <button {{action 'finalize'}} >{{t 'general.finalize'}}</button>
+    <button {{action 'finalize'}} >{{t 'general.finalize'}}</button>
   {{/unless}}
 </div>
 

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "clipboard": "~1.5.5",
     "papaparse": "~4.1.2",
     "zxcvbn": "~4.3.0",
-    "crypto-js": "^3.1.6"
+    "crypto-js": "^3.1.6",
+    "js-cookie": "^2.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -104,5 +104,8 @@
     "paths": [
       "lib/ilios-prerender"
     ]
+  },
+  "dependencies": {
+    "ember-cli-js-cookie": "0.0.1"
   }
 }


### PR DESCRIPTION
requires PR ilios/ilios#1613.

a spinner is shown on the d/l button once the request has started, but no response has been received yet.
once the actual file download has started, the d/l button gets unlocked and the spinner disappears.

this works, _i think_. this can't be tested successfully whilst proxying to the backend b/c of cross domain cookie access restrictions.