### PR TITLE
reworked 'save' task as action.

### DIFF
--- a/app/templates/components/course-rollover.hbs
+++ b/app/templates/components/course-rollover.hbs
@@ -11,8 +11,8 @@
     {{one-way-input
       value=title
       update=(pipe (action 'changeTitle') (action 'addErrorDisplayFor' 'title'))
-      onenter=(perform save)
-      disabled=save.isRunning
+      onenter=(action 'save')
+      disabled=isSaving
       focusOut=(action 'addErrorDisplayFor' 'title')
       keyDown=(action 'addErrorDisplayFor' 'title')
       placeholder=(t 'general.courseTitlePlaceholder')
@@ -76,8 +76,8 @@
   </div>
 
   <div class='buttons'>
-    <button disabled={{if (or save.isRunning (not selectedYear) (contains selectedYear loadUnavailableYears.lastSuccessful.value)) true}} class='done text' {{action (perform save)}}>
-      {{#if save.isRunning}}
+    <button disabled={{if (or isSaving (not selectedYear) (contains selectedYear loadUnavailableYears.lastSuccessful.value)) true}} class='done text' {{action 'save'}}>
+      {{#if isSaving}}
         {{fa-icon 'spinner' spin=true}}
       {{else}}
         {{t 'general.done'}}


### PR DESCRIPTION
fixes #2179.

Turns out that using a task here, and checking for the `isRunning` attribute of that task in the template (e.g. to lock buttons and input fields), is not going to work.
Ember will fail to change the component's state (see the aforementioned `isRunning` toggle) after transitioning to the new route. So we can't do it like that.
My proposed solution converts the task into an action, which works.