### PR TITLE
prevent deletion of learner groups with associated learners

### DIFF
--- a/app/models/learner-group.js
+++ b/app/models/learner-group.js
@@ -386,4 +386,37 @@ export default DS.Model.extend({
       });
     });
   }),
+
+  /**
+   * Checks if this group or any of its subgroups has any learners.
+   * @property hasLearnersInGroupOrSubgroups
+   * @type {Ember.computed}
+   * @public
+   */
+  hasLearnersInGroupOrSubgroups: computed('users.[]', 'children.@each.hasLearnersInGroupOrSubgroup', function() {
+    return new Promise(resolve => {
+      this.get('users').then(users => {
+        if(users.get('length')) {
+          resolve(true);
+          return;
+        }
+
+        this.get('children').then(children => {
+          if(! children.get('length')) {
+            resolve(false);
+            return;
+          }
+
+          let promises = children.map(subgroup => {
+            return subgroup.get('hasLearnersInGroupOrSubgroups');
+          });
+          all(promises).then(hasLearnersInSubgroups => {
+            resolve(hasLearnersInSubgroups.reduce((acc, val) => {
+              return (acc || val);
+            }, false));
+          });
+        });
+      });
+    });
+  }),
 });

--- a/app/models/learner-group.js
+++ b/app/models/learner-group.js
@@ -395,26 +395,23 @@ export default DS.Model.extend({
    */
   hasLearnersInGroupOrSubgroups: computed('users.[]', 'children.@each.hasLearnersInGroupOrSubgroup', function() {
     return new Promise(resolve => {
-      this.get('users').then(users => {
-        if(users.get('length')) {
-          resolve(true);
+      const userIds = this.hasMany('users').ids();
+      if (userIds.length) {
+        resolve(true);
+      }
+      this.get('children').then(children => {
+        if(! children.get('length')) {
+          resolve(false);
           return;
         }
 
-        this.get('children').then(children => {
-          if(! children.get('length')) {
-            resolve(false);
-            return;
-          }
-
-          let promises = children.map(subgroup => {
-            return subgroup.get('hasLearnersInGroupOrSubgroups');
-          });
-          all(promises).then(hasLearnersInSubgroups => {
-            resolve(hasLearnersInSubgroups.reduce((acc, val) => {
-              return (acc || val);
-            }, false));
-          });
+        let promises = children.map(subgroup => {
+          return subgroup.get('hasLearnersInGroupOrSubgroups');
+        });
+        all(promises).then(hasLearnersInSubgroups => {
+          resolve(hasLearnersInSubgroups.reduce((acc, val) => {
+            return (acc || val);
+          }, false));
         });
       });
     });

--- a/app/templates/components/learnergroup-list.hbs
+++ b/app/templates/components/learnergroup-list.hbs
@@ -18,7 +18,15 @@
         <td class='text-center hide-from-small-screen'>{{learnerGroup.users.length}}</td>
         <td class='text-center hide-from-small-screen'>{{learnerGroup.children.length}}</td>
         <td class='text-right'>
-          <span class='clickable remove' {{action 'confirmRemove' learnerGroup}}>{{fa-icon 'trash'}}</span>
+          {{#if (is-fulfilled learnerGroup.hasLearnersInGroupOrSubgroups)}}
+            {{#if (await learnerGroup.hasLearnersInGroupOrSubgroups)}}
+              {{fa-icon 'trash' class='disabled'}}
+            {{else}}
+              <span class='clickable remove' {{action 'confirmRemove' learnerGroup}}>{{fa-icon 'trash'}}</span>
+            {{/if}}
+          {{else}}
+            {{fa-icon 'spinner' spin=true}}
+          {{/if}}
         </td>
       </tr>
       {{#if (contains learnerGroup learnerGroupsForRemovalConfirmation)}}

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -600,7 +600,6 @@ test('confirmation of remove message', function(assert) {
   });
   server.create('learnerGroup', {
     cohort: 1,
-    users: [2,3,4,5,6],
     offerings: [1,2],
     children: [2,3]
   });
@@ -615,8 +614,43 @@ test('confirmation of remove message', function(assert) {
     click('.list tbody tr:eq(0) td:eq(3) .remove').then(()=>{
       assert.ok(find('.list tbody tr:eq(0)').hasClass('confirm-removal'));
       assert.ok(find('.list tbody tr:eq(1)').hasClass('confirm-removal'));
-      assert.equal(getElementText(find('.list tbody tr:eq(1)')), getText('Are you sure you want to delete this learner group, with 5 learners and 2 subgroups? This action cannot be undone. Yes Cancel'));
+      assert.equal(getElementText(find('.list tbody tr:eq(1)')), getText('Are you sure you want to delete this learner group, with 0 learners and 2 subgroups? This action cannot be undone. Yes Cancel'));
     });
+  });
+});
+
+test('populated learner groups are not deletable', function(assert) {
+  server.create('user', {id: 4136});
+  server.createList('user', 5, {
+    learnerGroups: [1]
+  });
+  server.create('school', {
+    programs: [1]
+  });
+  server.create('program', {
+    school: 1,
+    programYears: [1]
+  });
+  server.create('programYear', {
+    program: 1,
+    cohort: 1
+  });
+  server.create('cohort', {
+    programYear: 1,
+    learnerGroups: [1]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    users: [2, 3, 4],
+    offerings: [1,2]
+  });
+
+  assert.expect(3);
+  visit('/learnergroups');
+  andThen(function() {
+    assert.equal(1, find('.list tbody tr').length);
+    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText('learnergroup 0'));
+    assert.notOk(find('.list tbody tr:eq(0) td:eq(3) .remove').length, 'No delete action is available');
   });
 });
 

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -410,3 +410,82 @@ test('check addUserToGroupAndAllParents', function(assert) {
     });
   });
 });
+
+
+test('has no learners in group without learners and without subgroups', function(assert) {
+  assert.expect(1);
+  let learnerGroup = this.subject();
+  Ember.run(() => {
+    learnerGroup.get('hasLearnersInGroupOrSubgroups').then(hasLearners => {
+      assert.notOk(hasLearners);
+    });
+  });
+});
+
+test('has learners in group with learners and but without learners in subgroups', function(assert) {
+  assert.expect(1);
+  let learnerGroup = this.subject();
+  let store = this.store();
+  Ember.run(() => {
+    let learner = store.createRecord('user');
+    learnerGroup.get('users').then(users => {
+      users.pushObject(learner);
+      learnerGroup.get('hasLearnersInGroupOrSubgroups').then(hasLearners => {
+        assert.ok(hasLearners);
+      });
+    });
+  });
+});
+
+
+test('has no learners with no learners in group nor in subgroups', function(assert) {
+  assert.expect(1);
+  let learnerGroup = this.subject();
+  let store = this.store();
+  Ember.run(() => {
+    let subgroup = store.createRecord('learner-group', { id: 2, parent: learnerGroup });
+    learnerGroup.get('children').then(subgroups => {
+      subgroups.pushObject(subgroup);
+      learnerGroup.get('hasLearnersInGroupOrSubgroups').then(hasLearners => {
+        assert.notOk(hasLearners);
+      });
+    });
+  });
+});
+
+
+test('has learners with no learners in group but with learners in subgroups', function(assert) {
+  assert.expect(1);
+  let learnerGroup = this.subject();
+  let store = this.store();
+  Ember.run(() => {
+    let learner = store.createRecord('user', { id: 1 });
+    let subgroup = store.createRecord('learner-group', { id: 2, users: [ learner ], parent: learnerGroup });
+    learnerGroup.get('children').then(subgroups => {
+      subgroups.pushObject(subgroup);
+      learnerGroup.get('hasLearnersInGroupOrSubgroups').then(hasLearners => {
+        assert.ok(hasLearners);
+      });
+    });
+  });
+});
+
+test('has learners with learners in group and with learners in subgroups', function(assert) {
+  assert.expect(1);
+  let learnerGroup = this.subject();
+  let store = this.store();
+  Ember.run(() => {
+    let learner = store.createRecord('user', { id: 1 });
+    let learner2 = store.createRecord('user', { id: 2 });
+    let subgroup = store.createRecord('learner-group', { id: 2, users: [ learner ], parent: learnerGroup });
+    learnerGroup.get('children').then(subgroups => {
+      subgroups.pushObject(subgroup);
+      learnerGroup.get('users').then(learners => {
+        learners.pushObject(learner2);
+        learnerGroup.get('hasLearnersInGroupOrSubgroups').then(hasLearners => {
+          assert.ok(hasLearners);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
fixes #2713 

in case a given group has learners, or any of its sub-groups has learners, we'll just render a greyed-out, non-clickable trashbin.

since this check is an asynchronous operation, we'll throw a spinner on every line until the check completes.

![selection_161](https://cloud.githubusercontent.com/assets/1410427/24067017/bc4bd82e-0b34-11e7-82e8-a759193c7ca4.png)
