### PR TITLE
Unpin our node-sass version

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
 /* global require, module */
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
-var nodeSass = require('node-sass'); // loads specific version of node-sass from package.json
 
 module.exports = function(defaults) {
   var env = EmberApp.env() || 'development';
@@ -29,10 +28,6 @@ module.exports = function(defaults) {
     },
     'ember-cli-qunit': {
       useLintTree: false
-    },
-    //fix for #2570
-    sassOptions: {
-      nodeSass: nodeSass
     },
     'ember-froala-editor': {
       languages: ['fr','es'],

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "liquid-fire": "0.27.1",
     "liquid-tether": "2.0.3",
     "loader.js": "^4.2.2",
-    "node-sass": "4.5.0",
     "normalize.css": "^4.1.1",
     "pluralize": "^3.0.0",
     "validator": "^7.0.0"


### PR DESCRIPTION
We updated to the latest version via greenkeeper in #2589 which is the
default provided by ember-cli-sass.  This just removes the now
superfluous code.

Fixes #2581