### PR TITLE
Better source maps in development

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -22,7 +22,8 @@ module.exports = function(defaults) {
     tests: env.EMBER_CLI_TEST_COMMAND || !isProductionLikeBuild,
     hinting: env.EMBER_CLI_TEST_COMMAND || !isProductionLikeBuild,
     'ember-cli-babel': {
-      includePolyfill: true
+      includePolyfill: true,
+      sourceMaps: isProductionLikeBuild?false:'inline'
     },
     'ember-cli-qunit': {
       useLintTree: false


### PR DESCRIPTION
This marginally slows down the build, but the result is so amazing it is
100% worth it. Instead of transpiled code we get the clean source in an
inspector. This has been missing from our lives for too long, let there
by SOURCE MAPS!