### PR TITLE
Speed up transitions in tests

### DIFF
--- a/app/transitions.js
+++ b/app/transitions.js
@@ -1,20 +1,26 @@
+import config from './config/environment';
+
+function getDuration(duration) {
+  return config.environment === 'test' ? 0 : duration;
+}
+
 export default function(){
   this.transition(
     this.hasClass('horizontal'),
     this.toValue(true),
-    this.use('toLeft', {duration: 1000}),
-    this.reverse('toRight', {duration: 1000})
+    this.use('toLeft', {duration: getDuration(1000)}),
+    this.reverse('toRight', {duration: getDuration(1000)})
   );
   this.transition(
     this.hasClass('vertical'),
     this.toValue(true),
-    this.use('toDown', {duration: 1000}),
-    this.reverse('toUp', {duration: 1000})
+    this.use('toDown', {duration: getDuration(1000)}),
+    this.reverse('toUp', {duration: getDuration(1000)})
   );
   this.transition(
     this.hasClass('crossFade'),
     this.toValue(true),
-    this.use('crossFade', {duration: 1000})
+    this.use('crossFade', {duration: getDuration(1000)})
   );
   this.transition(
     this.toRoute(function(){
@@ -28,12 +34,12 @@ export default function(){
       topRoutes.push('programs');
       return topRoutes.includes(this);
     }),
-    this.use('crossFade', {duration: 500})
+    this.use('crossFade', {duration: getDuration(500)})
   );
   this.transition(
     this.fromRoute('course.index', 'session.index'),
     this.toRoute('session.index', 'session.publicationCheck'),
-    this.use('toLeft', {duration: 1000}),
-    this.reverse('toRight', {duration: 1000})
+    this.use('toLeft', {duration: getDuration(1000)}),
+    this.reverse('toRight', {duration: getDuration(1000)})
   );
 }


### PR DESCRIPTION
When we are running tests there is no need for transitions to take any
time at all. This detects when we are testing and makes transitions
fast.