### PR TITLE
Add ancestry to copied program year objectives

### DIFF
--- a/app/components/programyear-list.js
+++ b/app/components/programyear-list.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
 
-const { Component, computed, inject, ObjectProxy, RSVP, run, isPresent } = Ember;
+const { Component, computed, inject, ObjectProxy, RSVP, run, isPresent, isEmpty } = Ember;
 const { service } = inject;
 const { mapBy, sort } = computed;
 const { hash } = RSVP;
@@ -104,6 +104,10 @@ export default Component.extend({
 
       for (let i = 0; i < objectives.length; i++) {
         let objectiveToCopy = objectives[i];
+        let ancestor = yield objectiveToCopy.get('ancestor');
+        if (isEmpty(ancestor)) {
+          ancestor = objectiveToCopy;
+        }
         let newObjective = store.createRecord(
           'objective',
           objectiveToCopy.getProperties('title')
@@ -111,6 +115,7 @@ export default Component.extend({
         let props = yield hash(objectiveToCopy.getProperties('meshDescriptors', 'competency'));
         newObjective.setProperties(props);
         newObjective.set('programYears', [savedProgramYear]);
+        newObjective.set('ancestor', ancestor);
         yield newObjective.save();
         this.incrementSavedItems();
       }

--- a/app/models/objective.js
+++ b/app/models/objective.js
@@ -30,6 +30,14 @@ export default Model.extend({
     async: true
   }),
   meshDescriptors: hasMany('mesh-descriptor', {async: true}),
+  ancestor: belongsTo('objective', {
+    inverse: 'descendants',
+    async: true
+  }),
+  descendants: hasMany('objective', {
+    inverse: 'ancestor',
+    async: true
+  }),
   hasMultipleParents: gt('parents.length', 1),
   hasParents: gte('parents.length', 1),
   hasMesh: gte('meshDescriptors.length', 1),

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -292,8 +292,16 @@ test('can add a program-year (with pre-existing program-year)', function(assert)
     programYears: [1],
     vocabulary: 1
   });
-  server.createList('objective', 3, {
+  server.create('objective', {
+    descendants: [4]
+  });
+
+  server.createList('objective', 2, {
     programYears: [1]
+  });
+  server.create('objective', {
+    ancestor: 1,
+    programYears: [1],
   });
   server.create('programYearSteward', {
     department: 1,
@@ -315,7 +323,7 @@ test('can add a program-year (with pre-existing program-year)', function(assert)
     directors: [2,3,4],
     competencies: [1,2,3],
     terms: [1,2,3],
-    objectives: [1,2,3],
+    objectives: [2,3,4],
     stewards: [1],
     published: false
   });


### PR DESCRIPTION
This will allow us to pin down the correct program year objective to
link course objectives to when rolling over a course.

Fixes #2623 