### PR TITLE
dropped obsolete user count from learner group deletion message.

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -87,7 +87,7 @@ export default {
     'confirmRemove': 'Are you sure you want to delete this offering with {{learnerGroupCount}} learner groups? This action cannot be undone.',
     'confirmRemoveCourse': 'Are you sure you want to delete this course, with {{publishedOfferingCount}} published offerings? This action will remove all sessions and offerings for this course, and cannot be undone.',
     'confirmRemoveInstructorGroup': 'Are you sure you want to delete this instructor group, with {{instructorCount}} instructors and {{courseCount}} courses? This action cannot be undone.',
-    'confirmRemoveLearnerGroup': 'Are you sure you want to delete this learner group, with {{learnerCount}} learners and {{subgroupCount}} subgroups? This action cannot be undone.',
+    'confirmRemoveLearnerGroup': 'Are you sure you want to delete this learner group, with {{subgroupCount}} subgroups? This action cannot be undone.',
     'confirmRemoveProgram': 'Are you sure you want to delete this program, with {{programYearCount}} program years and {{courseCount}} courses? This action will remove all courses and activities related to this program, and cannot be undone.',
     'confirmRemoveProgramYear': 'Are you sure you want to delete this program year? Doing so will also remove its associated student cohort and groups, and associations with {{courseCount}} course(s), and cannot be undone.',
     'confirmSessionRemoval': 'Are you sure you want to delete this session?',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -87,7 +87,7 @@ export default {
     'confirmRemove': '¿Estás seguro que quieres borrar este ofrecimiento con {{learnerGroupCount}} grupos de aprendedores? Esta acción no se puede deshacer.',
     'confirmRemoveCourse': ' ¿Estás seguro que quieres borrar este curso, con {{publishedOfferingCount}} ofrecimientos publicados? Esta acción borrará todas las sessiones y ofrecimientos para este curso y no se puede deshacer.',
     'confirmRemoveInstructorGroup': '¿Estás seguro que quieres remover este grupo de instructores, con {{instructorCount}} instructores y {{courseCount}} cursos? Esta acción no se puede deshacer.',
-    'confirmRemoveLearnerGroup': '¿Estás seguro que quieres borrar este grupo de aprendedores, con {{learnerCount}} aprendedores y {{subgroupCount}} grupos subordinados? Esta acción no se puede deshacer.',
+    'confirmRemoveLearnerGroup': '¿Estás seguro que quieres borrar este grupo de aprendedores, con {{subgroupCount}} grupos subordinados? Esta acción no se puede deshacer.',
     'confirmRemoveProgram': '¿Estás seguro que quieres borrar este programa, con {{programYearCount}} años de prgrama y {{courseCount}} cursos? Esta accion removerá todos los cursos y actividades relacionadas a este programa, y no se puede deshacer.',
     'confirmRemoveProgramYear': '¿Está seguro de que desea eliminar este año del programa?   Hacer tan también quitará su cohorte estudiantil asociada y grupos y asociaciones con {{courseCount}} curso(s), y no se puede deshacer.',
     'confirmSessionRemoval': "¿Está seguro que desea eliminar este sessión?",

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -87,7 +87,7 @@ export default {
     'confirmRemove': "Êtes-vous sûr vous voulez supprimer cette offre avec {{learnerGroupCount}} groupes d'apprenants?  Ça action ne peut pas être défait.",
     'confirmRemoveCourse': "Êtes-vous sûr vous voulez supprimer ce cours, avec {{publishedOfferingCount}} offres publié? Cela supprimera toutes sessions et offres pour ce cours, et ne peut pas être défait.",
     'confirmRemoveInstructorGroup': "Êtes-vous sûr vous voulez supprimer cette groupe des instructeurs, avec {{instructorCount}} membres et {{courseCount}} cours? Ça action ne peut pas être défait.",
-    'confirmRemoveLearnerGroup': "Êtes-vous sûr vous voulez supprimer cette groupe d'apprenants, avec {{learnerCount}} Étudiants et {{subgroupCount}} sous-groupes? Ça action ne peut pas être défait.",
+    'confirmRemoveLearnerGroup': "Êtes-vous sûr vous voulez supprimer cette groupe d'apprenants, avec {{subgroupCount}} sous-groupes? Ça action ne peut pas être défait.",
     'confirmRemoveProgram': "Êtes-vous certain que vous voulez supprimer ce diplôme, avec {{programYearCount}} années de diplôme et {{courseCount}} des cours? Cette action va supprimer tous les cours et les activités liées à ce diplôme, et ne peut être annulée.",
     'confirmRemoveProgramYear': "Êtes-vous certain que vous voulez supprimer cette année de diplôme? Cette action va supprimer tous les cohortes et groupes des étudiants associées, et liaisons avec {{courseCount}} des cours, et ne peut être annulée.",
     'confirmSessionRemoval': "Êtes vous sûr de vouloir supprimer cette séance?",

--- a/app/templates/components/learnergroup-list.hbs
+++ b/app/templates/components/learnergroup-list.hbs
@@ -33,7 +33,7 @@
         <tr class='confirm-removal'>
           <td colspan=5>
             <div class='confirm-message'>
-              {{t 'general.confirmRemoveLearnerGroup' learnerCount=learnerGroup.usersCount subgroupCount=learnerGroup.children.length}} <br>
+              {{t 'general.confirmRemoveLearnerGroup' subgroupCount=learnerGroup.children.length}} <br>
               <div class="confirm-buttons">
                 <button {{action this.attrs.remove learnerGroup}} class='remove text'>{{t 'general.yes'}}</button>
                 <button {{action 'cancelRemove' learnerGroup}} class='done text'>{{t 'general.cancel'}}</button>

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -614,7 +614,7 @@ test('confirmation of remove message', function(assert) {
     click('.list tbody tr:eq(0) td:eq(3) .remove').then(()=>{
       assert.ok(find('.list tbody tr:eq(0)').hasClass('confirm-removal'));
       assert.ok(find('.list tbody tr:eq(1)').hasClass('confirm-removal'));
-      assert.equal(getElementText(find('.list tbody tr:eq(1)')), getText('Are you sure you want to delete this learner group, with 0 learners and 2 subgroups? This action cannot be undone. Yes Cancel'));
+      assert.equal(getElementText(find('.list tbody tr:eq(1)')), getText('Are you sure you want to delete this learner group, with 2 subgroups? This action cannot be undone. Yes Cancel'));
     });
   });
 });


### PR DESCRIPTION

![selection_191](https://cloud.githubusercontent.com/assets/1410427/24477332/75541e62-148b-11e7-8e2d-8bf0665f10bf.png)


since we locked down deletion of populated learner groups, it is not necessary to list the number of users anymore. 

refs #2713.
fixes #2714

 