### PR TITLE
Show the ldap new user form when configured to

### DIFF
--- a/app/components/ilios-users.js
+++ b/app/components/ilios-users.js
@@ -9,6 +9,7 @@ const { service } = inject;
 
 export default Component.extend({
   store: service(),
+  iliosConfig: service(),
   classNames: ['ilios-users'],
   offset: null,
   limit: null,
@@ -35,7 +36,8 @@ export default Component.extend({
   }).cancelOn('deactivate').restartable(),
 
   newUserComponent: computed('iliosConfig.userSearchType', async function(){
-    const userSearchType = await this.get('iliosConfig.userSearchType');
+    const iliosConfig = this.get('iliosConfig');
+    const userSearchType = await iliosConfig.get('userSearchType');
 
     return userSearchType === 'ldap'?'new-directory-user':'new-user';
   }),

--- a/tests/integration/components/ilios-users-test.js
+++ b/tests/integration/components/ilios-users-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { RSVP, Service } = Ember;
+const { RSVP, Service, Object } = Ember;
 const { resolve } = RSVP;
 
 import wait from 'ember-test-helpers/wait';
@@ -42,4 +42,86 @@ test('param passing', async function(assert) {
 
   assert.equal(this.$(query).val().trim(), 'nothing');
   this.$(query).val('test').change();
+});
+
+test('add user form renders when configured to', async function(assert) {
+  assert.expect(3);
+  let storeMock = Service.extend({
+    query(){
+      return resolve([]);
+    }
+  });
+  this.register('service:store', storeMock);
+  const iliosConfigMock = Service.extend({
+    userSearchType: resolve('form')
+  });
+  this.register('service:iliosConfig', iliosConfigMock);
+  const mockSchools = [
+    {id: 1, title: 'first', cohorts: resolve([])},
+  ];
+  const mockUser = Object.create({
+    schools: resolve(mockSchools),
+    school: resolve(Object.create(mockSchools[0]))
+  });
+
+  const currentUserMock = Service.extend({
+    model: resolve(mockUser)
+  });
+  this.register('service:currentUser', currentUserMock);
+
+  this.set('nothing', parseInt);
+  this.render(hbs`{{ilios-users
+    setShowNewUserForm=(action nothing)
+    transitionToUser=(action nothing)
+    setSearchTerms=(action nothing)
+    showNewUserForm=true
+  }}`);
+  const form = '.new-user-form';
+  const blocks = `${form} .item`;
+  const directorySearchBox = '.new-directory-user-search-tools';
+  await wait();
+  assert.equal(this.$(form).length, 1, 'the user search form is present');
+  assert.ok(this.$(blocks).length > 4, 'there are many form fields for adding a new user');
+  assert.equal(this.$(directorySearchBox).length, 0, 'the directory form search form is not present');
+});
+
+test('directory search renders when configured to', async function(assert) {
+  assert.expect(3);
+  let storeMock = Service.extend({
+    query(){
+      return resolve([]);
+    }
+  });
+  this.register('service:store', storeMock);
+  const iliosConfigMock = Service.extend({
+    userSearchType: resolve('ldap')
+  });
+  this.register('service:iliosConfig', iliosConfigMock);
+  const mockSchools = [
+    {id: 1, title: 'first'},
+  ];
+  const mockUser = Object.create({
+    schools: resolve(mockSchools),
+    school: resolve(Object.create(mockSchools[0]))
+  });
+
+  const currentUserMock = Service.extend({
+    model: resolve(mockUser)
+  });
+  this.register('service:currentUser', currentUserMock);
+
+  this.set('nothing', parseInt);
+  this.render(hbs`{{ilios-users
+    setShowNewUserForm=(action nothing)
+    transitionToUser=(action nothing)
+    setSearchTerms=(action nothing)
+    showNewUserForm=true
+  }}`);
+  const form = '.new-user-form';
+  const blocks = `${form} .item`;
+  const directorySearchBox = '.new-directory-user-search-tools';
+  await wait();
+  assert.equal(this.$(form).length, 0, 'the user search form is not present');
+  assert.equal(this.$(blocks).length, 0, 'there are no form fields for adding a new user');
+  assert.equal(this.$(directorySearchBox).length, 1, 'the directory form search form is present');
 });


### PR DESCRIPTION
We were not injecting the iliosConfig service which was dying without
error and presenting the default form for adding new users instead of
the directory.

Fixes #2779