### PR TITLE
re-styled list of course directors as tag list.

### DIFF
--- a/app/templates/components/course-overview.hbs
+++ b/app/templates/components/course-overview.hbs
@@ -105,7 +105,9 @@
     <span class="universallocator"><strong>{{universalLocator}}{{course.id}}</strong></span>
   </div>
   <div class="coursedirectors">
-    <label>{{t 'general.directors'}}:</label>
+    <label class={{if editable 'clickable link'}} onclick={{if editable (action (toggle 'manageDirectors' this))}}>
+      {{t 'general.directors'}}:
+    </label>
     {{#unless showDirectorManagerLoader}}
       {{#if manageDirectors}}
         {{course-director-manager
@@ -114,13 +116,15 @@
           close=(toggle-action 'manageDirectors' this)
         }}
       {{else}}
-        <span class={{if editable 'clickable link'}} onclick={{if editable (action (toggle 'manageDirectors' this))}}>
-          {{#if (get (await course.directors) 'length')}}
-            {{join '; ' (map-by 'fullName' (sort-by 'lastName' (await course.directors)))}}
-          {{else}}
-            {{t 'general.none'}}
-          {{/if}}
-        </span>
+        {{#if (get (await course.directors) 'length')}}
+          <ul class="tag-list">
+            {{#each (sort-by 'lastName' (await course.directors)) as |director|}}
+              <li>{{director.fullName}}</li>
+            {{/each}}
+          </ul>
+        {{else}}
+          <span>{{t 'general.none'}}</span>
+        {{/if}}
       {{/if}}
     {{else}}
       <span>{{fa-icon 'spinner' spin=true}}</span>

--- a/tests/integration/components/course-overview-test.js
+++ b/tests/integration/components/course-overview-test.js
@@ -175,3 +175,29 @@ test('course external id validation passes on empty value', function(assert) {
     });
   });
 });
+
+test('shows a list of course directors', function(assert) {
+  let storeMock = Service.extend({
+    findAll(what){
+      assert.equal('course-clerkship-type', what);
+      return resolve([]);
+    }
+  });
+  this.register('service:store', storeMock);
+
+  let course = Object.create({
+    clerkshipType: resolve(Object.create()),
+    directors: resolve([
+      Object.create({ 'fullName': 'Adam Zyzzyva', 'lastName': 'Zyzzyva' }),
+      Object.create({ 'fullName': 'Zoe Aaardvark', 'lastName': 'Aardvark' }),
+      Object.create({ 'fullName': 'Mike Middleman', 'lastName': 'Middleman' })
+    ])
+  });
+  this.set('course', course);
+  this.render(hbs`{{course-overview course=course}}`);
+
+  const directorsList = '.coursedirectors ul';
+  assert.equal(this.$(`${directorsList} li:eq(0)`).text().trim(), 'Zoe Aaardvark');
+  assert.equal(this.$(`${directorsList} li:eq(1)`).text().trim(), 'Mike Middleman');
+  assert.equal(this.$(`${directorsList} li:eq(2)`).text().trim(), 'Adam Zyzzyva');
+});


### PR DESCRIPTION
fixes #1729.

before:

![selection_045](https://cloud.githubusercontent.com/assets/1410427/19787433/8bc6cce6-9c57-11e6-9d53-d995bed72fe2.png)

after:

![selection_046](https://cloud.githubusercontent.com/assets/1410427/19787438/922f56ac-9c57-11e6-919b-4e0fcd804a1f.png)

