### PR TITLE
Update reports to include terms

### DIFF
--- a/app/services/reporting.js
+++ b/app/services/reporting.js
@@ -209,5 +209,23 @@ export default Service.extend({
       };
     });
     return RSVP.resolve(map);
-  }
+  },
+  termsResults(results){
+    return RSVP.map (results.toArray(), result => {
+      return new RSVP.Promise(resolve => {
+        result.get('vocabulary').then(vocabulary => {
+          result.get('titleWithParentTitles').then(titleWithParentTitles => {
+            const title = vocabulary.get('title') + ' > ' + titleWithParentTitles;
+            resolve({value: title});
+          });
+        });
+      });
+    });
+  },
+  objectivesResults(results){
+    return this.titleResults(results);
+  },
+  learnerGroupsResults(results){
+    return this.titleResults(results);
+  },
 });

--- a/app/templates/components/new-myreport.hbs
+++ b/app/templates/components/new-myreport.hbs
@@ -85,11 +85,11 @@
           }}
         {{/if}}
       {{else}}
-        {{#liquid-if prepositionalObjectIdList.isFulfilled class='crossFade'}}
+        {{#liquid-if (is-fulfilled prepositionalObjectIdList) class='crossFade'}}
           <select onchange={{action "changePrepositionalObjectId" value="target.value"}}>
-            {{#each prepositionalObjectIdList as |option|}}
-              <option value={{option.value}} selected={{is-equal option.value currentPrepositionalObjectId}}>
-                {{option.label}}
+            {{#each (sort-by 'label' (await prepositionalObjectIdList)) as |option|}}
+              <option value={{option.value}}>
+                {{await option.label}}
               </option>
             {{/each}}
           </select>

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "ember-truth-helpers": "1.3.0",
     "ember-uploader": "1.2.3",
     "ember-watson": "^0.8.5",
-    "eslint": "^3.13.1",
+    "eslint": "^3.14.1",
     "ilios-calendar": "^7.2.0",
     "liquid-fire": "0.27.0",
     "liquid-tether": "2.0.3",

--- a/tests/integration/components/new-myreport-test.js
+++ b/tests/integration/components/new-myreport-test.js
@@ -218,14 +218,13 @@ test('choosing term selects correct objects', function(assert) {
 test('choosing session type selects correct objects', function(assert) {
   return checkObjects(this, assert, 10, 'session type', [
     'course',
-    'session',
-    'program year',
     'program',
     'instructor',
+    'instructor group',
     'learning material',
     'competency',
     'mesh term',
-    'session type',
+    'term'
   ]);
 });
 

--- a/tests/integration/components/new-myreport-test.js
+++ b/tests/integration/components/new-myreport-test.js
@@ -16,7 +16,7 @@ moduleForComponent('new-myreport', 'Integration | Component | new myreport', {
 });
 
 test('it renders', function(assert) {
-  assert.expect(29);
+  assert.expect(31);
 
   const mockSchools = [
     {id: 2, title: 'second'},
@@ -54,6 +54,7 @@ test('it renders', function(assert) {
   const eighthSubject = `${subjects}:eq(7)`;
   const ninthSubject = `${subjects}:eq(8)`;
   const tenthSubject = `${subjects}:eq(9)`;
+  const eleventhSubject = `${subjects}:eq(10)`;
 
 
   assert.equal(this.$(title).text(), 'New Report');
@@ -84,8 +85,10 @@ test('it renders', function(assert) {
   assert.equal(this.$(eighthSubject).val(), 'competency');
   assert.equal(this.$(ninthSubject).text().trim(), 'MeSH Terms');
   assert.equal(this.$(ninthSubject).val(), 'mesh term');
-  assert.equal(this.$(tenthSubject).text().trim(), 'Session Types');
-  assert.equal(this.$(tenthSubject).val(), 'session type');
+  assert.equal(this.$(tenthSubject).text().trim(), 'Terms');
+  assert.equal(this.$(tenthSubject).val(), 'term');
+  assert.equal(this.$(eleventhSubject).text().trim(), 'Session Types');
+  assert.equal(this.$(eleventhSubject).val(), 'session type');
 });
 
 let checkObjects = function(context, assert, subjectNum, subjectVal, expectedObjects){
@@ -199,15 +202,30 @@ test('choosing mesh term selects correct objects', function(assert) {
   ]);
 });
 
-test('choosing session type selects correct objects', function(assert) {
-  return checkObjects(this, assert, 9, 'session type', [
+test('choosing term selects correct objects', function(assert) {
+  return checkObjects(this, assert, 9, 'term', [
     'course',
+    'session',
+    'program year',
     'program',
     'instructor',
-    'instructor group',
     'learning material',
     'competency',
     'mesh term',
+  ]);
+});
+
+test('choosing session type selects correct objects', function(assert) {
+  return checkObjects(this, assert, 10, 'session type', [
+    'course',
+    'session',
+    'program year',
+    'program',
+    'instructor',
+    'learning material',
+    'competency',
+    'mesh term',
+    'session type',
   ]);
 });
 


### PR DESCRIPTION
Added learner group and objective to subject list  added term as prepositional object (filter) for course, session, program, program year, session type, learner group, and objective.  Note that there are still issues with learner group and objective, it is not currently possible to filter these by term, an error will result