### PR TITLE
removes code for creating cohort explicitly.

### DIFF
--- a/app/components/programyear-list.js
+++ b/app/components/programyear-list.js
@@ -11,7 +11,6 @@ export default Component.extend({
   classNames: ['programyear-list'],
 
   store: service(),
-  i18n: service(),
   currentUser: service(),
 
   program: null,
@@ -68,7 +67,6 @@ export default Component.extend({
     const latestProgramYear = this.get('sortedContent').get('lastObject');
     const program = this.get('program');
     const store = this.get('store');
-    const i18n = this.get('i18n');
     let itemsToSave = 0;
     this.resetSaveItems();
 

--- a/app/components/programyear-list.js
+++ b/app/components/programyear-list.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
 
-const { Component, computed, inject, ObjectProxy, RSVP, run } = Ember;
+const { Component, computed, inject, ObjectProxy, RSVP, run, isPresent } = Ember;
 const { service } = inject;
 const { mapBy, sort } = computed;
 const { hash } = RSVP;
@@ -95,14 +95,6 @@ export default Component.extend({
       newProgramYear.get('stewards').pushObjects(stewards.toArray());
     }
     let savedProgramYear = yield newProgramYear.save();
-    itemsToSave++;
-    this.incrementSavedItems();
-
-    const classOfYear = savedProgramYear.get('classOfYear');
-    const title = i18n.t('general.classOf', { year: classOfYear });
-
-    let cohort = store.createRecord('cohort', { programYear: savedProgramYear, title });
-    yield cohort.save();
     itemsToSave++;
     this.incrementSavedItems();
 
@@ -203,6 +195,10 @@ const ProgramYearProxy = ObjectProxy.extend({
           return;
         }
         programYear.get('cohort').then(cohort => {
+          if (! isPresent(cohort)) {
+            resolve(false);
+            return;
+          }
           cohort.get('users').then(users => {
             resolve(0 === users.length);
           });

--- a/app/mirage/config.js
+++ b/app/mirage/config.js
@@ -232,7 +232,21 @@ export default function() {
   this.get('api/programyears/:id', 'programYear');
   this.put('api/programyears/:id', 'programYear');
   this.delete('api/programyears/:id', 'programYear');
-  this.post('api/programyears', 'programYear');
+  this.post('api/programyears', function(db, request) {
+    let attrs = JSON.parse(request.requestBody);
+    let record = db.programYears.insert(attrs);
+    let programRecord = db.programs.find(record.programYear.program);
+    let cohortAttr = {
+      programYear: record.id,
+      title: 'Class of ' + (parseInt(programRecord.duration, 10) + parseInt(record.programYear.startYear, 10))
+    };
+    const cohortRecord = db.cohorts.insert(cohortAttr);
+    record.programYear.cohort = cohortRecord.id;
+    record = db.programYears.update(record.id, record.programYear);
+    return {
+      programYears: record
+    };
+  });
 
   this.get('api/programyearstewards', getAll);
   this.get('api/programyearstewards/:id', 'programYearSteward');

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -242,7 +242,6 @@ function getTableDataText(n, i, element = '') {
 }
 
 test('can add a program-year (with no pre-existing program-years)', function(assert) {
-  server.logging = true;
   server.create('program', {
     id: 1,
     school: 1,

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -262,11 +262,12 @@ test('can add a program-year (with no pre-existing program-years)', function(ass
     find(selectField).eq(0).val(thisYear).change();
     click(saveButton);
     const academicYear = `${thisYear.toString()} - ${(thisYear + 1).toString()}`;
-    const classOfYear = `Class of ${(thisYear + 4).toString()}`;
-
     andThen(() => {
       assert.equal(getTableDataText(0, 0).text().trim(), academicYear, 'academic year shown');
-      assert.equal(getTableDataText(0, 1).text().trim(), classOfYear, 'cohort class year shown');
+      // The assertion below has been commented in b/c it is currently untestable.
+      // @todo bring back Mirage or the likes. [ST 2016/10/26]
+      //const classOfYear = `Class of ${(thisYear + 4).toString()}`;
+      //assert.equal(getTableDataText(0, 1).text().trim(), classOfYear, 'cohort class year shown');
       assert.ok(getTableDataText(0, 2, 'i').hasClass('fa-warning'), 'warning label shown');
       assert.ok(getTableDataText(0, 3, 'i').hasClass('fa-warning'), 'warning label shown');
       assert.ok(getTableDataText(0, 4, 'i').hasClass('fa-warning'), 'warning label shown');
@@ -347,10 +348,11 @@ test('can add a program-year (with pre-existing program-year)', function(assert)
     click(saveButton);
     andThen(() => {
       const academicYear = `${(thisYear + 1).toString()} - ${(thisYear + 2).toString()}`;
-      const cohortClassYear = `Class of ${(thisYear + 5).toString()}`;
-
       assert.equal(getTableDataText(1, 0).text().trim(), academicYear, 'academic year shown');
-      assert.equal(getTableDataText(1, 1).text(), cohortClassYear, 'cohort class year shown');
+      // The assertion below has been commented in b/c it is currently untestable.
+      // @todo bring back Mirage or the likes. [ST 2016/10/26]
+      //assert.equal(getTableDataText(1, 1).text(), cohortClassYear, 'cohort class year shown');
+      //const cohortClassYear = `Class of ${(thisYear + 5).toString()}`;
       assert.equal(getTableDataText(1, 2).text().trim(), '3', 'copied correctly from latest program-year');
       assert.equal(getTableDataText(1, 3).text().trim(), '3', 'copied correctly from latest program-year');
       assert.equal(getTableDataText(1, 4).text().trim(), '3', 'copied correctly from latest program-year');

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -242,7 +242,9 @@ function getTableDataText(n, i, element = '') {
 }
 
 test('can add a program-year (with no pre-existing program-years)', function(assert) {
+  server.logging = true;
   server.create('program', {
+    id: 1,
     school: 1,
   });
 
@@ -264,10 +266,8 @@ test('can add a program-year (with no pre-existing program-years)', function(ass
     const academicYear = `${thisYear.toString()} - ${(thisYear + 1).toString()}`;
     andThen(() => {
       assert.equal(getTableDataText(0, 0).text().trim(), academicYear, 'academic year shown');
-      // The assertion below has been commented in b/c it is currently untestable.
-      // @todo bring back Mirage or the likes. [ST 2016/10/26]
-      //const classOfYear = `Class of ${(thisYear + 4).toString()}`;
-      //assert.equal(getTableDataText(0, 1).text().trim(), classOfYear, 'cohort class year shown');
+      const classOfYear = `Class of ${(thisYear + 4).toString()}`;
+      assert.equal(getTableDataText(0, 1).text().trim(), classOfYear, 'cohort class year shown');
       assert.ok(getTableDataText(0, 2, 'i').hasClass('fa-warning'), 'warning label shown');
       assert.ok(getTableDataText(0, 3, 'i').hasClass('fa-warning'), 'warning label shown');
       assert.ok(getTableDataText(0, 4, 'i').hasClass('fa-warning'), 'warning label shown');
@@ -349,10 +349,8 @@ test('can add a program-year (with pre-existing program-year)', function(assert)
     andThen(() => {
       const academicYear = `${(thisYear + 1).toString()} - ${(thisYear + 2).toString()}`;
       assert.equal(getTableDataText(1, 0).text().trim(), academicYear, 'academic year shown');
-      // The assertion below has been commented in b/c it is currently untestable.
-      // @todo bring back Mirage or the likes. [ST 2016/10/26]
-      //assert.equal(getTableDataText(1, 1).text(), cohortClassYear, 'cohort class year shown');
-      //const cohortClassYear = `Class of ${(thisYear + 5).toString()}`;
+      const cohortClassYear = `Class of ${(thisYear + 5).toString()}`;
+      assert.equal(getTableDataText(1, 1).text(), cohortClassYear, 'cohort class year shown');
       assert.equal(getTableDataText(1, 2).text().trim(), '3', 'copied correctly from latest program-year');
       assert.equal(getTableDataText(1, 3).text().trim(), '3', 'copied correctly from latest program-year');
       assert.equal(getTableDataText(1, 4).text().trim(), '3', 'copied correctly from latest program-year');


### PR DESCRIPTION
fixes #2286.
this is now handled server-side when the program year gets created. 

this follows ilios/ilios#1633.