### PR TITLE
Update our deployments to be tag based

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
   - ember exam --split=$SPLIT --partition=$PARTITION --filter=$FILTER --parallel=$PARALLEL
 
 after_success:
-  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && node_modules/.bin/ember deploy production
+  - test $TRAVIS_TAG && test $TRAVIS_BRANCH == "master" && node_modules/.bin/ember deploy production --activate
 
 #encrypted the slack token to post to #info so that it doesn't run on pull requests or forks
 notifications:

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -16,7 +16,7 @@ module.exports = function(deployTarget) {
       bucket: 'frontend-json-config',
     },
     'revision-data': {
-      type: 'git-commit',
+      type: 'git-tag-commit',
     },
     gzip: {
       //dont gzip the json index file


### PR DESCRIPTION
This switches our strategy to only deploy git tags in travis and to use
the tag name as the deployment key.  We also activate each tag
automatically instead of needed to do that step manually.