### PR TITLE
Fix overflow issue for tooltips

### DIFF
--- a/app/styles/newcomponents/chart-bar.scss
+++ b/app/styles/newcomponents/chart-bar.scss
@@ -1,4 +1,4 @@
-.ilios-chart {
+.chart-bar {
 
   .bar:hover {
     fill: $scheduled-brown;

--- a/app/styles/newcomponents/chart-bar.scss
+++ b/app/styles/newcomponents/chart-bar.scss
@@ -1,4 +1,4 @@
-.chart-container {
+.ilios-chart {
 
   .bar:hover {
     fill: $scheduled-brown;

--- a/app/styles/newcomponents/ilios-chart-tooltip.scss
+++ b/app/styles/newcomponents/ilios-chart-tooltip.scss
@@ -9,16 +9,18 @@
   margin: 0;
   max-height: 150px;
   opacity: .9;
+  overflow: auto;
   padding: 10px;
   position: absolute;
   width: 380px;
 
   .header {
+    border-bottom: 1px solid $dark-grey;
     font-size: $h6-font-size;
     line-height: $base-line-height;
 
     .title {
-      font-weight: bold;
+      font-weight: 500;
     }
 
     .attr {

--- a/app/styles/newcomponents/ilios-chart-tooltip.scss
+++ b/app/styles/newcomponents/ilios-chart-tooltip.scss
@@ -7,7 +7,6 @@
   font-size: $base-font-size;
   line-height: $base-line-height;
   margin: 0;
-  max-height: 150px;
   opacity: .9;
   overflow: auto;
   padding: 10px;


### PR DESCRIPTION
Add "auto scroll" to tooltips when content exceeds max-height of 150px. Update parent selector for .bar:hover to .ilios-chart. Change font-weight value to "500" for tooltips titles and add bottom-border to separate titles from tooltip content.