### PR TITLE
Handle initial active users for user-search better

### DIFF
--- a/app/components/user-search.js
+++ b/app/components/user-search.js
@@ -57,7 +57,7 @@ export default Component.extend({
       };
     }
     let users = yield this.get('store').query('user', query);
-    const currentlyActiveUsers = isEmpty(this.get('currentlyActiveUsers'))?[]:this.get('currentlyActiveUsers');
+    const currentlyActiveUsers = this.get('currentlyActiveUsers') === null?[]:this.get('currentlyActiveUsers');
     let results = users.map(user => {
       return userProxy.create({
         content: user,

--- a/app/templates/components/programyear-overview.hbs
+++ b/app/templates/components/programyear-overview.hbs
@@ -19,7 +19,7 @@
   {{#if editable}}
     {{user-search
       addUser='addDirector'
-      currentlyActiveUsers=programYear.directors
+      currentlyActiveUsers=(await programYear.directors)
     }}
     <br>
     <br>

--- a/tests/acceptance/program/programyear/overview-test.js
+++ b/tests/acceptance/program/programyear/overview-test.js
@@ -112,3 +112,30 @@ test('remove director', function(assert) {
     });
   });
 });
+
+test('first director added is disabled #2770', async function(assert) {
+  assert.expect(5);
+  server.create('programYear', {
+    program: 1,
+    directors: []
+  });
+  server.create('cohort');
+  server.db.programs.update(1, {programYears: [1, 2]});
+  const overview = '.programyear-overview';
+  const directors = `${overview} .removable-list li`;
+  const search = `${overview} .live-search`;
+  const input = `${search} input`;
+  const results = `${search} .results li`;
+  const firstResult = `${results}:eq(1)`;
+
+  await visit('/programs/1/programyears/2');
+
+  assert.equal(currentPath(), 'program.programYear.index');
+  assert.equal(find(directors).length, 0, 'no directors initially');
+  await fillIn(input, 'guy');
+  assert.notOk(find(firstResult).hasClass('inactive'), 'the first user is active now');
+  await click(firstResult);
+  assert.equal(find(directors).length, 1, 'director is selected');
+  assert.ok(find(firstResult).hasClass('inactive'), 'the first user is now marked as inactive');
+
+});


### PR DESCRIPTION
When and empty array was sent to the user-search currentlyActiveUsers
property we were replacing it with a new empty array. This prevented
updates to the array from being tracked. Instead check for null
explicitly and user empty arrays as is.

Fixes #2770