### PR TITLE
Lint for semi-colons

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,17 +1,18 @@
 {
-  "env": {
-    "browser": true,
-    "es6": true,
+  env: {
+    browser: true,
+    es6: true,
   },
-  "extends": "eslint:recommended",
-  "parserOptions": {
-    "sourceType": "module",
+  extends: "eslint:recommended",
+  parserOptions: {
+    sourceType: "module",
   },
-  "rules": {
+  rules: {
     /* Possible Errors http://eslint.org/docs/rules/#possible-errors */
-    "comma-dangle": [2, "only-multiline"],
+    comma-dangle: [2, "only-multiline"],
 
     /* Stylistic Issues http://eslint.org/docs/rules/#stylistic-issues */
-    "indent": [2, 2], /* two-space indentation */
-  },
+    indent: [2, 2], /* two-space indentation */
+    semi: 2 /* require semi-colons */
+  }
 }

--- a/app/components/assign-students.js
+++ b/app/components/assign-students.js
@@ -57,7 +57,7 @@ export default Component.extend({
       return [];
     }
     return students.filter(user => {
-      return (!savedUserIds.contains(user.get('id')))
+      return (!savedUserIds.contains(user.get('id')));
     }).sortBy('lastName', 'firstName').slice(offset, end);
   }),
 

--- a/app/components/course-materials.js
+++ b/app/components/course-materials.js
@@ -74,8 +74,8 @@ export default Component.extend(SortableTable, {
 
           resolve(filteredObjs);
         }
-      })
-    })
+      });
+    });
   }),
   sessions: computed('course.sessions.[]', function(){
     const course = this.get('course');

--- a/app/components/course-overview.js
+++ b/app/components/course-overview.js
@@ -95,7 +95,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
         });
       }
 
-    })
+    });
   }),
 
   actions: {

--- a/app/components/curriculum-inventory-report-overview.js
+++ b/app/components/curriculum-inventory-report-overview.js
@@ -55,7 +55,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
           resolve(hasRole);
         });
       }
-    })
+    });
   }),
 
   classNames: ['curriculum-inventory-report-overview'],

--- a/app/components/curriculum-inventory-sequence-block-list.js
+++ b/app/components/curriculum-inventory-sequence-block-list.js
@@ -43,7 +43,7 @@ export default Component.extend({
         sequenceBlocks,
         savedBlock: null,
         saved: false,
-      })
+      });
     }
   }),
 

--- a/app/components/curriculum-inventory-sequence-block-overview.js
+++ b/app/components/curriculum-inventory-sequence-block-overview.js
@@ -217,7 +217,7 @@ export default Component.extend({
           parent.get('children').then(children => {
             children.invoke('reload');
           });
-        })
+        });
       });
     },
     changeDatesAndDuration(start, end, duration) {

--- a/app/components/curriculum-inventory-sequence-block-session-manager.js
+++ b/app/components/curriculum-inventory-sequence-block-session-manager.js
@@ -101,7 +101,7 @@ export default Component.extend({
       this.get('setSortBy')(what);
     },
     close() {
-      this.sendAction('cancel')
+      this.sendAction('cancel');
     }
   }
 });

--- a/app/components/ilios-event.js
+++ b/app/components/ilios-event.js
@@ -51,7 +51,7 @@ export default Component.extend({
       } else {
         store.findRecord('offering', offeringId).then(offering => {
           resolve(offering);
-        })
+        });
       }
     });
   }),
@@ -64,7 +64,7 @@ export default Component.extend({
       } else {
         store.findRecord('ilm-session', ilmSessionId).then(ilmSession => {
           resolve(ilmSession);
-        })
+        });
       }
     });
   }),

