### PR TITLE
Provide attendanceRequired to the calendar

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -29,6 +29,7 @@ export default {
     'associatedCourses': 'Associated Courses',
     'associatedGroups': 'Associated Groups',
     'associatedWith': 'Associated with',
+    'attendanceIsRequired': 'Attendance is <strong><em>required</em></strong>',
     'attendanceRequired': 'Attendance Required',
     'attribute': 'Attribute',
     'author': 'Author',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -29,6 +29,7 @@ export default {
     'associatedCourses': 'Cursos Asociados',
     'associatedGroups': 'Grupos Associados',
     'associatedWith': 'Ssociado con',
+    'attendanceIsRequired': 'Se <strong><em>require</em></strong> asistencia',
     'attendanceRequired': 'Asistencia Requerida',
     'attribute': 'Atributo',
     'author': 'Autor',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -29,6 +29,7 @@ export default {
     'associatedCourses': "Cours Associés",
     'associatedGroups': "Groupes Associés",
     'associatedWith': "associée de",
+    'attendanceIsRequired': 'Présence <strong><em>requise</em></strong>',
     'attendanceRequired': 'Participation Requise',
     'attribute': 'Attribut',
     'author': 'Auteur',

--- a/app/templates/components/ilios-event.hbs
+++ b/app/templates/components/ilios-event.hbs
@@ -29,6 +29,8 @@
     attireRequiredPhrase=(t 'general.specialAttireIsRequired')
     equipmentRequired=(get (await session) 'equipmentRequired')
     equipmentRequiredPhrase=(t 'general.specialEquipmentIsRequired')
+    attendanceRequired=(get (await session) 'attendanceRequired')
+    attendanceRequiredPhrase=(t 'general.attendanceIsRequired')
   }}
 {{else}}
   {{pulse-loader}}


### PR DESCRIPTION
This will allow it to show up on the single event page once the calendar is updated, but this can be merged before that is done without harm.

Fixes #2626