### PR TITLE
Remove unused block parameters

### DIFF
--- a/app/templates/components/course-objective-list-item.hbs
+++ b/app/templates/components/course-objective-list-item.hbs
@@ -6,7 +6,6 @@
         isSaveDisabled=(and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))
         save=(action 'saveTitleChanges' )
         close=(action 'revertTitleChanges')
-        as |isSaving save close|
       }}
         {{froala-editor
           params=editorParams


### PR DESCRIPTION
We aren't using these here because the froala editor doesn't really need
them.

Fixes #2366