### PR TITLE
Remove prefixer functions

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -75,10 +75,10 @@ $base-link-color: $base-accent-color;
 $hover-link-color: darken($base-accent-color, 15);
 
 // Neat Breakpoints
-$small-screen: em(320);
-$medium-screen: em(640);
-$large-screen: em(860);
-$giant-screen: em(1480);
+$small-screen: 320px;
+$medium-screen: 640px;
+$large-screen: 860px;
+$giant-screen: 1480px;
 
 $medium-screen-up: new-breakpoint(min-width $medium-screen 4);
 $large-screen-up: new-breakpoint(min-width $large-screen 8);

--- a/app/styles/components/_action-menu.scss
+++ b/app/styles/components/_action-menu.scss
@@ -49,7 +49,6 @@ $dropdown-distance-from-menu: $dropdown-padding * 2;
   }
 
   .dropdown-menu {
-    @include transition (all .2s ease-in-out);
     background-color: $white;
     border-radius: $base-border-radius;
     box-shadow: 0 2px 2px transparentize($black, .8);
@@ -62,6 +61,7 @@ $dropdown-distance-from-menu: $dropdown-padding * 2;
     position: absolute;
     text-align: left;
     top: 100%;
+    transition: all .2s ease-in-out;
     white-space: nowrap;
     z-index: 100;
 

--- a/app/styles/components/_global.scss
+++ b/app/styles/components/_global.scss
@@ -15,7 +15,7 @@ a,
 }
 
 button {
-  @include appearance(none);
+  appearance: none;
   background-color: $base-link-color;
   border: 0;
   border-radius: $base-border-radius;

--- a/app/styles/components/_lists.scss
+++ b/app/styles/components/_lists.scss
@@ -74,11 +74,11 @@
 
 .columnar-list {
   @include media($medium-screen) {
-    @include column-count(3);
+    column-count: 3;
   }
 
   @include media($large-screen) {
-    @include column-count(4);
+    column-count: 4;
   }
 }
 

--- a/app/styles/components/_livesearch.scss
+++ b/app/styles/components/_livesearch.scss
@@ -3,7 +3,6 @@
   position: relative;
 
   .results {
-    @include transition (all .2s ease-in-out);
     background: $white;
     border: 1px solid $background-grey;
     border-radius: $base-border-radius;
@@ -14,6 +13,7 @@
     min-width: 191px;
     overflow: visible;
     top: 2em;
+    transition: all .2s ease-in-out;
     z-index: 100;
 
     li {

--- a/app/styles/components/_navigation.scss
+++ b/app/styles/components/_navigation.scss
@@ -13,9 +13,7 @@ $sliding-menu-color-hover: #fff;
 
 .sliding-navigation {
   .sliding-menu-button {
-    @include transform(rotate(90deg));
     @include position(fixed, 105px 0 0 -45px);
-    @include transition(all .25s linear);
 
     background-color: $sliding-menu-background;
     border-color: $ilios-orange;
@@ -34,6 +32,8 @@ $sliding-menu-color-hover: #fff;
     -webkit-overflow-scrolling: touch;
     padding-top: .4em;
     text-align: center;
+    transform: rotate(90deg);
+    transition: all .25s linear;
     width: 120px;
     z-index: 201;
 
@@ -42,30 +42,30 @@ $sliding-menu-color-hover: #fff;
     }
 
     i {
-      @include transform(rotate(-90deg));
       margin-right: 10px;
+      transform: rotate(-90deg);
     }
 
     &.is-menu-visible {
-      @include transform(translateX(180px) rotate(90deg));
+      transform: translateX(180px) rotate(90deg);
     }
   }
 
   .sliding-menu-content {
     @include position(fixed, 60px auto 0 0);
     @include size(180px 100%);
-    @include transform(translateX(-190px));
-    @include transition(all .25s linear);
     background: $sliding-menu-background;
     border-right: 1px solid $header-grey;
     box-shadow: 2px 1px 3px $navigation-shadow-1, inset 1px 0 2px $navigation-shadow-2;
     color: $sliding-menu-color;
     -webkit-overflow-scrolling: touch;
     padding-top: 2em;
+    transform: translateX(-190px);
+    transition: all .25s linear;
     z-index: 201;
 
     @include media($giant-screen) {
-      @include transform(translateX(0));
+      transform: translateX(0);
     }
 
     li {
@@ -91,13 +91,12 @@ $sliding-menu-color-hover: #fff;
     }
 
     &.is-menu-visible {
-      @include transform(translateX(0));
+      transform: translateX(0);
     }
   }
 
   .menu-screen {
     @include position(fixed, 0 0 0 0);
-    @include transition;
     background: $sliding-menu-background;
     opacity: 0;
     visibility: hidden;

--- a/app/styles/components/_pulseloader.scss
+++ b/app/styles/components/_pulseloader.scss
@@ -2,7 +2,7 @@
   margin-left: 150px;
   margin-top: 50px;
 
-  @include keyframes(pulse) {
+  @keyframes pulse {
     0% {
       stroke-dashoffset: 691;
      }
@@ -19,12 +19,12 @@
   }
 
   &.is-full-size {
-    @include align-items(center);
+    align-items: center;
     display: flex;
     min-height: 100px;
   }
 
   .path {
-    @include animation(pulse 2.2s infinite ease-in-out);
+    animation: pulse 2.2s infinite ease-in-out;
   }
 }

--- a/app/styles/components/_searchbox.scss
+++ b/app/styles/components/_searchbox.scss
@@ -6,9 +6,9 @@
   margin-bottom: 10px;
 
   input {
-    @include appearance(none);
     @include margin(0);
     @include padding(0 0 0 28px);
+    appearance: none;
     background: $white;
     border: 1px solid $input-box-grey;
     border-radius: $base-border-radius;

--- a/app/styles/components/_toggles.scss
+++ b/app/styles/components/_toggles.scss
@@ -19,7 +19,7 @@ $almost-visible-black: rgba(0, 0, 0, .15);
 $more-visible-black: rgba(0, 0, 0, .2);
 
 .switch {
-  @include background-image(linear-gradient(top bottom, $switch-grey, $white 25px));
+  background-image: (linear-gradient(to bottom, $switch-grey, $white 25px));
   border-radius: 18px;
   box-shadow: inset 0 -1px $white, inset 0 1px 1px $barely-visible-black;
   cursor: pointer;
@@ -40,9 +40,6 @@ $more-visible-black: rgba(0, 0, 0, .2);
 }
 
 .switch-label {
-  @include transition-property(opacity background);
-  @include transition-duration(.15s);
-  @include transition-timing-function(ease-out);
   background: $switch-label-blue;
   border-radius: inherit;
   box-shadow: inset 0 1px 2px $almost-visible-black, inset 0 0 2px $almost-visible-black;
@@ -52,15 +49,18 @@ $more-visible-black: rgba(0, 0, 0, .2);
   height: inherit;
   position: relative;
   text-transform: uppercase;
+  transition-duration: .15s;
+  transition-property: opacity background;
+  transition-timing-function: ease-out;
 }
 
 .switch-label::before,
 .switch-label::after {
-  @include transition(inherit);
   line-height: 1;
   margin-top: -.5em;
   position: absolute;
   top: 50%;
+  transition: inherit;
 }
 
 .switch-label::before {
@@ -92,21 +92,21 @@ $more-visible-black: rgba(0, 0, 0, .2);
 }
 
 .switch-handle {
-  @include background-image(linear-gradient(top , $white 40%, $toggle-background-grey));
-  @include transition(left .15s ease-out);
   background: $white;
+  background-image: (linear-gradient(to top , $white 40%, $toggle-background-grey));
   border-radius: 10px;
   box-shadow: 1px 1px 5px $more-visible-black;
   height: 18px;
   left: 4px;
   position: absolute;
   top: 4px;
+  transition: left .15s ease-out;
   width: 18px;
 }
 
 .switch-handle::before {
-  @include background-image(linear-gradient(top , $switch-grey, $white));
   background: $switch-handle-grey;
+  background-image: (linear-gradient(to top , $switch-grey, $white));
   border-radius: 6px;
   box-shadow: inset 0 1px $barely-visible-black;
   content: '';
@@ -150,8 +150,8 @@ $more-visible-black: rgba(0, 0, 0, .2);
 
 //Calendar Switch
 .switch-wide {
-  @include background-image(linear-gradient(top , $switch-grey, $white 25px));
   background-color: $white;
+  background-image: (linear-gradient(to top , $switch-grey, $white 25px));
   border-radius: 18px;
   box-shadow: inset 0 -1px $white, inset 0 1px 1px $barely-visible-black;
   cursor: pointer;
@@ -173,8 +173,8 @@ $more-visible-black: rgba(0, 0, 0, .2);
 }
 
 .switch-blue {
-  @include background-image(linear-gradient(top , $switch-grey, $white 25px));
   background-color: $white;
+  background-image: (linear-gradient(to top , $switch-grey, $white 25px));
   border-radius: 18px;
   box-shadow: inset 0 -1px $white, inset 0 1px 1px $barely-visible-black;
   cursor: pointer;
@@ -226,8 +226,8 @@ $more-visible-black: rgba(0, 0, 0, .2);
 
 //Offerings
 .switch-offering {
-  @include background-image(linear-gradient(top , $switch-grey, $white 25px));
   background-color: $white;
+  background-image: (linear-gradient(to top , $switch-grey, $white 25px));
   border-radius: 18px;
   box-shadow: inset 0 -1px $white, inset 0 1px 1px $barely-visible-black;
   cursor: pointer;

--- a/app/styles/components/_waveloader.scss
+++ b/app/styles/components/_waveloader.scss
@@ -1,6 +1,6 @@
 .waveloader {
   &.is-full-size {
-    @include align-items(center);
+    align-items: center;
     display: flex;
     min-height: 100px;
   }
@@ -19,7 +19,7 @@
       position: relative;
 
       span {
-        @include animation(wave 2s infinite ease-in-out);
+        animation: wave 2s infinite ease-in-out;
         background: $ilios-orange;
         bottom: 0;
         display: block;
@@ -33,35 +33,35 @@
       $delay: $i * 2 / 10 + s;
 
       .widget span:nth-child(#{$i + 1}) {
-        @include animation-delay($delay);
+        animation-delay: $delay;
         left: $i * 11px;
       }
     }
   }
 }
 
-@include keyframes(wave) {
+@keyframes wave {
   0% {
-    @include transform(translateY(0));
     background: $ilios-orange;
     height: 10px;
+    transform: translateY(0);
   }
 
   25% {
-    @include transform(translateY(30px));
     background: $wave-loader-yellow;
     height: 60px;
+    transform: translateY(30px);
   }
 
   50% {
-    @include transform(translateY(0));
     background: $ilios-orange;
     height: 10px;
+    transform: translateY(0);
   }
 
   100% {
-    @include transform(translateY(0));
     background: $ilios-orange;
     height: 10px;
+    transform: translateY(0);
   }
 }

--- a/app/styles/mixins/user-search.scss
+++ b/app/styles/mixins/user-search.scss
@@ -1,5 +1,4 @@
 @mixin user-search-results () {
-  @include transition (all .2s ease-in-out);
 
   background: $white;
   border: 1px solid $background-grey;
@@ -9,6 +8,7 @@
   max-height: 23em;
   overflow-y: scroll;
   position: absolute;
+  transition: all .2s ease-in-out;
   width: 100%;
   z-index: 100;
 

--- a/app/styles/newcomponents/publish-menu.scss
+++ b/app/styles/newcomponents/publish-menu.scss
@@ -50,7 +50,6 @@ $dropdown-distance-from-menu: $dropdown-padding * 2;
   }
 
   .rl-dropdown {
-    @include transition (all .2s ease-in-out);
     background-color: $white;
     border-radius: $base-border-radius;
     box-shadow: 0 2px 2px transparentize($black, .8);
@@ -62,6 +61,7 @@ $dropdown-distance-from-menu: $dropdown-padding * 2;
     position: absolute;
     text-align: left;
     top: 100%;
+    transition: all .2s ease-in-out;
     white-space: nowrap;
     z-index: 100;
 


### PR DESCRIPTION
Bourbon is dropping support for their prefixing functions in favor of
autoprefixer which we already use.  This removes all the function
references and replaces them with their plain property brethren.

Fixes #2704