### PR TITLE
Lock ember-data version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-concurrency": "0.7.19",
     "ember-cp-validations": "3.2.3",
     "ember-cryptojs-shim": "^2.0.0",
-    "ember-data": "^2.11.0",
+    "ember-data": "2.11.1",
     "ember-drag-drop": "0.4.2",
     "ember-exam": "0.6.0",
     "ember-export-application-global": "^1.0.5",


### PR DESCRIPTION
v2.11.2 of ember data breaks some things for us so I'm going to lock our
version here for now.