### PR TITLE
correctly pass login error message keys. provide fallback by passing …

### DIFF
--- a/app/authenticators/ilios-jwt.js
+++ b/app/authenticators/ilios-jwt.js
@@ -43,8 +43,11 @@ export default JwtTokenAuthenticator.extend({
           response = Ember.merge(response, tokenExpireData);
           resolve(this.getResponseData(response));
         }, e => {
-          const errors = e.errors || [];
-          reject(errors);
+          let error = {
+            'message': e.message,
+            'keys': e.payload.errors || [],
+          };
+          reject(error);
         });
       }
     });

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -15,12 +15,11 @@ export default Controller.extend({
       let authenticator = 'authenticator:ilios-jwt';
       this.set('errors', []);
       this.get('session').authenticate(authenticator, credentials).then(() => {
-
-      }, errors => {
-        let mappedErrors = errors.map(e => {
-          return 'general.' + e.title;
+      }, error => {
+        let keys = error.keys.map(key => {
+          return ('general.' + key);
         });
-        this.set('errors', mappedErrors);
+        this.set('error', { 'message': error.message, 'keys': keys });
       });
     }
   }

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -1,8 +1,10 @@
 <div class='login-form'>
   {{#unless noAccountExistsError}}
     <h2>{{t 'general.login'}}</h2>
-    {{#each errors as |errorKey|}}
-      <div class='error'>{{t errorKey}}</div>
+    {{#each error.keys as |key|}}
+      <div class='error'>{{t key}}</div>
+    {{else}}
+      <div class='error'>{{error.message}}</div>
     {{/each}}
     <form id='user-login-form' {{action 'authenticate' on='submit'}}>
       <div class='form-container'>


### PR DESCRIPTION
…raw response message.

fixes #2207 

the fallback is necessary, b/c Ember i18n does not provide a means to check if a given translation key is backed by a translation.

the recommended way for dealing with missing translations is documented [here](https://github.com/jamesarosen/ember-i18n/wiki/Doc:-Missing-Translations) - overriding the callback won't work for us.