### PR TITLE
Don't reload records when navigating back to school

### DIFF
--- a/app/routes/course/index.js
+++ b/app/routes/course/index.js
@@ -14,6 +14,14 @@ export default  Route.extend({
     const courses = [model.get('id')];
     const course = model.get('id');
     const sessions = model.hasMany('sessions').ids();
+    const existingSessionsInStore = store.peekAll('session');
+    const existingSessionIds = existingSessionsInStore.mapBy('id');
+    const unloadedSessions = sessions.filter(id => !existingSessionIds.includes(id));
+
+    //if we have already loaded all of these sessions we can just proceed normally
+    if (unloadedSessions.length === 0) {
+      return;
+    }
 
     return all([
       store.query('session', {filters: {course}, limit: 1000}),


### PR DESCRIPTION
We need to look inside the store first to see if we have already loaded
all of these records. Otherwise we will fire off network requests to
repeat the same work again.

This can be tested by navigating back and forth between courses in a session. When going back to a course no new network requests should be sent.