### PR TITLE
Replace deprecated contains with includes

### DIFF
--- a/app/components/assign-students.js
+++ b/app/components/assign-students.js
@@ -57,7 +57,7 @@ export default Component.extend({
       return [];
     }
     return students.filter(user => {
-      return (!savedUserIds.contains(user.get('id')));
+      return (!savedUserIds.includes(user.get('id')));
     }).sortBy('lastName', 'firstName').slice(offset, end);
   }),
 
@@ -109,7 +109,7 @@ export default Component.extend({
     let cohort = yield this.get('bestSelectedCohort');
     let students = this.get('students');
     let studentsToModify = students.filter(user => {
-      return ids.contains(user.get('id'));
+      return ids.includes(user.get('id'));
     });
     if (!cohort || studentsToModify.length < 1) {
       return;
@@ -147,7 +147,7 @@ export default Component.extend({
       }
     },
     toggleUserSelection(userId){
-      if (this.get('selectedUserIds').contains(userId)) {
+      if (this.get('selectedUserIds').includes(userId)) {
         this.get('selectedUserIds').removeObject(userId);
       } else {
         this.get('selectedUserIds').pushObject(userId);

--- a/app/components/bulk-new-users.js
+++ b/app/components/bulk-new-users.js
@@ -115,7 +115,7 @@ export default Component.extend(NewUser, {
     this.set('fileUploadError', false);
     return new Promise(resolve => {
       let allowedFileTypes = ['text/plain', 'text/csv'];
-      if (!allowedFileTypes.contains(file.type)) {
+      if (!allowedFileTypes.includes(file.type)) {
         const i18n = this.get('i18n');
         this.set('fileUploadError', true);
         throw new Error(i18n.t('general.fileTypeError', {fileType: file.type}));
@@ -232,7 +232,7 @@ export default Component.extend(NewUser, {
         yield RSVP.all(authentications.invoke('save'));
       } catch (e) {
         let userErrors = parts.filter(obj => obj.user.get('isError'));
-        let authenticationErrors = parts.filter(obj => !userErrors.contains(obj) && isPresent(obj.authentication) && obj.authentication.get('isError'));
+        let authenticationErrors = parts.filter(obj => !userErrors.includes(obj) && isPresent(obj.authentication) && obj.authentication.get('isError'));
         this.get('savingUserErrors').pushObjects(userErrors);
         this.get('savingAuthenticationErrors').pushObjects(authenticationErrors);
       } finally {
@@ -266,7 +266,7 @@ export default Component.extend(NewUser, {
     },
     toggleUserSelection(obj){
       let selectedUsers = this.get('selectedUsers');
-      if (selectedUsers.contains(obj)) {
+      if (selectedUsers.includes(obj)) {
         selectedUsers.removeObject(obj);
       } else {
         selectedUsers.pushObject(obj);

--- a/app/components/collapsed-learnergroups.js
+++ b/app/components/collapsed-learnergroups.js
@@ -24,7 +24,7 @@ export default Component.extend({
       let cohorts = yield map(learnerGroups.toArray(), (group => group.get('cohort')));
       let summaryBlocks =  cohorts.reduce((set, cohort) => {
         let key = 'cohort' + cohort.get('id');
-        if (!Object.keys(set).contains(key)) {
+        if (!Object.keys(set).includes(key)) {
           set[key] = {
             cohort,
             count: 0

--- a/app/components/course-objective-manager.js
+++ b/app/components/course-objective-manager.js
@@ -18,7 +18,7 @@ var competencyGroup = Ember.Object.extend({
 var objectiveProxy = Ember.ObjectProxy.extend({
   courseObjective: null,
   selected: computed('content', 'courseObjective.parents.[]', function(){
-    return this.get('courseObjective.parents').contains(this.get('content'));
+    return this.get('courseObjective.parents').includes(this.get('content'));
   }),
 });
 

--- a/app/components/course-overview.js
+++ b/app/components/course-overview.js
@@ -100,7 +100,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
           currentUser.get('userIsCourseDirector'),
           currentUser.get('userIsDeveloper')
         ]).then(hasRole => {
-          resolve(hasRole.contains(true));
+          resolve(hasRole.includes(true));
         });
       }
 

--- a/app/components/course-summary-header.js
+++ b/app/components/course-summary-header.js
@@ -21,7 +21,7 @@ export default Component.extend({
           currentUser.get('userIsCourseDirector'),
           currentUser.get('userIsDeveloper')
         ]).then(hasRole => {
-          resolve(hasRole.contains(true));
+          resolve(hasRole.includes(true));
         });
       }
 

--- a/app/components/curriculum-inventory-sequence-block-overview.js
+++ b/app/components/curriculum-inventory-sequence-block-overview.js
@@ -145,7 +145,7 @@ export default Component.extend({
           report.get('linkedCourses').then(linkedCourses => {
             // Filter out all courses that are linked to (sequence blocks in) this report.
             let linkableCourses = allLinkableCourses.filter(function(course) {
-              return ! linkedCourses.contains(course);
+              return ! linkedCourses.includes(course);
             });
             // Always add the currently linked course to this list, if existent.
             sequenceBlock.get('course').then(course => {

--- a/app/components/curriculum-inventory-sequence-block-session-manager.js
+++ b/app/components/curriculum-inventory-sequence-block-session-manager.js
@@ -36,7 +36,7 @@ export default Component.extend({
       return false;
     }
     linkableSessions.forEach(linkableSession => {
-      if (! linkedSessions.contains(linkableSession)) {
+      if (! linkedSessions.includes(linkableSession)) {
         return false;
       }
     });
@@ -58,7 +58,7 @@ export default Component.extend({
 
     let isSelected = false;
     linkedSessions.forEach(linkedSession => {
-      if (linkableSessions.contains(linkedSession)) {
+      if (linkableSessions.includes(linkedSession)) {
         isSelected = true;
       }
     });
@@ -79,7 +79,7 @@ export default Component.extend({
   actions: {
     changeSession(session) {
       let sessions = this.get('linkedSessionsBuffer');
-      if (sessions.contains(session)) {
+      if (sessions.includes(session)) {
         sessions.removeObject(session);
       } else {
         sessions.addObject(session);

--- a/app/components/dashboard-calendar.js
+++ b/app/components/dashboard-calendar.js
@@ -102,7 +102,7 @@ export default Component.extend({
           ourEvents.then(events => {
             let filteredEvents = events.filter(event => {
               return allFilteredEvents.every(arr => {
-                let bool = arr.contains(event);
+                let bool = arr.includes(event);
 
                 return bool;
               });
@@ -129,7 +129,7 @@ export default Component.extend({
     events.forEach(event => {
       if (event.ilmSession || event.offering) {
         promises.pushObject(this.get('userEvents').getSessionTypeIdForEvent(event).then(id => {
-          if (selectedSessionTypes.contains(id)) {
+          if (selectedSessionTypes.includes(id)) {
             matchingEvents.pushObject(event);
           }
         }));
@@ -155,7 +155,7 @@ export default Component.extend({
     events.forEach(event => {
       if (event.ilmSession || event.offering) {
         promises.pushObject(this.get('userEvents').getCourseLevelForEvent(event).then(level => {
-          if (selectedCourseLevels.contains(level)) {
+          if (selectedCourseLevels.includes(level)) {
             matchingEvents.pushObject(event);
           }
         }));
@@ -182,7 +182,7 @@ export default Component.extend({
       if (event.ilmSession || event.offering) {
         promises.pushObject(this.get('userEvents').getCohortIdsForEvent(event).then(cohorts => {
           if (cohorts.any(cohortId => {
-            return selectedCohorts.contains(cohortId);
+            return selectedCohorts.includes(cohortId);
           })) {
             matchingEvents.pushObject(event);
           }
@@ -209,7 +209,7 @@ export default Component.extend({
     events.forEach(event => {
       if (event.ilmSession || event.offering) {
         promises.pushObject(this.get('userEvents').getCourseIdForEvent(event).then(courseId => {
-          if (selectedCourses.contains(courseId)) {
+          if (selectedCourses.includes(courseId)) {
             matchingEvents.pushObject(event);
           }
         }));
@@ -387,28 +387,28 @@ export default Component.extend({
 
   actions: {
     toggleSessionType(sessionType){
-      if(this.get('selectedSessionTypes').contains(sessionType)){
+      if(this.get('selectedSessionTypes').includes(sessionType)){
         this.get('selectedSessionTypes').removeObject(sessionType);
       } else {
         this.get('selectedSessionTypes').pushObject(sessionType);
       }
     },
     toggleCourseLevel(level){
-      if(this.get('selectedCourseLevels').contains(level)){
+      if(this.get('selectedCourseLevels').includes(level)){
         this.get('selectedCourseLevels').removeObject(level);
       } else {
         this.get('selectedCourseLevels').pushObject(level);
       }
     },
     toggleCohort(cohort){
-      if(this.get('selectedCohorts').contains(cohort)){
+      if(this.get('selectedCohorts').includes(cohort)){
         this.get('selectedCohorts').removeObject(cohort);
       } else {
         this.get('selectedCohorts').pushObject(cohort);
       }
     },
     toggleCourse(course){
-      if(this.get('selectedCourses').contains(course)){
+      if(this.get('selectedCourses').includes(course)){
         this.get('selectedCourses').removeObject(course);
       } else {
         this.get('selectedCourses').pushObject(course);

--- a/app/components/detail-cohort-manager.js
+++ b/app/components/detail-cohort-manager.js
@@ -27,7 +27,7 @@ export default Component.extend({
         let availableCohorts = usableCohorts.filter(cohort => {
           return (
             this.get('selectedCohorts') &&
-            !this.get('selectedCohorts').contains(cohort)
+            !this.get('selectedCohorts').includes(cohort)
           );
         });
         defer.resolve(availableCohorts);

--- a/app/components/detail-cohorts.js
+++ b/app/components/detail-cohorts.js
@@ -23,7 +23,7 @@ export default Component.extend({
       course.get('cohorts').then(cohortList => {
         let bufferedCohorts = this.get('bufferedCohorts');
         let removedCohorts = cohortList.filter(cohort => {
-          return !bufferedCohorts.contains(cohort);
+          return !bufferedCohorts.includes(cohort);
         });
         cohortList.clear();
         bufferedCohorts.forEach(cohort=>{

--- a/app/components/detail-instructors.js
+++ b/app/components/detail-instructors.js
@@ -33,7 +33,7 @@ export default Component.extend({
       var ilmSession = this.get('ilmSession.content');
 
       let instructorGroups = ilmSession.get('instructorGroups');
-      let removableInstructorGroups = instructorGroups.filter(group => !this.get('instructorGroupBuffer').contains(group));
+      let removableInstructorGroups = instructorGroups.filter(group => !this.get('instructorGroupBuffer').includes(group));
       instructorGroups.clear();
       removableInstructorGroups.forEach(group => {
         group.get('ilmSessions').then(ilmSessions => {
@@ -49,7 +49,7 @@ export default Component.extend({
       });
 
       let instructors = ilmSession.get('instructors');
-      let removableInstructors = instructors.filter(user => !this.get('instructorBuffer').contains(user));
+      let removableInstructors = instructors.filter(user => !this.get('instructorBuffer').includes(user));
       instructors.clear();
       removableInstructors.forEach(user => {
         user.get('instructorIlmSessions').then(ilmSessions => {

--- a/app/components/detail-learnergroups-list.js
+++ b/app/components/detail-learnergroups-list.js
@@ -51,7 +51,7 @@ export default Component.extend({
       filter(learnerGroups, group => {
         return new Promise(resolve => {
           group.get('allDescendants').then(children => {
-            let selectedChildren = children.filter(child => ids.contains(child.get('id')));
+            let selectedChildren = children.filter(child => ids.includes(child.get('id')));
             resolve(selectedChildren.length === 0);
           });
         });

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -127,7 +127,7 @@ export default Component.extend({
         let promises = [];
 
         let oldTerms = terms.filter(term => {
-          return !this.get('bufferTerms').contains(term);
+          return !this.get('bufferTerms').includes(term);
         });
         terms.clear();
         terms.addObjects(this.get('bufferTerms'));

--- a/app/components/detail-objectives.js
+++ b/app/components/detail-objectives.js
@@ -73,7 +73,7 @@ export default Component.extend({
         let objective = this.get('mangeParentsObjective');
         objective.get('parents').then(newParents => {
           let oldParents = this.get('initialStateForManageParentsObjective').filter(parent => {
-            return !newParents.contains(parent);
+            return !newParents.includes(parent);
           });
           oldParents.forEach(parent => {
             parent.get('children').removeObject(objective);
@@ -88,7 +88,7 @@ export default Component.extend({
         let objective = this.get('manageDescriptorsObjective');
         objective.get('meshDescriptors').then(newDescriptors => {
           let oldDescriptors = this.get('initialStateForManageMeshObjective').filter(descriptor => {
-            return !newDescriptors.contains(descriptor);
+            return !newDescriptors.includes(descriptor);
           });
           oldDescriptors.forEach(descriptor => {
             descriptor.get('objectives').removeObject(objective);

--- a/app/components/detail-steward-manager.js
+++ b/app/components/detail-steward-manager.js
@@ -29,7 +29,7 @@ export default Component.extend({
       //display those with departments or those who are not already solo-assigned
       display: computed('content', 'departments.length', function(){
         return this.get('departments').length > 0 ||
-               !this.get('selectedSchools').contains(this.get('content'));
+               !this.get('selectedSchools').includes(this.get('content'));
       }),
     });
     this.get('schools').then(schools => {
@@ -42,7 +42,7 @@ export default Component.extend({
         });
         let promise = school.get('departments').then(departments => {
           let filteredDepartments = departments.filter(
-             department => !this.get('selectedDepartments').contains(department)
+             department => !this.get('selectedDepartments').includes(department)
           );
           proxy.set('departments', filteredDepartments);
           schoolProxies.pushObject(proxy);
@@ -66,7 +66,7 @@ export default Component.extend({
       //display those with departments or those who are not already solo-assigned
       display: computed('content', 'departments.length', function(){
         return this.get('departments').length > 0 ||
-               this.get('selectedSchools').contains(this.get('content'));
+               this.get('selectedSchools').includes(this.get('content'));
       })
     });
     this.get('schools').then(schools => {
@@ -79,7 +79,7 @@ export default Component.extend({
         });
         let promise = school.get('departments').then(departments => {
           let filteredDepartments = departments.filter(
-             department => this.get('selectedDepartments').contains(department)
+             department => this.get('selectedDepartments').includes(department)
           );
           proxy.set('departments', filteredDepartments);
           schoolProxies.pushObject(proxy);
@@ -103,7 +103,7 @@ export default Component.extend({
       this.sendAction('add', steward);
       schoolProxy.get('content').get('departments').then(departments => {
         let selectedDepartments = this.get('stewardedDepartments').mapBy('content');
-        let newDepartments = departments.filter(deparment => !selectedDepartments.contains(deparment));
+        let newDepartments = departments.filter(deparment => !selectedDepartments.includes(deparment));
         newDepartments.forEach(department => {
           let steward = this.get('store').createRecord('program-year-steward', {
             school: schoolProxy.get('content'),

--- a/app/components/detail-stewards.js
+++ b/app/components/detail-stewards.js
@@ -59,7 +59,7 @@ export default Component.extend({
     save: function(){
       let programYear = this.get('programYear');
       programYear.get('stewards').then(stewards => {
-        let removableStewards = stewards.filter(steward => !this.get('bufferStewards').contains(steward));
+        let removableStewards = stewards.filter(steward => !this.get('bufferStewards').includes(steward));
         stewards.clear();
         var promises = [];
         removableStewards.forEach(steward => {

--- a/app/components/ilios-course-list.js
+++ b/app/components/ilios-course-list.js
@@ -39,7 +39,7 @@ const CourseProxy = ObjectProxy.extend({
           } else {
             currentUser.get('model').then(user => {
               user.get('directedCourses').then(directedCourses => {
-                resolve(directedCourses.contains(course));
+                resolve(directedCourses.includes(course));
               });
             });
           }
@@ -57,7 +57,7 @@ const CourseProxy = ObjectProxy.extend({
         } else {
           currentUser.get('model').then(user => {
             user.get('directedCourses').then(directedCourses => {
-              resolve(directedCourses.contains(course));
+              resolve(directedCourses.includes(course));
             });
           });
         }

--- a/app/components/ilios-navigation.js
+++ b/app/components/ilios-navigation.js
@@ -18,8 +18,8 @@ export default Component.extend({
         user.get('roles').then(roles => {
           let ids = roles.mapBy('id');
           let permissions = {
-            isFaculty: ids.contains('1')||ids.contains('2')||ids.contains('3'),
-            isAdmin: ids.contains('2'),
+            isFaculty: ids.includes('1')||ids.includes('2')||ids.includes('3'),
+            isAdmin: ids.includes('2'),
           };
           resolve(permissions);
         });

--- a/app/components/ilios-sessions-list.js
+++ b/app/components/ilios-sessions-list.js
@@ -21,7 +21,7 @@ const SessionProxy = ObjectProxy.extend({
         this.get('content').get('course').then(course => {
           this.get('currentUser.model').then(user => {
             user.get('directedCourses').then(directedCourses => {
-              defer.resolve(directedCourses.contains(course));
+              defer.resolve(directedCourses.includes(course));
             });
           });
         });

--- a/app/components/leadership-search.js
+++ b/app/components/leadership-search.js
@@ -65,7 +65,7 @@ export default Component.extend({
 
   clickUser: task(function * (user) {
     const existingUserIds = this.get('existingUserIds');
-    if (existingUserIds.contains(user.get('id'))) {
+    if (existingUserIds.includes(user.get('id'))) {
       return;
     }
     this.set('searchValue', null);

--- a/app/components/learnergroup-cohort-user-manager.js
+++ b/app/components/learnergroup-cohort-user-manager.js
@@ -82,7 +82,7 @@ export default Component.extend({
       this.get('setSortBy')(what);
     },
     toggleUserSelection(user){
-      if (this.get('selectedUsers').contains(user)) {
+      if (this.get('selectedUsers').includes(user)) {
         this.get('selectedUsers').removeObject(user);
       } else {
         this.get('selectedUsers').pushObject(user);

--- a/app/components/learnergroup-summary.js
+++ b/app/components/learnergroup-summary.js
@@ -172,7 +172,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     const users = yield cohort.get('users');
 
     let filteredUsers = users.filter(
-      user => !currentUsers.contains(user)
+      user => !currentUsers.includes(user)
     );
 
     this.set('showCohortManagerLoader', false);

--- a/app/components/learnergroup-tree.js
+++ b/app/components/learnergroup-tree.js
@@ -26,7 +26,7 @@ export default Component.extend({
     const selectedGroups = this.get('selectedGroups');
     return new Promise(resolve => {
       filter(children.toArray(), (child => {
-        if (!selectedGroups.contains(child)) {
+        if (!selectedGroups.includes(child)) {
           return true;
         }
         return child.get('children').then(children => {
@@ -56,7 +56,7 @@ export default Component.extend({
       let filterTitle = yield learnerGroup.get('filterTitle');
       filterMatch = filterTitle.match(exp) != null;
     }
-    let available = hasUnSelectedChildren || !selectedGroups.contains(learnerGroup);
+    let available = hasUnSelectedChildren || !selectedGroups.includes(learnerGroup);
 
     this.set('isVisible', filterMatch && available);
     this.set('selectable', available);

--- a/app/components/learnergroup-user-manager.js
+++ b/app/components/learnergroup-user-manager.js
@@ -116,7 +116,7 @@ export default Component.extend({
       this.get('setSortBy')(what);
     },
     toggleUserSelection(user){
-      if (this.get('selectedUsers').contains(user)) {
+      if (this.get('selectedUsers').includes(user)) {
         this.get('selectedUsers').removeObject(user);
       } else {
         this.get('selectedUsers').pushObject(user);

--- a/app/components/mesh-manager.js
+++ b/app/components/mesh-manager.js
@@ -7,7 +7,7 @@ const { Component, computed } = Ember;
 var ProxiedDescriptors = Ember.ObjectProxy.extend({
   terms: [],
   isActive: computed('content', 'terms.[]', function(){
-    return !this.get('terms').contains(this.get('content'));
+    return !this.get('terms').includes(this.get('content'));
   })
 });
 

--- a/app/components/new-course.js
+++ b/app/components/new-course.js
@@ -39,7 +39,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     this.set('years', years);
 
     const currentYear = this.get('currentYear');
-    if (isPresent(currentYear) && years.contains(parseInt(currentYear.get('title')))) {
+    if (isPresent(currentYear) && years.includes(parseInt(currentYear.get('title')))) {
       this.set('selectedYear', currentYear.get('title'));
     } else {
       this.set('selectedYear', thisYear);

--- a/app/components/new-curriculum-inventory-sequence-block.js
+++ b/app/components/new-curriculum-inventory-sequence-block.js
@@ -173,7 +173,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
           report.get('linkedCourses').then(linkedCourses => {
             // Filter out all courses that are linked to (sequence blocks in) this report.
             let linkableCourses = allLinkableCourses.filter(function(course) {
-              return ! linkedCourses.contains(course);
+              return ! linkedCourses.includes(course);
             });
             resolve(linkableCourses);
           });

--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -60,7 +60,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
 
     const subject = this.get('currentSubject');
 
-    return list.filter(item =>item.subjects.contains(subject));
+    return list.filter(item =>item.subjects.includes(subject));
   }),
   prepositionalObjectIdList: computed('currentPrepositionalObject', 'currentSchool', function(){
     const type = this.get('currentPrepositionalObject');
@@ -90,7 +90,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
         'instructor-group',
         'competency',
       ];
-      if(schoolScopedModels.contains(model)) {
+      if(schoolScopedModels.includes(model)) {
         if ('session' === model) {
           query.filters.schools = [this.get('currentSchool').get('id')];
         } else {

--- a/app/components/objective-manage-competency.js
+++ b/app/components/objective-manage-competency.js
@@ -86,7 +86,7 @@ export default Component.extend({
           filter(domains.toArray(), (domain => {
             return new Promise(resolve => {
               domain.get('children').then(children => {
-                let availableChildren = children.filter(child => competencies.contains(child));
+                let availableChildren = children.filter(child => competencies.includes(child));
                 resolve(availableChildren.length === 0);
               });
             });

--- a/app/components/offering-form.js
+++ b/app/components/offering-form.js
@@ -331,7 +331,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
       filter(learnerGroups, group => {
         return new Promise(resolve => {
           group.get('allDescendants').then(children => {
-            let selectedChildren = children.filter(child => ids.contains(child.get('id')));
+            let selectedChildren = children.filter(child => ids.includes(child.get('id')));
             resolve(selectedChildren.length === 0);
           });
         });
@@ -383,7 +383,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     },
     toggleRecurringDay(day){
       let recurringDays = this.get('recurringDays');
-      if (recurringDays.contains(day)) {
+      if (recurringDays.includes(day)) {
         recurringDays.removeObject(day);
       } else {
         recurringDays.pushObject(day);

--- a/app/components/offering-manager.js
+++ b/app/components/offering-manager.js
@@ -26,13 +26,13 @@ export default Component.extend({
           } else {
             this.get('currentUser.model').then(user => {
               offering.get('allInstructors').then(allInstructors => {
-                if(allInstructors.contains(user)){
+                if(allInstructors.includes(user)){
                   resolve(true);
                 } else {
                   offering.get('session').then(session => {
                     session.get('course').then(course => {
                       user.get('directedCourses').then(directedCourses => {
-                        resolve(directedCourses.contains(course));
+                        resolve(directedCourses.includes(course));
                       });
                     });
                   });

--- a/app/components/programyear-competencies.js
+++ b/app/components/programyear-competencies.js
@@ -76,7 +76,7 @@ export default Component.extend({
         filter(competencies.toArray(), (competency => {
           return new Promise(resolve => {
             competency.get('treeChildren').then(children => {
-              let selectedChildren = children.filter(competency => selectedCompetencies.contains(competency));
+              let selectedChildren = children.filter(competency => selectedCompetencies.includes(competency));
               resolve(selectedChildren.length > 0);
             });
           });

--- a/app/components/programyear-list.js
+++ b/app/components/programyear-list.js
@@ -40,7 +40,7 @@ export default Component.extend({
       }
 
       return years.filter((year) => {
-        return !this.get('existingStartYears').contains(year.toString());
+        return !this.get('existingStartYears').includes(year.toString());
       }).map((startYear) => {
         return { label: `${startYear} - ${startYear + 1}`, value: startYear };
       });

--- a/app/components/publish-all-sessions.js
+++ b/app/components/publish-all-sessions.js
@@ -92,7 +92,7 @@ export default Component.extend({
   
   actions: {
     toggleSession(session){
-      if(this.get('sessionsToOverride').contains(session)){
+      if(this.get('sessionsToOverride').includes(session)){
         this.get('sessionsToOverride').removeObject(session);
       } else{
         this.get('sessionsToOverride').pushObject(session);
@@ -100,14 +100,14 @@ export default Component.extend({
     },
     publishAllAsIs(){
       this.get('overridableSessions').forEach(session =>{
-        if(!this.get('sessionsToOverride').contains(session)){
+        if(!this.get('sessionsToOverride').includes(session)){
           this.get('sessionsToOverride').pushObject(session);
         }
       });
     },
     publishNoneAsIs(){
       this.get('overridableSessions').forEach(session =>{
-        if(this.get('sessionsToOverride').contains(session)){
+        if(this.get('sessionsToOverride').includes(session)){
           this.get('sessionsToOverride').removeObject(session);
         }
       });
@@ -117,7 +117,7 @@ export default Component.extend({
       let asIsSessions = this.get('sessionsToOverride');
       let sessionsToSave = [];
       this.get('overridableSessions').forEach(session =>{
-        session.set('publishedAsTbd', !asIsSessions.contains(session));
+        session.set('publishedAsTbd', !asIsSessions.includes(session));
         session.set('published', true);
         sessionsToSave.pushObject(session);
       });

--- a/app/components/school-competencies-expanded.js
+++ b/app/components/school-competencies-expanded.js
@@ -49,7 +49,7 @@ export default Component.extend({
     },
     removeCompetencyFromBuffer(competency){
       let buffer = this.get('bufferedCompetencies');
-      if (buffer.contains(competency)) {
+      if (buffer.includes(competency)) {
         buffer.removeObject(competency);
       }
     },
@@ -61,7 +61,7 @@ export default Component.extend({
         let domainsToRemove = [];
         let bufferedCompetencies = this.get('bufferedCompetencies');
         schoolCompetencies.filter(competency => {
-          return !bufferedCompetencies.contains(competency);
+          return !bufferedCompetencies.includes(competency);
         }).forEach(competency => {
           competency.deleteRecord();
           if (competency.get('isDomain')) {

--- a/app/components/selectable-search-result.js
+++ b/app/components/selectable-search-result.js
@@ -6,7 +6,7 @@ export default Component.extend({
   selectedItems: Ember.A(),
   item: null,
   selected: computed('item', 'selectedItems.[]', function(){
-    return this.get('selectedItems').contains(this.item);
+    return this.get('selectedItems').includes(this.item);
   }),
   click: function() {
     this.sendAction('action', this.get('item'));

--- a/app/components/selectable-terms-list-item.js
+++ b/app/components/selectable-terms-list-item.js
@@ -11,7 +11,7 @@ export default Component.extend({
   isSelected: computed('term', 'selectedTerms.[]', function() {
     let term = this.get('term');
     let selectedTerms = this.get('selectedTerms');
-    return selectedTerms.contains(term);
+    return selectedTerms.includes(term);
   }),
 
   click: function() {

--- a/app/components/session-objective-manager.js
+++ b/app/components/session-objective-manager.js
@@ -6,7 +6,7 @@ const { Component, computed, observer, on } = Ember;
 var objectiveProxy = Ember.ObjectProxy.extend({
   sessionObjective: null,
   selected: computed('content', 'sessionObjective.parents.[]', function(){
-    return this.get('sessionObjective.parents').contains(this.get('content'));
+    return this.get('sessionObjective.parents').includes(this.get('content'));
   }),
 });
 

--- a/app/components/session-overview.js
+++ b/app/components/session-overview.js
@@ -79,7 +79,7 @@ export default Component.extend(Publishable, Validations, ValidationErrorDisplay
           currentUser.get('userIsCourseDirector'),
           currentUser.get('userIsDeveloper')
         ]).then(hasRole => {
-          resolve(hasRole.contains(true));
+          resolve(hasRole.includes(true));
         });
       }
 

--- a/app/components/user-profile-cohorts.js
+++ b/app/components/user-profile-cohorts.js
@@ -91,7 +91,7 @@ export default Component.extend({
               resolve(
                 programYear.get('published') &&
                 !programYear.get('archived') &&
-                !selectedCohorts.contains(cohort)
+                !selectedCohorts.includes(cohort)
               );
             });
           });

--- a/app/components/user-profile-ics.js
+++ b/app/components/user-profile-ics.js
@@ -65,7 +65,7 @@ export default Component.extend({
         host = window.location.protocol + '//' + window.location.hostname;
         const port = window.location.port;
 
-        if (![80, 443].contains(port)) {
+        if (![80, 443].includes(port)) {
           host += ':' + port;
         }
       }

--- a/app/components/user-profile-roles.js
+++ b/app/components/user-profile-roles.js
@@ -97,7 +97,7 @@ export default Component.extend({
     const flipped = this.get('isCourseDirectorFlipped');
     return new Promise(resolve => {
       this.get('roleTitles').then(roleTitles => {
-        const originallyYes = roleTitles.contains('course director');
+        const originallyYes = roleTitles.includes('course director');
 
         resolve((originallyYes && !flipped) || (!originallyYes && flipped));
       });
@@ -108,7 +108,7 @@ export default Component.extend({
     const flipped = this.get('isFacultyFlipped');
     return new Promise(resolve => {
       this.get('roleTitles').then(roleTitles => {
-        const originallyYes = roleTitles.contains('faculty');
+        const originallyYes = roleTitles.includes('faculty');
 
         resolve((originallyYes && !flipped) || (!originallyYes && flipped));
       });
@@ -119,7 +119,7 @@ export default Component.extend({
     const flipped = this.get('isDeveloperFlipped');
     return new Promise(resolve => {
       this.get('roleTitles').then(roleTitles => {
-        const originallyYes = roleTitles.contains('developer');
+        const originallyYes = roleTitles.includes('developer');
 
         resolve((originallyYes && !flipped) || (!originallyYes && flipped));
       });
@@ -130,7 +130,7 @@ export default Component.extend({
     const flipped = this.get('isStudentFlipped');
     return new Promise(resolve => {
       this.get('roleTitles').then(roleTitles => {
-        const originallyYes = roleTitles.contains('student');
+        const originallyYes = roleTitles.includes('student');
 
         resolve((originallyYes && !flipped) || (!originallyYes && flipped));
       });
@@ -141,7 +141,7 @@ export default Component.extend({
     const flipped = this.get('isFormerStudentFlipped');
     return new Promise(resolve => {
       this.get('roleTitles').then(roleTitles => {
-        const originallyYes = roleTitles.contains('former student');
+        const originallyYes = roleTitles.includes('former student');
 
         resolve((originallyYes && !flipped) || (!originallyYes && flipped));
       });

--- a/app/components/user-profile-schools.js
+++ b/app/components/user-profile-schools.js
@@ -30,7 +30,7 @@ export default Component.extend({
 
     const readSchools = yield this.get('readSchools');
     const writeSchools = yield this.get('writeSchools');
-    const readOnlySchools = readSchools.filter(school => !writeSchools.contains(school));
+    const readOnlySchools = readSchools.filter(school => !writeSchools.includes(school));
 
     const userPermissions = yield user.get('permissions');
     yield userPermissions.invoke('destroyRecord');
@@ -120,7 +120,7 @@ export default Component.extend({
       this.get('secondarySchools').then(schools => {
         let overriddenIds = schools.filter(school => {
           const permission = school.get('id') + 'read';
-          return togglePermissions.contains(permission);
+          return togglePermissions.includes(permission);
         }).mapBy('id');
         user.get('permissions').then(permissions => {
           let existingIds = permissions.filter(permission => {
@@ -128,8 +128,8 @@ export default Component.extend({
           }).mapBy('tableRowId');
           let readSchools = schools.filter(school => {
             let id = school.get('id');
-            return (existingIds.contains(id) && !overriddenIds.contains(id)) ||
-                   (!existingIds.contains(id) && overriddenIds.contains(id));
+            return (existingIds.includes(id) && !overriddenIds.includes(id)) ||
+                   (!existingIds.includes(id) && overriddenIds.includes(id));
           });
 
           resolve(readSchools);
@@ -147,7 +147,7 @@ export default Component.extend({
       this.get('secondarySchools').then(schools => {
         let overriddenIds = schools.filter(school => {
           const permission = school.get('id') + 'write';
-          return togglePermissions.contains(permission);
+          return togglePermissions.includes(permission);
         }).mapBy('id');
         user.get('permissions').then(permissions => {
           let existingIds = permissions.filter(permission => {
@@ -155,8 +155,8 @@ export default Component.extend({
           }).mapBy('tableRowId');
           let writeSchools = schools.filter(school => {
             let id = school.get('id');
-            return (existingIds.contains(id) && !overriddenIds.contains(id)) ||
-                   (!existingIds.contains(id) && overriddenIds.contains(id));
+            return (existingIds.includes(id) && !overriddenIds.includes(id)) ||
+                   (!existingIds.includes(id) && overriddenIds.includes(id));
           });
 
           resolve(writeSchools);
@@ -170,7 +170,7 @@ export default Component.extend({
   actions: {
     toggleReadSchool(school){
       const permission = school.get('id') + 'read';
-      if (this.get('togglePermissions').contains(permission)) {
+      if (this.get('togglePermissions').includes(permission)) {
         this.get('togglePermissions').removeObject(permission);
       } else {
         this.get('togglePermissions').pushObject(permission);
@@ -178,7 +178,7 @@ export default Component.extend({
     },
     toggleWriteSchool(school){
       const permission = school.get('id') + 'write';
-      if (this.get('togglePermissions').contains(permission)) {
+      if (this.get('togglePermissions').includes(permission)) {
         this.get('togglePermissions').removeObject(permission);
       } else {
         this.get('togglePermissions').pushObject(permission);

--- a/app/components/user-profile-secondary-cohorts-manager.js
+++ b/app/components/user-profile-secondary-cohorts-manager.js
@@ -28,7 +28,7 @@ export default Component.extend({
         let assignableCohorts = usableCohorts.filter(cohort => {
           return (
             this.get('cohorts') &&
-            !this.get('cohorts').contains(cohort)
+            !this.get('cohorts').includes(cohort)
           );
         });
         defer.resolve(assignableCohorts);

--- a/app/components/user-search.js
+++ b/app/components/user-search.js
@@ -12,7 +12,7 @@ let userProxy = Ember.ObjectProxy.extend({
     if(!user.get('enabled')){
       return false;
     }
-    return !this.get('currentlyActiveUsers').contains(user);
+    return !this.get('currentlyActiveUsers').includes(user);
   }),
   sortTerm: computed('content.firstName', 'content.lastName', function(){
     return this.get('content.lastName')+this.get('content.firstName');
@@ -22,7 +22,7 @@ let instructorGroupProxy = Ember.ObjectProxy.extend({
   isInstructorGroup: true,
   currentlyActiveInstructorGroups: [],
   isActive: computed('content', 'currentlyActiveInstructorGroups.[]', function(){
-    return !this.get('currentlyActiveInstructorGroups').contains(this.get('content'));
+    return !this.get('currentlyActiveInstructorGroups').includes(this.get('content'));
   }),
   sortTerm: oneWay('content.title'),
 });
@@ -88,14 +88,14 @@ export default Component.extend({
     addUser: function(user){
       //don't send actions to the calling component if the user is already in the list
       //prevents a complicated if/else on the template.
-      if(!this.get('currentlyActiveUsers').contains(user)){
+      if(!this.get('currentlyActiveUsers').includes(user)){
         this.sendAction('addUser', user);
       }
     },
     addInstructorGroup: function(group){
       //don't send actions to the calling component if the user is already in the list
       //prevents a complicated if/else on the template.
-      if(!this.get('currentlyActiveInstructorGroups').contains(group)){
+      if(!this.get('currentlyActiveInstructorGroups').includes(group)){
         this.sendAction('addInstructorGroup', group);
       }
     }

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -68,7 +68,7 @@ export default Controller.extend({
       if (isPresent(selectedYear)) {
         let selectedYearTitle = selectedYear.get('title');
         let newCourses = this.get('newCourses').filter(course => {
-          return course.get('year') === selectedYearTitle && !all.contains(course);
+          return course.get('year') === selectedYearTitle && !all.includes(course);
         });
         all.pushObjects(newCourses.toArray());
       }
@@ -122,7 +122,7 @@ export default Controller.extend({
         if(filterMyCourses){
           this.get('allRelatedCourses').then(allRelatedCourses => {
             let myFilteredCourses = filteredCourses.filter(course => {
-              return allRelatedCourses.contains(course);
+              return allRelatedCourses.includes(course);
             });
 
             defer.resolve(myFilteredCourses);

--- a/app/controllers/curriculum-inventory-reports.js
+++ b/app/controllers/curriculum-inventory-reports.js
@@ -116,7 +116,7 @@ export default Controller.extend({
       const selectedProgram = this.get('selectedProgram');
       if (isPresent(selectedProgram)) {
         let newReports = this.get('newReports').filter(report => {
-          return report.get('program').get('id') === selectedProgram.get('id') && !all.contains(report);
+          return report.get('program').get('id') === selectedProgram.get('id') && !all.includes(report);
         });
         all.pushObjects(newReports.toArray());
       }
@@ -173,7 +173,7 @@ export default Controller.extend({
 
     removeCurriculumInventoryReport(report) {
       let newReports = this.get('newReports');
-      if (newReports.contains(report)) {
+      if (newReports.includes(report)) {
         newReports.removeObject(report);
       }
       return report.destroyRecord();

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -86,7 +86,7 @@ export default Controller.extend({
     },
 
     setShow(what) {
-      if (!['agenda', 'materials', 'calendar'].contains(what)) {
+      if (!['agenda', 'materials', 'calendar'].includes(what)) {
         what = 'agenda';
       }
 

--- a/app/controllers/pending-user-updates.js
+++ b/app/controllers/pending-user-updates.js
@@ -63,7 +63,7 @@ export default Controller.extend({
     return this.get('allUpdates')
       .sortBy('user.lastName', 'user.firstName')
       .slice(offset, end).filter(update => {
-        return !this.get('deletedUpdates').contains(update) &&
+        return !this.get('deletedUpdates').includes(update) &&
         (isEmpty(update.get('user.fullName')) || update.get('user.fullName').match(exp));
       });
   }),

--- a/app/helpers/intersection-count.js
+++ b/app/helpers/intersection-count.js
@@ -15,7 +15,7 @@ export function intersectionCount([a, b]/*, hash*/) {
 
   let count = 0;
   a.forEach((item) => {
-    if (b.contains(item)) {
+    if (b.includes(item)) {
       count++;
     }
   });

--- a/app/helpers/is-in.js
+++ b/app/helpers/is-in.js
@@ -11,7 +11,7 @@ export function isIn([values, item]) {
     return false;
   }
 
-  return values.contains(item);
+  return values.includes(item);
 }
 
 export default Helper.extend({

--- a/app/helpers/not-in.js
+++ b/app/helpers/not-in.js
@@ -11,7 +11,7 @@ export function notIn([values, item]) {
     return false;
   }
 
-  return !values.contains(item);
+  return !values.includes(item);
 }
 
 export default Helper.extend({

--- a/app/models/course.js
+++ b/app/models/course.js
@@ -73,7 +73,7 @@ export default Model.extend(PublishableModel, CategorizableModel, {
           }
           if(competency.get('id') !== domain.get('id')){
             let subCompetencies = domainContainer[domain.get('id')].get('subCompetencies');
-            if(!subCompetencies.contains(competency)){
+            if(!subCompetencies.includes(competency)){
               subCompetencies.pushObject(competency);
               subCompetencies.sortBy('title');
             }

--- a/app/models/learner-group.js
+++ b/app/models/learner-group.js
@@ -101,7 +101,7 @@ export default DS.Model.extend({
                 });
               });
               var availableUsers = parentUsers.filter(function(user){
-                return !selectedUsers.contains(user);
+                return !selectedUsers.includes(user);
               });
               resolve(availableUsers);
             });
@@ -166,7 +166,7 @@ export default DS.Model.extend({
           let promises = [];
           users.forEach(user => {
             let promise = user.get('learnerGroups').then(userGroups => {
-              var subGroups = userGroups.filter(group => descendants.contains(group));
+              var subGroups = userGroups.filter(group => descendants.includes(group));
               if(subGroups.length === 0){
                 membersAtThisLevel.pushObject(user);
               }
@@ -312,7 +312,7 @@ export default DS.Model.extend({
     let modifiedGroups = [];
     const userId = user.get('id');
     return new Promise(resolve => {
-      if (this.hasMany('users').ids().contains(userId)) {
+      if (this.hasMany('users').ids().includes(userId)) {
         this.get('users').removeObject(user);
         modifiedGroups.pushObject(this);
       }
@@ -340,7 +340,7 @@ export default DS.Model.extend({
     let modifiedGroups = [];
     const userId = user.get('id');
     return new Promise(resolve => {
-      if (!this.hasMany('users').ids().contains(userId)) {
+      if (!this.hasMany('users').ids().includes(userId)) {
         this.get('users').pushObject(user);
         modifiedGroups.pushObject(this);
       }

--- a/app/models/objective.js
+++ b/app/models/objective.js
@@ -100,7 +100,7 @@ export default Model.extend({
         parents.forEach(parent => {
           promises.pushObject(parent.get('programYears').then(programYears => {
             let programYear = programYears.get('firstObject');
-            if(programYearsToRemove.contains(programYear)){
+            if(programYearsToRemove.includes(programYear)){
               parents.removeObject(parent);
               parent.get('children').removeObject(this);
             }

--- a/app/models/program-year.js
+++ b/app/models/program-year.js
@@ -53,7 +53,7 @@ export default DS.Model.extend(PublishableModel, CategorizableModel, {
           }
           if(competency.get('id') !== domain.get('id')){
             var subCompetencies = domainContainer[domain.get('id')].get('subCompetencies');
-            if(!subCompetencies.contains(competency)){
+            if(!subCompetencies.includes(competency)){
               subCompetencies.pushObject(competency);
               subCompetencies.sortBy('title');
             }

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -241,11 +241,11 @@ var User = DS.Model.extend({
     return new Promise(resolve => {
       user.get('learnerGroups').then(userGroups => {
         //all the groups a user is in that are in our current learner groups tree
-        let relevantGroups = userGroups.filter(group => learnerGroupTree.contains(group));
+        let relevantGroups = userGroups.filter(group => learnerGroupTree.includes(group));
         let relevantGroupIds = relevantGroups.mapBy('id');
         let lowestGroup = relevantGroups.find( group => {
           let childIds = group.hasMany('children').ids();
-          let childGroupsWhoAreUserGroupMembers = childIds.filter(id => relevantGroupIds.contains(id));
+          let childGroupsWhoAreUserGroupMembers = childIds.filter(id => relevantGroupIds.includes(id));
           return childGroupsWhoAreUserGroupMembers.length === 0;
         });
 

--- a/app/routes/print-course.js
+++ b/app/routes/print-course.js
@@ -23,7 +23,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
         currentUser.get('userIsFaculty'),
         currentUser.get('userIsDeveloper'),
       ]).then(hasRole => {
-        if (!hasRole.contains(true)) {
+        if (!hasRole.includes(true)) {
           transition.abort();
         } else {
           this.preloadCourseData(course).then(()=> {

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -45,7 +45,7 @@ export default Ember.Service.extend({
   availableCohortsObserver: observer('availableCohorts.[]', function(){
     var self = this;
     this.get('availableCohorts').then(function(cohorts){
-      if(!cohorts.contains(self.get('currentCohort'))){
+      if(!cohorts.includes(self.get('currentCohort'))){
         self.set('currentCohort', null);
       }
     });
@@ -136,42 +136,42 @@ export default Ember.Service.extend({
   userIsCourseDirector: computed('useRoleTitles.[]', function(){
     return new Ember.RSVP.Promise((resolve) => {
       this.get('userRoleTitles').then(roleTitles => {
-        resolve(roleTitles.contains('course director'));
+        resolve(roleTitles.includes('course director'));
       });
     });
   }),
   userIsFaculty: computed('useRoleTitles.[]', function(){
     return new Ember.RSVP.Promise((resolve) => {
       this.get('userRoleTitles').then(roleTitles => {
-        resolve(roleTitles.contains('faculty'));
+        resolve(roleTitles.includes('faculty'));
       });
     });
   }),
   userIsDeveloper: computed('useRoleTitles.[]', function(){
     return new Ember.RSVP.Promise((resolve) => {
       this.get('userRoleTitles').then(roleTitles => {
-        resolve(roleTitles.contains('developer'));
+        resolve(roleTitles.includes('developer'));
       });
     });
   }),
   userIsStudent: computed('useRoleTitles.[]', function(){
     return new Ember.RSVP.Promise((resolve) => {
       this.get('userRoleTitles').then(roleTitles => {
-        resolve(roleTitles.contains('student'));
+        resolve(roleTitles.includes('student'));
       });
     });
   }),
   userIsPublic: computed('useRoleTitles.[]', function(){
     return new Ember.RSVP.Promise((resolve) => {
       this.get('userRoleTitles').then(roleTitles => {
-        resolve(roleTitles.contains('public'));
+        resolve(roleTitles.includes('public'));
       });
     });
   }),
   userIsFormerStudent: computed('useRoleTitles.[]', function(){
     return new Ember.RSVP.Promise((resolve) => {
       this.get('userRoleTitles').then(roleTitles => {
-        resolve(roleTitles.contains('former student'));
+        resolve(roleTitles.includes('former student'));
       });
     });
   }),
@@ -209,8 +209,8 @@ export default Ember.Service.extend({
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         if ( !(this.get('isDestroyed') || this.get('isDestroying')) ) {
-          this.set('canViewSchools', hasRole.contains(true));
-          this.set('canEditSchools', hasRole.contains(true));
+          this.set('canViewSchools', hasRole.includes(true));
+          this.set('canEditSchools', hasRole.includes(true));
         }
       });
     }
@@ -228,8 +228,8 @@ export default Ember.Service.extend({
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         if ( !(this.get('isDestroyed') || this.get('isDestroying')) ) {
-          this.set('canViewPrograms', hasRole.contains(true));
-          this.set('canEditPrograms', hasRole.contains(true));
+          this.set('canViewPrograms', hasRole.includes(true));
+          this.set('canEditPrograms', hasRole.includes(true));
         }
       });
     }
@@ -249,9 +249,9 @@ export default Ember.Service.extend({
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         if ( !(this.get('isDestroyed') || this.get('isDestroying')) ) {
-          this.set('canViewCourses', hasRole.contains(true));
-          this.set('canEditCourses', hasRole.contains(true));
-          this.set('canPrintUnpublishedCourse', hasRole.contains(true));
+          this.set('canViewCourses', hasRole.includes(true));
+          this.set('canEditCourses', hasRole.includes(true));
+          this.set('canPrintUnpublishedCourse', hasRole.includes(true));
         }
       });
     }
@@ -265,8 +265,8 @@ export default Ember.Service.extend({
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         if ( !(this.get('isDestroyed') || this.get('isDestroying')) ) {
-          this.set('canViewInstructorGroups', hasRole.contains(true));
-          this.set('canEditInstructorGroups', hasRole.contains(true));
+          this.set('canViewInstructorGroups', hasRole.includes(true));
+          this.set('canEditInstructorGroups', hasRole.includes(true));
         }
       });
     }
@@ -284,8 +284,8 @@ export default Ember.Service.extend({
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         if ( !(this.get('isDestroyed') || this.get('isDestroying')) ) {
-          this.set('canViewLearnerGroups', hasRole.contains(true));
-          this.set('canEditLearnerGroups', hasRole.contains(true));
+          this.set('canViewLearnerGroups', hasRole.includes(true));
+          this.set('canEditLearnerGroups', hasRole.includes(true));
         }
       });
     }
@@ -303,7 +303,7 @@ export default Ember.Service.extend({
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         if ( !(this.get('isDestroyed') || this.get('isDestroying')) ) {
-          this.set('canViewCurriculumInventory', hasRole.contains(true));
+          this.set('canViewCurriculumInventory', hasRole.includes(true));
         }
       });
     }
@@ -315,7 +315,7 @@ export default Ember.Service.extend({
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         if ( !(this.get('isDestroyed') || this.get('isDestroying')) ) {
-          this.set('canEditCurriculumInventory', hasRole.contains(true));
+          this.set('canEditCurriculumInventory', hasRole.includes(true));
         }
       });
     }
@@ -336,7 +336,7 @@ export default Ember.Service.extend({
         this.get('userIsDeveloper')
       ]).then(hasRole => {
         if ( !(this.get('isDestroyed') || this.get('isDestroying')) ) {
-          this.set('canViewAdminDashboard', hasRole.contains(true));
+          this.set('canViewAdminDashboard', hasRole.includes(true));
         }
       });
     }

--- a/app/services/reporting.js
+++ b/app/services/reporting.js
@@ -81,13 +81,13 @@ export default Service.extend({
 
       if(subject === 'session'){
         let sessionSingulars = ['sessionTypes', 'courses'];
-        if(sessionSingulars.contains(what)){
+        if(sessionSingulars.includes(what)){
           what = singularize(what);
         }
       }
       if(subject === 'instructor'){
         let specialInstructed = ['learningMaterials', 'sessionTypes', 'courses', 'sessions'];
-        if(specialInstructed.contains(what)){
+        if(specialInstructed.includes(what)){
           what = 'instructed' + what.capitalize();
         }
       }

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -26,7 +26,7 @@ export default function(){
       topRoutes.push('instructorGroups');
       topRoutes.push('instructorGroup');
       topRoutes.push('programs');
-      return topRoutes.contains(this);
+      return topRoutes.includes(this);
     }),
     this.use('crossFade', {duration: 500})
   );

--- a/app/validators/async-exclusion.js
+++ b/app/validators/async-exclusion.js
@@ -13,7 +13,7 @@ export default BaseValidator.extend({
 
     return new Promise(resolve => {
       promise.then(excluded => {
-        if (excluded.contains(value)) {
+        if (excluded.includes(value)) {
           resolve(this.createErrorMessage('exclusion', value, options));
         } else {
           resolve(true);

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -8,6 +8,5 @@ window.deprecationWorkflow.config = {
     { handler: "silence", matchId: "ember-views.render-double-modify"},
     { handler: "silence", matchId: "ember-metal.merge"},
     { handler: "silence", matchId: "ember-htmlbars.ember-handlebars-safestring"},
-    { handler: "silence", matchId: "ember-runtime.enumerable-contains"},
   ]
 };

--- a/tests/integration/components/new-directory-user-test.js
+++ b/tests/integration/components/new-directory-user-test.js
@@ -190,7 +190,7 @@ test('create new user', function(assert) {
           save(){
             const roles = this.get('roles');
             assert.equal(roles.length, 1, 'Only one new role was added');
-            assert.ok(roles.contains(facultyRole), 'The faculty role was added');
+            assert.ok(roles.includes(facultyRole), 'The faculty role was added');
             assert.ok(true, 'save gets called');
 
             return Object.create({

--- a/tests/integration/components/new-user-test.js
+++ b/tests/integration/components/new-user-test.js
@@ -160,7 +160,7 @@ test('create new user', function(assert) {
           save(){
             const roles = this.get('roles');
             assert.equal(roles.length, 1, 'Only one new role was added');
-            assert.ok(roles.contains(facultyRole), 'The faculty role was added');
+            assert.ok(roles.includes(facultyRole), 'The faculty role was added');
             assert.ok(true, 'save gets called');
 
             return Object.create({

--- a/tests/integration/components/user-profile-cohorts-test.js
+++ b/tests/integration/components/user-profile-cohorts-test.js
@@ -140,9 +140,9 @@ test('can edit user cohorts', function(assert) {
   user.set('save', ()=> {
     assert.equal(user.get('primaryCohort'), cohort2, 'user has correct primary cohort');
 
-    assert.ok(!usercohorts.contains(cohort1), 'cohort1 has been removed');
-    assert.ok(usercohorts.contains(cohort2), 'cohort2 is still present');
-    assert.ok(usercohorts.contains(cohort3), 'cohort3 has been added');
+    assert.ok(!usercohorts.includes(cohort1), 'cohort1 has been removed');
+    assert.ok(usercohorts.includes(cohort2), 'cohort2 is still present');
+    assert.ok(usercohorts.includes(cohort3), 'cohort3 has been added');
 
     return resolve(user);
   });

--- a/tests/integration/components/user-profile-roles-test.js
+++ b/tests/integration/components/user-profile-roles-test.js
@@ -92,11 +92,11 @@ test('can edit user roles', function(assert) {
     assert.equal(user.get('enabled'), false, 'user is disabled');
     assert.equal(user.get('userSyncIgnore'), true, 'user is sync ignored');
 
-    assert.notOk(userRoles.contains(courseDirectorRole));
-    assert.ok(userRoles.contains(facultyRole));
-    assert.ok(userRoles.contains(developerRole));
-    assert.ok(userRoles.contains(formerStudentRole));
-    assert.ok(userRoles.contains(studentRole));
+    assert.notOk(userRoles.includes(courseDirectorRole));
+    assert.ok(userRoles.includes(facultyRole));
+    assert.ok(userRoles.includes(developerRole));
+    assert.ok(userRoles.includes(formerStudentRole));
+    assert.ok(userRoles.includes(studentRole));
 
     return resolve(user);
   });

--- a/tests/unit/models/course-test.js
+++ b/tests/unit/models/course-test.js
@@ -62,9 +62,9 @@ test('check competencies', function(assert) {
 
     return course.get('competencies').then(competencies => {
       assert.equal(competencies.length, 3);
-      assert.ok(competencies.contains(competency1));
-      assert.ok(competencies.contains(competency2));
-      assert.ok(competencies.contains(competency3));
+      assert.ok(competencies.includes(competency1));
+      assert.ok(competencies.includes(competency2));
+      assert.ok(competencies.includes(competency3));
 
       let competency4 = store.createRecord('competency');
       let competency5 = store.createRecord('competency');
@@ -75,11 +75,11 @@ test('check competencies', function(assert) {
 
       return course.get('competencies').then(competencies => {
         assert.equal(competencies.length, 5);
-        assert.ok(competencies.contains(competency1));
-        assert.ok(competencies.contains(competency2));
-        assert.ok(competencies.contains(competency3));
-        assert.ok(competencies.contains(competency4));
-        assert.ok(competencies.contains(competency5));
+        assert.ok(competencies.includes(competency1));
+        assert.ok(competencies.includes(competency2));
+        assert.ok(competencies.includes(competency3));
+        assert.ok(competencies.includes(competency4));
+        assert.ok(competencies.includes(competency5));
       });
 
     });

--- a/tests/unit/models/curriculum-inventory-report-test.js
+++ b/tests/unit/models/curriculum-inventory-report-test.js
@@ -32,8 +32,8 @@ test('get top level sequence blocks', function(assert){
     model.get('sequenceBlocks').pushObjects([ block1, block2, block3 ]);
     model.get('topLevelSequenceBlocks').then(blocks => {
       assert.equal(blocks.length, 2);
-      assert.ok(blocks.contains(block1));
-      assert.ok(blocks.contains(block2));
+      assert.ok(blocks.includes(block1));
+      assert.ok(blocks.includes(block2));
     });
   });
 });
@@ -79,9 +79,9 @@ test('get linked courses', function(assert) {
     });
     model.get('sequenceBlocks').pushObjects([ block1, block2, block3 ]);
     model.get('linkedCourses').then(linkedCourses => {
-      assert.ok(linkedCourses.contains(course1));
-      assert.ok(linkedCourses.contains(course2));
-      assert.notOk(linkedCourses.contains(course3));
+      assert.ok(linkedCourses.includes(course1));
+      assert.ok(linkedCourses.includes(course2));
+      assert.notOk(linkedCourses.includes(course3));
     });
   });
 });

--- a/tests/unit/models/ilm-session-test.js
+++ b/tests/unit/models/ilm-session-test.js
@@ -31,17 +31,17 @@ test('check allInstructors', function(assert) {
 
     return model.get('allInstructors').then(instructors => {
       assert.equal(instructors.length, 2);
-      assert.ok(instructors.contains(user1));
-      assert.ok(instructors.contains(user2));
+      assert.ok(instructors.includes(user1));
+      assert.ok(instructors.includes(user2));
 
       return instructorGroup.get('users').then(users =>{
         let user3 = store.createRecord('user');
         users.pushObject(user3);
         return model.get('allInstructors').then(instructors => {
           assert.equal(instructors.length, 3);
-          assert.ok(instructors.contains(user1));
-          assert.ok(instructors.contains(user2));
-          assert.ok(instructors.contains(user3));
+          assert.ok(instructors.includes(user1));
+          assert.ok(instructors.includes(user2));
+          assert.ok(instructors.includes(user3));
         });
       });
 

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -80,9 +80,9 @@ test('list available users', function(assert) {
     model.get('availableUsers').then(function(users){
       var names = users.mapBy('firstName');
       assert.equal(users.get('length'), 3);
-      assert.ok(names.contains(2));
-      assert.ok(names.contains(3));
-      assert.ok(names.contains(4));
+      assert.ok(names.includes(2));
+      assert.ok(names.includes(3));
+      assert.ok(names.includes(4));
     });
   });
 });
@@ -124,9 +124,9 @@ test('check allDescendantUsers', function(assert) {
 
     return learnerGroup.get('allDescendantUsers').then(users => {
       assert.equal(users.length, 3);
-      assert.ok(users.contains(user1));
-      assert.ok(users.contains(user2));
-      assert.ok(users.contains(user3));
+      assert.ok(users.includes(user1));
+      assert.ok(users.includes(user2));
+      assert.ok(users.includes(user3));
       let user4 = store.createRecord('user');
       let user5 = store.createRecord('user');
       learnerGroup.get('users').pushObject(user4);
@@ -135,11 +135,11 @@ test('check allDescendantUsers', function(assert) {
 
       return learnerGroup.get('allDescendantUsers').then(users => {
         assert.equal(users.length, 5);
-        assert.ok(users.contains(user1));
-        assert.ok(users.contains(user2));
-        assert.ok(users.contains(user3));
-        assert.ok(users.contains(user4));
-        assert.ok(users.contains(user5));
+        assert.ok(users.includes(user1));
+        assert.ok(users.includes(user2));
+        assert.ok(users.includes(user3));
+        assert.ok(users.includes(user4));
+        assert.ok(users.includes(user5));
       });
 
     });
@@ -160,9 +160,9 @@ test('check allDescendants', function(assert) {
 
     return learnerGroup.get('allDescendants').then(groups => {
       assert.equal(groups.length, 3);
-      assert.ok(groups.contains(subGroup1));
-      assert.ok(groups.contains(subGroup2));
-      assert.ok(groups.contains(subGroup3));
+      assert.ok(groups.includes(subGroup1));
+      assert.ok(groups.includes(subGroup2));
+      assert.ok(groups.includes(subGroup3));
 
       let subGroup4 = store.createRecord('learner-group');
       learnerGroup.get('children').pushObject(subGroup4);
@@ -171,11 +171,11 @@ test('check allDescendants', function(assert) {
 
       return learnerGroup.get('allDescendants').then(groups => {
         assert.equal(groups.length, 5);
-        assert.ok(groups.contains(subGroup1));
-        assert.ok(groups.contains(subGroup2));
-        assert.ok(groups.contains(subGroup3));
-        assert.ok(groups.contains(subGroup4));
-        assert.ok(groups.contains(subGroup5));
+        assert.ok(groups.includes(subGroup1));
+        assert.ok(groups.includes(subGroup2));
+        assert.ok(groups.includes(subGroup3));
+        assert.ok(groups.includes(subGroup4));
+        assert.ok(groups.includes(subGroup5));
       });
 
     });
@@ -222,9 +222,9 @@ test('check allinstructors', function(assert) {
 
     return learnerGroup.get('allInstructors').then(users => {
       assert.equal(users.length, 3);
-      assert.ok(users.contains(user1));
-      assert.ok(users.contains(user2));
-      assert.ok(users.contains(user3));
+      assert.ok(users.includes(user1));
+      assert.ok(users.includes(user2));
+      assert.ok(users.includes(user3));
       let user4 = store.createRecord('user');
       let user5 = store.createRecord('user');
       learnerGroup.get('instructors').pushObject(user4);
@@ -233,11 +233,11 @@ test('check allinstructors', function(assert) {
 
       return learnerGroup.get('allInstructors').then(users => {
         assert.equal(users.length, 5);
-        assert.ok(users.contains(user1));
-        assert.ok(users.contains(user2));
-        assert.ok(users.contains(user3));
-        assert.ok(users.contains(user4));
-        assert.ok(users.contains(user5));
+        assert.ok(users.includes(user1));
+        assert.ok(users.includes(user2));
+        assert.ok(users.includes(user3));
+        assert.ok(users.includes(user4));
+        assert.ok(users.includes(user5));
       });
 
     });
@@ -376,11 +376,11 @@ test('check removeUserFromGroupAndAllDescendants', function(assert) {
 
     return subGroup1.removeUserFromGroupAndAllDescendants(user1).then(groups => {
       assert.equal(groups.length, 3);
-      assert.notOk(groups.contains(learnerGroup));
-      assert.ok(groups.contains(subGroup1));
-      assert.ok(groups.contains(subGroup2));
-      assert.ok(groups.contains(subGroup3));
-      assert.notOk(groups.contains(subGroup4));
+      assert.notOk(groups.includes(learnerGroup));
+      assert.ok(groups.includes(subGroup1));
+      assert.ok(groups.includes(subGroup2));
+      assert.ok(groups.includes(subGroup3));
+      assert.notOk(groups.includes(subGroup4));
     });
   });
 });
@@ -402,11 +402,11 @@ test('check addUserToGroupAndAllParents', function(assert) {
 
     return subGroup3.addUserToGroupAndAllParents(user1).then(groups => {
       assert.equal(groups.length, 3);
-      assert.ok(groups.contains(learnerGroup));
-      assert.notOk(groups.contains(subGroup1));
-      assert.ok(groups.contains(subGroup2));
-      assert.ok(groups.contains(subGroup3));
-      assert.notOk(groups.contains(subGroup4));
+      assert.ok(groups.includes(learnerGroup));
+      assert.notOk(groups.includes(subGroup1));
+      assert.ok(groups.includes(subGroup2));
+      assert.ok(groups.includes(subGroup3));
+      assert.notOk(groups.includes(subGroup4));
     });
   });
 });

--- a/tests/unit/models/objective-test.js
+++ b/tests/unit/models/objective-test.js
@@ -70,8 +70,8 @@ test('corrent top parents with multi parent tree', function(assert) {
 
     model.get('topParents').then(topParents => {
       assert.ok(topParents.get('length') === 2);
-      assert.ok(topParents.contains(parent3));
-      assert.ok(topParents.contains(parent4));
+      assert.ok(topParents.includes(parent3));
+      assert.ok(topParents.includes(parent4));
     });
   });
 

--- a/tests/unit/models/offering-test.js
+++ b/tests/unit/models/offering-test.js
@@ -32,9 +32,9 @@ test('check allinstructors', function(assert) {
 
     return offering.get('allInstructors').then(users => {
       assert.equal(users.length, 3);
-      assert.ok(users.contains(user1));
-      assert.ok(users.contains(user2));
-      assert.ok(users.contains(user3));
+      assert.ok(users.includes(user1));
+      assert.ok(users.includes(user2));
+      assert.ok(users.includes(user3));
       let user4 = store.createRecord('user');
       let user5 = store.createRecord('user');
       offering.get('instructors').pushObject(user4);
@@ -43,11 +43,11 @@ test('check allinstructors', function(assert) {
 
       return offering.get('allInstructors').then(users => {
         assert.equal(users.length, 5);
-        assert.ok(users.contains(user1));
-        assert.ok(users.contains(user2));
-        assert.ok(users.contains(user3));
-        assert.ok(users.contains(user4));
-        assert.ok(users.contains(user5));
+        assert.ok(users.includes(user1));
+        assert.ok(users.includes(user2));
+        assert.ok(users.includes(user3));
+        assert.ok(users.includes(user4));
+        assert.ok(users.includes(user5));
       });
 
     });

--- a/tests/unit/models/session-test.js
+++ b/tests/unit/models/session-test.js
@@ -67,9 +67,9 @@ test('check associatedOfferingLearnerGroups', function(assert) {
 
     return session.get('associatedOfferingLearnerGroups').then(groups => {
       assert.equal(groups.length, 3);
-      assert.ok(groups.contains(learnerGroup1));
-      assert.ok(groups.contains(learnerGroup2));
-      assert.ok(groups.contains(learnerGroup3));
+      assert.ok(groups.includes(learnerGroup1));
+      assert.ok(groups.includes(learnerGroup2));
+      assert.ok(groups.includes(learnerGroup3));
 
       let learnerGroup4 = store.createRecord('learner-group');
       let offering3 = store.createRecord('offering', {learnerGroups: [learnerGroup4]});
@@ -79,11 +79,11 @@ test('check associatedOfferingLearnerGroups', function(assert) {
 
       return session.get('associatedOfferingLearnerGroups').then(groups => {
         assert.equal(groups.length, 5);
-        assert.ok(groups.contains(learnerGroup1));
-        assert.ok(groups.contains(learnerGroup2));
-        assert.ok(groups.contains(learnerGroup3));
-        assert.ok(groups.contains(learnerGroup4));
-        assert.ok(groups.contains(learnerGroup5));
+        assert.ok(groups.includes(learnerGroup1));
+        assert.ok(groups.includes(learnerGroup2));
+        assert.ok(groups.includes(learnerGroup3));
+        assert.ok(groups.includes(learnerGroup4));
+        assert.ok(groups.includes(learnerGroup5));
       });
 
     });
@@ -107,19 +107,19 @@ test('check associatedIlmLearnerGroups', function(assert) {
 
     return session.get('associatedIlmLearnerGroups').then(groups => {
       assert.equal(groups.length, 3);
-      assert.ok(groups.contains(learnerGroup1));
-      assert.ok(groups.contains(learnerGroup2));
-      assert.ok(groups.contains(learnerGroup3));
+      assert.ok(groups.includes(learnerGroup1));
+      assert.ok(groups.includes(learnerGroup2));
+      assert.ok(groups.includes(learnerGroup3));
 
       let learnerGroup4 = store.createRecord('learner-group');
       session.get('ilmSession').get('learnerGroups').pushObject(learnerGroup4);
 
       return session.get('associatedIlmLearnerGroups').then(groups => {
         assert.equal(groups.length, 4);
-        assert.ok(groups.contains(learnerGroup1));
-        assert.ok(groups.contains(learnerGroup2));
-        assert.ok(groups.contains(learnerGroup3));
-        assert.ok(groups.contains(learnerGroup4));
+        assert.ok(groups.includes(learnerGroup1));
+        assert.ok(groups.includes(learnerGroup2));
+        assert.ok(groups.includes(learnerGroup3));
+        assert.ok(groups.includes(learnerGroup4));
       });
     });
   });
@@ -145,9 +145,9 @@ test('check associatedLearnerGroups', function(assert) {
 
     return session.get('associatedLearnerGroups').then(groups => {
       assert.equal(groups.length, 3);
-      assert.ok(groups.contains(learnerGroup1));
-      assert.ok(groups.contains(learnerGroup2));
-      assert.ok(groups.contains(learnerGroup3));
+      assert.ok(groups.includes(learnerGroup1));
+      assert.ok(groups.includes(learnerGroup2));
+      assert.ok(groups.includes(learnerGroup3));
 
       let learnerGroup4 = store.createRecord('learner-group');
       session.get('ilmSession').get('learnerGroups').pushObject(learnerGroup4);
@@ -156,11 +156,11 @@ test('check associatedLearnerGroups', function(assert) {
 
       return session.get('associatedLearnerGroups').then(groups => {
         assert.equal(groups.length, 5);
-        assert.ok(groups.contains(learnerGroup1));
-        assert.ok(groups.contains(learnerGroup2));
-        assert.ok(groups.contains(learnerGroup3));
-        assert.ok(groups.contains(learnerGroup4));
-        assert.ok(groups.contains(learnerGroup5));
+        assert.ok(groups.includes(learnerGroup1));
+        assert.ok(groups.includes(learnerGroup2));
+        assert.ok(groups.includes(learnerGroup3));
+        assert.ok(groups.includes(learnerGroup4));
+        assert.ok(groups.includes(learnerGroup5));
       });
     });
   });

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -50,7 +50,7 @@ test('gets all directed courses', function(assert) {
     model.get('allRelatedCourses').then(allRelatedCourses => {
       assert.equal(allRelatedCourses.length, courses.length);
       courses.forEach(course => {
-        assert.ok(allRelatedCourses.contains(course));
+        assert.ok(allRelatedCourses.includes(course));
       });
     });
   });
@@ -91,7 +91,7 @@ test('gets all learner group courses', function(assert) {
     model.get('allRelatedCourses').then(allRelatedCourses => {
       assert.equal(allRelatedCourses.length, courses.length);
       courses.forEach(course => {
-        assert.ok(allRelatedCourses.contains(course));
+        assert.ok(allRelatedCourses.includes(course));
       });
     });
   });
@@ -132,7 +132,7 @@ test('gets all instructor group courses', function(assert) {
     model.get('allRelatedCourses').then(allRelatedCourses => {
       assert.equal(allRelatedCourses.length, courses.length);
       courses.forEach(course => {
-        assert.ok(allRelatedCourses.contains(course));
+        assert.ok(allRelatedCourses.includes(course));
       });
     });
   });
@@ -168,7 +168,7 @@ test('gets all instructed offering courses', function(assert) {
     model.get('allRelatedCourses').then(allRelatedCourses => {
       assert.equal(allRelatedCourses.length, courses.length);
       courses.forEach(course => {
-        assert.ok(allRelatedCourses.contains(course));
+        assert.ok(allRelatedCourses.includes(course));
       });
     });
   });
@@ -204,7 +204,7 @@ test('gets all learner offering courses', function(assert) {
     model.get('allRelatedCourses').then(allRelatedCourses => {
       assert.equal(allRelatedCourses.length, courses.length);
       courses.forEach(course => {
-        assert.ok(allRelatedCourses.contains(course));
+        assert.ok(allRelatedCourses.includes(course));
       });
     });
   });
@@ -245,7 +245,7 @@ test('gets all learner group ILMSession courses', function(assert) {
     model.get('allRelatedCourses').then(allRelatedCourses => {
       assert.equal(allRelatedCourses.length, courses.length);
       courses.forEach(course => {
-        assert.ok(allRelatedCourses.contains(course));
+        assert.ok(allRelatedCourses.includes(course));
       });
     });
   });
@@ -292,7 +292,7 @@ test('gets all instructor group ILMSession courses', function(assert) {
     model.get('allRelatedCourses').then(allRelatedCourses => {
       assert.equal(allRelatedCourses.length, courses.length);
       courses.forEach(course => {
-        assert.ok(allRelatedCourses.contains(course));
+        assert.ok(allRelatedCourses.includes(course));
       });
     });
   });
@@ -324,7 +324,7 @@ test('gets all learner ilm courses', function(assert) {
     model.get('allRelatedCourses').then(allRelatedCourses => {
       assert.equal(allRelatedCourses.length, courses.length);
       courses.forEach(course => {
-        assert.ok(allRelatedCourses.contains(course));
+        assert.ok(allRelatedCourses.includes(course));
       });
     });
   });
@@ -356,7 +356,7 @@ test('gets all instructor ilm courses', function(assert) {
     model.get('allRelatedCourses').then(allRelatedCourses => {
       assert.equal(allRelatedCourses.length, courses.length);
       courses.forEach(course => {
-        assert.ok(allRelatedCourses.contains(course));
+        assert.ok(allRelatedCourses.includes(course));
       });
     });
   });
@@ -454,9 +454,9 @@ test('gets secondary cohorts (all cohorts not the primary cohort)', function(ass
 
     model.get('secondaryCohorts').then(cohorts => {
       assert.equal(cohorts.length, 2);
-      assert.ok(cohorts.contains(secondaryCohort));
-      assert.ok(cohorts.contains(anotherCohort));
-      assert.notOk(cohorts.contains(primaryCohort));
+      assert.ok(cohorts.includes(secondaryCohort));
+      assert.ok(cohorts.includes(anotherCohort));
+      assert.notOk(cohorts.includes(primaryCohort));
     });
   });
 


### PR DESCRIPTION
The `contains` method on ennumerables was deprecated because correct ES
syntax is to use `includes`.