--- a/app/components/learnergroup-subgroup-list.js
+++ b/app/components/learnergroup-subgroup-list.js
@@ -59,7 +59,7 @@ export default Component.extend({
                   saveSomeGroups(groups);
                 } else {
                   this.set('isSaving', false);
-                  this.set('showNewLearnerGroupForm', false)
+                  this.set('showNewLearnerGroupForm', false);
                   this.get('flashMessages').success('general.savedSuccessfully');
                   resolve();
                 }

--- a/app/components/learnergroup-tree.js
+++ b/app/components/learnergroup-tree.js
@@ -56,7 +56,7 @@ export default Component.extend({
       let filterTitle = yield learnerGroup.get('filterTitle');
       filterMatch = filterTitle.match(exp) != null;
     }
-    let available = hasUnSelectedChildren || !selectedGroups.contains(learnerGroup)
+    let available = hasUnSelectedChildren || !selectedGroups.contains(learnerGroup);
 
     this.set('isVisible', filterMatch && available);
     this.set('selectable', available);

--- a/app/components/my-profile.js
+++ b/app/components/my-profile.js
@@ -43,7 +43,7 @@ export default Ember.Component.extend({
       user.get('roles').then(roles => {
         resolve(roles.mapBy('title'));
       });
-    })
+    });
   }),
   apiDocsUrl: computed('host', 'namespace', function(){
     let apiPath = '/' + this.get('namespace');

--- a/app/components/new-learnergroup-single.js
+++ b/app/components/new-learnergroup-single.js
@@ -32,7 +32,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
         }
       }).finally(()=>{
         this.set('isSaving', false);
-      })
+      });
     },
   }
 });

--- a/app/components/new-learningmaterial.js
+++ b/app/components/new-learningmaterial.js
@@ -176,7 +176,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
 
           this.get('save')(learningMaterial).finally(()=>{
             this.send('clearErrorDisplay');
-          })
+          });
         }
       }).finally(() => {
         this.set('isSaving', false);

--- a/app/components/new-program.js
+++ b/app/components/new-program.js
@@ -35,7 +35,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
           });
           this.get('save')(program).finally(()=>{
             this.set('isSaving', false);
-          })
+          });
         } else {
           this.set('isSaving', false);
         }

--- a/app/components/programyear-competencies.js
+++ b/app/components/programyear-competencies.js
@@ -48,7 +48,7 @@ export default Component.extend({
 
   competencies: computed('programYear.program.school.competencies.[]', function(){
     return new Promise(resolve => {
-      const programYear = this.get('programYear')
+      const programYear = this.get('programYear');
       programYear.get('program').then(program => {
         program.get('school').then(school => {
           school.get('competencies').then(competencies => {

--- a/app/components/school-competencies-manager.js
+++ b/app/components/school-competencies-manager.js
@@ -16,7 +16,7 @@ export default Component.extend({
         return {
           domain,
           competencies: []
-        }
+        };
       }
       let domainCompetencies = competencies.filter(
         competency => competency.belongsTo('parent').id() === domain.get('id')

--- a/app/components/school-list.js
+++ b/app/components/school-list.js
@@ -58,7 +58,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
           newSchool.save().then(school => {
             this.get('newSchools').pushObject(school);
           }).finally(() => {
-            this.send('clearErrorDisplay')
+            this.send('clearErrorDisplay');
             this.set('title', null);
             this.set('showNewSchoolForm', false);
             this.set('isSavingNewSchool', false);

--- a/app/components/school-vocabularies-expanded.js
+++ b/app/components/school-vocabularies-expanded.js
@@ -17,7 +17,7 @@ export default Component.extend({
     return new Promise(resolve => {
       const isManaging = this.get('isManaging');
       this.get('school.vocabularies').then(vocabularies => {
-        resolve(vocabularies.get('length') && ! isManaging)
+        resolve(vocabularies.get('length') && ! isManaging);
       });
     });
 

--- a/app/components/school-vocabulary-term-manager.js
+++ b/app/components/school-vocabulary-term-manager.js
@@ -64,8 +64,8 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
       const term = this.get('term');
       if (isPresent(term)) {
         term.get('allParents').then(allParents => {
-          resolve(allParents.toArray().reverse())
-        })
+          resolve(allParents.toArray().reverse());
+        });
       }
     });
   }),

--- a/app/components/session-overview.js
+++ b/app/components/session-overview.js
@@ -78,7 +78,7 @@ export default Component.extend(Publishable, Validations, ValidationErrorDisplay
         });
       }
 
-    })
+    });
   }),
 
   actions: {

--- a/app/components/taxonomy-manager.js
+++ b/app/components/taxonomy-manager.js
@@ -71,7 +71,7 @@ export default Component.extend({
       this.sendAction('remove', term);
     },
     changeSelectedVocabulary(vocabId) {
-      this.set('vocabId', vocabId)
+      this.set('vocabId', vocabId);
     }
   }
 });

--- a/app/components/unassigned-students-summary.js
+++ b/app/components/unassigned-students-summary.js
@@ -17,7 +17,7 @@ export default Component.extend({
       this.get('currentUser.model').then(user => {
         user.get('schools').then(schools => {
           resolve(schools);
-        })
+        });
       });
     });
   }),

