### PR TITLE
Update ajax headers when we get a new token

### DIFF
--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -11,9 +11,10 @@ export default AjaxService.extend({
 
   host: reads('iliosConfig.apiHost'),
 
-  headers: computed('session.isAuthenticated', function(){
+  headers: computed('session.isAuthenticated', 'session.data.authenticated.jwt', function(){
+    const session = this.get('session');
     let headers = {};
-    this.get('session').authorize('authorizer:token', (headerName, headerValue) => {
+    session.authorize('authorizer:token', (headerName, headerValue) => {
       headers[headerName] = headerValue;
     });
 


### PR DESCRIPTION
The CP which loads the Token into AJAX requests was not depending on the
right properties of the session.  This caused refreshes of the token to
not be reflected in traffic we were sending to the server.

Fixes #2527