### PR TITLE
Add a space into the material filter search string

### DIFF
--- a/app/components/my-materials.js
+++ b/app/components/my-materials.js
@@ -20,9 +20,9 @@ export default Component.extend(SortableTable, {
       const exp = new RegExp(val, 'gi');
 
       materials = materials.filter(material => {
-        let searchString = material.title + material.courseTitle + material.sessionTitle;
+        let searchString = material.title + ' ' + material.courseTitle + ' ' + material.sessionTitle + ' ';
         if (isPresent(material.instructors)) {
-          searchString += material.instructors.join('');
+          searchString += material.instructors.join(' ');
         }
         return searchString.match(exp);
       });


### PR DESCRIPTION
Without this space the end of the session title is forced onto the start
of the instructor names.  This leads to a search for 'dean' returning
results of suicideAngela which is incorrect.