### PR TITLE
Focus when editing

### DIFF
--- a/app/components/editable-field.js
+++ b/app/components/editable-field.js
@@ -31,4 +31,12 @@ export default Component.extend({
     yield this.get('close')();
     this.set('isEditing', false);
   }).drop(),
+
+  edit: task(function * () {
+    this.set('isEditing', true);
+    yield timeout(10);
+    const control = this.$('.editor').find('input,textarea,select,.fr-element').filter(':visible:first');
+
+    control.focus();
+  }).drop(),
 });

--- a/app/templates/components/editable-field.hbs
+++ b/app/templates/components/editable-field.hbs
@@ -1,6 +1,6 @@
 <span class='content'>
   {{#unless isEditing}}
-    <span onclick={{action (mut isEditing) true}} class='editable'>
+    <span onclick={{perform edit}} class='editable'>
       {{#if value}}
         {{#if looksEmpty}}
           {{fa-icon 'edit'}}

--- a/tests/integration/components/editable-field-test.js
+++ b/tests/integration/components/editable-field-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
 
 moduleForComponent('editable-field', 'Integration | Component | editable field', {
   integration: true
@@ -38,4 +39,49 @@ test('it renders an edit icon when it looks empty', function(assert) {
 
   assert.equal(this.$().text().trim(), '');
   assert.equal(this.$(icon).length, 1);
+});
+
+test('placed focus in the input element', async function(assert) {
+  const el = 'input';
+  const editable = '.editable';
+  this.render(hbs`
+    {{#editable-field value='text'}}
+       <input>
+     {{/editable-field}}
+ `);
+
+  assert.equal(this.$().text().trim(), 'text');
+  this.$(editable).click();
+  await wait();
+  assert.ok(this.$(el).is(":focus"));
+});
+
+test('placed focus in the select element', async function(assert) {
+  const el = 'select';
+  const editable = '.editable';
+  this.render(hbs`
+    {{#editable-field value='text'}}
+       <select></select>
+     {{/editable-field}}
+ `);
+
+  assert.equal(this.$().text().trim(), 'text');
+  this.$(editable).click();
+  await wait();
+  assert.ok(this.$(el).is(":focus"));
+});
+
+test('placed focus in the textarea element', async function(assert) {
+  const el = 'textarea';
+  const editable = '.editable';
+  this.render(hbs`
+    {{#editable-field value='text'}}
+       <textarea></textarea>
+     {{/editable-field}}
+ `);
+
+  assert.equal(this.$().text().trim(), 'text');
+  this.$(editable).click();
+  await wait();
+  assert.ok(this.$(el).is(":focus"));
 });

--- a/tests/integration/components/editable-field-test.js
+++ b/tests/integration/components/editable-field-test.js
@@ -1,6 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import wait from 'ember-test-helpers/wait';
 
 moduleForComponent('editable-field', 'Integration | Component | editable field', {
   integration: true
@@ -39,49 +38,4 @@ test('it renders an edit icon when it looks empty', function(assert) {
 
   assert.equal(this.$().text().trim(), '');
   assert.equal(this.$(icon).length, 1);
-});
-
-test('placed focus in the input element', async function(assert) {
-  const el = 'input';
-  const editable = '.editable';
-  this.render(hbs`
-    {{#editable-field value='text'}}
-       <input>
-     {{/editable-field}}
- `);
-
-  assert.equal(this.$().text().trim(), 'text');
-  this.$(editable).click();
-  await wait();
-  assert.ok(this.$(el).is(":focus"));
-});
-
-test('placed focus in the select element', async function(assert) {
-  const el = 'select';
-  const editable = '.editable';
-  this.render(hbs`
-    {{#editable-field value='text'}}
-       <select></select>
-     {{/editable-field}}
- `);
-
-  assert.equal(this.$().text().trim(), 'text');
-  this.$(editable).click();
-  await wait();
-  assert.ok(this.$(el).is(":focus"));
-});
-
-test('placed focus in the textarea element', async function(assert) {
-  const el = 'textarea';
-  const editable = '.editable';
-  this.render(hbs`
-    {{#editable-field value='text'}}
-       <textarea></textarea>
-     {{/editable-field}}
- `);
-
-  assert.equal(this.$().text().trim(), 'text');
-  this.$(editable).click();
-  await wait();
-  assert.ok(this.$(el).is(":focus"));
 });


### PR DESCRIPTION
When we open an editable field focus is places in the element we are now
editing. This makes it much easier to start working right away without
an extra click.

Fixes #446