### PR TITLE
When pluralizing French don't use a 'zero' form

### DIFF
--- a/app/locales/fr/config.js
+++ b/app/locales/fr/config.js
@@ -1,0 +1,10 @@
+/**
+* For some reason ember-i18n think FR has a 'zero' pluralization
+* but it does not so we shouldn't use one.
+**/
+export default {
+  pluralForm: function frenchWithoutZero(n) {
+    if (n === 1) { return 'one'; }
+    return 'other';
+  }
+};


### PR DESCRIPTION
All of our FR translations expect a count of 0 to fall under 'other' not
'zero' key.

Fixes #2423