### PR TITLE
Check our addons for conflicting dependencies

### DIFF
--- a/config/dependency-lint.js
+++ b/config/dependency-lint.js
@@ -1,0 +1,8 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = {
+  allowedVersions: {
+    'ember-getowner-polyfill': '^1.0.0',
+  }
+};

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ember-cli-clipboard": "0.5.0",
     "ember-cli-content-security-policy": "0.6.0",
     "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-dependency-lint": "1.0.1",
     "ember-cli-deploy": "0.6.4",
     "ember-cli-deploy-build": "0.1.1",
     "ember-cli-deploy-display-revisions": "0.2.2",


### PR DESCRIPTION
When addons all depend on the same addon it can cause mysterious issues
as their output has the possibility of overriding each other.  This
ensures that when we add or update and addon that we test for this
problem.  The only conflict we currently have is with
ember-getowner-polyfill - I excluded it from our currently check and we
can work to bring versions into line through PRs.