### PR TITLE
Preload some course data to speed up rendering

### DIFF
--- a/app/mirage/config.js
+++ b/app/mirage/config.js
@@ -229,13 +229,48 @@ export default function() {
   this.delete('api/meshpreviousindexings/:id', 'meshPreviousIndexing');
   this.post('api/meshpreviousindexings', 'meshPreviousIndexing');
 
-  this.get('api/objectives', getAll);
+  this.get('api/objectives', (db, request) => {
+    const params = request.queryParams;
+    const keys = Object.keys(params);
+    const courseKey = 'filters[courses]';
+    if (keys.includes(courseKey)) {
+      const coursesFilter = params[courseKey];
+      const objectives = db.objectives.filter(objective => {
+        const courseId = parseInt(objective.course);
+        return coursesFilter.includes(courseId.toString());
+      });
+
+      return {objectives};
+
+    } else {
+      return getAll(db, request);
+    }
+  });
   this.get('api/objectives/:id', 'objective');
   this.put('api/objectives/:id', 'objective');
   this.delete('api/objectives/:id', 'objective');
   this.post('api/objectives', 'objective');
 
-  this.get('api/offerings', getAll);
+  this.get('api/offerings', (db, request) => {
+    const params = request.queryParams;
+    const keys = Object.keys(params);
+    const courseKey = 'filters[courses]';
+    if (keys.includes(courseKey)) {
+      const coursesFilter = params[courseKey];
+      const offerings = db.offerings.filter(offering => {
+        const sessionId = parseInt(offering.session);
+        const session = db.sessions.find(sessionId);
+        const courseId = session.course;
+
+        return coursesFilter.includes(courseId.toString());
+      });
+
+      return {offerings};
+
+    } else {
+      return getAll(db, request);
+    }
+  });
   this.get('api/offerings/:id', 'offering');
   this.put('api/offerings/:id', 'offering');
   this.delete('api/offerings/:id', 'offering');

--- a/app/routes/course/index.js
+++ b/app/routes/course/index.js
@@ -1,7 +1,26 @@
 import Ember from 'ember';
 
-export default  Ember.Route.extend({
-  model: function() {
-    return this.modelFor('course');
+const { Route, RSVP, inject } = Ember;
+const { all } = RSVP;
+const { service } = inject;
+
+export default  Route.extend({
+  store: service(),
+  /**
+   * Prefetch related data to limit network requests
+  */
+  afterModel(model) {
+    const store = this.get('store');
+    const courses = [model.get('id')];
+    const course = model.get('id');
+    const sessions = model.hasMany('sessions').ids();
+
+    return all([
+      store.query('session', {filters: {course}, limit: 1000}),
+      store.query('offering', {filters: {courses}, limit: 1000}),
+      store.query('ilm-session', {filters: {courses}, limit: 1000}),
+      store.query('objective', {filters: {courses}, limit: 1000}),
+      store.query('objective', {filters: {sessions}, limit: 1000}),
+    ]);
   }
 });

--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v1.20';
+module.exports = 'v1.21';


### PR DESCRIPTION
By pre-loading the things we need on the session list we can avoid
several expensive round trip network calls.

Requires API v1.21 (not currently released).