### PR TITLE
ability to specify sort order for learning materials

### DIFF
--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -7,7 +7,7 @@ import SortableByPosition from 'ilios/mixins/sortable-by-position';
 const { isEmpty, Component, computed, inject, RSVP, ObjectProxy } = Ember;
 const { notEmpty, or, not } = computed;
 const { service } = inject;
-const { all, Promise, resolve } = RSVP;
+const { all, Promise } = RSVP;
 const { PromiseArray } = DS;
 
 export default Component.extend(SortableByPosition, {

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -200,6 +200,15 @@ export default Component.extend(SortableByPosition, {
       });
     },
 
+    saveSortOrder($learningMaterials){
+      // @todo bulk save learning materials [ST 2017/02/13]
+      this.set('isSorting', false);
+    },
+
+    cancelSorting() {
+      this.set('isSorting', false);
+    },
+
     cancelNewLearningMaterial() {
       this.set('isEditing', false);
     },

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import { translationMacro as t } from "ember-i18n";
 
-const { Component, computed, inject, RSVP, ObjectProxy } = Ember;
+const { isEmpty, Component, computed, inject, RSVP, ObjectProxy } = Ember;
 const { notEmpty, or, not } = computed;
 const { service } = inject;
 const { Promise } = RSVP;
@@ -196,7 +196,10 @@ export default Component.extend({
         lm.save().then((savedLm) => {
           subject.get('learningMaterials').then(learningMaterials => {
             let lmSubject;
-            let position = learningMaterials.length + 1;
+            let position = 0;
+            if (! isEmpty(learningMaterials)) {
+              position = learningMaterials.toArray().sortBy('position').reverse()[0].get('position') + 1;
+            }
             if (isCourse) {
               lmSubject = store.createRecord('course-learning-material', { course: subject, position });
             } else {
@@ -256,7 +259,11 @@ export default Component.extend({
           lmCollectionType = 'sessionLearningMaterials';
         }
         subject.get('learningMaterials').then(learningMaterials => {
-          newLearningMaterial.set('position', learningMaterials.length);
+          let position = 0;
+          if (! isEmpty(learningMaterials)) {
+            position = learningMaterials.toArray().sortBy('position').reverse()[0].get('position') + 1;
+          }
+          newLearningMaterial.set('position', position);
           newLearningMaterial.save().then(savedLearningMaterial => {
             parentLearningMaterial.get(lmCollectionType).then(children => {
               children.pushObject(savedLearningMaterial);

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -30,8 +30,8 @@ export default Component.extend(SortableByPosition, {
   newButtonTitle: t('general.add'),
   bufferMaterial: null,
   bufferTerms: [],
-  currentMaterialsSaved: 0,
-  totalMaterialsToSave: 0,
+  totalMaterialsToSave: null,
+  currentMaterialsSaved: null,
 
   isEditing: false,
   type: null,
@@ -221,8 +221,9 @@ export default Component.extend(SortableByPosition, {
         let lm = learningMaterials[i];
         lm.set('position', i + 1);
       }
-
       this.set('totalMaterialsToSave', learningMaterials.length);
+      this.set('currentMaterialsSaved', 0);
+
       this.saveSomeMaterials(learningMaterials).then(() => {
         this.set('isSaving', false);
         this.set('isSorting', false);

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -58,7 +58,7 @@ export default Component.extend(SortableByPosition, {
       promise: self.get('store').findAll('learning-material-user-role')
     });
   }),
-  proxyMaterials: computed('subject.learningMaterials.[]', function(){
+  proxyMaterials: computed('subject.learningMaterials.@each.{position}', function(){
     return new Promise(resolve => {
       let materialProxy = ObjectProxy.extend({
         sortTerms: ['name'],

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -36,13 +36,14 @@ export default Component.extend(SortableByPosition, {
   isEditing: false,
   type: null,
 
-  displaySearchBox: computed('isManaging', 'isEditing', {
+  displaySearchBox: computed('isManaging', 'isEditing', 'isSorting', {
     get() {
       const isManaging = this.get('isManaging');
       const isEditing = this.get('isEditing');
       const editable = this.get('editable');
+      const isSorting = this.get('isSorting');
 
-      return isManaging ? false : isEditing ? false : editable;
+      return (!isManaging && !isEditing && !isSorting && editable);
     }
   }).readOnly(),
 

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -7,7 +7,7 @@ import SortableByPosition from 'ilios/mixins/sortable-by-position';
 const { isEmpty, Component, computed, inject, RSVP, ObjectProxy } = Ember;
 const { notEmpty, or, not } = computed;
 const { service } = inject;
-const { all, Promise } = RSVP;
+const { all, Promise, resolve } = RSVP;
 const { PromiseArray } = DS;
 
 export default Component.extend(SortableByPosition, {
@@ -93,6 +93,14 @@ export default Component.extend(SortableByPosition, {
     });
     return PromiseArray.create({
       promise: defer.promise
+    });
+  }),
+
+  hasMoreThanOneLearningMaterial: computed('subject.learningMaterials.[]', function() {
+    return new Promise(resolve => {
+      this.get('subject').get('learningMaterials').then(materials => {
+        resolve(materials.length > 1);
+      });
     });
   }),
 

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import { translationMacro as t } from "ember-i18n";
+import SortableByPosition from 'ilios/mixins/sortable-by-position';
+
 
 const { isEmpty, Component, computed, inject, RSVP, ObjectProxy } = Ember;
 const { notEmpty, or, not } = computed;
@@ -8,7 +10,7 @@ const { service } = inject;
 const { Promise } = RSVP;
 const { PromiseArray } = DS;
 
-export default Component.extend({
+export default Component.extend(SortableByPosition, {
   currentUser: service(),
   store: service(),
   i18n: service(),
@@ -61,25 +63,7 @@ export default Component.extend({
         sortedDescriptors: computed.sort('content.meshDescriptors', 'sortTerms')
       });
       this.get('subject').get('learningMaterials').then(materials => {
-        let sortedMaterials = materials.toArray().sort((lm1, lm2) => {
-          let pos1 = lm1.get('position');
-          let pos2 = lm2.get('position');
-          if (pos1 > pos2) {
-            return 1;
-          } else if (pos1 < pos2) {
-            return -1;
-          }
-
-          let id1 = lm1.get('id');
-          let id2 = lm2.get('id');
-          if (id1 > id2) {
-            return -1;
-          } else if (id1 < id2) {
-            return 1;
-          }
-          return 0;
-        });
-
+        let sortedMaterials = materials.toArray().sort(this.get('learningMaterialSortingCallback'));
         resolve(sortedMaterials.map(material => {
           return materialProxy.create({
             content: material

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -266,6 +266,7 @@ export default Component.extend(SortableByPosition, {
           newLearningMaterial = this.get('store').createRecord('course-learning-material', {
             course: subject,
             learningMaterial: parentLearningMaterial,
+            position: 0,
           });
           lmCollectionType = 'courseLearningMaterials';
 
@@ -274,12 +275,13 @@ export default Component.extend(SortableByPosition, {
           newLearningMaterial = this.get('store').createRecord('session-learning-material', {
             session: subject,
             learningMaterial: parentLearningMaterial,
+            position: 0
           });
           lmCollectionType = 'sessionLearningMaterials';
         }
         subject.get('learningMaterials').then(learningMaterials => {
           let position = 0;
-          if (! isEmpty(learningMaterials)) {
+          if (learningMaterials.length > 1) {
             position = learningMaterials.toArray().sortBy('position').reverse()[0].get('position') + 1;
           }
           newLearningMaterial.set('position', position);

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -67,7 +67,7 @@ export default Component.extend(SortableByPosition, {
         sortedDescriptors: computed.sort('content.meshDescriptors', 'sortTerms')
       });
       this.get('subject').get('learningMaterials').then(materials => {
-        let sortedMaterials = materials.toArray().sort(this.get('learningMaterialSortingCallback'));
+        let sortedMaterials = materials.toArray().sort(this.get('positionSortingCallback'));
         resolve(sortedMaterials.map(material => {
           return materialProxy.create({
             content: material

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -17,6 +17,7 @@ export default Component.extend({
   subject: null,
   isCourse: false,
   editable: true,
+  isSorting: false,
   isManaging: or('isManagingMaterial', 'isManagingMesh'),
   isManagingMaterial: notEmpty('managingMaterial'),
   isManagingMesh: notEmpty('meshMaterial'),

--- a/app/components/ilios-event.js
+++ b/app/components/ilios-event.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
+import SortableByPosition from 'ilios/mixins/sortable-by-position';
 
 const { Component, computed, inject, RSVP, isEmpty} = Ember;
 const { notEmpty } = computed;
 const { service } = inject;
 const { Promise, map } = RSVP;
 
-export default Component.extend({
+export default Component.extend(SortableByPosition, {
   store: service(),
   i18n: service(),
   event: null,
@@ -113,7 +114,8 @@ export default Component.extend({
           },
           limit: 1000
         }).then((courseLearningMaterials) => {
-          map(courseLearningMaterials.toArray(), clm => {
+          let sortedMaterials = courseLearningMaterials.toArray().sort(this.get('learningMaterialSortingCallback'));
+          map(sortedMaterials, clm => {
             return new Promise(resolve => {
               clm.get('learningMaterial').then(learningMaterial => {
                 const { required, storedNotes, publicNotes } = clm.getProperties('required', 'notes', 'publicNotes');
@@ -188,7 +190,8 @@ export default Component.extend({
           },
           limit: 1000
         }).then((sessionLearningMaterials) => {
-          map(sessionLearningMaterials.toArray(), slm => {
+          let sortedMaterials = sessionLearningMaterials.toArray().sort(this.get('learningMaterialSortingCallback'));
+          map(sortedMaterials, slm => {
             return new Promise(resolve => {
               slm.get('learningMaterial').then(learningMaterial => {
                 const { required, storedNotes, publicNotes } = slm.getProperties('required', 'notes', 'publicNotes');

--- a/app/components/ilios-event.js
+++ b/app/components/ilios-event.js
@@ -114,7 +114,7 @@ export default Component.extend(SortableByPosition, {
           },
           limit: 1000
         }).then((courseLearningMaterials) => {
-          let sortedMaterials = courseLearningMaterials.toArray().sort(this.get('learningMaterialSortingCallback'));
+          let sortedMaterials = courseLearningMaterials.toArray().sort(this.get('positionSortingCallback'));
           map(sortedMaterials, clm => {
             return new Promise(resolve => {
               clm.get('learningMaterial').then(learningMaterial => {
@@ -190,7 +190,7 @@ export default Component.extend(SortableByPosition, {
           },
           limit: 1000
         }).then((sessionLearningMaterials) => {
-          let sortedMaterials = sessionLearningMaterials.toArray().sort(this.get('learningMaterialSortingCallback'));
+          let sortedMaterials = sessionLearningMaterials.toArray().sort(this.get('positionSortingCallback'));
           map(sortedMaterials, slm => {
             return new Promise(resolve => {
               slm.get('learningMaterial').then(learningMaterial => {

--- a/app/components/learning-materials-sort-manager.js
+++ b/app/components/learning-materials-sort-manager.js
@@ -12,8 +12,11 @@ export default Component.extend(SortableByPosition, {
       this.get('learningMaterials').toArray().sort(this.get('learningMaterialSortingCallback')));
   },
   actions: {
-    sortEndAction(){
-
+    cancel(){
+      this.sendAction('cancel');
+    },
+    save() {
+      this.sendAction('save', this.get('learningMaterials'));
     }
   }
 });

--- a/app/components/learning-materials-sort-manager.js
+++ b/app/components/learning-materials-sort-manager.js
@@ -1,23 +1,31 @@
 import Ember from 'ember';
 import SortableByPosition from 'ilios/mixins/sortable-by-position';
-
+import { task } from 'ember-concurrency';
 
 const { Component } = Ember;
 
 export default Component.extend(SortableByPosition, {
   sortableObjectList: null,
-  learningMaterials: null,
+  subject: null,
+
   didReceiveAttrs() {
     this._super(...arguments);
-    this.set('sortableObjectList',
-      this.get('learningMaterials').toArray().sort(this.get('learningMaterialSortingCallback')));
+    let subject = this.get('subject');
+    this.get('loadAttr').perform(subject);
+
   },
+
+  loadAttr: task(function * (subject) {
+    let learningMaterials = yield subject.get('learningMaterials');
+    this.set('sortableObjectList', learningMaterials.toArray().sort(this.get('learningMaterialSortingCallback')));
+  }),
+
   actions: {
     cancel(){
       this.sendAction('cancel');
     },
     save() {
-      this.sendAction('save', this.get('learningMaterials'));
+      this.sendAction('save', this.get('sortableObjectList'));
     }
   }
 });

--- a/app/components/learning-materials-sort-manager.js
+++ b/app/components/learning-materials-sort-manager.js
@@ -5,6 +5,7 @@ import { task } from 'ember-concurrency';
 const { Component } = Ember;
 
 export default Component.extend(SortableByPosition, {
+  classNames: ['learning-materials-sort-manager'],
   sortableObjectList: null,
   subject: null,
 

--- a/app/components/learning-materials-sort-manager.js
+++ b/app/components/learning-materials-sort-manager.js
@@ -18,7 +18,7 @@ export default Component.extend(SortableByPosition, {
 
   loadAttr: task(function * (subject) {
     let learningMaterials = yield subject.get('learningMaterials');
-    this.set('sortableObjectList', learningMaterials.toArray().sort(this.get('learningMaterialSortingCallback')));
+    this.set('sortableObjectList', learningMaterials.toArray().sort(this.get('positionSortingCallback')));
   }),
 
   actions: {

--- a/app/components/learning-materials-sort-manager.js
+++ b/app/components/learning-materials-sort-manager.js
@@ -1,0 +1,33 @@
+import Ember from 'ember';
+
+const { Component } = Ember;
+
+export default Component.extend({
+  sortableObjectList: null,
+  learningMaterials: null,
+  didReceiveAttrs() {
+    this.set('sortableObjectList', this.get('learningMaterials').toArray().sort((lm1, lm2) => {
+      let pos1 = lm1.get('position');
+      let pos2 = lm2.get('position');
+      if (pos1 > pos2) {
+        return 1;
+      } else if (pos1 < pos2) {
+        return -1;
+      }
+
+      let id1 = lm1.get('id');
+      let id2 = lm2.get('id');
+      if (id1 > id2) {
+        return -1;
+      } else if (id1 < id2) {
+        return 1;
+      }
+      return 0;
+    }));
+  },
+  actions: {
+    sortEndAction(){
+
+    }
+  }
+});

--- a/app/components/learning-materials-sort-manager.js
+++ b/app/components/learning-materials-sort-manager.js
@@ -8,6 +8,7 @@ export default Component.extend(SortableByPosition, {
   sortableObjectList: null,
   learningMaterials: null,
   didReceiveAttrs() {
+    this._super(...arguments);
     this.set('sortableObjectList',
       this.get('learningMaterials').toArray().sort(this.get('learningMaterialSortingCallback')));
   },

--- a/app/components/learning-materials-sort-manager.js
+++ b/app/components/learning-materials-sort-manager.js
@@ -1,29 +1,15 @@
 import Ember from 'ember';
+import SortableByPosition from 'ilios/mixins/sortable-by-position';
+
 
 const { Component } = Ember;
 
-export default Component.extend({
+export default Component.extend(SortableByPosition, {
   sortableObjectList: null,
   learningMaterials: null,
   didReceiveAttrs() {
-    this.set('sortableObjectList', this.get('learningMaterials').toArray().sort((lm1, lm2) => {
-      let pos1 = lm1.get('position');
-      let pos2 = lm2.get('position');
-      if (pos1 > pos2) {
-        return 1;
-      } else if (pos1 < pos2) {
-        return -1;
-      }
-
-      let id1 = lm1.get('id');
-      let id2 = lm2.get('id');
-      if (id1 > id2) {
-        return -1;
-      } else if (id1 < id2) {
-        return 1;
-      }
-      return 0;
-    }));
+    this.set('sortableObjectList',
+      this.get('learningMaterials').toArray().sort(this.get('learningMaterialSortingCallback')));
   },
   actions: {
     sortEndAction(){

--- a/app/components/print-course.js
+++ b/app/components/print-course.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
+import SortableByPosition from 'ilios/mixins/sortable-by-position';
 
 const { Component, computed, RSVP, ObjectProxy, inject } = Ember;
 const { Promise } = RSVP;
 const { service } = inject;
 
-export default Component.extend({
+export default Component.extend(SortableByPosition, {
   store: service(),
   course: null,
   includeUnpublishedSessions: false,
@@ -14,25 +15,6 @@ export default Component.extend({
   sortDirectorsBy: ['lastName', 'firstName'],
   sortedDirectors: computed.sort('course.directors', 'sortDirectorsBy'),
   sortedMeshDescriptors: computed.sort('course.meshDescriptors', 'sortTitle'),
-
-  learningMaterialSortingCallback(lm1, lm2) {
-    let pos1 = lm1.get('position');
-    let pos2 = lm2.get('position');
-    if (pos1 > pos2) {
-      return 1;
-    } else if (pos1 < pos2) {
-      return -1;
-    }
-
-    let id1 = lm1.get('id');
-    let id2 = lm2.get('id');
-    if (id1 > id2) {
-      return -1;
-    } else if (id1 < id2) {
-      return 1;
-    }
-    return 0;
-  },
 
   /**
    * A list of proxied course sessions, sorted by title.

--- a/app/components/print-course.js
+++ b/app/components/print-course.js
@@ -42,7 +42,7 @@ export default Component.extend(SortableByPosition, {
                 session
               }
             }).then(learningMaterials => {
-              resolve(learningMaterials.toArray().sort(this.get('learningMaterialSortingCallback')));
+              resolve(learningMaterials.toArray().sort(this.get('positionSortingCallback')));
             });
           });
         })
@@ -70,7 +70,7 @@ export default Component.extend(SortableByPosition, {
           course
         }
       }).then(learningMaterials => {
-        resolve(learningMaterials.toArray().sort(this.get('learningMaterialSortingCallback')));
+        resolve(learningMaterials.toArray().sort(this.get('positionSortingCallback')));
       });
     });
   })

--- a/app/components/print-course.js
+++ b/app/components/print-course.js
@@ -15,6 +15,25 @@ export default Component.extend({
   sortedDirectors: computed.sort('course.directors', 'sortDirectorsBy'),
   sortedMeshDescriptors: computed.sort('course.meshDescriptors', 'sortTitle'),
 
+  learningMaterialSortingCallback(lm1, lm2) {
+    let pos1 = lm1.get('position');
+    let pos2 = lm2.get('position');
+    if (pos1 > pos2) {
+      return 1;
+    } else if (pos1 < pos2) {
+      return -1;
+    }
+
+    let id1 = lm1.get('id');
+    let id2 = lm2.get('id');
+    if (id1 > id2) {
+      return -1;
+    } else if (id1 < id2) {
+      return 1;
+    }
+    return 0;
+  },
+
   /**
    * A list of proxied course sessions, sorted by title.
    * @property sortedSessionProxies
@@ -34,11 +53,15 @@ export default Component.extend({
         sortTitle: ['title'],
         sortedMeshDescriptors: computed.sort('content.meshDescriptors', 'sortTitle'),
         sessionLearningMaterials: computed('content', function(){
-          let session = this.get('content').get('id');
-          return this.get('store').query('sessionLearningMaterial', {
-            filters: {
-              session
-            }
+          return new Promise(resolve => {
+            let session = this.get('content').get('id');
+            this.get('store').query('sessionLearningMaterial', {
+              filters: {
+                session
+              }
+            }).then(learningMaterials => {
+              resolve(learningMaterials.toArray().sort(this.get('learningMaterialSortingCallback')));
+            });
           });
         })
       });
@@ -58,12 +81,16 @@ export default Component.extend({
   }),
 
   courseLearningMaterials: computed('course', function(){
-    let course = this.get('course').get('id');
-    return this.get('store').query('courseLearningMaterial', {
-      filters: {
-        course
-      }
+    return new Promise(resolve => {
+      let course = this.get('course').get('id');
+      this.get('store').query('courseLearningMaterial', {
+        filters: {
+          course
+        }
+      }).then(learningMaterials => {
+        resolve(learningMaterials.toArray().sort(this.get('learningMaterialSortingCallback')));
+      });
     });
-  }),
+  })
 
 });

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -482,6 +482,7 @@ export default {
     'singleGroup': 'Single Group',
     'smallGroupMessage': "Please select at least one learner group to attach to your small group offering. If you wish to schedule this offering without groups, please select the 'offering' button above.",
     'smallGroups': 'Small Groups',
+    'sortMaterials': 'Sort Materials',
     'specialAttireIsRequired': 'Special Attire is <strong><em>required</em></strong>',
     'specialAttireRequired': 'Special Attire Required',
     'specialEquipmentIsRequired': 'Special Equipment is <strong><em>required</em></strong>',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -367,6 +367,7 @@ export default {
     'other': 'Other',
     'otherId': 'Other ID',
     'overview': 'Overview',
+    'ownedBy': 'owned by {{owner}}',
     'owner': 'Owner',
     'pagedResultsCount': 'Showing {{start}} - {{end}} of {{total}}',
     'parallel': 'Parallel',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -482,6 +482,7 @@ export default {
     'singleGroup': 'Solo grupo',
     'smallGroupMessage': "Por favor seleccione al menos un grupo de alumnos para adjuntar a su ofrecimiento de grupos pequeños. Si usted desea programar este ofrecimiento sin grupos, favor de seleccionar el botón de 'ofrecimiento' de arriba.",
     'smallGroups': 'Grupos Pequeños',
+    'sortMaterials': 'Clasificar los materiales',
     'specialAttireIsRequired': 'Se <strong><em>require</em></strong> vestimenta especial',
     'specialAttireRequired': 'Vestimenta Especial Requerido',
     'specialEquipmentIsRequired': 'Se <strong><em>require</em></strong> equipo especial',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -367,6 +367,7 @@ export default {
     'other': 'Otro',
     'otherId': 'Otro ID',
     'overview': 'Visión Amplia',
+    'ownedBy': 'propiedad de {{owner}}',
     'owner': 'Dueño',
     'pagedResultsCount': 'Mostrando {{start}} - {{end}} de {{total}}',
     'parallel': 'Paralelo',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -482,6 +482,7 @@ export default {
     'singleGroup': 'Seul groupe',
     'smallGroupMessage': "S'il vous plaît choisir au moins un groupe d'apprenants à joindre à votre offrande de 'small groups'. Si vous souhaitez programmer cette offrande sans groupes, s'il vous plaît choisir le bouton 'offre' au-dessus.",
     'smallGroups': "Groupes Particulaires",
+    'sortMaterials': 'Trier les matériaux',
     'specialAttireIsRequired': "Vêtements particuliers est <strong><em>requis</em></strong>",
     'specialAttireRequired': "Vêtements particuliers requis",
     'specialEquipmentIsRequired': "Équipage particulier est <strong><em>requis</em></strong>",

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -367,6 +367,7 @@ export default {
     'other': "Autre",
     'otherId': 'Autre ID',
     'overview': "Conception Général",
+    'ownedBy': 'Possédé par {{owner}}',
     'owner': "Propriétaire",
     'pagedResultsCount': 'Montrant {{start}} - {{end}} de {{total}}',
     'parallel': 'Parallèle',

--- a/app/mixins/sortable-by-position.js
+++ b/app/mixins/sortable-by-position.js
@@ -6,13 +6,14 @@ export default Mixin.create({
 
   /**
    * Callback function for <code>Array.sort()<code>.
+   * Compares two given Objects by their position property (in ascending order), and then by id (descending).
    *
-   * @method learningMaterialSortingCallback
+   * @method positionSortingCallback
    * @param {Ember.Object} obj1
    * @param {Ember.Object} obj2
    * @return {Number}
    */
-  learningMaterialSortingCallback(obj1, obj2) {
+  positionSortingCallback(obj1, obj2) {
     let pos1 = obj1.get('position');
     let pos2 = obj2.get('position');
     // 1. position, asc

--- a/app/mixins/sortable-by-position.js
+++ b/app/mixins/sortable-by-position.js
@@ -1,0 +1,35 @@
+import Ember from 'ember';
+
+const { Mixin } = Ember;
+
+export default Mixin.create({
+
+  /**
+   * Callback function for <code>Array.sort()<code>.
+   *
+   * @method learningMaterialSortingCallback
+   * @param {Ember.Object} obj1
+   * @param {Ember.Object} obj2
+   * @return {Number}
+   */
+  learningMaterialSortingCallback(obj1, obj2) {
+    let pos1 = obj1.get('position');
+    let pos2 = obj2.get('position');
+    // 1. position, asc
+    if (pos1 > pos2) {
+      return 1;
+    } else if (pos1 < pos2) {
+      return -1;
+    }
+
+    // 2. id, desc
+    let id1 = obj1.get('id');
+    let id2 = obj2.get('id');
+    if (id1 > id2) {
+      return -1;
+    } else if (id1 < id2) {
+      return 1;
+    }
+    return 0;
+  },
+});

--- a/app/models/course-learning-material.js
+++ b/app/models/course-learning-material.js
@@ -8,5 +8,6 @@ export default Model.extend({
   publicNotes: attr('boolean', { defaultValue: true }),
   course: belongsTo('course', { async: true }),
   learningMaterial: belongsTo('learning-material', { async: true }),
-  meshDescriptors: hasMany('mesh-descriptors', { async: true })
+  meshDescriptors: hasMany('mesh-descriptors', { async: true }),
+  position: attr('number')
 });

--- a/app/models/session-learning-material.js
+++ b/app/models/session-learning-material.js
@@ -8,5 +8,6 @@ export default Model.extend({
   publicNotes: attr('boolean', { defaultValue: true }),
   session: belongsTo('session', { async: true }),
   learningMaterial: belongsTo('learning-material', { async: true }),
-  meshDescriptors: hasMany('mesh-descriptors', { async: true })
+  meshDescriptors: hasMany('mesh-descriptors', { async: true }),
+  position: attr('number')
 });

--- a/app/styles/newcomponents.scss
+++ b/app/styles/newcomponents.scss
@@ -82,3 +82,4 @@
 @import 'newcomponents/programyear-details';
 @import 'newcomponents/school-session-attributes-collapsed';
 @import 'newcomponents/school-session-attributes-expanded';
+@import 'newcomponents/learning-materials-sort-manager';

--- a/app/styles/newcomponents/learning-materials-sort-manager.scss
+++ b/app/styles/newcomponents/learning-materials-sort-manager.scss
@@ -1,0 +1,3 @@
+.learning-materials-sort-manager {
+
+}

--- a/app/styles/newcomponents/learning-materials-sort-manager.scss
+++ b/app/styles/newcomponents/learning-materials-sort-manager.scss
@@ -20,9 +20,29 @@
     @include fill-parent;
     background-color: $header-grey;
     border-radius: 4px;
+    cursor: pointer;
     margin-right: .3em;
     margin-top: 10px;
     padding: .2em .4em .2em .6em;
     vertical-align: middle;
+
+    .fa {
+      vertical-align: top;
+    }
+  }
+
+  .draggable-object-content {
+    display: inline-block;
+
+    .details {
+      font-size: smaller;
+    }
+
+    .title {
+      @include fill-parent;
+      display: inline-block;
+    }
   }
 }
+
+

--- a/app/styles/newcomponents/learning-materials-sort-manager.scss
+++ b/app/styles/newcomponents/learning-materials-sort-manager.scss
@@ -12,9 +12,10 @@
   }
 
   .content {
-    clear:both;
-    padding: 0.5em 0 0 0;
+    clear: both;
+    padding-top: .5em;
   }
+
   .draggable-object {
     @include fill-parent;
     background-color: $header-grey;

--- a/app/styles/newcomponents/learning-materials-sort-manager.scss
+++ b/app/styles/newcomponents/learning-materials-sort-manager.scss
@@ -1,3 +1,27 @@
 .learning-materials-sort-manager {
+  .actions {
+    @include fill-parent;
+    vertical-align: middle;
 
+    @include media($large-screen) {
+      @include span-columns(2 of 12);
+      @include omega();
+      @include shift(10);
+      text-align: right;
+    }
+  }
+
+  .content {
+    clear:both;
+    padding: 0.5em 0 0 0;
+  }
+  .draggable-object {
+    @include fill-parent;
+    background-color: $header-grey;
+    border-radius: 4px;
+    margin-right: .3em;
+    margin-top: 10px;
+    padding: .2em .4em .2em .6em;
+    vertical-align: middle;
+  }
 }

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -75,8 +75,9 @@
     {{/liquid-if}}
 
     {{#if (get (await proxyMaterials) 'length')}}
-      <button {{action (mut isSorting) true}}>{{t 'general.sortMaterials'}}</button>
-
+      {{#if (and editable (await hasMoreThanOneLearningMaterial))}}
+          <button {{action (mut isSorting) true}}>{{t 'general.sortMaterials'}}</button>
+      {{/if}}
       <table>
         <thead>
           <tr>

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -1,6 +1,6 @@
 <div class='title'>
   {{#unless isManaging}}
-    {{t 'general.learningMaterials'}} ({{proxyMaterials.length}})
+    {{t 'general.learningMaterials'}} ({{get (await proxyMaterials) 'length'}})
   {{/unless}}
   {{#if isManagingMaterial}}
     <span class='specific-title'>
@@ -68,7 +68,7 @@
         cancel=(action 'cancelNewLearningMaterial')}}
     {{/liquid-if}}
 
-    {{#if proxyMaterials.length}}
+    {{#if (get (await proxyMaterials) 'length')}}
       <table>
         <thead>
           <tr>
@@ -83,7 +83,7 @@
           </tr>
         </thead>
         <tbody>
-          {{#each proxyMaterials as |lmProxy|}}
+          {{#each (await proxyMaterials) as |lmProxy|}}
             <tr class="{{if lmProxy.showRemoveConfirmation 'confirm-removal'}}">
               <td class='text-left clickable link' colspan=3 {{action 'manageMaterial' lmProxy.content}}>
                 {{fa-icon 'external-link-square'}} {{lmProxy.learningMaterial.title}}

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -59,7 +59,7 @@
       }}
     {{/if}}
   {{else if isSorting}}
-      {{learning-materials-sort-manager learningMaterials=subject.learningMaterials}}
+      {{learning-materials-sort-manager save=(action 'saveSortOrder') cancel=(action 'cancelSorting') learningMaterials=subject.learningMaterials}}
   {{else}}
     {{#liquid-if isEditing class="vertical"}}
       {{new-learningmaterial

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -75,7 +75,7 @@
     {{/liquid-if}}
 
     {{#if (get (await proxyMaterials) 'length')}}
-      <button {{action (mut isSorting) true}}>Sort Materials</button>
+      <button {{action (mut isSorting) true}}>{{t 'general.sortMaterials'}}</button>
 
       <table>
         <thead>

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -25,7 +25,7 @@
   {{else}}
     {{#if isEditing}}
       <button class="collapse-button" {{action 'cancelNewLearningMaterial'}}>{{fa-icon 'minus'}}</button>
-    {{else if editable}}
+    {{else if (and editable (not isSorting))}}
       {{#action-menu title=newButtonTitle icon=false classNames='blend-button right-edge'}}
         <li {{action 'addNewLearningMaterial' 'file'}}>{{t 'general.file'}}</li>
         <li {{action 'addNewLearningMaterial' 'link'}}>{{t 'general.link'}}</li>

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -76,7 +76,7 @@
 
     {{#if (get (await proxyMaterials) 'length')}}
       {{#if (and editable (await hasMoreThanOneLearningMaterial))}}
-          <button {{action (mut isSorting) true}}>{{t 'general.sortMaterials'}}</button>
+        <button {{action (mut isSorting) true}}>{{t 'general.sortMaterials'}}</button>
       {{/if}}
       <table>
         <thead>

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -58,6 +58,8 @@
         targetItemTitle=meshMaterial.learningMaterial.title
       }}
     {{/if}}
+  {{else if isSorting}}
+      {{learning-materials-sort-manager learningMaterials=subject.learningMaterials}}
   {{else}}
     {{#liquid-if isEditing class="vertical"}}
       {{new-learningmaterial
@@ -69,6 +71,8 @@
     {{/liquid-if}}
 
     {{#if (get (await proxyMaterials) 'length')}}
+      <button {{action (mut isSorting) true}}>Sort Materials</button>
+
       <table>
         <thead>
           <tr>

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -59,7 +59,11 @@
       }}
     {{/if}}
   {{else if isSorting}}
-      {{learning-materials-sort-manager save=(action 'saveSortOrder') cancel=(action 'cancelSorting') learningMaterials=subject.learningMaterials}}
+      {{learning-materials-sort-manager
+        save=(action 'saveSortOrder')
+        cancel=(action 'cancelSorting')
+        subject=subject
+      }}
   {{else}}
     {{#liquid-if isEditing class="vertical"}}
       {{new-learningmaterial
@@ -159,3 +163,11 @@
     {{/if}}
   {{/if}}
 </div>
+{{#liquid-if isSaving class='crossFade'}}
+  {{wait-saving
+    showProgress=true
+    totalProgress=totalMaterialsToSave
+    currentProgress=currentMaterialsSaved
+  }}
+{{/liquid-if}}
+

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -76,7 +76,7 @@
 
     {{#if (get (await proxyMaterials) 'length')}}
       {{#if (and editable (await hasMoreThanOneLearningMaterial))}}
-        <button {{action (mut isSorting) true}}>{{t 'general.sortMaterials'}}</button>
+        <button class="sort-materials-btn" {{action (mut isSorting) true}}>{{t 'general.sortMaterials'}}</button>
       {{/if}}
       <table>
         <thead>

--- a/app/templates/components/detail-learning-materials.hbs
+++ b/app/templates/components/detail-learning-materials.hbs
@@ -59,11 +59,11 @@
       }}
     {{/if}}
   {{else if isSorting}}
-      {{learning-materials-sort-manager
-        save=(action 'saveSortOrder')
-        cancel=(action 'cancelSorting')
-        subject=subject
-      }}
+    {{learning-materials-sort-manager
+      save=(action 'saveSortOrder')
+      cancel=(action 'cancelSorting')
+      subject=subject
+    }}
   {{else}}
     {{#liquid-if isEditing class="vertical"}}
       {{new-learningmaterial

--- a/app/templates/components/learning-materials-sort-manager.hbs
+++ b/app/templates/components/learning-materials-sort-manager.hbs
@@ -12,7 +12,7 @@
     }}
       {{#each sortableObjectList as |item|}}
         {{#draggable-object content=item isSortable=true sortingScope="sortingGroup"}}
-          <strong>::</strong> {{item.learningMaterial.title}}
+          <strong>::</strong> {{get (await item.learningMaterial) 'title'}}
         {{/draggable-object}}
       {{/each}}
     {{/sortable-objects}}

--- a/app/templates/components/learning-materials-sort-manager.hbs
+++ b/app/templates/components/learning-materials-sort-manager.hbs
@@ -1,9 +1,11 @@
-<button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
-<button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
-{{#sortable-objects sortableObjectList=sortableObjectList enableSort=true useSwap=true sortingScope="sortingGroup"}}
-  {{#each sortableObjectList as |item|}}
-    {{#draggable-object content=item isSortable=true sortingScope="sortingGroup"}}
-      {{item.learningMaterial.title}}
-    {{/draggable-object}}
-  {{/each}}
-{{/sortable-objects}}
+{{#unless loadAttr.isRunning}}
+  <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
+  <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
+  {{#sortable-objects sortableObjectList=sortableObjectList enableSort=true useSwap=true sortingScope="sortingGroup"}}
+    {{#each sortableObjectList as |item|}}
+      {{#draggable-object content=item isSortable=true sortingScope="sortingGroup"}}
+        {{item.learningMaterial.title}}
+      {{/draggable-object}}
+    {{/each}}
+  {{/sortable-objects}}
+{{/unless}}

--- a/app/templates/components/learning-materials-sort-manager.hbs
+++ b/app/templates/components/learning-materials-sort-manager.hbs
@@ -1,4 +1,6 @@
-{{#sortable-objects sortableObjectList=sortableObjectList sortEndAction='sortEndAction' enableSort=true useSwap=true sortingScope="sortingGroup"}}
+<button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
+<button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
+{{#sortable-objects sortableObjectList=sortableObjectList enableSort=true useSwap=true sortingScope="sortingGroup"}}
   {{#each sortableObjectList as |item|}}
     {{#draggable-object content=item isSortable=true sortingScope="sortingGroup"}}
       {{item.learningMaterial.title}}

--- a/app/templates/components/learning-materials-sort-manager.hbs
+++ b/app/templates/components/learning-materials-sort-manager.hbs
@@ -1,0 +1,7 @@
+{{#sortable-objects sortableObjectList=sortableObjectList sortEndAction='sortEndAction' enableSort=true useSwap=true sortingScope="sortingGroup"}}
+  {{#each sortableObjectList as |item|}}
+    {{#draggable-object content=item isSortable=true sortingScope="sortingGroup"}}
+      {{item.learningMaterial.title}}
+    {{/draggable-object}}
+  {{/each}}
+{{/sortable-objects}}

--- a/app/templates/components/learning-materials-sort-manager.hbs
+++ b/app/templates/components/learning-materials-sort-manager.hbs
@@ -11,8 +11,20 @@
       sortingScope="sortingGroup"
     }}
       {{#each sortableObjectList as |item|}}
-        {{#draggable-object content=item isSortable=true sortingScope="sortingGroup"}}
-          <strong>::</strong> {{get (await item.learningMaterial) 'title'}}
+        {{#draggable-object
+          content=item
+          isSortable=true
+          sortingScope="sortingGroup"
+        }}
+          {{fa-icon 'arrows'}}
+          <span class="draggable-object-content">
+            <span class="title">{{get (await item.learningMaterial) 'title'}}</span>
+            <span class="details">
+              {{capitalize (get (await item.learningMaterial) 'type')}},
+              {{t 'general.ownedBy' owner=(get (await item.learningMaterial.owningUser) 'fullName')}},
+              {{t 'general.status'}}: {{get (await item.learningMaterial.status) 'title'}}
+            </span>
+          </span>
         {{/draggable-object}}
       {{/each}}
     {{/sortable-objects}}

--- a/app/templates/components/learning-materials-sort-manager.hbs
+++ b/app/templates/components/learning-materials-sort-manager.hbs
@@ -1,11 +1,20 @@
 {{#unless loadAttr.isRunning}}
-  <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
-  <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
-  {{#sortable-objects sortableObjectList=sortableObjectList enableSort=true useSwap=true sortingScope="sortingGroup"}}
-    {{#each sortableObjectList as |item|}}
-      {{#draggable-object content=item isSortable=true sortingScope="sortingGroup"}}
-        {{item.learningMaterial.title}}
-      {{/draggable-object}}
-    {{/each}}
-  {{/sortable-objects}}
+  <div class="actions">
+    <button class='bigadd' {{action 'save'}}>{{fa-icon 'check'}}</button>
+    <button class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
+  </div>
+  <div class="content">
+    {{#sortable-objects
+      sortableObjectList=sortableObjectList
+      enableSort=true
+      useSwap=true
+      sortingScope="sortingGroup"
+    }}
+      {{#each sortableObjectList as |item|}}
+        {{#draggable-object content=item isSortable=true sortingScope="sortingGroup"}}
+          <strong>::</strong> {{item.learningMaterial.title}}
+        {{/draggable-object}}
+      {{/each}}
+    {{/sortable-objects}}
+  </div>
 {{/unless}}

--- a/app/templates/components/learning-materials-sort-manager.hbs
+++ b/app/templates/components/learning-materials-sort-manager.hbs
@@ -20,9 +20,9 @@
           <span class="draggable-object-content">
             <span class="title">{{get (await item.learningMaterial) 'title'}}</span>
             <span class="details">
-              {{capitalize (get (await item.learningMaterial) 'type')}},
-              {{t 'general.ownedBy' owner=(get (await item.learningMaterial.owningUser) 'fullName')}},
-              {{t 'general.status'}}: {{get (await item.learningMaterial.status) 'title'}}
+              {{capitalize item.learningMaterial.type}},
+              {{t 'general.ownedBy' owner=item.learningMaterial.owningUser.fullName}},
+              {{t 'general.status'}}: {{item.learningMaterial.status.title}}
             </span>
           </span>
         {{/draggable-object}}

--- a/app/templates/components/print-course.hbs
+++ b/app/templates/components/print-course.hbs
@@ -102,10 +102,10 @@
 
       <section class='detail-block'>
         <div class='detail-title'>
-          {{t 'general.learningMaterials'}} ({{courseLearningMaterials.length}})
+          {{t 'general.learningMaterials'}} ({{get (await courseLearningMaterials) 'length'}})
         </div>
         <div class='detail-content'>
-          {{#if courseLearningMaterials.length}}
+          {{#if (get (await courseLearningMaterials) 'length')}}
             <table>
               <thead>
                 <tr>
@@ -117,7 +117,7 @@
                 </tr>
               </thead>
               <tbody>
-                {{#each courseLearningMaterials as |lm|}}
+                {{#each (await courseLearningMaterials) as |lm|}}
                   <tr>
                     <td class='text-left text-top' colspan=2>
                       {{lm.learningMaterial.title}}
@@ -218,10 +218,10 @@
 
       <section class='detail-block'>
         <div class='detail-title'>
-          {{t 'general.learningMaterials'}}({{session.sessionLearningMaterials.length}})
+          {{t 'general.learningMaterials'}}({{get (await session.sessionLearningMaterials) 'length'}})
         </div>
         <div class='detail-content'>
-          {{#if session.sessionLearningMaterials.length}}
+          {{#if (get (await session.sessionLearningMaterials) 'length')}}
             <table>
               <thead>
                 <tr>
@@ -233,7 +233,7 @@
                 </tr>
               </thead>
               <tbody>
-                {{#each session.sessionLearningMaterials as |lm|}}
+                {{#each (await session.sessionLearningMaterials) as |lm|}}
                   <tr>
                     <td class='text-left text-top' colspan=2>
                       {{lm.learningMaterial.title}}

--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v1.14';
+module.exports = 'v1.15';

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ember-cp-validations": "3.2.3",
     "ember-cryptojs-shim": "^2.0.0",
     "ember-data": "^2.11.0",
+    "ember-drag-drop": "0.4.2",
     "ember-exam": "0.6.0",
     "ember-export-application-global": "^1.0.5",
     "ember-font-awesome": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-cli-server-variables": "2.0.2",
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
+    "ember-cli-string-helpers": "1.0.0",
     "ember-cli-template-lint": "0.5.2",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -88,21 +88,25 @@ module('Acceptance: Course - Learning Materials', {
       learningMaterial: 1,
       course: 1,
       required: false,
-      meshDescriptors: [2,3]
+      meshDescriptors: [2,3],
+      position: 0,
     }));
     fixtures.courseLearningMaterials.pushObject(server.create('courseLearningMaterial',{
       learningMaterial: 2,
       course: 1,
       required: false,
+      position: 1,
     }));
     fixtures.courseLearningMaterials.pushObject(server.create('courseLearningMaterial',{
       learningMaterial: 3,
       course: 1,
       publicNotes: false,
+      position: 2,
     }));
     fixtures.courseLearningMaterials.pushObject(server.create('courseLearningMaterial',{
       learningMaterial: 4,
       course: 1,
+      position: 3,
     }));
 
     fixtures.course = server.create('course', {

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -96,21 +96,25 @@ module('Acceptance: Session - Learning Materials', {
       learningMaterial: 1,
       session: 1,
       required: false,
-      meshDescriptors: [2,3]
+      meshDescriptors: [2,3],
+      position: 0,
     }));
     fixtures.sessionLearningMaterials.pushObject(server.create('sessionLearningMaterial',{
       learningMaterial: 2,
       session: 1,
       required: false,
+      position: 1,
     }));
     fixtures.sessionLearningMaterials.pushObject(server.create('sessionLearningMaterial',{
       learningMaterial: 3,
       session: 1,
       publicNotes: false,
+      position: 2,
     }));
     fixtures.sessionLearningMaterials.pushObject(server.create('sessionLearningMaterial',{
       learningMaterial: 4,
       session: 1,
+      position: 3,
     }));
 
     fixtures.session = server.create('session', {

--- a/tests/integration/components/detail-learning-materials-test.js
+++ b/tests/integration/components/detail-learning-materials-test.js
@@ -1,0 +1,197 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+import wait from 'ember-test-helpers/wait';
+
+const { Object, RSVP } = Ember;
+const { resolve } = RSVP;
+
+moduleForComponent('detail-learning-materials', 'Integration | Component | detail learning materials', {
+  integration: true
+});
+
+test('sort button visible when lm list has 2+ items and editing is allowed', function(assert){
+  assert.expect(1);
+
+  let clm1 = Object.create({
+    id: 1,
+    learningMaterial: resolve(Object.create({
+      id: 1,
+    }))
+  });
+
+  let clm2 = Object.create({
+    id: 2,
+    learningMaterial: resolve(Object.create({
+      id: 2,
+    }))
+  });
+  let clms = [ clm1, clm2 ];
+
+  let subject = Object.create({
+    id: 1,
+    learningMaterials: resolve(clms)
+  });
+
+  this.set('subject', subject);
+
+  this.render(hbs`{{detail-learning-materials subject=subject isCourse=true editable=true}}`);
+
+  return wait().then(() => {
+    assert.equal(this.$('.sort-materials-btn').length, 1);
+  });
+});
+
+test('sort button not visible when in read-only mode', function(assert){
+  assert.expect(1);
+
+  let lm1 = Object.create({
+    id: 1,
+  });
+
+  let lm2 = Object.create({
+    id: 2,
+  });
+  let lms = [ lm1, lm2 ];
+
+  let subject = Object.create({
+    id: 1,
+    learningMaterials: resolve(lms)
+  });
+
+  this.set('subject', subject);
+
+  this.render(hbs`{{detail-learning-materials subject=subject isCourse=true editable=false }}`);
+
+  return wait().then(() => {
+    assert.equal(this.$('.sort-materials-btn').length, 0);
+  });
+});
+
+test('sort button not visible when lm list is empty', function(assert){
+  assert.expect(1);
+
+  let subject = Object.create({
+    id: 1,
+    learningMaterials: resolve([])
+  });
+
+  this.set('subject', subject);
+
+  this.render(hbs`{{detail-learning-materials subject=subject isCourse=true editable=true}}`);
+
+  return wait().then(() => {
+    assert.equal(this.$('.sort-materials-btn').length, 0);
+  });
+});
+
+test('sort button not visible when lm list only contains one item', function(assert){
+  let clm1 = Object.create({
+    id: 1,
+    learningMaterial: resolve(Object.create({
+      id: 1,
+    }))
+  });
+
+  let clms = [ clm1 ];
+
+  let subject = Object.create({
+    id: 1,
+    learningMaterials: resolve(clms)
+  });
+
+  this.set('subject', subject);
+
+  this.render(hbs`{{detail-learning-materials subject=subject isCourse=true editable=true}}`);
+
+  return wait().then(() => {
+    assert.equal(this.$('.sort-materials-btn').length, 0);
+  });
+});
+
+test('click sort button, then cancel', function(assert){
+  assert.expect(6);
+
+  let clm1 = Object.create({
+    id: 1,
+    learningMaterial: resolve(Object.create({
+      id: 1,
+    }))
+  });
+
+  let clm2 = Object.create({
+    id: 2,
+    learningMaterial: resolve(Object.create({
+      id: 2,
+    }))
+  });
+  let clms = [ clm1, clm2 ];
+
+  let subject = Object.create({
+    id: 1,
+    learningMaterials: resolve(clms)
+  });
+
+  this.set('subject', subject);
+
+  this.render(hbs`{{detail-learning-materials subject=subject isCourse=true editable=true}}`);
+
+  return wait().then(() => {
+    assert.equal(this.$('.sort-materials-btn').length, 1, 'Sort materials button is visible');
+    assert.equal(this.$('.learning-materials-sort-manager').length, 0, 'LM sort manager is not visible');
+
+    this.$('.sort-materials-btn').click();
+    return wait().then(() => {
+      assert.equal(this.$('.sort-materials-btn').length, 0, 'Sort materials button is not visible');
+      assert.equal(this.$('.learning-materials-sort-manager').length, 1, 'LM sort manager is visible');
+      this.$('.learning-materials-sort-manager .bigcancel').click();
+      return wait().then(() => {
+        assert.equal(this.$('.sort-materials-btn').length, 1, 'Sort materials button is visible again');
+        assert.equal(this.$('.learning-materials-sort-manager').length, 0, 'LM sort manager is not visible again');
+      });
+    });
+  });
+});
+
+test('click sort button, then save', function(assert){
+  assert.expect(2);
+
+  let clm1 = Object.create({
+    id: 1,
+    learningMaterial: resolve(Object.create({
+      id: 1,
+    })),
+    save() {
+      assert.ok(true, 'Save() method was invoked');
+      resolve(this);
+    }
+  });
+
+  let clm2 = Object.create({
+    id: 2,
+    learningMaterial: resolve(Object.create({
+      id: 2,
+    })),
+    save() {
+      assert.ok(true, 'Save() method was invoked');
+      resolve(this);
+    }
+  });
+  let clms = [ clm1, clm2 ];
+
+  let subject = Object.create({
+    id: 1,
+    learningMaterials: resolve(clms)
+  });
+
+  this.set('subject', subject);
+
+  this.render(hbs`{{detail-learning-materials subject=subject isCourse=true editable=true}}`);
+
+  return wait().then(() => {
+    this.$('.sort-materials-btn').click();
+    return wait().then(() => {
+      this.$('.learning-materials-sort-manager .bigadd').click();
+    });
+  });
+});

--- a/tests/integration/components/learning-materials-sort-manager-test.js
+++ b/tests/integration/components/learning-materials-sort-manager-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('learning-materials-sort-manager', 'Integration | Component | learning materials sort manager', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{learning-materials-sort-manager}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#learning-materials-sort-manager}}
+      template block text
+    {{/learning-materials-sort-manager}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/learning-materials-sort-manager-test.js
+++ b/tests/integration/components/learning-materials-sort-manager-test.js
@@ -1,25 +1,135 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+import { moduleForComponent } from 'ember-qunit';
+import { test, skip } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
+import tHelper from "ember-i18n/helper";
+const { Object, RSVP } = Ember;
+const { resolve } = RSVP;
 
 moduleForComponent('learning-materials-sort-manager', 'Integration | Component | learning materials sort manager', {
-  integration: true
+
+  integration: true,
+
+  beforeEach: function () {
+    this.container.lookup('service:i18n').set('locale', 'en');
+    this.registry.register('helper:t', tHelper);
+  }
 });
 
 test('it renders', function(assert) {
+  assert.expect(5);
 
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  let lm1 = Object.create({
+    title: 'Lorem Ipsum'
+  });
 
-  this.render(hbs`{{learning-materials-sort-manager}}`);
+  let lm2 = Object.create({
+    title: 'Baba Booey'
+  });
 
-  assert.equal(this.$().text().trim(), '');
+  let clm1 = Object.create({
+    id: 1,
+    learningMaterial: resolve(lm1),
+    position: 1,
+  });
 
-  // Template block usage:
-  this.render(hbs`
-    {{#learning-materials-sort-manager}}
-      template block text
-    {{/learning-materials-sort-manager}}
-  `);
+  let clm2 = Object.create({
+    id: 2,
+    learningMaterial: resolve(lm2),
+    position: 0,
+  });
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  let clms = [ clm1, clm2 ];
+
+  let subject = Object.create({
+    learningMaterials: resolve(clms)
+  });
+
+  this.set('subject', subject);
+
+  this.render(hbs`{{learning-materials-sort-manager subject=subject}}`);
+
+  return wait().then(() => {
+    assert.equal(this.$('.draggable-object').length, 2);
+    assert.equal(this.$('.draggable-object:eq(0)').text().trim(), ':: ' + lm2.get('title'));
+    assert.equal(this.$('.draggable-object:eq(1)').text().trim(), ':: ' + lm1.get('title'));
+    assert.equal(this.$('.actions .bigadd').length, 1);
+    assert.equal(this.$('.actions .bigcancel').length, 1);
+  });
+});
+
+test('cancel', function(assert) {
+  assert.expect(1);
+  let subject = Object.create({
+    learningMaterials: resolve([
+      Object.create({
+        id: 1,
+        position: 1,
+        learningMaterial: resolve(Object.create({
+          title: 'First'
+        }))
+      }),
+      Object.create({
+        id: 2,
+        position: 2,
+        learningMaterial: resolve(Object.create({
+          title: 'Second'
+        }))
+      })
+    ]),
+  });
+  this.set('subject', subject);
+  this.on('cancel', function(){
+    assert.ok(true, 'Cancel action was invoked correctly.');
+  });
+
+  this.render(hbs`{{learning-materials-sort-manager subject=subject cancel=(action 'cancel')}}`);
+
+  return wait().then(() => {
+    this.$('.actions .bigcancel').click();
+  });
+});
+
+test('save', function(assert) {
+  assert.expect(3);
+
+  let clm1 = Object.create({
+    id: 1,
+    position: 1,
+    learningMaterial: resolve(Object.create({
+      title: 'First'
+    }))
+  });
+
+  let clm2 = Object.create({
+    id: 2,
+    position: 2,
+    learningMaterial: resolve(Object.create({
+      title: 'Second'
+    }))
+  });
+
+  let clms = [ clm1, clm2 ];
+
+  let subject = Object.create({
+    learningMaterials: resolve(clms),
+  });
+  this.set('subject', subject);
+  this.on('save', function(data){
+    assert.equal(data.length, clms.length);
+    assert.ok(data.contains(clm1));
+    assert.ok(data.contains(clm2));
+  });
+
+  this.render(hbs`{{learning-materials-sort-manager subject=subject save=(action 'save')}}`);
+
+  return wait().then(() => {
+    this.$('.actions .bigadd').click();
+  });
+});
+
+skip('reorder and save', function(assert) {
+  assert.ok(false);
+  // @todo figure out how to simulate drag and drop and implement this test [ST 2017/02/13]
 });

--- a/tests/integration/components/learning-materials-sort-manager-test.js
+++ b/tests/integration/components/learning-materials-sort-manager-test.js
@@ -18,25 +18,51 @@ moduleForComponent('learning-materials-sort-manager', 'Integration | Component |
 });
 
 test('it renders', function(assert) {
-  assert.expect(5);
+  assert.expect(7);
+
+  let owner1 = Object.create({
+    id: 1,
+    fullName: 'Hans Wurst'
+  });
+
+  let owner2 = Object.create({
+    id: 2,
+    fullName: 'Hans Dampf'
+  });
+
+  let status1 = Object.create({
+    id: 1,
+    title: 'Done and done'
+  });
+
+  let status2 = Object.create({
+    id: 2,
+    title: 'Draft'
+  });
 
   let lm1 = Object.create({
-    title: 'Lorem Ipsum'
+    title: 'Lorem Ipsum',
+    status: status1,
+    owningUser: owner1,
+    type: 'file'
   });
 
   let lm2 = Object.create({
-    title: 'Baba Booey'
+    title: 'Foo Bar',
+    status: status2,
+    owningUser: owner2,
+    type: 'citation'
   });
 
   let clm1 = Object.create({
     id: 1,
-    learningMaterial: resolve(lm1),
+    learningMaterial: lm1,
     position: 1,
   });
 
   let clm2 = Object.create({
     id: 2,
-    learningMaterial: resolve(lm2),
+    learningMaterial: lm2,
     position: 0,
   });
 
@@ -52,8 +78,17 @@ test('it renders', function(assert) {
 
   return wait().then(() => {
     assert.equal(this.$('.draggable-object').length, 2);
-    assert.equal(this.$('.draggable-object:eq(0)').text().trim(), ':: ' + lm2.get('title'));
-    assert.equal(this.$('.draggable-object:eq(1)').text().trim(), ':: ' + lm1.get('title'));
+    assert.equal(this.$('.draggable-object:eq(0) .title').text().trim(), lm2.get('title'));
+    assert.equal(
+      this.$('.draggable-object:eq(0) .details').text().replace(/[\s\n\t]+/g, ''),
+      `${lm2.type.capitalize()}, owned by ${owner2.fullName}, Status: ${status2.title}`.replace(/[\s\n\t]+/g, '')
+    );
+
+    assert.equal(this.$('.draggable-object:eq(1) .title').text().trim(), lm1.get('title'));
+    assert.equal(
+      this.$('.draggable-object:eq(1) .details').text().replace(/[\s\n\t]+/g, ''),
+      `${lm1.type.capitalize()}, owned by ${owner1.fullName}, Status: ${status1.title}`.replace(/[\s\n\t]+/g, '')
+    );
     assert.equal(this.$('.actions .bigadd').length, 1);
     assert.equal(this.$('.actions .bigcancel').length, 1);
   });

--- a/tests/unit/mixins/sortable-by-position-test.js
+++ b/tests/unit/mixins/sortable-by-position-test.js
@@ -1,12 +1,39 @@
 import Ember from 'ember';
 import SortableByPositionMixin from 'ilios/mixins/sortable-by-position';
 import { module, test } from 'qunit';
+const { Object } = Ember;
 
 module('Unit | Mixin | sortable by position');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
-  let SortableByPositionObject = Ember.Object.extend(SortableByPositionMixin);
-  let subject = SortableByPositionObject.create();
-  assert.ok(subject);
+test('learning materials sorting callback', function(assert) {
+  const SortableByPositionObject = Object.extend(SortableByPositionMixin);
+  const subject = SortableByPositionObject.create();
+
+  const obj1 = Object.create({
+    id: 1,
+    position: 3,
+  });
+
+  const obj2 = Object.create({
+    id: 2,
+    position: 2,
+  });
+  const obj3 = Object.create({
+    id: 3,
+    position: 1,
+  });
+  const obj4 = Object.create({
+    id: 4,
+    position: 2
+  });
+
+  let objects = [ obj1, obj2, obj3, obj4 ];
+
+  let sortedObjects = objects.sort(subject.get('learningMaterialSortingCallback'));
+
+  assert.equal(sortedObjects.length, objects.length);
+  assert.equal(sortedObjects[0], obj3);
+  assert.equal(sortedObjects[1], obj4);
+  assert.equal(sortedObjects[2], obj2);
+  assert.equal(sortedObjects[3], obj1);
 });

--- a/tests/unit/mixins/sortable-by-position-test.js
+++ b/tests/unit/mixins/sortable-by-position-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import SortableByPositionMixin from 'ilios/mixins/sortable-by-position';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | sortable by position');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let SortableByPositionObject = Ember.Object.extend(SortableByPositionMixin);
+  let subject = SortableByPositionObject.create();
+  assert.ok(subject);
+});

--- a/tests/unit/mixins/sortable-by-position-test.js
+++ b/tests/unit/mixins/sortable-by-position-test.js
@@ -5,7 +5,7 @@ const { Object } = Ember;
 
 module('Unit | Mixin | sortable by position');
 
-test('learning materials sorting callback', function(assert) {
+test('position sorting callback', function(assert) {
   const SortableByPositionObject = Object.extend(SortableByPositionMixin);
   const subject = SortableByPositionObject.create();
 
@@ -29,7 +29,7 @@ test('learning materials sorting callback', function(assert) {
 
   let objects = [ obj1, obj2, obj3, obj4 ];
 
-  let sortedObjects = objects.sort(subject.get('learningMaterialSortingCallback'));
+  let sortedObjects = objects.sort(subject.get('positionSortingCallback'));
 
   assert.equal(sortedObjects.length, objects.length);
   assert.equal(sortedObjects[0], obj3);


### PR DESCRIPTION
replaces #2641
fixes #1269

![selection_143](https://cloud.githubusercontent.com/assets/1410427/22942652/3bb840e2-f29f-11e6-80a5-44b16b8eeada.png)

Some things worth mentioning:

1. Test coverage can be improved upon. 
For one, the DnD library we're using is currently not exposing its test helpers, but there is a ticket on that.
Then, the integration tests for the wrapping `detail-learning-materials` component needs to be massively fleshed out. 

2. Some help text ("drag and drop the items in the list below to reorder these learning materials", or the likes) might be in order.

Overall, i think this is done for a first iteration. Please review, thanks!

