### PR TITLE
Add logic to detect and turn off labels when resized for icons

### DIFF
--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -77,7 +77,7 @@ export default Component.extend({
       leftScale.call(axisLeft(y))
       .selectAll("text")
       .attr("x", -8)
-      .attr("y", y(y.ticks(10).pop()) + 0)
+      .attr("y", y(y.ticks(1).pop()) + 0.5)
       .attr("dy", "0.35em")
       .attr("text-anchor", "end")
       .attr("fill", "#000");

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -20,7 +20,7 @@ export default Component.extend({
   height: null,
   draw(){
     const data = get(this, 'data');
-    const dataOrArray = data?data:[];
+    const dataOrArray = data?data:[{data: 1, label: '', empty: true}];
     const svg = select(this.element);
     const width = get(this, 'width');
     const height = get(this, 'height');
@@ -30,15 +30,16 @@ export default Component.extend({
     const color = scaleOrdinal(schemeCategory10);
 
     const x = scaleBand().range([0, chartWidth]).padding(0.4);
+    x.domain(dataOrArray.map(d => d.label));
+
     svg.attr('style', 'width:' + width +'px;height:' + height +'px;');
 
     if (dataOrArray.length === 0) {
       return;
     }
 
-    x.domain(dataOrArray.map(d => d.label));
-
     const container = svg.append('g').attr('transform', "translate(" + margin.left + "," + margin.top + ")");
+
     let chartHeight = height;
 
     if (!isIcon) {

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -67,12 +67,6 @@ export default Component.extend({
     bottomScale.attr("transform", "translate(0," + chartHeight + ")");
 
     if (!isIcon) {
-      container.append("text")
-      .attr("transform", "translate(" + (chartWidth/20) + " ," + (chartHeight + margin.top + 20) + ")")
-      .style("text-anchor", "end")
-      .attr("font", "10px")
-      .text("Label");
-
       container.append("g").call(axisLeft(y))
       .selectAll("text")
       .attr("x", -8)

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -72,13 +72,14 @@ export default Component.extend({
     y.domain([0, max(dataOrArray, d => d.total)]);
 
     if (!isIcon) {
-      const leftScale = container.append("g").call(axisLeft(y));
-      leftScale.selectAll("text")
+      const leftScale = container.append("g");
+      leftScale.call(axisLeft(y))
+      .selectAll("text")
       .attr("x", -8)
-      .attr("y", y(y.ticks(10).pop()) + 0.5)
+      .attr("y", y(y.ticks(10).pop()) + 0)
       .attr("dy", "0.35em")
-      .attr("fill", "#000")
-      .style("text-anchor", "end");
+      .attr("text-anchor", "end")
+      .attr("fill", "#000");
     }
 
     container.selectAll('.bar').data(dataOrArray).enter()

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -27,6 +27,7 @@ export default Component.extend({
     const height = get(this, 'height');
     const chartWidth = width - margin.left - margin.right;
     const color = scaleOrdinal(schemeCategory10);
+    const isIcon = width < 100 || height < 100;
 
     const x = scaleBand().range([0, chartWidth]).padding(0.4);
 
@@ -40,12 +41,15 @@ export default Component.extend({
     const container = svg.append('g').attr('transform', "translate(" + margin.left + "," + margin.top + ")");
 
     const bottomScale = container.append("g").call(axisBottom(x));
-    const labels = bottomScale.selectAll("text")
+    const labels = bottomScale
+    if (!isIcon) {
+      bottomScale.selectAll("text")
       .attr("y", 0)
       .attr("x", 9)
       .attr("dy", ".35em")
       .attr("transform", "rotate(75)")
       .style("text-anchor", "start");
+    }
 
     // This loop will figure out the tallest bottom label height,
     // so that it can be substracted to
@@ -62,6 +66,7 @@ export default Component.extend({
     y.domain([0, max(dataOrArray, d => d.total)]);
     bottomScale.attr("transform", "translate(0," + chartHeight + ")");
 
+    if (!isIcon) {
     container.append("text")
       .attr("transform", "translate(" + (chartWidth/20) + " ," + (chartHeight + margin.top + 20) + ")")
       .style("text-anchor", "end")
@@ -75,6 +80,7 @@ export default Component.extend({
       .attr("dy", "0.35em")
       .attr("text-anchor", "end")
       .attr("fill", "#000");
+    }
 
     container.selectAll('.bar').data(dataOrArray).enter()
       .append('rect')

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -43,10 +43,11 @@ export default Component.extend({
     let chartHeight = height;
 
     if (!isIcon) {
-      const bottomScale = container.append("g").call(axisBottom(x));
+      const bottomScale = container.append("g");
       const labels = bottomScale;
       if (!isIcon) {
-        bottomScale.selectAll("text")
+        bottomScale.call(axisBottom(x))
+        .selectAll("text")
         .attr("y", 0)
         .attr("x", 10)
         .attr("dy", ".35em")

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -44,8 +44,8 @@ export default Component.extend({
     const labels = bottomScale;
     if (!isIcon) {
       bottomScale.selectAll("text")
-      .attr("y", 10)
-      .attr("x", 0)
+      .attr("y", 0)
+      .attr("x", 10)
       .attr("dy", ".35em")
       .attr("transform", "rotate(75)")
       .style("text-anchor", "start");
@@ -71,9 +71,9 @@ export default Component.extend({
     const y = scaleLinear().range([chartHeight, 0]);
     y.domain([0, max(dataOrArray, d => d.total)]);
 
-    container.append("g").call(axisLeft(y));
+
     if (!isIcon) {
-      container.selectAll("text")
+    container.append("g").call(axisLeft(y)).selectAll("text")
       .attr("x", -8)
       .attr("y", y(y.ticks(10).pop()) + 0.5)
       .attr("dy", "0.35em")

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -63,7 +63,7 @@ export default Component.extend({
 
     let chartHeight = height - margin.top - margin.bottom - maxLabelHeight;
     if (isIcon) {
-     chartHeight = height;
+      chartHeight = height;
     }
 
     bottomScale.attr("transform", "translate(0," + chartHeight + ")");
@@ -71,9 +71,9 @@ export default Component.extend({
     const y = scaleLinear().range([chartHeight, 0]);
     y.domain([0, max(dataOrArray, d => d.total)]);
 
+    container.append("g").call(axisLeft(y));
     if (!isIcon) {
-    container.append("g").call(axisLeft(y))
-      .selectAll("text")
+     container.selectAll("text")
       .attr("x", -8)
       .attr("y", y(y.ticks(10).pop()) + 0.5)
       .attr("dy", "0.35em")

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -38,6 +38,7 @@ export default Component.extend({
     }
 
     x.domain(dataOrArray.map(d => d.label));
+
     const container = svg.append('g').attr('transform', "translate(" + margin.left + "," + margin.top + ")");
 
     const bottomScale = container.append("g").call(axisBottom(x));
@@ -71,14 +72,14 @@ export default Component.extend({
     const y = scaleLinear().range([chartHeight, 0]);
     y.domain([0, max(dataOrArray, d => d.total)]);
 
-
     if (!isIcon) {
-    container.append("g").call(axisLeft(y)).selectAll("text")
+      container.append("g").call(axisLeft(y)).selectAll("text")
       .attr("x", -8)
       .attr("y", y(y.ticks(10).pop()) + 0.5)
       .attr("dy", "0.35em")
-      .attr("text-anchor", "end")
-      .attr("fill", "#000");
+      .attr("transform", "translate")
+      .attr("fill", "#000")
+      .style("text-anchor", "end");
     }
 
     container.selectAll('.bar').data(dataOrArray).enter()

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -44,8 +44,8 @@ export default Component.extend({
     const labels = bottomScale;
     if (!isIcon) {
       bottomScale.selectAll("text")
-      .attr("y", 0)
-      .attr("x", 10)
+      .attr("y", 10)
+      .attr("x", 0)
       .attr("dy", ".35em")
       .attr("transform", "rotate(75)")
       .style("text-anchor", "start");
@@ -73,7 +73,7 @@ export default Component.extend({
 
     container.append("g").call(axisLeft(y));
     if (!isIcon) {
-     container.selectAll("text")
+      container.selectAll("text")
       .attr("x", -8)
       .attr("y", y(y.ticks(10).pop()) + 0.5)
       .attr("dy", "0.35em")

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -30,7 +30,6 @@ export default Component.extend({
     const color = scaleOrdinal(schemeCategory10);
 
     const x = scaleBand().range([0, chartWidth]).padding(0.4);
-    console.log(isIcon);
     svg.attr('style', 'width:' + width +'px;height:' + height +'px;');
 
     if (dataOrArray.length === 0) {

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -22,12 +22,12 @@ export default Component.extend({
     const data = get(this, 'data');
     const dataOrArray = data?data:[];
     const svg = select(this.element);
-    const margin = {top: 10, right: 20, bottom: 30, left: 25};
+    const isIcon = width < 100 || height < 100;
+    const margin = isIcon ? {top: 0, right: 0, bottom: 0, left: 0} : {top: 10, right: 20, bottom: 30, left: 25};
     const width = get(this, 'width');
     const height = get(this, 'height');
     const chartWidth = width - margin.left - margin.right;
     const color = scaleOrdinal(schemeCategory10);
-    const isIcon = width < 100 || height < 100;
 
     const x = scaleBand().range([0, chartWidth]).padding(0.4);
 
@@ -45,7 +45,7 @@ export default Component.extend({
     if (!isIcon) {
       bottomScale.selectAll("text")
       .attr("y", 0)
-      .attr("x", 9)
+      .attr("x", 10)
       .attr("dy", ".35em")
       .attr("transform", "rotate(75)")
       .style("text-anchor", "start");
@@ -61,13 +61,18 @@ export default Component.extend({
       maxLabelHeight = Math.max(maxLabelHeight, Math.ceil(labelDimensions.height));
     });
 
-    const chartHeight = height - margin.top - margin.bottom - maxLabelHeight;
-    const y = scaleLinear().range([chartHeight, 0]);
-    y.domain([0, max(dataOrArray, d => d.total)]);
+    let chartHeight = height - margin.top - margin.bottom - maxLabelHeight;
+    if (isIcon) {
+     chartHeight = height;
+    }
+
     bottomScale.attr("transform", "translate(0," + chartHeight + ")");
 
+    const y = scaleLinear().range([chartHeight, 0]);
+    y.domain([0, max(dataOrArray, d => d.total)]);
+
     if (!isIcon) {
-      container.append("g").call(axisLeft(y))
+    container.append("g").call(axisLeft(y))
       .selectAll("text")
       .attr("x", -8)
       .attr("y", y(y.ticks(10).pop()) + 0.5)

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -72,12 +72,13 @@ export default Component.extend({
     const y = scaleLinear().range([chartHeight, 0]);
     y.domain([0, max(dataOrArray, d => d.total)]);
 
+    const leftScale = container.append("g").call(axisLeft(y));
+
     if (!isIcon) {
-      container.append("g").call(axisLeft(y)).selectAll("text")
+      leftScale.selectAll("text")
       .attr("x", -8)
       .attr("y", y(y.ticks(10).pop()) + 0.5)
       .attr("dy", "0.35em")
-      .attr("transform", "translate")
       .attr("fill", "#000")
       .style("text-anchor", "end");
     }
@@ -87,6 +88,7 @@ export default Component.extend({
       .attr('class', 'bar')
       .attr('x', d => x(d.label))
       .attr('y', d => y(d.total))
+      .attr("transform", "translate")
       .attr("width", x.bandwidth())
       .attr('height', d => chartHeight - y(d.total))
       .attr('fill', d =>  color(d.label));

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -20,7 +20,7 @@ export default Component.extend({
   height: null,
   draw(){
     const data = get(this, 'data');
-    const dataOrArray = data?data:[];
+    const dataOrArray = data?data:[{data: 1, label: '', empty: true}];
     const svg = select(this.element);
     const margin = {top: 10, right: 20, bottom: 30, left: 25};
     const width = get(this, 'width');

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -20,7 +20,7 @@ export default Component.extend({
   height: null,
   draw(){
     const data = get(this, 'data');
-    const dataOrArray = data?data:[{data: 1, label: '', empty: true}];
+    const dataOrArray = data?data:[];
     const svg = select(this.element);
     const margin = {top: 10, right: 20, bottom: 30, left: 25};
     const width = get(this, 'width');

--- a/app/components/chart-bar.js
+++ b/app/components/chart-bar.js
@@ -41,7 +41,7 @@ export default Component.extend({
     const container = svg.append('g').attr('transform', "translate(" + margin.left + "," + margin.top + ")");
 
     const bottomScale = container.append("g").call(axisBottom(x));
-    const labels = bottomScale
+    const labels = bottomScale;
     if (!isIcon) {
       bottomScale.selectAll("text")
       .attr("y", 0)
@@ -67,13 +67,13 @@ export default Component.extend({
     bottomScale.attr("transform", "translate(0," + chartHeight + ")");
 
     if (!isIcon) {
-    container.append("text")
+      container.append("text")
       .attr("transform", "translate(" + (chartWidth/20) + " ," + (chartHeight + margin.top + 20) + ")")
       .style("text-anchor", "end")
       .attr("font", "10px")
       .text("Label");
 
-    container.append("g").call(axisLeft(y))
+      container.append("g").call(axisLeft(y))
       .selectAll("text")
       .attr("x", -8)
       .attr("y", y(y.ticks(10).pop()) + 0.5)

--- a/app/components/chart-horz-bar.js
+++ b/app/components/chart-horz-bar.js
@@ -43,7 +43,7 @@ export default Component.extend({
       leftScale = container.append("g").call(axisLeft(y));
     }
 
-    let labels = leftScale
+    let labels = leftScale;
     if (!isIcon) {
       labels.selectAll("text")
         .attr("y", 0)
@@ -61,9 +61,9 @@ export default Component.extend({
 
     svg.attr('style', 'width:' + width +'px;height:' + maxLabelLeftPosition +'px;');
 
-    let bottomScale = container;
+    let bottomScale = container.append("g");
     if (!isIcon) {
-      bottomScale = container.append("g").call(axisBottom(x))
+      bottomScale = bottomScale.call(axisBottom(x))
         .attr("transform", "translate(0," + chartHeight + ")")
         .selectAll("text")
         .attr("x", x(x.ticks(10).pop()) + 0)
@@ -71,7 +71,7 @@ export default Component.extend({
         .attr("dy", "0.35em")
         .attr("text-anchor", "end")
         .attr("fill", "#000");
-      }
+    }
 
     container.selectAll('.bar').data(dataOrArray).enter()
       .append('rect')

--- a/app/components/chart-horz-bar.js
+++ b/app/components/chart-horz-bar.js
@@ -61,9 +61,9 @@ export default Component.extend({
 
     svg.attr('style', 'width:' + width +'px;height:' + maxLabelLeftPosition +'px;');
 
-    let bottomScale = container.append("g");
+    const bottomScale = container.append("g");
     if (!isIcon) {
-      bottomScale = bottomScale.call(axisBottom(x))
+      bottomScale.call(axisBottom(x))
         .attr("transform", "translate(0," + chartHeight + ")")
         .selectAll("text")
         .attr("x", x(x.ticks(10).pop()) + 0)

--- a/app/components/chart-horz-bar.js
+++ b/app/components/chart-horz-bar.js
@@ -58,14 +58,14 @@ export default Component.extend({
       const labelDimensions = currentLabel.getBoundingClientRect();
       maxLabelLeftPosition = Math.max(maxLabelLeftPosition, chartWidth + labelDimensions.width + margin.left);
     });
-  
+
     svg.attr('style', 'width:' + width +'px;height:' + maxLabelLeftPosition +'px;');
     if (!isIcon) {
       const bottomScale = container.append("g");
       bottomScale.call(axisBottom(x))
         .attr("transform", "translate(0," + chartHeight + ")")
         .selectAll("text")
-        .attr("x", x(x.ticks(10).pop()) + 0)
+        .attr("x", x(x.ticks(1).pop()) + 0.5)
         .attr("y", 16)
         .attr("dy", "0.35em")
         .attr("text-anchor", "end")

--- a/app/components/chart-horz-bar.js
+++ b/app/components/chart-horz-bar.js
@@ -58,7 +58,7 @@ export default Component.extend({
       const labelDimensions = currentLabel.getBoundingClientRect();
       maxLabelLeftPosition = Math.max(maxLabelLeftPosition, chartWidth + labelDimensions.width + margin.left);
     });
-
+  
     svg.attr('style', 'width:' + width +'px;height:' + maxLabelLeftPosition +'px;');
     if (!isIcon) {
       const bottomScale = container.append("g");

--- a/app/components/chart-horz-bar.js
+++ b/app/components/chart-horz-bar.js
@@ -22,13 +22,13 @@ export default Component.extend({
     const data = get(this, 'data');
     const dataOrArray = data?data:[{data: 1, label: '', empty: true}];
     const svg = select(this.element);
-    const margin = {top: 10, right: 20, bottom: 30, left: 25};
     const width = get(this, 'width');
     const height = get(this, 'height');
+    const isIcon = width < 100 || height < 100;
+    const margin = isIcon ? {top: 0, right: 0, bottom: 0, left: 0} : {top: 10, right: 20, bottom: 30, left: 25};
     const chartWidth = width - margin.left - margin.right;
     const chartHeight = height - margin.top - margin.bottom;
     const color = scaleOrdinal(schemeCategory10);
-    const isIcon = width < 100 || height < 100;
 
     const x = scaleLinear().range([chartWidth, 0]);
     const y = scaleBand().range([0, chartHeight]).padding(0.4);
@@ -60,9 +60,8 @@ export default Component.extend({
     });
 
     svg.attr('style', 'width:' + width +'px;height:' + maxLabelLeftPosition +'px;');
-
-    const bottomScale = container.append("g");
     if (!isIcon) {
+      const bottomScale = container.append("g");
       bottomScale.call(axisBottom(x))
         .attr("transform", "translate(0," + chartHeight + ")")
         .selectAll("text")

--- a/app/components/chart-horz-bar.js
+++ b/app/components/chart-horz-bar.js
@@ -28,6 +28,7 @@ export default Component.extend({
     const chartWidth = width - margin.left - margin.right;
     const chartHeight = height - margin.top - margin.bottom;
     const color = scaleOrdinal(schemeCategory10);
+    const isIcon = width < 100 || height < 100;
 
     const x = scaleLinear().range([chartWidth, 0]);
     const y = scaleBand().range([0, chartHeight]).padding(0.4);
@@ -37,13 +38,19 @@ export default Component.extend({
 
     const container = svg.append('g').attr('transform', "translate(" + margin.left + "," + margin.top + ")");
 
-    const leftScale = container.append("g").call(axisLeft(y));
-    const labels = leftScale.selectAll("text")
-      .attr("y", 0)
-      .attr("x", -8)
-      .attr("dy", "0.35em")
-      .attr("fill", "#000")
-      .style("text-anchor", "end");
+    let leftScale = container;
+    if (!isIcon) {
+      leftScale = container.append("g").call(axisLeft(y));
+    }
+
+    let labels = leftScale
+    if (!isIcon) {
+      labels.selectAll("text")
+        .attr("y", 0)
+        .attr("x", -8)
+        .attr("dy", "0.35em")
+        .style("text-anchor", "end");
+    }
 
     let maxLabelLeftPosition = width;
     labels.each(function(label, index, allLabels) {
@@ -54,14 +61,17 @@ export default Component.extend({
 
     svg.attr('style', 'width:' + width +'px;height:' + maxLabelLeftPosition +'px;');
 
-    const bottomScale = container.append("g").call(axisBottom(x));
-    bottomScale.attr("transform", "translate(0," + chartHeight + ")")
-      .selectAll("text")
-      .attr("x", x(x.ticks(10).pop()) + 0)
-      .attr("y", 16)
-      .attr("dy", "0.35em")
-      .attr("text-anchor", "end")
-      .attr("fill", "#000");
+    let bottomScale = container;
+    if (!isIcon) {
+      bottomScale = container.append("g").call(axisBottom(x))
+        .attr("transform", "translate(0," + chartHeight + ")")
+        .selectAll("text")
+        .attr("x", x(x.ticks(10).pop()) + 0)
+        .attr("y", 16)
+        .attr("dy", "0.35em")
+        .attr("text-anchor", "end")
+        .attr("fill", "#000");
+      }
 
     container.selectAll('.bar').data(dataOrArray).enter()
       .append('rect')

--- a/app/components/chart-line.js
+++ b/app/components/chart-line.js
@@ -58,16 +58,16 @@ export default Component.extend({
       .attr("transform", "translate(0," + chartHeight + ")").call(axisBottom(x));
 
     if (!isIcon) {
-    container.append("text")
+      container.append("text")
       .attr("transform", "translate(" + (chartWidth/2) + " ," + (chartHeight + margin.top + 20) + ")")
       .style("text-anchor", "middle")
       .text("Label");
     }
 
     if (!isIcon) {
-    container.append("g").call(axisLeft(y).tickFormat(format(".0%")));
+      container.append("g").call(axisLeft(y).tickFormat(format(".0%")));
 
-    container.append("text")
+      container.append("text")
       .attr("transform", "rotate(-90)")
       .attr("y", 20 - margin.right)
       .attr("x", 0 - (chartHeight / 8))

--- a/app/components/chart-line.js
+++ b/app/components/chart-line.js
@@ -50,7 +50,7 @@ export default Component.extend({
     const container = svg.append('g').attr('transform', "translate(" + margin.left + "," + margin.top + ")");
 
     container.append("g").attr("transform", "translate(0," + chartHeight + ")").call(axisBottom(x));
-    
+
     container.append("path")
       .data([dataOrArray])
       .attr("class", "line")
@@ -63,9 +63,8 @@ export default Component.extend({
       .text("Label");
     }
 
-    container.append("g").call(axisLeft(y).tickFormat(format(".0%")));
-
     if (!isIcon) {
+      container.append("g").call(axisLeft(y).tickFormat(format(".0%")));
       container.append("text")
       .attr("transform", "rotate(-90)")
       .attr("y", 20 - margin.right)

--- a/app/components/chart-line.js
+++ b/app/components/chart-line.js
@@ -24,12 +24,12 @@ export default Component.extend({
     const data = get(this, 'data');
     const dataOrArray = data?data:[{data: 1, label: '', empty: true}];
     const svg = select(this.element);
-    const margin = {top: 20, right: 20, bottom: 50, left: 30};
     const width = get(this, 'width');
     const height = get(this, 'height');
+    const isIcon = width < 100 || height < 100;
+    const margin = isIcon ? {top: 0, right: 0, bottom: 0, left: 0} : {top: 10, right: 20, bottom: 30, left: 25};
     const chartWidth = width - margin.left - margin.right;
     const chartHeight = height - margin.top - margin.bottom;
-    const isIcon = width < 100 || height < 100;
 
     const x = scaleLinear().range([0, chartWidth]);
     const y = scaleLinear().range([chartHeight, 0]);
@@ -49,13 +49,12 @@ export default Component.extend({
 
     const container = svg.append('g').attr('transform', "translate(" + margin.left + "," + margin.top + ")");
 
+    container.append("g").attr("transform", "translate(0," + chartHeight + ")").call(axisBottom(x));
+    
     container.append("path")
       .data([dataOrArray])
       .attr("class", "line")
       .attr("d", valueline);
-
-    container.append("g")
-      .attr("transform", "translate(0," + chartHeight + ")").call(axisBottom(x));
 
     if (!isIcon) {
       container.append("text")
@@ -64,9 +63,9 @@ export default Component.extend({
       .text("Label");
     }
 
-    if (!isIcon) {
-      container.append("g").call(axisLeft(y).tickFormat(format(".0%")));
+    container.append("g").call(axisLeft(y).tickFormat(format(".0%")));
 
+    if (!isIcon) {
       container.append("text")
       .attr("transform", "rotate(-90)")
       .attr("y", 20 - margin.right)

--- a/app/components/chart-line.js
+++ b/app/components/chart-line.js
@@ -22,13 +22,14 @@ export default Component.extend({
   height: null,
   draw(){
     const data = get(this, 'data');
-    const dataOrArray = data?data:[];
+    const dataOrArray = data?data:[{data: 1, label: '', empty: true}];
     const svg = select(this.element);
     const margin = {top: 20, right: 20, bottom: 50, left: 30};
     const width = get(this, 'width');
     const height = get(this, 'height');
     const chartWidth = width - margin.left - margin.right;
     const chartHeight = height - margin.top - margin.bottom;
+    const isIcon = width < 100 || height < 100;
 
     const x = scaleLinear().range([0, chartWidth]);
     const y = scaleLinear().range([chartHeight, 0]);
@@ -56,11 +57,14 @@ export default Component.extend({
     container.append("g")
       .attr("transform", "translate(0," + chartHeight + ")").call(axisBottom(x));
 
+    if (!isIcon) {
     container.append("text")
       .attr("transform", "translate(" + (chartWidth/2) + " ," + (chartHeight + margin.top + 20) + ")")
       .style("text-anchor", "middle")
       .text("Label");
+    }
 
+    if (!isIcon) {
     container.append("g").call(axisLeft(y).tickFormat(format(".0%")));
 
     container.append("text")
@@ -70,6 +74,7 @@ export default Component.extend({
       .attr("dy", "1em")
       .style("text-anchor", "start")
       .text("Value");
+    }
 
   },
 });

--- a/app/components/chart-stacked-bar.js
+++ b/app/components/chart-stacked-bar.js
@@ -83,14 +83,14 @@ export default Component.extend({
     svg.attr('style', 'width:' + width +'px;height:' + maxLabelBottomPosition +'px;');
 
     if (!isIcon) {
-    container.append("text")
+      container.append("text")
       .attr("transform", "translate(" + (chartWidth/20) + " ," + (chartHeight + margin.top + 20) + ")")
       .style("text-anchor", "end")
       .text("Label");
     }
 
     if (!isIcon) {
-    container.append("g").call(axisLeft(y))
+      container.append("g").call(axisLeft(y))
       .selectAll("text")
       .attr("x", -8)
       .attr("y", y(y.ticks(10).pop()) + 0.5)

--- a/app/components/chart-stacked-bar.js
+++ b/app/components/chart-stacked-bar.js
@@ -27,6 +27,7 @@ export default Component.extend({
     const height = get(this, 'height');
     const chartWidth = width - margin.left - margin.right;
     const chartHeight = height - margin.top - margin.bottom;
+    const isIcon = width < 100 || height < 100;
 
     const x = scaleBand().range([0, chartWidth]).padding(0.4);
     const y = scaleLinear().range([chartHeight, 0]);
@@ -62,13 +63,16 @@ export default Component.extend({
 
     const container = svg.append('g').attr('transform', "translate(" + margin.left + "," + margin.top + ")");
 
-    const labels = container.append("g").attr("transform", "translate(0," + chartHeight + ")").call(axisBottom(x))
-      .selectAll("text")
-      .attr("y", 0)
-      .attr("x", 9)
-      .attr("dy", ".35em")
-      .attr("transform", "rotate(75)")
-      .style("text-anchor", "start");
+    let labels = container;
+    if (!isIcon) {
+      labels = container.append("g").attr("transform", "translate(0," + chartHeight + ")").call(axisBottom(x))
+        .selectAll("text")
+        .attr("y", 0)
+        .attr("x", 9)
+        .attr("dy", ".35em")
+        .attr("transform", "rotate(75)")
+        .style("text-anchor", "start");
+    }
 
     let maxLabelBottomPosition = height;
     labels.each(function(label, index, allLabels) {
@@ -78,11 +82,14 @@ export default Component.extend({
     });
     svg.attr('style', 'width:' + width +'px;height:' + maxLabelBottomPosition +'px;');
 
+    if (!isIcon) {
     container.append("text")
       .attr("transform", "translate(" + (chartWidth/20) + " ," + (chartHeight + margin.top + 20) + ")")
       .style("text-anchor", "end")
       .text("Label");
+    }
 
+    if (!isIcon) {
     container.append("g").call(axisLeft(y))
       .selectAll("text")
       .attr("x", -8)
@@ -90,6 +97,7 @@ export default Component.extend({
       .attr("dy", "0.35em")
       .attr("text-anchor", "end")
       .attr("fill", "#000");
+    }
 
     container.selectAll('.bar')
       .data(stack().keys(keysList)(dataOrArray))

--- a/app/components/chart-stacked-bar.js
+++ b/app/components/chart-stacked-bar.js
@@ -22,12 +22,12 @@ export default Component.extend({
   draw(){
     const data = get(this, 'data') || [];
     const svg = select(this.element);
-    const margin = {top: 20, right: 20, bottom: 30, left: 25};
     const width = get(this, 'width');
     const height = get(this, 'height');
+    const isIcon = width < 100 || height < 100;
+    const margin = isIcon ? {top: 0, right: 0, bottom: 0, left: 0} : {top: 10, right: 20, bottom: 30, left: 25};
     const chartWidth = width - margin.left - margin.right;
     const chartHeight = height - margin.top - margin.bottom;
-    const isIcon = width < 100 || height < 100;
 
     const x = scaleBand().range([0, chartWidth]).padding(0.4);
     const y = scaleLinear().range([chartHeight, 0]);

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -366,6 +366,7 @@ export default {
     'objectives': 'Objectives',
     'objectivesTotalInstructionalTime': 'Objectives: Total Instructional Time',
     'objectivesWithNoHours': 'The following course objectives are either not linked to any session, or only linked to sessions without offering or duration data.',
+    'objectivesWithNoLink': 'No Course Objectives Currently Linked to Instructional Time.',
     'objectiveTitle': 'Session Objective',
     'off': 'Off',
     'offeredAt': 'On {{date}}',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -366,7 +366,7 @@ export default {
     'objectives': 'Objetivos',
     'objectivesTotalInstructionalTime': 'Objetivos: Tiempo de Instrucción Total',
     'objectivesWithNoHours': 'Los siguientes objetivos del curso no están vinculados a ninguna sesión, o están vinculados sólo a las sesiones sin datos de duración.',
-    'objectivesWithNoLink': 'No Course Objectives Currently Linked to Instructional Time.',
+    'objectivesWithNoLink': 'No hay objetivos del curso actualmente vinculados a tiempo de instrucción.',
     'objectiveTitle': 'Objetivos de la Sesión',
     'off': 'Apagado',
     'offeredAt': 'en {{date}}',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -366,6 +366,7 @@ export default {
     'objectives': 'Objetivos',
     'objectivesTotalInstructionalTime': 'Objetivos: Tiempo de Instrucción Total',
     'objectivesWithNoHours': 'Los siguientes objetivos del curso no están vinculados a ninguna sesión, o están vinculados sólo a las sesiones sin datos de duración.',
+    'objectivesWithNoLink': 'No Course Objectives Currently Linked to Instructional Time.',
     'objectiveTitle': 'Objetivos de la Sesión',
     'off': 'Apagado',
     'offeredAt': 'en {{date}}',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -366,6 +366,7 @@ export default {
     'objectives': "Objectifs",
     'objectivesTotalInstructionalTime': "Objectifs: Totalité du Temps d'Enseignement",
     'objectivesWithNoHours': "Les objectifs de cours suivant ne sont ou liés avec aucune séance, ou liés seulement aux séance sans offrir ou ou des données de durée.",
+    'objectivesWithNoLink': 'Nul objectifs de course actuellement lié au temps dénseignment.',
     'objectiveTitle': "Objectif de Séance",
     'off': "Éteindre",
     'offeredAt': "À {{date}}",

--- a/app/styles/newcomponents/visualizer-course-objectives.scss
+++ b/app/styles/newcomponents/visualizer-course-objectives.scss
@@ -19,6 +19,16 @@
     }
   }
 
+  .with-hours {
+    p {
+      margin-top: .5em;
+    }
+
+    .meh-o {
+      font-size: 30em;
+    }
+  }
+
   &.not-icon {
     .ilios-chart {
       @include fill-parent;
@@ -27,7 +37,8 @@
       }
     }
 
-    .zero-hours {
+    .zero-hours,
+    .with-hours {
       @include fill-parent;
       @include media($large-screen) {
         @include span-columns(6);

--- a/app/templates/components/visualizer-course-objectives.hbs
+++ b/app/templates/components/visualizer-course-objectives.hbs
@@ -11,9 +11,9 @@
     {{chart.tooltip content=donutHover.lastSuccessful.value.content title=donutHover.lastSuccessful.value.title}}
   {{/ilios-chart}}
 
-  {{else}}
+{{else}}
     <div class='with-hours'>
-      <p>No Course Objectives Currently Linked to Instructional Time.</p>
+      <p>{{t 'general.objectivesWithNoLink'}}</p>
       <h4>{{fa-icon 'meh-o' class='meh-o'}}</h4>
     </div>
 {{/if}}

--- a/app/templates/components/visualizer-course-objectives.hbs
+++ b/app/templates/components/visualizer-course-objectives.hbs
@@ -1,14 +1,22 @@
-{{#ilios-chart
-  name='donut'
-  width=width
-  height=height
-  data=(await objectiveWithHours)
-  hover=(perform donutHover)
-  leave=(perform donutHover)
-  as |chart|
-}}
-  {{chart.tooltip content=donutHover.lastSuccessful.value.content title=donutHover.lastSuccessful.value.title}}
-{{/ilios-chart}}
+{{#if (or icon (gt (get (await objectiveWithHours) 'length') 0))}}
+  {{#ilios-chart
+    name='donut'
+    width=width
+    height=height
+    data=(await objectiveWithHours)
+    hover=(perform donutHover)
+    leave=(perform donutHover)
+    as |chart|
+  }}
+    {{chart.tooltip content=donutHover.lastSuccessful.value.content title=donutHover.lastSuccessful.value.title}}
+  {{/ilios-chart}}
+
+  {{else}}
+    <div class='with-hours'>
+      <p>No Course Objectives Currently Linked to Instructional Time.</p>
+      <h4>{{fa-icon 'meh-o' class='meh-o'}}</h4>
+    </div>
+{{/if}}
 
 {{#unless (or icon (eq (get (await objectiveWithoutHours) 'length') 0))}}
   <div class='zero-hours'>

--- a/tests/integration/components/chart-line-test.js
+++ b/tests/integration/components/chart-line-test.js
@@ -1,11 +1,11 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('chart-line', 'Integration | Component | chart bar', {
+moduleForComponent('chart-line', 'Integration | Component | chart line', {
   integration: true
 });
 
 test('it renders', function(assert) {
   this.render(hbs`{{chart-line}}`);
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$().text().trim(), '0.00.20.40.60.81.01.21.41.61.82.0');
 });

--- a/tests/integration/components/chart-stacked-bar-test.js
+++ b/tests/integration/components/chart-stacked-bar-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('chart-stacked-bar', 'Integration | Component | chart bar', {
+moduleForComponent('chart-stacked-bar', 'Integration | Component | chart stacked bar', {
   integration: true
 });
 


### PR DESCRIPTION
When charts are detected at a width and height of less than 100px the labels and axes for the charts are turned off.

The labels for all charts are hidden, but only the donut/pie and line charts are rendering the "colored" elements required (see screenshot). Will continue to work on a solution for this issue.  

One option is use only one icon chart for the user to select in the Course and Session panels. 

 All charts displayed on the "dashboard" will also render on the Course and Session page as icons unless turned off.  At the moment there is empty space where the icons would appear if they were rendering correctly.

To test please drop in the following to visualizer-course-objectives.hbs

```
{{#ilios-chart
  name='donut'
  width=width
  height=height
  data=(await condensedObjectiveData)
  hover=(perform donutHover)
  leave=(perform donutHover)
  as |chart|
}}
  {{chart.tooltip content=donutHover.lastSuccessful.value.content title=donutHover.lastSuccessful.value.title}}
{{/ilios-chart}}
{{ilios-chart
  name='line'
  width=width
  height=height
  data=(await condensedObjectiveData)
}}
{{ilios-chart
  name='bar'
  width=width
  height=height
  data=(await sessionsObjectivesData)
}}
{{ilios-chart
  name='horz-bar'
  width=width
  height=height
  data=(await sessionsObjectivesData)
}}
{{ilios-chart
  name='stacked-bar'
  width=width
  height=height
  data=(await sessionsObjectivesData)
}}
```
<img width="319" alt="screen shot 2017-05-04 at 8 41 16 pm" src="https://cloud.githubusercontent.com/assets/597090/25733096/bb4d104a-310a-11e7-8d31-b6f0524533e9.png">
