### PR TITLE
Hackey fix for flaky tests

### DIFF
--- a/app/templates/components/user-profile-schools.hbs
+++ b/app/templates/components/user-profile-schools.hbs
@@ -27,9 +27,9 @@
           <td>
             {{#if isManaging}}
               {{one-way-checkbox
-                checked=(or (contains school.id (map-by 'id' (await readSchools))) (contains school.id (map-by 'id' (await writeSchools))))
+                checked=(is-in (await readAndWriteSchoolIds) school.id)
                 update=(action 'toggleReadSchool' school)
-                disabled=(contains school.id (map-by 'id' (await writeSchools)))
+                disabled=(is-in (await writeSchoolIds) school.id)
               }}
             {{else}}
               {{fa-icon

--- a/tests/integration/components/learning-materials-sort-manager-test.js
+++ b/tests/integration/components/learning-materials-sort-manager-test.js
@@ -153,8 +153,8 @@ test('save', function(assert) {
   this.set('subject', subject);
   this.on('save', function(data){
     assert.equal(data.length, clms.length);
-    assert.ok(data.contains(clm1));
-    assert.ok(data.contains(clm2));
+    assert.ok(data.includes(clm1));
+    assert.ok(data.includes(clm2));
   });
 
   this.render(hbs`{{learning-materials-sort-manager subject=subject save=(action 'save')}}`);

--- a/tests/integration/components/objective-sort-manager-test.js
+++ b/tests/integration/components/objective-sort-manager-test.js
@@ -94,8 +94,8 @@ test('save', function(assert) {
   this.set('subject', subject);
   this.on('save', function(data){
     assert.equal(data.length, objectives.length);
-    assert.ok(data.contains(objective1));
-    assert.ok(data.contains(objective2));
+    assert.ok(data.includes(objective1));
+    assert.ok(data.includes(objective2));
   });
 
   this.render(hbs`{{objective-sort-manager subject=subject save=(action 'save')}}`);

--- a/tests/integration/components/pending-updates-summary-test.js
+++ b/tests/integration/components/pending-updates-summary-test.js
@@ -7,12 +7,15 @@ const { Object:EmberObject, Service, RSVP } = Ember;
 const { resolve } = RSVP;
 
 let storeMock;
+let currentUserMock;
 
 moduleForComponent('pending-updates-summary', 'Integration | Component | pending updates summary', {
   integration: true,
   beforeEach(){
     storeMock = Service.extend({});
+    currentUserMock = Service.extend({});
     this.register('service:store', storeMock);
+    this.register('service:currentUser', currentUserMock);
   }
 });
 
@@ -30,12 +33,10 @@ test('it renders', async function(assert) {
     school: resolve(primarySchool),
     schools: resolve([primarySchool, secondarySchool])
   });
-  let currentUserMock = Service.extend({
+  currentUserMock.reopen({
     model: resolve(user)
   });
 
-
-  this.register('service:currentUser', currentUserMock);
   storeMock.reopen({
     query(what){
       assert.equal('pending-user-update', what);

--- a/tests/integration/components/user-profile-schools-test.js
+++ b/tests/integration/components/user-profile-schools-test.js
@@ -7,9 +7,23 @@ const { RSVP, Object: EmberObject, Service } = Ember;
 const { resolve } = RSVP;
 
 let user;
+let storeMock;
+let som = EmberObject.create({
+  id: '1',
+  title: 'SOM'
+});
+let sod = EmberObject.create({
+  id: '2',
+  title: 'SOD'
+});
+let sop = EmberObject.create({
+  id: '3',
+  title: 'SOP'
+});
 moduleForComponent('user-profile-schools', 'Integration | Component | user profile schools', {
   integration: true,
   beforeEach(){
+    storeMock = Service.extend({});
     let sodPermission = EmberObject.create({
       user,
       tableName: 'school',
@@ -33,29 +47,16 @@ moduleForComponent('user-profile-schools', 'Integration | Component | user profi
       }))
     });
     this.register('service:currentUser', currentUser);
+    this.register('service:store', storeMock);
   }
 });
 
-let som = EmberObject.create({
-  id: '1',
-  title: 'SOM'
-});
-let sod = EmberObject.create({
-  id: '2',
-  title: 'SOD'
-});
-let sop = EmberObject.create({
-  id: '3',
-  title: 'SOP'
-});
-
 test('it renders', function(assert) {
-  let store = Service.extend({
+  storeMock.reopen({
     findAll(){
       return resolve([som, sod, sop]);
     }
   });
-  this.register('service:store', store);
 
   this.set('user', user);
   this.render(hbs`{{user-profile-schools user=user}}`);
@@ -81,12 +82,11 @@ test('it renders', function(assert) {
 
 test('clicking manage sends the action', function(assert) {
   assert.expect(1);
-  let store = Service.extend({
+  storeMock.reopen({
     findAll(){
       return resolve([som, sod, sop]);
     }
   });
-  this.register('service:store', store);
   this.set('user', user);
   this.set('click', (what) =>{
     assert.ok(what, 'recieved boolean true value');
@@ -99,7 +99,7 @@ test('clicking manage sends the action', function(assert) {
 test('can edit user school permissions', function(assert) {
   assert.expect(16);
 
-  let store = Service.extend({
+  storeMock.reopen({
     findAll(){
       return resolve([som, sod, sop]);
     },
@@ -125,7 +125,6 @@ test('can edit user school permissions', function(assert) {
       }
     },
   });
-  this.register('service:store', store);
   this.set('user', user);
   this.set('nothing', parseInt);
 
@@ -156,17 +155,14 @@ test('can edit user school permissions', function(assert) {
   });
 });
 
-
-
-test('clicking write selects read', function(assert) {
+test('clicking write selects read', async function(assert) {
   assert.expect(6);
 
-  let store = Service.extend({
+  storeMock.reopen({
     findAll(){
       return resolve([som, sod, sop]);
     },
   });
-  this.register('service:store', store);
   this.set('user', user);
   this.set('nothing', parseInt);
 
@@ -177,27 +173,24 @@ test('clicking write selects read', function(assert) {
   const secondRowCanRead = `${secondRowPermissions} input:eq(0)`;
   const secondRowCanWrite = `${secondRowPermissions} input:eq(1)`;
 
-  return wait().then(()=>{
-    assert.ok(this.$(secondRowCanRead).not(':checked'), 'sop can not read');
-    assert.ok(this.$(secondRowCanWrite).not(':checked'), 'sop can not write');
-    assert.ok(this.$(secondRowCanRead).not(':disabled'), 'sop can not write');
+  await wait();
+  assert.ok(this.$(secondRowCanRead).not(':checked'), 'sop can not read');
+  assert.ok(this.$(secondRowCanWrite).not(':checked'), 'sop can not write');
+  assert.ok(this.$(secondRowCanRead).not(':disabled'), 'sop read is not disabled');
 
-    this.$(secondRowCanWrite).click().change();
-    return wait().then(()=>{
-      assert.ok(this.$(secondRowCanRead).is(':checked'), 'sop canRead');
-      assert.ok(this.$(secondRowCanWrite).is(':checked'), 'sop canWrite');
-      assert.ok(this.$(secondRowCanRead).is(':disabled'), 'sop read selected');
-    });
-  });
+  this.$(secondRowCanWrite).click().change();
+  await wait();
+  assert.ok(this.$(secondRowCanRead).is(':checked'), 'sop canRead');
+  assert.ok(this.$(secondRowCanWrite).is(':checked'), 'sop canWrite');
+  assert.ok(this.$(secondRowCanRead).is(':disabled'), 'sop read is disabled');
 });
 
 test('changing user modifies display #2389', async function(assert) {
-  let store = Service.extend({
+  storeMock.reopen({
     findAll(){
       return resolve([som, sod, sop]);
     }
   });
-  this.register('service:store', store);
   let user2 = EmberObject.create({
     id: 14,
     enabled: true,


### PR DESCRIPTION
When pending-updates-summary-test is run before user-profile-schools it
breaks the  clicking write selects read test. I wasn't able to come up
with a good solution, but using our 'is-in' helper and a set of computed
properties on the component resolves it for some reason.

The easiest way to see this failure is to visit http://localhost:4200/tests?testId=c2c9b934&testId=f41a6e34 which will run these two tests together.