### PR TITLE
Translate Dates Correctly

### DIFF
--- a/app/components/ilios-header.js
+++ b/app/components/ilios-header.js
@@ -7,6 +7,7 @@ export default Component.extend({
   session: service(),
   currentUser: service(),
   i18n: service(),
+  moment: service(),
   classNames: ['ilios-header'],
   tagName: 'header',
   title: null,
@@ -18,6 +19,7 @@ export default Component.extend({
   actions: {
     changeLocale(newLocale){
       this.get('i18n').set('locale', newLocale);
+      this.get('moment').setLocale(newLocale);
     }
   }
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -9,6 +9,7 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
   flashMessages: service(),
   ajax: service(),
   i18n: service(),
+  moment: service(),
 
   /**
   * Leave titles as an array
@@ -34,6 +35,11 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
         }
       });
     }
+  },
+  beforeModel() {
+    const i18n = this.get('i18n');
+    const moment = this.get('moment');
+    moment.setLocale(i18n.get('locale'));
   },
 
   actions: {

--- a/app/templates/components/course-materials.hbs
+++ b/app/templates/components/course-materials.hbs
@@ -101,7 +101,7 @@
             <td colspan="3">{{lmObject.sessionTitle}}</td>
             <td>
               {{#if lmObject.firstOfferingDate}}
-                {{moment-format lmObject.firstOfferingDate 'MM/DD/YYYY'}}
+                {{moment-format lmObject.firstOfferingDate 'L'}}
               {{else}}
                 {{t 'general.none'}}
               {{/if}}

--- a/app/templates/components/course-overview.hbs
+++ b/app/templates/components/course-overview.hbs
@@ -77,7 +77,7 @@
     <span>
       {{#if editable}}
         {{#editable-field
-          value=(moment-format course.startDate 'MM/DD/YY')
+          value=(moment-format course.startDate 'L')
           save=(action 'changeStartDate')
           close=(action 'revertStartDateChanges')
         }}
@@ -92,7 +92,7 @@
           {{/if}}
         {{/editable-field}}
       {{else}}
-        {{moment-format course.startDate 'MM/DD/YY'}}&nbsp;
+        {{moment-format course.startDate 'L'}}&nbsp;
       {{/if}}
     </span>
   </div>
@@ -101,7 +101,7 @@
     <span>
       {{#if editable}}
         {{#editable-field
-          value=(moment-format course.endDate 'MM/DD/YY')
+          value=(moment-format course.endDate 'L')
           save=(action 'changeEndDate')
           close=(action 'revertEndDateChanges')
         }}
@@ -116,7 +116,7 @@
           {{/if}}
         {{/editable-field}}
       {{else}}
-        {{moment-format course.endDate 'MM/DD/YY'}}&nbsp;
+        {{moment-format course.endDate 'L'}}&nbsp;
       {{/if}}
     </span>
   </div>

--- a/app/templates/components/course-overview.hbs
+++ b/app/templates/components/course-overview.hbs
@@ -83,7 +83,7 @@
         }}
           {{pikaday-input
             value=startDate
-            format='MM/DD/YY'
+            format='L'
             onSelection=(action (mut startDate))
             focusOut=(action 'addErrorDisplayFor' 'startDate')
           }}
@@ -107,7 +107,7 @@
         }}
           {{pikaday-input
             value=endDate
-            format='MM/DD/YY'
+            format='L'
             onSelection=(action (mut endDate))
             focusOut=(action 'addErrorDisplayFor' 'endDate')
           }}

--- a/app/templates/components/course-summary-header.hbs
+++ b/app/templates/components/course-summary-header.hbs
@@ -17,7 +17,7 @@
 <div class='course-summary-content'>
   <div class="block">
     <label>{{t 'general.startDate'}}:</label>
-    <span>{{moment-format course.startDate 'MM/DD/YY'}}</span>
+    <span>{{moment-format course.startDate 'L'}}</span>
   </div>
   <div class="block">
     <label>{{t 'general.externalId'}}:</label>
@@ -25,7 +25,7 @@
   </div>
   <div class="block">
     <label>{{t 'general.endDate'}}:</label>
-    <span>{{moment-format course.endDate 'MM/DD/YY'}}</span>
+    <span>{{moment-format course.endDate 'L'}}</span>
   </div>
   <div class="block">
     <label>{{t 'general.level'}}:</label>

--- a/app/templates/components/curriculum-inventory-report-list.hbs
+++ b/app/templates/components/curriculum-inventory-report-list.hbs
@@ -36,8 +36,8 @@
         </td>
         <td class='text-center' colspan=2 {{action 'edit' report}}>{{report.program.title}}</td>
         <td class='text-center' colspan=2 {{action 'edit' report}}>{{report.yearLabel}}</td>
-        <td class='text-center' colspan=2 {{action 'edit' report}}>{{moment-format report.startDate 'MM/DD/YY'}}</td>
-        <td class='text-center' colspan=2 {{action 'edit' report}}>{{moment-format report.endDate 'MM/DD/YY'}}</td>
+        <td class='text-center' colspan=2 {{action 'edit' report}}>{{moment-format report.startDate 'L'}}</td>
+        <td class='text-center' colspan=2 {{action 'edit' report}}>{{moment-format report.endDate 'L'}}</td>
         <td class='text-center' colspan=2 {{action 'edit' report}}>
           {{#if report.isFinalized}}{{fa-icon 'lock'}}{{/if}}
           {{publication-status

--- a/app/templates/components/curriculum-inventory-report-overview.hbs
+++ b/app/templates/components/curriculum-inventory-report-overview.hbs
@@ -12,10 +12,10 @@
       <label>{{t 'general.start'}}:</label>
       <span>
         {{#if isFinalized}}
-          {{moment-format report.startDate 'MM/DD/YY'}}
+          {{moment-format report.startDate 'L'}}
         {{else}}
           {{#editable-field
-            value=(moment-format report.startDate 'MM/DD/YY')
+            value=(moment-format report.startDate 'L')
             save=(action 'changeStartDate')
             close=(action 'revertStartDateChanges')
           }}
@@ -36,10 +36,10 @@
       <label>{{t 'general.end'}}:</label>
       <span>
         {{#if isFinalized}}
-          {{moment-format report.endDate 'MM/DD/YY'}}
+          {{moment-format report.endDate 'L'}}
         {{else}}
           {{#editable-field
-            value=(moment-format report.endDate 'MM/DD/YY')
+            value=(moment-format report.endDate 'L')
             save=(action 'changeEndDate')
             close=(action 'revertEndDateChanges')
           }}

--- a/app/templates/components/curriculum-inventory-report-overview.hbs
+++ b/app/templates/components/curriculum-inventory-report-overview.hbs
@@ -21,7 +21,7 @@
           }}
             {{pikaday-input
               value=startDate
-              format='MM/DD/YY'
+              format='L'
               onSelection=(action (mut startDate))
               focusOut=(action 'addErrorDisplayFor' 'startDate')
             }}
@@ -45,7 +45,7 @@
           }}
             {{pikaday-input
               value=endDate
-              format='MM/DD/YY'
+              format='L'
               onSelection=(action (mut endDate))
               focusOut=(action 'addErrorDisplayFor' 'endDate')
             }}

--- a/app/templates/components/curriculum-inventory-sequence-block-list.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-list.hbs
@@ -61,14 +61,14 @@
                     </td>
                     <td class='text-center' colspan=2>
                       {{#if block.startDate}}
-                        {{moment-format block.startDate 'MM/DD/YY'}}
+                        {{moment-format block.startDate 'L'}}
                       {{else}}
                         {{t 'general.notApplicableAbbr'}}
                       {{/if}}
                     </td>
                     <td class='text-center' colspan=2>
                       {{#if block.endDate}}
-                        {{moment-format block.endDate 'MM/DD/YY'}}
+                        {{moment-format block.endDate 'L'}}
                       {{else}}
                         {{t 'general.notApplicableAbbr'}}
                       {{/if}}

--- a/app/templates/components/curriculum-inventory-sequence-block-overview.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-overview.hbs
@@ -88,7 +88,7 @@
         {{#if isFinalized}}
           <span>
             {{#if sequenceBlock.startDate}}
-              {{moment-format sequenceBlock.startDate 'MM/DD/YY'}}
+              {{moment-format sequenceBlock.startDate 'L'}}
             {{else}}
               {{t 'general.notApplicableAbbr'}}
             {{/if}}
@@ -97,7 +97,7 @@
           <span class="editinplace">
             <span {{action "editDatesAndDuration"}} class="editable">
               {{#if sequenceBlock.startDate}}
-                {{moment-format sequenceBlock.startDate 'MM/DD/YY'}}
+                {{moment-format sequenceBlock.startDate 'L'}}
               {{else}}
                 {{t 'general.clickToEdit'}}
               {{/if}}
@@ -110,7 +110,7 @@
         {{#if isFinalized}}
           <span>
             {{#if sequenceBlock.endDate}}
-              {{moment-format sequenceBlock.endDate 'MM/DD/YY'}}
+              {{moment-format sequenceBlock.endDate 'L'}}
             {{else}}
               {{t 'general.notApplicableAbbr'}}
             {{/if}}
@@ -119,7 +119,7 @@
           <span class="editinplace">
             <span {{action "editDatesAndDuration"}} class="editable">
               {{#if sequenceBlock.endDate}}
-                {{moment-format sequenceBlock.endDate 'MM/DD/YY'}}
+                {{moment-format sequenceBlock.endDate 'L'}}
               {{else}}
                 {{t 'general.clickToEdit'}}
               {{/if}}

--- a/app/templates/components/dashboard-calendar.hbs
+++ b/app/templates/components/dashboard-calendar.hbs
@@ -172,5 +172,6 @@
     icsFeedUrl=(get (await currentUser.model) 'absoluteIcsUri')
     icsInstructions=icsInstructionsTranslation
     showMore=(t 'general.showMore')
+    locale=i18n.locale
   }}
 </section>

--- a/app/templates/components/dashboard-materials.hbs
+++ b/app/templates/components/dashboard-materials.hbs
@@ -29,7 +29,7 @@
             <td colspan="1">{{join ', ' (sort-by (action 'sortString') lmObject.instructors)}}</td>
             <td>
               {{#if lmObject.firstOfferingDate}}
-                {{moment-format lmObject.firstOfferingDate 'MM/DD/YYYY'}}
+                {{moment-format lmObject.firstOfferingDate 'L'}}
               {{else}}
                 {{t 'general.none'}}
               {{/if}}

--- a/app/templates/components/ilios-course-list.hbs
+++ b/app/templates/components/ilios-course-list.hbs
@@ -68,8 +68,8 @@
         <td class='text-center hide-from-small-screen' colspan=2>{{course.school.title}}</td>
         <td class='text-center hide-from-small-screen' colspan=2>{{course.academicYear}}</td>
         <td class='text-center hide-from-small-screen' colspan=1>{{course.level}}</td>
-        <td class='text-center hide-from-small-screen' colspan=2>{{moment-format course.startDate 'MM/DD/YY'}}</td>
-        <td class='text-center hide-from-small-screen' colspan=2>{{moment-format course.endDate 'MM/DD/YY'}}</td>
+        <td class='text-center hide-from-small-screen' colspan=2>{{moment-format course.startDate 'L'}}</td>
+        <td class='text-center hide-from-small-screen' colspan=2>{{moment-format course.endDate 'L'}}</td>
         <td class='text-left' colspan=3>
           {{#if course.isSaving}}
             {{fa-icon 'spinner' spin=true}}

--- a/app/templates/components/ilios-event.hbs
+++ b/app/templates/components/ilios-event.hbs
@@ -33,6 +33,7 @@
     attendanceRequiredPhrase=(t 'general.attendanceIs_Required_')
     groupByCompetencies=(t 'general.groupByCompetencies')
     listByPriorityPhrase=(t 'general.listByPriority')
+    locale=i18n.locale
   }}
 {{else}}
   {{pulse-loader}}

--- a/app/templates/components/ilios-sessions-list.hbs
+++ b/app/templates/components/ilios-sessions-list.hbs
@@ -119,9 +119,9 @@
                 <td class='text-left' colspan=2>
                   {{#if sessionProxy.firstOfferingDate}}
                     {{#if sessionProxy.ilmSession}}
-                      <strong>{{t 'general.ilm'}}: {{t 'general.dueBy'}}</strong> {{moment-format sessionProxy.firstOfferingDate 'MM/DD/YYYY'}}
+                      <strong>{{t 'general.ilm'}}: {{t 'general.dueBy'}}</strong> {{moment-format sessionProxy.firstOfferingDate 'L'}}
                     {{else}}
-                      {{moment-format sessionProxy.firstOfferingDate 'MM/DD/YYYY h:mma'}}
+                      {{moment-format sessionProxy.firstOfferingDate 'L LT'}}
                     {{/if}}
                   {{/if}}
                 </td>

--- a/app/templates/components/my-materials.hbs
+++ b/app/templates/components/my-materials.hbs
@@ -78,7 +78,7 @@
             <td colspan="1">{{join ', ' (sort-by (action 'sortString') lmObject.instructors)}}</td>
             <td>
               {{#if lmObject.firstOfferingDate}}
-                {{moment-format lmObject.firstOfferingDate 'MM/DD/YYYY'}}
+                {{moment-format lmObject.firstOfferingDate 'L'}}
               {{else}}
                 {{t 'general.none'}}
               {{/if}}

--- a/app/templates/components/print-course.hbs
+++ b/app/templates/components/print-course.hbs
@@ -18,7 +18,7 @@
         <div class='detail-content'>
           <div class="inline-label-data-block">
             <label>{{t 'general.start'}}:</label>
-            <div>{{moment-format course.startDate 'MM/DD/YYYY'}}</div>
+            <div>{{moment-format course.startDate 'L'}}</div>
           </div>
           <div class="inline-label-data-block">
             <label>{{t 'general.externalId'}}:</label>
@@ -30,7 +30,7 @@
           </div>
           <div class="inline-label-data-block">
             <label>{{t 'general.end'}}:</label>
-            <div>{{moment-format course.endDate 'MM/DD/YYYY'}}</div>
+            <div>{{moment-format course.endDate 'L'}}</div>
           </div>
           <br>
           <br>
@@ -301,8 +301,8 @@
                 {{#each session.offerings as |offering|}}
                   <tr>
                     <td class='text-left'>
-                      {{moment-format offering.startDate 'MM/DD/YYYY LT'}} -
-                      {{moment-format offering.endDate 'MM/DD/YYYY LT'}}
+                      {{moment-format offering.startDate 'L LT'}} -
+                      {{moment-format offering.endDate 'L LT'}}
                     </td>
                     <td class='text-left'>{{offering.room}}</td>
                     <td class='text-left'>

--- a/app/templates/components/session-overview.hbs
+++ b/app/templates/components/session-overview.hbs
@@ -206,7 +206,7 @@
                 }}
                   {{pikaday-input
                     value=dueDate
-                    format='MM/DD/YY'
+                    format='L'
                     onSelection=(action (mut dueDate))
                     focusOut=(action 'addErrorDisplayFor' 'dueDate')
                   }}

--- a/app/templates/components/session-overview.hbs
+++ b/app/templates/components/session-overview.hbs
@@ -200,7 +200,7 @@
             {{#if (is-fulfilled session.ilmSession)}}
               {{#if editable}}
                 {{#editable-field
-                  value=(moment-format session.ilmSession.dueDate 'MM/DD/YY')
+                  value=(moment-format session.ilmSession.dueDate 'L')
                   save=(action 'changeIlmDueDate')
                   close=(action 'revertIlmDueDateChanges')
                 }}
@@ -215,7 +215,7 @@
                   {{/if}}
                 {{/editable-field}}
               {{else}}
-                {{moment-format session.ilmSession.dueDate 'MM/DD/YY'}}
+                {{moment-format session.ilmSession.dueDate 'L'}}
               {{/if}}
             {{/if}}
           </span>

--- a/config/environment.js
+++ b/config/environment.js
@@ -47,6 +47,10 @@ module.exports = function(environment) {
     'ember-metrics': {
       includeAdapters: ['google-analytics']
     },
+    moment: {
+      // Full list of locales: https://github.com/moment/moment/tree/2.10.3/locale
+      includeLocales: ['es', 'fr']
+    },
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
@@ -106,6 +110,9 @@ module.exports = function(environment) {
     ENV.serverVariables.defaults['api-host'] = '';
 
     ENV.IliosFeatures.accessCourseVisualizations = true;
+
+    //silence warnings in tests when dates are not initialized
+    ENV.moment.allowEmpty = true;
   }
 
 /*

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -55,11 +55,11 @@ test('check fields', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.index');
     var container = find('.course-overview');
-    var startDate = moment.utc(course.startDate).format('MM/DD/YY');
+    var startDate = moment.utc(course.startDate).format('L');
     assert.equal(getElementText(find('.coursestartdate', container)), 'Start:' + startDate);
     assert.equal(getElementText(find('.courseexternalid', container)), 'CourseID:123');
     assert.equal(getElementText(find('.courselevel', container)), 'Level:3');
-    var endDate = moment.utc(course.endDate).format('MM/DD/YY');
+    var endDate = moment.utc(course.endDate).format('L');
     assert.equal(getElementText(find('.courseenddate', container)), 'End:' + endDate);
     assert.equal(getElementText(find('.universallocator', container)), 'ILIOS' + course.id);
     assert.equal(getElementText(find('.clerkshiptype', container)), getText('Clerkship Type:' + clerkshipType.title));
@@ -88,11 +88,11 @@ test('check detail fields', function(assert) {
   andThen(function() {
     assert.equal(currentPath(), 'course.index');
     var container = find('.course-overview');
-    var startDate = moment.utc(course.startDate).format('MM/DD/YY');
+    var startDate = moment.utc(course.startDate).format('L');
     assert.equal(getElementText(find('.coursestartdate .editable', container)), startDate);
     assert.equal(getElementText(find('.courseexternalid .editable', container)), 123);
     assert.equal(getElementText(find('.courselevel .editable', container)), 3);
-    var endDate = moment.utc(course.endDate).format('MM/DD/YY');
+    var endDate = moment.utc(course.endDate).format('L');
     assert.equal(getElementText(find('.courseenddate .editable', container)), endDate);
     assert.equal(getElementText(find('.clerkshiptype .editable', container)), getText(clerkshipType.title));
   });
@@ -226,7 +226,7 @@ test('change start date', function(assert) {
     endDate: new Date('2015-05-22'),
     school: 1,
   });
-  var startDate = moment.utc(course.startDate).format('MM/DD/YY');
+  var startDate = moment.utc(course.startDate).format('L');
   visit(url);
   andThen(function() {
     assert.equal(getElementText(find('.course-overview .coursestartdate')), getText('Start:' + startDate));
@@ -245,7 +245,7 @@ test('change start date', function(assert) {
       interactor.selectDate(newDate.toDate());
       click(find('.coursestartdate .editinplace .actions .done', container));
       andThen(function(){
-        assert.equal(getElementText(find('.coursestartdate', container)), getText('Start:' + newDate.format('MM/DD/YY')));
+        assert.equal(getElementText(find('.coursestartdate', container)), getText('Start:' + newDate.format('L')));
       });
 
     });
@@ -290,7 +290,7 @@ test('change end date', function(assert) {
     startDate: new Date('2013-04-23'),
     endDate: new Date('2015-05-22'),
   });
-  var endDate = moment.utc(course.endDate).format('MM/DD/YY');
+  var endDate = moment.utc(course.endDate).format('L');
   visit(url);
   andThen(function() {
     assert.equal(getElementText(find('.course-overview .courseenddate')), getText('End:' + endDate));
@@ -309,7 +309,7 @@ test('change end date', function(assert) {
       interactor.selectDate(newDate.toDate());
       click(find('.courseenddate .editinplace .actions .done', container));
       andThen(function(){
-        assert.equal(getElementText(find('.courseenddate', container)), getText('End:' + newDate.format('MM/DD/YY')));
+        assert.equal(getElementText(find('.courseenddate', container)), getText('End:' + newDate.format('L')));
       });
 
     });

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -77,7 +77,7 @@ test('check remove ilm', function(assert) {
     var container = find('.session-overview');
     assert.equal(find('.sessionilmhours', container).length, 1);
     assert.equal(find('.sessionilmduedate', container).length, 1);
-    var dueDate = moment(ilmSession.dueDate).format('MM/DD/YY');
+    var dueDate = moment(ilmSession.dueDate).format('L');
     assert.equal(getElementText(find('.sessionilmhours .content', container)), ilmSession.hours);
     assert.equal(getElementText(find('.sessionilmduedate .editable', container)), dueDate);
     click(find('.independentlearningcontrol .switch-handle', container));
@@ -158,7 +158,7 @@ test('change ilm due date', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.sessionilmduedate');
-    var dueDate = moment(ilmSession.dueDate).format('MM/DD/YY');
+    var dueDate = moment(ilmSession.dueDate).format('L');
     assert.equal(getElementText(find('.editable', container)), dueDate);
     click(find('.editable', container));
     andThen(function(){
@@ -170,7 +170,7 @@ test('change ilm due date', function(assert) {
       interactor.selectDate(newDate.toDate());
       click(find('.editinplace .actions .done', container));
       andThen(function(){
-        assert.equal(getElementText(find('.editable', container)), newDate.format('MM/DD/YY'));
+        assert.equal(getElementText(find('.editable', container)), newDate.format('L'));
       });
     });
   });

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -125,7 +125,7 @@ test('check remove ilm', function(assert) {
     var container = find('.session-overview');
     assert.equal(find('.sessionilmhours', container).length, 1);
     assert.equal(find('.sessionilmduedate', container).length, 1);
-    var dueDate = moment(ilmSession.dueDate).format('MM/DD/YY');
+    var dueDate = moment(ilmSession.dueDate).format('L');
     assert.equal(getElementText(find('.sessionilmhours .content', container)), ilmSession.hours);
     assert.equal(getElementText(find('.sessionilmduedate .editable', container)), dueDate);
     click(find('.independentlearningcontrol .switch-handle', container));
@@ -196,7 +196,7 @@ test('change ilm due date', function(assert) {
   visit(url);
   andThen(function() {
     var container = find('.session-overview .sessionilmduedate');
-    var dueDate = moment(ilmSession.dueDate).format('MM/DD/YY');
+    var dueDate = moment(ilmSession.dueDate).format('L');
     assert.equal(getElementText(find('.editable', container)), dueDate);
     click(find('.editable', container));
     andThen(function(){
@@ -208,7 +208,7 @@ test('change ilm due date', function(assert) {
       interactor.selectDate(newDate.toDate());
       click(find('.editinplace .actions .done', container));
       andThen(function(){
-        assert.equal(getElementText(find('.editable', container)), newDate.format('MM/DD/YY'));
+        assert.equal(getElementText(find('.editable', container)), newDate.format('L'));
       });
     });
   });

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -224,7 +224,7 @@ test('first offering is updated when offering is updated #1276', function(assert
   const newStartDate = new Date(2010, 6, 4);
   andThen(function() {
     let container = find('.sessions-list');
-    assert.equal(getElementText(find('tr:eq(1) td:eq(3)', container), getText), getText(moment(fixtures.offerings[0].startDate).format('MM/DD/YYYY h:mma')));
+    assert.equal(getElementText(find('tr:eq(1) td:eq(3)', container)), getText(moment(fixtures.offerings[0].startDate).format('L LT')));
 
     click('tr:eq(1) .edit', container).then(()=> {
       assert.equal(currentPath(), 'course.session.index');

--- a/tests/integration/components/course-summary-header-test.js
+++ b/tests/integration/components/course-summary-header-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
 
 const { Object:EmberObject } = Ember;
 
@@ -43,9 +44,9 @@ test('it renders', function(assert) {
   assert.ok(this.$(materialsIcon).hasClass('fa-archive'));
   assert.ok(this.$(printIcon).hasClass('fa-print'));
   assert.ok(this.$(rolloverIcon).hasClass('fa-random'));
-  assert.equal(this.$(start).text().trim(), '05/06/20');
+  assert.equal(this.$(start).text().trim(), moment(course.startDate).format('L'));
   assert.equal(this.$(externalId).text().trim(), 'abc');
-  assert.equal(this.$(end).text().trim(), '12/11/20');
+  assert.equal(this.$(end).text().trim(), moment(course.endDate).format('L'));
   assert.equal(this.$(level).text().trim(), '3');
   assert.equal(this.$(status).text().trim(), 'Published');
 

--- a/tests/integration/components/curriculum-inventory-report-list-test.js
+++ b/tests/integration/components/curriculum-inventory-report-list-test.js
@@ -66,11 +66,11 @@ test('it renders', function(assert) {
       'Academic year shows.'
     );
     assert.equal(this.$(`tbody tr:eq(${i}) td:eq(3)`).text().trim(),
-      moment(report.get('startDate')).format('MM/DD/YY'),
+      moment(report.get('startDate')).format('L'),
       'Start date shows.'
     );
     assert.equal(this.$(`tbody tr:eq(${i}) td:eq(4)`).text().trim(),
-      moment(report.get('endDate')).format('MM/DD/YY'),
+      moment(report.get('endDate')).format('L'),
       'End date shows.'
     );
     assert.equal(this.$(`tbody tr:eq(${i}) td:eq(5)`).text().trim(),

--- a/tests/integration/components/curriculum-inventory-report-overview-test.js
+++ b/tests/integration/components/curriculum-inventory-report-overview-test.js
@@ -74,13 +74,13 @@ test('it renders', function (assert) {
       'Start date label is correct.'
     );
     assert.equal(this.$('.start-date .editinplace').text().trim(),
-      moment(report.get('startDate')).format('MM/DD/YY'), 'Start date is visible.'
+      moment(report.get('startDate')).format('L'), 'Start date is visible.'
     );
     assert.equal(this.$('.end-date label').text().trim(), 'End:',
       'End date label is correct.'
     );
     assert.equal(this.$('.end-date .editinplace').text().trim(),
-      moment(report.get('endDate')).format('MM/DD/YY'), 'End date is visible.'
+      moment(report.get('endDate')).format('L'), 'End date is visible.'
     );
     assert.equal(this.$('.academic-year label').text().trim(), 'Academic Year:',
       'Academic year label is correct.'
@@ -144,10 +144,10 @@ test('read-only/finalized mode', function (assert) {
   this.render(hbs`{{curriculum-inventory-report-details report=report}}`);
   return wait().then(() => {
     assert.equal(this.$('.start-date > span:eq(0)').text().trim(),
-      moment(report.get('startDate')).format('MM/DD/YY'), 'Start date is visible.'
+      moment(report.get('startDate')).format('L'), 'Start date is visible.'
     );
     assert.equal(this.$('.end-date > span:eq(0)').text().trim(),
-      moment(report.get('endDate')).format('MM/DD/YY'), 'End date is visible.'
+      moment(report.get('endDate')).format('L'), 'End date is visible.'
     );
     assert.equal(this.$('.academic-year > span:eq(0)').text().trim(),
       report.get('year') + ' - ' + (parseInt(report.get('year'), 10) + 1), 'Academic year is visible.'
@@ -256,14 +256,14 @@ test('change start date', function (assert) {
     this.$('.start-date .editinplace .editable').click();
     return wait().then(() => {
       let interactor = openDatepicker(this.$('.start-date input'));
-      assert.equal(this.$('.start-date input').val(), moment(report.get('startDate')).format('MM/DD/YY'),
+      assert.equal(this.$('.start-date input').val(), moment(report.get('startDate')).format('L'),
         "The report's current start date is pre-selected in date picker."
       );
       let newVal = moment('2015-04-01');
       interactor.selectDate(newVal.toDate());
       this.$('.start-date .actions .done').click();
       return wait().then(() => {
-        assert.equal(this.$('.start-date .editinplace').text().trim(), newVal.format('MM/DD/YY'),
+        assert.equal(this.$('.start-date .editinplace').text().trim(), newVal.format('L'),
           'Edit link shown new start date post-update.'
         );
         assert.equal(moment(report.get('startDate')).format('YYYY-MM-DD'), newVal.format('YYYY-MM-DD'),
@@ -378,14 +378,14 @@ test('change end date', function (assert) {
     this.$('.end-date .editinplace .editable').click();
     return wait().then(() => {
       let interactor = openDatepicker(this.$('.end-date input'));
-      assert.equal(this.$('.end-date input').val(), moment(report.get('endDate')).format('MM/DD/YY'),
+      assert.equal(this.$('.end-date input').val(), moment(report.get('endDate')).format('L'),
         "The report's current end date is pre-selected in date picker."
       );
       let newVal = moment('2016-05-01');
       interactor.selectDate(newVal.toDate());
       this.$('.end-date .actions .done').click();
       return wait().then(() => {
-        assert.equal(this.$('.end-date .editinplace').text().trim(), newVal.format('MM/DD/YY'),
+        assert.equal(this.$('.end-date .editinplace').text().trim(), newVal.format('L'),
           'Edit link shown new end date post-update.'
         );
         assert.equal(moment(report.get('endDate')).format('YYYY-MM-DD'), newVal.format('YYYY-MM-DD'),

--- a/tests/integration/components/curriculum-inventory-sequence-block-list-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-list-test.js
@@ -101,8 +101,8 @@ test('it renders with top-level sequence blocks', function(assert) {
     assert.equal(this.$('tbody tr:eq(1) td:eq(0)').text().trim(), block1.get('title'));
     assert.equal(this.$('tbody tr:eq(1) td:eq(1)').text().trim(), academicLevel1.get('level'));
     assert.equal(this.$('tbody tr:eq(1) td:eq(2)').text().trim(), 'n/a');
-    assert.equal(this.$('tbody tr:eq(1) td:eq(3)').text().trim(), moment(block1.get('startDate')).format('MM/DD/YY'));
-    assert.equal(this.$('tbody tr:eq(1) td:eq(4)').text().trim(), moment(block1.get('endDate')).format('MM/DD/YY'));
+    assert.equal(this.$('tbody tr:eq(1) td:eq(3)').text().trim(), moment(block1.get('startDate')).format('L'));
+    assert.equal(this.$('tbody tr:eq(1) td:eq(4)').text().trim(), moment(block1.get('endDate')).format('L'));
     assert.equal(this.$('tbody tr:eq(1) td:eq(5)').text().trim(), course.get('title'));
     assert.equal(this.$('tbody tr:eq(1) td:eq(6) .edit').length, 1, 'Edit link is visible.');
     assert.equal(this.$('tbody tr:eq(1) td:eq(6) .remove').length, 1, 'Remove link is visible.');
@@ -193,8 +193,8 @@ test('it renders with nested blocks', function(assert) {
     assert.equal(this.$('tbody tr:eq(0) td:eq(0)').text().trim(), block1.get('title'));
     assert.equal(this.$('tbody tr:eq(0) td:eq(1)').text().trim(), academicLevel1.get('level'));
     assert.equal(this.$('tbody tr:eq(0) td:eq(2)').text().trim(), block1.get('orderInSequence'));
-    assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), moment(block1.get('startDate')).format('MM/DD/YY'));
-    assert.equal(this.$('tbody tr:eq(0) td:eq(4)').text().trim(), moment(block1.get('endDate')).format('MM/DD/YY'));
+    assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), moment(block1.get('startDate')).format('L'));
+    assert.equal(this.$('tbody tr:eq(0) td:eq(4)').text().trim(), moment(block1.get('endDate')).format('L'));
     assert.equal(this.$('tbody tr:eq(0) td:eq(5)').text().trim(), course.get('title'));
     assert.equal(this.$('tbody tr:eq(0) td:eq(6) .edit').length, 1, 'Edit link is visible.');
     assert.equal(this.$('tbody tr:eq(0) td:eq(6) .remove').length, 1, 'Remove link is visible.');

--- a/tests/integration/components/curriculum-inventory-sequence-block-overview-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-overview-test.js
@@ -202,12 +202,12 @@ test('it renders', function(assert) {
     assert.ok(this.$('.track input').prop('checked'), 'Track toggle is set to "yes"');
     assert.equal(this.$('.start-date label').text().trim(), 'Start:', 'Start date label is correct.');
     assert.equal(
-      this.$('.start-date .editinplace').text().trim(), moment(block.get('startDate')).format('MM/DD/YY'),
+      this.$('.start-date .editinplace').text().trim(), moment(block.get('startDate')).format('L'),
       'Start date is visible.'
     );
     assert.equal(this.$('.end-date label').text().trim(), 'End:', 'End date label is correct.');
     assert.equal(
-      this.$('.end-date .editinplace').text().trim(), moment(block.get('endDate')).format('MM/DD/YY'),
+      this.$('.end-date .editinplace').text().trim(), moment(block.get('endDate')).format('L'),
       'End date is visible.'
     );
     assert.equal(this.$('.duration label').text().trim(), 'Duration (in Days):', 'Duration label is correct.');
@@ -1234,11 +1234,11 @@ test('finalized/read-only mode', function(assert) {
     assert.equal(this.$('.required > span:eq(0)').text().trim(), 'Optional (elective)', 'Required is visible.');
     assert.ok(this.$('.track > span:eq(0)').text().trim(), 'Is Track is visible.');
     assert.equal(
-      this.$('.start-date > span:eq(0)').text().trim(), moment(block.get('startDate')).format('MM/DD/YY'),
+      this.$('.start-date > span:eq(0)').text().trim(), moment(block.get('startDate')).format('L'),
       'Start date is visible.'
     );
     assert.equal(
-      this.$('.end-date > span:eq(0)').text().trim(), moment(block.get('endDate')).format('MM/DD/YY'),
+      this.$('.end-date > span:eq(0)').text().trim(), moment(block.get('endDate')).format('L'),
       'End date is visible.'
     );
     assert.equal(this.$('.duration > span:eq(0)').text().trim(), block.get('duration'), 'Duration is visible.');

--- a/tests/integration/components/dashboard-materials-test.js
+++ b/tests/integration/components/dashboard-materials-test.js
@@ -99,21 +99,21 @@ test('it renders with materials', function(assert) {
     assert.equal(this.$(firstLmSessionTitle).text().trim(), 'session1title');
     assert.equal(this.$(firstLmCourseTitle).text().trim(), 'course1title');
     assert.equal(this.$(firstLmInstructor).text().trim(), 'Instructor1name, Instructor2name');
-    assert.equal(this.$(firstLmFirstOffering).text().trim(), today.format('MM/DD/YYYY'));
+    assert.equal(this.$(firstLmFirstOffering).text().trim(), today.format('L'));
 
     assert.equal(this.$(secondLmTitle).text().replace(/[\t\n\s]+/g, ""), 'title3citationtext');
     assert.equal(this.$(secondLmLink).length, 0);
     assert.equal(this.$(secondLmSessionTitle).text().trim(), 'session3title');
     assert.equal(this.$(secondLmCourseTitle).text().trim(), 'course3title');
     assert.equal(this.$(secondLmInstructor).text().trim(), '');
-    assert.equal(this.$(secondLmFirstOffering).text().trim(), today.format('MM/DD/YYYY'));
+    assert.equal(this.$(secondLmFirstOffering).text().trim(), today.format('L'));
 
     assert.equal(this.$(thirdLmTitle).text().trim(), 'title2');
     assert.equal(this.$(thirdLmLink).prop('href').trim(), 'http://myhost.com/url2');
     assert.equal(this.$(thirdLmSessionTitle).text().trim(), 'session2title');
     assert.equal(this.$(thirdLmCourseTitle).text().trim(), 'course2title');
     assert.equal(this.$(thirdLmInstructor).text().trim(), 'Instructor1name, Instructor2name');
-    assert.equal(this.$(thirdLmFirstOffering).text().trim(), tomorrow.format('MM/DD/YYYY'));
+    assert.equal(this.$(thirdLmFirstOffering).text().trim(), tomorrow.format('L'));
   });
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,23 +1614,7 @@ broccoli-sri-hash@^2.1.0:
     sri-toolbox "^0.2.0"
     symlink-or-copy "^1.0.1"
 
-broccoli-stew@^1.0.4, broccoli-stew@^1.1.1, broccoli-stew@^1.2.0, broccoli-stew@^1.3.2, broccoli-stew@^1.3.3, broccoli-stew@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.4.0.tgz#1bdb0a1804d62a419d190abc26acb3c91878154d"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.0.0"
-    broccoli-persistent-filter "^1.1.6"
-    chalk "^1.1.3"
-    debug "^2.1.0"
-    ensure-posix-path "^1.0.1"
-    fs-extra "^0.30.0"
-    minimatch "^3.0.2"
-    resolve "^1.1.6"
-    rsvp "^3.0.16"
-    walk-sync "^0.3.0"
-
-broccoli-stew@^1.4.2:
+broccoli-stew@^1.0.4, broccoli-stew@^1.1.1, broccoli-stew@^1.3.3, broccoli-stew@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.4.2.tgz#9ec4062fd7162c6026561a2fbf64558363aff8d6"
   dependencies:
@@ -1647,6 +1631,22 @@ broccoli-stew@^1.4.2:
     rsvp "^3.0.16"
     sanitize-filename "^1.5.3"
     symlink-or-copy "^1.1.8"
+    walk-sync "^0.3.0"
+
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.2, broccoli-stew@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.4.0.tgz#1bdb0a1804d62a419d190abc26acb3c91878154d"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.0.0"
+    broccoli-persistent-filter "^1.1.6"
+    chalk "^1.1.3"
+    debug "^2.1.0"
+    ensure-posix-path "^1.0.1"
+    fs-extra "^0.30.0"
+    minimatch "^3.0.2"
+    resolve "^1.1.6"
+    rsvp "^3.0.16"
     walk-sync "^0.3.0"
 
 broccoli-string-replace@0.1.1:
@@ -2775,7 +2775,7 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cl
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.0.0.tgz#caab075780dca3759982c9f54ea70a9adb1f3550"
   dependencies:
@@ -2789,7 +2789,7 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-be
     clone "^2.0.0"
     ember-cli-version-checker "^1.2.0"
 
-ember-cli-babel@^6.1.0:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.1.0.tgz#d9c83a7d0c67cc8a3ccb9bd082971c3593e54fad"
   dependencies:
@@ -3207,9 +3207,9 @@ ember-cli-sri@^2.1.0:
   dependencies:
     broccoli-sri-hash "^2.1.0"
 
-ember-cli-string-helpers@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-string-helpers/-/ember-cli-string-helpers-1.2.0.tgz#e3c38c6380a5806db98b3d117730832edacb2f53"
+ember-cli-string-helpers@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-string-helpers/-/ember-cli-string-helpers-1.2.1.tgz#b557a0eb367cd386e0f43c4780e1513132997e9c"
   dependencies:
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^5.1.7"
@@ -6387,15 +6387,15 @@ nomnom@^1.8.1:
     chalk "~0.4.0"
     underscore "~1.6.0"
 
-"nopt@2 || 3", nopt@2.2.x:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-2.2.1.tgz#2aa09b7d1768487b3b89a9c5aa52335bff0baea7"
+"nopt@2 || 3", nopt@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   dependencies:
     abbrev "1"
 
-nopt@^3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+nopt@2.2.x:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-2.2.1.tgz#2aa09b7d1768487b3b89a9c5aa52335bff0baea7"
   dependencies:
     abbrev "1"
 


### PR DESCRIPTION
Dates in the format of MM/DD/YY need to be re-written for non-english locales.  Additionally we can take advantage of a new feature of the calendar to pass the locale in and get translations there as well.

Need to wait for https://github.com/ilios/calendar/pull/176 to be merged

Fixes #781