### PR TITLE
Don't allow shadow variables

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
 
     /* Stylistic Issues http://eslint.org/docs/rules/#stylistic-issues */
     indent: [2, 2], /* two-space indentation */
-    semi: 2 /* require semi-colons */
+    semi: 2, /* require semi-colons */
+    'no-shadow': [2, {builtinGlobals: true}], /* Prevent shadowing globals like Object*/
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,9 @@ module.exports = {
     /* Stylistic Issues http://eslint.org/docs/rules/#stylistic-issues */
     indent: [2, 2], /* two-space indentation */
     semi: 2, /* require semi-colons */
-    'no-shadow': [2, {builtinGlobals: true}], /* Prevent shadowing globals like Object*/
+    'no-shadow': [2, {
+      builtinGlobals: true,
+      allow: ['event', 'i', 'name', 'parent', 'resolve', 'self', 'select', 'scrollTo', 'status']
+    },], /* Prevent shadowing globals like Object*/
   }
 };

--- a/app/components/chart-donut.js
+++ b/app/components/chart-donut.js
@@ -61,8 +61,8 @@ export default Component.extend({
 
     function tweenDonut(b) {
       b.innerRadius = 0;
-      let i = interpolate({startAngle: 0, endAngle: 0}, b);
-      return function(t) { return createArc(i(t)); };
+      const i = interpolate({startAngle: 0, endAngle: 0}, b);
+      return p => createArc(i(p));
     }
 
     path.on('mouseover', (d, index, items) => {

--- a/app/components/chart-pie.js
+++ b/app/components/chart-pie.js
@@ -58,8 +58,8 @@ export default Component.extend({
 
     function tweenPie(b) {
       b.innerRadius = 0;
-      var i = interpolate({startAngle: 0, endAngle: 0}, b);
-      return function(t) { return createArc(i(t)); };
+      const i = interpolate({startAngle: 0, endAngle: 0}, b);
+      return (p) => createArc(i(p));
     }
 
     path.on('mouseover', (d, index, items) => {

--- a/app/components/course-editing.js
+++ b/app/components/course-editing.js
@@ -10,13 +10,8 @@ export default Component.extend({
   courseCompetencyDetails: false,
   actions: {
     save: function(){
-      var self = this;
-      var course = this.get('course');
-      course.save().then(function(course){
-        if(!self.get('isDestroyed')){
-          self.set('course', course);
-        }
-      });
+      const course = this.get('course');
+      course.save();
     },
   }
 });

--- a/app/components/course-materials.js
+++ b/app/components/course-materials.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import SortableTable from 'ilios/mixins/sortable-table';
 
-const { Component, RSVP, Object, computed, isEmpty, isPresent } = Ember;
+const { Component, RSVP, Object:EmberObject, computed, isEmpty, isPresent } = Ember;
 const { Promise, map } = RSVP;
 
 export default Component.extend(SortableTable, {
@@ -34,7 +34,7 @@ export default Component.extend(SortableTable, {
             sessionLearningMaterial.get('learningMaterial').then(learningMaterial => {
               sessionLearningMaterial.get('session').then(session => {
                 session.get('firstOfferingDate').then(firstOfferingDate => {
-                  let obj = Object.create({
+                  let obj = EmberObject.create({
                     title: learningMaterial.get('title'),
                     description: learningMaterial.get('description'),
                     author: learningMaterial.get('originalAuthor'),
@@ -100,7 +100,7 @@ export default Component.extend(SortableTable, {
         map(clms.toArray(), courseLearningMaterial => {
           return new Promise(resolve =>{
             courseLearningMaterial.get('learningMaterial').then(learningMaterial => {
-              let obj = Object.create({
+              let obj = EmberObject.create({
                 title: learningMaterial.get('title'),
                 description: learningMaterial.get('description'),
                 author: learningMaterial.get('originalAuthor'),

--- a/app/components/course-objective-manager.js
+++ b/app/components/course-objective-manager.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
 
-const { Component, computed, isEmpty, Object, ObjectProxy, RSVP } = Ember;
+const { Component, computed, isEmpty, Object:EmberObject, ObjectProxy, RSVP } = Ember;
 const { all, Promise } = RSVP;
 const { filterBy, gt, none, oneWay, sort, uniq } = computed;
 
-const competencyGroup = Object.extend({
+const competencyGroup = EmberObject.extend({
   title: '',
   originalObjectives: [],
   uniqueObjectives: uniq('originalObjectives'),
@@ -23,7 +23,7 @@ const objectiveProxy = ObjectProxy.extend({
   }),
 });
 
-const cohortProxy = Object.extend({
+const cohortProxy = EmberObject.extend({
   cohort: null,
   objective: null,
   id: oneWay('cohort.id'),

--- a/app/components/curriculum-inventory-sequence-block-list.js
+++ b/app/components/curriculum-inventory-sequence-block-list.js
@@ -29,10 +29,10 @@ export default Component.extend({
   loadAttr: task(function * (parent, report) {
     if (isPresent(parent)) {
       let sequenceBlocks = yield parent.get('children');
-      let report = yield parent.get('report');
+      let parentReport = yield parent.get('report');
       this.setProperties({
         sequenceBlocks,
-        report,
+        report: parentReport,
         savedBlock: null,
         saved: false,
       });

--- a/app/components/curriculum-inventory-sequence-block-overview.js
+++ b/app/components/curriculum-inventory-sequence-block-overview.js
@@ -233,8 +233,8 @@ export default Component.extend({
     changeChildSequenceOrder() {
       let block = this.get('sequenceBlock');
       block.set('childSequenceOrder', parseInt(this.get('childSequenceOrder'), 10));
-      block.save().then(block => {
-        block.get('children').then(children => {
+      block.save().then(savedBlock => {
+        savedBlock.get('children').then(children => {
           children.invoke('reload');
         });
       });
@@ -265,8 +265,8 @@ export default Component.extend({
     changeOrderInSequence() {
       let block = this.get('sequenceBlock');
       block.set('orderInSequence', this.get('orderInSequence'));
-      block.save().then(block => {
-        block.get('parent').then(parent => {
+      block.save().then(savedBlock => {
+        savedBlock.get('parent').then(parent => {
           parent.get('children').then(children => {
             children.invoke('reload');
           });

--- a/app/components/dashboard-calendar.js
+++ b/app/components/dashboard-calendar.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import Ember from 'ember';
 import momentFormat from 'ember-moment/computeds/format';
 
-const { Component, computed, isPresent, RSVP, Object, inject } = Ember;
+const { Component, computed, isPresent, RSVP, Object:EmberObject, inject } = Ember;
 const { service } = inject;
 const { all, Promise } = RSVP;
 
@@ -89,7 +89,7 @@ export default Component.extend({
             let proxies = [];
             let promises = [];
             cohorts.forEach(cohort => {
-              let proxy = Object.create({
+              let proxy = EmberObject.create({
                 cohort,
                 displayTitle: null
               });

--- a/app/components/detail-cohort-list.js
+++ b/app/components/detail-cohort-list.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { Component, computed, Object, RSVP } = Ember;
+const { Component, computed, Object:EmberObject, RSVP } = Ember;
 const { all, Promise } = RSVP;
 
 export default Component.extend({
@@ -21,7 +21,7 @@ export default Component.extend({
         let proxies = [];
         let sortedCohorts = [];
         cohorts.toArray().forEach(cohort => {
-          let proxy = Object.create({
+          let proxy = EmberObject.create({
             cohort,
             schoolTitle: null,
             displayTitle: null,

--- a/app/components/detail-cohort-manager.js
+++ b/app/components/detail-cohort-manager.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 import { translationMacro as t } from "ember-i18n";
 
-const { Component, computed, inject, RSVP, Object} = Ember;
+const { Component, computed, inject, RSVP, Object:EmberObject } = Ember;
 const { service } = inject;
 const { sort } = computed;
 const { all, Promise } = RSVP;
@@ -55,7 +55,7 @@ export default Component.extend({
         let promises = [];
         let proxies = [];
         cohorts.forEach(cohort => {
-          let proxy = Object.create({
+          let proxy = EmberObject.create({
             cohort,
             schoolTitle: null,
             programTitle: null

--- a/app/components/detail-learnergroups-list.js
+++ b/app/components/detail-learnergroups-list.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { Component, computed, Object, RSVP, isEmpty } = Ember;
+const { Component, computed, Object:EmberObject, RSVP, isEmpty } = Ember;
 const { Promise, filter, map, resolve } = RSVP;
 
 export default Component.extend({
@@ -25,11 +25,11 @@ export default Component.extend({
                   resolve(childTopLevelGroup === topLevelGroup);
                 });
               });
-            }).then(groups => {
-              resolve(groups);
+            }).then(filteredGroups => {
+              resolve(filteredGroups);
             });
           });
-          return Object.create({
+          return EmberObject.create({
             topLevelGroup,
             groups
           });

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { translationMacro as t } from "ember-i18n";
 import SortableByPosition from 'ilios/mixins/sortable-by-position';
 
-const { isEmpty, Component, computed, inject, RSVP, ObjectProxy, Object } = Ember;
+const { isEmpty, Component, computed, inject, RSVP, ObjectProxy, Object:EmberObject } = Ember;
 const { notEmpty, or, not } = computed;
 const { service } = inject;
 const { all, Promise } = RSVP;
@@ -115,7 +115,7 @@ export default Component.extend(SortableByPosition, {
 
   actions: {
     manageMaterial(learningMaterial){
-      let buffer = Object.create();
+      let buffer = EmberObject.create();
       buffer.set('publicNotes', learningMaterial.get('publicNotes'));
       buffer.set('required', learningMaterial.get('required'));
       buffer.set('notes', learningMaterial.get('notes'));

--- a/app/components/detail-objectives.js
+++ b/app/components/detail-objectives.js
@@ -164,10 +164,10 @@ export default Component.extend({
           if(this.get('isProgramYear')){
             newObjective.get('programYears').addObject(subject);
           }
-          newObjective.save().then(newObjective => {
+          newObjective.save().then(savedObjective => {
             this.set('newObjectiveEditorOn', false);
             this.get('flashMessages').success('general.newObjectiveSaved');
-            resolve(newObjective);
+            resolve(savedObjective);
           });
         });
       });

--- a/app/components/detail-steward-manager.js
+++ b/app/components/detail-steward-manager.js
@@ -126,11 +126,11 @@ export default Component.extend({
       return !selectedDepartments.includes(department);
     });
     newDepartments.forEach(department => {
-      const steward = store.createRecord('program-year-steward', {
+      const newSteward = store.createRecord('program-year-steward', {
         school,
         department
       });
-      this.get('add')(steward);
+      this.get('add')(newSteward);
     });
   }),
   addDepartment: task(function * (school, department){

--- a/app/components/ilios-chart-tooltip.js
+++ b/app/components/ilios-chart-tooltip.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
-const { Component, computed, isEmpty, String, $ } = Ember;
-const { htmlSafe } = String;
+const { Component, computed, isEmpty, String:EmberString, $ } = Ember;
+const { htmlSafe } = EmberString;
 
 export default Component.extend({
   classNameBindings: [':ilios-chart-tooltip', 'hidden:hidden'],
@@ -10,11 +10,12 @@ export default Component.extend({
   title: null,
   attr: null,
   content: null,
+  location: null,
   style: computed('slice', 'location', function(){
     const slice = this.get('slice');
-    const location = this.get('location');
+    const position = this.get('location');
     const width = this.get('width');
-    if (isEmpty(slice) || isEmpty(location) ) {
+    if (isEmpty(slice) || isEmpty(position) ) {
       return htmlSafe('');
     }
 
@@ -26,8 +27,8 @@ export default Component.extend({
       height: $(svgParent).height(),
     };
 
-    let tooltipTop = svgParentsvgOffset.top - svgParentOffset.top + svgDimensions.height / 2 + location[1] + 20;
-    let tooltipLeft = Math.max(0 ,svgParentsvgOffset.left - svgParentOffset.left + svgDimensions.width / 2 - width / 2 + location[0]);
+    let tooltipTop = svgParentsvgOffset.top - svgParentOffset.top + svgDimensions.height / 2 + position[1] + 20;
+    let tooltipLeft = Math.max(0 ,svgParentsvgOffset.left - svgParentOffset.left + svgDimensions.width / 2 - width / 2 + position[0]);
 
     return htmlSafe('top:' + tooltipTop + 'px; left:' + tooltipLeft + 'px;');
   }),

--- a/app/components/ilios-chart.js
+++ b/app/components/ilios-chart.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-const { Component, computed, get, String } = Ember;
-const { htmlSafe } = String;
+const { Component, computed, get, String:EmberString } = Ember;
+const { htmlSafe } = EmberString;
 
 export default Component.extend({
   attributeBindings: ['style'],
@@ -24,11 +24,11 @@ export default Component.extend({
   }),
 
   actions: {
-    hover(data, slice, location){
+    hover(data, slice, tooltipLocation){
       const hover = get(this, 'hover');
       hover(data);
       this.set('tooltipSlice', slice);
-      this.set('tooltipLocation', location);
+      this.set('tooltipLocation', tooltipLocation);
     },
     leave(){
       const leave = get(this, 'leave');

--- a/app/components/ilios-sessions-list.js
+++ b/app/components/ilios-sessions-list.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import escapeRegExp from '../utils/escape-reg-exp';
 
-const { Component, computed, inject, RSVP, ObjectProxy, Object } = Ember;
+const { Component, computed, inject, RSVP, ObjectProxy, Object:EmberObject } = Ember;
 const { service } = inject;
 const { not, alias } = computed;
 const { all, hash, map, Promise } = RSVP;
@@ -133,7 +133,7 @@ export default Component.extend({
           let promises = [];
           let proxies = [];
           sessions.forEach(session => {
-            let proxy = Object.create({
+            let proxy = EmberObject.create({
               session,
               content: session,
               sortValue: null
@@ -161,7 +161,7 @@ export default Component.extend({
           let promises = [];
           let proxies = [];
           sessions.forEach(session => {
-            let proxy = Object.create({
+            let proxy = EmberObject.create({
               session,
               content: session,
               sortValue: null

--- a/app/components/learnergroup-subgroup-list.js
+++ b/app/components/learnergroup-subgroup-list.js
@@ -64,13 +64,13 @@ export default Component.extend({
               groups.pushObject(newGroup);
             }
 
-            let saveSomeGroups = (groups) => {
-              let chunk = groups.splice(0, 6);
+            let saveSomeGroups = (groupsToSave) => {
+              let chunk = groupsToSave.splice(0, 6);
 
               RSVP.all(chunk.invoke('save')).then(() => {
-                if (groups.length){
+                if (groupsToSave.length){
                   this.set('currentGroupsSaved', this.get('currentGroupsSaved') + chunk.length);
-                  saveSomeGroups(groups);
+                  saveSomeGroups(groupsToSave);
                 } else {
                   this.set('isSaving', false);
                   this.set('showNewLearnerGroupForm', false);

--- a/app/components/learnergroup-summary.js
+++ b/app/components/learnergroup-summary.js
@@ -59,8 +59,8 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
       learnerGroup.get('topLevelGroup').then(topLevelGroup => {
         let treeGroups = [];
         treeGroups.pushObject(topLevelGroup);
-        topLevelGroup.get('allDescendants').then((all) => {
-          treeGroups.pushObjects(all);
+        topLevelGroup.get('allDescendants').then(allDescendants => {
+          treeGroups.pushObjects(allDescendants);
           resolve(treeGroups);
         });
       });

--- a/app/components/learnergroup-tree.js
+++ b/app/components/learnergroup-tree.js
@@ -29,8 +29,8 @@ export default Component.extend({
         if (!selectedGroups.includes(child)) {
           return true;
         }
-        return child.get('children').then(children => {
-          return this.hasUnSelectedChildren(children);
+        return child.get('children').then(childChildren => {
+          return this.hasUnSelectedChildren(childChildren);
         });
       })).then(unselectedChildren => {
         resolve(unselectedChildren.length > 0);

--- a/app/components/new-learningmaterial.js
+++ b/app/components/new-learningmaterial.js
@@ -77,13 +77,13 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     });
 
     this.get('learningMaterialStatuses').then((statuses) => {
-      let defaultStatus = statuses.find((status) => status.get('title') === 'Final');
+      let defaultStatusObject = statuses.findBy('title', 'Final');
 
-      if (!defaultStatus) {
-        defaultStatus = statuses.get('firstObject');
+      if (!defaultStatusObject) {
+        defaultStatusObject = statuses.get('firstObject');
       }
 
-      this.set('status', defaultStatus);
+      this.set('status', defaultStatusObject);
     });
 
     this.get('learningMaterialUserRoles').then((roles) => {

--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -3,7 +3,7 @@ import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 import { task } from 'ember-concurrency';
 
-const { Component, computed, inject, RSVP, isEmpty, isPresent, Object } = Ember;
+const { Component, computed, inject, RSVP, isEmpty, isPresent, Object:EmberObject } = Ember;
 const { map, Promise } = RSVP;
 const { service } = inject;
 const { oneWay } = computed;
@@ -17,7 +17,7 @@ const Validations = buildValidations({
   ]
 });
 
-const PrepositionObject = Object.extend({
+const PrepositionObject = EmberObject.extend({
   model: null,
   type: null,
   value: oneWay('model.id'),

--- a/app/components/objective-manage-competency.js
+++ b/app/components/objective-manage-competency.js
@@ -54,7 +54,8 @@ export default Component.extend({
             filter(competencies.toArray(), (competency => {
               return new Promise(resolve => {
                 competency.get('treeChildren').then(children => {
-                  let selectedChildren = children.filter(competency => selectedCompetency.get('id') === competency.get('id'));
+                  const selectedCompetencyId = selectedCompetency.get('id');
+                  const selectedChildren = children.filterBy('id', selectedCompetencyId);
                   resolve(selectedChildren.length > 0);
                 });
               });

--- a/app/components/pending-updates-summary.js
+++ b/app/components/pending-updates-summary.js
@@ -25,10 +25,9 @@ export default Component.extend({
     return new Promise(resolve => {
       this.get('currentUser').get('model').then(user => {
         user.get('schools').then(schools => {
-          if(isPresent(this.get('schoolId'))){
-            let school =  schools.find(school => {
-              return school.get('id') === this.get('schoolId');
-            });
+          const schoolId = this.get('schoolId');
+          if(isPresent(schoolId)){
+            const school = schools.findBy('id', schoolId);
             if(school){
               resolve(school);
               return;

--- a/app/components/programyear-competencies.js
+++ b/app/components/programyear-competencies.js
@@ -76,7 +76,7 @@ export default Component.extend({
         filter(competencies.toArray(), (competency => {
           return new Promise(resolve => {
             competency.get('treeChildren').then(children => {
-              let selectedChildren = children.filter(competency => selectedCompetencies.includes(competency));
+              let selectedChildren = children.filter(c => selectedCompetencies.includes(c));
               resolve(selectedChildren.length > 0);
             });
           });

--- a/app/components/progress-bar.js
+++ b/app/components/progress-bar.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
-const { String, computed } = Ember;
-const { htmlSafe } = String;
+const { String:EmberString, computed } = Ember;
+const { htmlSafe } = EmberString;
 
 export default Ember.Component.extend({
   classNames: ['progress-bar'],

--- a/app/components/school-session-attributes-expanded.js
+++ b/app/components/school-session-attributes-expanded.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
 
-const { Component, Object, isEmpty } = Ember;
+const { Component, Object:EmberObject, isEmpty } = Ember;
 
 export default Component.extend({
   tagName: 'section',
@@ -41,7 +41,7 @@ export default Component.extend({
     const showSessionSpecialAttireRequired = isEmpty(bufferedShowSessionSpecialAttireRequired)?false:bufferedShowSessionSpecialAttireRequired;
     const showSessionSpecialEquipmentRequired = isEmpty(bufferedShowSessionSpecialEquipmentRequired)?false:bufferedShowSessionSpecialEquipmentRequired;
 
-    const values = Object.create({
+    const values = EmberObject.create({
       showSessionAttendanceRequired,
       showSessionSupplemental,
       showSessionSpecialAttireRequired,

--- a/app/components/school-session-attributes.js
+++ b/app/components/school-session-attributes.js
@@ -1,15 +1,12 @@
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
-import config from '../config/environment';
 
-const { IliosFeatures: { schoolSessionAttributes } } = config;
 const { Component, RSVP, inject, computed } = Ember;
 const { all } = RSVP;
 const { service } = inject;
 
 export default Component.extend({
   store: service(),
-  schoolSessionAttributes,
   classNames: ['school-session-attributes'],
   school: null,
   isManaging: false,

--- a/app/components/school-vocabularies-list.js
+++ b/app/components/school-vocabularies-list.js
@@ -54,8 +54,8 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
         if (validations.get('isValid')) {
           const school = this.get('school');
           let vocabulary = this.get('store').createRecord('vocabulary', {title, school});
-          vocabulary.save().then(vocabulary => {
-            this.get('newVocabularies').pushObject(vocabulary);
+          vocabulary.save().then(savedVocabulary => {
+            this.get('newVocabularies').pushObject(savedVocabulary);
           }).finally(() => {
             if (!self.get('isDestroyed')) {
               self.send('removeErrorDisplayFor', 'newVocabularyTitle');

--- a/app/components/session-copy.js
+++ b/app/components/session-copy.js
@@ -159,7 +159,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     },
     changeSelectedCourse(id){
       let courses = this.get('loadCourses.lastSuccessful.value');
-      let course = courses.find(course => course.get('id') === id);
+      let course = courses.findBy('id', id);
 
       this.set('selectedCourse', course);
     }

--- a/app/components/session-details.js
+++ b/app/components/session-details.js
@@ -20,13 +20,8 @@ export default Component.extend({
   },
   actions: {
     save: function(){
-      var self = this;
-      var  session = this.get('session');
-      session.save().then(function(session){
-        if(!self.get('isDestroyed')){
-          self.set('session', session);
-        }
-      });
+      const  session = this.get('session');
+      session.save();
     },
   }
 });

--- a/app/components/session-offerings-list.js
+++ b/app/components/session-offerings-list.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import Ember from 'ember';
 import momentFormat from 'ember-moment/computeds/format';
 
-const { Component, computed, RSVP, Object } = Ember;
+const { Component, computed, RSVP, Object:EmberObject } = Ember;
 const { oneWay, sort } = computed;
 const { Promise } = RSVP;
 
@@ -23,9 +23,9 @@ export default Component.extend({
       if (offerings == null) {
         resolve([]);
       }
-      offerings.then(offerings => {
+      offerings.then(arr => {
         let dateBlocks = {};
-        offerings.forEach(offering => {
+        arr.forEach(offering => {
           let key = offering.get('dateKey');
           if (!(key in dateBlocks)) {
             dateBlocks[key] = OfferingDateBlock.create({
@@ -56,7 +56,7 @@ export default Component.extend({
   }
 });
 
-let OfferingBlock = Object.extend({
+let OfferingBlock = EmberObject.extend({
   //we have to init the offerins array because otherwise it gets passed by reference
   //and shared among isntances
   init: function(){

--- a/app/components/user-profile-learnergroups.js
+++ b/app/components/user-profile-learnergroups.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { Component, RSVP, Object, computed, isEmpty } = Ember;
+const { Component, RSVP, Object:EmberObject, computed, isEmpty } = Ember;
 const { Promise, map } = RSVP;
 
 export default Component.extend({
@@ -27,7 +27,7 @@ export default Component.extend({
                   const programTitle = program.get('title');
                   const cohortTitle = cohort.get('title');
 
-                  let learnerGroupObject = Object.create({
+                  let learnerGroupObject = EmberObject.create({
                     allParentsTitle,
                     title,
                     schoolTitle,

--- a/app/components/visualizer-course-objectives.js
+++ b/app/components/visualizer-course-objectives.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
 
-const { Component, RSVP, computed, isEmpty, isPresent, String } = Ember;
+const { Component, RSVP, computed, isEmpty, isPresent, String:EmberString } = Ember;
 const { map, filter } = RSVP;
-const { htmlSafe } = String;
+const { htmlSafe } = EmberString;
 
 export default Component.extend({
   course: null,
@@ -56,7 +56,7 @@ export default Component.extend({
         courseObjective,
         sessionObjectives
       };
-      const data = hours.reduce((total, hours) => total + parseInt(hours), 0);
+      const data = hours.reduce((accumulator, current) => accumulator + parseInt(current), 0);
 
       return {
         data,
@@ -81,9 +81,9 @@ export default Component.extend({
       const total = Number(hours);
       const splitHours = total / objectives.length;
 
-      const values = objectives.map(label => {
+      const values = objectives.map(objectiveLabel => {
         return {
-          label,
+          label: objectiveLabel,
           value: splitHours
         };
       });

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -119,10 +119,9 @@ export default Controller.extend({
   selectedSchool: computed('model.schools.[]', 'schoolId', 'primarySchool', function(){
     const schools = this.get('model.schools');
     const primarySchool = this.get('model.primarySchool');
-    if(isPresent(this.get('schoolId'))){
-      let school =  schools.find(school => {
-        return school.get('id') === this.get('schoolId');
-      });
+    const schoolId = this.get('schoolId');
+    if(isPresent(schoolId)){
+      let school = schools.findBy('id', schoolId);
       if(school){
         return school;
       }

--- a/app/controllers/curriculum-inventory-reports.js
+++ b/app/controllers/curriculum-inventory-reports.js
@@ -38,10 +38,9 @@ export default Controller.extend({
   selectedSchool: computed('schools.[]', 'schoolId', function(){
     return new Promise(resolve => {
       let schools = this.get('schools');
-      if(isPresent(this.get('schoolId'))){
-        let school =  schools.find(school => {
-          return school.get('id') === this.get('schoolId');
-        });
+      const schoolId = this.get('schoolId');
+      if(isPresent(schoolId)){
+        let school = schools.findBy('id', schoolId);
         if(school){
           resolve(school);
         }
@@ -93,9 +92,7 @@ export default Controller.extend({
         let program;
         let programId = this.get('programId');
         if(isPresent(programId)){
-          program = programs.find(program => {
-            return program.get('id') === this.get('programId');
-          });
+          program = programs.findBy('id', programId);
         }
         if(program){
           resolve(program);

--- a/app/controllers/instructor-groups.js
+++ b/app/controllers/instructor-groups.js
@@ -79,8 +79,9 @@ export default Controller.extend({
   selectedSchool: computed('model.schools.[]', 'schoolId', 'primarySchool', function(){
     const schools = this.get('model.schools');
     const primarySchool = this.get('model.primarySchool');
-    if(isPresent(this.get('schoolId'))){
-      let school =  schools.find(school => school.get('id') === this.get('schoolId'));
+    const schoolId = this.get('schoolId');
+    if(isPresent(schoolId)){
+      let school =  schools.findBy('id', schoolId);
       if(school){
         return school;
       }

--- a/app/controllers/learner-groups.js
+++ b/app/controllers/learner-groups.js
@@ -139,10 +139,9 @@ export default Controller.extend({
 
   selectedSchool: computed('model.schools.[]', 'schoolId', function(){
     let schools = this.get('model.schools');
-    if(isPresent(this.get('schoolId'))){
-      let school =  schools.find(school => {
-        return school.get('id') === this.get('schoolId');
-      });
+    const schoolId = this.get('schoolId');
+    if(isPresent(schoolId)){
+      const school = schools.findBy('id', schoolId);
       if(school){
         return PromiseObject.create({
           promise: RSVP.resolve(school)
@@ -162,11 +161,9 @@ export default Controller.extend({
     let defer = RSVP.defer();
     this.get('programs').then(programs => {
       let program;
-      if(isPresent(this.get('programId'))){
-        program =  programs.find(program => {
-          return program.get('id') === this.get('programId');
-        });
-
+      const programId = this.get('programId');
+      if(isPresent(programId)){
+        program = programs.findBy('id', programId);
       }
       if(program){
         defer.resolve(program);
@@ -189,10 +186,9 @@ export default Controller.extend({
     let defer = RSVP.defer();
     this.get('programYears').then(programYears => {
       let programYear;
-      if(isPresent(this.get('programYearId'))){
-        programYear =  programYears.find(programYear => {
-          return programYear.get('id') === this.get('programYearId');
-        });
+      const programYearId = this.get('programYearId');
+      if(isPresent(programYearId)){
+        programYear = programYears.findBy('id', programYearId);
       }
       if(programYear){
         defer.resolve(programYear);
@@ -256,7 +252,7 @@ export default Controller.extend({
     },
 
     changeSelectedProgramYear(programYearId) {
-      let programYear = this.get('programYears').find(programYear => programYear.get('id') === programYearId);
+      let programYear = this.get('programYears').findBy('id', programYearId);
       programYear.get('program').then(program => {
         program.get('school').then(school => {
           this.set('schoolId', school.get('id'));

--- a/app/controllers/pending-user-updates.js
+++ b/app/controllers/pending-user-updates.js
@@ -18,10 +18,9 @@ export default Controller.extend({
   sortedSchools: sort('model.schools', 'sortSchoolsBy'),
   selectedSchool: computed('model.schools.[]', 'model.primarySchool', 'school', function(){
     let schools = this.get('model.schools');
-    if(isPresent(this.get('school'))){
-      let school =  schools.find(school => {
-        return school.get('id') === this.get('school');
-      });
+    const schoolId = this.get('school');
+    if(isPresent(schoolId)){
+      const school = schools.findBy('id', schoolId);
       if(school){
         return school;
       }

--- a/app/controllers/programs.js
+++ b/app/controllers/programs.js
@@ -67,7 +67,8 @@ export default Controller.extend({
     const schools = this.get('model.schools');
     const primarySchool = this.get('model.primarySchool');
     if(isPresent(this.get('schoolId'))){
-      let school =  schools.find(school => school.get('id') === this.get('schoolId'));
+      const schoolId = this.get('schoolId');
+      const school = schools.findBy('id', schoolId);
       if(school){
         return school;
       }

--- a/app/controllers/weeklyevents.js
+++ b/app/controllers/weeklyevents.js
@@ -17,12 +17,12 @@ export default Controller.extend({
     return arr;
   }),
   actions: {
-    toggleOpenWeek(week, open) {
+    toggleOpenWeek(week, shouldOpen) {
       const expanded = this.get('expanded');
       const expandedString = expanded?expanded:'';
       let arr =  expandedString.split('-');
       arr.removeObject(week);
-      if (open) {
+      if (shouldOpen) {
         arr.pushObject(week);
       }
       arr = arr.sort();

--- a/app/instance-initializers/error.js
+++ b/app/instance-initializers/error.js
@@ -96,8 +96,8 @@ export default {
       this.incrementLastErrorSent();
       ajax.post('/errors', {
         data: {data: JSON.stringify(error)}
-      }).catch(function(error){
-        console.log('Error sending error message', error);
+      }).catch(function(e){
+        console.log('Error sending error message', e);
         //prevent throwing errors on errors
       });
     }

--- a/app/models/cohort.js
+++ b/app/models/cohort.js
@@ -64,7 +64,7 @@ export default Model.extend({
       } else {
         this.get('programYear').then(programYear => {
           let classOfYear = programYear ? programYear.get('classOfYear') : null;
-          let title = this.get('i18n').t('general.classOf', {year: classOfYear});
+          title = this.get('i18n').t('general.classOf', {year: classOfYear});
           resolve(title);
         });
       }

--- a/app/models/learner-group.js
+++ b/app/models/learner-group.js
@@ -33,15 +33,15 @@ export default DS.Model.extend({
         if(!offerings.length){
           resolve();
         }
-        let promises = [];
+        let promises2 = [];
         offerings.forEach(offering => {
-          promises.pushObject(offering.get('session').then(session =>{
+          promises2.pushObject(offering.get('session').then(session =>{
             return session.get('course').then(course => {
               allCourses.pushObject(course);
             });
           }));
         });
-        Ember.RSVP.all(promises).then(()=>{
+        Ember.RSVP.all(promises2).then(()=>{
           resolve();
         });
       });
@@ -51,9 +51,9 @@ export default DS.Model.extend({
         if(!ilmSessions.length){
           resolve();
         }
-        let promises = [];
+        let promises2 = [];
         ilmSessions.forEach(ilmSession => {
-          promises.pushObject(ilmSession.get('session').then(session =>{
+          promises2.pushObject(ilmSession.get('session').then(session =>{
             if(!session){
               return;
             }
@@ -62,7 +62,7 @@ export default DS.Model.extend({
             });
           }));
         });
-        Ember.RSVP.all(promises).then(()=>{
+        Ember.RSVP.all(promises2).then(()=>{
           resolve();
         });
       });
@@ -364,8 +364,8 @@ export default DS.Model.extend({
         users.pushObjects(instructors.toArray());
         this.get('instructorGroups').then(instructorGroups => {
           RSVP.all(instructorGroups.mapBy('users')).then(arr => {
-            arr.forEach(instructors =>{
-              users.pushObjects(instructors.toArray());
+            arr.forEach(groupInstructors =>{
+              users.pushObjects(groupInstructors.toArray());
             });
             resolve(users.uniq());
           });

--- a/app/models/program.js
+++ b/app/models/program.js
@@ -35,13 +35,13 @@ export default DS.Model.extend(PublishableModel,{
           if(!programYears.length){
             resolve();
           }
-          let promises = [];
+          let promises2 = [];
           programYears.forEach(programYear => {
-            promises.pushObject(programYear.get('cohort').then(cohort =>{
+            promises2.pushObject(programYear.get('cohort').then(cohort =>{
               allCohorts.pushObject(cohort);
             }));
           });
-          all(promises).then(()=>{
+          all(promises2).then(()=>{
             resolve();
           });
         });
@@ -68,15 +68,15 @@ export default DS.Model.extend(PublishableModel,{
           if(!cohorts.length){
             resolve();
           }
-          let promises = [];
+          let promises2 = [];
           cohorts.forEach(cohort => {
-            promises.pushObject(cohort.get('courses').then(courses =>{
+            promises2.pushObject(cohort.get('courses').then(courses =>{
               courses.forEach(course => {
                 allCourses.pushObject(course);
               });
             }));
           });
-          all(promises).then(()=>{
+          all(promises2).then(()=>{
             resolve();
           });
         });

--- a/app/models/term.js
+++ b/app/models/term.js
@@ -32,13 +32,13 @@ export default Model.extend({
    */
   allParents: computed('parent', 'parent.allParents.[]', function(){
     return new Promise(resolve => {
-      this.get('parent').then(parent => {
+      this.get('parent').then(parentTerm => {
         let parents = [];
-        if(!parent){
+        if(!parentTerm){
           resolve(parents);
         } else {
-          parents.pushObject(parent);
-          parent.get('allParents').then(allParents => {
+          parents.pushObject(parentTerm);
+          parentTerm.get('allParents').then(allParents => {
             parents.pushObjects(allParents);
             resolve(parents);
           });
@@ -75,12 +75,12 @@ export default Model.extend({
    */
   allParentTitles: computed('parent.{title,allParentTitles.[]}', function() {
     return new Promise(resolve => {
-      this.get('parent').then(parent => {
+      this.get('parent').then(parentTerm => {
         let titles = [];
-        if(!parent){
+        if(!parentTerm){
           resolve(titles);
         } else {
-          parent.get('allParents').then(parents => {
+          parentTerm.get('allParents').then(parents => {
             titles = titles.concat(parents.mapBy('title'));
             titles.push(this.get('parent.title'));
             resolve(titles);

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-const { computed, PromiseProxyMixin, Object, RSVP } = Ember;
+const { computed, PromiseProxyMixin, Object:EmberObject, RSVP } = Ember;
 const { attr, belongsTo, hasMany, PromiseArray, Model } = DS;
 const { all, defer, Promise } = RSVP;
 
-const ProxyContent = Object.extend(PromiseProxyMixin);
+const ProxyContent = EmberObject.extend(PromiseProxyMixin);
 
 export default Model.extend({
   lastName: attr('string'),
@@ -156,8 +156,8 @@ export default Model.extend({
       }));
       promises.pushObject(new Promise(resolve => {
         this.get('learnerGroups').then(groups => {
-          all(groups.mapBy('courses')).then(all => {
-            all.forEach(arr => {
+          all(groups.mapBy('courses')).then(courses => {
+            courses.forEach(arr => {
               allCourses.pushObjects(arr);
             });
             resolve();
@@ -166,8 +166,8 @@ export default Model.extend({
       }));
       promises.pushObject(new Promise(resolve => {
         this.get('instructorGroups').then(groups => {
-          all(groups.mapBy('courses')).then(all => {
-            all.forEach(arr => {
+          all(groups.mapBy('courses')).then(courses => {
+            courses.forEach(arr => {
               allCourses.pushObjects(arr);
             });
             resolve();

--- a/app/routes/course-visualize-objectives.js
+++ b/app/routes/course-visualize-objectives.js
@@ -1,23 +1,13 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import config from '../config/environment';
 
 const { Route, RSVP, inject } = Ember;
 const { service } = inject;
-const { IliosFeatures: { accessCourseVisualizations } } = config;
 const { all, map } = RSVP;
 
 export default Route.extend(AuthenticatedRouteMixin, {
   store: service(),
   titleToken: 'general.coursesAndSessions',
-  accessCourseVisualizations,
-  beforeModel(){
-    this._super(...arguments);
-    const accessCourseVisualizations = this.get('accessCourseVisualizations');
-    if (!accessCourseVisualizations) {
-      this.transitionTo('index');
-    }
-  },
   async afterModel(course){
     const sessions = await course.get('sessions');
     return await all([

--- a/app/routes/events.js
+++ b/app/routes/events.js
@@ -11,14 +11,14 @@ export default Route.extend(AuthenticatedRouteMixin, {
   model(params){
     let slug = params.slug;
     let container = slug.substring(0, 1);
-    let service;
+    let eventService;
     if(container === 'S'){
-      service = this.get('schoolEvents');
+      eventService = this.get('schoolEvents');
     }
     if(container === 'U'){
-      service = this.get('userEvents');
+      eventService = this.get('userEvents');
     }
 
-    return service.getEventForSlug(slug);
+    return eventService.getEventForSlug(slug);
   }
 });

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -53,11 +53,10 @@ export default Route.extend(UnauthenticatedRouteMixin, {
       }
 
       if(config.type === 'cas'){
-        let location = window.location;
-        let currentUrl = [location.protocol, '//', location.host, location.pathname].join('');
+        let currentUrl = [window.location.protocol, '//', window.location.host, window.location.pathname].join('');
         let queryParams = {};
-        if (location.search.length > 1) {
-          location.search.substr(1).split('&').forEach(str => {
+        if (window.location.search.length > 1) {
+          window.location.search.substr(1).split('&').forEach(str => {
             let arr = str.split('=');
             queryParams[arr[0]] = arr[1];
           });

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -53,17 +53,17 @@ export default Service.extend({
           let promises = programs.map(program => {
             return program.get('programYears');
           });
-          hash(promises).then(hash => {
-            let promises = [];
-            Object.keys(hash).forEach(key => {
-              hash[key].forEach(programYear => {
-                promises.push(programYear.get('cohort'));
+          hash(promises).then(obj => {
+            let promises2 = [];
+            Object.keys(obj).forEach(key => {
+              obj[key].forEach(programYear => {
+                promises2.push(programYear.get('cohort'));
               });
             });
-            hash(promises).then(hash => {
+            hash(promises2).then(obj2 => {
               let cohorts = A();
-              Object.keys(hash).forEach(key => {
-                cohorts.pushObject(hash[key]);
+              Object.keys(obj2).forEach(key => {
+                cohorts.pushObject(obj2[key]);
               });
               resolve(cohorts);
             });

--- a/app/services/reporting.js
+++ b/app/services/reporting.js
@@ -98,7 +98,7 @@ export default Service.extend({
   },
   coursesResults(results){
     const canViewCourses = this.get('currentUser.canViewCourses');
-    let map = results.map(course => {
+    let mappedResults = results.map(course => {
       let rhett = {};
       rhett.value = course.get('academicYear') + ' ' + course.get('title');
       if(canViewCourses){
@@ -109,11 +109,11 @@ export default Service.extend({
       return rhett;
     });
 
-    return resolve(map);
+    return resolve(mappedResults);
   },
   sessionsResults(results){
     const canView = this.get('currentUser.canViewCourses');
-    let map = results.map(item => {
+    let mappedResults = results.map(item => {
       return new Promise(resolve => {
         let rhett = {};
         item.get('course').then(course => {
@@ -128,11 +128,11 @@ export default Service.extend({
       });
     });
 
-    return all(map);
+    return all(mappedResults);
   },
   programsResults(results){
     const canView = this.get('currentUser.canViewPrograms');
-    let map = results.map(item => {
+    let mappedResults = results.map(item => {
       return new Promise(resolve => {
         let rhett = {};
         item.get('school').then(school => {
@@ -146,11 +146,11 @@ export default Service.extend({
       });
     });
 
-    return all(map);
+    return all(mappedResults);
   },
   programYearsResults(results){
     const canView = this.get('currentUser.canViewPrograms');
-    let map = results.map(item => {
+    let mappedResults = results.map(item => {
       return new Promise(resolve => {
         let rhett = {};
         item.get('program').then(program => {
@@ -168,23 +168,23 @@ export default Service.extend({
       });
     });
 
-    return all(map);
+    return all(mappedResults);
   },
   instructorsResults(results){
-    let map = results.map( result => {
+    let mappedResults = results.map( result => {
       return {
         value: result.get('fullName')
       };
     });
-    return resolve(map);
+    return resolve(mappedResults);
   },
   titleResults(results){
-    let map = results.map( result => {
+    let mappedResults = results.map( result => {
       return {
         value: result.get('title')
       };
     });
-    return resolve(map);
+    return resolve(mappedResults);
   },
   instructorGroupsResults(results){
     return this.titleResults(results);
@@ -199,12 +199,12 @@ export default Service.extend({
     return this.titleResults(results);
   },
   meshTermsResults(results){
-    let map = results.map( result => {
+    let mappedResults = results.map( result => {
       return {
         value: result.get('name')
       };
     });
-    return resolve(map);
+    return resolve(mappedResults);
   },
   termsResults(results){
     return map(results.toArray(), result => {

--- a/app/templates/components/school-session-attributes.hbs
+++ b/app/templates/components/school-session-attributes.hbs
@@ -1,24 +1,22 @@
-{{#if schoolSessionAttributes}}
-  {{#if (and (is-fulfilled showSessionAttendanceRequired) (is-fulfilled showSessionSupplemental) (is-fulfilled showSessionSpecialAttireRequired) (is-fulfilled showSessionSpecialEquipmentRequired))}}
-    {{#if details}}
-      {{school-session-attributes-expanded
-        showSessionAttendanceRequired=(await showSessionAttendanceRequired)
-        showSessionSupplemental=(await showSessionSupplemental)
-        showSessionSpecialAttireRequired=(await showSessionSpecialAttireRequired)
-        showSessionSpecialEquipmentRequired=(await showSessionSpecialEquipmentRequired)
-        collapse=collapse
-        isManaging=isManaging
-        manage=manage
-        saveAll=(perform save)
-      }}
-    {{else}}
-      {{school-session-attributes-collapsed
-        showSessionAttendanceRequired=(await showSessionAttendanceRequired)
-        showSessionSupplemental=(await showSessionSupplemental)
-        showSessionSpecialAttireRequired=(await showSessionSpecialAttireRequired)
-        showSessionSpecialEquipmentRequired=(await showSessionSpecialEquipmentRequired)
-        expand=expand
-      }}
-    {{/if}}
+{{#if (and (is-fulfilled showSessionAttendanceRequired) (is-fulfilled showSessionSupplemental) (is-fulfilled showSessionSpecialAttireRequired) (is-fulfilled showSessionSpecialEquipmentRequired))}}
+  {{#if details}}
+    {{school-session-attributes-expanded
+      showSessionAttendanceRequired=(await showSessionAttendanceRequired)
+      showSessionSupplemental=(await showSessionSupplemental)
+      showSessionSpecialAttireRequired=(await showSessionSpecialAttireRequired)
+      showSessionSpecialEquipmentRequired=(await showSessionSpecialEquipmentRequired)
+      collapse=collapse
+      isManaging=isManaging
+      manage=manage
+      saveAll=(perform save)
+    }}
+  {{else}}
+    {{school-session-attributes-collapsed
+      showSessionAttendanceRequired=(await showSessionAttendanceRequired)
+      showSessionSupplemental=(await showSessionSupplemental)
+      showSessionSpecialAttireRequired=(await showSessionSpecialAttireRequired)
+      showSessionSpecialEquipmentRequired=(await showSessionSpecialEquipmentRequired)
+      expand=expand
+    }}
   {{/if}}
 {{/if}}

--- a/tests/acceptance/course/cohorts-test.js
+++ b/tests/acceptance/course/cohorts-test.js
@@ -144,7 +144,7 @@ test('removing a cohort remove course objectives parents linked to that cohort',
       click('.detail-cohorts .removable-list li:eq(0)');
       click('.detail-cohorts button.bigadd');
       andThen(function(){
-        let parents = find('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
+        parents = find('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
         assert.equal(parents.length, 1);
         assert.equal(getElementText(parents), getText(fixtures.parentObjective2.title));
       });

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -472,7 +472,7 @@ test('edit learning material', function(assert) {
 
             click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
             andThen(function(){
-              let container = $('.learningmaterial-manager');
+              container = $('.learningmaterial-manager');
               assert.equal(getElementText(find('.notes', container)), getText(newNote));
               assert.equal(getElementText(find('.status', container)), getText('status 2'));
             });
@@ -652,7 +652,7 @@ test('find and add learning material', function(assert) {
         click(searchResults[0]);
 
         andThen(function(){
-          let rows = find('.detail-learningmaterials-content tbody tr', container);
+          rows = find('.detail-learningmaterials-content tbody tr', container);
           assert.equal(rows.length, fixtures.course.learningMaterials.length + 1);
         });
       }, 1000);

--- a/tests/acceptance/course/mesh-test.js
+++ b/tests/acceptance/course/mesh-test.js
@@ -127,7 +127,7 @@ test('manage mesh', function(assert) {
         click(searchResults[3]);
         andThen(function(){
           assert.ok($(find('.mesh-search-results > li:eq(3)', meshManager)).hasClass('disabled'));
-          let removableItems = find('.removable-list li', meshManager);
+          removableItems = find('.removable-list li', meshManager);
           assert.equal(
             getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
             getText('descriptor 0')

--- a/tests/acceptance/course/objectivecreate-test.js
+++ b/tests/acceptance/course/objectivecreate-test.js
@@ -49,7 +49,7 @@ test('save new objective', function(assert) {
       Ember.run.later(()=>{
         click('.detail-objectives .newobjective button.done');
         andThen(function(){
-          let objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
+          objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
           assert.equal(objectiveRows.length, fixtures.course.objectives.length + 1);
           let tds = find('td', objectiveRows.eq(0));
           assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));

--- a/tests/acceptance/course/objectivelist-test.js
+++ b/tests/acceptance/course/objectivelist-test.js
@@ -84,10 +84,10 @@ test('list objectives', function(assert) {
 
       let parentTitle = '';
       if('parents' in objective){
-        let parent = fixtures.parentObjectives[objective.parents[0] - 1];
-        parentTitle = parent.title;
-        if('competency' in parent){
-          parentTitle += `(${fixtures.competencies[parent.competency - 1].title})`;
+        let parentObjective = fixtures.parentObjectives[objective.parents[0] - 1];
+        parentTitle = parentObjective.title;
+        if('competency' in parentObjective){
+          parentTitle += `(${fixtures.competencies[parentObjective.competency - 1].title})`;
         }
       } else {
         parentTitle = 'Add New';

--- a/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -135,8 +135,8 @@ test('list parent objectives by competency', function(assert) {
 
       pickOption(find('.group-picker select', objectiveManager), 'program 0 cohort 1', assert);
       andThen(()=>{
-        let parentPicker = find('.parent-picker', objectiveManager).eq(0);
-        let competencyTitles = find('.competency-title', parentPicker);
+        parentPicker = find('.parent-picker', objectiveManager).eq(0);
+        competencyTitles = find('.competency-title', parentPicker);
         assert.equal(competencyTitles.length, fixtures.competencies.length);
         //every competency is in the list
         assert.equal(getElementText(competencyTitles.eq(0)), getText('competency 0'));
@@ -144,7 +144,7 @@ test('list parent objectives by competency', function(assert) {
         assert.equal(getElementText(competencyTitles.eq(1)), getText('competency 1'));
         assert.ok(!competencyTitles.eq(1).hasClass('selected'));
 
-        let items = find('li', parentPicker);
+        items = find('li', parentPicker);
         assert.equal(getElementText(items.eq(0)), getText('objective 3'));
         assert.equal(getElementText(items.eq(1)), getText('objective 4'));
         assert.equal(getElementText(items.eq(2)), getText('objective 5'));

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -541,11 +541,11 @@ test('search twice and list should be correct', function(assert) {
       assert.equal(getElementText($(searchResults[1])), getText('0 guy M. Mc0son'));
       assert.equal(getElementText($(searchResults[2])), getText('Added M. Guy'));
       click(searchResults[1]).then(function(){
-        let searchBoxInput = find('input', searchBox);
+        searchBoxInput = find('input', searchBox);
         fillIn(searchBoxInput, 'guy');
         click('span.search-icon', searchBox);
         andThen(function(){
-          let searchResults = find('.live-search li', directors);
+          searchResults = find('.live-search li', directors);
           assert.equal(searchResults.length, 3);
           assert.equal(getElementText($(searchResults[0])), getText('2 Results'));
           assert.equal(getElementText($(searchResults[1])), getText('0 guy M. Mc0son'));

--- a/tests/acceptance/course/session/ilm-test.js
+++ b/tests/acceptance/course/session/ilm-test.js
@@ -174,13 +174,13 @@ test('add instructor group', function(assert) {
       assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
       click('.bigadd', container);
       andThen(function(){
-        let selectedGroups = find('.columnar-list:eq(0) li', container);
-        assert.equal(selectedGroups.length, 4);
-        assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2 instructor group 3'));
+        let groups = find('.columnar-list:eq(0) li', container);
+        assert.equal(groups.length, 4);
+        assert.equal(getElementText(groups), getText('instructor group 0 instructor group 1 instructor group 2 instructor group 3'));
 
-        let selectedUsers = find('.columnar-list:eq(1) li', container);
-        assert.equal(selectedUsers.length, 3);
-        assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
+        let users = find('.columnar-list:eq(1) li', container);
+        assert.equal(users.length, 3);
+        assert.equal(getElementText(users), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
       });
     });
   });
@@ -238,13 +238,13 @@ test('remove instructor group', function(assert) {
       assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
       click('.bigadd', container);
       andThen(function(){
-        let selectedGroups = find('.columnar-list:eq(0) li', container);
-        assert.equal(selectedGroups.length, 2);
-        assert.equal(getElementText(selectedGroups), getText('instructor group 1 instructor group 2'));
+        let groups = find('.columnar-list:eq(0) li', container);
+        assert.equal(groups.length, 2);
+        assert.equal(getElementText(groups), getText('instructor group 1 instructor group 2'));
 
-        let selectedUsers = find('.columnar-list:eq(1) li', container);
-        assert.equal(selectedUsers.length, 3);
-        assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
+        let users = find('.columnar-list:eq(1) li', container);
+        assert.equal(users.length, 3);
+        assert.equal(getElementText(users), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
       });
     });
   });
@@ -268,13 +268,13 @@ test('remove instructor', function(assert) {
       assert.equal(getElementText(selectedUsers), getText('2 guy M. Mc2son 3 guy M. Mc3son'));
       click('.bigadd', container);
       andThen(function(){
-        let selectedGroups = find('.columnar-list:eq(0) li', container);
-        assert.equal(selectedGroups.length, 3);
-        assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2'));
+        let groups = find('.columnar-list:eq(0) li', container);
+        assert.equal(groups.length, 3);
+        assert.equal(getElementText(groups), getText('instructor group 0 instructor group 1 instructor group 2'));
 
-        let selectedUsers = find('.columnar-list:eq(1) li', container);
-        assert.equal(selectedUsers.length, 2);
-        assert.equal(getElementText(selectedUsers), getText('2 guy M. Mc2son 3 guy M. Mc3son'));
+        let users = find('.columnar-list:eq(1) li', container);
+        assert.equal(users.length, 2);
+        assert.equal(getElementText(users), getText('2 guy M. Mc2son 3 guy M. Mc3son'));
       });
     });
   });
@@ -299,13 +299,13 @@ test('undo instructor/group changes', function(assert) {
       assert.equal(getElementText(selectedUsers), getText('2 guy M. Mc2son 3 guy M. Mc3son'));
       click('.bigcancel', container);
       andThen(function(){
-        let selectedGroups = find('.columnar-list:eq(0) li', container);
-        assert.equal(selectedGroups.length, 3);
-        assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2'));
+        let groups = find('.columnar-list:eq(0) li', container);
+        assert.equal(groups.length, 3);
+        assert.equal(getElementText(groups), getText('instructor group 0 instructor group 1 instructor group 2'));
 
-        let selectedUsers = find('.columnar-list:eq(1) li', container);
-        assert.equal(selectedUsers.length, 3);
-        assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
+        let users = find('.columnar-list:eq(1) li', container);
+        assert.equal(users.length, 3);
+        assert.equal(getElementText(users), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
       });
     });
   });

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -458,7 +458,7 @@ test('edit learning material', function(assert) {
 
             click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
             andThen(function(){
-              let container = $('.learningmaterial-manager');
+              container = $('.learningmaterial-manager');
               assert.equal(getElementText(find('.notes', container)), getText(newNote));
               assert.equal(getElementText(find('.status', container)), getText('status 2'));
             });
@@ -638,7 +638,7 @@ test('find and add learning material', function(assert) {
         click(searchResults[0]);
 
         andThen(function(){
-          let rows = find('.detail-learningmaterials-content tbody tr', container);
+          rows = find('.detail-learningmaterials-content tbody tr', container);
           assert.equal(rows.length, fixtures.session.learningMaterials.length + 1);
         });
       }, 1000);

--- a/tests/acceptance/course/session/mesh-test.js
+++ b/tests/acceptance/course/session/mesh-test.js
@@ -100,7 +100,7 @@ test('manage mesh', function(assert) {
         click(searchResults[3]);
         andThen(function(){
           assert.ok($(find('.mesh-search-results li:eq(3)', meshManager)).hasClass('disabled'));
-          let removableItems = find('.removable-list li', meshManager);
+          removableItems = find('.removable-list li', meshManager);
           assert.equal(
             getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
             getText('descriptor 0')

--- a/tests/acceptance/course/session/objectivecreate-test.js
+++ b/tests/acceptance/course/session/objectivecreate-test.js
@@ -46,7 +46,7 @@ test('save new objective', function(assert) {
       Ember.run.later(()=>{
         click('.detail-objectives .newobjective button.done');
         andThen(function(){
-          let objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
+          objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
           assert.equal(objectiveRows.length, fixtures.session.objectives.length + 1);
           let tds = find('td', objectiveRows.eq(0));
           assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -286,7 +286,7 @@ test('users can create a new offering single day', function(assert) {
   const startTimes = '.start-time select';
   const durationHours = '.offering-duration .hours input';
   const durationMinutes = '.offering-duration .minutes input';
-  const location = '.room input';
+  const offeringLocation = '.room input';
 
   const availableLearnerGroups = '.available-learner-groups .tree-groups-list';
   const learnerGroupOne = `${availableLearnerGroups} li:eq(0) .clickable`;
@@ -320,7 +320,7 @@ test('users can create a new offering single day', function(assert) {
 
   fillIn(durationHours, 15);
   fillIn(durationMinutes, 15);
-  fillIn(location, 'Rm. 111');
+  fillIn(offeringLocation, 'Rm. 111');
   click(learnerGroupOne);
   click(learnerGroupTwo);
   fillIn(searchBox, 'guy');
@@ -350,7 +350,7 @@ test('users can create a new offering multi-day', function(assert) {
   const startTimes = `${form} .start-time select`;
   const durationHours = `${form} .offering-duration .hours input`;
   const durationMinutes = `${form} .offering-duration .minutes input`;
-  const location = `${form} .room input`;
+  const offeringLocation = `${form} .room input`;
 
   const availableLearnerGroups = `${form} .available-learner-groups .tree-groups-list`;
   const learnerGroupOne = `${availableLearnerGroups} li:eq(0) .clickable`;
@@ -384,7 +384,7 @@ test('users can create a new offering multi-day', function(assert) {
 
   fillIn(durationHours, 39);
   fillIn(durationMinutes, 15);
-  fillIn(location, 'Rm. 111');
+  fillIn(offeringLocation, 'Rm. 111');
   click(learnerGroupOne);
   click(learnerGroupTwo);
   fillIn(searchBox, 'guy');
@@ -471,7 +471,7 @@ test('users can edit existing offerings', function(assert) {
   const startTimes = `${form} .start-time select`;
   const durationHours = `${form} .offering-duration .hours input`;
   const durationMinutes = `${form} .offering-duration .minutes input`;
-  const location = `${form} .room input`;
+  const offeringLocation = `${form} .room input`;
 
   const removeLearnerGroupOne = `${form} .selected-learner-groups .remove-all-subgroups:eq(0)`;
   const removeFirstInstructor = `${form} .instructors .removable-list:eq(1) li:first i`;
@@ -500,7 +500,7 @@ test('users can edit existing offerings', function(assert) {
 
     fillIn(durationHours, 6);
     fillIn(durationMinutes, 10);
-    fillIn(location, 'Rm. 111');
+    fillIn(offeringLocation, 'Rm. 111');
     click(removeLearnerGroupOne);
     click(removeFirstInstructor);
     click(removeFirstInstructorGroup);

--- a/tests/acceptance/course/sessionlist-test.js
+++ b/tests/acceptance/course/sessionlist-test.js
@@ -232,10 +232,10 @@ test('first offering is updated when offering is updated #1276', function(assert
       assert.equal(offerings.length, 3);
       let offering = find('.offering-block-time-offering').eq(0);
       return click('.offering-block-time-offering-actions .edit', offering).then(function(){
-        let container = find('.offering-manager');
-        const startDateInput = '.start-date input';
-        const doneButton = '.done';
-        let startDateInteractor = openDatepicker(find(startDateInput, container));
+        const offeringManager = '.offering-manager';
+        const startDateInput = `${offeringManager} .start-date input`;
+        const doneButton = `${offeringManager} .done`;
+        let startDateInteractor = openDatepicker(find(startDateInput));
         startDateInteractor.selectDate(newStartDate);
         return click(doneButton).then(() => {
           return click('.backtosessionlink a');
@@ -244,7 +244,7 @@ test('first offering is updated when offering is updated #1276', function(assert
 
     });
     andThen(function(){
-      let container = find('.sessions-list');
+      container = find('.sessions-list');
       assert.equal(currentPath(), 'course.index');
       let actualDateText = getElementText(find('tr:eq(1) td:eq(3)', container), getText);
       let expectedDateText = getText(moment(newStartDate).format('MM/DD/YYYY'));

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -401,7 +401,7 @@ test('test session type filter', function(assert) {
     let events = find('div.event');
     assert.equal(events.length, 2);
     pickSessionType(0).then(() => {
-      let events = find('div.event');
+      events = find('div.event');
       assert.equal(events.length, 1);
     });
 
@@ -454,7 +454,7 @@ test('test course level filter', function(assert) {
     let events = find('div.event');
     assert.equal(events.length, 2);
     pickCourseLevel(0).then(() => {
-      let events = find('div.event');
+      events = find('div.event');
       assert.equal(events.length, 2);
     });
   });
@@ -498,7 +498,7 @@ test('test cohort filter', function(assert) {
     let events = find('div.event');
     assert.equal(events.length, 2);
     pickCohort(0).then(() => {
-      let events = find('div.event');
+      events = find('div.event');
       assert.equal(events.length, 2);
     });
   });
@@ -553,7 +553,7 @@ test('test course filter', function(assert) {
     let events = find('div.event');
     assert.equal(events.length, 3);
     pickCourse(0).then(() => {
-      let events = find('div.event');
+      events = find('div.event');
       assert.equal(events.length, 2);
     });
   });
@@ -593,7 +593,7 @@ test('test course and session type filter together', function(assert) {
     let events = find('div.event');
     assert.equal(events.length, 3);
     pickCourse(0).then(() => {
-      let events = find('div.event');
+      events = find('div.event');
       assert.equal(events.length, 2);
     });
   });

--- a/tests/acceptance/instructorgroup-test.js
+++ b/tests/acceptance/instructorgroup-test.js
@@ -139,7 +139,7 @@ test('add instructor', function(assert) {
 
     fillIn(find('.search-box input', container), 'guy').then(function(){
       click('.results li:eq(4)', container).then(function(){
-        let items = find('.removable-list li', container);
+        items = find('.removable-list li', container);
         assert.equal(items.length, 3);
         assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
         assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));

--- a/tests/acceptance/program/programyear/objectives-test.js
+++ b/tests/acceptance/program/programyear/objectives-test.js
@@ -227,7 +227,7 @@ test('manage competencies', function(assert) {
 
       andThen(function(){
         click('.parent-picker .clickable:eq(2)', objectiveManager).then(function(){
-          let items = find('.parent-picker .clickable');
+          items = find('.parent-picker .clickable');
           assert.ok(!$(items[0]).hasClass('selected'));
           assert.ok(!$(items[1]).hasClass('selected'));
           assert.ok($(items[2]).hasClass('selected'));

--- a/tests/acceptance/program/programyear/overview-test.js
+++ b/tests/acceptance/program/programyear/overview-test.js
@@ -77,8 +77,8 @@ test('add director', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'program.programYear.index');
-    var container = find('.programyear-overview').eq(0);
-    var items = find('.removable-list li', container);
+    let container = find('.programyear-overview').eq(0);
+    let items = find('.removable-list li', container);
     assert.equal(items.length, 3);
     assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
     assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
@@ -86,7 +86,7 @@ test('add director', function(assert) {
 
     fillIn(find('.search-box input', container), 'guy').then(function(){
       click('.results li:eq(6)', container).then(function(){
-        var items = find('.removable-list li', container);
+        items = find('.removable-list li', container);
         assert.equal(items.length, 4);
         assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
         assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));

--- a/tests/integration/components/api-version-check-test.js
+++ b/tests/integration/components/api-version-check-test.js
@@ -5,7 +5,7 @@ import ENV from 'ilios/config/environment';
 
 const { apiVersion } = ENV.APP;
 
-const { Service, RSVP, $ } = Ember;
+const { Service, RSVP, $:jQuery } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('api-version-check', 'Integration | Component | api version check', {
@@ -19,7 +19,7 @@ test('shows no warning when versions match', function(assert) {
   const warningOverlay = '.api-version-check-warning';
   this.register('service:iliosConfig', iliosConfigMock);
   this.render(hbs`{{api-version-check}}`);
-  assert.equal($(warningOverlay).length, 0);
+  assert.equal(jQuery(warningOverlay).length, 0);
 
 });
 

--- a/tests/integration/components/assign-students-test.js
+++ b/tests/integration/components/assign-students-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, Service, RSVP } = Ember;
+const { Object:EmberObject, Service, RSVP } = Ember;
 const { resolve } = RSVP;
 
 let storeMock;
@@ -21,31 +21,31 @@ test('nothing', function(assert){
 });
 
 test('it renders', function(assert) {
-  let program = Object.create({
+  let program = EmberObject.create({
     duration: 20,
     title: 'program title'
   });
-  let programYear = Object.create({
+  let programYear = EmberObject.create({
     program,
     startYear: 2020
   });
-  let cohort = Object.create({
+  let cohort = EmberObject.create({
     title: 'test cohort',
     programYear
   });
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id: 1,
     cohorts: resolve([cohort])
   });
   let students = [
-    Object.create({
+    EmberObject.create({
       id: 1,
       fullName: 'test person',
       email: 'tstemail',
       campusId: 'id123'
     }),
-    Object.create({
+    EmberObject.create({
       id: 2,
       fullName: 'second person',
       email: '2nd@.com',
@@ -89,12 +89,12 @@ test('it renders', function(assert) {
 });
 
 test('check all checks all', function(assert) {
-  let school = Object.create({
+  let school = EmberObject.create({
     id: 1,
     cohorts: resolve([])
   });
   let students = [
-    Object.create({
+    EmberObject.create({
       id: 1,
       fullName: 'test person',
       email: 'tstemail',
@@ -135,18 +135,18 @@ test('check all checks all', function(assert) {
 });
 
 test('check some sets indeterminate state', function(assert) {
-  let school = Object.create({
+  let school = EmberObject.create({
     id: 1,
     cohorts: resolve([])
   });
   let students = [
-    Object.create({
+    EmberObject.create({
       id: 1,
       fullName: 'test person',
       email: 'tstemail',
       campusId: 'id123'
     }),
-    Object.create({
+    EmberObject.create({
       id: 2,
       fullName: 'test person2',
       email: 'tstemail2',
@@ -191,18 +191,18 @@ test('check some sets indeterminate state', function(assert) {
 });
 
 test('when some are selected check all checks all', function(assert) {
-  let school = Object.create({
+  let school = EmberObject.create({
     id: 1,
     cohorts: resolve([])
   });
   let students = [
-    Object.create({
+    EmberObject.create({
       id: 1,
       fullName: 'test person',
       email: 'tstemail',
       campusId: 'id123'
     }),
-    Object.create({
+    EmberObject.create({
       id: 2,
       fullName: 'test person2',
       email: 'tstemail2',
@@ -254,26 +254,26 @@ test('save sets primary cohort', function(assert) {
     }
   });
   this.register('service:flashMessages', flashmessagesMock);
-  let program = Object.create({
+  let program = EmberObject.create({
     duration: 20,
     title: 'program title'
   });
-  let programYear = Object.create({
+  let programYear = EmberObject.create({
     program,
     startYear: 2020
   });
-  let cohort = Object.create({
+  let cohort = EmberObject.create({
     id: 1,
     title: 'test cohort',
     programYear
   });
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id: 1,
     cohorts: resolve([cohort])
   });
   let students = [
-    Object.create({
+    EmberObject.create({
       id: 1,
       fullName: 'test person',
       email: 'tstemail',

--- a/tests/integration/components/bulk-new-users-test.js
+++ b/tests/integration/components/bulk-new-users-test.js
@@ -4,16 +4,16 @@ import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import moment from 'moment';
 
-const { RSVP, Service, Object, run } = Ember;
+const { RSVP, Service, Object:EmberObject, run } = Ember;
 const { resolve } = RSVP;
 const duration = 4;
-const program = Object.create({id: 1, title: 'Program', duration});
+const program = EmberObject.create({id: 1, title: 'Program', duration});
 const startYear = moment().format('YYYY');
-const py1 = Object.create({program, startYear});
-const py2 = Object.create({program, startYear});
+const py1 = EmberObject.create({program, startYear});
+const py2 = EmberObject.create({program, startYear});
 const mockCohorts = [
-  Object.create({id: 2, title: 'second', programYear: py1}),
-  Object.create({id: 1, title: 'first', programYear: py2}),
+  EmberObject.create({id: 2, title: 'second', programYear: py1}),
+  EmberObject.create({id: 1, title: 'first', programYear: py2}),
 ];
 
 const mockSchools = [
@@ -21,9 +21,9 @@ const mockSchools = [
   {id: 1, title: 'first', cohorts: resolve([])},
   {id: 3, title: 'third', cohorts: resolve([])},
 ];
-const mockUser = Object.create({
+const mockUser = EmberObject.create({
   schools: resolve(mockSchools),
-  school: resolve(Object.create(mockSchools[0]))
+  school: resolve(EmberObject.create(mockSchools[0]))
 });
 
 const currentUserMock = Service.extend({
@@ -205,7 +205,7 @@ test('saves valid faculty users', async function(assert) {
       return [facultyRole, studentRole];
     },
     createRecord(what, obj) {
-      let rhett = Object.create(obj);
+      let rhett = EmberObject.create(obj);
       switch (called) {
       case 0:
         assert.equal(what, 'user');
@@ -299,7 +299,7 @@ test('saves valid student users', async function(assert) {
       return [facultyRole, studentRole];
     },
     createRecord(what, obj) {
-      let rhett = Object.create(obj);
+      let rhett = EmberObject.create(obj);
       switch (called) {
       case 0:
         assert.equal(what, 'user');
@@ -549,7 +549,7 @@ test('duplicate username errors on save', async function(assert) {
       return [facultyRole, studentRole];
     },
     createRecord(what, obj) {
-      let rhett = Object.create(obj);
+      let rhett = EmberObject.create(obj);
       switch (called) {
       case 0:
         assert.equal(what, 'user');
@@ -600,7 +600,7 @@ test('error saving user', async function(assert) {
       return [facultyRole, studentRole];
     },
     createRecord(what, obj) {
-      let rhett = Object.create(obj);
+      let rhett = EmberObject.create(obj);
       switch (called) {
       case 0:
         assert.equal(what, 'user');
@@ -677,7 +677,7 @@ test('dont create authentication if username is not set', async function(assert)
       return [{id: '3'}, {id: '4'}];
     },
     createRecord(what, obj) {
-      let rhett = Object.create(obj);
+      let rhett = EmberObject.create(obj);
       switch (called) {
       case 0:
         rhett.reopen({

--- a/tests/integration/components/collapsed-competencies-test.js
+++ b/tests/integration/components/collapsed-competencies-test.js
@@ -5,7 +5,7 @@ import startMirage from '../../helpers/start-mirage';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 
 moduleForComponent('collapsed-competencies', 'Integration | Component | collapsed competencies', {
   integration: true,
@@ -19,13 +19,13 @@ test('it renders', function(assert) {
   assert.expect(4);
   let schoolA = server.create('school', {title: 'Medicine'});
   let schoolB = server.create('school', {title: 'Pharmacy'});
-  let competencyA = Object.create(server.create('competency', { school: 1 }));
+  let competencyA = EmberObject.create(server.create('competency', { school: 1 }));
   competencyA.school = RSVP.resolve(schoolA);
-  let competencyB = Object.create(server.create('competency', { school: 2 }));
+  let competencyB = EmberObject.create(server.create('competency', { school: 2 }));
   competencyB.school = RSVP.resolve(schoolB);
   let competencies = [competencyA, competencyB];
 
-  const course = Object.create({
+  const course = EmberObject.create({
     competencies: RSVP.resolve(competencies)
   });
 
@@ -45,13 +45,13 @@ test('clicking the header expands the list', function(assert) {
   assert.expect(2);
   let schoolA = server.create('school', {title: 'Medicine'});
   let schoolB = server.create('school', {title: 'Pharmacy'});
-  let competencyA = Object.create(server.create('competency', { school: 1 }));
+  let competencyA = EmberObject.create(server.create('competency', { school: 1 }));
   competencyA.school = RSVP.resolve(schoolA);
-  let competencyB = Object.create(server.create('competency', { school: 2 }));
+  let competencyB = EmberObject.create(server.create('competency', { school: 2 }));
   competencyB.school = RSVP.resolve(schoolB);
   let competencies = [competencyA, competencyB];
 
-  const course = Object.create({
+  const course = EmberObject.create({
     competencies: RSVP.resolve(competencies)
   });
 

--- a/tests/integration/components/collapsed-learnergroups-test.js
+++ b/tests/integration/components/collapsed-learnergroups-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('collapsed-learnergroups', 'Integration | Component | collapsed learnergroups', {
@@ -13,44 +13,44 @@ moduleForComponent('collapsed-learnergroups', 'Integration | Component | collaps
 
 test('displays summary data', function(assert) {
   assert.expect(6);
-  let cohort1 = Object.create({
+  let cohort1 = EmberObject.create({
     id: '1',
     title: 'cohort 1',
-    programYear: resolve(Object.create({
-      program: resolve(Object.create({
+    programYear: resolve(EmberObject.create({
+      program: resolve(EmberObject.create({
         title: 'program 1'
       }))
     }))
   });
-  let cohort2 = Object.create({
+  let cohort2 = EmberObject.create({
     id: '2',
     title: 'cohort 2',
-    programYear: resolve(Object.create({
-      program: resolve(Object.create({
+    programYear: resolve(EmberObject.create({
+      program: resolve(EmberObject.create({
         title: 'program 2'
       }))
     }))
   });
 
-  let learnerGroup1 = Object.create({
+  let learnerGroup1 = EmberObject.create({
     id: 1,
     cohort: resolve(cohort1)
   });
-  let learnerGroup2 = Object.create({
+  let learnerGroup2 = EmberObject.create({
     id: 2,
     cohort: resolve(cohort1)
   });
-  let learnerGroup3 = Object.create({
+  let learnerGroup3 = EmberObject.create({
     id: 3,
     cohort: resolve(cohort1)
   });
-  let learnerGroup4 = Object.create({
+  let learnerGroup4 = EmberObject.create({
     id: 4,
     cohort: resolve(cohort2)
   });
   let learnerGroups = [learnerGroup1, learnerGroup2, learnerGroup3, learnerGroup4];
 
-  const subject = Object.create({
+  const subject = EmberObject.create({
     learnerGroups: resolve(learnerGroups)
   });
 
@@ -70,7 +70,7 @@ test('displays summary data', function(assert) {
 test('clicking expand icon opens full view', function(assert) {
   assert.expect(2);
 
-  const subject = Object.create({
+  const subject = EmberObject.create({
     learnerGroups: resolve([])
   });
 

--- a/tests/integration/components/collapsed-objectives-test.js
+++ b/tests/integration/components/collapsed-objectives-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import startMirage from '../../helpers/start-mirage';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('collapsed-objectives', 'Integration | Component | collapsed objectives', {
   integration: true,
@@ -23,7 +23,7 @@ test('displays summary data', function(assert) {
   let plain = server.create('objective');
   let objectives = [hasMesh, hasParents, plain].map(obj => Ember.Object.create(obj));
 
-  const course = Object.create({
+  const course = EmberObject.create({
     objectives
   });
 
@@ -46,7 +46,7 @@ test('displays summary data', function(assert) {
 test('clicking expand icon opens full view', function(assert) {
   assert.expect(2);
 
-  const course = Object.create();
+  const course = EmberObject.create();
 
   this.set('subject', course);
   this.on('click', function() {
@@ -66,7 +66,7 @@ test('icons all parents correctly', function(assert) {
   });
   let objectives = [objective].map(obj => Ember.Object.create(obj));
 
-  const course = Object.create({
+  const course = EmberObject.create({
     objectives
   });
 
@@ -88,7 +88,7 @@ test('icons no parents correctly', function(assert) {
   });
   let objectives = [objective].map(obj => Ember.Object.create(obj));
 
-  const course = Object.create({
+  const course = EmberObject.create({
     objectives
   });
 
@@ -110,7 +110,7 @@ test('icons all mesh correctly', function(assert) {
   });
   let objectives = [objective].map(obj => Ember.Object.create(obj));
 
-  const course = Object.create({
+  const course = EmberObject.create({
     objectives
   });
 
@@ -132,7 +132,7 @@ test('icons no mesh correctly', function(assert) {
   });
   let objectives = [objective].map(obj => Ember.Object.create(obj));
 
-  const course = Object.create({
+  const course = EmberObject.create({
     objectives
   });
 

--- a/tests/integration/components/collapsed-stewards-test.js
+++ b/tests/integration/components/collapsed-stewards-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('collapsed-stewards', 'Integration | Component | collapsed stewards', {
@@ -12,38 +12,38 @@ moduleForComponent('collapsed-stewards', 'Integration | Component | collapsed st
 
 test('it renders', function(assert) {
   assert.expect(5);
-  let school1 = Object.create({
+  let school1 = EmberObject.create({
     id: 1,
     title: 'school1'
   });
-  let school2 = Object.create({
+  let school2 = EmberObject.create({
     id: 2,
     title: 'school2'
   });
-  let department1 = Object.create({
+  let department1 = EmberObject.create({
     id: 1,
     school: resolve(school1)
   });
-  let department2 = Object.create({
+  let department2 = EmberObject.create({
     id: 2,
     school: resolve(school1)
   });
   school1.set('departments', resolve([department1, department2]));
-  let department3 = Object.create({
+  let department3 = EmberObject.create({
     id: 3,
     school: resolve(school2)
   });
   school2.set('departments', resolve([department3]));
 
-  let programYear = Object.create();
-  let steward1 = Object.create({
+  let programYear = EmberObject.create();
+  let steward1 = EmberObject.create({
     programYear: resolve(programYear),
     school: resolve(school1),
     department: resolve(department1)
   });
   department1.set('stewards', resolve([steward1]));
 
-  let steward2 = Object.create({
+  let steward2 = EmberObject.create({
     programYear: resolve(programYear),
     school: resolve(school1),
     department: resolve(department2)
@@ -51,7 +51,7 @@ test('it renders', function(assert) {
   department2.set('stewards', resolve([steward2]));
   school1.set('stewards', resolve([steward1, steward2]));
 
-  let steward3 = Object.create({
+  let steward3 = EmberObject.create({
     programYear: resolve(programYear),
     school: resolve(school2),
     department: resolve(department3)
@@ -88,7 +88,7 @@ test('it renders', function(assert) {
 
 test('clicking the header expands the list', function(assert) {
   assert.expect(1);
-  let programYear = Object.create({
+  let programYear = EmberObject.create({
     stewards: resolve([])
   });
   this.set('programYear', programYear);

--- a/tests/integration/components/competency-title-editor-test.js
+++ b/tests/integration/components/competency-title-editor-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('competency-title-editor', 'Integration | Component | competency title editor', {
   integration: true
@@ -11,7 +11,7 @@ moduleForComponent('competency-title-editor', 'Integration | Component | compete
 
 test('validation errors do not show up initially', function(assert) {
   assert.expect(1);
-  let competency = Object.create({
+  let competency = EmberObject.create({
     title: 'test'
   });
   this.set('competency', competency);
@@ -23,7 +23,7 @@ test('validation errors do not show up initially', function(assert) {
 
 test('validation errors show up when saving', function(assert) {
   assert.expect(1);
-  let competency = Object.create({
+  let competency = EmberObject.create({
     title: 'test'
   });
   this.set('competency', competency);

--- a/tests/integration/components/course-director-manager-test.js
+++ b/tests/integration/components/course-director-manager-test.js
@@ -3,15 +3,15 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('course-director-manager', 'Integration | Component | course director manager', {
   integration: true
 });
 
 test('it renders', function(assert) {
-  const fakeUser1 = Object.create({fullName: 'test person 1'});
-  const fakeUser2 = Object.create({fullName: 'test person 2'});
+  const fakeUser1 = EmberObject.create({fullName: 'test person 1'});
+  const fakeUser2 = EmberObject.create({fullName: 'test person 2'});
 
   this.set('nothing', parseInt);
   this.set('users', [fakeUser1, fakeUser2]);
@@ -28,8 +28,8 @@ test('it renders', function(assert) {
 
 test('can remove users', function(assert) {
   assert.expect(4);
-  const fakeUser1 = Object.create({fullName: 'test person 1'});
-  const fakeUser2 = Object.create({fullName: 'test person 2'});
+  const fakeUser1 = EmberObject.create({fullName: 'test person 1'});
+  const fakeUser2 = EmberObject.create({fullName: 'test person 2'});
 
   const user1 = 'li:eq(0)';
   const user2 = 'li:eq(1)';

--- a/tests/integration/components/course-materials-test.js
+++ b/tests/integration/components/course-materials-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('course-materials', 'Integration | Component | course materials', {
@@ -11,18 +11,18 @@ moduleForComponent('course-materials', 'Integration | Component | course materia
 });
 
 test('course lms render', function(assert) {
-  let lm1 = Object.create({
+  let lm1 = EmberObject.create({
     title: 'title1',
     description: 'description1',
     originalAuthor: 'author1',
     link: 'url1',
     type: 'link',
   });
-  let courseLm1 = Object.create({
+  let courseLm1 = EmberObject.create({
     learningMaterial: resolve(lm1),
   });
 
-  let course = Object.create({
+  let course = EmberObject.create({
     sessions: resolve([]),
     learningMaterials: resolve([courseLm1])
   });
@@ -48,21 +48,21 @@ test('course lms render', function(assert) {
 });
 
 let setupSessionLms = function(){
-  let lm1 = Object.create({
+  let lm1 = EmberObject.create({
     title: 'title1',
     description: 'description1',
     originalAuthor: 'author1',
     url: 'http://myhost.com/url1',
     type: 'link',
   });
-  let lm2 = Object.create({
+  let lm2 = EmberObject.create({
     title: 'title2',
     description: 'description2',
     originalAuthor: 'author2',
     url: 'http://myhost.com/url2',
     type: 'file',
   });
-  let lm3 = Object.create({
+  let lm3 = EmberObject.create({
     title: 'title3',
     description: 'description3',
     originalAuthor: 'author3',
@@ -70,16 +70,16 @@ let setupSessionLms = function(){
     type: 'citation',
     citation: 'citationtext',
   });
-  let sessionLm1 = Object.create({
+  let sessionLm1 = EmberObject.create({
     learningMaterial: resolve(lm1),
   });
-  let sessionLm2 = Object.create({
+  let sessionLm2 = EmberObject.create({
     learningMaterial: resolve(lm2),
   });
-  let sessionLm3 = Object.create({
+  let sessionLm3 = EmberObject.create({
     learningMaterial: resolve(lm3),
   });
-  let session1 = Object.create({
+  let session1 = EmberObject.create({
     title: 'session1title',
     learningMaterials: resolve([sessionLm1, sessionLm2, sessionLm3]),
     firstOfferingDate: resolve(new Date(2020, 1, 2, 12)),
@@ -88,7 +88,7 @@ let setupSessionLms = function(){
   sessionLm2.set('session', resolve(session1));
   sessionLm3.set('session', resolve(session1));
 
-  let course = Object.create({
+  let course = EmberObject.create({
     sessions: resolve([session1])
   });
 

--- a/tests/integration/components/course-objective-list-item-test.js
+++ b/tests/integration/components/course-objective-list-item-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('course-objective-list-item', 'Integration | Component | course objective list item', {
@@ -10,7 +10,7 @@ moduleForComponent('course-objective-list-item', 'Integration | Component | cour
 });
 
 test('it renders', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);
@@ -30,7 +30,7 @@ test('it renders', function(assert) {
 });
 
 test('renders removable', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);
@@ -48,7 +48,7 @@ test('renders removable', function(assert) {
 });
 
 test('can change title', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title',
     save(){
       assert.equal(this.get('title'), '<p>new title</p>');
@@ -73,7 +73,7 @@ test('can change title', function(assert) {
 });
 
 test('can manage parents', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);
@@ -94,7 +94,7 @@ test('can manage parents', function(assert) {
 });
 
 test('can manage descriptors', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);
@@ -115,7 +115,7 @@ test('can manage descriptors', function(assert) {
 });
 
 test('can trigger removal', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);
@@ -136,7 +136,7 @@ test('can trigger removal', function(assert) {
 });
 
 test('read-only mode', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);

--- a/tests/integration/components/course-objective-list-test.js
+++ b/tests/integration/components/course-objective-list-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('course-objective-list', 'Integration | Component | course objective list', {
@@ -13,19 +13,19 @@ moduleForComponent('course-objective-list', 'Integration | Component | course ob
 test('it renders', function(assert){
   assert.expect(7);
 
-  let objective1 = Object.create({
+  let objective1 = EmberObject.create({
     title: 'Objective A',
     position: 0
   });
 
-  let objective2 = Object.create({
+  let objective2 = EmberObject.create({
     title: 'Objective B',
     position: 0
   });
 
   let objectives = [ objective1, objective2 ];
 
-  let course = Object.create({
+  let course = EmberObject.create({
     sortedObjectives: resolve(objectives),
   });
 
@@ -50,7 +50,7 @@ test('it renders', function(assert){
 
 test('empty list', function(assert){
   assert.expect(2);
-  let course = Object.create({
+  let course = EmberObject.create({
     objectives: resolve([]),
   });
   this.set('subject', course);
@@ -64,10 +64,10 @@ test('empty list', function(assert){
 
 test('no "sort objectives" button in list with one item', function(assert){
   assert.expect(2);
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'Objective A',
   });
-  let course = Object.create({
+  let course = EmberObject.create({
     sortedObjectives: resolve([ objective ]),
   });
 

--- a/tests/integration/components/course-overview-test.js
+++ b/tests/integration/components/course-overview-test.js
@@ -12,7 +12,7 @@ moduleForComponent('course-overview', 'Integration | Component | course overview
   }
 });
 
-const { Object, Service, RSVP } = Ember;
+const { Object:EmberObject, Service, RSVP } = Ember;
 const { resolve } = RSVP;
 
 test('renders with no course id', function(assert) {
@@ -23,8 +23,8 @@ test('renders with no course id', function(assert) {
     }
   });
 
-  let course = Object.create({
-    clerkshipType: resolve(Object.create())
+  let course = EmberObject.create({
+    clerkshipType: resolve(EmberObject.create())
   });
   this.set('course', course);
   this.render(hbs`{{course-overview course=course}}`);
@@ -42,18 +42,18 @@ test('course external id validation fails if value is too short', function(asser
     }
   });
 
-  let course = Object.create({
-    clerkshipType: resolve(Object.create()),
+  let course = EmberObject.create({
+    clerkshipType: resolve(EmberObject.create()),
   });
   this.set('course', course);
   this.render(hbs`{{course-overview course=course}}`);
 
   const item = '.courseexternalid';
   const error = `${item} .validation-error-message`;
-  const open = `${item} .clickable`;
+  const button = `${item} .clickable`;
   const save = `${item} .actions .done`;
   const input = `${item} input`;
-  this.$(open).click();
+  this.$(button).click();
   return wait().then(()=>{
     assert.equal(this.$(error).length, 0, 'No validation errors shown initially.');
     this.$(input).val('a').change();
@@ -72,18 +72,18 @@ test('course external id validation fails if value is too long', function(assert
     }
   });
 
-  let course = Object.create({
-    clerkshipType: resolve(Object.create()),
+  let course = EmberObject.create({
+    clerkshipType: resolve(EmberObject.create()),
   });
   this.set('course', course);
   this.render(hbs`{{course-overview course=course}}`);
 
   const item = '.courseexternalid';
   const error = `${item} .validation-error-message`;
-  const open = `${item} .clickable`;
+  const button = `${item} .clickable`;
   const save = `${item} .actions .done`;
   const input = `${item} input`;
-  this.$(open).click();
+  this.$(button).click();
   return wait().then(()=>{
     assert.equal(this.$(error).length, 0, 'No validation errors shown initially.');
     this.$(input).val('tooLong'.repeat(50)).change();
@@ -102,8 +102,8 @@ test('course external id validation passes on changed value within boundaries', 
     }
   });
 
-  let course = Object.create({
-    clerkshipType: resolve(Object.create()),
+  let course = EmberObject.create({
+    clerkshipType: resolve(EmberObject.create()),
     externalid: 'abcde',
     save() {
       let that = this;
@@ -121,10 +121,10 @@ test('course external id validation passes on changed value within boundaries', 
 
   const item = '.courseexternalid';
   const error = `${item} .validation-error-message`;
-  const open = `${item} .clickable`;
+  const button = `${item} .clickable`;
   const save = `${item} .actions .done`;
   const input = `${item} input`;
-  this.$(open).click();
+  this.$(button).click();
   return wait().then(()=>{
     assert.equal(this.$(error).length, 0, 'No validation errors shown initially.');
     this.$(input).val('legit').change();
@@ -143,8 +143,8 @@ test('course external id validation passes on empty value', function(assert) {
     }
   });
 
-  let course = Object.create({
-    clerkshipType: resolve(Object.create()),
+  let course = EmberObject.create({
+    clerkshipType: resolve(EmberObject.create()),
     externalid: 'abcde',
     save() {
       let that = this;
@@ -162,10 +162,10 @@ test('course external id validation passes on empty value', function(assert) {
 
   const item = '.courseexternalid';
   const error = `${item} .validation-error-message`;
-  const open = `${item} .clickable`;
+  const button = `${item} .clickable`;
   const save = `${item} .actions .done`;
   const input = `${item} input`;
-  this.$(open).click();
+  this.$(button).click();
   return wait().then(()=>{
     assert.equal(this.$(error).length, 0, 'No validation errors shown initially.');
     this.$(input).val('').change();
@@ -184,12 +184,12 @@ test('shows a list of course directors', function(assert) {
     }
   });
 
-  let course = Object.create({
-    clerkshipType: resolve(Object.create()),
+  let course = EmberObject.create({
+    clerkshipType: resolve(EmberObject.create()),
     directors: resolve([
-      Object.create({ 'fullName': 'Adam Zyzzyva', 'lastName': 'Zyzzyva' }),
-      Object.create({ 'fullName': 'Zoe Aaardvark', 'lastName': 'Aardvark' }),
-      Object.create({ 'fullName': 'Mike Middleman', 'lastName': 'Middleman' })
+      EmberObject.create({ 'fullName': 'Adam Zyzzyva', 'lastName': 'Zyzzyva' }),
+      EmberObject.create({ 'fullName': 'Zoe Aaardvark', 'lastName': 'Aardvark' }),
+      EmberObject.create({ 'fullName': 'Mike Middleman', 'lastName': 'Middleman' })
     ])
   });
   this.set('course', course);

--- a/tests/integration/components/course-rollover-test.js
+++ b/tests/integration/components/course-rollover-test.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 import wait from 'ember-test-helpers/wait';
 
-const { Service, RSVP, Object, run, getOwner } = Ember;
+const { Service, RSVP, Object:EmberObject, run, getOwner } = Ember;
 const { Promise, resolve } = RSVP;
 
 let storeMock;
@@ -24,7 +24,7 @@ test('it renders', function(assert) {
     }
   });
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'old course'
   });
@@ -48,7 +48,7 @@ test('it renders', function(assert) {
 
 test('rollover course', function(assert) {
   assert.expect(14);
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'old title',
     startDate: moment().hour(0).minute(0).second(0).toDate()
@@ -86,7 +86,7 @@ test('rollover course', function(assert) {
       assert.equal(what, 'course');
       assert.equal(id, 14);
 
-      return Object.create({
+      return EmberObject.create({
         id: 14
       });
     },
@@ -115,7 +115,7 @@ test('rollover course', function(assert) {
 
 test('rollover course with new title', function(assert) {
   assert.expect(5);
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'old title',
     startDate: moment().hour(0).minute(0).second(0).toDate()
@@ -144,7 +144,7 @@ test('rollover course with new title', function(assert) {
     peekRecord(what, id){
       assert.equal(what, 'course');
       assert.equal(id, 14);
-      return Object.create({
+      return EmberObject.create({
         id: 14
       });
     },
@@ -194,7 +194,7 @@ test('disable years when title already exists', function(assert) {
     }
   });
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'to be rolled',
   });
@@ -224,7 +224,7 @@ test('rollover course with new start date', function(assert) {
 
   const rolloverDate = moment(courseStartDate).add(1, 'week');
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     startDate: courseStartDate.toDate(),
     title: 'old course'
@@ -317,7 +317,7 @@ test('rollover course prohibit non-matching day-of-week date selection', functio
   }
   const rolloverDate = moment(courseStartDate).add(1, 'week').day(3);
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'test title',
     startDate: courseStartDate.toDate()
@@ -402,7 +402,7 @@ test('rollover start date adjustment with former year course start date', functi
     .isoWeek(courseStartDate.isoWeek())
     .isoWeekday(courseStartDate.isoWeekday());
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     startDate: courseStartDate.toDate(),
     title: 'old course'
@@ -457,7 +457,7 @@ test('rollover start date adjustment with former year course start date', functi
 
 test('rollover course with no offerings', function(assert) {
   assert.expect(3);
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'old course'
   });
@@ -514,7 +514,7 @@ test('errors do not show up initially', function(assert) {
       return [];
     }
   });
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1
   });
   this.set('course', course);
@@ -532,7 +532,7 @@ test('errors show up', function(assert) {
       return [];
     }
   });
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1
   });
   this.set('course', course);
@@ -566,7 +566,7 @@ test('changing the title looks for new matching courses', function(assert) {
     }
   });
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'to be rolled',
   });

--- a/tests/integration/components/course-summary-header-test.js
+++ b/tests/integration/components/course-summary-header-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('course-summary-header', 'Integration | Component | course summary header', {
   integration: true,
@@ -15,7 +15,7 @@ moduleForComponent('course-summary-header', 'Integration | Component | course su
 });
 
 test('it renders', function(assert) {
-  let course = Object.create({
+  let course = EmberObject.create({
     title: 'title',
     startDate: new Date(2020, 4, 6, 12),
     endDate: new Date(2020, 11, 11, 12),
@@ -59,7 +59,7 @@ test('no link to materials when that is the current route', function(assert) {
   });
   this.register('service:-routing', routerMock);
 
-  let course = Object.create({
+  let course = EmberObject.create({
     title: 'title',
     startDate: new Date(2020, 4, 6, 12),
     endDate: new Date(2020, 11, 11, 12),
@@ -82,7 +82,7 @@ test('no link to rollover when that is the current route', function(assert) {
   });
   this.register('service:-routing', routerMock);
 
-  let course = Object.create({
+  let course = EmberObject.create({
     title: 'title',
     startDate: new Date(2020, 4, 6, 12),
     endDate: new Date(2020, 11, 11, 12),

--- a/tests/integration/components/curriculum-inventory-report-details-test.js
+++ b/tests/integration/components/curriculum-inventory-report-details-test.js
@@ -6,7 +6,7 @@ import wait from 'ember-test-helpers/wait';
 import moment from 'moment';
 import tHelper from "ember-i18n/helper";
 
-const { RSVP, Object, Service } = Ember;
+const { RSVP, Object:EmberObject, Service } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('curriculum-inventory-report-details', 'Integration | Component | curriculum inventory report details', {
@@ -21,20 +21,20 @@ moduleForComponent('curriculum-inventory-report-details', 'Integration | Compone
 test('it renders', function(assert) {
   assert.expect(2);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i + 1}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i + 1}` }));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
@@ -64,20 +64,20 @@ test('it renders', function(assert) {
 test('finalize report', function(assert) {
   assert.expect(8);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i + 1}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i + 1}` }));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
@@ -94,7 +94,7 @@ test('finalize report', function(assert) {
     createRecord(what, params) {
       assert.equal(what, 'curriculumInventoryExport', 'createRecord() got invoked for export.');
       assert.equal(params.report, report, 'Report gets passed to correctly.');
-      return Object.create({
+      return EmberObject.create({
         save() {
           return resolve(this);
         }
@@ -130,20 +130,20 @@ test('finalize report', function(assert) {
 
 test('start finalizing report, then cancel', function(assert){
   assert.expect(3);
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i + 1}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i + 1}` }));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),

--- a/tests/integration/components/curriculum-inventory-report-header-test.js
+++ b/tests/integration/components/curriculum-inventory-report-header-test.js
@@ -4,7 +4,7 @@ import { test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('curriculum-inventory-report-header', 'Integration | Component | curriculum inventory report header', {
@@ -12,7 +12,7 @@ moduleForComponent('curriculum-inventory-report-header', 'Integration | Componen
 });
 
 test('it renders', function(assert) {
-  let report = Object.create({
+  let report = EmberObject.create({
     isFinalized: false,
     absoluteFileUri: 'foo/bar',
     name: 'Report name'
@@ -26,7 +26,7 @@ test('it renders', function(assert) {
 });
 
 test('finalized reports render in read-only mode.', function(assert) {
-  let report = Object.create({
+  let report = EmberObject.create({
     isFinalized: true,
     absoluteFileUri: 'foo/bar',
     name: 'Report name'
@@ -42,7 +42,7 @@ test('finalized reports render in read-only mode.', function(assert) {
 test('change name', function(assert) {
   assert.expect(3);
   const newName = 'new name';
-  let report = Object.create({
+  let report = EmberObject.create({
     isFinalized: false,
     absoluteFileUri: 'foo/bar',
     name: 'old name',
@@ -65,7 +65,7 @@ test('change name', function(assert) {
 
 test('change name fails on empty value', function(assert) {
   assert.expect(2);
-  let report = Object.create({
+  let report = EmberObject.create({
     isFinalized: false,
     absoluteFileUri: 'foo/bar',
     name: 'old name',
@@ -87,7 +87,7 @@ test('change name fails on empty value', function(assert) {
 
 test('clicking on finalize button fires action', function(assert){
   assert.expect(1);
-  let report = Object.create({
+  let report = EmberObject.create({
     isFinalized: false,
     absoluteFileUri: 'foo/bar',
     name: 'Report name'

--- a/tests/integration/components/curriculum-inventory-report-list-test.js
+++ b/tests/integration/components/curriculum-inventory-report-list-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import moment from 'moment';
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('curriculum-inventory-report-list', 'Integration | Component | curriculum inventory report list', {
@@ -10,26 +10,26 @@ moduleForComponent('curriculum-inventory-report-list', 'Integration | Component 
 });
 
 test('it renders', function(assert) {
-  let report1 = Object.create({
+  let report1 = EmberObject.create({
     id: 1,
     name: 'Zeppelin',
     year: 2017,
     yearLabel: '2017 - 2018',
     startDate: moment('2017-07-01').toDate(),
     endDate: moment('2018-06-30').toDate(),
-    program: Object.create({
+    program: EmberObject.create({
       'title': 'Doctor of Medicine'
     }),
     isFinalized: false,
   });
-  let report2 = Object.create({
+  let report2 = EmberObject.create({
     id: 2,
     name: 'Aardvark',
     year: 2016,
     startDate: moment('2016-07-01').toDate(),
     endDate: moment('2017-06-30').toDate(),
     yearLabel: '2016 - 2017',
-    program: Object.create({
+    program: EmberObject.create({
       'title': 'Doctor of Rocket Surgery'
     }),
     isFinalized: true,
@@ -37,7 +37,7 @@ test('it renders', function(assert) {
 
   const reports = [ report1, report2 ];
 
-  const program = Object.create({
+  const program = EmberObject.create({
     curriculumInventoryReports: resolve(reports)
   });
 
@@ -96,7 +96,7 @@ test('it renders', function(assert) {
 });
 
 test('empty list', function(assert) {
-  const program = Object.create({
+  const program = EmberObject.create({
     curriculumInventoryReports: resolve([])
   });
 
@@ -109,11 +109,11 @@ test('empty list', function(assert) {
 
 test('delete and confirm', function(assert) {
   assert.expect(3);
-  let report = Object.create();
+  let report = EmberObject.create();
   let removeAction =  function(obj) {
     assert.equal(report, obj, 'Report is passed to remove action.');
   };
-  const program = Object.create({
+  const program = EmberObject.create({
     curriculumInventoryReports: resolve([ report ])
   });
 
@@ -128,11 +128,11 @@ test('delete and confirm', function(assert) {
 
 test('delete and cancel', function(assert) {
   assert.expect(3);
-  let report = Object.create();
+  let report = EmberObject.create();
   let removeAction =  function() {
     assert.ok(false, 'Remove action should not have been invoked.');
   };
-  const program = Object.create({
+  const program = EmberObject.create({
     curriculumInventoryReports: resolve([ report ])
   });
 
@@ -148,10 +148,10 @@ test('delete and cancel', function(assert) {
 
 test('sorting', function(assert) {
   assert.expect(4);
-  let report = Object.create();
+  let report = EmberObject.create();
   let count = 0;
   let sortBys = ['name', 'name:desc', 'year', 'year:desc'];
-  const program = Object.create({
+  const program = EmberObject.create({
     curriculumInventoryReports: resolve([ report ])
   });
 
@@ -171,11 +171,11 @@ test('sorting', function(assert) {
 
 test('edit', function(assert) {
   assert.expect(5);
-  let report = Object.create({ id: 1 });
+  let report = EmberObject.create({ id: 1 });
   let editAction =  function(obj) {
     assert.equal(report, obj, 'Report is passed to edit action.');
   };
-  const program = Object.create({
+  const program = EmberObject.create({
     curriculumInventoryReports: resolve([ report ])
   });
 

--- a/tests/integration/components/curriculum-inventory-report-overview-test.js
+++ b/tests/integration/components/curriculum-inventory-report-overview-test.js
@@ -7,7 +7,7 @@ import moment from 'moment';
 import tHelper from "ember-i18n/helper";
 import {openDatepicker} from 'ember-pikaday/helpers/pikaday';
 
-const {RSVP, Object, Service} = Ember;
+const { RSVP, Object:EmberObject, Service } = Ember;
 const {resolve} = RSVP;
 
 moduleForComponent('curriculum-inventory-report-overview', 'Integration | Component | curriculum inventory report overview', {
@@ -23,7 +23,7 @@ moduleForComponent('curriculum-inventory-report-overview', 'Integration | Compon
 test('it renders', function (assert) {
   assert.expect(12);
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id() {
       return 1;
     }
@@ -31,10 +31,10 @@ test('it renders', function (assert) {
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({id: i, name: `Year ${i + 1}`}));
+    academicLevels.pushObject(EmberObject.create({id: i, name: `Year ${i + 1}`}));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     },
@@ -42,7 +42,7 @@ test('it renders', function (assert) {
     shortTitle: 'DRS'
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program,
@@ -107,7 +107,7 @@ test('it renders', function (assert) {
 test('read-only/finalized mode', function (assert) {
   assert.expect(5);
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id() {
       return 1;
     }
@@ -115,10 +115,10 @@ test('read-only/finalized mode', function (assert) {
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({id: i, name: `Year ${i + 1}`}));
+    academicLevels.pushObject(EmberObject.create({id: i, name: `Year ${i + 1}`}));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     },
@@ -126,7 +126,7 @@ test('read-only/finalized mode', function (assert) {
     shortTitle: 'DRS'
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program,
@@ -164,7 +164,7 @@ test('read-only/finalized mode', function (assert) {
 test('rollover button not visible for non-developer user', function (assert) {
   assert.expect(1);
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id() {
       return 1;
     }
@@ -172,10 +172,10 @@ test('rollover button not visible for non-developer user', function (assert) {
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({id: i, name: `Year ${i + 1}`}));
+    academicLevels.pushObject(EmberObject.create({id: i, name: `Year ${i + 1}`}));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     },
@@ -183,7 +183,7 @@ test('rollover button not visible for non-developer user', function (assert) {
     shortTitle: 'DRS'
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program,
@@ -213,7 +213,7 @@ test('rollover button not visible for non-developer user', function (assert) {
 test('change start date', function (assert) {
   assert.expect(3);
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id() {
       return 1;
     }
@@ -221,10 +221,10 @@ test('change start date', function (assert) {
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({id: i, name: `Year ${i + 1}`}));
+    academicLevels.pushObject(EmberObject.create({id: i, name: `Year ${i + 1}`}));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     },
@@ -232,7 +232,7 @@ test('change start date', function (assert) {
     shortTitle: 'DRS'
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program,
@@ -277,7 +277,7 @@ test('change start date', function (assert) {
 test('validation fails if given start date follows end date', function (assert) {
   assert.expect(2);
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id() {
       return 1;
     }
@@ -285,10 +285,10 @@ test('validation fails if given start date follows end date', function (assert) 
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({id: i, name: `Year ${i + 1}`}));
+    academicLevels.pushObject(EmberObject.create({id: i, name: `Year ${i + 1}`}));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     },
@@ -296,7 +296,7 @@ test('validation fails if given start date follows end date', function (assert) 
     shortTitle: 'DRS'
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program,
@@ -335,7 +335,7 @@ test('validation fails if given start date follows end date', function (assert) 
 test('change end date', function (assert) {
   assert.expect(3);
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id() {
       return 1;
     }
@@ -343,10 +343,10 @@ test('change end date', function (assert) {
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({id: i, name: `Year ${i + 1}`}));
+    academicLevels.pushObject(EmberObject.create({id: i, name: `Year ${i + 1}`}));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     },
@@ -354,7 +354,7 @@ test('change end date', function (assert) {
     shortTitle: 'DRS'
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program,
@@ -399,7 +399,7 @@ test('change end date', function (assert) {
 test('validation fails if given end date precedes end date', function (assert) {
   assert.expect(2);
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id() {
       return 1;
     }
@@ -407,10 +407,10 @@ test('validation fails if given end date precedes end date', function (assert) {
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({id: i, name: `Year ${i + 1}`}));
+    academicLevels.pushObject(EmberObject.create({id: i, name: `Year ${i + 1}`}));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     },
@@ -418,7 +418,7 @@ test('validation fails if given end date precedes end date', function (assert) {
     shortTitle: 'DRS'
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program,
@@ -457,7 +457,7 @@ test('validation fails if given end date precedes end date', function (assert) {
 test('change academic year', function (assert) {
   assert.expect(4);
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id() {
       return 1;
     }
@@ -465,10 +465,10 @@ test('change academic year', function (assert) {
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({id: i, name: `Year ${i + 1}`}));
+    academicLevels.pushObject(EmberObject.create({id: i, name: `Year ${i + 1}`}));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     },
@@ -476,7 +476,7 @@ test('change academic year', function (assert) {
     shortTitle: 'DRS'
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: parseInt(moment().format('YYYY'), 10),
     program,
@@ -518,7 +518,7 @@ test('change academic year', function (assert) {
 test('academic year unchangeable if course has been linked', function (assert) {
   assert.expect(2);
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id() {
       return 1;
     }
@@ -526,10 +526,10 @@ test('academic year unchangeable if course has been linked', function (assert) {
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({id: i, name: `Year ${i + 1}`}));
+    academicLevels.pushObject(EmberObject.create({id: i, name: `Year ${i + 1}`}));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     },
@@ -537,7 +537,7 @@ test('academic year unchangeable if course has been linked', function (assert) {
     shortTitle: 'DRS'
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program,
@@ -567,7 +567,7 @@ test('academic year unchangeable if course has been linked', function (assert) {
 test('change description', function (assert) {
   assert.expect(3);
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id() {
       return 1;
     }
@@ -575,10 +575,10 @@ test('change description', function (assert) {
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({id: i, name: `Year ${i + 1}`}));
+    academicLevels.pushObject(EmberObject.create({id: i, name: `Year ${i + 1}`}));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     },
@@ -586,7 +586,7 @@ test('change description', function (assert) {
     shortTitle: 'DRS'
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program,
@@ -623,7 +623,7 @@ test('change description', function (assert) {
 test('description validation fails if text is too long', function (assert) {
   assert.expect(3);
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id() {
       return 1;
     }
@@ -631,10 +631,10 @@ test('description validation fails if text is too long', function (assert) {
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({id: i, name: `Year ${i + 1}`}));
+    academicLevels.pushObject(EmberObject.create({id: i, name: `Year ${i + 1}`}));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     },
@@ -642,7 +642,7 @@ test('description validation fails if text is too long', function (assert) {
     shortTitle: 'DRS'
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program,

--- a/tests/integration/components/curriculum-inventory-report-rollover-test.js
+++ b/tests/integration/components/curriculum-inventory-report-rollover-test.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Service, RSVP, Object } = Ember;
+const { Service, RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('curriculum-inventory-report-rollover', 'Integration | Component | curriculum inventory report rollover', {
@@ -21,7 +21,7 @@ test('it renders', function(assert) {
   this.register('service:store', storeMock);
 
   const thisYear = parseInt(moment().format('YYYY'));
-  let report = Object.create({
+  let report = EmberObject.create({
     id: 1,
     name: 'old report',
     description: 'this is an old report',
@@ -49,7 +49,7 @@ test('it renders', function(assert) {
 test('rollover report', function(assert) {
   assert.expect(12);
   const thisYear = parseInt(moment().format('YYYY'));
-  let report = Object.create({
+  let report = EmberObject.create({
     id: 1,
     name: 'old report',
     description: 'this is an old report',
@@ -58,7 +58,6 @@ test('rollover report', function(assert) {
 
   let ajaxMock = Service.extend({
     request(url, {method, data}){
-      let thisYear = parseInt(moment().format('YYYY'));
       assert.equal(url.trim(), `/api/curriculuminventoryreports/${report.get('id')}/rollover`);
       assert.equal(method, 'POST');
       assert.equal(data.year, thisYear + 1);
@@ -86,7 +85,7 @@ test('rollover report', function(assert) {
       assert.equal(what, 'curriculum-inventory-report');
       assert.equal(id, 14);
 
-      return Object.create({
+      return EmberObject.create({
         id: 14
       });
     },
@@ -117,7 +116,7 @@ test('rollover report', function(assert) {
 test('rollover report with new name, description and year', function(assert) {
   assert.expect(7);
   const thisYear = parseInt(moment().format('YYYY'));
-  let report = Object.create({
+  let report = EmberObject.create({
     id: 1,
     name: 'old report',
     description: 'this is an old report',
@@ -151,7 +150,7 @@ test('rollover report with new name, description and year', function(assert) {
     peekRecord(what, id){
       assert.equal(what, 'curriculum-inventory-report');
       assert.equal(id, 14);
-      return Object.create({
+      return EmberObject.create({
         id: 14
       });
     },
@@ -191,7 +190,7 @@ test('no input validation errors are shown initially', function(assert) {
     }
   });
   this.register('service:store', storeMock);
-  let report = Object.create({
+  let report = EmberObject.create({
     id: 1,
   });
   this.set('report', report);
@@ -210,7 +209,7 @@ test('input validation fails on blank reort name', function(assert) {
     }
   });
   this.register('service:store', storeMock);
-  let report = Object.create({
+  let report = EmberObject.create({
     id: 1,
     name: 'report name',
   });

--- a/tests/integration/components/curriculum-inventory-sequence-block-dates-duration-editor-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-dates-duration-editor-test.js
@@ -6,7 +6,7 @@ import moment from 'moment';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 import wait from 'ember-test-helpers/wait';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent(
   'curriculum-inventory-sequence-block-dates-duration-editor',
@@ -17,7 +17,7 @@ moduleForComponent(
 );
 
 test('it renders', function(assert) {
-  let block = Object.create({
+  let block = EmberObject.create({
     startDate: moment('2016-04-23').toDate(),
     endDate: moment('2016-06-02').toDate(),
     duration: 10
@@ -47,7 +47,7 @@ test('save', function(assert) {
   const newStartDate = moment('2016-10-30');
   const newEndDate = moment('2016-11-02');
   const newDuration = '5';
-  let block = Object.create({
+  let block = EmberObject.create({
     startDate: moment('2016-04-23').toDate(),
     endDate: moment('2016-06-02').toDate(),
     duration: 5
@@ -74,7 +74,7 @@ test('save with date range and a zero duration', function(assert) {
   const newStartDate = moment('2016-10-30');
   const newEndDate = moment('2016-11-02');
   const newDuration = '0';
-  let block = Object.create();
+  let block = EmberObject.create();
   let saveAction = function(startDate, endDate, duration) {
     assert.equal(moment(startDate).format('YYYY-MM-DD'), newStartDate.format('YYYY-MM-DD'), 'New start date on save.');
     assert.equal(moment(endDate).format('YYYY-MM-DD'), newEndDate.format('YYYY-MM-DD'), 'New end date on save.');
@@ -95,7 +95,7 @@ test('save with date range and a zero duration', function(assert) {
 test('save with non-zero duration and no date range', function(assert) {
   assert.expect(3);
   const newDuration = '5';
-  let block = Object.create();
+  let block = EmberObject.create();
 
   let saveAction = function(startDate, endDate, duration) {
     assert.equal(startDate, null, 'NULL for start date on save.');
@@ -112,7 +112,7 @@ test('save with non-zero duration and no date range', function(assert) {
 
 test('cancel', function(assert) {
   assert.expect(1);
-  let block = Object.create({
+  let block = EmberObject.create({
     startDate: moment('2016-04-23').toDate(),
     endDate: moment('2016-06-02').toDate(),
     duration: 10
@@ -131,7 +131,7 @@ test('save fails if end-date is older than start-date', function(assert) {
   assert.expect(2);
   const newStartDate = moment('2016-10-30');
   const newEndDate = moment('2013-11-02');
-  let block = Object.create({ duration: 0 });
+  let block = EmberObject.create({ duration: 0 });
   let saveAction = function() {
     assert.ok(false, 'Save action should have not been invoked.');
   };
@@ -151,7 +151,7 @@ test('save fails if end-date is older than start-date', function(assert) {
 
 test('save fails on missing duration', function(assert) {
   assert.expect(2);
-  let block = Object.create({
+  let block = EmberObject.create({
     startDate: moment('2016-04-23').toDate(),
     endDate: moment('2016-06-02').toDate(),
     duration: 10
@@ -173,7 +173,7 @@ test('save fails on missing duration', function(assert) {
 
 test('save fails on invalid duration', function(assert) {
   assert.expect(2);
-  let block = Object.create({
+  let block = EmberObject.create({
     startDate: moment('2016-04-23').toDate(),
     endDate: moment('2016-06-02').toDate(),
     duration: 10
@@ -195,7 +195,7 @@ test('save fails on invalid duration', function(assert) {
 
 test('save fails if neither date range nor duration is provided', function(assert) {
   assert.expect(2);
-  let block = Object.create({ duration: 0 });
+  let block = EmberObject.create({ duration: 0 });
   let saveAction = function() {
     assert.ok(false, 'Save action should have not been invoked.');
   };
@@ -211,7 +211,7 @@ test('save fails if neither date range nor duration is provided', function(asser
 
 test('save fails if start-date is given but no end-date is provided', function(assert) {
   assert.expect(2);
-  let block = Object.create({ duration: 0 });
+  let block = EmberObject.create({ duration: 0 });
   let saveAction = function() {
     assert.ok(false, 'Save action should have not been invoked.');
   };

--- a/tests/integration/components/curriculum-inventory-sequence-block-details-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-details-test.js
@@ -6,7 +6,7 @@ import wait from 'ember-test-helpers/wait';
 import moment from 'moment';
 import tHelper from "ember-i18n/helper";
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('curriculum-inventory-sequence-block-details', 'Integration | Component | curriculum inventory sequence block details', {
@@ -20,20 +20,20 @@ moduleForComponent('curriculum-inventory-sequence-block-details', 'Integration |
 test('it renders', function(assert) {
   assert.expect(7);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i + 1}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i + 1}` }));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
@@ -41,12 +41,12 @@ test('it renders', function(assert) {
     isFinalized: resolve(false)
   });
 
-  let grandParentBlock = Object.create({
+  let grandParentBlock = EmberObject.create({
     id: 1,
     title: 'Okely Dokely',
   });
 
-  let parentBlock = Object.create({
+  let parentBlock = EmberObject.create({
     id: 2,
     title: 'Foo',
     parent: resolve(grandParentBlock)
@@ -56,7 +56,7 @@ test('it renders', function(assert) {
 
   let academicLevel = academicLevels[0];
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 3,
     description: 'lorem ipsum',
     report: resolve(report),

--- a/tests/integration/components/curriculum-inventory-sequence-block-header-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-header-test.js
@@ -4,7 +4,7 @@ import { test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('curriculum-inventory-sequence-block-header', 'Integration | Component | curriculum inventory sequence block header', {
@@ -12,7 +12,7 @@ moduleForComponent('curriculum-inventory-sequence-block-header', 'Integration | 
 });
 
 test('it renders', function(assert) {
-  let block = Object.create({
+  let block = EmberObject.create({
     title: 'Block title'
   });
   this.set('sequenceBlock', block);
@@ -22,7 +22,7 @@ test('it renders', function(assert) {
 });
 
 test('read-only mode for block in finalized report', function(assert) {
-  let block = Object.create({
+  let block = EmberObject.create({
     title: 'Block title',
     report: {
       isFinalized: true
@@ -36,7 +36,7 @@ test('read-only mode for block in finalized report', function(assert) {
 test('change title', function(assert) {
   assert.expect(3);
   const newTitle = 'new title';
-  let block = Object.create({
+  let block = EmberObject.create({
     title: 'block title',
     save(){
       assert.equal(this.get('title'), newTitle);
@@ -57,7 +57,7 @@ test('change title', function(assert) {
 
 test('change title fails on empty value', function(assert) {
   assert.expect(2);
-  let block = Object.create({
+  let block = EmberObject.create({
     title: 'block title',
     save(){
       assert.ok(false, 'Save action should not have been invoked.');
@@ -77,7 +77,7 @@ test('change title fails on empty value', function(assert) {
 
 test('change title fails on too-short value', function(assert) {
   assert.expect(2);
-  let block = Object.create({
+  let block = EmberObject.create({
     title: 'block title',
     save(){
       assert.ok(false, 'Save action should not have been invoked.');
@@ -97,7 +97,7 @@ test('change title fails on too-short value', function(assert) {
 
 test('change title fails on overlong value', function(assert) {
   assert.expect(2);
-  let block = Object.create({
+  let block = EmberObject.create({
     title: 'block title',
     save(){
       assert.ok(false, 'Save action should not have been invoked.');

--- a/tests/integration/components/curriculum-inventory-sequence-block-list-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-list-test.js
@@ -6,7 +6,7 @@ import wait from 'ember-test-helpers/wait';
 import moment from 'moment';
 import tHelper from "ember-i18n/helper";
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('curriculum-inventory-sequence-block-list', 'Integration | Component | curriculum inventory sequence block list', {
@@ -21,23 +21,23 @@ moduleForComponent('curriculum-inventory-sequence-block-list', 'Integration | Co
 test('it renders with top-level sequence blocks', function(assert) {
   assert.expect(25);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: "Life Lessons",
   });
 
-  let academicLevel1 = Object.create({ id: 1, level: '2'});
-  let academicLevel2 = Object.create({ id: 2, level: '1'});
+  let academicLevel1 = EmberObject.create({ id: 1, level: '2'});
+  let academicLevel2 = EmberObject.create({ id: 2, level: '1'});
 
-  let block1 = Object.create({
+  let block1 = EmberObject.create({
     id: 1,
     academicLevel: resolve(academicLevel1),
     title: 'Foo',
@@ -47,7 +47,7 @@ test('it renders with top-level sequence blocks', function(assert) {
     orderInSequence: 0,
   });
 
-  let block2 = Object.create({
+  let block2 = EmberObject.create({
     id: 2,
     academicLevel: resolve(academicLevel2),
     title: 'Bar',
@@ -59,7 +59,7 @@ test('it renders with top-level sequence blocks', function(assert) {
 
   let blocks = [block1, block2];
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: resolve([]),
     year: '2016',
     program: resolve(program),
@@ -113,24 +113,24 @@ test('it renders with top-level sequence blocks', function(assert) {
 test('it renders with nested blocks', function(assert) {
   assert.expect(18);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: "Life Lessons",
   });
 
-  let academicLevel1 = Object.create({ id: 1, level: '2'});
-  let academicLevel2 = Object.create({ id: 2, level: '1'});
+  let academicLevel1 = EmberObject.create({ id: 1, level: '2'});
+  let academicLevel2 = EmberObject.create({ id: 2, level: '1'});
 
 
-  let block1 = Object.create({
+  let block1 = EmberObject.create({
     id: 2,
     academicLevel: resolve(academicLevel1),
     title: 'Foo',
@@ -140,7 +140,7 @@ test('it renders with nested blocks', function(assert) {
     orderInSequence: 1,
   });
 
-  let block2 = Object.create({
+  let block2 = EmberObject.create({
     id: 3,
     academicLevel: resolve(academicLevel2),
     title: 'Bar',
@@ -152,7 +152,7 @@ test('it renders with nested blocks', function(assert) {
 
   let nestedBlocks = [block1, block2];
 
-  let parentBlock = Object.create({
+  let parentBlock = EmberObject.create({
     id: 1,
     academicLevel: resolve(academicLevel1),
     title: 'Parent Block',
@@ -161,7 +161,7 @@ test('it renders with nested blocks', function(assert) {
     children: resolve(nestedBlocks),
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: resolve([]),
     year: '2016',
     program: resolve(program),
@@ -214,24 +214,24 @@ test('it renders with nested blocks', function(assert) {
 test('finalized/read-only mode', function(assert){
   assert.expect(3);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let block1 = Object.create({
+  let block1 = EmberObject.create({
     id: 1,
-    academicLevel: resolve(Object.create({ id: 1, level: '2'})),
+    academicLevel: resolve(EmberObject.create({ id: 1, level: '2'})),
     title: 'Bar',
     startDate: new Date('2015-02-23'),
     endDate: new Date('2016-12-03'),
     course: resolve(null),
     orderInSequence: 0,
   });
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: resolve([]),
     year: '2016',
     program: resolve(program),
@@ -257,17 +257,17 @@ test('finalized/read-only mode', function(assert){
 test('delete', function(assert){
   assert.expect(4);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let block1 = Object.create({
+  let block1 = EmberObject.create({
     id: 1,
-    academicLevel: resolve(Object.create({ id: 1, level: '2'})),
+    academicLevel: resolve(EmberObject.create({ id: 1, level: '2'})),
     title: 'Foo',
     startDate: new Date('2015-02-23'),
     endDate: new Date('2016-12-03'),
@@ -275,7 +275,7 @@ test('delete', function(assert){
     orderInSequence: 0,
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: resolve([]),
     year: '2016',
     program: resolve(program),
@@ -307,17 +307,17 @@ test('delete', function(assert){
 test('cancel delete', function(assert){
   assert.expect(2);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let block1 = Object.create({
+  let block1 = EmberObject.create({
     id: 1,
-    academicLevel: resolve(Object.create({ id: 1, level: '2'})),
+    academicLevel: resolve(EmberObject.create({ id: 1, level: '2'})),
     title: 'Foo',
     startDate: new Date('2015-02-23'),
     endDate: new Date('2016-12-03'),
@@ -325,7 +325,7 @@ test('cancel delete', function(assert){
     orderInSequence: 0,
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: resolve([]),
     year: '2016',
     program: resolve(program),
@@ -352,15 +352,15 @@ test('cancel delete', function(assert){
 test('empty top level blocks list', function(assert) {
   assert.expect(2);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: resolve([]),
     year: '2016',
     program: resolve(program),
@@ -389,24 +389,24 @@ test('empty top level blocks list', function(assert) {
 test('empty nested blocks list', function(assert) {
   assert.expect(2);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let parentBlock = Object.create({
+  let parentBlock = EmberObject.create({
     id: 1,
-    academicLevel: resolve(Object.create({ id: 1, level: '2'})),
+    academicLevel: resolve(EmberObject.create({ id: 1, level: '2'})),
     title: 'Parent Block',
     course: resolve(null),
     isOrdered: true,
     children: resolve([]),
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: resolve([]),
     year: '2016',
     program: resolve(program),

--- a/tests/integration/components/curriculum-inventory-sequence-block-min-max-editor-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-min-max-editor-test.js
@@ -4,14 +4,14 @@ import { test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('curriculum-inventory-sequence-block-min-max-editor', 'Integration | Component | curriculum inventory sequence block min max editor', {
   integration: true
 });
 
 test('it renders', function(assert) {
-  let block = Object.create({
+  let block = EmberObject.create({
     minimum: 5,
     maximum: 10,
   });
@@ -29,7 +29,7 @@ test('save', function(assert) {
   assert.expect(2);
   const newMinimum = '50';
   const newMaximum = '100';
-  let block = Object.create({
+  let block = EmberObject.create({
     minimum: 5,
     maximum: 10
   });
@@ -49,7 +49,7 @@ test('save', function(assert) {
 
 test('cancel', function(assert) {
   assert.expect(1);
-  let block = Object.create({
+  let block = EmberObject.create({
     minimum: 5,
     maximum: 10,
   });
@@ -64,7 +64,7 @@ test('cancel', function(assert) {
 
 test('save fails when minimum is larger than maximum', function(assert) {
   assert.expect(2);
-  let block = Object.create();
+  let block = EmberObject.create();
   let saveAction = function() {
     assert.ok(false, 'Save action should have not been invoked.');
   };
@@ -84,7 +84,7 @@ test('save fails when minimum is larger than maximum', function(assert) {
 
 test('save fails when minimum is less than zero', function(assert) {
   assert.expect(2);
-  let block = Object.create();
+  let block = EmberObject.create();
   let saveAction = function() {
     assert.ok(false, 'Save action should have not been invoked.');
   };
@@ -104,7 +104,7 @@ test('save fails when minimum is less than zero', function(assert) {
 
 test('save fails when minimum is empty', function(assert) {
   assert.expect(2);
-  let block = Object.create();
+  let block = EmberObject.create();
   let saveAction = function() {
     assert.ok(false, 'Save action should have not been invoked.');
   };
@@ -124,7 +124,7 @@ test('save fails when minimum is empty', function(assert) {
 
 test('save fails when maximum is empty', function(assert) {
   assert.expect(2);
-  let block = Object.create();
+  let block = EmberObject.create();
   let saveAction = function() {
     assert.ok(false, 'Save action should have not been invoked.');
   };

--- a/tests/integration/components/curriculum-inventory-sequence-block-overview-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-overview-test.js
@@ -6,7 +6,7 @@ import wait from 'ember-test-helpers/wait';
 import moment from 'moment';
 import tHelper from "ember-i18n/helper";
 
-const { RSVP, Object, Service } = Ember;
+const { RSVP, Object:EmberObject, Service } = Ember;
 const { resolve } = RSVP;
 
 let storeMock;
@@ -23,29 +23,29 @@ moduleForComponent('curriculum-inventory-sequence-block-overview', 'Integration 
 test('it renders', function(assert) {
   assert.expect(38);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i + 1}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i + 1}` }));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let linkedCourse = Object.create({
+  let linkedCourse = EmberObject.create({
     id: 1,
     title: 'Course A',
     startDate: new Date('2015-02-02'),
     endDate: new Date('2015-03-30'),
-    clerkshipType: Object.create({ title: 'Block' }),
+    clerkshipType: EmberObject.create({ title: 'Block' }),
     level: 4
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
@@ -53,7 +53,7 @@ test('it renders', function(assert) {
     isFinalized: resolve(false)
   });
 
-  let parentBlock = Object.create({
+  let parentBlock = EmberObject.create({
     id: 1,
     isOrdered: true,
     children: null,
@@ -61,7 +61,7 @@ test('it renders', function(assert) {
 
   let academicLevel = academicLevels[0];
 
-  let ilmSession = Object.create({
+  let ilmSession = EmberObject.create({
     id: 1,
     course: resolve(linkedCourse),
     title: 'Session A',
@@ -76,14 +76,14 @@ test('it renders', function(assert) {
         };
       }
     },
-    sessionType: Object.create({
+    sessionType: EmberObject.create({
       'title': 'Independent Learning'
     }),
     maxSingleOfferingDuration: resolve(10),
     totalSumOfferingsDuration: resolve(20)
   });
 
-  let session1 = Object.create({
+  let session1 = EmberObject.create({
     id: 1,
     course: resolve(linkedCourse),
     title: 'Session B',
@@ -98,14 +98,14 @@ test('it renders', function(assert) {
         };
       }
     },
-    sessionType: resolve(Object.create({
+    sessionType: resolve(EmberObject.create({
       'title': 'Presentation'
     })),
     maxSingleOfferingDuration: resolve(10),
     totalSumOfferingsDuration: resolve(20)
   });
 
-  let session2 = Object.create({
+  let session2 = EmberObject.create({
     id: 2,
     course: resolve(linkedCourse),
     title: 'Session C',
@@ -120,14 +120,14 @@ test('it renders', function(assert) {
         };
       }
     },
-    sessionType: resolve(Object.create({
+    sessionType: resolve(EmberObject.create({
       'title': 'Lecture'
     }))
   });
 
   linkedCourse.set('sessions', resolve([session1, session2, ilmSession]));
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: 'lorem ipsum',
     report: resolve(report),
@@ -254,13 +254,13 @@ test('it renders', function(assert) {
 
 test('order in sequence is n/a for top level block', function(assert) {
   assert.expect(1);
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
-      return  Object.create({ id() { return 1; }});
+      return  EmberObject.create({ id() { return 1; }});
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -268,7 +268,7 @@ test('order in sequence is n/a for top level block', function(assert) {
     isFinalized: resolve(false)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: 'lorem ipsum',
     report: resolve(report),
@@ -284,7 +284,7 @@ test('order in sequence is n/a for top level block', function(assert) {
     track: true,
     minimum: 0,
     maximum: 0,
-    academicLevel: resolve(Object.create({ name: 'Year 1'}))
+    academicLevel: resolve(EmberObject.create({ name: 'Year 1'}))
   });
 
   storeMock.reopen({
@@ -310,13 +310,13 @@ test('order in sequence is n/a for top level block', function(assert) {
 
 test('order in sequence is n/a for nested sequence block in non-ordered sequence ', function(assert) {
   assert.expect(1);
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
-      return  Object.create({ id() { return 1; }});
+      return  EmberObject.create({ id() { return 1; }});
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -324,13 +324,13 @@ test('order in sequence is n/a for nested sequence block in non-ordered sequence
     isFinalized: resolve(false)
   });
 
-  let parentBlock = Object.create({
+  let parentBlock = EmberObject.create({
     id: 1,
     isOrdered: false,
     children: null,
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: 'lorem ipsum',
     report: resolve(report),
@@ -346,7 +346,7 @@ test('order in sequence is n/a for nested sequence block in non-ordered sequence
     track: true,
     minimum: 0,
     maximum: 0,
-    academicLevel: resolve(Object.create({ name: 'Year 1'}))
+    academicLevel: resolve(EmberObject.create({ name: 'Year 1'}))
   });
 
   parentBlock.set('children', resolve([block]));
@@ -371,37 +371,37 @@ test('order in sequence is n/a for nested sequence block in non-ordered sequence
 
 test('change course', function(assert) {
   assert.expect(11);
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
-      return  Object.create({ id() { return 1; }});
+      return  EmberObject.create({ id() { return 1; }});
     }
   });
 
-  let linkedCourse = Object.create({
+  let linkedCourse = EmberObject.create({
     id: 1,
     title: 'Course A',
     sessions: resolve([]),
     startDate: new Date('2015-02-02'),
     endDate: new Date('2015-03-30'),
-    clerkshipType: Object.create({ title: 'Block' }),
+    clerkshipType: EmberObject.create({ title: 'Block' }),
     level: 4
   });
 
-  let linkableCourse1 = Object.create({
+  let linkableCourse1 = EmberObject.create({
     id: 2,
     title: 'Course C',
     startDate: new Date('2013-02-02'),
     endDate: new Date('2013-03-30'),
-    clerkshipType: Object.create({ title: 'Something else' }),
+    clerkshipType: EmberObject.create({ title: 'Something else' }),
     level: 4
   });
 
-  let linkableCourse2 = Object.create({
+  let linkableCourse2 = EmberObject.create({
     id: 3,
     title: 'Course B',
     startDate: new Date('2012-02-02'),
     endDate: new Date('2012-03-30'),
-    clerkshipType: Object.create({ title: 'Indeed.' }),
+    clerkshipType: EmberObject.create({ title: 'Indeed.' }),
     level: 4
   });
 
@@ -411,7 +411,7 @@ test('change course', function(assert) {
     linkableCourse2,
   ];
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -419,7 +419,7 @@ test('change course', function(assert) {
     isFinalized: resolve(false)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: 'lorem ipsum',
     report: resolve(report),
@@ -435,7 +435,7 @@ test('change course', function(assert) {
     track: true,
     minimum: 0,
     maximum: 0,
-    academicLevel: resolve(Object.create({ name: 'Year 1'})),
+    academicLevel: resolve(EmberObject.create({ name: 'Year 1'})),
     save() {
       assert.ok(true, "The sequence block's  save() function was invoked.");
     }
@@ -499,13 +499,13 @@ test('change course', function(assert) {
 
 test('change description', function(assert) {
   assert.expect(4);
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
-      return  Object.create({ id() { return 1; }});
+      return  EmberObject.create({ id() { return 1; }});
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -513,7 +513,7 @@ test('change description', function(assert) {
     isFinalized: resolve(false)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: '',
     report: resolve(report),
@@ -529,7 +529,7 @@ test('change description', function(assert) {
     track: true,
     minimum: 0,
     maximum: 0,
-    academicLevel: resolve(Object.create({ name: 'Year 1'})),
+    academicLevel: resolve(EmberObject.create({ name: 'Year 1'})),
     save() {
       assert.ok(true, "The sequence block's  save() function was invoked.");
     }
@@ -565,13 +565,13 @@ test('change description', function(assert) {
 
 test('change required', function(assert) {
   assert.expect(4);
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
-      return  Object.create({ id() { return 1; }});
+      return  EmberObject.create({ id() { return 1; }});
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -579,7 +579,7 @@ test('change required', function(assert) {
     isFinalized: resolve(false)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: '',
     report: resolve(report),
@@ -595,7 +595,7 @@ test('change required', function(assert) {
     track: true,
     minimum: 0,
     maximum: 0,
-    academicLevel: resolve(Object.create({ name: 'Year 1'})),
+    academicLevel: resolve(EmberObject.create({ name: 'Year 1'})),
     save() {
       assert.ok(true, "The sequence block's  save() function was invoked.");
     }
@@ -631,13 +631,13 @@ test('change required', function(assert) {
 
 test('change track', function(assert) {
   assert.expect(3);
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
-      return  Object.create({ id() { return 1; }});
+      return  EmberObject.create({ id() { return 1; }});
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -645,7 +645,7 @@ test('change track', function(assert) {
     isFinalized: resolve(false)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: '',
     report: resolve(report),
@@ -661,7 +661,7 @@ test('change track', function(assert) {
     track: true,
     minimum: 0,
     maximum: 0,
-    academicLevel: resolve(Object.create({ name: 'Year 1'})),
+    academicLevel: resolve(EmberObject.create({ name: 'Year 1'})),
     save() {
       assert.ok(true, "The sequence block's  save() function was invoked.");
     }
@@ -690,13 +690,13 @@ test('change track', function(assert) {
 
 test('change child sequence order', function(assert) {
   assert.expect(3);
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
-      return  Object.create({ id() { return 1; }});
+      return  EmberObject.create({ id() { return 1; }});
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -704,7 +704,7 @@ test('change child sequence order', function(assert) {
     isFinalized: resolve(false)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: '',
     report: resolve(report),
@@ -720,7 +720,7 @@ test('change child sequence order', function(assert) {
     track: true,
     minimum: 0,
     maximum: 0,
-    academicLevel: resolve(Object.create({ name: 'Year 1'})),
+    academicLevel: resolve(EmberObject.create({ name: 'Year 1'})),
     children: resolve([]),
     save() {
       return resolve(this);
@@ -757,20 +757,20 @@ test('change child sequence order', function(assert) {
 test('change order in sequence', function(assert) {
   assert.expect(7);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i + 1}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i + 1}` }));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
@@ -778,13 +778,13 @@ test('change order in sequence', function(assert) {
     isFinalized: resolve(false)
   });
 
-  let parentBlock = Object.create({
+  let parentBlock = EmberObject.create({
     id: 1,
     isOrdered: true,
     children: null,
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: 'lorem ipsum',
     report: resolve(report),
@@ -806,7 +806,7 @@ test('change order in sequence', function(assert) {
     }
   });
 
-  let siblingBlock = Object.create({
+  let siblingBlock = EmberObject.create({
     id: 3,
     orderInSequence: 2
   });
@@ -852,18 +852,18 @@ test('change order in sequence', function(assert) {
 
 test('change academic level', function(assert) {
   assert.expect(4);
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
-      return  Object.create({ id() { return 1; }});
+      return  EmberObject.create({ id() { return 1; }});
     }
   });
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i + 1}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i + 1}` }));
   }
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
@@ -871,7 +871,7 @@ test('change academic level', function(assert) {
     isFinalized: resolve(false)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: '',
     report: resolve(report),
@@ -924,29 +924,29 @@ test('change academic level', function(assert) {
 test('manage sessions', function(assert) {
   assert.expect(7);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i + 1}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i + 1}` }));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let linkedCourse = Object.create({
+  let linkedCourse = EmberObject.create({
     id: 1,
     title: 'Course A',
     startDate: new Date('2015-02-02'),
     endDate: new Date('2015-03-30'),
-    clerkshipType: Object.create({ title: 'Block' }),
+    clerkshipType: EmberObject.create({ title: 'Block' }),
     level: 4
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
@@ -954,7 +954,7 @@ test('manage sessions', function(assert) {
     isFinalized: resolve(false)
   });
 
-  let session1 = Object.create({
+  let session1 = EmberObject.create({
     id: 1,
     course: resolve(linkedCourse),
     title: 'Session B',
@@ -969,14 +969,14 @@ test('manage sessions', function(assert) {
         };
       }
     },
-    sessionType: resolve(Object.create({
+    sessionType: resolve(EmberObject.create({
       'title': 'Presentation'
     })),
     maxSingleOfferingDuration: resolve(10),
     totalSumOfferingsDuration: resolve(20)
   });
 
-  let session2 = Object.create({
+  let session2 = EmberObject.create({
     id: 2,
     course: resolve(linkedCourse),
     title: 'Session C',
@@ -991,14 +991,14 @@ test('manage sessions', function(assert) {
         };
       }
     },
-    sessionType: resolve(Object.create({
+    sessionType: resolve(EmberObject.create({
       'title': 'Lecture'
     }))
   });
 
   linkedCourse.set('sessions', resolve([session1, session2]));
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: 'lorem ipsum',
     report: resolve(report),
@@ -1061,29 +1061,29 @@ test('manage sessions', function(assert) {
 test('finalized/read-only mode', function(assert) {
   assert.expect(23);
 
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
 
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i + 1}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i + 1}` }));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let linkedCourse = Object.create({
+  let linkedCourse = EmberObject.create({
     id: 1,
     title: 'Course A',
     startDate: new Date('2015-02-02'),
     endDate: new Date('2015-03-30'),
-    clerkshipType: Object.create({ title: 'Block' }),
+    clerkshipType: EmberObject.create({ title: 'Block' }),
     level: 4
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
@@ -1091,7 +1091,7 @@ test('finalized/read-only mode', function(assert) {
     isFinalized: resolve(true)
   });
 
-  let parentBlock = Object.create({
+  let parentBlock = EmberObject.create({
     id: 1,
     isOrdered: true,
     children: null,
@@ -1099,7 +1099,7 @@ test('finalized/read-only mode', function(assert) {
 
   let academicLevel = academicLevels[0];
 
-  let ilmSession = Object.create({
+  let ilmSession = EmberObject.create({
     id: 1,
     course: resolve(linkedCourse),
     title: 'Session A',
@@ -1114,14 +1114,14 @@ test('finalized/read-only mode', function(assert) {
         };
       }
     },
-    sessionType: Object.create({
+    sessionType: EmberObject.create({
       'title': 'Independent Learning'
     }),
     maxSingleOfferingDuration: resolve(10),
     totalSumOfferingsDuration: resolve(20)
   });
 
-  let session1 = Object.create({
+  let session1 = EmberObject.create({
     id: 1,
     course: resolve(linkedCourse),
     title: 'Session B',
@@ -1136,14 +1136,14 @@ test('finalized/read-only mode', function(assert) {
         };
       }
     },
-    sessionType: resolve(Object.create({
+    sessionType: resolve(EmberObject.create({
       'title': 'Presentation'
     })),
     maxSingleOfferingDuration: resolve(10),
     totalSumOfferingsDuration: resolve(20)
   });
 
-  let session2 = Object.create({
+  let session2 = EmberObject.create({
     id: 2,
     course: resolve(linkedCourse),
     title: 'Session C',
@@ -1158,14 +1158,14 @@ test('finalized/read-only mode', function(assert) {
         };
       }
     },
-    sessionType: resolve(Object.create({
+    sessionType: resolve(EmberObject.create({
       'title': 'Lecture'
     }))
   });
 
   linkedCourse.set('sessions', resolve([session1, session2, ilmSession]));
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 2,
     description: 'lorem ipsum',
     report: resolve(report),

--- a/tests/integration/components/curriculum-inventory-sequence-block-session-list-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-session-list-test.js
@@ -4,7 +4,7 @@ import { test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 moduleForComponent('curriculum-inventory-sequence-block-session-list', 'Integration | Component | curriculum inventory sequence block session list', {
   integration: true,
@@ -18,23 +18,23 @@ moduleForComponent('curriculum-inventory-sequence-block-session-list', 'Integrat
 test('it renders', function(assert) {
   assert.expect(20);
 
-  let offering1 = Object.create({id: 1});
-  let offering2 = Object.create({id: 2});
-  let offering3 = Object.create({id: 3});
+  let offering1 = EmberObject.create({id: 1});
+  let offering2 = EmberObject.create({id: 2});
+  let offering3 = EmberObject.create({id: 3});
 
   let offerings1 = [ offering1, offering2 ];
   let offerings2 = [ offering3 ];
   let offerings3 = [];
 
-  let sessionType1 = Object.create({ title: 'Lecture'});
-  let sessionType2 = Object.create({ title: 'Ceremony'});
-  let sessionType3 = Object.create({ title: 'Small Group'});
+  let sessionType1 = EmberObject.create({ title: 'Lecture'});
+  let sessionType2 = EmberObject.create({ title: 'Ceremony'});
+  let sessionType3 = EmberObject.create({ title: 'Small Group'});
 
   let totalTime1 = (30).toFixed(2);
   let totalTime2 = (15).toFixed(2);
   let totalTime3 = (0).toFixed(2);
 
-  let session1 = Object.create({
+  let session1 = EmberObject.create({
     id: 1,
     title: 'Aardvark',
     offerings: resolve(offerings1),
@@ -42,7 +42,7 @@ test('it renders', function(assert) {
     maxSingleOfferingDuration: resolve(totalTime1)
   });
 
-  let session2 = Object.create({
+  let session2 = EmberObject.create({
     id: 2,
     title: 'Bluebird',
     offerings: resolve(offerings2),
@@ -50,7 +50,7 @@ test('it renders', function(assert) {
     totalSumOfferingsDuration: resolve(totalTime2)
   });
 
-  let session3 = Object.create({
+  let session3 = EmberObject.create({
     id: 3,
     title: 'Zeppelin',
     offerings: resolve(offerings3),
@@ -61,7 +61,7 @@ test('it renders', function(assert) {
   let linkedSessions = [session1, session3];
   let linkableSessions = [session1, session2, session3];
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve(linkedSessions),
   });
@@ -99,7 +99,7 @@ test('it renders', function(assert) {
 test('empty list', function(assert) {
   assert.expect(2);
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([]),
   });
@@ -115,15 +115,15 @@ test('empty list', function(assert) {
 
 test('sort by title', function(assert) {
   assert.expect(1);
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'Zeppelin',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(0)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([ session ]),
   });
@@ -140,15 +140,15 @@ test('sort by title', function(assert) {
 
 test('sort by session type', function(assert) {
   assert.expect(1);
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'Zeppelin',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(0)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([ session ]),
   });
@@ -165,15 +165,15 @@ test('sort by session type', function(assert) {
 
 test('sort by offerings total', function(assert) {
   assert.expect(1);
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'Zeppelin',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(0)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([ session ]),
   });

--- a/tests/integration/components/curriculum-inventory-sequence-block-session-manager-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-session-manager-test.js
@@ -4,7 +4,7 @@ import { test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('curriculum-inventory-sequence-block-session-manager', 'Integration | Component | curriculum inventory sequence block session manager', {
@@ -19,23 +19,23 @@ moduleForComponent('curriculum-inventory-sequence-block-session-manager', 'Integ
 test('it renders', function(assert) {
   assert.expect(22);
 
-  let offering1 = Object.create({id: 1});
-  let offering2 = Object.create({id: 2});
-  let offering3 = Object.create({id: 3});
+  let offering1 = EmberObject.create({id: 1});
+  let offering2 = EmberObject.create({id: 2});
+  let offering3 = EmberObject.create({id: 3});
 
   let offerings1 = [ offering1, offering2 ];
   let offerings2 = [ offering3 ];
   let offerings3 = [];
 
-  let sessionType1 = Object.create({ title: 'Lecture'});
-  let sessionType2 = Object.create({ title: 'Ceremony'});
-  let sessionType3 = Object.create({ title: 'Small Group'});
+  let sessionType1 = EmberObject.create({ title: 'Lecture'});
+  let sessionType2 = EmberObject.create({ title: 'Ceremony'});
+  let sessionType3 = EmberObject.create({ title: 'Small Group'});
 
   let totalTime1 = (30).toFixed(2);
   let totalTime2 = (15).toFixed(2);
   let totalTime3 = (0).toFixed(2);
 
-  let session1 = Object.create({
+  let session1 = EmberObject.create({
     id: 1,
     title: 'Aardvark',
     offerings: resolve(offerings1),
@@ -43,7 +43,7 @@ test('it renders', function(assert) {
     maxSingleOfferingDuration: resolve(totalTime1)
   });
 
-  let session2 = Object.create({
+  let session2 = EmberObject.create({
     id: 2,
     title: 'Bluebird',
     offerings: resolve(offerings2),
@@ -51,7 +51,7 @@ test('it renders', function(assert) {
     totalSumOfferingsDuration: resolve(totalTime2)
   });
 
-  let session3 = Object.create({
+  let session3 = EmberObject.create({
     id: 3,
     title: 'Zeppelin',
     offerings: resolve(offerings3),
@@ -62,7 +62,7 @@ test('it renders', function(assert) {
   let linkedSessions = [session1, session3];
   let linkableSessions = [session1, session2, session3];
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve(linkedSessions),
   });
@@ -104,7 +104,7 @@ test('it renders', function(assert) {
 test('empty list', function(assert) {
   assert.expect(2);
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([]),
   });
@@ -120,15 +120,15 @@ test('empty list', function(assert) {
 
 test('sort by title', function(assert) {
   assert.expect(1);
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'Zeppelin',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(0)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([ session ]),
   });
@@ -145,15 +145,15 @@ test('sort by title', function(assert) {
 
 test('sort by session type', function(assert) {
   assert.expect(1);
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'Zeppelin',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(0)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([ session ]),
   });
@@ -170,15 +170,15 @@ test('sort by session type', function(assert) {
 
 test('sort by offerings total', function(assert) {
   assert.expect(1);
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'Zeppelin',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(0)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([ session ]),
   });
@@ -197,16 +197,16 @@ test('change count as one offering', function(assert) {
   assert.expect(3);
   let maxSingleOfferingDuration = (20).toFixed(2);
   let totalSumOfferingsDuration = (15).toFixed(2);
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'Zeppelin',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(maxSingleOfferingDuration),
     totalSumOfferingsDuration: resolve(totalSumOfferingsDuration)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([ session ]),
   });
@@ -227,25 +227,25 @@ test('change count as one offering for all sessions', function(assert) {
   assert.expect(6);
   let maxSingleOfferingDuration = (20).toFixed(2);
   let totalSumOfferingsDuration = (15).toFixed(2);
-  let session1 = Object.create({
+  let session1 = EmberObject.create({
     id: 1,
     title: 'Alpha',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(maxSingleOfferingDuration),
     totalSumOfferingsDuration: resolve(totalSumOfferingsDuration)
   });
 
-  let session2 = Object.create({
+  let session2 = EmberObject.create({
     id: 2,
     title: 'Omega',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(maxSingleOfferingDuration),
     totalSumOfferingsDuration: resolve(totalSumOfferingsDuration)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([ session1 ]),
   });
@@ -270,25 +270,25 @@ test('change count as one offering for all sessions', function(assert) {
 test('save', function(assert) {
   assert.expect(3);
 
-  let session1 = Object.create({
+  let session1 = EmberObject.create({
     id: 1,
     title: 'Alpha',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(0),
     totalSumOfferingsDuration: resolve(0)
   });
 
-  let session2 = Object.create({
+  let session2 = EmberObject.create({
     id: 2,
     title: 'Omega',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(0),
     totalSumOfferingsDuration: resolve(0)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([ session1 ]),
   });
@@ -309,16 +309,16 @@ test('save', function(assert) {
 test('cancel', function(assert) {
   assert.expect(1);
 
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'Alpha',
     offerings: resolve([]),
-    sessionType: resolve(Object.create({ title: 'Lecture'})),
+    sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
     maxSingleOfferingDuration: resolve(0),
     totalSumOfferingsDuration: resolve(0)
   });
 
-  let block = Object.create({
+  let block = EmberObject.create({
     id: 1,
     sessions: resolve([ session ]),
   });

--- a/tests/integration/components/dashboard-materials-test.js
+++ b/tests/integration/components/dashboard-materials-test.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Service, RSVP } = Ember;
+const { Service, Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('dashboard-materials', 'Integration | Component | dashboard materials', {
@@ -13,7 +13,7 @@ moduleForComponent('dashboard-materials', 'Integration | Component | dashboard m
 
 let today = moment();
 let tomorrow = moment().add(1, 'day');
-let lm1 = Object.create({
+let lm1 = EmberObject.create({
   title: 'title1',
   absoluteFileUri: 'http://myhost.com/url1',
   sessionTitle: 'session1title',
@@ -22,7 +22,7 @@ let lm1 = Object.create({
   instructors: ['Instructor1name', 'Instructor2name'],
   firstOfferingDate: today.toDate(),
 });
-let lm2 = Object.create({
+let lm2 = EmberObject.create({
   title: 'title2',
   link: 'http://myhost.com/url2',
   sessionTitle: 'session2title',
@@ -31,7 +31,7 @@ let lm2 = Object.create({
   instructors: ['Instructor1name', 'Instructor2name'],
   firstOfferingDate: tomorrow.toDate(),
 });
-let lm3 = Object.create({
+let lm3 = EmberObject.create({
   title: 'title3',
   citation: 'citationtext',
   sessionTitle: 'session3title',
@@ -67,7 +67,7 @@ test('it renders with materials', function(assert) {
   });
   this.register('service:ajax', ajaxMock);
   this.render(hbs`{{dashboard-materials}}`);
-    
+
   const title = 'h3';
   const table = 'table:eq(0)';
   const materials = `${table} tbody tr`;

--- a/tests/integration/components/dashboard-myreports-test.js
+++ b/tests/integration/components/dashboard-myreports-test.js
@@ -4,16 +4,16 @@ import tHelper from "ember-i18n/helper";
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { computed, Object, RSVP, Service } = Ember;
+const { computed, Object:EmberObject, RSVP, Service } = Ember;
 const { resolve } = RSVP;
 
 let mockReports = [
-  Object.create({
+  EmberObject.create({
     displayTitle: resolve('all courses'),
     subject: 'courses',
     user: 1
   }),
-  Object.create({
+  EmberObject.create({
     displayTitle: resolve('courses for session'),
     subject: 'courses',
     prepositionalObject: 'session',
@@ -45,7 +45,7 @@ moduleForComponent('dashboard-myreports', 'Integration | Component | dashboard m
 test('list reports', function(assert) {
   assert.expect(4);
   let currentUserMock = Service.extend({
-    model: resolve(Object.create({
+    model: resolve(EmberObject.create({
       reports: resolve(mockReports)
     }))
   });
@@ -68,7 +68,7 @@ test('list reports', function(assert) {
 test('display none when no reports', function(assert) {
   assert.expect(2);
   let currentUserMock = Service.extend({
-    model: resolve(Object.create({
+    model: resolve(EmberObject.create({
       reports: resolve([])
     }))
   });

--- a/tests/integration/components/dashboard-week-test.js
+++ b/tests/integration/components/dashboard-week-test.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 import initializer from "ilios/instance-initializers/ember-i18n";
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Service, Object } = Ember;
+const { RSVP, Service, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 let today = moment();
@@ -82,7 +82,7 @@ const userEventsMock = Service.extend({
     return new resolve(mockEvents);
   },
   getSessionForEvent() {
-    return Object.create({
+    return EmberObject.create({
       attireRequired: false,
       equipmentRequired: false,
       attendanceRequired: false,
@@ -103,7 +103,6 @@ moduleForComponent('dashboard-week', 'Integration | Component | dashboard week',
 });
 
 const getTitle = function(){
-  const today = moment().day(1);
   const startOfWeek = today.clone().day(1).hour(0).minute(0).second(0);
   const endOfWeek = today.clone().day(7).hour(23).minute(59).second(59);
 

--- a/tests/integration/components/detail-learnergroups-list-test.js
+++ b/tests/integration/components/detail-learnergroups-list-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('detail-learnergroups-list', 'Integration | Component | detail learnergroups list', {
@@ -21,7 +21,7 @@ test('it renders', function(assert) {
   const set2Group1 = set2 + ' li:eq(0)';
   const set2Group2 = set2 + ' li:eq(1)';
 
-  let tlg1 = Object.create({
+  let tlg1 = EmberObject.create({
     allParentTitles: [],
     title: 'tlg1',
     hasMany(){
@@ -33,7 +33,7 @@ test('it renders', function(assert) {
     }
   });
   tlg1.set('topLevelGroup', resolve(tlg1));
-  let subGroup1 = Object.create({
+  let subGroup1 = EmberObject.create({
     allParentTitles: ['tlg1'],
     topLevelGroup: resolve(tlg1),
     title: 'sub group 1',
@@ -45,7 +45,7 @@ test('it renders', function(assert) {
       };
     }
   });
-  let subSubGroup1 = Object.create({
+  let subSubGroup1 = EmberObject.create({
     allParentTitles: ['tlg1', 'sub group 1'],
     topLevelGroup: resolve(tlg1),
     title: 'sub sub group 1',
@@ -57,7 +57,7 @@ test('it renders', function(assert) {
       };
     }
   });
-  let tlg2 = Object.create({
+  let tlg2 = EmberObject.create({
     allParentTitles: [],
     title: 'tlg2',
     hasMany(){
@@ -69,7 +69,7 @@ test('it renders', function(assert) {
     }
   });
   tlg2.set('topLevelGroup', resolve(tlg2));
-  let subGroup2 = Object.create({
+  let subGroup2 = EmberObject.create({
     topLevelGroup: resolve(tlg2),
     allParentTitles: ['tlg2'],
     title: 'sub group 2',

--- a/tests/integration/components/detail-learning-materials-test.js
+++ b/tests/integration/components/detail-learning-materials-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('detail-learning-materials', 'Integration | Component | detail learning materials', {
@@ -13,22 +13,22 @@ moduleForComponent('detail-learning-materials', 'Integration | Component | detai
 test('sort button visible when lm list has 2+ items and editing is allowed', function(assert){
   assert.expect(1);
 
-  let clm1 = Object.create({
+  let clm1 = EmberObject.create({
     id: 1,
-    learningMaterial: resolve(Object.create({
+    learningMaterial: resolve(EmberObject.create({
       id: 1,
     }))
   });
 
-  let clm2 = Object.create({
+  let clm2 = EmberObject.create({
     id: 2,
-    learningMaterial: resolve(Object.create({
+    learningMaterial: resolve(EmberObject.create({
       id: 2,
     }))
   });
   let clms = [ clm1, clm2 ];
 
-  let subject = Object.create({
+  let subject = EmberObject.create({
     id: 1,
     learningMaterials: resolve(clms)
   });
@@ -45,16 +45,16 @@ test('sort button visible when lm list has 2+ items and editing is allowed', fun
 test('sort button not visible when in read-only mode', function(assert){
   assert.expect(1);
 
-  let lm1 = Object.create({
+  let lm1 = EmberObject.create({
     id: 1,
   });
 
-  let lm2 = Object.create({
+  let lm2 = EmberObject.create({
     id: 2,
   });
   let lms = [ lm1, lm2 ];
 
-  let subject = Object.create({
+  let subject = EmberObject.create({
     id: 1,
     learningMaterials: resolve(lms)
   });
@@ -71,7 +71,7 @@ test('sort button not visible when in read-only mode', function(assert){
 test('sort button not visible when lm list is empty', function(assert){
   assert.expect(1);
 
-  let subject = Object.create({
+  let subject = EmberObject.create({
     id: 1,
     learningMaterials: resolve([])
   });
@@ -86,16 +86,16 @@ test('sort button not visible when lm list is empty', function(assert){
 });
 
 test('sort button not visible when lm list only contains one item', function(assert){
-  let clm1 = Object.create({
+  let clm1 = EmberObject.create({
     id: 1,
-    learningMaterial: resolve(Object.create({
+    learningMaterial: resolve(EmberObject.create({
       id: 1,
     }))
   });
 
   let clms = [ clm1 ];
 
-  let subject = Object.create({
+  let subject = EmberObject.create({
     id: 1,
     learningMaterials: resolve(clms)
   });
@@ -112,22 +112,22 @@ test('sort button not visible when lm list only contains one item', function(ass
 test('click sort button, then cancel', function(assert){
   assert.expect(6);
 
-  let clm1 = Object.create({
+  let clm1 = EmberObject.create({
     id: 1,
-    learningMaterial: resolve(Object.create({
+    learningMaterial: resolve(EmberObject.create({
       id: 1,
     }))
   });
 
-  let clm2 = Object.create({
+  let clm2 = EmberObject.create({
     id: 2,
-    learningMaterial: resolve(Object.create({
+    learningMaterial: resolve(EmberObject.create({
       id: 2,
     }))
   });
   let clms = [ clm1, clm2 ];
 
-  let subject = Object.create({
+  let subject = EmberObject.create({
     id: 1,
     learningMaterials: resolve(clms)
   });
@@ -156,9 +156,9 @@ test('click sort button, then cancel', function(assert){
 test('click sort button, then save', function(assert){
   assert.expect(2);
 
-  let clm1 = Object.create({
+  let clm1 = EmberObject.create({
     id: 1,
-    learningMaterial: resolve(Object.create({
+    learningMaterial: resolve(EmberObject.create({
       id: 1,
     })),
     save() {
@@ -167,9 +167,9 @@ test('click sort button, then save', function(assert){
     }
   });
 
-  let clm2 = Object.create({
+  let clm2 = EmberObject.create({
     id: 2,
-    learningMaterial: resolve(Object.create({
+    learningMaterial: resolve(EmberObject.create({
       id: 2,
     })),
     save() {
@@ -179,7 +179,7 @@ test('click sort button, then save', function(assert){
   });
   let clms = [ clm1, clm2 ];
 
-  let subject = Object.create({
+  let subject = EmberObject.create({
     id: 1,
     learningMaterials: resolve(clms)
   });

--- a/tests/integration/components/ilios-users-test.js
+++ b/tests/integration/components/ilios-users-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { RSVP, Service, Object } = Ember;
+const { RSVP, Service, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 import wait from 'ember-test-helpers/wait';
@@ -59,9 +59,9 @@ test('add user form renders when configured to', async function(assert) {
   const mockSchools = [
     {id: 1, title: 'first', cohorts: resolve([])},
   ];
-  const mockUser = Object.create({
+  const mockUser = EmberObject.create({
     schools: resolve(mockSchools),
-    school: resolve(Object.create(mockSchools[0]))
+    school: resolve(EmberObject.create(mockSchools[0]))
   });
 
   const currentUserMock = Service.extend({
@@ -100,9 +100,9 @@ test('directory search renders when configured to', async function(assert) {
   const mockSchools = [
     {id: 1, title: 'first'},
   ];
-  const mockUser = Object.create({
+  const mockUser = EmberObject.create({
     schools: resolve(mockSchools),
-    school: resolve(Object.create(mockSchools[0]))
+    school: resolve(EmberObject.create(mockSchools[0]))
   });
 
   const currentUserMock = Service.extend({

--- a/tests/integration/components/instructorgroup-header-test.js
+++ b/tests/integration/components/instructorgroup-header-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('instructorgroup-header', 'Integration | Component | instructorgroup header', {
@@ -12,7 +12,7 @@ moduleForComponent('instructorgroup-header', 'Integration | Component | instruct
 
 test('it renders', function(assert) {
   assert.expect(3);
-  let instructorGroup = Object.create({
+  let instructorGroup = EmberObject.create({
     title: 'lorem ipsum',
     school: {title: 'medicine'},
     users: [{}, {}, {}],
@@ -28,7 +28,7 @@ test('it renders', function(assert) {
 
 test('can change title', function(assert) {
   assert.expect(3);
-  let instructorGroup = Object.create({
+  let instructorGroup = EmberObject.create({
     title: 'lorem ipsum',
     save(){
       assert.equal(this.get('title'), 'new title');

--- a/tests/integration/components/leadership-list-test.js
+++ b/tests/integration/components/leadership-list-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('leadership-list', 'Integration | Component | leadership list', {
   integration: true
@@ -10,12 +10,12 @@ moduleForComponent('leadership-list', 'Integration | Component | leadership list
 
 test('it renders with data', function(assert) {
   assert.expect(5);
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     firstName: 'a',
     lastName: 'person',
     fullName: 'a b person',
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     firstName: 'b',
     lastName: 'person',
     fullName: 'b a person',

--- a/tests/integration/components/leadership-manager-test.js
+++ b/tests/integration/components/leadership-manager-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Service, RSVP, Object } = Ember;
+const { Service, RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('leadership-manager', 'Integration | Component | leadership manager', {
@@ -12,12 +12,12 @@ moduleForComponent('leadership-manager', 'Integration | Component | leadership m
 
 test('it renders with data', function(assert) {
   assert.expect(5);
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     firstName: 'a',
     lastName: 'person',
     fullName: 'a b person',
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     firstName: 'b',
     lastName: 'person',
     fullName: 'b a person',
@@ -67,7 +67,7 @@ test('it renders without data', function(assert) {
 
 test('it remove director', function(assert) {
   assert.expect(3);
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     firstName: 'a',
     lastName: 'person',
     fullName: 'a b person',
@@ -97,7 +97,7 @@ test('it remove director', function(assert) {
 
 test('it remove administrator', function(assert) {
   assert.expect(3);
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     firstName: 'a',
     lastName: 'person',
     fullName: 'a b person',
@@ -127,7 +127,7 @@ test('it remove administrator', function(assert) {
 
 test('add director', function(assert) {
   assert.expect(6);
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     fullName: 'test person',
     email: 'testemail'
   });
@@ -176,7 +176,7 @@ test('add director', function(assert) {
 
 test('add administrator', function(assert) {
   assert.expect(6);
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     fullName: 'test person',
     email: 'testemail'
   });

--- a/tests/integration/components/leadership-search-test.js
+++ b/tests/integration/components/leadership-search-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Service, RSVP, Object } = Ember;
+const { Service, RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('leadership-search', 'Integration | Component | leadership search', {
@@ -41,7 +41,7 @@ test('input triggers search', function(assert) {
       assert.equal('user', what);
       assert.equal(100, limit);
       assert.equal('search words', q);
-      return resolve([Object.create({fullName: 'test person', email: 'testemail'})]);
+      return resolve([EmberObject.create({fullName: 'test person', email: 'testemail'})]);
     }
   });
   this.register('service:store', storeMock);
@@ -88,7 +88,7 @@ test('no results displays messages', function(assert) {
 });
 
 test('click user fires add user', function(assert) {
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     fullName: 'test person',
     email: 'testemail'
   });
@@ -117,12 +117,12 @@ test('click user fires add user', function(assert) {
 
 test('can not add users twice', function(assert) {
   assert.expect(6);
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     id: 1,
     fullName: 'test person',
     email: 'testemail'
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     id: 2,
     fullName: 'test person2',
     email: 'testemail2'

--- a/tests/integration/components/learnergroup-cohort-user-manager-test.js
+++ b/tests/integration/components/learnergroup-cohort-user-manager-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('learnergroup-cohort-user-manager', 'Integration | Component | learnergroup cohort user manager', {
   integration: true
@@ -22,14 +22,14 @@ test('it renders', function(assert) {
   const user2CampusId = 'tbody tr:eq(1) td:eq(3)';
   const user2Email = 'tbody tr:eq(1) td:eq(4)';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     firstName: 'Jasper',
     lastName: 'Dog',
     campusId: '1234',
     email: 'testemail',
     enabled: true,
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     firstName: 'Jackson',
     lastName: 'Doggy',
     campusId: '123',
@@ -72,10 +72,10 @@ test('sort by firstName', function(assert) {
   const user1FirstName = 'tbody tr:eq(0) td:eq(1)';
   const user2FirstName = 'tbody tr:eq(1) td:eq(1)';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     firstName: 'Jasper',
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     firstName: 'Jackson',
   });
 
@@ -103,7 +103,7 @@ test('add multiple users', async function(assert) {
   const user1CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
   const button = 'button.done';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
   });
 
@@ -135,7 +135,7 @@ test('add single user', function(assert) {
   assert.expect(1);
   const action = 'tbody tr:eq(0) td:eq(5) .clickable';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
   });
 
@@ -164,7 +164,7 @@ test('when users are selected single action is disabled', function(assert) {
   const user1CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
   const action = 'tbody tr:eq(0) td:eq(5) .clickable';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
   });
 
@@ -193,10 +193,10 @@ test('checkall', function(assert) {
   const user2CheckBox = 'tbody tr:eq(1) td:eq(0) input[type=checkbox]';
   const button = 'button.done';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     enabled: true,
   });
 
@@ -231,10 +231,10 @@ test('checking one puts checkall box into indeterminate state', function(assert)
   const user1CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
   const user2CheckBox = 'tbody tr:eq(1) td:eq(0) input[type=checkbox]';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     enabled: true,
   });
 

--- a/tests/integration/components/learnergroup-header-test.js
+++ b/tests/integration/components/learnergroup-header-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('learnergroup-header', 'Integration | Component | learnergroup header', {
@@ -11,7 +11,7 @@ moduleForComponent('learnergroup-header', 'Integration | Component | learnergrou
 });
 
 test('it renders', function(assert) {
-  let learnerGroup = Object.create({
+  let learnerGroup = EmberObject.create({
     title: 'our group',
     allParents: resolve([{title: 'parent group'}])
   });
@@ -24,7 +24,7 @@ test('it renders', function(assert) {
 });
 
 test('can change title', async function(assert) {
-  let learnerGroup = Object.create({
+  let learnerGroup = EmberObject.create({
     title: 'our group',
     save(){
       assert.equal(this.get('title'), 'new title');
@@ -43,16 +43,16 @@ test('can change title', async function(assert) {
 });
 
 test('counts members correctly', function(assert) {
-  let cohort = Object.create({
+  let cohort = EmberObject.create({
     title: 'test group',
     users: [1, 2]
   });
-  let subGroup = Object.create({
+  let subGroup = EmberObject.create({
     title: 'test sub-group',
     users: [],
     children: [],
   });
-  let learnerGroup = Object.create({
+  let learnerGroup = EmberObject.create({
     title: 'test group',
     usersOnlyAtThisLevel: [1],
     cohort,
@@ -73,7 +73,7 @@ test('validate title length', async function(assert) {
   const done = `${title} .done`;
   const errors = `${title} .validation-error-message`;
 
-  let learnerGroup = Object.create({
+  let learnerGroup = EmberObject.create({
     title: 'our group',
     save(){
       assert.ok(false, 'should not be called');

--- a/tests/integration/components/learnergroup-instructor-manager-test.js
+++ b/tests/integration/components/learnergroup-instructor-manager-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('learnergroup-instructor-manager', 'Integration | Component | learnergroup instructor manager', {
@@ -11,14 +11,14 @@ moduleForComponent('learnergroup-instructor-manager', 'Integration | Component |
 });
 
 test('it renders', function(assert) {
-  const learnerGroup = Object.create({
+  const learnerGroup = EmberObject.create({
     title: 'this group',
     instructors: resolve([
-      Object.create({
+      EmberObject.create({
         fullName: 'test person'
       })
     ]),
-    instructorGroups: resolve([Object.create({
+    instructorGroups: resolve([EmberObject.create({
       title: 'test group'
     })]),
   });
@@ -41,22 +41,22 @@ test('can remove groups', function(assert) {
   const group1 = 'li:eq(2)';
   const group2 = 'li:eq(3)';
   const saveButton = 'button.bigadd';
-  const learnerGroup = Object.create({
+  const learnerGroup = EmberObject.create({
     title: 'this group',
     instructors: resolve([
-      Object.create({
+      EmberObject.create({
         fullName: 'test person'
       }),
-      Object.create({
+      EmberObject.create({
         fullName: 'test person 2'
       })
     ]),
     instructorGroups: resolve([
-      Object.create({
+      EmberObject.create({
         id: 42,
         title: 'test group'
       }),
-      Object.create({
+      EmberObject.create({
         id: 'beans',
         title: 'test group 2'
       }),
@@ -90,22 +90,22 @@ test('can remove users', function(assert) {
   const user1 = 'li:eq(0)';
   const user2 = 'li:eq(1)';
   const saveButton = 'button.bigadd';
-  const learnerGroup = Object.create({
+  const learnerGroup = EmberObject.create({
     title: 'this group',
     instructors: resolve([
-      Object.create({
+      EmberObject.create({
         fullName: 'test person'
       }),
-      Object.create({
+      EmberObject.create({
         fullName: 'test person 2'
       })
     ]),
     instructorGroups: resolve([
-      Object.create({
+      EmberObject.create({
         id: 42,
         title: 'test group'
       }),
-      Object.create({
+      EmberObject.create({
         id: 'beans',
         title: 'test group 2'
       }),

--- a/tests/integration/components/learnergroup-subgroup-list-test.js
+++ b/tests/integration/components/learnergroup-subgroup-list-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object, Service } = Ember;
+const { RSVP, Object:EmberObject, Service } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('learnergroup-subgroup-list', 'Integration | Component | learnergroup subgroup list', {
@@ -98,18 +98,18 @@ test('add new group', function(assert) {
   };
 
   let storeMock = Service.extend({
-    createRecord(what, {title, cohort, parent}){
+    createRecord(what, {title, cohort:groupCohort, parent:groupParent}){
       assert.equal('learner-group', what);
       assert.equal('new group', title);
-      assert.equal(cohort, cohort);
+      assert.equal(cohort, groupCohort, 'cohort is correct');
 
       let newGroup = {
         title,
-        cohort,
-        parent
+        cohort: groupCohort,
+        parent: groupParent
       };
 
-      return Object.create({
+      return EmberObject.create({
         save(){
           return resolve(newGroup);
         }
@@ -118,7 +118,7 @@ test('add new group', function(assert) {
   });
   this.register('service:store', storeMock);
 
-  this.set('parentGroup', Object.create(parentGroup));
+  this.set('parentGroup', EmberObject.create(parentGroup));
 
   this.render(hbs`{{learnergroup-subgroup-list parentGroup=parentGroup}}`);
   assert.equal(this.$('tbody tr:eq(0) td:eq(0)').text().trim(), 'first');
@@ -142,12 +142,12 @@ test('add new group', function(assert) {
 test('add multiple new groups', async function(assert) {
   assert.expect(7);
   let cohort = {a: 1};
-  let subGroup1 = Object.create({
+  let subGroup1 = EmberObject.create({
     title: 'group 1',
     users: [1,2],
     children: []
   });
-  let parentGroup = Object.create({
+  let parentGroup = EmberObject.create({
     title: 'group',
     children: resolve([subGroup1]),
     cohort: resolve(cohort),
@@ -155,19 +155,19 @@ test('add multiple new groups', async function(assert) {
   });
 
   let storeMock = Service.extend({
-    createRecord(what, {title, cohort, parent}){
+    createRecord(what, {title, cohort:groupCohort, parent:groupParent}){
       assert.equal('learner-group', what);
       assert.equal('group 2', title);
-      assert.equal(cohort, cohort);
-      assert.equal(parent, parentGroup);
+      assert.equal(cohort, groupCohort);
+      assert.equal(groupParent, parentGroup);
 
       let newGroup = {
         title,
-        cohort,
-        parent
+        cohort: groupCohort,
+        parent: groupParent
       };
 
-      return Object.create({
+      return EmberObject.create({
         save(){
           parentGroup.set('children', resolve([subGroup1, newGroup]));
           return resolve(newGroup);
@@ -214,7 +214,7 @@ test('truncates multiple group with long name', async function(assert) {
   let cohort = {a: 1};
   const longTitle = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit ames';
   const expectedGroupTitle = longTitle.substring(0, 58) + ' 1';
-  let parentGroup = Object.create({
+  let parentGroup = EmberObject.create({
     title: longTitle,
     children: resolve([]),
     cohort: resolve(cohort),
@@ -222,19 +222,19 @@ test('truncates multiple group with long name', async function(assert) {
   });
 
   let storeMock = Service.extend({
-    createRecord(what, {title, cohort, parent}){
+    createRecord(what, {title, cohort:groupCohort, parent:groupParent}){
       assert.equal('learner-group', what);
       assert.equal(title, expectedGroupTitle, 'correct truncated title');
-      assert.equal(cohort, cohort);
-      assert.equal(parent, parentGroup);
+      assert.equal(cohort, groupCohort);
+      assert.equal(groupParent, parentGroup);
 
       let newGroup = {
         title,
-        cohort,
-        parent
+        cohort: groupCohort,
+        parent: groupParent
       };
 
-      return Object.create({
+      return EmberObject.create({
         save(){
           parentGroup.set('children', resolve([newGroup]));
           return resolve(newGroup);

--- a/tests/integration/components/learnergroup-summary-test.js
+++ b/tests/integration/components/learnergroup-summary-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('learnergroup-summary', 'Integration | Component | learnergroup summary', {
@@ -11,35 +11,35 @@ moduleForComponent('learnergroup-summary', 'Integration | Component | learnergro
 });
 
 test('renders with data', function(assert) {
-  const user1 = Object.create({
+  const user1 = EmberObject.create({
     fullName: 'user1'
   });
-  const user2 = Object.create({
+  const user2 = EmberObject.create({
     fullName: 'user2'
   });
-  const user3 = Object.create({
+  const user3 = EmberObject.create({
     fullName: 'user3'
   });
-  const user4 = Object.create({
+  const user4 = EmberObject.create({
     fullName: 'user4'
   });
-  const user5 = Object.create({
+  const user5 = EmberObject.create({
     fullName: 'user5'
   });
-  const user6 = Object.create({
+  const user6 = EmberObject.create({
     fullName: 'user6'
   });
 
-  const cohort = Object.create({
+  const cohort = EmberObject.create({
     title: 'this cohort',
     users: resolve([user1, user2, user3, user4]),
   });
-  let subGroup = Object.create({
+  let subGroup = EmberObject.create({
     title: 'test sub-group',
     users: resolve([]),
     children: resolve([]),
   });
-  let learnerGroup = Object.create({
+  let learnerGroup = EmberObject.create({
     title: 'test group',
     location: 'test location',
     children: resolve([subGroup]),
@@ -65,12 +65,12 @@ test('renders with data', function(assert) {
     isEditing=false
   }}`);
 
-  const location = '.learnergroup-overview .defaultlocation span:eq(0)';
+  const defaultLocation = '.learnergroup-overview .defaultlocation span:eq(0)';
   const instructors = '.learnergroup-overview .defaultinstructors span';
   const courses = '.learnergroup-overview .associatedcourses div';
 
   return wait().then(()=>{
-    assert.equal(this.$(location).text().trim(), 'test location');
+    assert.equal(this.$(defaultLocation).text().trim(), 'test location');
     assert.equal(this.$(instructors).text().trim(), 'user5; user6');
     assert.equal(this.$(courses).text().trim(), 'test course 1; test course 2');
   });
@@ -79,16 +79,16 @@ test('renders with data', function(assert) {
 test('Update location', function(assert) {
   assert.expect(3);
 
-  const cohort = Object.create({
+  const cohort = EmberObject.create({
     title: 'this cohort',
     users: resolve([]),
   });
-  let subGroup = Object.create({
+  let subGroup = EmberObject.create({
     title: 'test sub-group',
     users: resolve([]),
     children: resolve([]),
   });
-  let learnerGroup = Object.create({
+  let learnerGroup = EmberObject.create({
     title: 'test group',
     location: 'test location',
     children: resolve([subGroup]),
@@ -117,18 +117,18 @@ test('Update location', function(assert) {
     isEditing=false
   }}`);
 
-  const location = '.learnergroup-overview .defaultlocation span:eq(0)';
-  const editLocation = `${location} .editable`;
-  const input =  `${location} input`;
-  const save =  `${location} .done`;
+  const defaultLocation = '.learnergroup-overview .defaultlocation span:eq(0)';
+  const editLocation = `${defaultLocation} .editable`;
+  const input =  `${defaultLocation} input`;
+  const save =  `${defaultLocation} .done`;
   return wait().then(()=>{
-    assert.equal(this.$(location).text().trim(), 'test location');
+    assert.equal(this.$(defaultLocation).text().trim(), 'test location');
     this.$(editLocation).click();
     return wait().then(()=> {
       this.$(input).val('new location name').change();
       this.$(save).click();
       return wait().then(()=> {
-        assert.equal(this.$(location).text().trim(), 'new location name');
+        assert.equal(this.$(defaultLocation).text().trim(), 'new location name');
       });
     });
   });

--- a/tests/integration/components/learnergroup-tree-test.js
+++ b/tests/integration/components/learnergroup-tree-test.js
@@ -2,14 +2,14 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('learnergroup-tree', 'Integration | Component | learnergroup tree', {
   integration: true
 });
 
 test('it renders', function(assert) {
-  let learnerGroup = Object.create({
+  let learnerGroup = EmberObject.create({
     children: []
   });
   this.set('learnerGroup', learnerGroup);

--- a/tests/integration/components/learnergroup-user-manager-test.js
+++ b/tests/integration/components/learnergroup-user-manager-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, ObjectProxy } = Ember;
+const { Object:EmberObject, ObjectProxy } = Ember;
 
 moduleForComponent('learnergroup-user-manager', 'Integration | Component | learnergroup user manager', {
   integration: true
@@ -21,14 +21,14 @@ test('it renders', function(assert) {
   const user2CampusId = 'tbody tr:eq(1) td:eq(3)';
   const user2Email = 'tbody tr:eq(1) td:eq(4)';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     firstName: 'Jasper',
     lastName: 'Dog',
     campusId: '1234',
     email: 'testemail',
     enabled: true,
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     firstName: 'Jackson',
     lastName: 'Doggy',
     campusId: '123',
@@ -81,23 +81,23 @@ test('it renders when editing', function(assert) {
   const user2CampusId = 'tbody tr:eq(1) td:eq(3)';
   const user2Email = 'tbody tr:eq(1) td:eq(4)';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     firstName: 'Jasper',
     lastName: 'Dog',
     campusId: '1234',
     email: 'testemail',
     enabled: true,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     firstName: 'Jackson',
     lastName: 'Doggy',
     campusId: '123',
     email: 'testemail2',
     enabled: false,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });
@@ -142,15 +142,15 @@ test('sort by firstName', function(assert) {
   const user1FirstName = 'tbody tr:eq(0) td:eq(1)';
   const user2FirstName = 'tbody tr:eq(1) td:eq(1)';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     firstName: 'Jasper',
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     firstName: 'Jackson',
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });
@@ -184,9 +184,9 @@ test('add multiple users', async function(assert) {
   const user1CheckBox = 'table:eq(1) tbody tr:eq(0) td:eq(0) input[type=checkbox]';
   const button = 'button.done';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });
@@ -227,9 +227,9 @@ test('remove multiple users', async function(assert) {
   const user1CheckBox = 'table:eq(1) tbody tr:eq(0) td:eq(0) input[type=checkbox]';
   const button = 'button.cancel';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });
@@ -268,9 +268,9 @@ test('remove single user', function(assert) {
   assert.expect(1);
   const action = 'table:eq(1) tbody tr:eq(0) td:eq(6) .clickable';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });
@@ -304,9 +304,9 @@ test('add single user', function(assert) {
   assert.expect(1);
   const action = 'table:eq(2) tbody tr:eq(0) td:eq(6) .clickable';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 2
     }),
   });
@@ -342,16 +342,16 @@ test('when users are selected single action is disabled', function(assert) {
   const action1 = 'table:eq(1) tbody tr:eq(0) td:eq(6) .clickable';
   const action2 = 'table:eq(2) tbody tr:eq(0) td:eq(6) .clickable';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });
 
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     enabled: true,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 2
     }),
   });
@@ -387,15 +387,15 @@ test('checkall', function(assert) {
   const user2CheckBox = 'tbody tr:eq(1) td:eq(0) input[type=checkbox]';
   const button = 'button.done';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     enabled: true,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });
@@ -436,15 +436,15 @@ test('checking one puts checkall box into indeterminate state', function(assert)
   const user1CheckBox = 'tbody tr:eq(0) td:eq(0) input[type=checkbox]';
   const user2CheckBox = 'tbody tr:eq(1) td:eq(0) input[type=checkbox]';
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     enabled: true,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     enabled: true,
-    lowestGroupInTree: Object.create({
+    lowestGroupInTree: EmberObject.create({
       id: 1
     }),
   });

--- a/tests/integration/components/learning-materials-sort-manager-test.js
+++ b/tests/integration/components/learning-materials-sort-manager-test.js
@@ -4,7 +4,7 @@ import { test, skip } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import tHelper from "ember-i18n/helper";
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('learning-materials-sort-manager', 'Integration | Component | learning materials sort manager', {
@@ -20,47 +20,47 @@ moduleForComponent('learning-materials-sort-manager', 'Integration | Component |
 test('it renders', function(assert) {
   assert.expect(7);
 
-  let owner1 = Object.create({
+  let owner1 = EmberObject.create({
     id: 1,
     fullName: 'Hans Wurst'
   });
 
-  let owner2 = Object.create({
+  let owner2 = EmberObject.create({
     id: 2,
     fullName: 'Hans Dampf'
   });
 
-  let status1 = Object.create({
+  let status1 = EmberObject.create({
     id: 1,
     title: 'Done and done'
   });
 
-  let status2 = Object.create({
+  let status2 = EmberObject.create({
     id: 2,
     title: 'Draft'
   });
 
-  let lm1 = Object.create({
+  let lm1 = EmberObject.create({
     title: 'Lorem Ipsum',
     status: status1,
     owningUser: owner1,
     type: 'file'
   });
 
-  let lm2 = Object.create({
+  let lm2 = EmberObject.create({
     title: 'Foo Bar',
     status: status2,
     owningUser: owner2,
     type: 'citation'
   });
 
-  let clm1 = Object.create({
+  let clm1 = EmberObject.create({
     id: 1,
     learningMaterial: lm1,
     position: 1,
   });
 
-  let clm2 = Object.create({
+  let clm2 = EmberObject.create({
     id: 2,
     learningMaterial: lm2,
     position: 0,
@@ -68,7 +68,7 @@ test('it renders', function(assert) {
 
   let clms = [ clm1, clm2 ];
 
-  let subject = Object.create({
+  let subject = EmberObject.create({
     learningMaterials: resolve(clms)
   });
 
@@ -96,19 +96,19 @@ test('it renders', function(assert) {
 
 test('cancel', function(assert) {
   assert.expect(1);
-  let subject = Object.create({
+  let subject = EmberObject.create({
     learningMaterials: resolve([
-      Object.create({
+      EmberObject.create({
         id: 1,
         position: 1,
-        learningMaterial: resolve(Object.create({
+        learningMaterial: resolve(EmberObject.create({
           title: 'First'
         }))
       }),
-      Object.create({
+      EmberObject.create({
         id: 2,
         position: 2,
-        learningMaterial: resolve(Object.create({
+        learningMaterial: resolve(EmberObject.create({
           title: 'Second'
         }))
       })
@@ -129,25 +129,25 @@ test('cancel', function(assert) {
 test('save', function(assert) {
   assert.expect(3);
 
-  let clm1 = Object.create({
+  let clm1 = EmberObject.create({
     id: 1,
     position: 1,
-    learningMaterial: resolve(Object.create({
+    learningMaterial: resolve(EmberObject.create({
       title: 'First'
     }))
   });
 
-  let clm2 = Object.create({
+  let clm2 = EmberObject.create({
     id: 2,
     position: 2,
-    learningMaterial: resolve(Object.create({
+    learningMaterial: resolve(EmberObject.create({
       title: 'Second'
     }))
   });
 
   let clms = [ clm1, clm2 ];
 
-  let subject = Object.create({
+  let subject = EmberObject.create({
     learningMaterials: resolve(clms),
   });
   this.set('subject', subject);

--- a/tests/integration/components/my-materials-test.js
+++ b/tests/integration/components/my-materials-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('my-materials', 'Integration | Component | my materials', {
   integration: true
@@ -10,7 +10,7 @@ moduleForComponent('my-materials', 'Integration | Component | my materials', {
 
 
 let createMaterials = function(){
-  let lm1 = Object.create({
+  let lm1 = EmberObject.create({
     title: 'title1',
     absoluteFileUri: 'http://myhost.com/url1',
     sessionTitle: 'session1title',
@@ -19,7 +19,7 @@ let createMaterials = function(){
     instructors: ['Instructor1name', 'Instructor2name'],
     firstOfferingDate: new Date(2003, 1, 2, 12),
   });
-  let lm2 = Object.create({
+  let lm2 = EmberObject.create({
     title: 'title2',
     link: 'http://myhost.com/url2',
     sessionTitle: 'session2title',
@@ -28,7 +28,7 @@ let createMaterials = function(){
     instructors: ['Instructor1name', 'Instructor2name'],
     firstOfferingDate: new Date(2016, 1, 2, 12),
   });
-  let lm3 = Object.create({
+  let lm3 = EmberObject.create({
     title: 'title3',
     citation: 'citationtext',
     sessionTitle: 'session3title',

--- a/tests/integration/components/my-profile-test.js
+++ b/tests/integration/components/my-profile-test.js
@@ -5,7 +5,7 @@ import wait from 'ember-test-helpers/wait';
 import moment from 'moment';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 
-const { Object, RSVP, Service } = Ember;
+const { Object:EmberObject, RSVP, Service } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('my-profile', 'Integration | Component | my profile', {
@@ -13,33 +13,33 @@ moduleForComponent('my-profile', 'Integration | Component | my profile', {
 });
 
 test('it renders all yes', function(assert) {
-  const cohort = Object.create({
+  const cohort = EmberObject.create({
     title: 'test cohort',
-    programYear: Object.create({
-      program: Object.create({
+    programYear: EmberObject.create({
+      program: EmberObject.create({
         title: 'test program'
       })
     })
   });
-  const user = Object.create({
+  const user = EmberObject.create({
     fullName: 'test name',
     isStudent: true,
     roles: resolve([
-      Object.create({title: 'Course Director'}),
-      Object.create({title: 'Faculty'}),
-      Object.create({title: 'Developer'}),
-      Object.create({title: 'Former Student'}),
+      EmberObject.create({title: 'Course Director'}),
+      EmberObject.create({title: 'Faculty'}),
+      EmberObject.create({title: 'Developer'}),
+      EmberObject.create({title: 'Former Student'}),
     ]),
     userSyncIgnore: true,
-    school: resolve(Object.create({title: 'test school'})),
-    primaryCohort: resolve(Object.create({title: 'test cohort'})),
+    school: resolve(EmberObject.create({title: 'test school'})),
+    primaryCohort: resolve(EmberObject.create({title: 'test cohort'})),
     secondaryCohorts: resolve([
-      Object.create({title: 'second cohort'}),
-      Object.create({title: 'a third cohort'}),
+      EmberObject.create({title: 'second cohort'}),
+      EmberObject.create({title: 'a third cohort'}),
     ]),
     learnerGroups: resolve([
-      Object.create({title: 'first group', cohort}),
-      Object.create({title: 'a second group', cohort}),
+      EmberObject.create({title: 'first group', cohort}),
+      EmberObject.create({title: 'a second group', cohort}),
     ]),
   });
 
@@ -65,7 +65,7 @@ test('it renders all yes', function(assert) {
 });
 
 test('it renders all no', function(assert) {
-  const user = Object.create({
+  const user = EmberObject.create({
     fullName: 'test name',
     isStudent: false,
     roles: resolve([]),

--- a/tests/integration/components/new-curriculum-inventory-report-test.js
+++ b/tests/integration/components/new-curriculum-inventory-report-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('new-curriculum-inventory-report', 'Integration | Component | new curriculum inventory report', {
@@ -13,7 +13,7 @@ moduleForComponent('new-curriculum-inventory-report', 'Integration | Component |
 test('it renders', function(assert) {
   assert.expect(20);
 
-  const program = Object.create({
+  const program = EmberObject.create({
     id: 1,
     title: 'Doctor of Medicine'
   });
@@ -82,7 +82,7 @@ test('it renders', function(assert) {
 test('save', function(assert) {
   assert.expect(6);
 
-  this.set('program', Object.create());
+  this.set('program', EmberObject.create());
   this.set('saveReport', (report) => {
     const currentYear = parseInt(moment().format('YYYY'));
     const expectedSelectedYear = currentYear - 5;
@@ -113,7 +113,7 @@ test('save', function(assert) {
 
 test('cancel', function(assert) {
   assert.expect(1);
-  this.set('program', Object.create());
+  this.set('program', EmberObject.create());
   this.set('cancelReport', () => {
     assert.ok(true, 'Cancel action got invoked.');
   });
@@ -124,7 +124,7 @@ test('cancel', function(assert) {
 test('pressing enter in name input field fires save action', function(assert){
   assert.expect(1);
 
-  this.set('program', Object.create());
+  this.set('program', EmberObject.create());
   this.set('saveReport', () => {
     assert.ok(true, 'Save action got invoked.');
     return resolve(true);
@@ -138,14 +138,14 @@ test('pressing enter in name input field fires save action', function(assert){
 
 test('validation errors do not show up initially', function(assert) {
   assert.expect(1);
-  this.set('program', Object.create());
+  this.set('program', EmberObject.create());
   this.render(hbs`{{new-curriculum-inventory-report currentProgram=program}}`);
   assert.equal(this.$('.validation-error-message').length, 0);
 });
 
 test('validation errors show up when saving with empty report name', function(assert) {
   assert.expect(1);
-  this.set('program', Object.create());
+  this.set('program', EmberObject.create());
   this.render(hbs`{{new-curriculum-inventory-report currentProgram=program}}`);
   this.$('button.done').click();
   assert.equal(this.$('.validation-error-message').length, 1);
@@ -153,7 +153,7 @@ test('validation errors show up when saving with empty report name', function(as
 
 test('validation errors show up when saving with a too long report name', function(assert) {
   assert.expect(1);
-  this.set('program', Object.create());
+  this.set('program', EmberObject.create());
   this.render(hbs`{{new-curriculum-inventory-report currentProgram=program}}`);
   this.$('.name input').val('0123456789'.repeat(7)).change();
   this.$('button.done').click();

--- a/tests/integration/components/new-curriculum-inventory-sequence-block-test.js
+++ b/tests/integration/components/new-curriculum-inventory-sequence-block-test.js
@@ -5,7 +5,7 @@ import wait from 'ember-test-helpers/wait';
 import moment from 'moment';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 
-const { RSVP, Object, Service } = Ember;
+const { RSVP, Object:EmberObject, Service } = Ember;
 const { resolve } = RSVP;
 
 let storeMock;
@@ -19,21 +19,21 @@ moduleForComponent('new-curriculum-inventory-sequence-block', 'Integration | Com
 
 test('it renders', function(assert) {
   assert.expect(75);
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i}` }));
   }
-  let course1 = Object.create({ title: 'Belial', id: 1 });
-  let course2 = Object.create({ title: 'Behemoth', id: 2 });
-  let course3 = Object.create({ title: 'Beelzebub', id: 3 });
+  let course1 = EmberObject.create({ title: 'Belial', id: 1 });
+  let course2 = EmberObject.create({ title: 'Behemoth', id: 2 });
+  let course3 = EmberObject.create({ title: 'Beelzebub', id: 3 });
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
@@ -113,13 +113,13 @@ test('it renders', function(assert) {
 
 test('order-in-sequence options are visible for ordered parent sequence block', function(assert) {
   assert.expect(24);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -128,10 +128,10 @@ test('order-in-sequence options are visible for ordered parent sequence block', 
 
   let siblings = [];
   for (let i = 0; i < 10; i++) {
-    siblings.pushObject(Object.create());
+    siblings.pushObject(EmberObject.create());
   }
 
-  let parentBlock = Object.create({
+  let parentBlock = EmberObject.create({
     isOrdered: true,
     children: resolve(siblings)
   });
@@ -158,11 +158,11 @@ test('order-in-sequence options are visible for ordered parent sequence block', 
 
 test('selecting course reveals additional course info', function(assert) {
   assert.expect(4);
-  let school = Object.create({ id() { return 1; }});
-  let clerkshipType = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let clerkshipType = EmberObject.create({
     title: 'selective'
   });
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'my fancy course',
     startDate: moment('2016-05-01').toDate(),
@@ -171,12 +171,12 @@ test('selecting course reveals additional course info', function(assert) {
     clerkshipType
   });
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -206,22 +206,22 @@ test('selecting course reveals additional course info', function(assert) {
 
 test('save with defaults', function(assert) {
   assert.expect(17);
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i}` }));
   }
   let newTitle = 'new sequence block';
   let newDescription = 'lorem ipsum';
   let newStartDate = moment('2016-01-05');
   let newEndDate = moment('2016-02-12');
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
@@ -257,7 +257,7 @@ test('save with defaults', function(assert) {
       assert.equal(data.course, null, 'No course gets selected/passed by default.');
       assert.equal(data.duration, 0, 'Duration defaults to zero');
       assert.equal(data.report, report, 'Given report gets passed.');
-      return Object.create();
+      return EmberObject.create();
     }
   });
   this.set('report', report);
@@ -278,23 +278,23 @@ test('save with defaults', function(assert) {
 
 test('save with non-defaults', function(assert) {
   assert.expect(9);
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i}` }));
   }
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'Test Course'
   });
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
@@ -318,7 +318,7 @@ test('save with non-defaults', function(assert) {
       assert.equal(data.maximum, maximum, 'Given maximum gets passed.');
       assert.equal(data.course, course, 'Selected course gets passed.');
       assert.equal(data.duration, duration, 'Given duration gets passed.');
-      return Object.create();
+      return EmberObject.create();
     }
   });
   this.set('report', report);
@@ -345,27 +345,27 @@ test('save with non-defaults', function(assert) {
 
 test('save nested block in ordered sequence', function(assert) {
   assert.expect(3);
-  let school = Object.create({ id() { return 1; }});
+  let school = EmberObject.create({ id() { return 1; }});
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
-    academicLevels.pushObject(Object.create({ id: i, name: `Year ${i}` }));
+    academicLevels.pushObject(EmberObject.create({ id: i, name: `Year ${i}` }));
   }
 
-  let program = Object.create({
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels,
     year: '2016',
     program: resolve(program),
     linkedCourses: resolve([])
   });
 
-  let parentBlock = Object.create({
+  let parentBlock = EmberObject.create({
     isOrdered: true,
-    children: resolve([ Object.create()])
+    children: resolve([ EmberObject.create()])
   });
 
   storeMock.reopen({
@@ -375,7 +375,7 @@ test('save nested block in ordered sequence', function(assert) {
     createRecord(what, data) {
       assert.equal(data.orderInSequence, 2, 'Selected order-in-sequence gets passed.');
       assert.equal(data.parent, parentBlock, 'Parent gets passed.');
-      return Object.create();
+      return EmberObject.create();
     }
   });
   this.set('report', report);
@@ -396,14 +396,14 @@ test('save nested block in ordered sequence', function(assert) {
 
 test('cancel', function(assert) {
   assert.expect(1);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -432,14 +432,14 @@ test('clear dates', function(assert) {
   assert.expect(4);
   const newStartDate = moment('2016-01-12');
   const newEndDate = moment('2017-02-22');
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -472,14 +472,14 @@ test('clear dates', function(assert) {
 
 test('save fails when minimum is larger than maximum', function(assert) {
   assert.expect(2);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -514,14 +514,14 @@ test('save fails when minimum is larger than maximum', function(assert) {
 
 test('save fails when minimum is less than zero', function(assert) {
   assert.expect(2);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -555,14 +555,14 @@ test('save fails when minimum is less than zero', function(assert) {
 
 test('save fails when minimum is empty', function(assert) {
   assert.expect(2);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -596,14 +596,14 @@ test('save fails when minimum is empty', function(assert) {
 
 test('save fails when maximum is empty', function(assert) {
   assert.expect(2);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -637,14 +637,14 @@ test('save fails when maximum is empty', function(assert) {
 
 test('save with date range and a zero duration', function(assert) {
   assert.expect(1);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -657,7 +657,7 @@ test('save with date range and a zero duration', function(assert) {
     },
     createRecord(what, data) {
       assert.equal(data.duration, '0');
-      return Object.create();
+      return EmberObject.create();
     }
   });
   this.set('saveBlock', () => {
@@ -681,14 +681,14 @@ test('save with date range and a zero duration', function(assert) {
 
 test('save with non-zero duration and no date range', function(assert) {
   assert.expect(1);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -703,7 +703,7 @@ test('save with non-zero duration and no date range', function(assert) {
     },
     createRecord(what, data) {
       assert.equal(data.duration, duration);
-      return Object.create();
+      return EmberObject.create();
     }
   });
   this.set('saveBlock', () => {
@@ -721,14 +721,14 @@ test('save with non-zero duration and no date range', function(assert) {
 
 test('save fails if end-date is older than start-date', function(assert) {
   assert.expect(2);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -762,14 +762,14 @@ test('save fails if end-date is older than start-date', function(assert) {
 
 test('save fails on missing duration', function(assert) {
   assert.expect(2);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -803,14 +803,14 @@ test('save fails on missing duration', function(assert) {
 
 test('save fails on invalid duration', function(assert) {
   assert.expect(2);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -844,14 +844,14 @@ test('save fails on invalid duration', function(assert) {
 
 test('save fails if neither date range nor non-zero duration is provided', function(assert) {
   assert.expect(1);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),
@@ -878,14 +878,14 @@ test('save fails if neither date range nor non-zero duration is provided', funct
 
 test('save fails if start-date is given but no end-date is provided', function(assert) {
   assert.expect(1);
-  let school = Object.create({ id() { return 1; }});
-  let program = Object.create({
+  let school = EmberObject.create({ id() { return 1; }});
+  let program = EmberObject.create({
     belongsTo() {
       return school;
     }
   });
 
-  let report = Object.create({
+  let report = EmberObject.create({
     academicLevels: [],
     year: '2016',
     program: resolve(program),

--- a/tests/integration/components/new-directory-user-test.js
+++ b/tests/integration/components/new-directory-user-test.js
@@ -4,7 +4,7 @@ import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import initializer from "ilios/instance-initializers/ember-i18n";
 
-const { Service, Object, RSVP } = Ember;
+const { Service, Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 const mockSchools = [
@@ -12,9 +12,9 @@ const mockSchools = [
   {id: 1, title: 'first', cohorts: resolve([])},
   {id: 3, title: 'third', cohorts: resolve([])},
 ];
-const mockUser = Object.create({
+const mockUser = EmberObject.create({
   schools: resolve(mockSchools),
-  school: resolve(Object.create(mockSchools[0]))
+  school: resolve(EmberObject.create(mockSchools[0]))
 });
 
 const currentUserMock = Service.extend({
@@ -103,15 +103,15 @@ test('initial search input fires search and fills input', function(assert) {
 
 test('create new user', function(assert) {
   assert.expect(42);
-  let facultyRole = Object.create({
+  let facultyRole = EmberObject.create({
     id: 3,
     title: 'Faculty'
   });
-  let studentRole = Object.create({
+  let studentRole = EmberObject.create({
     id: 4,
     title: 'Student'
   });
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     firstName: 'user1-first',
     lastName: 'user1-last',
     campusId: 'user1-campus',
@@ -120,7 +120,7 @@ test('create new user', function(assert) {
     user: null,
     username: 'user1-username',
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     firstName: 'user2-first',
     lastName: 'user2-last',
     campusId: 'user2-campus',
@@ -129,7 +129,7 @@ test('create new user', function(assert) {
     user: 4136,
     username: 'user2-username',
   });
-  let user3 = Object.create({
+  let user3 = EmberObject.create({
     firstName: 'user3-first',
     lastName: 'user3-last',
     campusId: null,
@@ -186,14 +186,14 @@ test('create new user', function(assert) {
         assert.equal(phone, user1.get('telephoneNumber'), 'record created with correct value for phone');
         assert.equal(email, user1.get('email'), 'record created with correct value for email');
 
-        return new Object({
+        return new EmberObject({
           save(){
             const roles = this.get('roles');
             assert.equal(roles.length, 1, 'Only one new role was added');
             assert.ok(roles.includes(facultyRole), 'The faculty role was added');
             assert.ok(true, 'save gets called');
 
-            return Object.create({
+            return EmberObject.create({
               id: '13'
             });
           }
@@ -207,7 +207,7 @@ test('create new user', function(assert) {
         assert.equal(password, null, 'record has no password');
         assert.equal(user.get('id'), '13', 'we are linking to the expected user');
 
-        return new Object({
+        return new EmberObject({
           save(){
             assert.ok(true, 'save gets called');
           }

--- a/tests/integration/components/new-myreport-test.js
+++ b/tests/integration/components/new-myreport-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import tHelper from "ember-i18n/helper";
-const { RSVP, Service, Object } = Ember;
+const { RSVP, Service, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 import wait from 'ember-test-helpers/wait';
@@ -23,9 +23,9 @@ test('it renders', async function(assert) {
     {id: 1, title: 'first'},
     {id: 3, title: 'third'},
   ];
-  const mockUser = Object.create({
+  const mockUser = EmberObject.create({
     schools: resolve(mockSchools),
-    school: resolve(Object.create(mockSchools[0]))
+    school: resolve(EmberObject.create(mockSchools[0]))
   });
 
   const currentUserMock = Service.extend({
@@ -99,9 +99,9 @@ test('it renders', async function(assert) {
 let checkObjects = async function(context, assert, subjectNum, subjectVal, expectedObjects){
   assert.expect(expectedObjects.length + 2);
   const mockSchools = [{id: 2, title: 'second'}];
-  const mockUser = Object.create({
+  const mockUser = EmberObject.create({
     schools: resolve(mockSchools),
-    school: resolve(Object.create(mockSchools[0]))
+    school: resolve(EmberObject.create(mockSchools[0]))
   });
 
   const currentUserMock = Service.extend({
@@ -244,9 +244,9 @@ test('can search for user #2506', async function(assert) {
   const mockSchools = [
     {id: 1, title: 'first'},
   ];
-  const mockUser = Object.create({
+  const mockUser = EmberObject.create({
     schools: resolve(mockSchools),
-    school: resolve(Object.create(mockSchools[0]))
+    school: resolve(EmberObject.create(mockSchools[0]))
   });
   const currentUserMock = Service.extend({
     model: resolve(mockUser)
@@ -254,7 +254,7 @@ test('can search for user #2506', async function(assert) {
   this.register('service:current-user', currentUserMock);
 
 
-  const user = Object.create({
+  const user = EmberObject.create({
     id: 1,
     fullName: 'Test Person',
     email: 'test@sample.com',

--- a/tests/integration/components/new-user-test.js
+++ b/tests/integration/components/new-user-test.js
@@ -4,7 +4,7 @@ import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import initializer from "ilios/instance-initializers/ember-i18n";
 
-const { Service, Object, RSVP } = Ember;
+const { Service, Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 const mockSchools = [
@@ -12,9 +12,9 @@ const mockSchools = [
   {id: 1, title: 'first', cohorts: resolve([])},
   {id: 3, title: 'third', cohorts: resolve([])},
 ];
-const mockUser = Object.create({
+const mockUser = EmberObject.create({
   schools: resolve(mockSchools),
-  school: resolve(Object.create(mockSchools[0]))
+  school: resolve(EmberObject.create(mockSchools[0]))
 });
 
 const currentUserMock = Service.extend({
@@ -123,11 +123,11 @@ test('errors show up', function(assert) {
 
 test('create new user', function(assert) {
   assert.expect(21);
-  let facultyRole = Object.create({
+  let facultyRole = EmberObject.create({
     id: 3,
     title: 'Faculty'
   });
-  let studentRole = Object.create({
+  let studentRole = EmberObject.create({
     id: 4,
     title: 'Student'
   });
@@ -156,14 +156,14 @@ test('create new user', function(assert) {
         assert.equal(phone, 'phone', 'with the correct phone');
         assert.equal(email, 'test@test.com', 'with the correct email');
 
-        return new Object({
+        return new EmberObject({
           save(){
             const roles = this.get('roles');
             assert.equal(roles.length, 1, 'Only one new role was added');
             assert.ok(roles.includes(facultyRole), 'The faculty role was added');
             assert.ok(true, 'save gets called');
 
-            return Object.create({
+            return EmberObject.create({
               id: '13'
             });
           }
@@ -177,7 +177,7 @@ test('create new user', function(assert) {
         assert.equal(password, 'password123', 'with the correct password');
         assert.equal(user.get('id'), '13', 'with the correct userId');
 
-        return new Object({
+        return new EmberObject({
           save(){
             assert.ok(true, 'save gets called');
           }

--- a/tests/integration/components/objective-sort-manager-test.js
+++ b/tests/integration/components/objective-sort-manager-test.js
@@ -4,7 +4,7 @@ import { test, skip } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import tHelper from "ember-i18n/helper";
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('objective-sort-manager', 'Integration | Component | objective sort manager', {
@@ -20,17 +20,17 @@ moduleForComponent('objective-sort-manager', 'Integration | Component | objectiv
 test('it renders', function(assert) {
   assert.expect(5);
 
-  let objective1 = Object.create({
+  let objective1 = EmberObject.create({
     title: 'Objective 1',
     position: 1,
   });
 
-  let objective2 = Object.create({
+  let objective2 = EmberObject.create({
     title: 'Objective 2',
     position: 0
   });
 
-  let subject = Object.create({
+  let subject = EmberObject.create({
     objectives: resolve([ objective1, objective2 ])
   });
 
@@ -49,13 +49,13 @@ test('it renders', function(assert) {
 
 test('cancel', function(assert) {
   assert.expect(1);
-  let subject = Object.create({
+  let subject = EmberObject.create({
     objectives: resolve([
-      Object.create({
+      EmberObject.create({
         title: 'Objective A',
         position: 1,
       }),
-      Object.create({
+      EmberObject.create({
         title: 'Objective B',
         position: 2
       })
@@ -76,19 +76,19 @@ test('cancel', function(assert) {
 test('save', function(assert) {
   assert.expect(3);
 
-  let objective1 = Object.create({
+  let objective1 = EmberObject.create({
     title: 'Objective1',
     position: 0
   });
 
-  let objective2 = Object.create({
+  let objective2 = EmberObject.create({
     title: 'Objective2',
     position: 0
   });
 
   let objectives = [ objective1, objective2 ];
 
-  let subject = Object.create({
+  let subject = EmberObject.create({
     objectives: resolve(objectives),
   });
   this.set('subject', subject);

--- a/tests/integration/components/offering-form-test.js
+++ b/tests/integration/components/offering-form-test.js
@@ -6,7 +6,7 @@ import wait from 'ember-test-helpers/wait';
 import moment from 'moment';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 const nothing = ()=>{};
@@ -259,9 +259,9 @@ test('close sends close', function(assert) {
   this.set('close', ()=>{
     assert.ok(true);
   });
-  const close = '.buttons .cancel';
+  const closeButton = '.buttons .cancel';
   this.render(hbs`{{offering-form close=(action close)}}`);
-  this.$(close).click();
+  this.$(closeButton).click();
 });
 
 test('save not recurring', function(assert) {
@@ -492,7 +492,7 @@ test('learnerGroup validation errors show up when saving', function(assert) {
 });
 
 test('renders when an offering is provided', function(assert) {
-  let offering = Object.create({
+  let offering = EmberObject.create({
     room: 'emerald bay',
     startDate: moment('2005-06-24').hour(18).minute(24).toDate(),
     endDate: moment('2005-06-24').hour(19).minute(24).toDate(),

--- a/tests/integration/components/pending-updates-summary-test.js
+++ b/tests/integration/components/pending-updates-summary-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, Service, RSVP } = Ember;
+const { Object:EmberObject, Service, RSVP } = Ember;
 const { resolve } = RSVP;
 
 let storeMock;
@@ -18,15 +18,15 @@ moduleForComponent('pending-updates-summary', 'Integration | Component | pending
 
 test('it renders', async function(assert) {
   const container = 'div';
-  let primarySchool = Object.create({
+  let primarySchool = EmberObject.create({
     id: 1,
     title: 'school 0'
   });
-  let secondarySchool = Object.create({
+  let secondarySchool = EmberObject.create({
     id: 2,
     title: 'school 1'
   });
-  let user = Object.create({
+  let user = EmberObject.create({
     school: resolve(primarySchool),
     schools: resolve([primarySchool, secondarySchool])
   });

--- a/tests/integration/components/programyear-competencies-test.js
+++ b/tests/integration/components/programyear-competencies-test.js
@@ -2,24 +2,24 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
-let school = Object.create({
+let school = EmberObject.create({
 });
-let program = Object.create({
+let program = EmberObject.create({
   school: resolve(school)
 });
-let programYear = Object.create({
+let programYear = EmberObject.create({
   program: resolve(program)
 });
-let domain1 = Object.create({
+let domain1 = EmberObject.create({
   id: 1,
   title: 'domain1',
   programYears: resolve([programYear]),
 });
 domain1.set('domain', resolve(domain1));
-let competency1 = Object.create({
+let competency1 = EmberObject.create({
   id: 2,
   domain: resolve(domain1),
   title: 'competency1',
@@ -27,7 +27,7 @@ let competency1 = Object.create({
   programYears: resolve([programYear]),
   treeChildren: resolve([]),
 });
-let competency2 = Object.create({
+let competency2 = EmberObject.create({
   id: 2,
   domain: resolve(domain1),
   title: 'competency2',

--- a/tests/integration/components/programyear-objective-list-item-test.js
+++ b/tests/integration/components/programyear-objective-list-item-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('programyear-objective-list-item', 'Integration | Component | programyear objective list item', {
@@ -10,7 +10,7 @@ moduleForComponent('programyear-objective-list-item', 'Integration | Component |
 });
 
 test('it renders', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);
@@ -30,7 +30,7 @@ test('it renders', function(assert) {
 
 
 test('can change title', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title',
     save(){
       assert.equal(this.get('title'), '<p>new title</p>');
@@ -56,7 +56,7 @@ test('can change title', function(assert) {
 });
 
 test('can manage competency', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);
@@ -78,7 +78,7 @@ test('can manage competency', function(assert) {
 });
 
 test('can manage descriptors', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);

--- a/tests/integration/components/programyear-objective-list-test.js
+++ b/tests/integration/components/programyear-objective-list-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('programyear-objective-list', 'Integration | Component | programyear objective list', {
@@ -13,19 +13,19 @@ moduleForComponent('programyear-objective-list', 'Integration | Component | prog
 test('it renders', function(assert){
   assert.expect(6);
 
-  let objective1 = Object.create({
+  let objective1 = EmberObject.create({
     title: 'Objective A',
     position: 0
   });
 
-  let objective2 = Object.create({
+  let objective2 = EmberObject.create({
     title: 'Objective B',
     position: 0
   });
 
   let objectives = [ objective1, objective2 ];
 
-  let programYear = Object.create({
+  let programYear = EmberObject.create({
     sortedObjectives: resolve(objectives),
   });
 
@@ -49,7 +49,7 @@ test('it renders', function(assert){
 
 test('empty list', function(assert){
   assert.expect(2);
-  let programYear = Object.create({
+  let programYear = EmberObject.create({
     objectives: resolve([]),
   });
   this.set('subject', programYear);
@@ -63,10 +63,10 @@ test('empty list', function(assert){
 
 test('no "sort objectives" button in list with one item', function(assert){
   assert.expect(2);
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'Objective A',
   });
-  let programYear = Object.create({
+  let programYear = EmberObject.create({
     sortedObjectives: resolve([ objective ]),
   });
 

--- a/tests/integration/components/publish-all-sessions-test.js
+++ b/tests/integration/components/publish-all-sessions-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('publish-all-sessions', 'Integration | Component | publish all sessions', {
@@ -12,36 +12,36 @@ moduleForComponent('publish-all-sessions', 'Integration | Component | publish al
 
 test('it renders', async function(assert) {
   assert.expect(4);
-  const unpublishableSession = Object.create({
+  const unpublishableSession = EmberObject.create({
     id: 1,
     title: 'session 1',
-    requiredPublicationIssues: Object.create({
+    requiredPublicationIssues: EmberObject.create({
       length: 1
     }),
-    optionalPublicationIssues: Object.create({
+    optionalPublicationIssues: EmberObject.create({
       length: 1
     }),
     published: false,
   });
-  const completeSession = Object.create({
+  const completeSession = EmberObject.create({
     id: 2,
     title: 'session 2',
-    requiredPublicationIssues: Object.create({
+    requiredPublicationIssues: EmberObject.create({
       length: 0
     }),
-    optionalPublicationIssues: Object.create({
+    optionalPublicationIssues: EmberObject.create({
       length: 0
     }),
     allPublicationIssuesLength: 0,
     published: true,
   });
-  const publishableSession = Object.create({
+  const publishableSession = EmberObject.create({
     id: 3,
     title: 'session 3',
-    requiredPublicationIssues: Object.create({
+    requiredPublicationIssues: EmberObject.create({
       length: 0
     }),
-    optionalPublicationIssues: Object.create({
+    optionalPublicationIssues: EmberObject.create({
       length: 1
     }),
     published: false,

--- a/tests/integration/components/publish-menu-test.js
+++ b/tests/integration/components/publish-menu-test.js
@@ -1,12 +1,15 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('publish-menu', 'Integration | Component | publish menu', {
   integration: true
 });
 
 test('it renders', function(assert) {
-  let testObj = Object.create({
+  let testObj = EmberObject.create({
     allPublicationIssuesLength: 3
   });
   this.set('testObj', testObj);
@@ -135,10 +138,10 @@ test('unpublish action fires', function(assert) {
 });
 
 test('it renders with parent review object', function(assert) {
-  let testObj = Object.create({
+  let testObj = EmberObject.create({
     allPublicationIssuesLength: 3
   });
-  let parentTestObject = Object.create({
+  let parentTestObject = EmberObject.create({
     allPublicationIssuesLength: 8
   });
   this.set('testObj', testObj);

--- a/tests/integration/components/school-competencies-collapsed-test.js
+++ b/tests/integration/components/school-competencies-collapsed-test.js
@@ -5,7 +5,7 @@ import startMirage from '../../helpers/start-mirage';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('school-competencies-collapsed', 'Integration | Component | school competencies collapsed', {
   integration: true,
@@ -20,9 +20,9 @@ test('it renders', function(assert) {
   let domain = server.create('competency', {school: 1, isDomain: true, children: [2]});
   let competency = server.create('competency', {school: 1, isNotDomain: true, parent: 1});
 
-  let competencies = [domain, competency].map(obj => Object.create(obj));
+  let competencies = [domain, competency].map(obj => EmberObject.create(obj));
 
-  const school = Object.create({
+  const school = EmberObject.create({
     competencies
   });
 

--- a/tests/integration/components/school-competencies-expanded-test.js
+++ b/tests/integration/components/school-competencies-expanded-test.js
@@ -5,7 +5,7 @@ import startMirage from '../../helpers/start-mirage';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('school-competencies-expanded', 'Integration | Component | school competencies expanded', {
   integration: true,
@@ -22,9 +22,9 @@ test('it renders', function(assert) {
   let competency2 = server.create('competency', {school: 1, parent: 1, isNotDomain: true});
   domain.children = [competency1, competency2];
 
-  let competencies = [domain, competency1, competency2].map(obj => Object.create(obj));
+  let competencies = [domain, competency1, competency2].map(obj => EmberObject.create(obj));
 
-  const school = Object.create({
+  const school = EmberObject.create({
     competencies
   });
 

--- a/tests/integration/components/school-competencies-list-test.js
+++ b/tests/integration/components/school-competencies-list-test.js
@@ -4,7 +4,7 @@ import startMirage from '../../helpers/start-mirage';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('school-competencies-list', 'Integration | Component | school competencies list', {
   integration: true,
@@ -22,7 +22,7 @@ test('it renders', function(assert) {
   let competency2 = server.create('competency', {school: 1, parent: 1});
   domain.children = [competency1, competency2];
 
-  let competencies = [domain, competency1, competency2].map(obj => Object.create(obj));
+  let competencies = [domain, competency1, competency2].map(obj => EmberObject.create(obj));
 
 
   this.set('competencies', competencies);

--- a/tests/integration/components/school-competencies-manager-test.js
+++ b/tests/integration/components/school-competencies-manager-test.js
@@ -3,9 +3,9 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
-let Competency = Object.extend({
+let Competency = EmberObject.extend({
   id: null,
   title: null,
   parent: null,
@@ -16,9 +16,9 @@ let Competency = Object.extend({
     let self = this;
     return {
       id(){
-        let parent = self.parent;
-        if (parent) {
-          return parent.id;
+        let parentCompetency = self.parent;
+        if (parentCompetency) {
+          return parentCompetency.id;
         }
 
         return null;

--- a/tests/integration/components/school-leadership-expanded-test.js
+++ b/tests/integration/components/school-leadership-expanded-test.js
@@ -2,7 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('school-leadership-expanded', 'Integration | Component | school leadership expanded', {
@@ -13,17 +13,17 @@ moduleForComponent('school-leadership-expanded', 'Integration | Component | scho
 test('it renders', function(assert) {
   assert.expect(6);
 
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     firstName: 'a',
     lastName: 'person',
     fullName: 'a b person',
   });
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     firstName: 'b',
     lastName: 'person',
     fullName: 'b a person',
   });
-  let school = Object.create({
+  let school = EmberObject.create({
     directors: resolve([user1]),
     administrators: resolve([user1, user2]),
     hasMany(what){
@@ -71,7 +71,7 @@ test('it renders', function(assert) {
 
 test('clicking the header collapses', function(assert) {
   assert.expect(1);
-  let school = Object.create({
+  let school = EmberObject.create({
     directors: resolve([]),
     administrators: resolve([]),
     hasMany(what){
@@ -111,7 +111,7 @@ test('clicking the header collapses', function(assert) {
 
 test('clicking manage fires action', function(assert) {
   assert.expect(1);
-  let school = Object.create({
+  let school = EmberObject.create({
     directors: resolve([]),
     administrators: resolve([]),
     hasMany(what){

--- a/tests/integration/components/school-list-test.js
+++ b/tests/integration/components/school-list-test.js
@@ -4,7 +4,7 @@ import initializer from "ilios/instance-initializers/ember-i18n";
 import startMirage from '../../helpers/start-mirage';
 import Ember from 'ember';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('school-list', 'Integration | Component | school list', {
   integration: true,
@@ -18,7 +18,7 @@ test('it renders', function(assert) {
   let school1 = server.create('school');
   let school2 = server.create('school');
 
-  const schools = [school1, school2].map(obj => Object.create(obj));
+  const schools = [school1, school2].map(obj => EmberObject.create(obj));
 
   this.set('schools', schools);
   this.render(hbs`{{school-list schools=schools}}`);

--- a/tests/integration/components/school-session-attributes-test.js
+++ b/tests/integration/components/school-session-attributes-test.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('school-session-attributes', 'Integration | Component | school session attributes', {
   integration: true
@@ -11,7 +11,7 @@ moduleForComponent('school-session-attributes', 'Integration | Component | schoo
 
 test('it renders collapsed', async function(assert) {
   assert.expect(13);
-  const school = Object.create({
+  const school = EmberObject.create({
     async getConfigValue(name){
       if (name === 'showSessionSupplemental') {
         return true;
@@ -63,7 +63,7 @@ test('it renders collapsed', async function(assert) {
 
 test('it renders expanded', async function(assert) {
   assert.expect(13);
-  const school = Object.create({
+  const school = EmberObject.create({
     async getConfigValue(name){
       if (name === 'showSessionSupplemental') {
         return true;
@@ -115,7 +115,7 @@ test('it renders expanded', async function(assert) {
 
 test('clicking expand fires action', async function(assert) {
   assert.expect(1);
-  const school = Object.create({
+  const school = EmberObject.create({
     async getConfigValue(){
       return false;
     },
@@ -140,7 +140,7 @@ test('clicking expand fires action', async function(assert) {
 
 test('clicking collapse fires action', async function(assert) {
   assert.expect(1);
-  const school = Object.create({
+  const school = EmberObject.create({
     async getConfigValue(){
       return false;
     },

--- a/tests/integration/components/school-vocabularies-collapsed-test.js
+++ b/tests/integration/components/school-vocabularies-collapsed-test.js
@@ -5,7 +5,7 @@ import startMirage from '../../helpers/start-mirage';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('school-vocabularies-collapsed', 'Integration | Component | school vocabularies collapsed', {
   integration: true,
@@ -22,9 +22,9 @@ test('it renders', function(assert) {
   server.createList('term', { vocabulary: [1]}, 2);
   server.createList('term', { vocabulary: [2]}, 1);
 
-  let vocabularies = [vocabulary1, vocabulary2].map(obj => Object.create(obj));
+  let vocabularies = [vocabulary1, vocabulary2].map(obj => EmberObject.create(obj));
 
-  const school = Object.create({
+  const school = EmberObject.create({
     vocabularies
   });
 
@@ -45,9 +45,9 @@ test('clicking the header expands the list', function(assert) {
   assert.expect(2);
   let  vocabulary = server.create('vocabulary', {school: 1});
 
-  let vocabularies = [vocabulary].map(obj => Object.create(obj));
+  let vocabularies = [vocabulary].map(obj => EmberObject.create(obj));
 
-  const school = Object.create({
+  const school = EmberObject.create({
     vocabularies
   });
   const title = '.title';

--- a/tests/integration/components/school-vocabularies-expanded-test.js
+++ b/tests/integration/components/school-vocabularies-expanded-test.js
@@ -5,7 +5,7 @@ import initializer from "ilios/instance-initializers/ember-i18n";
 import startMirage from '../../helpers/start-mirage';
 import Ember from 'ember';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 
 moduleForComponent('school-vocabularies-expanded', 'Integration | Component | school vocabularies expanded', {
   integration: true,
@@ -22,9 +22,9 @@ test('it renders', function(assert) {
   server.createList('term', { vocabulary: [1]}, 2);
   server.createList('term', { vocabulary: [2]}, 1);
 
-  let vocabularies = [vocabulary1, vocabulary2].map(obj => Object.create(obj));
+  let vocabularies = [vocabulary1, vocabulary2].map(obj => EmberObject.create(obj));
 
-  const school = Object.create({
+  const school = EmberObject.create({
     vocabularies: RSVP.resolve(vocabularies)
   });
 

--- a/tests/integration/components/school-vocabularies-list-test.js
+++ b/tests/integration/components/school-vocabularies-list-test.js
@@ -5,7 +5,7 @@ import initializer from "ilios/instance-initializers/ember-i18n";
 import startMirage from '../../helpers/start-mirage';
 import Ember from 'ember';
 
-const { Object, Service, RSVP } = Ember;
+const { Object:EmberObject, Service, RSVP } = Ember;
 
 moduleForComponent('school-vocabularies-list', 'Integration | Component | school vocabularies list', {
   integration: true,
@@ -22,9 +22,9 @@ test('it renders', function(assert) {
   server.createList('term', { vocabulary: [1]}, 2);
   server.createList('term', { vocabulary: [2]}, 1);
 
-  let vocabularies = [vocabulary1, vocabulary2].map(obj => Object.create(obj));
+  let vocabularies = [vocabulary1, vocabulary2].map(obj => EmberObject.create(obj));
 
-  const school = Object.create({
+  const school = EmberObject.create({
     vocabularies: RSVP.resolve(vocabularies)
   });
 
@@ -60,7 +60,7 @@ test('can create new vocabulary', function(assert) {
   this.register('service:store', storeMock);
 
 
-  const school = Object.create({
+  const school = EmberObject.create({
     vocabularies: RSVP.resolve([])
   });
 
@@ -86,9 +86,9 @@ test('cannot delete vocabularies with terms', function(assert) {
   server.createList('term', { vocabulary: [1]}, 2);
   server.createList('term', { vocabulary: [2]}, 1);
 
-  let vocabularies = [vocabulary1, vocabulary2, vocabulary3].map(obj => Object.create(obj));
+  let vocabularies = [vocabulary1, vocabulary2, vocabulary3].map(obj => EmberObject.create(obj));
 
-  const school = Object.create({
+  const school = EmberObject.create({
     vocabularies: RSVP.resolve(vocabularies)
   });
 
@@ -117,9 +117,9 @@ test('clicking delete removes the vocabulary', function(assert) {
     }
   };
 
-  let vocabularies = [vocabulary].map(obj => Object.create(obj));
+  let vocabularies = [vocabulary].map(obj => EmberObject.create(obj));
 
-  const school = Object.create({
+  const school = EmberObject.create({
     vocabularies: RSVP.resolve(vocabularies)
   });
   this.on('edit', parseInt);
@@ -144,9 +144,9 @@ test('clicking edit fires the action to manage the vocab', function(assert) {
   let  vocabulary1 = server.create('vocabulary', {school: 1, isNew: false});
   let  vocabulary2 = server.create('vocabulary', {school: 1, isNew: false});
 
-  let vocabularies = [vocabulary1, vocabulary2].map(obj => Object.create(obj));
+  let vocabularies = [vocabulary1, vocabulary2].map(obj => EmberObject.create(obj));
 
-  const school = Object.create({
+  const school = EmberObject.create({
     vocabularies: RSVP.resolve(vocabularies)
   });
 

--- a/tests/integration/components/school-vocabulary-manager-test.js
+++ b/tests/integration/components/school-vocabulary-manager-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('school-vocabulary-manager', 'Integration | Component | school vocabulary manager', {
@@ -10,7 +10,7 @@ moduleForComponent('school-vocabulary-manager', 'Integration | Component | schoo
 });
 
 test('it renders', function(assert) {
-  let vocabulary = Object.create({
+  let vocabulary = EmberObject.create({
     title: 'fake vocab',
     terms: resolve([])
   });

--- a/tests/integration/components/school-vocabulary-term-manager-test.js
+++ b/tests/integration/components/school-vocabulary-term-manager-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('school-vocabulary-term-manager', 'Integration | Component | school vocabulary term manager', {
@@ -15,12 +15,12 @@ test('it renders', function(assert) {
     {id: 2, title: 'second'},
   ]);
   let children = resolve([]);
-  let vocabulary = Object.create({
+  let vocabulary = EmberObject.create({
     title: 'fake vocab'
   });
   let title = 'fake term';
   let description = 'fake tescription';
-  let term = Object.create({
+  let term = EmberObject.create({
     allParents,
     children,
     vocabulary: resolve(vocabulary),

--- a/tests/integration/components/session-copy-test.js
+++ b/tests/integration/components/session-copy-test.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { Service, RSVP, Object } = Ember;
+const { Service, RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('session-copy', 'Integration | Component | session copy', {
@@ -17,23 +17,23 @@ test('it renders', function(assert) {
   let lastYear = thisYear - 1;
   let nextYear = thisYear + 1;
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id: 1
   });
 
-  let course1 = Object.create({
+  let course1 = EmberObject.create({
     id: 1,
     title: 'old course',
     school: school
   });
 
-  let course2 = Object.create({
+  let course2 = EmberObject.create({
     id: 1,
     title: 'old course 2',
     school: school
   });
 
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'old session',
     course: course1
@@ -52,7 +52,7 @@ test('it renders', function(assert) {
       assert.equal(what, 'academicYear');
 
       return [lastYear, thisYear, nextYear].map(year => {
-        return Object.create({
+        return EmberObject.create({
           id: year,
           title: year
         });
@@ -89,41 +89,41 @@ test('copy session', function(assert) {
 
   let thisYear = parseInt(moment().format('YYYY'));
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id: 1
   });
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'old course',
     school: school
   });
-  let lm = Object.create();
-  let learningMaterial = Object.create({
+  let lm = EmberObject.create();
+  let learningMaterial = EmberObject.create({
     notes: 'soem notes',
     required: false,
     publicNotes: true,
     learningMaterial: resolve(lm),
     position: 3,
   });
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'session objective title',
-    parents: [Object.create()],
+    parents: [EmberObject.create()],
     position: 3,
   });
   let objectives = [objective];
-  let meshDescriptors = [Object.create()];
-  let terms = [Object.create()];
+  let meshDescriptors = [EmberObject.create()];
+  let terms = [EmberObject.create()];
 
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'old session',
     course,
     attireRequired: true,
     equipmentRequired: false,
     supplemental: true,
-    sessionType: resolve(Object.create()),
-    sessionDescription: resolve(Object.create({
+    sessionType: resolve(EmberObject.create()),
+    sessionDescription: resolve(EmberObject.create({
       id: 13,
       description: 'test description'
     })),
@@ -139,7 +139,7 @@ test('copy session', function(assert) {
     },
     findAll(){
       return [thisYear].map(year => {
-        return Object.create({
+        return EmberObject.create({
           id: year,
           title: year
         });
@@ -152,7 +152,7 @@ test('copy session', function(assert) {
         assert.equal(session.supplemental, props.supplemental);
         assert.equal(session.title, props.title);
 
-        return Object.create({
+        return EmberObject.create({
           id: 14,
           save(){
             assert.equal(course, this.get('course'));
@@ -167,7 +167,7 @@ test('copy session', function(assert) {
         assert.equal(learningMaterial.get('publicNotes'), props.publicNotes);
         assert.equal(learningMaterial.get('position'), props.position);
 
-        return Object.create({
+        return EmberObject.create({
           save(){
             assert.equal(this.get('session.id'), 14);
             assert.equal(this.get('learningMaterial.id'), lm.get('id'));
@@ -177,7 +177,7 @@ test('copy session', function(assert) {
       if (what === 'sessionDescription') {
         assert.equal('test description', props.description);
 
-        return Object.create({
+        return EmberObject.create({
           save(){
             assert.equal(this.get('session.id'), 14);
           }
@@ -187,7 +187,7 @@ test('copy session', function(assert) {
         assert.equal(objective.title, props.title);
         assert.equal(objective.position, props.position);
 
-        return Object.create({
+        return EmberObject.create({
           save(){
             let sessions = this.get('sessions');
             assert.equal(sessions.length, 1);
@@ -233,17 +233,17 @@ test('errors do not show up initially and save cannot be clicked', function(asse
   this.register('service:store', storeMock);
 
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id: 1
   });
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'old course',
     school: school
   });
 
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'old session',
     course
@@ -266,17 +266,17 @@ test('changing the year looks for new matching courses', function(assert) {
   let thisYear = parseInt(moment().format('YYYY'));
   let nextYear = thisYear + 1;
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id: 1
   });
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'old course',
     school: school
   });
 
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'old session',
     course
@@ -303,7 +303,7 @@ test('changing the year looks for new matching courses', function(assert) {
     },
     findAll(){
       return [thisYear, nextYear].map(year => {
-        return Object.create({
+        return EmberObject.create({
           id: year,
           title: year
         });
@@ -327,25 +327,25 @@ test('copy session into the first course in a different year year #2130', functi
   let thisYear = parseInt(moment().format('YYYY'));
   let nextYear = parseInt(moment().add(1, 'year').format('YYYY'));
 
-  let school = Object.create({
+  let school = EmberObject.create({
     id: 1
   });
 
-  let course = Object.create({
+  let course = EmberObject.create({
     id: 1,
     title: 'old course',
     school: school,
     year: thisYear
   });
 
-  let firstCourse = Object.create({
+  let firstCourse = EmberObject.create({
     id: 2,
     title: 'old course',
     school: school,
     year: nextYear
   });
 
-  let targetCourse = Object.create({
+  let targetCourse = EmberObject.create({
     id: 3,
     title: 'alpha first',
     school: school,
@@ -353,15 +353,15 @@ test('copy session into the first course in a different year year #2130', functi
   });
 
 
-  let session = Object.create({
+  let session = EmberObject.create({
     id: 1,
     title: 'old session',
     course,
     attireRequired: true,
     equipmentRequired: false,
     supplemental: true,
-    sessionType: resolve(Object.create()),
-    sessionDescription: resolve(Object.create()),
+    sessionType: resolve(EmberObject.create()),
+    sessionDescription: resolve(EmberObject.create()),
     objectives: resolve([]),
     meshDescriptors: resolve([]),
     terms: resolve([]),
@@ -375,11 +375,11 @@ test('copy session into the first course in a different year year #2130', functi
       assert.ok('year' in filters, 'filtered by year');
 
       const year = parseInt(filters.year);
-      return [course, firstCourse, targetCourse].filter(course => course.get('year') === year);
+      return [course, firstCourse, targetCourse].filter(c => c.get('year') === year);
     },
     findAll(){
       return [thisYear, nextYear].map(year => {
-        return Object.create({
+        return EmberObject.create({
           id: year,
           title: year
         });
@@ -387,7 +387,7 @@ test('copy session into the first course in a different year year #2130', functi
     },
     createRecord(what){
       if (what === 'session') {
-        return Object.create({
+        return EmberObject.create({
           id: 14,
           save(){
             assert.equal(targetCourse.get('id'), this.get('course.id'), 'the correct course was selected');
@@ -396,7 +396,7 @@ test('copy session into the first course in a different year year #2130', functi
       }
 
       if (what === 'sessionDescription') {
-        return Object.create({
+        return EmberObject.create({
           save(){
           }
         });

--- a/tests/integration/components/session-objective-list-item-test.js
+++ b/tests/integration/components/session-objective-list-item-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const { Object, RSVP } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('session-objective-list-item', 'Integration | Component | session objective list item', {
@@ -10,7 +10,7 @@ moduleForComponent('session-objective-list-item', 'Integration | Component | ses
 });
 
 test('it renders', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);
@@ -30,7 +30,7 @@ test('it renders', function(assert) {
 });
 
 test('renders removable', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);
@@ -48,7 +48,7 @@ test('renders removable', function(assert) {
 });
 
 test('can change title', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title',
     save(){
       assert.equal(this.get('title'), '<p>new title</p>');
@@ -73,7 +73,7 @@ test('can change title', function(assert) {
 });
 
 test('can manage parents', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);
@@ -94,7 +94,7 @@ test('can manage parents', function(assert) {
 });
 
 test('can manage descriptors', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);
@@ -115,7 +115,7 @@ test('can manage descriptors', function(assert) {
 });
 
 test('can trigger removal', function(assert) {
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'fake title'
   });
   this.set('objective', objective);

--- a/tests/integration/components/session-objective-list-test.js
+++ b/tests/integration/components/session-objective-list-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('session-objective-list', 'Integration | Component | session objective list', {
@@ -13,19 +13,19 @@ moduleForComponent('session-objective-list', 'Integration | Component | session 
 test('it renders', function(assert){
   assert.expect(7);
 
-  let objective1 = Object.create({
+  let objective1 = EmberObject.create({
     title: 'Objective A',
     position: 0
   });
 
-  let objective2 = Object.create({
+  let objective2 = EmberObject.create({
     title: 'Objective B',
     position: 0
   });
 
   let objectives = [ objective1, objective2 ];
 
-  let session = Object.create({
+  let session = EmberObject.create({
     sortedObjectives: resolve(objectives),
   });
 
@@ -50,7 +50,7 @@ test('it renders', function(assert){
 
 test('empty list', function(assert){
   assert.expect(2);
-  let session = Object.create({
+  let session = EmberObject.create({
     objectives: resolve([]),
   });
   this.set('subject', session);
@@ -64,10 +64,10 @@ test('empty list', function(assert){
 
 test('no "sort objectives" button in list with one item', function(assert){
   assert.expect(2);
-  let objective = Object.create({
+  let objective = EmberObject.create({
     title: 'Objective A',
   });
-  let session = Object.create({
+  let session = EmberObject.create({
     sortedObjectives: resolve([ objective ]),
   });
 

--- a/tests/integration/components/unassigned-students-summary-test.js
+++ b/tests/integration/components/unassigned-students-summary-test.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 import startMirage from '../../helpers/start-mirage';
 import wait from 'ember-test-helpers/wait';
 
-const { Object, Service, RSVP } = Ember;
+const { Object:EmberObject, Service, RSVP } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('unassigned-students-summary', 'Integration | Component | unassigned students summary', {
@@ -15,9 +15,9 @@ moduleForComponent('unassigned-students-summary', 'Integration | Component | una
 });
 
 test('it renders', function(assert) {
-  let primarySchool = Object.create(server.create('school'));
-  let secondarySchool = Object.create(server.create('school'));
-  let user = Object.create({
+  let primarySchool = EmberObject.create(server.create('school'));
+  let secondarySchool = EmberObject.create(server.create('school'));
+  let user = EmberObject.create({
     school: resolve(primarySchool),
     schools: resolve([primarySchool, secondarySchool])
   });
@@ -55,8 +55,8 @@ test('it renders', function(assert) {
 });
 
 test('it renders empty', function(assert) {
-  let primarySchool = Object.create(server.create('school'));
-  let user = Object.create({
+  let primarySchool = EmberObject.create(server.create('school'));
+  let user = EmberObject.create({
     school: resolve(primarySchool),
     schools: resolve([primarySchool])
   });

--- a/tests/integration/components/user-profile-bio-test.js
+++ b/tests/integration/components/user-profile-bio-test.js
@@ -3,19 +3,19 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object, Service } = Ember;
+const { RSVP, Object:EmberObject, Service } = Ember;
 const { resolve } = RSVP;
 let user;
 let authentication;
 moduleForComponent('user-profile-bio', 'Integration | Component | user profile bio', {
   integration: true,
   beforeEach(){
-    authentication = Object.create({
+    authentication = EmberObject.create({
       username: 'test-username',
       user: 13,
       password: null
     });
-    user = Object.create({
+    user = EmberObject.create({
       id: 13,
       fullName: 'Test Person Name Thing',
       firstName: 'Test Person',

--- a/tests/integration/components/user-profile-cohorts-test.js
+++ b/tests/integration/components/user-profile-cohorts-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object, Service } = Ember;
+const { RSVP, Object:EmberObject, Service } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('user-profile-cohorts', 'Integration | Component | user profile cohorts', {
@@ -12,38 +12,38 @@ moduleForComponent('user-profile-cohorts', 'Integration | Component | user profi
     this.register('service:currentUser', currentUserMock);
   }
 });
-let som = Object.create({
+let som = EmberObject.create({
   id: '1',
   title: 'SOM'
 });
-let sod = Object.create({
+let sod = EmberObject.create({
   id: '2',
   title: 'SOD'
 });
-let program1 = Object.create({
+let program1 = EmberObject.create({
   title: 'Program1',
   school: resolve(som)
 });
-let program2 = Object.create({
+let program2 = EmberObject.create({
   title: 'Program2',
   school: resolve(sod)
 });
-let programYear1 = Object.create({
+let programYear1 = EmberObject.create({
   program: resolve(program1),
   published: true,
   archived: false,
 });
-let programYear2 = Object.create({
+let programYear2 = EmberObject.create({
   program: resolve(program2),
   published: true,
   archived: false,
 });
-let programYear3 = Object.create({
+let programYear3 = EmberObject.create({
   program: resolve(program2),
   published: true,
   archived: false,
 });
-let programYear4 = Object.create({
+let programYear4 = EmberObject.create({
   program: resolve(program2),
   published: true,
   archived: false,
@@ -51,7 +51,7 @@ let programYear4 = Object.create({
 program1.set('programYears', resolve([programYear1, programYear4]));
 program2.set('programYears', resolve([programYear2, programYear3]));
 
-let cohort1 = Object.create({
+let cohort1 = EmberObject.create({
   id: 1,
   title: 'Cohort1',
   programYear: resolve(programYear1),
@@ -59,7 +59,7 @@ let cohort1 = Object.create({
   school: resolve(som)
 });
 
-let cohort2 = Object.create({
+let cohort2 = EmberObject.create({
   id: 2,
   title: 'Cohort2',
   programYear: resolve(programYear2),
@@ -67,7 +67,7 @@ let cohort2 = Object.create({
   school: resolve(sod)
 });
 
-let cohort3 = Object.create({
+let cohort3 = EmberObject.create({
   id: 3,
   title: 'Cohort3',
   programYear: resolve(programYear3),
@@ -75,7 +75,7 @@ let cohort3 = Object.create({
   school: resolve(sod)
 });
 
-let cohort4 = Object.create({
+let cohort4 = EmberObject.create({
   id: 4,
   title: 'Cohort4',
   programYear: resolve(programYear4),
@@ -91,12 +91,12 @@ sod.set('programs', resolve([program2]));
 
 let usercohorts = [cohort1, cohort2];
 
-let user = Object.create({
+let user = EmberObject.create({
   primaryCohort: resolve(cohort1),
   cohorts: resolve(usercohorts),
 });
 
-const mockCurrentUser = Object.create({
+const mockCurrentUser = EmberObject.create({
   schools: resolve([som, sod]),
   school: resolve(som),
 });

--- a/tests/integration/components/user-profile-ics-test.js
+++ b/tests/integration/components/user-profile-ics-test.js
@@ -3,13 +3,13 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object, Service } = Ember;
+const { RSVP, Object:EmberObject, Service } = Ember;
 const { resolve } = RSVP;
 let user;
 moduleForComponent('user-profile-ics', 'Integration | Component | user profile ics', {
   integration: true,
   beforeEach(){
-    user = Object.create({
+    user = EmberObject.create({
       id: 13,
       icsFeedKey: 'testkey'
     });

--- a/tests/integration/components/user-profile-learnergroups-test.js
+++ b/tests/integration/components/user-profile-learnergroups-test.js
@@ -3,36 +3,36 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object } = Ember;
+const { RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('user-profile-learnergroups', 'Integration | Component | user profile learnergroups', {
   integration: true
 });
-let som = Object.create({
+let som = EmberObject.create({
   id: '1',
   title: 'SOM'
 });
-let sod = Object.create({
+let sod = EmberObject.create({
   id: '2',
   title: 'SOD'
 });
-let program1 = Object.create({
+let program1 = EmberObject.create({
   title: 'Program1',
   school: resolve(som)
 });
-let program2 = Object.create({
+let program2 = EmberObject.create({
   title: 'Program2',
   school: resolve(sod)
 });
 som.set('programs', resolve([program1]));
 sod.set('programs', resolve([program2]));
-let programYear1 = Object.create({
+let programYear1 = EmberObject.create({
   program: resolve(program1),
   published: true,
   archived: false,
 });
-let programYear2 = Object.create({
+let programYear2 = EmberObject.create({
   program: resolve(program2),
   published: true,
   archived: false,
@@ -40,7 +40,7 @@ let programYear2 = Object.create({
 program1.set('programYears', resolve([programYear1]));
 program2.set('programYears', resolve([programYear2]));
 
-let cohort1 = Object.create({
+let cohort1 = EmberObject.create({
   id: 1,
   title: 'Cohort1',
   programYear: resolve(programYear1),
@@ -48,7 +48,7 @@ let cohort1 = Object.create({
   school: resolve(som)
 });
 
-let cohort2 = Object.create({
+let cohort2 = EmberObject.create({
   id: 2,
   title: 'Cohort2',
   programYear: resolve(programYear2),
@@ -57,12 +57,12 @@ let cohort2 = Object.create({
 });
 programYear1.set('cohort', resolve(cohort1));
 programYear2.set('cohort', resolve(cohort2));
-let learnerGroup1 = Object.create({
+let learnerGroup1 = EmberObject.create({
   id: 1,
   title: 'LearnerGroup1',
   cohort: resolve(cohort1),
 });
-let learnerGroup2 = Object.create({
+let learnerGroup2 = EmberObject.create({
   id: 2,
   title: 'LearnerGroup2',
   cohort: resolve(cohort2),
@@ -70,7 +70,7 @@ let learnerGroup2 = Object.create({
 
 let userlearnergroups = [learnerGroup1, learnerGroup2];
 
-let user = Object.create({
+let user = EmberObject.create({
   learnerGroups: resolve(userlearnergroups),
 });
 

--- a/tests/integration/components/user-profile-roles-test.js
+++ b/tests/integration/components/user-profile-roles-test.js
@@ -3,14 +3,14 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object, Service } = Ember;
+const { RSVP, Object:EmberObject, Service } = Ember;
 const { resolve } = RSVP;
 
 let user;
 moduleForComponent('user-profile-roles', 'Integration | Component | user profile roles', {
   integration: true,
   beforeEach(){
-    user = Object.create({
+    user = EmberObject.create({
       id: 6,
       enabled: true,
       userSyncIgnore: false,
@@ -18,19 +18,19 @@ moduleForComponent('user-profile-roles', 'Integration | Component | user profile
     });
   }
 });
-let courseDirectorRole = Object.create({
+let courseDirectorRole = EmberObject.create({
   title: 'Course Director'
 });
-let facultyRole = Object.create({
+let facultyRole = EmberObject.create({
   title: 'Faculty'
 });
-let developerRole = Object.create({
+let developerRole = EmberObject.create({
   title: 'Developer'
 });
-let formerStudentRole = Object.create({
+let formerStudentRole = EmberObject.create({
   title: 'Former Student'
 });
-let studentRole = Object.create({
+let studentRole = EmberObject.create({
   title: 'Student'
 });
 

--- a/tests/integration/components/user-profile-schools-test.js
+++ b/tests/integration/components/user-profile-schools-test.js
@@ -3,21 +3,21 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { RSVP, Object, Service } = Ember;
+const { RSVP, Object: EmberObject, Service } = Ember;
 const { resolve } = RSVP;
 
 let user;
 moduleForComponent('user-profile-schools', 'Integration | Component | user profile schools', {
   integration: true,
   beforeEach(){
-    let sodPermission = Object.create({
+    let sodPermission = EmberObject.create({
       user,
       tableName: 'school',
       tableRowId: '2',
       canRead: true,
       canWrite: true
     });
-    user = Object.create({
+    user = EmberObject.create({
       id: 13,
       enabled: true,
       userSyncIgnore: false,
@@ -27,7 +27,7 @@ moduleForComponent('user-profile-schools', 'Integration | Component | user profi
     });
 
     let currentUser = Service.extend({
-      model: resolve(Object.create({
+      model: resolve(EmberObject.create({
         school: resolve(sod),
         schools: resolve([som, sod, sop])
       }))
@@ -36,15 +36,15 @@ moduleForComponent('user-profile-schools', 'Integration | Component | user profi
   }
 });
 
-let som = Object.create({
+let som = EmberObject.create({
   id: '1',
   title: 'SOM'
 });
-let sod = Object.create({
+let sod = EmberObject.create({
   id: '2',
   title: 'SOD'
 });
-let sop = Object.create({
+let sop = EmberObject.create({
   id: '3',
   title: 'SOP'
 });
@@ -198,7 +198,7 @@ test('changing user modifies display #2389', async function(assert) {
     }
   });
   this.register('service:store', store);
-  let user2 = Object.create({
+  let user2 = EmberObject.create({
     id: 14,
     enabled: true,
     userSyncIgnore: false,

--- a/tests/integration/components/user-search-test.js
+++ b/tests/integration/components/user-search-test.js
@@ -3,7 +3,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const { Service, RSVP, Object } = Ember;
+const { Service, RSVP, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('user-search', 'Integration | Component | user search', {
@@ -32,7 +32,7 @@ test('input triggers search', function(assert) {
       assert.equal('user', what);
       assert.equal(100, limit);
       assert.equal('search words', q);
-      return resolve([Object.create({fullName: 'test person', email: 'testemail'})]);
+      return resolve([EmberObject.create({fullName: 'test person', email: 'testemail'})]);
     }
   });
   this.register('service:store', storeMock);
@@ -74,10 +74,10 @@ test('search for groups', function(assert) {
     }
   });
   this.register('service:store', storeMock);
-  let group1 = Object.create({
+  let group1 = EmberObject.create({
     title: 'test1'
   });
-  let group2 = Object.create({
+  let group2 = EmberObject.create({
     title: 'test2'
   });
   this.set('availableInstructorGroups', [group1, group2]);
@@ -93,7 +93,7 @@ test('search for groups', function(assert) {
 });
 
 test('click user fires add user', function(assert) {
-  let user1 = Object.create({
+  let user1 = EmberObject.create({
     fullName: 'test person',
     email: 'testemail'
   });
@@ -125,7 +125,7 @@ test('click group fires add group', function(assert) {
   });
   this.register('service:store', storeMock);
 
-  let group1 = Object.create({
+  let group1 = EmberObject.create({
     title: 'test1'
   });
   this.on('action', function(group){

--- a/tests/integration/components/visualizer-course-objectives-test.js
+++ b/tests/integration/components/visualizer-course-objectives-test.js
@@ -2,14 +2,14 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 moduleForComponent('visualizer-course-objectives', 'Integration | Component | visualizer course objectives', {
   integration: true
 });
 
 test('it renders', function(assert) {
-  const course = Object.create({
+  const course = EmberObject.create({
     title: 'test'
   });
   this.set('course', course);

--- a/tests/integration/components/week-glance-session-attrs-test.js
+++ b/tests/integration/components/week-glance-session-attrs-test.js
@@ -5,7 +5,7 @@ import initializer from "ilios/instance-initializers/ember-i18n";
 import wait from 'ember-test-helpers/wait';
 
 
-const { RSVP, Service, Object } = Ember;
+const { RSVP, Service, Object:EmberObject } = Ember;
 const { resolve } = RSVP;
 
 moduleForComponent('week-glance-session-attrs', 'Integration | Component | week glance session attrs', {
@@ -18,11 +18,11 @@ moduleForComponent('week-glance-session-attrs', 'Integration | Component | week 
 test('it renders', async function(assert) {
   assert.expect(4);
 
-  const mockEvent = Object.create({});
+  const mockEvent = EmberObject.create({});
   const userEventsMock = Service.extend({
-    getSessionForEvent(event){
-      assert.equal(event, mockEvent);
-      let mockSession = Object.create({
+    getSessionForEvent(e){
+      assert.equal(e, mockEvent);
+      let mockSession = EmberObject.create({
         attireRequired: true,
         equipmentRequired: true,
         attendanceRequired: true,
@@ -46,11 +46,11 @@ test('it renders', async function(assert) {
 test('only show applicable session attributes', async function(assert) {
   assert.expect(4);
 
-  const mockEvent = Object.create({});
+  const mockEvent = EmberObject.create({});
   const userEventsMock = Service.extend({
-    getSessionForEvent(event){
-      assert.equal(event, mockEvent);
-      let mockSession = Object.create({
+    getSessionForEvent(e){
+      assert.equal(e, mockEvent);
+      let mockSession = EmberObject.create({
         attireRequired: true,
         equipmentRequired: false,
         attendanceRequired: false,

--- a/tests/integration/components/week-glance-test.js
+++ b/tests/integration/components/week-glance-test.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 import initializer from "ilios/instance-initializers/ember-i18n";
 import wait from 'ember-test-helpers/wait';
 
-const { Object, RSVP, Service } = Ember;
+const { Object:EmberObject, RSVP, Service } = Ember;
 const { resolve } = RSVP;
 
 const today = moment();
@@ -82,14 +82,14 @@ const userEventsMock = Service.extend({
     return new resolve(mockEvents);
   },
   getSessionForEvent() {
-    return Object.create({
+    return EmberObject.create({
       attireRequired: false,
       equipmentRequired: false,
       attendanceRequired: false,
     });
   }
 });
-const blankEventsMock = Service.extend({
+let blankEventsMock = Service.extend({
   getEvents(){
     return new resolve([]);
   }
@@ -305,7 +305,7 @@ test('changing passed properties re-renders', async function(assert) {
   assert.expect(10);
   const nextYear = today.clone().add(1, 'year');
   let count = 1;
-  const blankEventsMock = Service.extend({
+  blankEventsMock = Service.reopen({
     getEvents(fromStamp, toStamp){
       const from = moment(fromStamp, 'X');
       const to = moment(toStamp, 'X');

--- a/tests/unit/mixins/sortable-by-position-test.js
+++ b/tests/unit/mixins/sortable-by-position-test.js
@@ -1,28 +1,28 @@
 import Ember from 'ember';
 import SortableByPositionMixin from 'ilios/mixins/sortable-by-position';
 import { module, test } from 'qunit';
-const { Object } = Ember;
+const { Object:EmberObject } = Ember;
 
 module('Unit | Mixin | sortable by position');
 
 test('position sorting callback', function(assert) {
-  const SortableByPositionObject = Object.extend(SortableByPositionMixin);
+  const SortableByPositionObject = EmberObject.extend(SortableByPositionMixin);
   const subject = SortableByPositionObject.create();
 
-  const obj1 = Object.create({
+  const obj1 = EmberObject.create({
     id: 1,
     position: 3,
   });
 
-  const obj2 = Object.create({
+  const obj2 = EmberObject.create({
     id: 2,
     position: 2,
   });
-  const obj3 = Object.create({
+  const obj3 = EmberObject.create({
     id: 3,
     position: 1,
   });
-  const obj4 = Object.create({
+  const obj4 = EmberObject.create({
     id: 4,
     position: 2
   });

--- a/tests/unit/models/curriculum-inventory-sequence-block-test.js
+++ b/tests/unit/models/curriculum-inventory-sequence-block-test.js
@@ -16,13 +16,13 @@ test('get all ancestors of nested sequence block', function(assert) {
   let model = this.subject();
   let store = this.store();
   Ember.run(() => {
-    let parent = store.createRecord('curriculumInventorySequenceBlock', { 'children': [ model ] });
-    let grandParent = store.createRecord('curriculumInventorySequenceBlock', { 'children': [ parent ] });
-    parent.set('parent', grandParent);
-    model.set('parent', parent);
+    let parentBlock = store.createRecord('curriculumInventorySequenceBlock', { 'children': [ model ] });
+    let grandParent = store.createRecord('curriculumInventorySequenceBlock', { 'children': [ parentBlock ] });
+    parentBlock.set('parent', grandParent);
+    model.set('parent', parentBlock);
     model.get('allParents').then(ancestors => {
       assert.equal(ancestors.length, 2);
-      assert.equal(ancestors[0], parent);
+      assert.equal(ancestors[0], parentBlock);
       assert.equal(ancestors[1], grandParent);
     });
   });

--- a/tests/unit/models/ilm-session-test.js
+++ b/tests/unit/models/ilm-session-test.js
@@ -29,19 +29,19 @@ test('check allInstructors', function(assert) {
     model.get('instructors').pushObject(user1);
     model.get('instructorGroups').pushObject(instructorGroup);
 
-    return model.get('allInstructors').then(instructors => {
-      assert.equal(instructors.length, 2);
-      assert.ok(instructors.includes(user1));
-      assert.ok(instructors.includes(user2));
+    return model.get('allInstructors').then(allInstructors => {
+      assert.equal(allInstructors.length, 2);
+      assert.ok(allInstructors.includes(user1));
+      assert.ok(allInstructors.includes(user2));
 
       return instructorGroup.get('users').then(users =>{
         let user3 = store.createRecord('user');
         users.pushObject(user3);
-        return model.get('allInstructors').then(instructors => {
-          assert.equal(instructors.length, 3);
-          assert.ok(instructors.includes(user1));
-          assert.ok(instructors.includes(user2));
-          assert.ok(instructors.includes(user3));
+        return model.get('allInstructors').then(allInstructors2 => {
+          assert.equal(allInstructors2.length, 3);
+          assert.ok(allInstructors2.includes(user1));
+          assert.ok(allInstructors2.includes(user2));
+          assert.ok(allInstructors2.includes(user3));
         });
       });
 

--- a/tests/unit/models/learner-group-test.js
+++ b/tests/unit/models/learner-group-test.js
@@ -124,24 +124,24 @@ test('check allDescendantUsers', function(assert) {
     let subGroup2 = store.createRecord('learner-group', {users: [user3]});
     learnerGroup.get('children').pushObjects([subGroup1, subGroup2]);
 
-    return learnerGroup.get('allDescendantUsers').then(users => {
-      assert.equal(users.length, 3);
-      assert.ok(users.includes(user1));
-      assert.ok(users.includes(user2));
-      assert.ok(users.includes(user3));
+    return learnerGroup.get('allDescendantUsers').then(allDescendantUsers => {
+      assert.equal(allDescendantUsers.length, 3);
+      assert.ok(allDescendantUsers.includes(user1));
+      assert.ok(allDescendantUsers.includes(user2));
+      assert.ok(allDescendantUsers.includes(user3));
       let user4 = store.createRecord('user');
       let user5 = store.createRecord('user');
       learnerGroup.get('users').pushObject(user4);
       let subGroup3 = store.createRecord('learner-group', {users: [user5]});
       learnerGroup.get('children').pushObject(subGroup3);
 
-      return learnerGroup.get('allDescendantUsers').then(users => {
-        assert.equal(users.length, 5);
-        assert.ok(users.includes(user1));
-        assert.ok(users.includes(user2));
-        assert.ok(users.includes(user3));
-        assert.ok(users.includes(user4));
-        assert.ok(users.includes(user5));
+      return learnerGroup.get('allDescendantUsers').then(allDescendantUsers2 => {
+        assert.equal(allDescendantUsers2.length, 5);
+        assert.ok(allDescendantUsers2.includes(user1));
+        assert.ok(allDescendantUsers2.includes(user2));
+        assert.ok(allDescendantUsers2.includes(user3));
+        assert.ok(allDescendantUsers2.includes(user4));
+        assert.ok(allDescendantUsers2.includes(user5));
       });
 
     });
@@ -187,11 +187,11 @@ test('check subgroupNumberingOffset', function(assert) {
       assert.equal(offset, 1); // no subgroups. offset is 1.
       store.createRecord('learner-group', {parent: learnerGroup, title: groupTitle + ' 1' });
       store.createRecord('learner-group', {parent: learnerGroup, title: groupTitle + ' 3' });
-      learnerGroup.get('subgroupNumberingOffset').then((offset) => {
-        assert.equal(offset, 4); // highest number is 3. 3 + 1 = 4. offset is 4.
+      learnerGroup.get('subgroupNumberingOffset').then(subgroupNumberingOffset => {
+        assert.equal(subgroupNumberingOffset, 4); // highest number is 3. 3 + 1 = 4. offset is 4.
         store.createRecord('learner-group', {parent: learnerGroup, title: 'not the parent title 4' });
-        learnerGroup.get('subgroupNumberingOffset').then((offset) => {
-          assert.equal(offset, 4); // subgroup with title-mismatch is ignored, offset is still 4.
+        learnerGroup.get('subgroupNumberingOffset').then(subgroupNumberingOffset2 => {
+          assert.equal(subgroupNumberingOffset2, 4); // subgroup with title-mismatch is ignored, offset is still 4.
         });
       });
     });
@@ -214,24 +214,24 @@ test('check allinstructors', function(assert) {
     let instructorGroup2 = store.createRecord('instructor-group', {users: [user3]});
     learnerGroup.get('instructorGroups').pushObjects([instructorGroup1, instructorGroup2]);
 
-    return learnerGroup.get('allInstructors').then(users => {
-      assert.equal(users.length, 3);
-      assert.ok(users.includes(user1));
-      assert.ok(users.includes(user2));
-      assert.ok(users.includes(user3));
+    return learnerGroup.get('allInstructors').then(allInstructors => {
+      assert.equal(allInstructors.length, 3);
+      assert.ok(allInstructors.includes(user1));
+      assert.ok(allInstructors.includes(user2));
+      assert.ok(allInstructors.includes(user3));
       let user4 = store.createRecord('user');
       let user5 = store.createRecord('user');
       learnerGroup.get('instructors').pushObject(user4);
       let instructorGroup3 = store.createRecord('instructor-group', {users: [user5]});
       learnerGroup.get('instructorGroups').pushObject(instructorGroup3);
 
-      return learnerGroup.get('allInstructors').then(users => {
-        assert.equal(users.length, 5);
-        assert.ok(users.includes(user1));
-        assert.ok(users.includes(user2));
-        assert.ok(users.includes(user3));
-        assert.ok(users.includes(user4));
-        assert.ok(users.includes(user5));
+      return learnerGroup.get('allInstructors').then(allInstructors2 => {
+        assert.equal(allInstructors2.length, 5);
+        assert.ok(allInstructors2.includes(user1));
+        assert.ok(allInstructors2.includes(user2));
+        assert.ok(allInstructors2.includes(user3));
+        assert.ok(allInstructors2.includes(user4));
+        assert.ok(allInstructors2.includes(user5));
       });
 
     });
@@ -250,11 +250,11 @@ test('check allParents', function(assert) {
     let subGroup2 = store.createRecord('learner-group', {parent: subGroup1});
     let subGroup3 = store.createRecord('learner-group', {parent: subGroup2});
 
-    return subGroup3.get('allParents').then(groups => {
-      assert.equal(groups.length, 3);
-      assert.equal(groups[0], subGroup2);
-      assert.equal(groups[1], subGroup1);
-      assert.equal(groups[2], learnerGroup);
+    return subGroup3.get('allParents').then(allParents => {
+      assert.equal(allParents.length, 3);
+      assert.equal(allParents[0], subGroup2);
+      assert.equal(allParents[1], subGroup1);
+      assert.equal(allParents[2], learnerGroup);
     });
   });
 });
@@ -358,13 +358,13 @@ test('check removeUserFromGroupAndAllDescendants', function(assert) {
     let subGroup3 = store.createRecord('learner-group', {parent: subGroup2, users: [user1]});
     let subGroup4 = store.createRecord('learner-group', {parent: subGroup1});
 
-    return subGroup1.removeUserFromGroupAndAllDescendants(user1).then(groups => {
-      assert.equal(groups.length, 3);
-      assert.notOk(groups.includes(learnerGroup));
-      assert.ok(groups.includes(subGroup1));
-      assert.ok(groups.includes(subGroup2));
-      assert.ok(groups.includes(subGroup3));
-      assert.notOk(groups.includes(subGroup4));
+    return subGroup1.removeUserFromGroupAndAllDescendants(user1).then(groupsToRemove => {
+      assert.equal(groupsToRemove.length, 3);
+      assert.notOk(groupsToRemove.includes(learnerGroup));
+      assert.ok(groupsToRemove.includes(subGroup1));
+      assert.ok(groupsToRemove.includes(subGroup2));
+      assert.ok(groupsToRemove.includes(subGroup3));
+      assert.notOk(groupsToRemove.includes(subGroup4));
     });
   });
 });
@@ -384,13 +384,13 @@ test('check addUserToGroupAndAllParents', function(assert) {
     let subGroup3 = store.createRecord('learner-group', {id: 3, parent: subGroup2});
     let subGroup4 = store.createRecord('learner-group', {id: 4, parent: subGroup1});
 
-    return subGroup3.addUserToGroupAndAllParents(user1).then(groups => {
-      assert.equal(groups.length, 3);
-      assert.ok(groups.includes(learnerGroup));
-      assert.notOk(groups.includes(subGroup1));
-      assert.ok(groups.includes(subGroup2));
-      assert.ok(groups.includes(subGroup3));
-      assert.notOk(groups.includes(subGroup4));
+    return subGroup3.addUserToGroupAndAllParents(user1).then(groupsToAdd => {
+      assert.equal(groupsToAdd.length, 3);
+      assert.ok(groupsToAdd.includes(learnerGroup));
+      assert.notOk(groupsToAdd.includes(subGroup1));
+      assert.ok(groupsToAdd.includes(subGroup2));
+      assert.ok(groupsToAdd.includes(subGroup3));
+      assert.notOk(groupsToAdd.includes(subGroup4));
     });
   });
 });

--- a/tests/unit/models/offering-test.js
+++ b/tests/unit/models/offering-test.js
@@ -30,24 +30,24 @@ test('check allinstructors', function(assert) {
     let instructorGroup2 = store.createRecord('instructor-group', {users: [user3]});
     offering.get('instructorGroups').pushObjects([instructorGroup1, instructorGroup2]);
 
-    return offering.get('allInstructors').then(users => {
-      assert.equal(users.length, 3);
-      assert.ok(users.includes(user1));
-      assert.ok(users.includes(user2));
-      assert.ok(users.includes(user3));
+    return offering.get('allInstructors').then(allInstructors => {
+      assert.equal(allInstructors.length, 3);
+      assert.ok(allInstructors.includes(user1));
+      assert.ok(allInstructors.includes(user2));
+      assert.ok(allInstructors.includes(user3));
       let user4 = store.createRecord('user');
       let user5 = store.createRecord('user');
       offering.get('instructors').pushObject(user4);
       let instructorGroup3 = store.createRecord('instructor-group', {users: [user5]});
       offering.get('instructorGroups').pushObject(instructorGroup3);
 
-      return offering.get('allInstructors').then(users => {
-        assert.equal(users.length, 5);
-        assert.ok(users.includes(user1));
-        assert.ok(users.includes(user2));
-        assert.ok(users.includes(user3));
-        assert.ok(users.includes(user4));
-        assert.ok(users.includes(user5));
+      return offering.get('allInstructors').then(allInstructors2 => {
+        assert.equal(allInstructors2.length, 5);
+        assert.ok(allInstructors2.includes(user1));
+        assert.ok(allInstructors2.includes(user2));
+        assert.ok(allInstructors2.includes(user3));
+        assert.ok(allInstructors2.includes(user4));
+        assert.ok(allInstructors2.includes(user5));
       });
 
     });

--- a/tests/unit/serializers/curriculum-inventory-export-test.js
+++ b/tests/unit/serializers/curriculum-inventory-export-test.js
@@ -38,13 +38,13 @@ test('it removes all non postable fields', function(assert) {
   var store = this.store();
   Ember.run(()=> {
     var now = new Date();
-    var document = 'lorem ipsum';
+    var doc = 'lorem ipsum';
     var user = store.createRecord('user', {});
     record.set('createdAt', now);
-    record.set('document', document);
+    record.set('document', doc);
     record.set('createdBy', user);
     assert.equal(record.get('createdAt'), now);
-    assert.equal(record.get('document'), document);
+    assert.equal(record.get('document'), doc);
     record.get('createdBy').then(creator => {
       assert.equal(user, creator);
     });


### PR DESCRIPTION
This is mainly needed for an update to babel6 which doesn't play well with us shadowing the global `Object`.  But I cleaned up all of our other shadows as well.