### PR TITLE
Activate rule to prevent self closing tags

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -10,7 +10,7 @@ module.exports = {
     'block-indentation': true,
     'html-comments': true,
     'nested-interactive': true,
-    'self-closing-void-elements': false,
+    'self-closing-void-elements': true,
     'img-alt-attributes': false,
     'link-rel-noopener': true,
     'invalid-interactive': false,

--- a/app/templates/assign-students.hbs
+++ b/app/templates/assign-students.hbs
@@ -21,7 +21,7 @@
     </div>
 
     <div id='titlefilter' class="filter">
-      <input type='text' value={{filter}} placeholder={{t 'general.pendingUserUpdates.filterBy'}} oninput={{action (mut filter) value="target.value"}} />
+      <input type='text' value={{filter}} placeholder={{t 'general.pendingUserUpdates.filterBy'}} oninput={{action (mut filter) value="target.value"}}>
     </div>
   </div>
 

--- a/app/templates/components/assign-students.hbs
+++ b/app/templates/components/assign-students.hbs
@@ -48,7 +48,7 @@
             <input
              type='checkbox'
              checked={{eq selectedUserIds.length filteredStudents.length}}
-             indeterminate={{and (gt selectedUserIds.length 0) (lt selectedUserIds.length filteredStudents.length)}} />
+             indeterminate={{and (gt selectedUserIds.length 0) (lt selectedUserIds.length filteredStudents.length)}}>
             {{t 'general.all'}}
           </th>
           <th class='text-left' colspan="4">{{t 'general.fullName'}}</th>
@@ -61,9 +61,9 @@
           <tr class='{{if (is-in selectedUserIds user.id) "highlighted"}}'>
             <td class='text-left clickable' colspan="1" {{action 'toggleUserSelection' user.id}}>
               {{#if (is-in selectedUserIds user.id)}}
-                <input type='checkbox' checked />
+                <input type='checkbox' checked>
               {{else}}
-                <input type='checkbox' />
+                <input type='checkbox'>
               {{/if}}
             </td>
             <td class='text-left' colspan="4">{{#link-to 'user' user}}{{user.fullName}}{{/link-to}}</td>

--- a/app/templates/components/boolean-check.hbs
+++ b/app/templates/components/boolean-check.hbs
@@ -1,1 +1,1 @@
-<input type='checkbox' checked={{value}} />
+<input type='checkbox' checked={{value}}>

--- a/app/templates/components/bulk-new-users.hbs
+++ b/app/templates/components/bulk-new-users.hbs
@@ -40,7 +40,7 @@
     <label>
       {{t 'general.uploadUsers'}} (<a target='_blank' rel='noopener' href='/assets/files/SampleUserUpload.txt'>{{t 'general.sampleFile'}}</a>):
     </label>
-    <input type='file' onchange={{action 'updateSelectedFile' value="target.files"}} />
+    <input type='file' onchange={{action 'updateSelectedFile' value="target.files"}}>
   </div>
   {{#if parseFile.isRunning}}
     <div class='file-is-loading'>{{fa-icon 'spinner' spin=true}}</div>

--- a/app/templates/components/course-materials.hbs
+++ b/app/templates/components/course-materials.hbs
@@ -16,7 +16,7 @@
               {{#if (contains lmObject.type typesWithUrl)}}
                 <a href={{lmObject.url}} target='_blank' rel='noopener'>{{lmObject.title}}</a>
               {{else}}
-                {{lmObject.title}}<br />
+                {{lmObject.title}}<br>
                 <small>{{lmObject.citation}}</small>
               {{/if}}
             </td>
@@ -92,7 +92,7 @@
               {{#if (contains lmObject.type typesWithUrl)}}
                 <a href={{lmObject.url}} target='_blank' rel='noopener'>{{lmObject.title}}</a>
               {{else}}
-                {{lmObject.title}}<br />
+                {{lmObject.title}}<br>
                 <small>{{lmObject.citation}}</small>
               {{/if}}
             </td>

--- a/app/templates/components/course-objective-list-item.hbs
+++ b/app/templates/components/course-objective-list-item.hbs
@@ -29,7 +29,7 @@
             {{parent.programYear.program.title}}&nbsp;
             {{parent.programYear.cohort.displayTitle}}
           </strong>
-          <br />
+          <br>
         {{/if}}
         {{#if editable}}
           <span class='clickable link' {{action this.attrs.manageParents objective}}>
@@ -41,7 +41,7 @@
         {{#if parent.competency}}
           ({{parent.competency.title}})
         {{/if}}
-        <br />
+        <br>
       {{/each}}
     {{else}}
       {{#if editable}}

--- a/app/templates/components/course-objective-list.hbs
+++ b/app/templates/components/course-objective-list.hbs
@@ -23,7 +23,7 @@
           <tr class='confirm-removal'>
             <td colspan=8>
               <div class='confirm-message'>
-                {{t 'general.confirmObjectiveRemoval'}}<br />
+                {{t 'general.confirmObjectiveRemoval'}}<br>
                 <div class="confirm-buttons">
                   <button {{action 'remove' objective}} class='remove text'>{{t 'general.yes'}}</button>
                   <button {{action 'cancelRemove' objective}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/course-objective-manager.hbs
+++ b/app/templates/components/course-objective-manager.hbs
@@ -22,12 +22,12 @@
           {{#each competency.objectives as |objective|}}
             {{#if objective.selected}}
               <li class='selected clickable' {{action 'removeParent' objective}}>
-                <input type='radio' checked="checked" />
+                <input type='radio' checked="checked">
                 {{objective.textTitle}}
               </li>
             {{else}}
               <li class='clickable' {{action 'addParent' objective}}>
-                <input type='radio' />
+                <input type='radio'>
                 {{objective.textTitle}}
               </li>
             {{/if}}

--- a/app/templates/components/curriculum-inventory-report-details.hbs
+++ b/app/templates/components/curriculum-inventory-report-details.hbs
@@ -8,7 +8,7 @@
   {{#if showFinalizeConfirmation}}
     <div class='confirm-finalize'>
       <div class='confirm-message'>
-        {{t 'general.finalizeReportConfirmation'}} <br/>
+        {{t 'general.finalizeReportConfirmation'}} <br>
         <div class="confirm-buttons">
           <button {{action 'finalize'}} class='finalize text'>{{t 'general.yes'}}</button>
           <button {{action 'cancelFinalization'}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/curriculum-inventory-report-list.hbs
+++ b/app/templates/components/curriculum-inventory-report-list.hbs
@@ -63,7 +63,7 @@
         <tr class='confirm-removal'>
           <td colspan=16>
             <div class='confirm-message'>
-              {{t 'general.reportConfirmRemove'}} <br/>
+              {{t 'general.reportConfirmRemove'}} <br>
               <div class="confirm-buttons">
                 <button {{action 'remove' report}} class='remove text'>{{t 'general.yes'}}</button>
                 <button {{action 'cancelRemove' report}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/curriculum-inventory-sequence-block-list.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-list.hbs
@@ -93,7 +93,7 @@
                     <tr class='confirm-removal'>
                       <td colspan=15>
                         <div class='confirm-message'>
-                          {{t 'general.sequenceBlockConfirmRemove'}} <br/>
+                          {{t 'general.sequenceBlockConfirmRemove'}} <br>
                           <div class="confirm-buttons">
                             <button {{action 'remove' block}} class='remove text'>{{t 'general.yes'}}</button>
                             <button {{action 'cancelRemove' block}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/dashboard-calendar.hbs
+++ b/app/templates/components/dashboard-calendar.hbs
@@ -72,7 +72,7 @@
             <ul>
               {{#each courses as |course|}}
                 <li class='clickable'>
-                  <input {{action 'toggleCourse' course on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedCourses course}} />
+                  <input {{action 'toggleCourse' course on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedCourses course}}>
                   <span {{action 'toggleCourse' course}} class="list-indentation">{{course.title}}</span>
                 </li>
               {{/each}}
@@ -88,7 +88,7 @@
             <ul>
               {{#each sessionTypes as |type|}}
                 <li class='clickable'>
-                  <input {{action 'toggleSessionType' type on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedSessionTypes type}} />
+                  <input {{action 'toggleSessionType' type on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedSessionTypes type}}>
                   <span {{action 'toggleSessionType' type}} class="list-indentation">{{type.title}}</span>
                 </li>
               {{/each}}
@@ -104,7 +104,7 @@
             <ul>
               {{#each sessionTypes as |type|}}
                 <li class='clickable' {{action 'toggleSessionType' type}}>
-                  <input {{action 'toggleSessionType' type on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedSessionTypes type}} />
+                  <input {{action 'toggleSessionType' type on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedSessionTypes type}}>
                   <span {{action 'toggleSessionType' type}} class="list-indentation">{{type.title}}</span>
                 </li>
               {{/each}}
@@ -118,7 +118,7 @@
           <ul>
             {{#each courseLevels as |level|}}
               <li class='clickable'>
-                <input {{action 'toggleCourseLevel' level on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedCourseLevels level}} />
+                <input {{action 'toggleCourseLevel' level on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedCourseLevels level}}>
                 <span {{action 'toggleCourseLevel' level}} class="list-indentation">{{level}}</span>
               </li>
             {{/each}}
@@ -130,7 +130,7 @@
             <ul>
               {{#each cohorts as |cohort|}}
                 <li class='clickable'>
-                  <input {{action 'toggleCohort' cohort on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedCohorts cohort}} />
+                  <input {{action 'toggleCohort' cohort on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedCohorts cohort}}>
                   <span {{action 'toggleCohort' cohort}} class="list-indentation">{{cohort.displayTitle}} {{cohort.programYear.program.title}}</span>
                 </li>
               {{/each}}

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -140,7 +140,7 @@
               <tr class='confirm-removal'>
                 <td colspan=16>
                   <div class='confirm-message'>
-                    {{t 'general.confirmRemoval'}}<br />
+                    {{t 'general.confirmRemoval'}}<br>
                     <div class="confirm-buttons">
                       <button {{action 'remove' lmProxy}} class='remove text'>{{t 'general.yes'}}</button>
                       <button {{action 'cancelRemove' lmProxy}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/global-search.hbs
+++ b/app/templates/components/global-search.hbs
@@ -6,7 +6,7 @@
   onkeyup={{action 'changeValue' value="target.value"}}
   results=5
   autosave='ilios-global-search'
-/>
+>
 
 <ul class="results" {{action 'clear'}}>
   {{#if revisedQuery}}

--- a/app/templates/components/ilios-course-list.hbs
+++ b/app/templates/components/ilios-course-list.hbs
@@ -90,7 +90,7 @@
         <tr class='confirm-removal'>
           <td colspan=15>
             <div class='confirm-message'>
-              {{t 'general.confirmRemoveCourse' publishedOfferingcount=course.publishedOfferingCount}} <br />
+              {{t 'general.confirmRemoveCourse' publishedOfferingcount=course.publishedOfferingCount}} <br>
               <div class="confirm-buttons">
                 <button {{action 'remove' course}} class='remove text'>{{t 'general.yes'}}</button>
                 <button {{action 'cancelRemove' course}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/ilios-header.hbs
+++ b/app/templates/components/ilios-header.hbs
@@ -1,5 +1,5 @@
 {{#link-to "dashboard" classNames='logo'}}
-  <span class='image' />
+  <span class='image'></span>
   <span class='visually-hidden'>
     {{t 'general.dashboard'}}
   </span>

--- a/app/templates/components/ilios-sessions-list.hbs
+++ b/app/templates/components/ilios-sessions-list.hbs
@@ -147,7 +147,7 @@
                 <tr class='confirm-removal'>
                   <td colspan=10>
                     <div class='confirm-message'>
-                      {{t 'general.confirmSessionRemoval'}}<br />
+                      {{t 'general.confirmSessionRemoval'}}<br>
                       <div class="confirm-buttons">
                         <button {{action 'remove' sessionProxy}} class='remove text'>{{t 'general.yes'}}</button>
                         <button {{action 'cancelRemove' sessionProxy}} class='done text'>{{t 'general.cancel'}}</button>
@@ -188,6 +188,6 @@
       setLimit=this.attrs.setLimit
     }}
   {{else}}
-    <br /><h1>{{fa-icon 'spinner' spin=true}}</h1>
+    <br><h1>{{fa-icon 'spinner' spin=true}}</h1>
   {{/if}}
 </section>

--- a/app/templates/components/inplace-boolean.hbs
+++ b/app/templates/components/inplace-boolean.hbs
@@ -1,7 +1,7 @@
 <span class='content'>
   <span class='editor'>
     <span {{action 'toggleValue'}} class='control form-data switch yes-no switch-green'>
-      <input checked={{value}} type='checkbox' class="switch-input" disabled="disabled"/>
+      <input checked={{value}} type='checkbox' class="switch-input" disabled="disabled">
       <span class="switch-label" data-on='{{t 'general.yes'}}' data-off='{{t 'general.no'}}'></span>
       <span class="switch-handle"></span>
     </span>

--- a/app/templates/components/inplace-text.hbs
+++ b/app/templates/components/inplace-text.hbs
@@ -13,7 +13,7 @@
         <input type="text" value={{value}}
           onChange={{action "changeValue" value="target.value"}}
           oninput={{action "changeValue" value="target.value"}}
-          class="{{if topErrorMessage 'has-error'}}" />
+          class="{{if topErrorMessage 'has-error'}}">
       </span>
       <span class='actions'>
         <button class='done icon' title='{{t 'general.save'}}' {{action 'save'}}>{{fa-icon 'check'}}</button>

--- a/app/templates/components/instructorgroup-details.hbs
+++ b/app/templates/components/instructorgroup-details.hbs
@@ -34,7 +34,7 @@
             {{/each}}
           </ul>
         </div>
-      </div> <br />
+      </div> <br>
     </section>
   </div>
 </div>

--- a/app/templates/components/instructorgroup-list.hbs
+++ b/app/templates/components/instructorgroup-list.hbs
@@ -29,7 +29,7 @@
         <tr class='confirm-removal'>
           <td colspan=5>
             <div class='confirm-message'>
-              {{t 'general.confirmRemoveInstructorGroup' instructorCount=instructorGroup.users.length courseCount=instructorGroup.courses.length}} <br />
+              {{t 'general.confirmRemoveInstructorGroup' instructorCount=instructorGroup.users.length courseCount=instructorGroup.courses.length}} <br>
               <div class="confirm-buttons">
                 <button {{action 'remove' instructorGroup}} class='remove text'>{{t 'general.yes'}}</button>
                 <button {{action 'cancelRemove' instructorGroup}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/learnergroup-cohort-user-manager.hbs
+++ b/app/templates/components/learnergroup-cohort-user-manager.hbs
@@ -14,7 +14,7 @@
       <thead>
         <tr>
           <th class='text-left' colspan=1>
-            <input type='checkbox' onclick={{action 'toggleUserSelectionAllOrNone'}} />
+            <input type='checkbox' onclick={{action 'toggleUserSelectionAllOrNone'}}>
           </th>
           {{#sortable-th
             colspan=2

--- a/app/templates/components/learnergroup-list.hbs
+++ b/app/templates/components/learnergroup-list.hbs
@@ -25,7 +25,7 @@
         <tr class='confirm-removal'>
           <td colspan=5>
             <div class='confirm-message'>
-              {{t 'general.confirmRemoveLearnerGroup' learnerCount=learnerGroup.usersCount subgroupCount=learnerGroup.children.length}} <br />
+              {{t 'general.confirmRemoveLearnerGroup' learnerCount=learnerGroup.usersCount subgroupCount=learnerGroup.children.length}} <br>
               <div class="confirm-buttons">
                 <button {{action this.attrs.remove learnerGroup}} class='remove text'>{{t 'general.yes'}}</button>
                 <button {{action 'cancelRemove' learnerGroup}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/learnergroup-user-manager.hbs
+++ b/app/templates/components/learnergroup-user-manager.hbs
@@ -18,7 +18,7 @@
           <tr>
             <th class='text-left' colspan=1>
               {{#if isEditing}}
-                <input type='checkbox' onclick={{action 'toggleUserSelectionAllOrNone'}} />
+                <input type='checkbox' onclick={{action 'toggleUserSelectionAllOrNone'}}>
               {{/if}}
             </th>
             {{#sortable-th

--- a/app/templates/components/multiedit-select.hbs
+++ b/app/templates/components/multiedit-select.hbs
@@ -1,2 +1,2 @@
-<input type='checkbox' checked={{checked}} {{action "toggleCheckBox" on="change"}} />
+<input type='checkbox' checked={{checked}} {{action "toggleCheckBox" on="change"}}>
 <span class='non-editable'>{{displayValue}}</span>

--- a/app/templates/components/my-profile.hbs
+++ b/app/templates/components/my-profile.hbs
@@ -114,7 +114,7 @@
       {{#if generatedJwt}}
         <div class='new-token-result'>
           <h3>{{t 'general.newToken'}}:</h3>
-          <input readonly value={{generatedJwt}} />
+          <input readonly value={{generatedJwt}}>
           {{#copy-button success='tokenCopied' clipboardText=generatedJwt}}
             {{fa-icon 'copy'}}
           {{/copy-button}}

--- a/app/templates/components/new-learnergroup-single.hbs
+++ b/app/templates/components/new-learnergroup-single.hbs
@@ -19,10 +19,10 @@
   <div class="form-col form-col-radiogroup">
     <div class="form-label">{{t 'general.populateGroup'}}:</div>
     <div class="form-data form-data-text form-input-row clickable" onclick={{toggle 'fillWithCohort' this}}>
-      <input checked={{fillWithCohort}} type='radio' /> {{t 'general.yesPopulateGroup'}}
+      <input checked={{fillWithCohort}} type='radio'> {{t 'general.yesPopulateGroup'}}
     </div>
     <div class="form-data form-data-text form-input-row clickable" onclick={{toggle 'fillWithCohort' this}}>
-      <input checked={{not fillWithCohort}} type='radio' /> {{t 'general.noPopulateGroup'}}
+      <input checked={{not fillWithCohort}} type='radio'> {{t 'general.noPopulateGroup'}}
     </div>
   </div>
 {{/if}}

--- a/app/templates/components/not-found.hbs
+++ b/app/templates/components/not-found.hbs
@@ -1,4 +1,4 @@
 <p>
-  {{t 'general.notFoundMessage'}}< br />
+  {{t 'general.notFoundMessage'}}<br>
   {{#link-to "index"}}{{t 'general.backToDashboard'}}{{/link-to}}
 </p>

--- a/app/templates/components/objective-manage-competency.hbs
+++ b/app/templates/components/objective-manage-competency.hbs
@@ -7,9 +7,9 @@
         <li {{action (if (eq domain.id objective.competency.id) 'removeCurrentCompetency' 'changeCompetency') domain}} class="competency-title clickable {{if (eq domain.id objective.competency.id) 'selected'}}">
           <h5>
             {{#if (eq domain.id objective.competency.id)}}
-              <input type='checkbox' checked />
+              <input type='checkbox' checked>
             {{else}}
-              <input type='checkbox' />
+              <input type='checkbox'>
             {{/if}}
             {{domain.title}}
           </h5>
@@ -24,9 +24,9 @@
               {{#if (contains competency.id (map-by 'id' (await competencies)))}}
                 <li {{action (if (eq competency.id objective.competency.id) 'removeCurrentCompetency' 'changeCompetency') competency}} class="competency-title clickable {{if (eq competency.id objective.competency.id) 'selected'}}">
                   {{#if (eq competency.id objective.competency.id)}}
-                    <input type='checkbox' checked />
+                    <input type='checkbox' checked>
                   {{else}}
-                    <input type='checkbox' />
+                    <input type='checkbox'>
                   {{/if}}
                   {{competency.title}}
                 </li>

--- a/app/templates/components/offering-form.hbs
+++ b/app/templates/components/offering-form.hbs
@@ -10,7 +10,7 @@
   </div>
 
   <div class='item offering-duration'>
-    <label>{{t 'general.duration'}}:</label> <br />
+    <label>{{t 'general.duration'}}:</label> <br>
     <div class='hours'>
       {{one-way-input
         value=durationHours

--- a/app/templates/components/offering-manager.hbs
+++ b/app/templates/components/offering-manager.hbs
@@ -42,7 +42,7 @@
     {{#if showRemoveConfirmation class='vertical'}}
       <div class='confirm-removal'>
         <div class='confirm-message'>
-          {{t 'general.confirmRemove' learnerGroupCount=offering.learnerGroups.length}} <br />
+          {{t 'general.confirmRemove' learnerGroupCount=offering.learnerGroups.length}} <br>
           <div class="confirm-buttons">
             <button {{action 'remove'}} class='remove text'>{{t 'general.yes'}}</button>
             <button {{action 'cancelRemove'}} class='cancel text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/print-course.hbs
+++ b/app/templates/components/print-course.hbs
@@ -32,8 +32,8 @@
             <label>{{t 'general.end'}}:</label>
             <div>{{moment-format course.endDate 'MM/DD/YYYY'}}</div>
           </div>
-          <br />
-          <br />
+          <br>
+          <br>
 
           <div class="inline-label-data-block">
             <label>{{t 'general.directors'}}:</label>
@@ -174,7 +174,7 @@
             <label>{{t 'general.sessionType'}}:</label>
             <div>{{session.sessionType.title}}</div>
           </div>
-          <br />
+          <br>
           <div class="inline-label-data-block">
             <label>{{t 'general.supplementalCurriculum'}}:</label>
             <div>{{boolean-check value=session.supplemental}}</div>
@@ -187,7 +187,7 @@
             <label>{{t 'general.specialEquipmentRequired'}}:</label>
             <div>{{boolean-check value=session.equipmentRequired}}</div>
           </div>
-          <br />
+          <br>
           <div class="inline-label-data-block">
             <label>{{t 'general.description'}}:</label>
             <div>{{session.sessionDescription.textDescription}}</div>

--- a/app/templates/components/program-list.hbs
+++ b/app/templates/components/program-list.hbs
@@ -29,7 +29,7 @@
           <td colspan=9>
             <div class='confirm-message'>
               {{#if (is-fulfilled program.courses)}}
-                {{t 'general.confirmRemoveProgram' programYearCount=program.programYears.length courseCount=program.courses.length}} <br />
+                {{t 'general.confirmRemoveProgram' programYearCount=program.programYears.length courseCount=program.courses.length}} <br>
                 <div class="confirm-buttons">
                   <button {{action 'remove' program}} class='remove text'>{{t 'general.yes'}}</button>
                   <button {{action 'cancelRemove' program}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/programyear-competencies.hbs
+++ b/app/templates/components/programyear-competencies.hbs
@@ -29,17 +29,17 @@
           <li>
             {{#if (contains (get domain 'id') (map-by 'id' selectedCompetencies))}}
               <span class='clickable' onclick={{action 'removeCompetencyFromBuffer' domain}}>
-                <input type='checkbox' checked />
+                <input type='checkbox' checked>
                 {{domain.title}}
               </span>
             {{else if (contains domain (await competenciesWithSelectedChildren))}}
               <span class='clickable' onclick={{action 'addCompetencyToBuffer' domain}}>
-                <input type='checkbox' indeterminate={{true}} />
+                <input type='checkbox' indeterminate={{true}}>
                 {{domain.title}}
               </span>
             {{else}}
               <span class='clickable' onclick={{action 'addCompetencyToBuffer' domain}}>
-                <input type='checkbox' />
+                <input type='checkbox'>
                 {{domain.title}}
               </span>
             {{/if}}
@@ -49,12 +49,12 @@
                   <li>
                     {{#if (contains (get competency 'id') (map-by 'id' selectedCompetencies))}}
                       <span class='clickable' onclick={{action 'removeCompetencyFromBuffer' competency}}>
-                        <input type='checkbox' checked />
+                        <input type='checkbox' checked>
                         {{competency.title}}
                       </span>
                     {{else}}
                       <span class='clickable' onclick={{action 'addCompetencyToBuffer' competency}}>
-                        <input type='checkbox' />
+                        <input type='checkbox'>
                         {{competency.title}}
                       </span>
                     {{/if}}

--- a/app/templates/components/programyear-list.hbs
+++ b/app/templates/components/programyear-list.hbs
@@ -94,7 +94,7 @@
                 <tr class='confirm-removal'>
                   <td colspan=8>
                     <div class='confirm-message'>
-                      {{t 'general.confirmRemoveProgramYear' courseCount=programYearProxy.cohort.courses.length}} <br />
+                      {{t 'general.confirmRemoveProgramYear' courseCount=programYearProxy.cohort.courses.length}} <br>
                       <div class="confirm-buttons">
                         <button {{action 'confirmRemove' programYearProxy}} class='remove text'>{{t 'general.yes'}}</button>
                         <button {{action 'cancelRemove' programYearProxy}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/programyear-overview.hbs
+++ b/app/templates/components/programyear-overview.hbs
@@ -24,8 +24,8 @@
         addUser='addDirector'
         currentlyActiveUsers=programYear.directors
       }}
-      <br />
-      <br />
+      <br>
+      <br>
     {{/if}}
   </div>
 </section>

--- a/app/templates/components/school-vocabularies-list.hbs
+++ b/app/templates/components/school-vocabularies-list.hbs
@@ -76,7 +76,7 @@
               <tr class='confirm-removal'>
                 <td colspan=5>
                   <div class='confirm-message'>
-                    {{t 'general.confirmVocabularyRemoval'}}<br />
+                    {{t 'general.confirmVocabularyRemoval'}}<br>
                     <div class="confirm-buttons">
                       <button {{action 'remove' vocabulary}} class='remove text'>{{t 'general.yes'}}</button>
                       <button {{action 'cancelRemove' vocabulary}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/school-vocabulary-manager.hbs
+++ b/app/templates/components/school-vocabulary-manager.hbs
@@ -1,7 +1,7 @@
 <div class='breadcrumbs'>
   <span {{action this.attrs.manageVocabulary null}}>{{t 'general.allVocabularies'}}</span>
   <span>{{vocabulary.title}}</span>
-</div><br />
+</div><br>
 
 <p class='vocabulary-title'>{{inplace-text value=vocabulary.title save='changeVocabularyTitle'}}</p>
 

--- a/app/templates/components/session-objective-list-item.hbs
+++ b/app/templates/components/session-objective-list-item.hbs
@@ -32,7 +32,7 @@
         {{parent.textTitle}}
       {{/if}}
       {{#if objective.hasMultipleParents}}
-        <br /><br />
+        <br><br>
       {{/if}}
     {{/each}}
   {{else}}

--- a/app/templates/components/session-objective-list.hbs
+++ b/app/templates/components/session-objective-list.hbs
@@ -23,7 +23,7 @@
           <tr class='confirm-removal'>
             <td colspan=8>
               <div class='confirm-message'>
-                {{t 'general.confirmObjectiveRemoval'}}<br />
+                {{t 'general.confirmObjectiveRemoval'}}<br>
                 <div class="confirm-buttons">
                   <button {{action 'remove' objective}} class='remove text'>{{t 'general.yes'}}</button>
                   <button {{action 'cancelRemove' objective}} class='done text'>{{t 'general.cancel'}}</button>

--- a/app/templates/components/session-overview.hbs
+++ b/app/templates/components/session-overview.hbs
@@ -120,7 +120,7 @@
           {{/if}}
         </span>
       </div>
-      <hr />
+      <hr>
       <div class="independentlearningcontrol switch-block">
         <label>{{t 'general.independentLearning'}}:</label>
         <span>
@@ -205,7 +205,7 @@
       </span>
     </div>
     {{#unless session.isIndependentLearning}}
-      <br />
+      <br>
       <div class="sessionassociatedgroups">
         <label>{{t 'general.associatedGroups'}}:</label>
         <span>

--- a/app/templates/components/toggle-mycourses.hbs
+++ b/app/templates/components/toggle-mycourses.hbs
@@ -1,5 +1,5 @@
 <label class='switch switch-green switch-wide' {{action 'toggleMyCourses'}}>
-  <input class='switch-input' checked={{isChecked}} type='checkbox' />
+  <input class='switch-input' checked={{isChecked}} type='checkbox'>
   <span class="switch-label" data-on='{{t 'general.myCourses'}}' data-off='{{t 'general.allCourses'}}'></span>
   <span class="switch-handle"></span>
 </label>

--- a/app/templates/components/toggle-onoff.hbs
+++ b/app/templates/components/toggle-onoff.hbs
@@ -1,6 +1,6 @@
 <label class="form-label">{{t label}}:</label>
 <span class='control form-data switch yes-no switch-green'>
-  <input checked={{on}} type='checkbox' class="switch-input" />
+  <input checked={{on}} type='checkbox' class="switch-input">
   <span class="switch-label" data-on='{{t 'general.on'}}' data-off='{{t 'general.off'}}'></span>
   <span class="switch-handle"></span>
 </span>

--- a/app/templates/components/toggle-wide.hbs
+++ b/app/templates/components/toggle-wide.hbs
@@ -1,3 +1,3 @@
-<input class='switch-input' type='checkbox' id='{{cssId}}-input' checked={{switchValue}} />
+<input class='switch-input' type='checkbox' id='{{cssId}}-input' checked={{switchValue}}>
 <span {{action 'click'}} class="switch-label" id='{{cssId}}-label' data-on='{{t onLabel}}' data-off='{{t offLabel}}'></span>
 <span id='{{cssId}}-handle' class="switch-handle"></span>

--- a/app/templates/components/toggle-yesno.hbs
+++ b/app/templates/components/toggle-yesno.hbs
@@ -1,6 +1,6 @@
 <label class="form-label">{{t label}}:</label>
 <span class='control form-data switch yes-no switch-green'>
-  <input checked={{yes}} type='checkbox' class="switch-input" />
+  <input checked={{yes}} type='checkbox' class="switch-input">
   <span class="switch-label" data-on='{{t 'general.yes'}}' data-off='{{t 'general.no'}}'></span>
   <span class="switch-handle"></span>
 </span>

--- a/app/templates/components/user-profile-ics.hbs
+++ b/app/templates/components/user-profile-ics.hbs
@@ -10,7 +10,7 @@
 
 <p>
   {{#if icsFeedKey.length}}
-    <span class='ics-instructions'>{{t 'general.icsAdminInstructions'}}</span><br />
+    <span class='ics-instructions'>{{t 'general.icsAdminInstructions'}}</span><br>
     <span class='ics-link'><a href={{icsFeedUrl}}>{{t 'general.link'}}</a></span>
     {{#copy-button clipboardText=icsFeedUrl}}
       {{fa-icon 'copy'}}

--- a/app/templates/components/user-profile-roles.hbs
+++ b/app/templates/components/user-profile-roles.hbs
@@ -76,7 +76,7 @@
   {{/unless}}
 </div>
 
-<hr />
+<hr>
 
 <div class='item'>
   <label onclick={{if isManaging (action (mut isEnabledFlipped) (not isEnabledFlipped))}}>{{t 'general.accountEnabled'}}:</label>

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -13,7 +13,7 @@
               {{input value=identification elementId='user-login-username' autocorrect="off" autocapitalize="off"}}
             </div>
           </label>
-          <br />
+          <br>
           <label class="form-col form-col-6 multi-row">
             <div class="form-label">{{t 'general.password'}}:</div>
             <div class="form-data">

--- a/app/templates/pending-user-updates.hbs
+++ b/app/templates/pending-user-updates.hbs
@@ -21,7 +21,7 @@
     </div>
 
     <div id='titlefilter' class="filter">
-      <input type='text' value={{filter}} placeholder={{t 'general.pendingUserUpdates.filterBy'}} oninput={{action (mut filter) value="target.value"}} />
+      <input type='text' value={{filter}} placeholder={{t 'general.pendingUserUpdates.filterBy'}} oninput={{action (mut filter) value="target.value"}}>
     </div>
   </div>
 
@@ -42,7 +42,7 @@
             <tr>
               <th class='text-left' colspan=2>{{t 'general.fullName'}}</th>
               <th class='text-left' colspan=6>{{t 'general.description'}}</th>
-              <th />
+              <th></th>
               <th class='text-left' colspan=2>{{t 'general.actions'}}</th>
 
             </tr>
@@ -58,7 +58,7 @@
                     update=update
                   }}
                 </td>
-                <td />
+                <td></td>
                 <td class='text-left' colspan="2">
                   {{#if (is-in updatesBeingSaved update)}}
                     {{fa-icon 'spinner' spin=true}}
@@ -67,12 +67,12 @@
                       <span class='clickable link' onclick={{action 'updateEmailAddress' update}}>
                         {{fa-icon 'arrow-circle-up' class='yes' title=(t 'general.update')}}
                         {{t 'general.pendingUserUpdates.updateIlios'}}
-                      </span><br />
+                      </span><br>
                     {{/if}}
                     <span class='clickable link' onclick={{action 'excludeFromSync' update}}>
                       {{fa-icon 'ban' class='no' title=(t 'general.excludeFromSync')}}
                       {{t 'general.excludeFromSync'}}
-                    </span><br />
+                    </span><br>
                     <span class='clickable link' onclick={{action 'disableUser' update}}>
                       {{fa-icon 'times' class='no' title=(t 'general.disableUser')}}
                       {{t 'general.disableUser'}}


### PR DESCRIPTION
HTML5 doesn't not allow self closing tags.  Void elements like `<input>`
and `<br>` should end without closing.  Other elements require a closing
tag even if they are empty.