### PR TITLE
Move api configuration into iliosConfig

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -8,10 +8,10 @@ const { reads } = computed;
 const { RESTAdapter } = DS;
 
 export default RESTAdapter.extend(DataAdapterMixin, {
-  serverVariables: service(),
+  iliosConfig: service(),
 
-  host: reads('serverVariables.apiHost'),
-  namespace: reads('serverVariables.apiNameSpace'),
+  host: reads('iliosConfig.apiHost'),
+  namespace: reads('iliosConfig.apiNameSpace'),
 
   coalesceFindRequests: true,
 

--- a/app/components/bulk-new-users.js
+++ b/app/components/bulk-new-users.js
@@ -83,7 +83,7 @@ export default Component.extend(NewUser, {
   i18n: service(),
   ajax: service(),
   flashMessages: service(),
-  serverVariables: service(),
+  iliosConfig: service(),
 
   classNames: ['bulk-new-users'],
   file: null,
@@ -93,8 +93,8 @@ export default Component.extend(NewUser, {
   savingUserErrors: null,
   savingAuthenticationErrors: null,
   fileUploadError: false,
-  host: reads('serverVariables.apiHost'),
-  namespace: reads('serverVariables.apiNameSpace'),
+  host: reads('iliosConfig.apiHost'),
+  namespace: reads('iliosConfig.apiNameSpace'),
 
   existingUsernames(){
     const store = this.get('store');

--- a/app/components/course-rollover.js
+++ b/app/components/course-rollover.js
@@ -25,7 +25,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   ajax: service(),
   store: service(),
   flashMessages: service(),
-  serverVariables: service(),
+  iliosConfig: service(),
   didReceiveAttrs(){
     this._super(...arguments);
     let thisYear = parseInt(moment().format('YYYY'));
@@ -42,8 +42,8 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     this.get('loadUnavailableYears').perform();
     this.get('changeSelectedYear').perform(thisYear);
   },
-  host: reads('serverVariables.apiHost'),
-  namespace: reads('serverVariables.apiNameSpace'),
+  host: reads('iliosConfig.apiHost'),
+  namespace: reads('iliosConfig.apiNameSpace'),
   classNames: ['course-rollover'],
   years: [],
   selectedYear: null,

--- a/app/components/curriculum-inventory-report-rollover.js
+++ b/app/components/curriculum-inventory-report-rollover.js
@@ -22,7 +22,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   ajax: service(),
   store: service(),
   flashMessages: service(),
-  serverVariables: service(),
+  iliosConfig: service(),
   didReceiveAttrs(){
     this._super(...arguments);
     const report = this.get('report');
@@ -44,8 +44,8 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     this.set('years', years);
   },
 
-  host: reads('serverVariables.apiHost'),
-  namespace: reads('serverVariables.apiNameSpace'),
+  host: reads('iliosConfig.apiHost'),
+  namespace: reads('iliosConfig.apiNameSpace'),
   classNames: ['curriculum-inventory-report-rollover'],
   years: [],
   selectedYear: null,

--- a/app/components/my-profile.js
+++ b/app/components/my-profile.js
@@ -23,13 +23,13 @@ export default Ember.Component.extend({
     this.set('expiresAt', twoWeeksFromNow.toDate());
     this.set('generatedJwt', null);
   },
-  serverVariables: service(),
+  iliosConfig: service(),
   ajax: service(),
   flashMessages: service(),
   session: service(),
 
-  host: reads('serverVariables.apiHost'),
-  namespace: reads('serverVariables.apiNameSpace'),
+  host: reads('iliosConfig.apiHost'),
+  namespace: reads('iliosConfig.apiNameSpace'),
   expiresAt: null,
   maxDate: null,
   minDate: null,

--- a/app/components/new-learningmaterial.js
+++ b/app/components/new-learningmaterial.js
@@ -68,7 +68,7 @@ const Validations = buildValidations({
 export default Component.extend(Validations, ValidationErrorDisplay, {
   store: service(),
   currentUser: service(),
-  serverVariables: service(),
+  iliosConfig: service(),
   init() {
     this._super(...arguments);
     const component = this;
@@ -96,7 +96,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     set(this, 'showUploadStatus', false);
     set(this, 'fileUploadPercentage', 0);
   },
-  host: reads('serverVariables.apiHost'),
+  host: reads('iliosConfig.apiHost'),
   uploadPath: computed('host', function(){
     return this.get('host') + '/upload';
   }),

--- a/app/components/user-profile-ics.js
+++ b/app/components/user-profile-ics.js
@@ -7,7 +7,7 @@ const { service } = inject;
 const { reads } = computed;
 
 export default Component.extend({
-  serverVariables: service(),
+  iliosConfig: service(),
 
   didReceiveAttrs(){
     this._super(...arguments);
@@ -19,7 +19,7 @@ export default Component.extend({
     }
   },
 
-  host: reads('serverVariables.apiHost'),
+  host: reads('iliosConfig.apiHost'),
 
   classNameBindings: [':user-profile-ics', ':small-component', 'hasSavedRecently:has-saved:has-not-saved'],
 

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -6,10 +6,10 @@ const { service } = inject;
 const { reads } = computed;
 
 export default AjaxService.extend({
-  serverVariables: service(),
+  iliosConfig: service(),
   session: service(),
 
-  host: reads('serverVariables.apiHost'),
+  host: reads('iliosConfig.apiHost'),
 
   headers: computed('session.isAuthenticated', function(){
     let headers = {};

--- a/app/services/ilios-config.js
+++ b/app/services/ilios-config.js
@@ -1,13 +1,15 @@
 import Ember from 'ember';
 
-const { inject, computed } = Ember;
+const { inject, computed, isPresent } = Ember;
 const { service } = inject;
 
 export default Ember.Service.extend({
   ajax: service(),
+  serverVariables: service(),
 
-  config: computed(function(){
-    var url = '/application/config';
+  config: computed('apiHost', function(){
+    const apiHost = this.get('apiHost');
+    const url = apiHost + '/application/config';
     const ajax = this.get('ajax');
     return ajax.request(url);
   }),
@@ -32,5 +34,25 @@ export default Ember.Service.extend({
 
   apiVersion: computed('config.apiVersion', function(){
     return this.itemFromConfig('apiVersion');
-  })
+  }),
+
+  apiNameSpace: computed('serverVariables.apiNameSpace', function(){
+    const serverVariables = this.get('serverVariables');
+    const apiNameSpace = serverVariables.get('apiNameSpace');
+    if (isPresent(apiNameSpace)) {
+      //remove trailing slashes
+      return apiNameSpace.replace(/\/+$/, "");
+    }
+    return '';
+  }),
+
+  apiHost: computed('serverVariables.apiHost', function(){
+    const serverVariables = this.get('serverVariables');
+    const apiHost = serverVariables.get('apiHost');
+    if (isPresent(apiHost)) {
+      //remove trailing slashes
+      return apiHost.replace(/\/+$/, "");
+    }
+    return '';
+  }),
 });

--- a/app/services/school-events.js
+++ b/app/services/school-events.js
@@ -10,9 +10,9 @@ export default Ember.Service.extend(EventMixin, {
   store: service(),
   currentUser: service(),
   ajax: service(),
-  serverVariables: service(),
+  iliosConfig: service(),
 
-  namespace: reads('serverVariables.apiNameSpace'),
+  namespace: reads('iliosConfig.apiNameSpace'),
 
   getEvents(schoolId, from, to){
     var deferred = Ember.RSVP.defer();

--- a/app/services/user-events.js
+++ b/app/services/user-events.js
@@ -11,9 +11,9 @@ export default Ember.Service.extend(EventMixin, {
   currentUser: service(),
   session: service(),
   ajax: service(),
-  serverVariables: service(),
+  iliosConfig: service(),
 
-  namespace: reads('serverVariables.apiNameSpace'),
+  namespace: reads('iliosConfig.apiNameSpace'),
 
   getEvents(from, to){
     var deferred = Ember.RSVP.defer();


### PR DESCRIPTION
We were splitting some configuration information into two places.  iliosConfig handled the contents on the /application/config file and serverVarialbes read the data in the index.html file.  Instead put all of that into iliosConfig.  This allows us to handle two config cases better.
1. Trailing slashes can be removed
2. When the server is ‘’ we can return that instead of undefined.

WIP, needs testing for:
- [x] bulk new users
- [x] course rollover
- [x] curric report rollover
- [x] my profile - new token
- [x] my profile - link to API docs
- [x] new LM upload (obviously)
- [x] use profile ICS link
- [x] user profile sync button
- [x] dashbaord ics link
- [x] user and school events on the calendar
- [x] login
- [x] logout
- [x] directory user lookup and add

