### PR TITLE
Limit instructors shown in My Materials list

### DIFF
--- a/app/templates/components/dashboard-materials.hbs
+++ b/app/templates/components/dashboard-materials.hbs
@@ -7,7 +7,7 @@
           <th colspan="3">{{t 'general.title'}}</th>
           <th colspan="3">{{t 'general.course'}}</th>
           <th colspan="3">{{t 'general.session'}}</th>
-          <th>{{t 'general.instructor'}}</th>
+          <th class='hide-from-small-screen'>{{t 'general.instructor'}}</th>
           <th>{{t 'general.date'}}</th>
         </tr>
       </thead>
@@ -26,7 +26,7 @@
             </td>
             <td colspan="3">{{lmObject.courseTitle}}</td>
             <td colspan="3">{{lmObject.sessionTitle}}</td>
-            <td colspan="1">{{join ', ' (sort-by (action 'sortString') lmObject.instructors)}}</td>
+            <td colspan="1">{{big-text length=25 text=(join ', ' (sort-by (action 'sortString') lmObject.instructors))}}</td>
             <td>
               {{#if lmObject.firstOfferingDate}}
                 {{moment-format lmObject.firstOfferingDate 'MM/DD/YYYY'}}

--- a/app/templates/components/my-materials.hbs
+++ b/app/templates/components/my-materials.hbs
@@ -46,7 +46,7 @@
           }}
             {{t 'general.title'}}
           {{/sortable-th}}
-          <th>
+          <th class='hide-from-small-screen'>
             {{t 'general.instructor'}}
           </th>
           {{#sortable-th
@@ -75,7 +75,7 @@
                 <small>{{lmObject.citation}}</small>
               {{/if}}
             </td>
-            <td colspan="1">{{join ', ' (sort-by (action 'sortString') lmObject.instructors)}}</td>
+            <td colspan="1">{{big-text length=25 text=(join ', ' (sort-by (action 'sortString') lmObject.instructors))}}</td>
             <td>
               {{#if lmObject.firstOfferingDate}}
                 {{moment-format lmObject.firstOfferingDate 'MM/DD/YYYY'}}


### PR DESCRIPTION
Using big text to avoid very long instructor lists from displaying in my-materials pages, using hide-from-small-screens to avoid wide table problems on mobile devices or other small screens