### PR TITLE
Drop support for older browsers

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -1,9 +1,13 @@
 /* eslint-env node */
+
+// Which browsers are returned can be found at http://browserl.ist/
 module.exports = {
   browsers: [
-    'ie 9',
-    'last 1 Chrome versions',
-    'last 1 Firefox versions',
-    'last 1 Safari versions'
+    'last 1 edge versions',
+    'last 1 chrome versions',
+    'firefox esr', //actually points to the last 2 ESR releases as they overlap
+    'last 1 safari versions',
+    'last 1 ios versions',
+    'last 1 android versions',
   ]
 };


### PR DESCRIPTION
By only targeting modern evergreen browsers in our build we can
significantly reduce the amount of extra code we generate to be
compatible with older browsers. This will make our application smaller
to download and faster to parse.

This list is dynamic so overtime the actual result of our build will change as newer browsers are released. This should mean we continue to take advantage of new features as they are released in our oldest supported browser.