--- a/app/components/user-profile-learnergroups.js
+++ b/app/components/user-profile-learnergroups.js
@@ -44,7 +44,7 @@ export default Component.extend({
           });
         }).then(groupObjects => {
           resolve(groupObjects.sortBy('sortTitle'));
-        })
+        });
       });
     });
   }),

--- a/app/components/user-profile-roles.js
+++ b/app/components/user-profile-roles.js
@@ -90,7 +90,7 @@ export default Component.extend({
         let roleTitles = roles.map(role => role.get('title').toLowerCase());
         resolve(roleTitles);
       });
-    })
+    });
   }),
 
   isCourseDirector: computed('roleTitles.[]', 'isCourseDirectorFlipped', function(){

--- a/app/components/user-profile-secondary-cohorts-manager.js
+++ b/app/components/user-profile-secondary-cohorts-manager.js
@@ -17,7 +17,7 @@ export default Component.extend({
         return true;
       }
       return cohort.get('id') !== primaryCohort.get('id');
-    })
+    });
   }),
 
   assignableCohorts: computed('currentUser.cohortsInAllAssociatedSchools.[]', 'cohorts.[]', {

--- a/app/controllers/assign-students.js
+++ b/app/controllers/assign-students.js
@@ -26,7 +26,7 @@ export default Controller.extend({
 
   unassignedStudents: computed('selectedSchool', function(){
     return new Promise(resolve => {
-      let school = this.get('selectedSchool')
+      let school = this.get('selectedSchool');
       this.get('store').query('user', {
         limit: 1000,
         filters: {

--- a/app/controllers/learner-groups.js
+++ b/app/controllers/learner-groups.js
@@ -147,7 +147,7 @@ export default Controller.extend({
     return PromiseObject.create({
       promise: this.get('currentUser').get('model').then(user => {
         return user.get('school').then(school => {
-          return school
+          return school;
         });
       })
     });

--- a/app/models/cohort.js
+++ b/app/models/cohort.js
@@ -41,7 +41,7 @@ export default Model.extend({
   topLevelLearnerGroups: computed('learnerGroups.[]', function(){
     let defer = Ember.RSVP.defer();
     this.get('learnerGroups').then(learnerGroups => {
-      let topLevelGroups = learnerGroups.filter(learnerGroup => learnerGroup.belongsTo('parent').value() === null)
+      let topLevelGroups = learnerGroups.filter(learnerGroup => learnerGroup.belongsTo('parent').value() === null);
       defer.resolve(topLevelGroups);
     });
 

--- a/app/models/competency.js
+++ b/app/models/competency.js
@@ -50,8 +50,8 @@ export default Model.extend({
             return item != null;
           });
           resolve(rhett);
-        })
-      })
+        });
+      });
     });
 
   })

--- a/app/models/course.js
+++ b/app/models/course.js
@@ -184,7 +184,7 @@ export default Model.extend(PublishableModel, CategorizableModel, {
         schoolVocabs.forEach(vocabs => {
           vocabs.forEach(vocab => {
             v.pushObject(vocab);
-          })
+          });
         });
         v = v.sortBy('school.title', 'title');
         deferred.resolve(v);

--- a/app/models/curriculum-inventory-report.js
+++ b/app/models/curriculum-inventory-report.js
@@ -79,7 +79,7 @@ export default DS.Model.extend({
           resolve(courses);
         });
       });
-    })
+    });
   }),
 
   /**
@@ -93,7 +93,7 @@ export default DS.Model.extend({
       this.get('linkedCourses').then(linkedCourses => {
         let hasCourses = !Ember.isEmpty(linkedCourses);
         resolve(hasCourses);
-      })
+      });
     });
   })
 });

--- a/app/routes/assign-students.js
+++ b/app/routes/assign-students.js
@@ -13,7 +13,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
           return {
             primarySchool,
             schools
-          }
+          };
         });
       });
     });

--- a/app/routes/course-materials.js
+++ b/app/routes/course-materials.js
@@ -9,7 +9,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
     return all([
       this.loadCourseLearningMaterials(course),
       this.loadSessionLearningMaterials(course),
-    ])
+    ]);
 
   },
   loadCourseLearningMaterials(course){
@@ -17,7 +17,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       course.get('learningMaterials').then(courseLearningMaterials => {
         all(courseLearningMaterials.getEach('learningMaterial')).then(()=> {
           resolve();
-        })
+        });
       });
     });
   },
@@ -31,7 +31,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
           ]);
         }).then(()=>{
           resolve();
-        })
+        });
       });
     });
   }

--- a/app/routes/pending-user-updates.js
+++ b/app/routes/pending-user-updates.js
@@ -11,7 +11,7 @@ export default Ember.Route.extend({
           return {
             primarySchool,
             schools
-          }
+          };
         });
       });
     });

--- a/tests/acceptance/api-version-check-test.js
+++ b/tests/acceptance/api-version-check-test.js
@@ -24,7 +24,7 @@ module('Acceptance: API Version Check', {
 test('No warning shows up when api versions match', function(assert) {
   assert.expect(2);
   server.get('application/config', function() {
-    assert.ok(true, 'our config override was called')
+    assert.ok(true, 'our config override was called');
     return { config: {
       type: 'form',
       apiVersion
@@ -41,7 +41,7 @@ test('No warning shows up when api versions match', function(assert) {
 test('Warning shows up when api versions do not match', function(assert) {
   assert.expect(2);
   server.get('application/config', function() {
-    assert.ok(true, 'our config override was called')
+    assert.ok(true, 'our config override was called');
     return { config: {
       type: 'form',
       apiVersion: 'v0.bad'

--- a/tests/acceptance/assignstudents-test.js
+++ b/tests/acceptance/assignstudents-test.js
@@ -10,7 +10,7 @@ moduleForAcceptance('Acceptance | assign students', {
     application = startApp();
     setupAuthentication(application);
 
-    server.createList('school', 2)
+    server.createList('school', 2);
 
   },
   afterEach: function() {

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -537,7 +537,7 @@ test('rollover hidden from instructors', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'course.index');
-    assert.equal(find(rollover).length, 0)
+    assert.equal(find(rollover).length, 0);
   });
 });
 
@@ -560,7 +560,7 @@ test('rollover visible to developers', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'course.index');
-    assert.equal(find(rollover).length, 1)
+    assert.equal(find(rollover).length, 1);
   });
 });
 
@@ -583,7 +583,7 @@ test('rollover visible to course directors', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'course.index');
-    assert.equal(find(rollover).length, 1)
+    assert.equal(find(rollover).length, 1);
   });
 });
 
@@ -606,6 +606,6 @@ test('rollover hidden on rollover route', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'course.rollover');
-    assert.equal(find(rollover).length, 0)
+    assert.equal(find(rollover).length, 0);
   });
 });

--- a/tests/acceptance/course/session/objectivecreate-test.js
+++ b/tests/acceptance/course/session/objectivecreate-test.js
@@ -57,7 +57,7 @@ test('save new objective', function(assert) {
           assert.equal(getElementText(tds.eq(1)), getText('Add New'));
           assert.equal(getElementText(tds.eq(2)), getText('Add New'));
         });
-      }, 100)
+      }, 100);
     }, 100);
   });
 

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -459,7 +459,7 @@ test('copy hidden from instructors', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
-    assert.equal(find(copy).length, 0)
+    assert.equal(find(copy).length, 0);
   });
 });
 
@@ -482,7 +482,7 @@ test('copy visible to developers', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
-    assert.equal(find(copy).length, 1)
+    assert.equal(find(copy).length, 1);
   });
 });
 
@@ -505,7 +505,7 @@ test('copy visible to course directors', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'course.session.index');
-    assert.equal(find(copy).length, 1)
+    assert.equal(find(copy).length, 1);
   });
 });
 
@@ -528,6 +528,6 @@ test('copy hidden on copy route', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'course.session.copy');
-    assert.equal(find(copy).length, 0)
+    assert.equal(find(copy).length, 0);
   });
 });

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -12,7 +12,7 @@ module('Acceptance: Courses', {
   beforeEach: function() {
     application = startApp();
     setupAuthentication(application);
-    server.createList('school', 2)
+    server.createList('school', 2);
   },
 
   afterEach: function() {
@@ -346,7 +346,7 @@ test('new course can be deleted', function(assert) {
   server.create('userRole', {
     title: 'Developer'
   });
-  server.db.users.update(4136, {roles: [1]})
+  server.db.users.update(4136, {roles: [1]});
 
   assert.expect(7);
 
@@ -597,7 +597,7 @@ test('developer users can lock and unlock course', function(assert) {
   server.create('userRole', {
     title: 'Developer'
   });
-  server.db.users.update(4136, {roles: [1]})
+  server.db.users.update(4136, {roles: [1]});
   server.create('course', {
     year: 2014,
     school: 1,

--- a/tests/acceptance/curriculum-inventory/report-test.js
+++ b/tests/acceptance/curriculum-inventory/report-test.js
@@ -76,7 +76,7 @@ test('rollover hidden from instructors', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'curriculumInventoryReport.index');
-    assert.equal(find(rollover).length, 0)
+    assert.equal(find(rollover).length, 0);
   });
 });
 
@@ -107,7 +107,7 @@ test('rollover visible to developers', function(assert) {
   //return pauseTest();
   andThen(function() {
     assert.equal(currentPath(), 'curriculumInventoryReport.index');
-    assert.equal(find(rollover).length, 1)
+    assert.equal(find(rollover).length, 1);
   });
 });
 
@@ -137,7 +137,7 @@ test('rollover not visible to course directors', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'curriculumInventoryReport.index');
-    assert.equal(find(rollover).length, 0)
+    assert.equal(find(rollover).length, 0);
   });
 });
 
@@ -167,6 +167,6 @@ test('rollover hidden on rollover route', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'curriculumInventoryReport.rollover');
-    assert.equal(find(rollover).length, 0)
+    assert.equal(find(rollover).length, 0);
   });
 });

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -198,7 +198,7 @@ test('can delete a program-year', function(assert) {
   server.create('userRole', {
     title: 'Developer',
   });
-  server.db.users.update(4136, {roles: [1]})
+  server.db.users.update(4136, {roles: [1]});
 
   const deleteButton = '.remove';
   const confirmRemovalButton = '.confirm-message button.remove';
@@ -355,7 +355,7 @@ test('can add a program-year (with pre-existing program-year)', function(assert)
       assert.equal(getTableDataText(1, 4).text().trim(), '3', 'copied correctly from latest program-year');
       assert.equal(getTableDataText(1, 5).text().trim(), '3', 'copied correctly from latest program-year');
       assert.equal(getTableDataText(1, 6, 'span').text().trim(), 'Not Published', 'unpublished shown');
-    })
+    });
   });
 });
 
@@ -390,7 +390,7 @@ test('privileged users can lock and unlock program-year', function(assert) {
   server.create('userRole', {
     title: 'Developer'
   });
-  server.db.users.update(4136, {roles: [1]})
+  server.db.users.update(4136, {roles: [1]});
 
   visit(url);
   andThen(function() {

--- a/tests/helpers/setup-authentication.js
+++ b/tests/helpers/setup-authentication.js
@@ -8,7 +8,7 @@ export default function(application, userObject = {id: 4136}) {
   authenticateSession(application, token);
 
   if(userObject){
-    server.create('authentication', {id: userObject.id, user: userObject.id})
+    server.create('authentication', {id: userObject.id, user: userObject.id});
     return server.create('user', userObject);
   }
 

--- a/tests/integration/components/course-rollover-test.js
+++ b/tests/integration/components/course-rollover-test.js
@@ -38,7 +38,7 @@ test('it renders', function(assert) {
     }
     assert.equal(this.$(title).length, 1);
     assert.equal(this.$(title).val().trim(), course.get('title'));
-  })
+  });
 
 });
 

--- a/tests/integration/components/curriculum-inventory-report-rollover-test.js
+++ b/tests/integration/components/curriculum-inventory-report-rollover-test.js
@@ -43,7 +43,7 @@ test('it renders', function(assert) {
     assert.equal(this.$(name).val().trim(), report.get('name'));
     assert.equal(this.$(description).length, 1);
     assert.equal(this.$(description).val().trim(), report.get('description'));
-  })
+  });
 });
 
 test('rollover report', function(assert) {

--- a/tests/integration/components/curriculum-inventory-sequence-block-dates-duration-editor-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-dates-duration-editor-test.js
@@ -118,7 +118,7 @@ test('cancel', function(assert) {
     duration: 10
   });
   let cancelAction = function() {
-    assert.ok(true, 'Cancel action got invoked.')
+    assert.ok(true, 'Cancel action got invoked.');
   };
   this.set('block', block);
   this.set('cancel', cancelAction);

--- a/tests/integration/components/curriculum-inventory-sequence-block-min-max-editor-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-min-max-editor-test.js
@@ -36,7 +36,7 @@ test('save', function(assert) {
   let saveAction = function(min, max) {
     assert.equal(min, newMinimum, 'New minimum got passed to save action.');
     assert.equal(max, newMaximum, 'New maximum got passed to save action.');
-  }
+  };
   this.set('block', block);
   this.set('saveAction', saveAction);
   this.render(hbs`{{curriculum-inventory-sequence-block-min-max-editor sequenceBlock=block save=saveAction}}`);
@@ -54,7 +54,7 @@ test('cancel', function(assert) {
     maximum: 10,
   });
   let cancelAction = function() {
-    assert.ok(true, 'Cancel action got invoked.')
+    assert.ok(true, 'Cancel action got invoked.');
   };
   this.set('block', block);
   this.set('cancelAction', cancelAction);
@@ -86,7 +86,7 @@ test('save fails when minimum is less than zero', function(assert) {
   assert.expect(2);
   let block = Object.create();
   let saveAction = function() {
-    assert.ok(false, 'Save action should have not been invoked.')
+    assert.ok(false, 'Save action should have not been invoked.');
   };
   this.set('block', block);
   this.set('saveAction', saveAction);
@@ -106,7 +106,7 @@ test('save fails when minimum is empty', function(assert) {
   assert.expect(2);
   let block = Object.create();
   let saveAction = function() {
-    assert.ok(false, 'Save action should have not been invoked.')
+    assert.ok(false, 'Save action should have not been invoked.');
   };
   this.set('block', block);
   this.set('saveAction', saveAction);
@@ -126,7 +126,7 @@ test('save fails when maximum is empty', function(assert) {
   assert.expect(2);
   let block = Object.create();
   let saveAction = function() {
-    assert.ok(false, 'Save action should have not been invoked.')
+    assert.ok(false, 'Save action should have not been invoked.');
   };
   this.set('block', block);
   this.set('saveAction', saveAction);

--- a/tests/integration/components/detail-learnergroups-list-test.js
+++ b/tests/integration/components/detail-learnergroups-list-test.js
@@ -27,9 +27,9 @@ test('it renders', function(assert) {
     hasMany(){
       return {
         ids(){
-          return [1,2]
+          return [1,2];
         }
-      }
+      };
     }
   });
   tlg1.set('topLevelGroup', resolve(tlg1));
@@ -40,9 +40,9 @@ test('it renders', function(assert) {
     hasMany(){
       return {
         ids(){
-          return [1, 2, 3]
+          return [1, 2, 3];
         }
-      }
+      };
     }
   });
   let subSubGroup1 = Object.create({
@@ -52,9 +52,9 @@ test('it renders', function(assert) {
     hasMany(){
       return {
         ids(){
-          return [1]
+          return [1];
         }
-      }
+      };
     }
   });
   let tlg2 = Object.create({
@@ -63,9 +63,9 @@ test('it renders', function(assert) {
     hasMany(){
       return {
         ids(){
-          return [1,2]
+          return [1,2];
         }
-      }
+      };
     }
   });
   tlg2.set('topLevelGroup', resolve(tlg2));
@@ -76,9 +76,9 @@ test('it renders', function(assert) {
     hasMany(){
       return {
         ids(){
-          return []
+          return [];
         }
-      }
+      };
     }
   });
 
@@ -90,7 +90,7 @@ test('it renders', function(assert) {
 
 
   this.set('learnerGroups', [tlg1, subGroup1, subSubGroup1, subGroup2]);
-  this.set('nothing', parseInt)
+  this.set('nothing', parseInt);
 
   this.render(hbs`{{detail-learnergroups-list learnerGroups=learnerGroups remove=(action nothing)}}`);
 

--- a/tests/integration/components/school-competencies-manager-test.js
+++ b/tests/integration/components/school-competencies-manager-test.js
@@ -23,7 +23,7 @@ let Competency = Object.extend({
 
         return null;
       }
-    }
+    };
   }
 });
 
@@ -87,7 +87,7 @@ test('delete fires delete', function(assert) {
   this.set('nothing', parseInt);
   this.set('remove', (what) => {
     assert.equal(what, domain1);
-  })
+  });
   this.render(hbs`{{school-competencies-manager add=(action nothing) remove=(action remove) competencies=competencies}}`);
 
   const domains = '.hierarchical-list-manager';
@@ -111,7 +111,7 @@ test('add fires add', function(assert) {
   this.set('add', (what, title) => {
     assert.equal(what, domain1);
     assert.equal(title, 'new c');
-  })
+  });
   this.render(hbs`{{school-competencies-manager add=(action add) remove=(action nothing) competencies=competencies}}`);
 
   const domains = '.hierarchical-list-manager';

--- a/tests/integration/components/school-vocabularies-list-test.js
+++ b/tests/integration/components/school-vocabularies-list-test.js
@@ -54,7 +54,7 @@ test('can create new vocabulary', function(assert) {
           assert.ok(true);
           return RSVP.resolve(this);
         }
-      }
+      };
     }
   });
   this.register('service:store', storeMock);

--- a/tests/integration/components/search-box-test.js
+++ b/tests/integration/components/search-box-test.js
@@ -45,7 +45,7 @@ test('escape calls clear', function(assert) {
   this.on('clear', function(){
     assert.ok(true);
   });
-  this.on('search', parseInt)
+  this.on('search', parseInt);
   this.render(hbs`{{search-box search=(action 'search') clear=(action 'clear')}}`);
   run(() => {
     this.$('input').val('typed it');

--- a/tests/integration/components/session-copy-test.js
+++ b/tests/integration/components/session-copy-test.js
@@ -79,7 +79,7 @@ test('it renders', function(assert) {
     assert.equal(this.$(`${courseSelect} option:eq(1)`).text().trim(), course2.get('title'));
     assert.ok(this.$(save).not(':disabled'));
 
-  })
+  });
 
 });
 

--- a/tests/unit/models/ilm-session-test.js
+++ b/tests/unit/models/ilm-session-test.js
@@ -43,7 +43,7 @@ test('check allInstructors', function(assert) {
           assert.ok(instructors.contains(user2));
           assert.ok(instructors.contains(user3));
         });
-      })
+      });
 
     });
   });

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -331,7 +331,7 @@ test('check sortTitle on top group', function(assert) {
 
       store.createRecord('learner-group', {parent: learnerGroup, title: 'subGroup1'});
 
-      let sortTitle = learnerGroup.get('sortTitle')
+      let sortTitle = learnerGroup.get('sortTitle');
       assert.equal(sortTitle, 'topgroup');
     });
   });
@@ -352,7 +352,7 @@ test('check sortTitle on sub group', function(assert) {
       let subGroup2 = store.createRecord('learner-group', {parent: subGroup1, title: 'subGroup2'});
       let subGroup3 = store.createRecord('learner-group', {parent: subGroup2, title: 'subGroup3'});
 
-      let sortTitle = subGroup3.get('sortTitle')
+      let sortTitle = subGroup3.get('sortTitle');
       assert.equal(sortTitle, 'topgroupsubGroup1subGroup2subGroup3');
     });
   });


### PR DESCRIPTION
Add linting rule for semi-colons and semi-colons required by linting rule.

I also took the opportunity to remove unneeded quotation marks from the `.eslintrc` which *hopefully* makes it easier to read. I'm OK to undo that if others disagree.