### PR TITLE
Lock ember data in the 2.10.x series

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-concurrency": "0.7.17",
     "ember-cp-validations": "3.1.4",
     "ember-cryptojs-shim": "^2.0.0",
-    "ember-data": "^2.10.0",
+    "ember-data": "~2.10.0",
     "ember-exam": "0.6.0",
     "ember-export-application-global": "^1.0.5",
     "ember-font-awesome": "2.2.0",


### PR DESCRIPTION
2.11.x has some issues with out tests, need to investigate to see if the
issue is just on our end or if it is a problem with the version of
ember-data which included substantial changes internally.

Fixes #2494