### PR TITLE
Don't freeze the lockfile anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - yarn global add greenkeeper-lockfile@1
 
 install:
-  - yarn install --frozen-lockfile
+  - yarn install
   - bower install
 
 before_script:


### PR DESCRIPTION
Now that we use greenkeeper-lockfile to keep up to date we no longer
need to install against a frozen lockfile.