### PR TITLE
Temporarily disable userId in Google Analytics

### DIFF
--- a/app/services/ilios-metrics.js
+++ b/app/services/ilios-metrics.js
@@ -40,13 +40,16 @@ export default Service.extend({
       this.setup().then(setupSuccessful => {
         if (setupSuccessful) {
           const metrics = this.get('metrics');
-          const currentUser = this.get('currentUser');
-          currentUser.get('model').then(user => {
-            if (user) {
-              metrics.set('context.user', user.get('id'));
-            }
-            metrics.trackPage({ page, title });
-          });
+          //Disabled due to issues with currentUser abilities observers misbehaving
+          //Can be re-enabled when abilities are removed
+          // const currentUser = this.get('currentUser');
+          // currentUser.get('model').then(user => {
+          //   if (user) {
+          //     metrics.set('context.user', user.get('id'));
+          //   }
+          //   metrics.trackPage({ page, title });
+          // });
+          metrics.trackPage({ page, title });
         }
 
       });


### PR DESCRIPTION
Looking up the user on the login screen when they were not authenticated
causes their permissions to be locked at that point.  Those sections of
the app which rely on the currentUser properties for access to services
do not work correctly until the page is refreshed.

Fixes #2408