### PR TITLE
Remove translation service from models

### DIFF
--- a/app/components/course-objective-manager.js
+++ b/app/components/course-objective-manager.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
 
-const { Component, computed, isEmpty, Object:EmberObject, ObjectProxy, RSVP } = Ember;
-const { all, Promise } = RSVP;
+const { Component, computed, inject, isEmpty, Object:EmberObject, ObjectProxy, RSVP } = Ember;
+const { all, map, Promise } = RSVP;
 const { filterBy, gt, none, oneWay, sort, uniq } = computed;
+const { service } = inject;
 
 const competencyGroup = EmberObject.extend({
   title: '',
@@ -74,6 +75,7 @@ const cohortProxy = EmberObject.extend({
 });
 
 export default Component.extend({
+  i18n: service(),
   classNames: ['objective-manager', 'course-objective-manager'],
   courseObjective: null,
   selectedCohort: null,
@@ -95,51 +97,42 @@ export default Component.extend({
    * @type {Ember.computed}
    * @public
    */
-  cohorts: computed('courseObjective.courses.[]','courseObjective.courses.@each.cohorts', function() {
-    return new Promise(resolve => {
-      let courseObjective = this.get('courseObjective');
-      if (! courseObjective) {
-        resolve([]);
-      } else {
-        let groups = [];
-        courseObjective.get('courses').then(courses => {
-          let course = courses.get('firstObject');
-          course.get('cohorts').then(cohorts => {
-            let promises = cohorts.map(cohort => {
-              return new Promise(resolve => {
-                cohort.get('objectives').then(objectives => {
-                  let objectiveProxies = objectives.map(objective => {
-                    return objectiveProxy.create({
-                      content: objective,
-                      courseObjective,
-                    });
-                  });
-                  cohort.get('programYear.program').then(program => {
-                    let programTitle = program.get('title');
-                    cohort.get('displayTitle').then(cohortTitle => {
-                      let title = '';
-                      if(programTitle && cohortTitle) {
-                        title = programTitle + ' ' + cohortTitle;
-                      }
-                      let group = cohortProxy.create({
-                        id: cohort.get('id'),
-                        cohort: cohort,
-                        objectives: objectiveProxies,
-                        title
-                      });
-                      resolve(groups.pushObject(group));
-                    });
-                  });
-                });
-              });
-            });
-            all(promises).then(() => {
-              resolve(groups.sortBy('title'));
-            });
-          });
+  cohorts: computed('courseObjective.courses.[]','courseObjective.courses.@each.cohorts', async function() {
+    const courseObjective = this.get('courseObjective');
+    if (! courseObjective) {
+      return [];
+    }
+    const courses = await courseObjective.get('courses');
+    const course = courses.get('firstObject');
+    const cohorts = await course.get('cohorts');
+    const cohortProxies = await map(cohorts.toArray(), async cohort => {
+      const objectives = await cohort.get('objectives');
+      let objectiveProxies = objectives.map(objective => {
+        return objectiveProxy.create({
+          content: objective,
+          courseObjective,
         });
+      });
+      const programYear = await cohort.get('programYear');
+      const program = await programYear.get('program');
+      const programTitle = program.get('title');
+      let title = cohort.get('title');
+      if (isEmpty(title)) {
+        const i18n = this.get('i18n');
+        const classOfYear = programYear ? programYear.get('classOfYear') : null;
+        title = i18n.t('general.classOf', {year: classOfYear});
       }
+      title = programTitle + ' ' + title;
+
+      return cohortProxy.create({
+        id: cohort.get('id'),
+        cohort: cohort,
+        objectives: objectiveProxies,
+        title
+      });
     });
+
+    return cohortProxies.sortBy('title');
   }),
 
   /**

--- a/app/components/course-objective-manager.js
+++ b/app/components/course-objective-manager.js
@@ -116,13 +116,13 @@ export default Component.extend({
       const programYear = await cohort.get('programYear');
       const program = await programYear.get('program');
       const programTitle = program.get('title');
-      let title = cohort.get('title');
-      if (isEmpty(title)) {
+      let cohortTitle = cohort.get('title');
+      if (isEmpty(cohortTitle)) {
         const i18n = this.get('i18n');
-        const classOfYear = programYear ? programYear.get('classOfYear') : null;
-        title = i18n.t('general.classOf', {year: classOfYear});
+        const classOfYear = await cohort.get('classOfYear');
+        cohortTitle = i18n.t('general.classOf', {year: classOfYear});
       }
-      title = programTitle + ' ' + title;
+      const title = programTitle + ' ' + cohortTitle;
 
       return cohortProxy.create({
         id: cohort.get('id'),

--- a/app/components/dashboard-calendar.js
+++ b/app/components/dashboard-calendar.js
@@ -2,9 +2,9 @@ import moment from 'moment';
 import Ember from 'ember';
 import momentFormat from 'ember-moment/computeds/format';
 
-const { Component, computed, isPresent, RSVP, Object:EmberObject, inject } = Ember;
+const { Component, computed, isPresent, RSVP, Object:EmberObject, inject, isEmpty } = Ember;
 const { service } = inject;
-const { all, Promise } = RSVP;
+const { all, map, Promise } = RSVP;
 
 export default Component.extend({
   init() {
@@ -81,35 +81,29 @@ export default Component.extend({
    * @type {Ember.computed}
    * @public
    */
-  cohorts: computed('selectedSchool', 'selectedAcademicYear', function(){
-    return new Promise(resolve => {
-      this.get('selectedSchool').then(school => {
-        this.get('selectedAcademicYear').then(year => {
-          school.getCohortsForYear(year.get('title')).then(cohorts => {
-            let proxies = [];
-            let promises = [];
-            cohorts.forEach(cohort => {
-              let proxy = EmberObject.create({
-                cohort,
-                displayTitle: null
-              });
-              proxies.pushObject(proxy);
-              promises.pushObject(cohort.get('displayTitle').then(displayTitle => {
-                proxy.set('displayTitle', displayTitle);
-              }));
-            });
-            all(promises).then(() => {
-              let sortedCohorts = [];
-              let sortedProxies = proxies.sortBy('displayTitle');
-              sortedProxies.forEach(proxy => {
-                sortedCohorts.pushObject(proxy.get('cohort'));
-              });
-              resolve(sortedCohorts);
-            });
-          });
-        });
+  cohorts: computed('selectedSchool', 'selectedAcademicYear', async function(){
+    const school = await this.get('selectedSchool');
+    const year = await this.get('selectedAcademicYear');
+    const cohorts = await school.getCohortsForYear(year.get('title'));
+    const cohortProxies = await map(cohorts.toArray(), async cohort => {
+      let displayTitle = cohort.get('title');
+      if (isEmpty(displayTitle)) {
+        const i18n = this.get('i18n');
+        const classOfYear = await cohort.get('classOfYear');
+
+        displayTitle = i18n.t('general.classOf', {year: classOfYear});
+      }
+
+      return EmberObject.create({
+        cohort,
+        displayTitle
       });
     });
+
+    const sortedProxies = cohortProxies.sortBy('displayTitle');
+    const sortedCohorts = sortedProxies.mapBy('cohort');
+
+    return sortedCohorts;
   }),
 
   /**

--- a/app/components/dashboard-calendar.js
+++ b/app/components/dashboard-calendar.js
@@ -206,7 +206,12 @@ export default Component.extend({
           case 'cohort':
             hash.class = 'tag-cohort';
             hash.name = new Promise(resolve => {
-              filter.get('displayTitle').then(displayTitle => {
+              let displayTitle = filter.get('title');
+              const i18n = this.get('i18n');
+              filter.get('classOfYear').then(classOfYear => {
+                if (isEmpty(displayTitle)) {
+                  displayTitle = i18n.t('general.classOf', {year: classOfYear});
+                }
                 filter.get('programYear.program').then(program => {
                   resolve(`${displayTitle} ${program.get('title')}`);
                 });

--- a/app/helpers/report-title.js
+++ b/app/helpers/report-title.js
@@ -1,0 +1,79 @@
+import Ember from 'ember';
+
+const { Helper, inject } = Ember;
+const { service } = inject;
+
+export default Helper.extend({
+  i18n: service(),
+  store: service(),
+  reportTitle: null,
+  compute([report]) {
+    const reportTitle = this.get('reportTitle');
+    if (reportTitle) {
+      return reportTitle;
+    }
+    this.getReportTitle(report).then(title => {
+      this.set('reportTitle', title);
+      this.recompute();
+    });
+
+  },
+  async getReportTitle(report){
+    const title = report.get('title');
+    if (title) {
+      return title;
+    }
+    const i18n = this.get('i18n');
+    const store = this.get('store');
+    const subject = report.get('subject');
+    const subjectTranslation = i18n.t(this.subjectTranslations[subject]);
+    const prepositionalObject = report.get('prepositionalObject');
+
+    const school = await report.get('school');
+    const schoolTitle = school?school.get('title'):i18n.t('general.allSchools');
+
+    if (prepositionalObject) {
+      let model = prepositionalObject.dasherize();
+      if(model === 'instructor'){
+        model = 'user';
+      }
+      if(model === 'mesh-term'){
+        model = 'mesh-descriptor';
+      }
+      const prepositionalObjectTableRowId = report.get('prepositionalObjectTableRowId');
+      const record = await store.findRecord(model, prepositionalObjectTableRowId);
+      let object;
+      if(model === 'user'){
+        object = record.get('fullName');
+      } else if(model === 'mesh-descriptor'){
+        object = record.get('name');
+      } else {
+        object = record.get('title');
+      }
+
+      return i18n.t('general.reportDisplayTitleWithObject', {
+        subject: subjectTranslation,
+        object,
+        school: schoolTitle
+      });
+    }
+
+    return i18n.t('general.reportDisplayTitleWithoutObject', {
+      subject: subjectTranslation,
+      school: schoolTitle
+    });
+  },
+  subjectTranslations: {
+    'course': 'general.courses',
+    'session': 'general.sessions',
+    'program': 'general.programs',
+    'program year': 'general.programYears',
+    'instructor': 'general.instructors',
+    'instructor group': 'general.instructorGroups',
+    'learning material': 'general.learningMaterials',
+    'competency': 'general.competencies',
+    'mesh term': 'general.meshTerms',
+    'term': 'general.terms',
+    'session type': 'general.sessionTypes',
+  },
+});

--- a/app/mixins/publishable-model.js
+++ b/app/mixins/publishable-model.js
@@ -5,21 +5,11 @@ const { computed } = Ember;
 const { alias, oneWay, not } = computed;
 
 export default Ember.Mixin.create({
-  i18n: Ember.inject.service(),
   publishedAsTbd: DS.attr('boolean'),
   published: DS.attr('boolean'),
   isPublished: alias('published'),
   isNotPublished: not('isPublished'),
   isScheduled: oneWay('publishedAsTbd'),
-  status: computed('i18n.locale', 'isPublished', 'publishedAsTbd', function(){
-    if(this.get('publishedAsTbd')){
-      return this.get('i18n').t('general.scheduled');
-    }
-    if(this.get('isPublished')){
-      return this.get('i18n').t('general.published');
-    }
-    return this.get('i18n').t('general.notPublished');
-  }),
   isPublishedOrScheduled: computed('publishTarget.isPublished', 'publishTarget.isScheduled', function(){
     return this.get('publishedAsTbd') || this.get('isPublished');
   }),

--- a/app/mixins/publishable.js
+++ b/app/mixins/publishable.js
@@ -2,15 +2,26 @@ import Ember from 'ember';
 
 const { inject, computed } = Ember;
 const { service } = inject;
-const { not, oneWay, or } = computed;
+const { not, or } = computed;
 
 export default Ember.Mixin.create({
   publishTarget: null,
   currentUser: service(),
   flashMessages: service(),
   store: service(),
+  i18n: service(),
   showCheckLink: true,
-  menuTitle: oneWay('publishTarget.status'),
+  menuTitle: computed('i18n.locale', 'publishTarget.isPublished', 'publishTarget.publishedAsTbd', function(){
+    const publishTarget = this.get('publishTarget');
+    const i18n = this.get('i18n');
+    if(publishTarget.get('publishedAsTbd')){
+      return i18n.t('general.scheduled');
+    }
+    if(publishTarget.get('isPublished')){
+      return i18n.t('general.published');
+    }
+    return i18n.t('general.notPublished');
+  }),
   menuIcon: computed('publishTarget.isPublished', 'publishTarget.publishedAsTbd', function(){
     if(this.get('publishTarget.publishedAsTbd')){
       return 'clock-o';

--- a/app/models/cohort.js
+++ b/app/models/cohort.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import Ember from 'ember';
 import DS from 'ember-data';
 
-const { computed, isBlank, RSVP } = Ember;
+const { computed, RSVP } = Ember;
 const { alias } = computed;
 const { Model, PromiseArray } = DS;
 const { Promise } = RSVP;
@@ -47,27 +47,6 @@ export default Model.extend({
 
     return PromiseArray.create({
       promise: defer.promise
-    });
-  }),
-
-  /**
-   * The cohort's display title, which could either be an explicitly set title, or "Class of YYYY" as a fallback.
-   * @property displayTitle
-   * @type {Ember.computed}
-   * @public
-   */
-  displayTitle: computed('title', 'programYear.classOfYear', function(){
-    return new Promise(resolve => {
-      let title = this.get('title');
-      if (! isBlank(title)) {
-        resolve(title);
-      } else {
-        this.get('programYear').then(programYear => {
-          let classOfYear = programYear ? programYear.get('classOfYear') : null;
-          title = this.get('i18n').t('general.classOf', {year: classOfYear});
-          resolve(title);
-        });
-      }
     });
   }),
 

--- a/app/models/cohort.js
+++ b/app/models/cohort.js
@@ -96,5 +96,12 @@ export default Model.extend({
       });
     });
   }),
-  sortedObjectives: alias('programYear.sortedObjectives')
+  sortedObjectives: alias('programYear.sortedObjectives'),
+  classOfYear: computed('programYear.startYear', 'programYear.program.duration', async function(){
+    const programYear = await this.get('programYear');
+    const startYear = parseInt(programYear.get('startYear'));
+    const program = await programYear.get('program');
+    const duration = parseInt(program.get('duration'));
+    return (startYear + duration);
+  }),
 });

--- a/app/models/cohort.js
+++ b/app/models/cohort.js
@@ -8,7 +8,6 @@ const { Model, PromiseArray } = DS;
 const { Promise } = RSVP;
 
 export default Model.extend({
-  i18n: Ember.inject.service(),
   title: DS.attr('string'),
   programYear: DS.belongsTo('program-year', {async: true}),
   courses: DS.hasMany('course', {async: true}),

--- a/app/models/course.js
+++ b/app/models/course.js
@@ -225,6 +225,6 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
     const meta = this.hasMany('cohorts');
     const ids = meta.ids();
 
-    return ids.length > 0;
+    return ids.length > 1;
   }),
 });

--- a/app/models/course.js
+++ b/app/models/course.js
@@ -220,5 +220,11 @@ export default Model.extend(PublishableModel, CategorizableModel, SortableByPosi
         resolve(objectives.toArray().sort(this.positionSortingCallback));
       });
     });
-  })
+  }),
+  hasMultipleCohorts: computed('cohorts.[]', function(){
+    const meta = this.hasMany('cohorts');
+    const ids = meta.ids();
+
+    return ids.length > 0;
+  }),
 });

--- a/app/models/objective.js
+++ b/app/models/objective.js
@@ -122,5 +122,23 @@ export default Model.extend({
         });
       });
     });
