### PR TITLE
Stop running eslint explicitly in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,6 @@ script:
   - if [ "$LINT" = true ];
     then scss-lint;
     fi
-  - if [ "$LINT" = true ];
-    then eslint .;
-    fi
   - ember exam --split=$SPLIT --partition=$PARTITION --filter=$FILTER --parallel=$PARALLEL
 
 after_success:


### PR DESCRIPTION
eslint tests get run as part of the normal ember test run now that it is
the default linter for ember-cli