### PR TITLE
Provide bulk user sample file as a data-uri link

### DIFF
--- a/app/components/bulk-new-users.js
+++ b/app/components/bulk-new-users.js
@@ -113,7 +113,7 @@ export default Component.extend(NewUser, {
   getFileContents(file){
     this.set('fileUploadError', false);
     return new Promise(resolve => {
-      let allowedFileTypes = ['text/plain', 'text/csv'];
+      let allowedFileTypes = ['text/plain', 'text/csv', 'text/tab-separated-values'];
       if (!allowedFileTypes.includes(file.type)) {
         const i18n = this.get('i18n');
         this.set('fileUploadError', true);
@@ -251,6 +251,14 @@ export default Component.extend(NewUser, {
     this.set('proposedUsers', []);
 
   }).drop(),
+  sampleData: computed(function(){
+    const sampleUploadFields = ['First', 'Last', 'Middle', 'Phone', 'Email', 'CampusID', 'OtherID', 'Username', 'Password'];
+
+    const str = sampleUploadFields.join("\t");
+    const encoded = window.btoa(str);
+
+    return encoded;
+  }),
   actions: {
     updateSelectedFile(files){
       // Check for the various File API support.
@@ -270,6 +278,6 @@ export default Component.extend(NewUser, {
       } else {
         selectedUsers.pushObject(obj);
       }
-    }
+    },
   }
 });

--- a/app/templates/components/bulk-new-users.hbs
+++ b/app/templates/components/bulk-new-users.hbs
@@ -38,7 +38,10 @@
   </div>
   <div class='upload-users'>
     <label>
-      {{t 'general.uploadUsers'}} (<a target='_blank' rel='noopener' href='/assets/files/SampleUserUpload.txt'>{{t 'general.sampleFile'}}</a>):
+      {{t 'general.uploadUsers'}}(
+      <a target='_blank' rel='noopener' download="SampleUserUpload.tsv" href='data:application/octet-stream;charset=utf-8;base64,{{sampleData}}'>
+        {{t 'general.sampleFile'}}
+      </a>):
     </label>
     <input type='file' onchange={{action 'updateSelectedFile' value="target.files"}}>
   </div>

--- a/public/assets/files/SampleUserUpload.txt
+++ b/public/assets/files/SampleUserUpload.txt
@@ -1,1 +1,0 @@
-First	Last	Middle	Phone	Email	CampusID	OtherID	Username	Password


### PR DESCRIPTION
We've been having trouble getting this file from our CDN with a correct
link, instead we can just put the data into the link directly.

Fixes #3023