### PR TITLE
We're not ignore ember-resolver anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,7 @@
   "greenkeeper": {
     "ignore": [
       "ember-cli-mirage",
-      "ember-tether",
-      "ember-resolver"
+      "ember-tether"
     ]
   },
   "private": true


### PR DESCRIPTION
Greenkeeper should feel free to update it.