-  }
+  },
+  firstProgram: computed('programYears.[]', async function(){
+    const programYears = await this.get('programYears');
+    const programYear = programYears.get('firstObject');
+    const program = await programYear.get('program');
+
+    return program;
+  }),
+  firstCohort: computed('programYears.[]', async function(){
+    const programYears = await this.get('programYears');
+    const programYear = programYears.get('firstObject');
+    if (!programYear) {
+      return null;
+    }
+
+    const cohort = await programYear.get('cohort');
+
+    return cohort;
+  }),
 });

--- a/app/models/report.js
+++ b/app/models/report.js
@@ -1,12 +1,6 @@
-import Ember from 'ember';
 import DS from 'ember-data';
 
-const { computed, inject, isPresent, RSVP } = Ember;
-const { Promise } = RSVP;
-const { service }= inject;
-
 export default DS.Model.extend({
-  i18n: service(),
   title: DS.attr('string'),
   createdAt: DS.attr('date'),
   subject: DS.attr('string'),
@@ -14,79 +8,4 @@ export default DS.Model.extend({
   prepositionalObjectTableRowId: DS.attr('string'),
   user: DS.belongsTo('user', {async: true}),
   school: DS.belongsTo('school', {async: true}),
-
-  /**
-   * The report's display title.
-   * @property displayTitle
-   * @type {Ember.computed}
-   * @public
-   */
-  displayTitle: computed('title', 'i18n.locale', 'school', function(){
-    return new Promise(resolve => {
-      let title = this.get('title');
-      if(isPresent(title)){
-        resolve(title);
-        return;
-      }
-      const subjectTranslations = {
-        'course': 'general.courses',
-        'session': 'general.sessions',
-        'program': 'general.programs',
-        'program year': 'general.programYears',
-        'instructor': 'general.instructors',
-        'instructor group': 'general.instructorGroups',
-        'learning material': 'general.learningMaterials',
-        'competency': 'general.competencies',
-        'mesh term': 'general.meshTerms',
-        'term': 'general.terms',
-        'session type': 'general.sessionTypes',
-      };
-      const i18n = this.get('i18n');
-      let subject = this.get('subject');
-      const subjectTranslation = i18n.t(subjectTranslations[subject]);
-
-      let prepositionalObject = this.get('prepositionalObject');
-
-      this.get('school').then(schoolObj => {
-        let school;
-        if(schoolObj){
-          school = schoolObj.get('title');
-        } else {
-          school = this.get('i18n').t('general.allSchools');
-        }
-        if(isPresent(prepositionalObject)){
-          let model = prepositionalObject.dasherize();
-          if(model === 'instructor'){
-            model = 'user';
-          }
-          if(model === 'mesh-term'){
-            model = 'mesh-descriptor';
-          }
-          this.store.findRecord(model, this.get('prepositionalObjectTableRowId')).then(record => {
-            let object;
-            if(model === 'user'){
-              object = record.get('fullName');
-            } else if(model === 'mesh-descriptor'){
-              object = record.get('name');
-            } else {
-              object = record.get('title');
-            }
-            let displayTitle = this.get('i18n').t('general.reportDisplayTitleWithObject', {
-              subject: subjectTranslation,
-              object,
-              school
-            });
-
-            resolve(displayTitle);
-          });
-        } else {
-          let displayTitle = this.get('i18n').t('general.reportDisplayTitleWithoutObject', {
-            subject,
-            school
-          });
-          resolve(displayTitle);
-        }
-      });
-    });
-  })
 });

--- a/app/templates/components/course-objective-list-item.hbs
+++ b/app/templates/components/course-objective-list-item.hbs
@@ -24,8 +24,12 @@
       {{#each objective.parents as |parent|}}
         {{#if course.hasMultipleCohorts}}
           <strong>
-            {{parent.programYear.program.title}}&nbsp;
-            {{await parent.programYear.cohort.displayTitle}}
+            {{get (await parent.firstProgram) 'title'}}
+            {{#if (get (await parent.firstCohort) 'title')}}
+              {{get (await parent.firstCohort) 'title'}}
+            {{else}}
+              {{t 'general.classOf' year=(await (get (await parent.firstCohort) 'classOfYear'))}}
+            {{/if}}
           </strong>
           <br>
         {{/if}}

--- a/app/templates/components/dashboard-calendar.hbs
+++ b/app/templates/components/dashboard-calendar.hbs
@@ -131,7 +131,14 @@
               {{#each (await cohorts) as |cohort|}}
                 <li class='clickable'>
                   <input {{action 'toggleCohort' cohort on='change'}} class='checkbox' type='checkbox' checked={{is-in selectedCohorts cohort}}>
-                  <span {{action 'toggleCohort' cohort}} class="list-indentation">{{await cohort.displayTitle}} {{cohort.programYear.program.title}}</span>
+                  <span {{action 'toggleCohort' cohort}} class="list-indentation">
+                    {{#if cohort.title}}
+                      {{cohort.title}}
+                    {{else}}
+                      {{t 'general.classOf' year=(await cohort.classOfYear)}}
+                    {{/if}}
+                    {{get (await cohort.programYear.program) 'title'}}
+                  </span>
                 </li>
               {{/each}}
             </ul>

--- a/app/templates/components/dashboard-myreports.hbs
+++ b/app/templates/components/dashboard-myreports.hbs
@@ -11,7 +11,7 @@
   </div>
 
   {{#liquid-if selectedReport class='crossFade'}}
-    <h3>{{await selectedReport.displayTitle}}</h3>
+    <h3>{{report-title selectedReport}}</h3>
     {{#if (is-fulfilled reportResultsList)}}
       {{#if (get (await reportResultsList) 'length')}}
         <ul>
@@ -53,7 +53,7 @@
                 <tr>
                   <td {{action 'selectReport' report}} class='link clickable' colspan=4>
                     {{fa-icon 'external-link-square'}}
-                    {{await report.displayTitle}}
+                    {{report-title report}}
                   </td>
                   <td class='text-right clickable remove' colspan=1 {{action 'deleteReport' report}}>{{fa-icon 'trash'}}</td>
                 </tr>

--- a/app/templates/components/detail-cohorts.hbs
+++ b/app/templates/components/detail-cohorts.hbs
@@ -27,7 +27,7 @@
     }}
   {{else}}
     {{detail-cohort-list
-      cohorts=course.cohorts
+      cohorts=(await course.cohorts)
     }}
   {{/if}}
 </div>

--- a/app/templates/components/programyear-header.hbs
+++ b/app/templates/components/programyear-header.hbs
@@ -2,7 +2,13 @@
   {{#if programYear.locked}}{{fa-icon 'lock'}}{{/if}}
   {{#if programYear}}
     <h4>{{t 'general.matriculationYear'}} {{programYear.academicYear}}</h4>
-    <h5>{{await programYear.cohort.displayTitle}}</h5>
+    <h5>
+      {{#if (get (await programYear.cohort) 'title')}}
+        {{get (await programYear.cohort) 'title'}}
+      {{else}}
+        {{t 'general.classOf' year=(await programYear.cohort.classOfYear)}}
+      {{/if}}
+    </h5>
   {{/if}}
 </div>
 <div class ='programyear-publication'>

--- a/app/templates/components/programyear-list.hbs
+++ b/app/templates/components/programyear-list.hbs
@@ -42,7 +42,13 @@
                     {{fa-icon 'external-link-square'}} {{programYearProxy.academicYear}}
                   {{/link-to}}
                 </td>
-                <td class='text-left'>{{await programYearProxy.cohort.displayTitle}}</td>
+                <td class='text-left'>
+                  {{#if (get (await programYearProxy.cohort) 'title')}}
+                    {{get (await programYearProxy.cohort) 'title'}}
+                  {{else}}
+                    {{t 'general.classOf' year=(await programYearProxy.cohort.classOfYear)}}
+                  {{/if}}
+                </td>
 
                 <td class='text-left'>
                   {{#if programYearProxy.competencies.length}}

--- a/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -205,8 +205,10 @@ test('save changes', function(assert) {
   andThen(function(){
     let td = find('.course-objective-list tbody tr:eq(0) td:eq(1)');
     assert.equal(getElementText(td), getText(
+      'program0cohort0' +
       fixtures.parentObjectives[1].title +
       '(' + fixtures.competencies[fixtures.parentObjectives[1].competency - 1].title + ')' +
+      'program0cohort1' +
       fixtures.parentObjectives[4].title +
       '(' + fixtures.competencies[fixtures.parentObjectives[4].competency - 1].title + ')'
     ));
@@ -229,8 +231,10 @@ test('cancel changes', function(assert) {
   andThen(function(){
     let td = find('.course-objective-list tbody tr:eq(0) td:eq(1)');
     assert.equal(getElementText(td), getText(
+      'program0cohort0' +
       fixtures.parentObjectives[0].title +
       '(' + fixtures.competencies[fixtures.parentObjectives[0].competency - 1].title + ')' +
+        'program0cohort1' +
         fixtures.parentObjectives[3].title +
         '(' + fixtures.competencies[fixtures.parentObjectives[3].competency - 1].title + ')'
     ));

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -341,7 +341,7 @@ test('can add a program-year (with pre-existing program-year)', function(assert)
     const academicYear = `${thisYear.toString()} - ${(thisYear + 1).toString()}`;
 
     assert.equal(getTableDataText(0, 0).text().trim(), academicYear, 'academic year shown');
-    assert.equal(getTableDataText(0, 1).text(), 'cohort 0', 'cohort class year shown');
+    assert.equal(getTableDataText(0, 1).text().trim(), 'cohort 0', 'cohort class year shown');
     assert.equal(getTableDataText(0, 2).text().trim(), '3');
     assert.equal(getTableDataText(0, 3).text().trim(), '3');
     assert.equal(getTableDataText(0, 4).text().trim(), '3');
@@ -357,7 +357,7 @@ test('can add a program-year (with pre-existing program-year)', function(assert)
       const academicYear = `${(thisYear + 1).toString()} - ${(thisYear + 2).toString()}`;
       assert.equal(getTableDataText(1, 0).text().trim(), academicYear, 'academic year shown');
       const cohortClassYear = `Class of ${(thisYear + 5).toString()}`;
-      assert.equal(getTableDataText(1, 1).text(), cohortClassYear, 'cohort class year shown');
+      assert.equal(getTableDataText(1, 1).text().trim(), cohortClassYear, 'cohort class year shown');
       assert.equal(getTableDataText(1, 2).text().trim(), '3', 'copied correctly from latest program-year');
       assert.equal(getTableDataText(1, 3).text().trim(), '3', 'copied correctly from latest program-year');
       assert.equal(getTableDataText(1, 4).text().trim(), '3', 'copied correctly from latest program-year');

--- a/tests/integration/components/dashboard-myreports-test.js
+++ b/tests/integration/components/dashboard-myreports-test.js
@@ -1,6 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import tHelper from "ember-i18n/helper";
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
@@ -9,12 +8,12 @@ const { resolve } = RSVP;
 
 let mockReports = [
   EmberObject.create({
-    displayTitle: resolve('all courses'),
+    title: 'all courses',
     subject: 'courses',
     user: 1
   }),
   EmberObject.create({
-    displayTitle: resolve('courses for session'),
+    title: 'courses for session',
     subject: 'courses',
     prepositionalObject: 'session',
     prepositionalObjectTableRowId: 11,
@@ -35,11 +34,7 @@ let reportingMockNoReports = Service.extend({
 });
 
 moduleForComponent('dashboard-myreports', 'Integration | Component | dashboard myreports', {
-  integration: true,
-  beforeEach: function() {
-    this.container.lookup('service:i18n').set('locale', 'en');
-    this.registry.register('helper:t', tHelper);
-  }
+  integration: true
 });
 
 test('list reports', function(assert) {
@@ -57,9 +52,7 @@ test('list reports', function(assert) {
   return wait().then(()=> {
     for (let i = 0; i < 2; i++) {
       let tds = this.$(`table tr:eq(${i}) td`);
-      mockReports[i].get('displayTitle').then(displayTitle => {
-        assert.equal(tds.eq(0).text().trim(), displayTitle);
-      });
+      assert.equal(tds.eq(0).text().trim(), mockReports[i].get('title'));
     }
     assert.equal(this.$(`table tr`).length, 2);
   });

--- a/tests/unit/models/cohort-test.js
+++ b/tests/unit/models/cohort-test.js
@@ -53,28 +53,3 @@ test('list top level groups', function(assert) {
   });
 
 });
-//
-// test('get display title', function(assert) {
-//   assert.expect(2);
-//   var model = this.subject();
-//
-//   var store = model.store;
-//
-//   Ember.run(function(){
-//     var program = store.createRecord('program', {duration: 4});
-//     var programYear = store.createRecord('program-year', {startYear:'2000', program: program, cohort: model});
-//     model.set('programYear', programYear);
-//   });
-//
-//   Ember.run(function(){
-//     var displayTitle = model.get('displayTitle');
-//     assert.equal(displayTitle, 'Class of 2004');
-//   });
-//
-//   Ember.run(function(){
-//     model.set('title', 'testtitle');
-//     var displayTitle = model.get('displayTitle');
-//     assert.equal(displayTitle, 'testtitle');
-//   });
-//
-// });


### PR DESCRIPTION
Doing translation in the model was making it hard to extract the models from the frontend. Most of the translations can be done as well in the templates or components. For reports I created a report-title helper which does the heavy lifting.