### PR TITLE
Validate API Version

### DIFF
--- a/app/components/api-version-check.js
+++ b/app/components/api-version-check.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+import ENV from 'ilios/config/environment';
+
+const { Component, RSVP, computed, inject } = Ember;
+const { Promise } = RSVP;
+const { service } = inject;
+
+const { apiVersion } = ENV.APP;
+
+export default Component.extend({
+  iliosConfig: service(),
+  versionMismatch: computed('iliosConfig.apiVersion', function(){
+    const iliosConfig = this.get('iliosConfig');
+    return new Promise(resolve => {
+      iliosConfig.get('apiVersion').then(serverApiVersion => {
+        resolve(serverApiVersion !== apiVersion);
+      });
+    });
+  }),
+});

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -20,6 +20,8 @@ export default {
     'allSchools': 'All Schools',
     'allVocabularies': 'All Vocabularies',
     'anything': 'Anything',
+    'apiVersionMismatch': 'API Version Mismatch',
+    'apiVersionMismatchDetails': 'This frontend does not match the version of the API that it is communicating with. Please notify an administrator or technical owner of the system regarding this error <em>immediately</em>, You cannot work with Ilios until this is resolved',
     'assignedTerms': 'Assigned Terms',
     'associatedCourses': 'Associated Courses',
     'associatedGroups': 'Associated Groups',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -20,6 +20,8 @@ export default {
     'allSchools': 'Todas las Escuelas',
     'allVocabularies': 'Todos los Vocabularios',
     'anything': 'Caulquier Cosa',
+    'apiVersionMismatch': 'Incompatibilidad de versión de API',
+    'apiVersionMismatchDetails': 'Este interfaz de usuario no corresponde a la versión del API con el cual se comunica. Por favor notifique a un administrador o el dueño técnico del sistema con respecto a este error <em>inmediatamente</em>, no puede trabajar con Ilios hasta que esto sea resuelto',
     'assignedTerms': 'Términos asignados',
     'associatedCourses': 'Cursos Asociados',
     'associatedGroups': 'Grupos Associados',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -20,6 +20,8 @@ export default {
     'allSchools': 'Toutes les écoles',
     'allVocabularies': 'Touts vocabulaires',
     'anything': "Quelque chose",
+    'apiVersionMismatch': 'API  conflit de version',
+    'apiVersionMismatchDetails': "Ce 'frontend' ne correspond pas à la version de l'API avec laquelle il communique. Notifiez S'il vous plaît un administrateur ou un propriétaire technique du système quant à cette erreur immédiatement. Vous ne pouvez pas travailler avec Ilios avant que ce ne soit résolu.",
     'assignedTerms': 'Termes assignées',
     'associatedCourses': "Cours Associés",
     'associatedGroups': "Groupes Associés",

--- a/app/mirage/config.js
+++ b/app/mirage/config.js
@@ -1,6 +1,9 @@
 import moment from 'moment';
 import getAll from './helpers/get-all';
 import Mirage from 'ember-cli-mirage';
+import ENV from 'ilios/config/environment';
+
+const { apiVersion } = ENV.APP;
 
 export default function() {
   this.timing = 100;
@@ -406,7 +409,8 @@ export default function() {
 
   this.get('application/config', function() {
     return { config: {
-      type: 'form'
+      type: 'form',
+      apiVersion
     }};
     // return { config: {
     //   type: 'shibboleth',

--- a/app/services/ilios-config.js
+++ b/app/services/ilios-config.js
@@ -28,5 +28,9 @@ export default Ember.Service.extend({
 
   maxUploadSize: computed('config.maxUploadSize', function(){
     return this.itemFromConfig('maxUploadSize');
+  }),
+
+  apiVersion: computed('config.apiVersion', function(){
+    return this.itemFromConfig('apiVersion');
   })
 });

--- a/app/styles/newcomponents.scss
+++ b/app/styles/newcomponents.scss
@@ -1,3 +1,4 @@
+@import 'newcomponents/api-version-check';
 @import 'newcomponents/new-user';
 @import 'newcomponents/my-profile';
 @import 'newcomponents/ilios-header';

--- a/app/styles/newcomponents/api-version-check.scss
+++ b/app/styles/newcomponents/api-version-check.scss
@@ -1,0 +1,19 @@
+.api-version-check-warning {
+  background-color: rgba($ilios-orange, .95);
+}
+
+.api-version-check-container {
+  width: 80%;
+
+  .content {
+    padding: 2em;
+    
+    h1 {
+      @include ilios-heading-h1;
+    }
+
+    p {
+      width: 80%;
+    }
+  }
+}

--- a/app/styles/newcomponents/api-version-check.scss
+++ b/app/styles/newcomponents/api-version-check.scss
@@ -7,7 +7,7 @@
 
   .content {
     padding: 2em;
-    
+
     h1 {
       @include ilios-heading-h1;
     }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,5 @@
 {{ember-load-remover}}
+{{api-version-check}}
 {{#if showHeader}}
   {{ilios-header title=pageTitle}}
 {{/if}}

--- a/app/templates/components/api-version-check.hbs
+++ b/app/templates/components/api-version-check.hbs
@@ -1,0 +1,13 @@
+{{#if (await versionMismatch)}}
+  {{#tether-dialog
+    alignmentTarget='body'
+    attachment='middle center'
+    overlay-class='api-version-check-warning'
+    container-class='api-version-check-container'
+  }}
+    <div class='content'>
+      <h1>{{t 'general.apiVersionMismatch'}}</h1>
+      <p>{{t 'general.apiVersionMismatchDetails'}}</p>
+    </div>
+  {{/tether-dialog}}
+{{/if}}

--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,0 +1,3 @@
+/* eslint-env node */
+
+module.exports = 'v1.12';

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
+const API_VERSION = require('./api-version.js');
 
 module.exports = function(deployTarget) {
-  const API_VERSION = 'v1.12';
   var ENV = {
     build: {},
     exclude: ['.DS_Store', '*-test.js'],

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+const API_VERSION = require('./api-version.js');
 
 module.exports = function(environment) {
   var ENV = {
@@ -105,6 +106,7 @@ module.exports = function(environment) {
     },
 
     APP: {
+      apiVersion: API_VERSION,
       // Here you can pass flags/options to your application instance
       // when it is created
     },

--- a/tests/acceptance/api-version-check-test.js
+++ b/tests/acceptance/api-version-check-test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import startApp from 'ilios/tests/helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+
+import ENV from 'ilios/config/environment';
+const { apiVersion } = ENV.APP;
+
+let application;
+let url = '/';
+
+module('Acceptance: API Version Check', {
+  beforeEach() {
+    application = startApp();
+    setupAuthentication(application);
+    server.create('school');
+  },
+
+  afterEach() {
+    destroyApp(application);
+  }
+});
+
+test('No warning shows up when api versions match', function(assert) {
+  assert.expect(2);
+  server.get('application/config', function() {
+    assert.ok(true, 'our config override was called')
+    return { config: {
+      type: 'form',
+      apiVersion
+    }};
+  });
+  const warningOverlay = '.api-version-check-warning';
+
+  visit(url);
+  andThen(() => {
+    assert.equal($(warningOverlay).length, 0);
+  });
+});
+
+test('Warning shows up when api versions do not match', function(assert) {
+  assert.expect(2);
+  server.get('application/config', function() {
+    assert.ok(true, 'our config override was called')
+    return { config: {
+      type: 'form',
+      apiVersion: 'v0.bad'
+    }};
+  });
+  const warningOverlay = '.api-version-check-warning';
+
+  visit(url);
+  andThen(() => {
+    assert.equal($(warningOverlay).length, 1);
+  });
+});

--- a/tests/integration/components/api-version-check-test.js
+++ b/tests/integration/components/api-version-check-test.js
@@ -1,0 +1,33 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import ENV from 'ilios/config/environment';
+
+const { apiVersion } = ENV.APP;
+
+const { Service, RSVP, $ } = Ember;
+const { resolve } = RSVP;
+
+moduleForComponent('api-version-check', 'Integration | Component | api version check', {
+  integration: true
+});
+
+test('shows no warning when versions match', function(assert) {
+  const iliosConfigMock = Service.extend({
+    apiVersion: resolve(apiVersion)
+  });
+  this.register('service:iliosConfig', iliosConfigMock);
+  this.render(hbs`{{api-version-check}}`);
+  assert.equal($('.api-version-check-warning').length, 0);
+
+});
+
+test('shows warning on mismatch', function(assert) {
+  const iliosConfigMock = Service.extend({
+    apiVersion: resolve('bad')
+  });
+  this.register('service:iliosConfig', iliosConfigMock);
+  this.render(hbs`{{api-version-check}}`);
+  assert.equal($('.api-version-check-warning').length, 1);
+
+});

--- a/tests/integration/components/api-version-check-test.js
+++ b/tests/integration/components/api-version-check-test.js
@@ -16,9 +16,10 @@ test('shows no warning when versions match', function(assert) {
   const iliosConfigMock = Service.extend({
     apiVersion: resolve(apiVersion)
   });
+  const warningOverlay = '.api-version-check-warning';
   this.register('service:iliosConfig', iliosConfigMock);
   this.render(hbs`{{api-version-check}}`);
-  assert.equal($('.api-version-check-warning').length, 0);
+  assert.equal($(warningOverlay).length, 0);
 
 });
 
@@ -26,8 +27,9 @@ test('shows warning on mismatch', function(assert) {
   const iliosConfigMock = Service.extend({
     apiVersion: resolve('bad')
   });
+  const warningOverlay = '.api-version-check-warning';
   this.register('service:iliosConfig', iliosConfigMock);
   this.render(hbs`{{api-version-check}}`);
-  assert.equal($('.api-version-check-warning').length, 1);
+  assert.equal($(warningOverlay).length, 1);
 
 });


### PR DESCRIPTION
If a frontend attempts to contact an API with a mismatched version
string the user will see a message an be unable to continue. This will
prevent any kind of weird situation where an incorrect version gets
shipped or an advanced setup is set to point to an older API install.

Fixes #2284