### PR TITLE
Cache node_modules directory on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 
 cache:
   directories:
+    - node_modules
     - $HOME/.npm
     - $HOME/.cache
 


### PR DESCRIPTION
Npm@5 does a better job at bringing the node_modules directory into
shape so we can safely cache this directory.