### PR TITLE
Remove our pinned version of ember-cli-preprocessor-registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "ember-cli-moment-shim": "3.0.1",
     "ember-cli-neat": "0.0.5",
     "ember-cli-password-strength": "0.2.1",
-    "ember-cli-preprocess-registry": "^3.0.0",
     "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sass": "6.1.1",


### PR DESCRIPTION
The issue we were having has been resolved and a new version was
released.

WIP;
- [x] Needs to be tested on a production build where our CDN comes Into play.

Refs #2664