### PR TITLE
Remove moment from bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,8 +9,6 @@
     "lodash": "~4.0.0",
     "Faker": "~3.0.1",
     "font-awesome": "~4.5.0",
-    "moment": ">= 2.8.0",
-    "moment-timezone": ">= 0.1.0",
     "froala-wysiwyg-editor": "^2.2.3",
     "clipboard": "~1.5.5",
     "papaparse": "~4.1.2",


### PR DESCRIPTION
These packages are now pulled by ember-cli-moment-shim out of NPM.

Fixes #2432