### PR TITLE
Reset learner group list after saving changes

### DIFF
--- a/app/components/learnergroup-cohort-user-manager.js
+++ b/app/components/learnergroup-cohort-user-manager.js
@@ -56,6 +56,7 @@ export default Component.extend({
     yield timeout(10);
     yield this.get('addUsersToGroup')(users);
     this.get('usersBeingMoved').removeObjects(users);
+    this.set('selectedUsers', []);
   }),
 
   setCheckAllState(){

--- a/app/components/learnergroup-user-manager.js
+++ b/app/components/learnergroup-user-manager.js
@@ -82,6 +82,7 @@ export default Component.extend({
     yield timeout(10);
     yield this.get('addUsersToGroup')(users);
     this.get('usersBeingMoved').removeObjects(users);
+    this.set('selectedUsers', []);
   }),
   removeSelectedUsers: task(function * () {
     const users = this.get('selectedUsers');
@@ -90,6 +91,7 @@ export default Component.extend({
     yield timeout(10);
     yield this.get('removeUsersFromGroup')(users);
     this.get('usersBeingMoved').removeObjects(users);
+    this.set('selectedUsers', []);
   }),
 
   setCheckAllState(){

--- a/tests/integration/components/learnergroup-cohort-user-manager-test.js
+++ b/tests/integration/components/learnergroup-cohort-user-manager-test.js
@@ -98,8 +98,8 @@ test('sort by firstName', function(assert) {
   assert.equal(this.$(user2FirstName).text().trim(), 'Jasper');
 });
 
-test('add multiple users', function(assert) {
-  assert.expect(2);
+test('add multiple users', async function(assert) {
+  assert.expect(4);
   const user1CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
   const button = 'button.done';
 
@@ -123,10 +123,12 @@ test('add multiple users', function(assert) {
     addUsersToGroup=(action 'addMany')
   }}`);
 
+  assert.equal(this.$(button).length, 0);
   this.$(user1CheckBox).click();
   assert.equal(this.$(button).text().trim(), 'Move learner to this group');
-  return wait(this.$(button).click());
-
+  this.$(button).click();
+  await wait();
+  assert.equal(this.$(button).length, 0, 'button is hidden after save');
 });
 
 test('add single user', function(assert) {

--- a/tests/integration/components/learnergroup-user-manager-test.js
+++ b/tests/integration/components/learnergroup-user-manager-test.js
@@ -179,8 +179,8 @@ test('sort by firstName', function(assert) {
   assert.equal(this.$(user2FirstName).text().trim(), 'Jasper');
 });
 
-test('add multiple users', function(assert) {
-  assert.expect(3);
+test('add multiple users', async function(assert) {
+  assert.expect(5);
   const user1CheckBox = 'table:eq(1) tbody tr:eq(0) td:eq(0) input[type=checkbox]';
   const button = 'button.done';
 
@@ -212,15 +212,18 @@ test('add multiple users', function(assert) {
     removeUsersFromGroup=(action nothing)
   }}`);
 
+  assert.equal(this.$(button).length, 0);
   this.$(user1CheckBox).click();
   assert.ok(this.$(user1CheckBox).prop('checked'));
   assert.equal(this.$(button).text().trim(), 'Move learner to this group');
-  return wait(this.$(button).click());
+  this.$(button).click();
+  await wait();
+  assert.equal(this.$(button).length, 0);
 
 });
 
-test('remove multiple users', function(assert) {
-  assert.expect(3);
+test('remove multiple users', async function(assert) {
+  assert.expect(5);
   const user1CheckBox = 'table:eq(1) tbody tr:eq(0) td:eq(0) input[type=checkbox]';
   const button = 'button.cancel';
 
@@ -252,11 +255,13 @@ test('remove multiple users', function(assert) {
     removeUsersFromGroup=(action removeMany)
   }}`);
 
+  assert.equal(this.$(button).length, 0);
   this.$(user1CheckBox).click();
   assert.ok(this.$(user1CheckBox).prop('checked'));
   assert.equal(this.$(button).text().trim(), 'Remove learner to this cohort');
-  return wait(this.$(button).click());
-
+  this.$(button).click();
+  await wait();
+  assert.equal(this.$(button).length, 0);
 });
 
 test('remove single user', function(assert) {


### PR DESCRIPTION
We were not zeroing out the list of checked users so the count was
causing the buttons to be in a confusing and wrong state.

Fixes #2627