### PR TITLE
Remove ember-cli-bourbon

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "ember-cli-app-version": "^2.0.1",
     "ember-cli-autoprefixer": "0.6.0",
     "ember-cli-babel": "^5.1.9",
-    "ember-cli-bourbon": "^1.2.1",
     "ember-cli-clipboard": "0.5.0",
     "ember-cli-content-security-policy": "0.6.0",
     "ember-cli-dependency-checker": "^1.3.0",


### PR DESCRIPTION
The bourbon sass library is provided by ember-cli-neat we don't need to include this twice.