### PR TITLE
Lock our version of node-sass to v4.3.0

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 /* global require, module */
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+var nodeSass = require('node-sass'); // loads specific version of node-sass from package.json
 
 module.exports = function(defaults) {
   var env = EmberApp.env() || 'development';
@@ -20,7 +21,7 @@ module.exports = function(defaults) {
 
     tests: env.EMBER_CLI_TEST_COMMAND || !isProductionLikeBuild,
     hinting: env.EMBER_CLI_TEST_COMMAND || !isProductionLikeBuild,
-    emberCliFontAwesome: {
+    'ember-font-awesome': {
       useScss: true
     },
     babel: {
@@ -28,6 +29,10 @@ module.exports = function(defaults) {
     },
     'ember-cli-qunit': {
       useLintTree: false
+    },
+    //fix for #2570
+    sassOptions: {
+      nodeSass: nodeSass
     }
   });
   app.import('bower_components/froala-wysiwyg-editor/js/plugins/lists.min.js');

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "liquid-fire": "0.27.0",
     "liquid-tether": "2.0.3",
     "loader.js": "^4.0.11",
+    "node-sass": "4.3.0",
     "pluralize": "^3.0.0",
     "validator": "^6.0.0"
   },
@@ -111,7 +112,6 @@
     "ignore": [
       "ember-cli-mirage",
       "ember-tether"
-
     ]
   },
   "private": true


### PR DESCRIPTION
v4.4.0 (the latest at this time) breaks our build and has to be worked
around.

Fixes #2570