### PR TITLE
downgraded ember-tether due to dependency conflicts with ember-tooltips.

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "ember-rl-dropdown": "0.10.0",
     "ember-simple-auth": "1.1.0",
     "ember-simple-auth-token": "1.2.0",
-    "ember-tether": "0.4.0",
+    "ember-tether": "0.3.1",
     "ember-tooltips": "2.7.2",
     "ember-truth-helpers": "1.3.0",
     "ember-uploader": "1.2.2",


### PR DESCRIPTION
fixes #2478 