### PR TITLE
Temporary add beta version of ember-cli-babel override

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 ---
+dist: trusty
 language: node_js
 node_js:
   - "6"
 
 sudo: false
-
-addons:
-  firefox: "latest-esr"
 
 env:
   global:
@@ -60,7 +58,7 @@ script:
   - if [ "$LINT" = true ];
     then eslint .;
     fi
-  - ember exam --split=$SPLIT --partition=$PARTITION --launch=firefox --filter=$FILTER --parallel=$PARALLEL
+  - ember exam --split=$SPLIT --partition=$PARTITION --filter=$FILTER --parallel=$PARALLEL
 
 after_success:
   - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && node_modules/.bin/ember deploy production

--- a/config/dependency-lint.js
+++ b/config/dependency-lint.js
@@ -3,6 +3,7 @@
 
 module.exports = {
   allowedVersions: {
+    'ember-cli-babel': '* || >=6.0.0-beta.1',
     'ember-getowner-polyfill': '^1.0.0',
   }
 };

--- a/testem.js
+++ b/testem.js
@@ -6,10 +6,9 @@ module.exports = {
   "disable_watching": true,
   'parallel': 5,
   "launch_in_ci": [
-    "PhantomJS"
+    "Chrome"
   ],
   "launch_in_dev": [
-    "PhantomJS",
     "Chrome"
   ]
 };


### PR DESCRIPTION
Upstream library changes will make this unnecessary very soon, but for
now we need to specifically allow this beta version of the addon to get
builds passing again.