### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,9 +1,23 @@
 import Ember from 'ember';
 import config from './config/environment';
 
+const { inject } = Ember;
+const { service } = inject;
+
 const Router = Ember.Router.extend({
+  iliosMetrics: service(),
+
   location: config.locationType,
-  rootURL: config.rootURL
+  rootURL: config.rootURL,
+
+  didTransition() {
+    this._super(...arguments);
+    const iliosMetrics = this.get('iliosMetrics');
+    const page = this.get('url');
+    const title = this.getWithDefault('currentRouteName', 'unknown');
+    
+    iliosMetrics.track(page, title);
+  },
 });
 
 Router.map(function() {

--- a/app/services/ilios-config.js
+++ b/app/services/ilios-config.js
@@ -16,7 +16,9 @@ export default Ember.Service.extend({
 
   itemFromConfig(key){
     return this.get('config').then(config => {
-      return config.config[key];
+      const obj = config.config;
+      
+      return key in obj?obj[key]:null;
     });
   },
 
@@ -34,6 +36,14 @@ export default Ember.Service.extend({
 
   apiVersion: computed('config.apiVersion', function(){
     return this.itemFromConfig('apiVersion');
+  }),
+
+  trackingEnabled: computed('config.trackingEnabled', function(){
+    return this.itemFromConfig('trackingEnabled');
+  }),
+
+  trackingCode: computed('config.trackingCode', function(){
+    return this.itemFromConfig('trackingCode');
   }),
 
   apiNameSpace: computed('serverVariables.apiNameSpace', function(){

--- a/app/services/ilios-metrics.js
+++ b/app/services/ilios-metrics.js
@@ -1,0 +1,56 @@
+import Ember from 'ember';
+
+const { Service, RSVP, run, inject, isEmpty } = Ember;
+const { service } = inject;
+const { scheduleOnce } = run;
+const { Promise } = RSVP;
+
+export default Service.extend({
+  metrics: service(),
+  currentUser: service(),
+  iliosConfig: service(),
+
+  setup(){
+    const iliosConfig = this.get('iliosConfig');
+    const metrics = this.get('metrics');
+    return new Promise(resolve => {
+      iliosConfig.get('trackingEnabled').then(trackingEnabled => {
+        iliosConfig.get('trackingCode').then(trackingCode => {
+          if (!trackingEnabled || isEmpty(trackingCode)) {
+            resolve(false);
+          } else {
+            metrics.activateAdapters([
+              {
+                name: 'GoogleAnalytics',
+                environments: ['all'],
+                config: {
+                  id: trackingCode
+                }
+              }
+            ]);
+            resolve(true);
+          }
+        });
+      });
+    });
+  },
+
+  track(page, title) {
+    scheduleOnce('afterRender', this, () => {
+      this.setup().then(setupSuccessful => {
+        if (setupSuccessful) {
+          const metrics = this.get('metrics');
+          const currentUser = this.get('currentUser');
+          currentUser.get('model').then(user => {
+            if (user) {
+              metrics.set('context.user', user.get('id'));
+            }
+            metrics.trackPage({ page, title });
+          });
+        }
+
+      });
+
+    });
+  }
+});

--- a/config/environment.js
+++ b/config/environment.js
@@ -10,10 +10,10 @@ module.exports = function(environment) {
     redirectAfterShibLogin: true,
     contentSecurityPolicy: {
       'default-src': ["'none'"],
-      'script-src':  ["'self'", "'unsafe-eval'"],
+      'script-src':  ["'self'", "'unsafe-eval'", 'www.google-analytics.com'],
       'font-src':    ["'self'"],
-      'connect-src': ["'self'"],
-      'img-src':     ["'self'", 'data:'],
+      'connect-src': ["'self'", 'www.google-analytics.com'],
+      'img-src':     ["'self'", 'data:', 'www.google-analytics.com'],
       'style-src':   ["'self'", "'unsafe-inline'"],
       'media-src':   ["'self'"]
     },
@@ -91,6 +91,9 @@ module.exports = function(environment) {
         'api-name-space': process.env.ILIOS_FRONTEND_API_NAMESPACE || 'api/v1',
         'api-host': process.env.ILIOS_FRONTEND_API_HOST || null,
       }
+    },
+    'ember-metrics': {
+      includeAdapters: ['google-analytics']
     },
     EmberENV: {
       FEATURES: {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "ember-inflector": "1.9.6",
     "ember-load": "0.0.10",
     "ember-load-initializers": "^0.6.1",
+    "ember-metrics": "0.7.0",
     "ember-modal-dialog": "0.9.0",
     "ember-moment": "6.1.0",
     "ember-normalize": "1.0.0",

--- a/tests/unit/controllers/admin-dashboard-test.js
+++ b/tests/unit/controllers/admin-dashboard-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:admin-dashboard', 'Unit | Controller | AdminDashboard ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/application-test.js
+++ b/tests/unit/controllers/application-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('controller:application', 'ApplicationController', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/assign-students-test.js
+++ b/tests/unit/controllers/assign-students-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:assign-students', 'Unit | Controller | assign students', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/course-materials-test.js
+++ b/tests/unit/controllers/course-materials-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:course-materials', 'Unit | Controller | course materials', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/course-test.js
+++ b/tests/unit/controllers/course-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('controller:course', 'CourseController', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/course/index-test.js
+++ b/tests/unit/controllers/course/index-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:course/index', 'Unit | Controller | course/index', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/course/rollover-test.js
+++ b/tests/unit/controllers/course/rollover-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:course/rollover', 'Unit | Controller | course/rollover', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/courses-test.js
+++ b/tests/unit/controllers/courses-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('controller:courses', 'CoursesController', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/curriculum-inventory-report-test.js
+++ b/tests/unit/controllers/curriculum-inventory-report-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:curriculum-inventory-report', 'Unit | Controller | curriculum-inventory-report', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/curriculum-inventory-report/index-test.js
+++ b/tests/unit/controllers/curriculum-inventory-report/index-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:curriculum-inventory-report/index', 'Unit | Controller | curriculum inventory report/index', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/curriculum-inventory-report/rollover-test.js
+++ b/tests/unit/controllers/curriculum-inventory-report/rollover-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:curriculum-inventory-report/rollover', 'Unit | Controller | curriculum inventory report/rollover', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/curriculum-inventory-reports-test.js
+++ b/tests/unit/controllers/curriculum-inventory-reports-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:curriculum-inventory-reports', 'Unit | Controller | curriculum-inventory-reports', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/curriculum-inventory-sequence-block-test.js
+++ b/tests/unit/controllers/curriculum-inventory-sequence-block-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:curriculum-inventory-sequence-block', 'Unit | Controller | curriculum inventory sequence block', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/dashboard-test.js
+++ b/tests/unit/controllers/dashboard-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dashboard', 'Unit | Controller | Dashboad ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/error-test.js
+++ b/tests/unit/controllers/error-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:error', 'Unit | Controller | error', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/instructor-groups-test.js
+++ b/tests/unit/controllers/instructor-groups-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('controller:instructorGroups', 'Unit | Controller | InstructorGroups ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/learner-group-test.js
+++ b/tests/unit/controllers/learner-group-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:learner-group', 'Unit | Controller | learner group', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/learner-groups-test.js
+++ b/tests/unit/controllers/learner-groups-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('controller:learnerGroups', 'Unit | Controller | LearnerGroups ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/mymaterials-test.js
+++ b/tests/unit/controllers/mymaterials-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:mymaterials', 'Unit | Controller | mymaterials', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/myprofile-test.js
+++ b/tests/unit/controllers/myprofile-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:myprofile', 'Unit | Controller | myprofile', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/pending-user-updates-test.js
+++ b/tests/unit/controllers/pending-user-updates-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:pending-user-updates', 'Unit | Controller | pending user updates', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/print-course-test.js
+++ b/tests/unit/controllers/print-course-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:print-course', 'Unit | Controller | print course', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/program-test.js
+++ b/tests/unit/controllers/program-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('controller:program', 'Unit | Controller | Program ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/program-year-test.js
+++ b/tests/unit/controllers/program-year-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:program-year', 'Unit | Controller | ProgramYear ', {
-  // Specify the other units that are required for this test.
-  needs: ['controller:program']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/program-year/publication-check-test.js
+++ b/tests/unit/controllers/program-year/publication-check-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:program-year/publication-check', 'Unit | Controller | ProgramYearPublicationCheck', {
   // Specify the other units that are required for this test.
-  needs: ['controller:program', 'controller:programYear']
+  needs: ['controller:program', 'controller:programYear', 'service:iliosMetrics']
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/program/index-test.js
+++ b/tests/unit/controllers/program/index-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('controller:program/index', 'Unit | Controller | Program / Index ', {
-  // Specify the other units that are required for this test.
-  needs: ['controller:program']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/programs-test.js
+++ b/tests/unit/controllers/programs-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('controller:programs', 'Unit | Controller | Programs ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/school-test.js
+++ b/tests/unit/controllers/school-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:school', 'Unit | Controller | school', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/session-test.js
+++ b/tests/unit/controllers/session-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('controller:session', 'Unit | Controller | Session ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/session/copy-test.js
+++ b/tests/unit/controllers/session/copy-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:session/copy', 'Unit | Controller | session/copy', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/session/index-test.js
+++ b/tests/unit/controllers/session/index-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('controller:session/index', 'Unit | Controller | Session / Index ', {
-  // Specify the other units that are required for this test.
-  needs: ['controller:course', 'controller:session']
+  needs: ['controller:course', 'controller:session', 'service:iliosMetrics']
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/session/publication-check-test.js
+++ b/tests/unit/controllers/session/publication-check-test.js
@@ -5,7 +5,7 @@ import {
 
 moduleFor('controller:session/publicationCheck', 'Unit | Controller | PublicationCheck ', {
   // Specify the other units that are required for this test.
-  needs: ['controller:course', 'controller:session']
+  needs: ['controller:course', 'controller:session', 'service:iliosMetrics']
 });
 
 // Replace this with your real tests.

--- a/tests/unit/controllers/user-test.js
+++ b/tests/unit/controllers/user-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:user', 'Unit | Controller | user', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 // Replace this with your real tests.

--- a/tests/unit/routes/admin-dashboard-test.js
+++ b/tests/unit/routes/admin-dashboard-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:admin-dashboard', 'Unit | Route | admin dashboard ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/assign-students-test.js
+++ b/tests/unit/routes/assign-students-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:assign-students', 'Unit | Route | assign students', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/course-materials-test.js
+++ b/tests/unit/routes/course-materials-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:course-materials', 'Unit | Route | course materials', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/course-test.js
+++ b/tests/unit/routes/course-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:course', 'CourseRoute', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/course/index-test.js
+++ b/tests/unit/routes/course/index-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:course/index', 'Unit | Controller | Course/Index ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/courses-test.js
+++ b/tests/unit/routes/courses-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:courses', 'CoursesRoute', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/curriculum-inventory-report-test.js
+++ b/tests/unit/routes/curriculum-inventory-report-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:curriculum-inventory-report', 'Unit | Route | curriculum-inventory-report', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/curriculum-inventory-report/index-test.js
+++ b/tests/unit/routes/curriculum-inventory-report/index-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:curriculum-inventory-report/index', 'Unit | Route | curriculum inventory report/index', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/curriculum-inventory-report/rollover-test.js
+++ b/tests/unit/routes/curriculum-inventory-report/rollover-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:curriculum-inventory-report/rollover', 'Unit | Route | curriculum inventory report/rollover', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/curriculum-inventory-reports-test.js
+++ b/tests/unit/routes/curriculum-inventory-reports-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:curriculum-inventory-reports', 'Unit | Route | curriculum-inventory-reports', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/curriculum-inventory-sequence-block-test.js
+++ b/tests/unit/routes/curriculum-inventory-sequence-block-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:curriculum-inventory-sequence-block', 'Unit | Route | curriculum inventory sequence block', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/dashboard-test.js
+++ b/tests/unit/routes/dashboard-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:dashboard', 'DashboardRoute', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/events-test.js
+++ b/tests/unit/routes/events-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:events', 'Unit | Route | events ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/index-test.js
+++ b/tests/unit/routes/index-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:index', 'IndexRoute', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/instructor-group-test.js
+++ b/tests/unit/routes/instructor-group-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:instructor-group', 'Unit | Route | instructor group ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/instructor-groups-test.js
+++ b/tests/unit/routes/instructor-groups-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:instructorGroups', 'InstructorGroupsRoute', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/learner-group-test.js
+++ b/tests/unit/routes/learner-group-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:learner-group', 'Unit | Controller | LearnerGroup ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/learner-groups-test.js
+++ b/tests/unit/routes/learner-groups-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:learnerGroups', 'Unit | Controller | LearnerGroups ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/loading-test.js
+++ b/tests/unit/routes/loading-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:loading', 'LoadingRoute', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/login-test.js
+++ b/tests/unit/routes/login-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:login', 'Unit | Route | login ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/logout-test.js
+++ b/tests/unit/routes/logout-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:logout', 'Unit | Route | logout', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/mymaterials-test.js
+++ b/tests/unit/routes/mymaterials-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:mymaterials', 'Unit | Route | mymaterials', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/myprofile-test.js
+++ b/tests/unit/routes/myprofile-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:myprofile', 'Unit | Route | myprofile', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/pending-user-updates-test.js
+++ b/tests/unit/routes/pending-user-updates-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:pending-user-updates', 'Unit | Route | pending user updates', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/print-course-test.js
+++ b/tests/unit/routes/print-course-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:print-course', 'Unit | Controller | PrintCourse ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/program-test.js
+++ b/tests/unit/routes/program-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:program', 'Unit | Route | Program ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/program/index-test.js
+++ b/tests/unit/routes/program/index-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:program/index', 'Unit | Route | Program/Index ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/program/publication-check-test.js
+++ b/tests/unit/routes/program/publication-check-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:program/publicationCheck', 'Unit | Route | PublicationCheck ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/programs-test.js
+++ b/tests/unit/routes/programs-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:programs', 'Unit | Route | Programs ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/school-test.js
+++ b/tests/unit/routes/school-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:school', 'Unit | Route | school', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/schools-test.js
+++ b/tests/unit/routes/schools-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:schools', 'Unit | Route | schools', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/session-test.js
+++ b/tests/unit/routes/session-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:session', 'Unit | Route | Session ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/session/publication-check-test.js
+++ b/tests/unit/routes/session/publication-check-test.js
@@ -4,8 +4,7 @@ import {
 } from 'ember-qunit';
 
 moduleFor('route:session/publicationCheck', 'Unit | Route | Session/PublicationCheck ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/user-test.js
+++ b/tests/unit/routes/user-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:user', 'Unit | Route | user ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/routes/users-test.js
+++ b/tests/unit/routes/users-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:users', 'Unit | Route | users ', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:iliosMetrics'],
 });
 
 test('it exists', function(assert) {

--- a/tests/unit/services/ilios-metrics-test.js
+++ b/tests/unit/services/ilios-metrics-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:ilios-metrics', 'Unit | Service | ilios metrics', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
If a tracking ID is sent by the API then GA will be enabled and send
data on every route transition.

Requires: https://github.com/ilios/ilios/pull/1677 to send the tracking ID.

Fixes #2363