### PR TITLE
Provide Notification When Program Is Deleted #2348

### DIFF
--- a/app/controllers/programs.js
+++ b/app/controllers/programs.js
@@ -100,6 +100,7 @@ export default Controller.extend({
   editorOn: false,
 
   saved: false,
+  removed: false,
   savedProgram: null,
 
   actions: {
@@ -118,7 +119,9 @@ export default Controller.extend({
     removeProgram(program) {
       this.get('model.schools').removeObject(program);
       program.deleteRecord();
-      program.save();
+      return program.save().then((savedProgram) => {
+        this.setProperties({ deleted: true, saved: false, savedProgram });
+      });
     },
 
     save(program) {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -401,6 +401,7 @@ export default {
     'remove': 'Remove',
     'removeAll': 'Remove All',
     'removeCohort': 'Remove Cohort',
+    'removedSuccessfully': 'Removed Successfully',
     'removeLearnerToCohort': { 'one': 'Remove learner to {{cohort}}', 'other': 'Remove {{count}} learners to {{cohort}}' },
     'removePrimaryCohort': 'Remove Primary Cohort',
     'reportConfirmRemove': 'Are you sure you want to delete this report? This action cannot be undone.',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -401,6 +401,7 @@ export default {
     'remove': 'Remover',
     'removeAll': 'Quitar Todos',
     'removeCohort': 'Remover Cohorte',
+    'removedSuccessfully': 'Eliminado con éxito',
     'removeLearnerToCohort': { 'one': 'Quite estudiante a {{cohort}}', 'other': 'Quite {{count}} estudiantes a {{cohort}}' },
     'removePrimaryCohort': 'Remover Principal Cohorte',
     'reportConfirmRemove': '¿Está seguro que desea eliminar este informe? Esta acción no se puede deshacer.',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -401,6 +401,7 @@ export default {
     'remove': "Supprîme",
     'removeAll': 'Supprimer Tous',
     'removeCohort': 'Supprîmer Cohorte',
+    'removedSuccessfully': "Supprimé avec succès",
     'removeLearnerToCohort': { 'one': 'Renvoyer l’étudiant à {{cohort}}', 'other': 'Renvoyer {{count}} étudiants à {{cohort}}' },
     'removePrimaryCohort': 'Supprîmer Cohorte Primaire',
     'reportConfirmRemove': 'Êtes-vous sûrs que vous voulez supprimer ce rapport? Cette action ne peut pas être défaite.',

--- a/app/templates/programs.hbs
+++ b/app/templates/programs.hbs
@@ -41,6 +41,12 @@
         {{t 'general.savedSuccessfully'}}
       </div>
     {{/if}}
+	
+    {{#if deleted}}
+      <div class='saved-program'>
+        {{fa-icon 'external-link-square'}} {{savedProgram.title}} {{t 'general.removedSuccessfully'}}
+      </div>
+    {{/if}}
 
     <div class='list'>
       {{#if filteredPrograms.isFulfilled}}

--- a/app/templates/programs.hbs
+++ b/app/templates/programs.hbs
@@ -44,7 +44,7 @@
 	
     {{#if deleted}}
       <div class='saved-program'>
-        {{fa-icon 'external-link-square'}} {{savedProgram.title}} {{t 'general.removedSuccessfully'}}
+        {{savedProgram.title}} {{t 'general.removedSuccessfully'}}
       </div>
     {{/if}}
 

--- a/tests/acceptance/programs-test.js
+++ b/tests/acceptance/programs-test.js
@@ -139,7 +139,7 @@ test('add new program', function(assert) {
 });
 
 test('remove program', function(assert) {
-  assert.expect(4);
+  assert.expect(3);
   server.create('user', {id: 4136});
   server.create('school', {
     programs: [1]

--- a/tests/acceptance/programs-test.js
+++ b/tests/acceptance/programs-test.js
@@ -139,7 +139,7 @@ test('add new program', function(assert) {
 });
 
 test('remove program', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
   server.create('user', {id: 4136});
   server.create('school', {
     programs: [1]
@@ -156,6 +156,7 @@ test('remove program', function(assert) {
     });
   });
   andThen(function(){
+    assert.equal(find('.flash-messages').length, 1);
     assert.equal(0, find('.list tbody tr').length);
   });
 });

--- a/tests/acceptance/programs-test.js
+++ b/tests/acceptance/programs-test.js
@@ -139,7 +139,7 @@ test('add new program', function(assert) {
 });
 
 test('remove program', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
   server.create('user', {id: 4136});
   server.create('school', {
     programs: [1]


### PR DESCRIPTION
No confirmation message was provided for program delete.  Furthermore, the previous message was retained after delete.  As a result, a delete immediately after a save action provided an edit link to a deleted program, which caused null object errors. To fix, create a notification for program delete and clear the notification for saved program.

* update programs controller to clear save notification and add delete notification on program removal.

* update programs template to display removal notification on program removal.

* create text and translations for program removal.

* update tests to verify presence of removal notification

Fixes #2348 