### PR TITLE
Better File Upload

### DIFF
--- a/app/components/new-learningmaterial.js
+++ b/app/components/new-learningmaterial.js
@@ -108,8 +108,8 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
 
   classNames: ['new-learning-material'],
 
-  learningMaterialStatuses: [],
-  learningMaterialUserRoles: [],
+  learningMaterialStatuses: null,
+  learningMaterialUserRoles: null,
 
   editorParams: config.froalaEditorDefaults,
 
@@ -125,6 +125,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   copyrightRationale: null,
   owner: null,
   citation: null,
+  fileUploadErrorMessage: false,
 
   actions: {
     save: function(){
@@ -215,7 +216,8 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
         filename: e.filename,
         fileHash: e.fileHash,
         showUploadStatus: false,
-        fileUploadPercentage: 100
+        fileUploadPercentage: 100,
+        fileUploadErrorMessage: null,
       });
     },
 
@@ -223,6 +225,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
       set(this, 'fileHash', null);
       set(this, 'showUploadStatus', true);
       set(this, 'fileUploadPercentage', 0);
+      set(this, 'fileUploadErrorMessage', 0);
     },
 
     setFileUploadPercentage(percent) {

--- a/app/components/new-learningmaterial.js
+++ b/app/components/new-learningmaterial.js
@@ -4,7 +4,7 @@ import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 
 const { Component, computed, inject, set } = Ember;
-const { equal, not } = computed;
+const { equal, not, reads } = computed;
 const { service } = inject;
 
 const Validations = buildValidations({
@@ -68,6 +68,7 @@ const Validations = buildValidations({
 export default Component.extend(Validations, ValidationErrorDisplay, {
   store: service(),
   currentUser: service(),
+  serverVariables: service(),
   init() {
     this._super(...arguments);
     const component = this;
@@ -95,6 +96,11 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     set(this, 'showUploadStatus', false);
     set(this, 'fileUploadPercentage', 0);
   },
+  host: reads('serverVariables.apiHost'),
+  uploadPath: computed('host', function(){
+    return this.get('host') + '/upload';
+  }),
+
 
   isFile: equal('type', 'file'),
   isCitation: equal('type', 'citation'),

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -155,6 +155,7 @@ export default {
     'file': 'File',
     'fileSizeError': 'This file is too large.  Maximum size is {{maxSize}}.',
     'fileTypeError': 'Bad file type: {{fileType}} does not appear to be a properly delimited file.',
+    'fileUploadError': 'We were unable to upload this file.  Please ensure you are connected to the network.  If this problem persists please let us know.',
     'filterByNameOrEmail': 'Filter by name or email',
     'filterPlaceholder': 'Start typing to filter list',
     'finalErrorDisplayMessage': 'Zoinks! Something is very wrong. Please refresh your browser and let us know at support@iliosproject.org if you continue to see this message.',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -153,6 +153,7 @@ export default {
     'expandDetail': 'Show Details',
     'externalId': 'Course ID',
     'file': 'File',
+    'fileSizeError': 'This file is too large.  Maximum size is {{maxSize}}.',
     'fileTypeError': 'Bad file type: {{fileType}} does not appear to be a properly delimited file.',
     'filterByNameOrEmail': 'Filter by name or email',
     'filterPlaceholder': 'Start typing to filter list',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -155,6 +155,7 @@ export default {
     'file': 'Archivo',
     'fileSizeError': 'Este archivo es demasiado grande.  El tamaño máximo es {{maxSize}}.',
     'fileTypeError': 'Archivo mal subido: {{fileType}} no parece ser válido ficha separado archivo.',
+    'fileUploadError': 'No pudimos subir este archivo.   Por favor, asegúrese de que está conectado a la red.  Si este problema persiste, por favor avísenos.',
     'filterByNameOrEmail': 'Aplicar un Filtro por nombre o email',
     'filterPlaceholder': 'Empieza marcando para aplicar un filtro',
     'finalErrorDisplayMessage': '¡Zoinks! Algo es muy incorrecto. Por favor refresque su navegador y avísenos en support@iliosproject.org si sigue viendo este mensaje. ',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -153,6 +153,7 @@ export default {
     'expandDetail': 'Enseñar Detalles',
     'externalId': 'Identificación del Curso',
     'file': 'Archivo',
+    'fileSizeError': 'Este archivo es demasiado grande.  El tamaño máximo es {{maxSize}}.',
     'fileTypeError': 'Archivo mal subido: {{fileType}} no parece ser válido ficha separado archivo.',
     'filterByNameOrEmail': 'Aplicar un Filtro por nombre o email',
     'filterPlaceholder': 'Empieza marcando para aplicar un filtro',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -155,6 +155,7 @@ export default {
     'file': "Fichier",
     'fileSizeError': 'Ce dossier est trop grand. Taille maximale est {{maxSize}).',
     'fileTypeError': 'Mal fichier téléchargé : {{fileType}} ne semble pas être un fichier correctement délimité.',
+    'fileUploadError': "Nous n'avons pas pu télécharger ce dossier. Assurez S'il vous plaît que vous êtes connectés au réseau. Si ce problème persiste merci de nous faire savoir.",
     'filterByNameOrEmail': "Filtre par nom ou email",
     'filterPlaceholder': "Commencez à taper pour filtre la liste",
     'finalErrorDisplayMessage': "Zoinks! Quelque chose ne vas pas du tout. S'il vous plaît rafraîchir votre navigateur et prévenez-nous à support@iliosproject.org si vous continuez à voir ce message.",

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -153,6 +153,7 @@ export default {
     'expandDetail': "Afficher Détails",
     'externalId': "ID de Cours",
     'file': "Fichier",
+    'fileSizeError': 'Ce dossier est trop grand. Taille maximale est {{maxSize}).',
     'fileTypeError': 'Mal fichier téléchargé : {{fileType}} ne semble pas être un fichier correctement délimité.',
     'filterByNameOrEmail': "Filtre par nom ou email",
     'filterPlaceholder': "Commencez à taper pour filtre la liste",

--- a/app/services/ilios-config.js
+++ b/app/services/ilios-config.js
@@ -24,5 +24,9 @@ export default Ember.Service.extend({
 
   authenticationType: computed('config.type', function(){
     return this.itemFromConfig('type');
+  }),
+
+  maxUploadSize: computed('config.maxUploadSize', function(){
+    return this.itemFromConfig('maxUploadSize');
   })
 });

--- a/app/templates/components/new-learningmaterial.hbs
+++ b/app/templates/components/new-learningmaterial.hbs
@@ -134,7 +134,7 @@
           finishedUploading='setFile'
           startUploading='startUploadingFile'
           setUploadPercentage='setFileUploadPercentage'
-          url="/upload"
+          url=uploadPath
         }}
         {{#if showUploadStatus}}
           {{fa-icon 'spinner' spin=true}} {{fileUploadPercentage}}%

--- a/app/templates/components/new-learningmaterial.hbs
+++ b/app/templates/components/new-learningmaterial.hbs
@@ -131,15 +131,19 @@
       <label class="form-label">{{t 'general.file'}}:</label>
       <div class="form-data">
         {{file-upload
-          finishedUploading='setFile'
-          startUploading='startUploadingFile'
-          setUploadPercentage='setFileUploadPercentage'
+          finishedUploading=(action 'setFile')
+          startUploading=(action 'startUploadingFile')
+          setUploadPercentage=(action 'setFileUploadPercentage')
+          setErrorMessage=(action (mut fileUploadErrorMessage))
           url=uploadPath
         }}
         {{#if showUploadStatus}}
           {{fa-icon 'spinner' spin=true}} {{fileUploadPercentage}}%
         {{else if fileHash}}
           {{fa-icon 'check' class='add'}}
+        {{/if}}
+        {{#if fileUploadErrorMessage}}
+          <span class="validation-error-message">{{fileUploadErrorMessage}}</span>
         {{/if}}
       </div>
     </div>

--- a/app/utils/readable-file-size.js
+++ b/app/utils/readable-file-size.js
@@ -1,0 +1,11 @@
+/**
+ * Get a human readable file bytes from bytes
+ * modified from http://stackoverflow.com/a/20732091/796999
+ */
+export default function readableFilebytes(bytes) {
+  if (bytes === 0) {
+    return '0 b';
+  }
+  let i = Math.floor( Math.log(bytes) / Math.log(1024) );
+  return ( bytes / Math.pow(1024, i) ).toFixed(0) * 1 + ' ' + ['b', 'kB', 'MB', 'GB', 'TB'][i];
+}

--- a/tests/unit/utils/readable-file-size-test.js
+++ b/tests/unit/utils/readable-file-size-test.js
@@ -1,0 +1,29 @@
+import readableFileSize from 'ilios/utils/readable-file-size';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | readable file size');
+
+test('test 0', function(assert) {
+  let result = readableFileSize(0);
+  assert.equal(result, '0 b');
+});
+
+test('test B', function(assert) {
+  let result = readableFileSize(100);
+  assert.equal(result, '100 b');
+});
+
+test('test kB', function(assert) {
+  let result = readableFileSize(1024);
+  assert.equal(result, '1 kB');
+});
+
+test('test MB', function(assert) {
+  let result = readableFileSize(1124000);
+  assert.equal(result, '1 MB');
+});
+
+test('test GB', function(assert) {
+  let result = readableFileSize(1124000000);
+  assert.equal(result, '1 GB');
+});


### PR DESCRIPTION
Improved the process for uploading a learning material file in several ways.
1) Upload files to the API server based on the configuration and not to /upload on whatever host the fronted is on.
2) Detect if a file is too large and warn the user that it cannot be uploaded.
3) If an upload fails because of network or server issues try it again up to 3 times transparently before ultimately throwing an exception and notifying the user of the issue.

Fixes #2060
Fixes #1245