### PR TITLE
Check for yarn problems in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
+  - yarn check
   - ember exam --split=$SPLIT --partition=$PARTITION --filter=$FILTER --parallel=$PARALLEL
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - npm install -g bower
 
 install:
-  - yarn install --no-lockfile
+  - yarn install
   - bower install
 
 before_script:


### PR DESCRIPTION
Running `yarn check` as part of the test will fail with an error code if
the package.json was updated and then yarn.lock was not.