### PR TITLE
rm pikaday as bower dependency.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,6 @@
     "lodash": "~4.0.0",
     "Faker": "~3.0.1",
     "font-awesome": "~4.5.0",
-    "pikaday": "~1.3.3",
     "moment": ">= 2.8.0",
     "moment-timezone": ">= 0.1.0",
     "froala-wysiwyg-editor": "^2.2.3",


### PR DESCRIPTION
this follows at the heels of the most recent ember-pikaday upgrade.