### PR TITLE
Visualization page: Add SCSS breakpoints for “Meh” icon

### DIFF
--- a/app/components/chart-donut.js
+++ b/app/components/chart-donut.js
@@ -32,6 +32,7 @@ export default Component.extend({
     const donutWidth = width * .2;
     const color = scaleOrdinal(schemeCategory10);
     const isIcon = width < 100 || height < 100;
+    const margin = isIcon ? {top: 0, right: 0, bottom: 0, left: 0} : {top: 10, right: 20, bottom: 30, left: 25};
 
     let t = transition().duration(500).ease(easeLinear);
     let createArc = arc().innerRadius(radius - donutWidth).outerRadius(radius);

--- a/app/components/chart-donut.js
+++ b/app/components/chart-donut.js
@@ -32,7 +32,6 @@ export default Component.extend({
     const donutWidth = width * .2;
     const color = scaleOrdinal(schemeCategory10);
     const isIcon = width < 100 || height < 100;
-    const margin = isIcon ? {top: 0, right: 0, bottom: 0, left: 0} : {top: 10, right: 20, bottom: 30, left: 25};
 
     let t = transition().duration(500).ease(easeLinear);
     let createArc = arc().innerRadius(radius - donutWidth).outerRadius(radius);

--- a/app/styles/newcomponents/visualizer-course-objectives.scss
+++ b/app/styles/newcomponents/visualizer-course-objectives.scss
@@ -24,8 +24,22 @@
       margin-top: .5em;
     }
 
-    .meh-o {
-      font-size: 30em;
+    @include media($small-screen) {
+      .meh-o {
+        font-size: 15rem;
+      }
+    }
+
+    @include media($medium-screen) {
+      .meh-o {
+        font-size: 25rem;
+      }
+    }
+
+    @include media($large-screen) {
+      .meh-o {
+        font-size: 30rem;
+      }
     }
   }
 


### PR DESCRIPTION
"Meh" Icon resizes at mobile view now.

<img width="805" alt="screen shot 2017-05-15 at 11 13 24 am" src="https://cloud.githubusercontent.com/assets/597090/26074707/b303bdd4-3967-11e7-9a29-fbc438be625c.png">

<img width="398" alt="screen shot 2017-05-15 at 11 13 39 am" src="https://cloud.githubusercontent.com/assets/597090/26074708/b30562a6-3967-11e7-987e-49d2f1fc4e3f.png">

