### PR TITLE
Truncate long group names before saving

### DIFF
--- a/app/components/learnergroup-subgroup-list.js
+++ b/app/components/learnergroup-subgroup-list.js
@@ -8,6 +8,7 @@ const { Promise } = RSVP;
 
 export default Component.extend({
   store: service(),
+  flashMessages: service(),
   parentGroup: null,
   classNames: ['learnergroup-subgroup-list'],
   tagName: 'section',
@@ -52,9 +53,11 @@ export default Component.extend({
           parentGroup.get('cohort').then((cohort) => {
             let groups = [];
             const padBy = countDigits(offset + parseInt(num, 10));
+            const parentTitle = parentGroup.get('title');
+            const shortenedParentTitle = parentTitle.substring(0, 60 - 1 - padBy);
             for (let i = 0; i < num; i++) {
               let newGroup = store.createRecord('learner-group', {
-                title: parentGroup.get('title') + ' ' + pad(offset + i, padBy),
+                title: shortenedParentTitle + ' ' + pad(offset + i, padBy),
                 parent: parentGroup,
                 cohort
               });

--- a/app/templates/components/new-learnergroup.hbs
+++ b/app/templates/components/new-learnergroup.hbs
@@ -16,8 +16,8 @@
 
 <div class="detail-content">
   {{#if singleMode}}
-    {{new-learnergroup-single save=this.attrs.save cancel=this.attrs.cancel fillModeSupported=fillModeSupported}}
+    {{new-learnergroup-single save=save cancel=cancel fillModeSupported=fillModeSupported}}
   {{else}}
-    {{new-learnergroup-multiple generateNewLearnerGroups='generateNewLearnerGroups' cancel=this.attrs.cancel}}
+    {{new-learnergroup-multiple generateNewLearnerGroups='generateNewLearnerGroups' cancel=cancel}}
   {{/if}}
 </div>


### PR DESCRIPTION
If a learner group is approaching the database limit we need to truncate
the title before attempting to append a counter to it when generating
subgroups.  This prevents issues on the API server when we attempt to
save groups with bad titles.

Fixes #2869