### PR TITLE
learner groups and objectives are not included in reports

### DIFF
--- a/app/services/reporting.js
+++ b/app/services/reporting.js
@@ -222,10 +222,4 @@ export default Service.extend({
       });
     });
   },
-  objectivesResults(results){
-    return this.titleResults(results);
-  },
-  learnerGroupsResults(results){
-    return this.titleResults(results);
-  },
 });


### PR DESCRIPTION
removed uncallable code from reporting.js, we aren't reporting on learner groups and objectives.  