### PR TITLE
Re-hide the transition container

### DIFF
--- a/app/styles/newcomponents/visualizer-course-objectives.scss
+++ b/app/styles/newcomponents/visualizer-course-objectives.scss
@@ -1,7 +1,3 @@
-.liquid-container {
-  overflow: visible;
-}
-
 .visualizer-course-objectives {
   .zero-hours {
     p {


### PR DESCRIPTION
This line made it possible to see chart tooltips, but it made all other
animations on the site go crazy.

Fixes #3060