### PR TITLE
Remove custom select styles

### DIFF
--- a/app/styles/components/_global.scss
+++ b/app/styles/components/_global.scss
@@ -268,17 +268,6 @@ input[type=password] {
 
 //style a regular select element to look like the actions menu
 select {
-  //set up the corners of the select box to mimic the rounded button/input corners */
-  @include appearance(none);
-  @include border-top-radius($base-border-radius);
-  @include border-bottom-radius($base-border-radius);
-  //set the dropdown arrow image as the background to simulate the actions menu dropdown
-  background: url('images/select-down-arrow.png') no-repeat;
-  background-color: $default-background-color;
-  background-position: right 4px bottom 8px;
-  background-size: 12px 12px;
-  border-color: $header-grey;
-
   //handle the text and padding
   font-size: 1em;
   height: 1.8em;


### PR DESCRIPTION
Our messing with the dropdown arrow was causing issues with IE11 where
it was displayed with double dropdowns.  Instead lets rely on the
browsers default style to make this work.

Fixes #2317

Should be reviewed in multiple browsers to ensure consistency.