### PR TITLE
Convert all acceptance tests to use async/await syntax

### DIFF
--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,7 +1,4 @@
 module.exports = {
-  env: {
-    embertest: true
-  },
   "globals": {
     "$": true,
     "getElementText": true,
@@ -9,5 +6,18 @@ module.exports = {
     "pickOption": true,
     "select": true,
     "server": true,
+    // embertest ENV globals manually added since we're not supporting andThen anymore
+		"click": true,
+		"currentPath": true,
+		"currentRouteName": true,
+		"currentURL": true,
+		"fillIn": true,
+		"find": true,
+		"findWithAssert": true,
+		"keyEvent": true,
+		"pauseTest": true,
+		"resumeTest": true,
+		"triggerEvent": true,
+		"visit": true
   },
 };

--- a/tests/acceptance/admin-test.js
+++ b/tests/acceptance/admin-test.js
@@ -18,17 +18,15 @@ module('Acceptance: Admin', {
   }
 });
 
-test('can transition to `users` route', function(assert) {
+test('can transition to `users` route', async function(assert) {
   const button = '.manage-users-summary a:eq(0)';
 
-  visit(url);
-  click(button);
-  andThen(() => {
-    assert.equal(currentURL(), '/users', 'transition occurred');
-  });
+  await visit(url);
+  await click(button);
+  assert.equal(currentURL(), '/users', 'transition occurred');
 });
 
-test('can search for users', function(assert) {
+test('can search for users', async function(assert) {
   server.createList('user', 20, { email: 'user@example.edu' });
   server.createList('authentication', 20);
 
@@ -38,17 +36,13 @@ test('can search for users', function(assert) {
   const secondResultEmail = `${secondResult} .email`;
   const name = '.user-display-name';
 
-  visit(url);
-  fillIn(userSearch, 'son');
-  triggerEvent(userSearch, 'keyup');
-  andThen(() => {
-    assert.equal(find(secondResultUsername).text().trim(), '1 guy M. Mc1son', 'user name is correct');
-    assert.equal(find(secondResultEmail).text().trim(), 'user@example.edu', 'user email is correct');
-  });
+  await visit(url);
+  await fillIn(userSearch, 'son');
+  await triggerEvent(userSearch, 'keyup');
+  assert.equal(find(secondResultUsername).text().trim(), '1 guy M. Mc1son', 'user name is correct');
+  assert.equal(find(secondResultEmail).text().trim(), 'user@example.edu', 'user email is correct');
 
-  click(secondResultUsername);
-  andThen(() => {
-    assert.equal(currentURL(), '/users/2', 'new user profile is shown');
-    assert.equal(find(name).text().trim(), '1 guy M. Mc1son', 'user name is shown');
-  });
+  await click(secondResultUsername);
+  assert.equal(currentURL(), '/users/2', 'new user profile is shown');
+  assert.equal(find(name).text().trim(), '1 guy M. Mc1son', 'user name is shown');
 });

--- a/tests/acceptance/api-version-check-test.js
+++ b/tests/acceptance/api-version-check-test.js
@@ -21,7 +21,7 @@ module('Acceptance: API Version Check', {
   }
 });
 
-test('No warning shows up when api versions match', function(assert) {
+test('No warning shows up when api versions match', async function(assert) {
   assert.expect(2);
   server.get('application/config', function() {
     assert.ok(true, 'our config override was called');
@@ -32,13 +32,11 @@ test('No warning shows up when api versions match', function(assert) {
   });
   const warningOverlay = '.api-version-check-warning';
 
-  visit(url);
-  andThen(() => {
-    assert.equal($(warningOverlay).length, 0);
-  });
+  await visit(url);
+  assert.equal($(warningOverlay).length, 0);
 });
 
-test('Warning shows up when api versions do not match', function(assert) {
+test('Warning shows up when api versions do not match', async function(assert) {
   assert.expect(2);
   server.get('application/config', function() {
     assert.ok(true, 'our config override was called');
@@ -49,8 +47,6 @@ test('Warning shows up when api versions do not match', function(assert) {
   });
   const warningOverlay = '.api-version-check-warning';
 
-  visit(url);
-  andThen(() => {
-    assert.equal($(warningOverlay).length, 1);
-  });
+  await visit(url);
+  assert.equal($(warningOverlay).length, 1);
 });

--- a/tests/acceptance/assignstudents-test.js
+++ b/tests/acceptance/assignstudents-test.js
@@ -18,12 +18,10 @@ moduleForAcceptance('Acceptance | assign students', {
   }
 });
 
-test('visiting /admin/assignstudents', function(assert) {
-  visit('/admin/assignstudents');
+test('visiting /admin/assignstudents', async function(assert) {
+  await visit('/admin/assignstudents');
 
-  andThen(function() {
-    assert.equal(getElementText('#school-selection'), getText('school 0'));
+  assert.equal(getElementText('#school-selection'), getText('school 0'));
 
-    assert.equal(currentURL(), '/admin/assignstudents');
-  });
+  assert.equal(currentURL(), '/admin/assignstudents');
 });

--- a/tests/acceptance/course/cohorts-test.js
+++ b/tests/acceptance/course/cohorts-test.js
@@ -62,20 +62,18 @@ module('Acceptance: Course - Cohorts', {
   }
 });
 
-test('list cohorts', function(assert) {
+test('list cohorts', async function(assert) {
   assert.expect(4);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-cohorts');
-    var rows = find('tbody tr', container);
-    assert.equal(rows.length, fixtures.course.cohorts.length);
-    for(let i = 0; i < fixtures.course.cohorts.length; i++){
-      let cohort = fixtures.cohorts[fixtures.course.cohorts[i] - 1];
-      assert.equal(getElementText(find('td:eq(0)', rows[i])), getText('school 0'));
-      assert.equal(getElementText(find('td:eq(1)', rows[i])), getText('program 0'));
-      assert.equal(getElementText(find('td:eq(2)', rows[i])), getText(cohort.title));
-    }
-  });
+  await visit(url);
+  var container = find('.detail-cohorts');
+  var rows = find('tbody tr', container);
+  assert.equal(rows.length, fixtures.course.cohorts.length);
+  for(let i = 0; i < fixtures.course.cohorts.length; i++){
+    let cohort = fixtures.cohorts[fixtures.course.cohorts[i] - 1];
+    assert.equal(getElementText(find('td:eq(0)', rows[i])), getText('school 0'));
+    assert.equal(getElementText(find('td:eq(1)', rows[i])), getText('program 0'));
+    assert.equal(getElementText(find('td:eq(2)', rows[i])), getText(cohort.title));
+  }
 });
 
 test('manage cohorts', async function(assert) {
@@ -87,63 +85,42 @@ test('manage cohorts', async function(assert) {
   assert.equal(getElementText(find('.selectable-list ul li', container)), getText('school 0 | program 0 | cohort 1'));
 });
 
-test('save cohort chages', function(assert) {
+test('save cohort chages', async function(assert) {
   assert.expect(3);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-cohorts');
-    click(find('.actions button', container));
-    andThen(function(){
-      click(find('.removable-list li:eq(0)', container)).then(function(){
-        click(find('.selectable-list ul li:eq(0)', container)).then(function(){
-          click('button.bigadd', container);
-        });
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('tbody tr:eq(0) td:eq(0)', container)), getText('school 0'));
-        assert.equal(getElementText(find('tbody tr:eq(0) td:eq(1)', container)), getText('program 0'));
-        assert.equal(getElementText(find('tbody tr:eq(0) td:eq(2)', container)), getText(fixtures.cohorts[1].title));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.detail-cohorts');
+  await click(find('.actions button', container));
+  await click(find('.removable-list li:eq(0)', container));
+  await click(find('.selectable-list ul li:eq(0)', container));
+  await click('button.bigadd', container);
+
+  assert.equal(getElementText(find('tbody tr:eq(0) td:eq(0)', container)), getText('school 0'));
+  assert.equal(getElementText(find('tbody tr:eq(0) td:eq(1)', container)), getText('program 0'));
+  assert.equal(getElementText(find('tbody tr:eq(0) td:eq(2)', container)), getText(fixtures.cohorts[1].title));
 });
 
-test('cancel cohort changes', function(assert) {
+test('cancel cohort changes', async function(assert) {
   assert.expect(3);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-cohorts');
-    click(find('.actions button', container));
-    andThen(function(){
-      click(find('.removable-list li:eq(0)', container)).then(function(){
-        click(find('.selectable-list ul li:eq(0)', container)).then(function(){
-          click('button.bigcancel', container);
-        });
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('tbody tr:eq(0) td:eq(0)', container)), getText('school 0'));
-        assert.equal(getElementText(find('tbody tr:eq(0) td:eq(1)', container)), getText('program 0'));
-        assert.equal(getElementText(find('tbody tr:eq(0) td:eq(2)', container)), getText(fixtures.cohorts[0].title));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.detail-cohorts');
+  await click(find('.actions button', container));
+  await click(find('.removable-list li:eq(0)', container));
+  await click(find('.selectable-list ul li:eq(0)', container));
+  await click('button.bigcancel', container);
+  assert.equal(getElementText(find('tbody tr:eq(0) td:eq(0)', container)), getText('school 0'));
+  assert.equal(getElementText(find('tbody tr:eq(0) td:eq(1)', container)), getText('program 0'));
+  assert.equal(getElementText(find('tbody tr:eq(0) td:eq(2)', container)), getText(fixtures.cohorts[0].title));
 });
 
-test('removing a cohort remove course objectives parents linked to that cohort', function(assert) {
+test('removing a cohort remove course objectives parents linked to that cohort', async function(assert) {
   assert.expect(3);
-  visit(url);
-  andThen(function() {
-    let parents = find('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
-    assert.equal(parents.length, 2);
-    click('.detail-cohorts .actions button');
-    andThen(function(){
-      click('.detail-cohorts .removable-list li:eq(0)');
-      click('.detail-cohorts button.bigadd');
-      andThen(function(){
-        parents = find('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
-        assert.equal(parents.length, 1);
-        assert.equal(getElementText(parents), getText(fixtures.parentObjective2.title));
-      });
-    });
-  });
+  await visit(url);
+  let parents = find('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
+  assert.equal(parents.length, 2);
+  await click('.detail-cohorts .actions button');
+  await click('.detail-cohorts .removable-list li:eq(0)');
+  await click('.detail-cohorts button.bigadd');
+  parents = find('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
+  assert.equal(parents.length, 1);
+  assert.equal(getElementText(parents), getText(fixtures.parentObjective2.title));
 });

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -5,6 +5,7 @@ import {
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+import wait from 'ember-test-helpers/wait';
 import Ember from 'ember';
 import moment from 'moment';
 
@@ -125,42 +126,40 @@ module('Acceptance: Course - Learning Materials', {
   }
 });
 
-test('list learning materials', function(assert) {
-  visit(url);
-  andThen(function() {
-    const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
-    const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
-    assert.equal(currentPath(), 'course.index');
-    let container = find('.detail-learningmaterials');
-    let rows = find('.detail-learningmaterials-content tbody tr', container);
-    assert.equal(rows.length, fixtures.course.learningMaterials.length);
-    for (let i = 0; i < fixtures.course.learningMaterials.length; i++){
-      let row = rows.eq(i);
-      let courseLm = fixtures.courseLearningMaterials[fixtures.course.learningMaterials[i] - 1];
-      let lm = fixtures.learningMaterials[courseLm.learningMaterial - 1];
-      assert.equal(getElementText(find('td:eq(0)', row)), getText(lm.title));
-      // TODO: not checking for exact type icon yet, see comment below [ST 2017/08/01]
-      assert.equal(find('td:eq(0) .lm-type-icon i.fa', row).length, 1, 'LM type icon is present.');
-      //TODO: we are no longer populating for 'type', so we need to pull all these tests out
-      //of the loop and test individually
-      //assert.equal(getElementText(find('td:eq(1)', row)), getText(lm.type));
-      assert.equal(getElementText(find('td:eq(2)', row)), getText(userName));
-      let required = courseLm.required?'Yes':'No';
-      assert.equal(getElementText(find('td:eq(3)', row)), getText(required));
-      let notes = courseLm.notes? 'Yes' : 'No';
-      assert.equal(getElementText(find('td:eq(4)', row)), getText(notes));
-      let notesBool = courseLm.notes? true : false;
-      let publicNotes = courseLm.publicNotes ? true : false;
-      assert.equal(find('td:eq(4) i', row).hasClass('fa-eye'), publicNotes && notesBool);
-      let meshTerms = find('td:eq(5) li', row);
-      if('meshDescriptors' in courseLm){
-        assert.equal(meshTerms.length, courseLm.meshDescriptors.length);
-        for(let i = 0; i < courseLm.meshDescriptors.length; i++){
-          assert.equal(getElementText(meshTerms.eq(i)), getText(fixtures.meshDescriptors[courseLm.meshDescriptors[i] - 1].name));
-        }
+test('list learning materials', async function(assert) {
+  await visit(url);
+  const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
+  const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
+  assert.equal(currentPath(), 'course.index');
+  let container = find('.detail-learningmaterials');
+  let rows = find('.detail-learningmaterials-content tbody tr', container);
+  assert.equal(rows.length, fixtures.course.learningMaterials.length);
+  for (let i = 0; i < fixtures.course.learningMaterials.length; i++){
+    let row = rows.eq(i);
+    let courseLm = fixtures.courseLearningMaterials[fixtures.course.learningMaterials[i] - 1];
+    let lm = fixtures.learningMaterials[courseLm.learningMaterial - 1];
+    assert.equal(getElementText(find('td:eq(0)', row)), getText(lm.title));
+    // TODO: not checking for exact type icon yet, see comment below [ST 2017/08/01]
+    assert.equal(find('td:eq(0) .lm-type-icon i.fa', row).length, 1, 'LM type icon is present.');
+    //TODO: we are no longer populating for 'type', so we need to pull all these tests out
+    //of the loop and test individually
+    //assert.equal(getElementText(find('td:eq(1)', row)), getText(lm.type));
+    assert.equal(getElementText(find('td:eq(2)', row)), getText(userName));
+    let required = courseLm.required?'Yes':'No';
+    assert.equal(getElementText(find('td:eq(3)', row)), getText(required));
+    let notes = courseLm.notes? 'Yes' : 'No';
+    assert.equal(getElementText(find('td:eq(4)', row)), getText(notes));
+    let notesBool = courseLm.notes? true : false;
+    let publicNotes = courseLm.publicNotes ? true : false;
+    assert.equal(find('td:eq(4) i', row).hasClass('fa-eye'), publicNotes && notesBool);
+    let meshTerms = find('td:eq(5) li', row);
+    if('meshDescriptors' in courseLm){
+      assert.equal(meshTerms.length, courseLm.meshDescriptors.length);
+      for(let i = 0; i < courseLm.meshDescriptors.length; i++){
+        assert.equal(getElementText(meshTerms.eq(i)), getText(fixtures.meshDescriptors[courseLm.meshDescriptors[i] - 1].name));
       }
     }
-  });
+  }
 });
 
 //we can't upload a file so we cant run this test
@@ -213,456 +212,366 @@ test('list learning materials', function(assert) {
 //   });
 // });
 
-test('create new link learning material', function(assert) {
+test('create new link learning material', async function(assert) {
   const testTitle = 'testsome title';
   const testAuthor = 'testsome author';
   const testDescription = 'testsome description';
   const testUrl = 'http://www.ucsf.edu/';
   const searchBox = '.search-box';
 
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials');
-    let rows = find('.detail-learningmaterials-content tbody tr', container);
+  await visit(url);
+  let container = find('.detail-learningmaterials');
+  let rows = find('.detail-learningmaterials-content tbody tr', container);
 
-    assert.ok(isPresent(find(searchBox)), 'learner-group search box is visible');
-    assert.equal(rows.length, fixtures.course.learningMaterials.length);
-    click('.detail-learningmaterials-actions .button', container).then(function(){
-      //pick the link type
-      click('.detail-learningmaterials-actions ul li:eq(1)');
-    });
-  });
-  andThen(function(){
-    assert.ok(isEmpty(find(searchBox)), 'learner-group search box is hidden while new group are being added');
-    //check that we got the right form
-    let labels = find('.detail-learningmaterials .new-learning-material label');
-    assert.equal(labels.length, 7);
-    const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
-    const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
-    assert.equal(getElementText(find('.detail-learningmaterials .new-learning-material .owninguser')), getText(userName));
-    let newLmContainer = find('.detail-learningmaterials .new-learning-material');
-    let inputs = find('input', newLmContainer);
-    let selectBoxes = find('select', newLmContainer);
-    fillIn(inputs.eq(0), testTitle);
-    fillIn(inputs.eq(1), testAuthor);
-    fillIn(inputs.eq(2), testUrl);
-    pickOption(selectBoxes[0], fixtures.statuses[2].title, assert);
-    pickOption(selectBoxes[1], fixtures.roles[2].title, assert);
-    find('.fr-box', newLmContainer).froalaEditor('html.set', testDescription);
-    find('.fr-box', newLmContainer).froalaEditor('events.trigger', 'contentChanged');
-    click('.detail-learningmaterials .new-learning-material .done');
-    andThen(function(){
-      let container = find('.detail-learningmaterials');
-      let rows = find('.detail-learningmaterials-content tbody tr', container);
-      assert.equal(rows.length, fixtures.course.learningMaterials.length + 1);
-      let row = rows.eq(fixtures.course.learningMaterials.length);
-      assert.equal(getElementText(find('td:eq(0)', row)), getText(testTitle));
-      assert.equal(getElementText(find('td:eq(1)', row)), getText('link'));
-    });
-  });
-
+  assert.ok(isPresent(find(searchBox)), 'learner-group search box is visible');
+  assert.equal(rows.length, fixtures.course.learningMaterials.length);
+  await click('.detail-learningmaterials-actions .button', container);
+  //pick the link type
+  await click('.detail-learningmaterials-actions ul li:eq(1)');
+  assert.ok(isEmpty(find(searchBox)), 'learner-group search box is hidden while new group are being added');
+  //check that we got the right form
+  let labels = find('.detail-learningmaterials .new-learning-material label');
+  assert.equal(labels.length, 7);
+  const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
+  const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
+  assert.equal(getElementText(find('.detail-learningmaterials .new-learning-material .owninguser')), getText(userName));
+  let newLmContainer = find('.detail-learningmaterials .new-learning-material');
+  let inputs = find('input', newLmContainer);
+  let selectBoxes = find('select', newLmContainer);
+  await fillIn(inputs.eq(0), testTitle);
+  await fillIn(inputs.eq(1), testAuthor);
+  await fillIn(inputs.eq(2), testUrl);
+  await pickOption(selectBoxes[0], fixtures.statuses[2].title, assert);
+  await pickOption(selectBoxes[1], fixtures.roles[2].title, assert);
+  find('.fr-box', newLmContainer).froalaEditor('html.set', testDescription);
+  find('.fr-box', newLmContainer).froalaEditor('events.trigger', 'contentChanged');
+  await click('.detail-learningmaterials .new-learning-material .done');
+  container = find('.detail-learningmaterials');
+  rows = find('.detail-learningmaterials-content tbody tr', container);
+  assert.equal(rows.length, fixtures.course.learningMaterials.length + 1);
+  let row = rows.eq(fixtures.course.learningMaterials.length);
+  assert.equal(getElementText(find('td:eq(0)', row)), getText(testTitle));
+  assert.equal(getElementText(find('td:eq(1)', row)), getText('link'));
 });
 
-test('create new citation learning material', function(assert) {
+test('create new citation learning material', async function(assert) {
   const testTitle = 'testsome title';
   const testAuthor = 'testsome author';
   const testDescription = 'testsome description';
   const testCitation = 'testsome citation';
   const searchBox = '.search-box';
 
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials');
-    let rows = find('.detail-learningmaterials-content tbody tr', container);
+  await visit(url);
+  let container = find('.detail-learningmaterials');
+  let rows = find('.detail-learningmaterials-content tbody tr', container);
 
-    assert.ok(isPresent(find(searchBox)), 'learner-group search box is visible');
-    assert.equal(rows.length, fixtures.course.learningMaterials.length);
-    click('.detail-learningmaterials-actions .button', container).then(function(){
-      //pick the citation type
-      click('.detail-learningmaterials-actions ul li:eq(2)');
-    });
-  });
-  andThen(function(){
-    assert.ok(isEmpty(find(searchBox)), 'learner-group search box is hidden while new group are being added');
-    //check that we got the right form
-    let labels = find('.detail-learningmaterials .new-learning-material label');
-    assert.equal(labels.length, 7);
-    const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
-    const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
-    assert.equal(getElementText(find('.detail-learningmaterials .new-learning-material .owninguser')), getText(userName));
-    let newLmContainer = find('.detail-learningmaterials .new-learning-material');
-    let inputs = find('input', newLmContainer);
-    let selectBoxes = find('select', newLmContainer);
-    fillIn(inputs.eq(0), testTitle);
-    fillIn(inputs.eq(1), testAuthor);
-    fillIn(find('textarea', newLmContainer).eq(0), testCitation);
-    pickOption(selectBoxes[0], fixtures.statuses[2].title, assert);
-    pickOption(selectBoxes[1], fixtures.roles[2].title, assert);
-    find('.fr-box', newLmContainer).froalaEditor('html.set', testDescription);
-    find('.fr-box', newLmContainer).froalaEditor('events.trigger', 'contentChanged');
-    click('.detail-learningmaterials .new-learning-material .done');
-    andThen(function(){
-      let container = find('.detail-learningmaterials');
-      let rows = find('.detail-learningmaterials-content tbody tr', container);
-      assert.equal(rows.length, fixtures.course.learningMaterials.length + 1);
-      let row = rows.eq(fixtures.course.learningMaterials.length);
-      assert.equal(getElementText(find('td:eq(0)', row)), getText(testTitle));
-      assert.equal(getElementText(find('td:eq(1)', row)), getText('citation'));
-    });
-  });
+  assert.ok(isPresent(find(searchBox)), 'learner-group search box is visible');
+  assert.equal(rows.length, fixtures.course.learningMaterials.length);
+  await click('.detail-learningmaterials-actions .button', container);
+  //pick the citation type
+  await click('.detail-learningmaterials-actions ul li:eq(2)');
+  assert.ok(isEmpty(find(searchBox)), 'learner-group search box is hidden while new group are being added');
+  //check that we got the right form
+  let labels = find('.detail-learningmaterials .new-learning-material label');
+  assert.equal(labels.length, 7);
+  const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
+  const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
+  assert.equal(getElementText(find('.detail-learningmaterials .new-learning-material .owninguser')), getText(userName));
+  let newLmContainer = find('.detail-learningmaterials .new-learning-material');
+  let inputs = find('input', newLmContainer);
+  let selectBoxes = find('select', newLmContainer);
+  await fillIn(inputs.eq(0), testTitle);
+  await fillIn(inputs.eq(1), testAuthor);
+  await fillIn(find('textarea', newLmContainer).eq(0), testCitation);
+  await pickOption(selectBoxes[0], fixtures.statuses[2].title, assert);
+  await pickOption(selectBoxes[1], fixtures.roles[2].title, assert);
+  find('.fr-box', newLmContainer).froalaEditor('html.set', testDescription);
+  find('.fr-box', newLmContainer).froalaEditor('events.trigger', 'contentChanged');
+  await click('.detail-learningmaterials .new-learning-material .done');
+  container = find('.detail-learningmaterials');
+  rows = find('.detail-learningmaterials-content tbody tr', container);
+  assert.equal(rows.length, fixtures.course.learningMaterials.length + 1);
+  let row = rows.eq(fixtures.course.learningMaterials.length);
+  assert.equal(getElementText(find('td:eq(0)', row)), getText(testTitle));
+  assert.equal(getElementText(find('td:eq(1)', row)), getText('citation'));
 });
 
-test('can only add one learning-material at a time', function(assert) {
+test('can only add one learning-material at a time', async function(assert) {
   const addButton = '.detail-learningmaterials-actions .button';
   const fileButton = '.detail-learningmaterials-actions ul li:eq(0)';
   const collapseButton = '.collapse-button';
   const component = '.new-learning-material';
 
-  visit(url);
-  click(addButton);
-  click(fileButton);
-  andThen(() => {
-    assert.ok(isEmpty(find(addButton)), 'add button is not visible');
-    assert.ok(find(collapseButton).is(':visible'), 'new-add collapse button is visible');
-    assert.ok(find(component).is(':visible'), 'new-add learning-material component is visible');
-  });
+  await visit(url);
+  await click(addButton);
+  await click(fileButton);
+  assert.ok(isEmpty(find(addButton)), 'add button is not visible');
+  assert.ok(find(collapseButton).is(':visible'), 'new-add collapse button is visible');
+  assert.ok(find(component).is(':visible'), 'new-add learning-material component is visible');
 
-  click(collapseButton);
-  andThen(() => {
-    assert.ok(find(addButton).is(':visible'), 'add button is visible');
-    assert.ok(isEmpty(find(collapseButton)), 'new-add collapse button is not visible');
-    assert.ok(isEmpty(find(component)), 'new-add learning-material component is not visible');
-  });
+  await click(collapseButton);
+  assert.ok(find(addButton).is(':visible'), 'add button is visible');
+  assert.ok(isEmpty(find(collapseButton)), 'new-add collapse button is not visible');
+  assert.ok(isEmpty(find(component)), 'new-add learning-material component is not visible');
 });
 
-test('cancel new learning material', function(assert) {
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials');
-    let rows = find('.detail-learningmaterials-content tbody tr', container);
-    assert.equal(rows.length, fixtures.course.learningMaterials.length);
-    click('.detail-learningmaterials-actions .button', container);
-    click('.detail-learningmaterials-actions ul li:eq(0)');
-  });
-  andThen(function(){
-    click('.detail-learningmaterials .new-learning-material .cancel');
-  });
-  andThen(function(){
-    let rows = find('.detail-learningmaterials .detail-learningmaterials-content tbody tr');
-    assert.equal(rows.length, fixtures.course.learningMaterials.length);
-  });
+test('cancel new learning material', async function(assert) {
+  await visit(url);
+  let container = find('.detail-learningmaterials');
+  let rows = find('.detail-learningmaterials-content tbody tr', container);
+  assert.equal(rows.length, fixtures.course.learningMaterials.length);
+  await click('.detail-learningmaterials-actions .button', container);
+  await click('.detail-learningmaterials-actions ul li:eq(0)');
+  await click('.detail-learningmaterials .new-learning-material .cancel');
+  rows = find('.detail-learningmaterials .detail-learningmaterials-content tbody tr');
+  assert.equal(rows.length, fixtures.course.learningMaterials.length);
 
+  await wait();
 });
 
-test('view copyright file learning material details', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
-    andThen(function(){
-      var container = $('.learningmaterial-manager');
-      assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[0].title));
-      assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[0].originalAuthor));
-      assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[0].description));
-      assert.equal(getElementText(find('.copyrightpermission', container)), getText('Yes'));
-      assert.equal(find('.copyrightrationale', container).length, 0);
-    });
-  });
+test('view copyright file learning material details', async function(assert) {
+  await visit(url);
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
+  var container = $('.learningmaterial-manager');
+  assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[0].title));
+  assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[0].originalAuthor));
+  assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[0].description));
+  assert.equal(getElementText(find('.copyrightpermission', container)), getText('Yes'));
+  assert.equal(find('.copyrightrationale', container).length, 0);
 });
 
-test('view rationale file learning material details', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(1) td:eq(0)');
-    andThen(function(){
-      var container = $('.learningmaterial-manager');
-      assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[1].title));
-      assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[1].originalAuthor));
-      assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[1].description));
-      assert.equal(getElementText(find('.copyrightrationale', container)), getText(fixtures.learningMaterials[1].copyrightRationale));
-      assert.equal(find('.citation', container).length, 0);
-      assert.equal(find('.link', container).length, 0);
-    });
-  });
+test('view rationale file learning material details', async function(assert) {
+  await visit(url);
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(1) td:eq(0)');
+  var container = $('.learningmaterial-manager');
+  assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[1].title));
+  assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[1].originalAuthor));
+  assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[1].description));
+  assert.equal(getElementText(find('.copyrightrationale', container)), getText(fixtures.learningMaterials[1].copyrightRationale));
+  assert.equal(find('.citation', container).length, 0);
+  assert.equal(find('.link', container).length, 0);
 });
 
-test('view url file learning material details', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(1) td:eq(0)');
-    andThen(function(){
-      var container = $('.learningmaterial-manager');
-      assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[1].title));
-      assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[1].originalAuthor));
-      assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[1].description));
-      assert.equal(getElementText(find('.upload-date', container)),
-        moment(fixtures.learningMaterials[1].uploadDate).format('M-D-YYYY'));
-      assert.equal(getElementText(find('.downloadurl', container)), getText(fixtures.learningMaterials[1].filename));
-      assert.equal(find('.downloadurl a', container).attr('href'), fixtures.learningMaterials[1].absoluteFileUri);
-      assert.equal(find('.citation', container).length, 0);
-      assert.equal(find('.link', container).length, 0);
-    });
-  });
+test('view url file learning material details', async function(assert) {
+  await visit(url);
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(1) td:eq(0)');
+  var container = $('.learningmaterial-manager');
+  assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[1].title));
+  assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[1].originalAuthor));
+  assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[1].description));
+  assert.equal(getElementText(find('.upload-date', container)),
+    moment(fixtures.learningMaterials[1].uploadDate).format('M-D-YYYY'));
+  assert.equal(getElementText(find('.downloadurl', container)), getText(fixtures.learningMaterials[1].filename));
+  assert.equal(find('.downloadurl a', container).attr('href'), fixtures.learningMaterials[1].absoluteFileUri);
+  assert.equal(find('.citation', container).length, 0);
+  assert.equal(find('.link', container).length, 0);
 });
 
-test('view link learning material details', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(2) td:eq(0)');
-    andThen(function(){
-      var container = $('.learningmaterial-manager');
-      assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[2].title));
-      assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[2].originalAuthor));
-      assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[2].description));
-      assert.equal(getElementText(find('.link', container)), getText(fixtures.learningMaterials[2].link));
-      assert.equal(getElementText(find('.upload-date', container)),
-        moment(fixtures.learningMaterials[2].uploadDate).format('M-D-YYYY'));
-      assert.equal(find('.copyrightpermission', container).length, 0);
-      assert.equal(find('.copyrightrationale', container).length, 0);
-      assert.equal(find('.citation', container).length, 0);
-      assert.equal(find('.copyrightpermission', container).length, 0);
-    });
-  });
+test('view link learning material details', async function(assert) {
+  await visit(url);
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(2) td:eq(0)');
+  var container = $('.learningmaterial-manager');
+  assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[2].title));
+  assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[2].originalAuthor));
+  assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[2].description));
+  assert.equal(getElementText(find('.link', container)), getText(fixtures.learningMaterials[2].link));
+  assert.equal(getElementText(find('.upload-date', container)),
+    moment(fixtures.learningMaterials[2].uploadDate).format('M-D-YYYY'));
+  assert.equal(find('.copyrightpermission', container).length, 0);
+  assert.equal(find('.copyrightrationale', container).length, 0);
+  assert.equal(find('.citation', container).length, 0);
+  assert.equal(find('.copyrightpermission', container).length, 0);
 });
 
-test('view citation learning material details', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(3) td:eq(0)');
-    andThen(function(){
-      var container = $('.learningmaterial-manager');
-      assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[3].title));
-      assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[3].originalAuthor));
-      assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[3].description));
-      assert.equal(getElementText(find('.citation', container)), getText(fixtures.learningMaterials[3].citation));
-      assert.equal(getElementText(find('.upload-date', container)),
-        moment(fixtures.learningMaterials[3].uploadDate).format('M-D-YYYY'));
-      assert.equal(find('.copyrightrationale', container).length, 0);
-      assert.equal(find('.file', container).length, 0);
-      assert.equal(find('.copyrightpermission', container).length, 0);
-    });
-  });
+test('view citation learning material details', async function(assert) {
+  await visit(url);
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(3) td:eq(0)');
+  var container = $('.learningmaterial-manager');
+  assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[3].title));
+  assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[3].originalAuthor));
+  assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[3].description));
+  assert.equal(getElementText(find('.citation', container)), getText(fixtures.learningMaterials[3].citation));
+  assert.equal(getElementText(find('.upload-date', container)),
+    moment(fixtures.learningMaterials[3].uploadDate).format('M-D-YYYY'));
+  assert.equal(find('.copyrightrationale', container).length, 0);
+  assert.equal(find('.file', container).length, 0);
+  assert.equal(find('.copyrightpermission', container).length, 0);
 });
 
-test('edit learning material', function(assert) {
+test('edit learning material', async function(assert) {
   const searchBox = '.search-box';
 
-  visit(url);
-  andThen(function() {
-    assert.ok(isPresent(find(searchBox)), 'learner-gorup search box is visible');
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
-    andThen(function(){
-      let container = $('.learningmaterial-manager');
-      assert.ok(isEmpty(find(searchBox)), 'learner-gorup search box is hidden while in edit mode');
-      click(find('.required .switch-handle', container));
-      click(find('.publicnotes .switch-handle', container));
-      click(find('.status .editable', container)).then(function(){
-        pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
-        click(find('.status .done', container));
-      });
-      let newNote = 'text text.  Woo hoo!';
-      click(find('.notes .editable', container)).then(function(){
-        //wait for the editor to load
-        later(()=>{
-          find('.notes .fr-box', container).froalaEditor('html.set', newNote);
-          find('.notes .fr-box', container).froalaEditor('events.trigger', 'contentChanged');
-          click(find('.notes .done', container));
-          andThen(function(){
-            assert.equal(getElementText(find('.notes', container)), getText(`InstructionalNotes: ${newNote}`));
-          });
-          click('.detail-learningmaterials button.bigadd');
-          andThen(function(){
-            assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(3)')), getText('Yes'));
-            assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4)')), getText('Yes'), 'there is content in notes');
-            assert.ok(isEmpty(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is false and `eye` icon is not visible');
-            assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[2].title));
+  await visit(url);
+  assert.ok(isPresent(find(searchBox)), 'learner-gorup search box is visible');
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
+  let container = $('.learningmaterial-manager');
+  assert.ok(isEmpty(find(searchBox)), 'learner-gorup search box is hidden while in edit mode');
+  await click(find('.required .switch-handle', container));
+  await click(find('.publicnotes .switch-handle', container));
+  await click(find('.status .editable', container));
+  await pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
+  await click(find('.status .done', container));
+  let newNote = 'text text.  Woo hoo!';
+  await click(find('.notes .editable', container));
+  //wait for the editor to load
+  later(async ()=>{
+    find('.notes .fr-box', container).froalaEditor('html.set', newNote);
+    find('.notes .fr-box', container).froalaEditor('events.trigger', 'contentChanged');
+    await click(find('.notes .done', container));
+    assert.equal(getElementText(find('.notes', container)), getText(`InstructionalNotes: ${newNote}`));
+    await click('.detail-learningmaterials button.bigadd');
+    assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(3)')), getText('Yes'));
+    assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4)')), getText('Yes'), 'there is content in notes');
+    assert.ok(isEmpty(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is false and `eye` icon is not visible');
+    assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[2].title));
 
-            click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
-            andThen(function(){
-              container = $('.learningmaterial-manager');
-              assert.equal(getElementText(find('.notes', container)), getText(`InstructionalNotes: ${newNote}`));
-              assert.equal(getElementText(find('.status', container)), getText('Status: status 2'));
-            });
-          });
-        }, 100);
-      });
-    });
-  });
+    await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
+    container = $('.learningmaterial-manager');
+    assert.equal(getElementText(find('.notes', container)), getText(`InstructionalNotes: ${newNote}`));
+    assert.equal(getElementText(find('.status', container)), getText('Status: status 2'));
+  }, 100);
+  await wait();
 });
 
-test('cancel editing learning material', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
-    andThen(function(){
-      var container = $('.learningmaterial-manager');
-      click(find('.required .switch-handle', container));
-      click(find('.publicnotes .switch-handle', container));
-      click(find('.status .editable', container)).then(function(){
-        pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
-        click(find('.status .done', container));
-      });
-      click('.detail-learningmaterials button.bigcancel');
-      andThen(function(){
-        assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(3)')), getText('No'));
-        assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4)')), getText('No'), 'no content is available under notes');
-        assert.ok(isEmpty(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is true but notes are blank so `eye` icon is not visible');
-        assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[0].title));
-      });
-    });
-  });
+test('cancel editing learning material', async function(assert) {
+  await visit(url);
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
+  var container = $('.learningmaterial-manager');
+  await click(find('.required .switch-handle', container));
+  await click(find('.publicnotes .switch-handle', container));
+  await click(find('.status .editable', container));
+  await pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
+  await click(find('.status .done', container));
+  await click('.detail-learningmaterials button.bigcancel');
+  assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(3)')), getText('No'));
+  assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4)')), getText('No'), 'no content is available under notes');
+  assert.ok(isEmpty(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is true but notes are blank so `eye` icon is not visible');
+  assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[0].title));
+
+  await wait();
 });
 
-test('manage terms', function(assert) {
+test('manage terms', async function(assert) {
   assert.expect(24);
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials').eq(0);
-    click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container).then(function(){
-      assert.equal(getElementText(find('.specific-title', container)), 'SelectMeSHDescriptorsforLearningMaterials');
-    });
+  await visit(url);
+  let container = find('.detail-learningmaterials').eq(0);
+  await click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container);
+  assert.equal(getElementText(find('.specific-title', container)), 'SelectMeSHDescriptorsforLearningMaterials');
 
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container).eq(0);
-      let material = fixtures.courseLearningMaterials[0];
-      let removableItems = find('.removable-list li', meshManager);
-      assert.equal(removableItems.length, material.meshDescriptors.length);
-      for (let i = 0; i < material.meshDescriptors.length; i++){
-        let meshDescriptorName = find('.content .title', removableItems[i]).eq(0);
-        assert.equal(getElementText(meshDescriptorName), getText(fixtures.meshDescriptors[material.meshDescriptors[i] - 1].name));
-      }
+  let meshManager = find('.mesh-manager', container).eq(0);
+  let material = fixtures.courseLearningMaterials[0];
+  let removableItems = find('.removable-list li', meshManager);
+  assert.equal(removableItems.length, material.meshDescriptors.length);
+  for (let i = 0; i < material.meshDescriptors.length; i++){
+    let meshDescriptorName = find('.content .title', removableItems[i]).eq(0);
+    assert.equal(getElementText(meshDescriptorName), getText(fixtures.meshDescriptors[material.meshDescriptors[i] - 1].name));
+  }
 
-      let searchBox = find('.search-box', meshManager);
-      assert.equal(searchBox.length, 1);
-      searchBox = searchBox.eq(0);
-      let searchBoxInput = find('input', searchBox);
-      assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
-      fillIn(searchBoxInput, 'descriptor');
-      click('span.search-icon', searchBox);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        assert.equal(searchResults.length, fixtures.meshDescriptors.length);
+  let searchBox = find('.search-box', meshManager);
+  assert.equal(searchBox.length, 1);
+  searchBox = searchBox.eq(0);
+  let searchBoxInput = find('input', searchBox);
+  assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('span.search-icon', searchBox);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  assert.equal(searchResults.length, fixtures.meshDescriptors.length);
 
-        for(let i = 0; i < fixtures.meshDescriptors.length; i++){
-          let meshDescriptorName = find('.descriptor-name', searchResults[i]).eq(0);
-          assert.equal(getElementText(meshDescriptorName), getText(fixtures.meshDescriptors[i].name));
-        }
+  for(let i = 0; i < fixtures.meshDescriptors.length; i++){
+    let meshDescriptorName = find('.descriptor-name', searchResults[i]).eq(0);
+    assert.equal(getElementText(meshDescriptorName), getText(fixtures.meshDescriptors[i].name));
+  }
 
-        for (let i = 0; i < fixtures.meshDescriptors.length; i++){
-          if(material.meshDescriptors.indexOf(fixtures.meshDescriptors[i].id) !== -1){
-            assert.ok($(searchResults[i]).hasClass('disabled'));
-          } else {
-            assert.ok(!$(searchResults[i]).hasClass('disabled'));
-          }
-        }
-        click('.removable-list li:eq(0)', meshManager).then(function(){
-          assert.ok(!$(find('.mesh-search-results li:eq(1)', meshManager)).hasClass('disabled'));
-        });
-        click(searchResults[0]);
-        andThen(function(){
-          assert.ok($(find('.mesh-search-results li:eq(2)', meshManager)).hasClass('disabled'));
+  for (let i = 0; i < fixtures.meshDescriptors.length; i++){
+    if(material.meshDescriptors.indexOf(fixtures.meshDescriptors[i].id) !== -1){
+      assert.ok($(searchResults[i]).hasClass('disabled'));
+    } else {
+      assert.ok(!$(searchResults[i]).hasClass('disabled'));
+    }
+  }
+  await click('.removable-list li:eq(0)', meshManager);
+  assert.ok(!$(find('.mesh-search-results li:eq(1)', meshManager)).hasClass('disabled'));
+  await click(searchResults[0]);
+  assert.ok($(find('.mesh-search-results li:eq(2)', meshManager)).hasClass('disabled'));
 
-          let newExpectedMesh = [
-            fixtures.meshDescriptors[0],
-            fixtures.meshDescriptors[2]
-          ];
-          removableItems = find('.removable-list li', meshManager);
-          assert.equal(removableItems.length, 2);
-          for (let i = 0; i < 2; i++){
-            let meshDescriptorName = find('.title', removableItems[i]).eq(0);
-            assert.equal(getElementText(meshDescriptorName), getText(newExpectedMesh[i].name));
-          }
-        });
-      });
-    });
-  });
+  let newExpectedMesh = [
+    fixtures.meshDescriptors[0],
+    fixtures.meshDescriptors[2]
+  ];
+  removableItems = find('.removable-list li', meshManager);
+  assert.equal(removableItems.length, 2);
+  for (let i = 0; i < 2; i++){
+    let meshDescriptorName = find('.title', removableItems[i]).eq(0);
+    assert.equal(getElementText(meshDescriptorName), getText(newExpectedMesh[i].name));
+  }
+
+  await wait();
 });
 
-test('save terms', function(assert) {
+test('save terms', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials').eq(0);
-    click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container);
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container).eq(0);
-      let searchBoxInput = find('.search-box input', meshManager);
-      fillIn(searchBoxInput, 'descriptor');
-      click('.search-box span.search-icon', meshManager);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        click('.removable-list li:eq(0)', meshManager);
-        click(searchResults[0]);
-        click('button.bigadd', container);
-        andThen(function(){
-          let expectedMesh = fixtures.meshDescriptors[0].name + fixtures.meshDescriptors[2].name;
-          let tds = find('.detail-learningmaterials-content tbody tr:eq(0) td');
-          assert.equal(getElementText(tds.eq(5)), getText(expectedMesh));
-        });
-      });
-    });
-  });
+  await visit(url);
+  let container = find('.detail-learningmaterials').eq(0);
+  await click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container);
+  let meshManager = find('.mesh-manager', container).eq(0);
+  let searchBoxInput = find('.search-box input', meshManager);
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('.search-box span.search-icon', meshManager);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  await click('.removable-list li:eq(0)', meshManager);
+  await click(searchResults[0]);
+  await click('button.bigadd', container);
+  let expectedMesh = fixtures.meshDescriptors[0].name + fixtures.meshDescriptors[2].name;
+  let tds = find('.detail-learningmaterials-content tbody tr:eq(0) td');
+  assert.equal(getElementText(tds.eq(5)), getText(expectedMesh));
 });
 
-test('cancel term changes', function(assert) {
+test('cancel term changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials').eq(0);
-    click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container);
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container).eq(0);
-      let searchBoxInput = find('.search-box input', meshManager);
-      fillIn(searchBoxInput, 'descriptor');
-      click('.search-box span.search-icon', meshManager);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        click('.removable-list li:eq(0)', meshManager);
-        click(searchResults[2]);
-        click(searchResults[3]);
-        click(searchResults[4]);
-        click('button.bigcancel', container);
-        andThen(function(){
-          let tds = find('.detail-learningmaterials-content tbody tr:eq(0) td');
-          let expectedMesh = fixtures.meshDescriptors[1].name + fixtures.meshDescriptors[2].name;
-          assert.equal(getElementText(tds.eq(5)), getText(expectedMesh));
-        });
-      });
-    });
-  });
+  await visit(url);
+  let container = find('.detail-learningmaterials').eq(0);
+  await click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container);
+  let meshManager = find('.mesh-manager', container).eq(0);
+  let searchBoxInput = find('.search-box input', meshManager);
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('.search-box span.search-icon', meshManager);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  await click('.removable-list li:eq(0)', meshManager);
+  await click(searchResults[2]);
+  await click(searchResults[3]);
+  await click(searchResults[4]);
+  await click('button.bigcancel', container);
+  let tds = find('.detail-learningmaterials-content tbody tr:eq(0) td');
+  let expectedMesh = fixtures.meshDescriptors[1].name + fixtures.meshDescriptors[2].name;
+  assert.equal(getElementText(tds.eq(5)), getText(expectedMesh));
 });
 
-test('find and add learning material', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.index');
-    let container = find('.detail-learningmaterials');
-    let rows = find('.detail-learningmaterials-content tbody tr', container);
-    assert.equal(rows.length, fixtures.course.learningMaterials.length);
+test('find and add learning material', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'course.index');
+  let container = find('.detail-learningmaterials');
+  let rows = find('.detail-learningmaterials-content tbody tr', container);
+  assert.equal(rows.length, fixtures.course.learningMaterials.length);
 
-    let searchBoxInput = find('input', container);
-    fillIn(searchBoxInput, 'doc');
-    triggerEvent(searchBoxInput, 'keyup');
-    andThen(function(){
-      later(function(){
-        let searchResults = find('.lm-search-results > li', container);
-        assert.equal(searchResults.length, 1);
-        assert.equal(getElementText($('.lm-search-results > li:eq(0) h4')), getText('Letter to Doc Brown'));
-        assert.equal(find('.lm-search-results > li:eq(0) h4 .lm-type-icon .fa-file').length, 1, 'Shows LM type icon.');
-        let addlProps = find('.lm-search-results > li:eq(0) .learning-material-properties li', container);
-        assert.equal(addlProps.length, 3);
-        assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(0)')),
-          getText('Owner: 0 guy M. Mc0son'));
-        assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(1)')),
-          getText('Content Author: ' + fixtures.learningMaterials[4].originalAuthor));
-        assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(2)')),
-          getText('Upload date: ' + moment(fixtures.learningMaterials[4].uploadDate).format('M-D-YYYY')));
-        click(searchResults[0]);
-
-        andThen(function(){
-          rows = find('.detail-learningmaterials-content tbody tr', container);
-          assert.equal(rows.length, fixtures.course.learningMaterials.length + 1);
-        });
-      }, 1000);
-    });
-  });
+  let searchBoxInput = find('input', container);
+  await fillIn(searchBoxInput, 'doc');
+  await triggerEvent(searchBoxInput, 'keyup');
+  later(async () =>{
+    let searchResults = find('.lm-search-results > li', container);
+    assert.equal(searchResults.length, 1);
+    assert.equal(getElementText($('.lm-search-results > li:eq(0) h4')), getText('Letter to Doc Brown'));
+    assert.equal(find('.lm-search-results > li:eq(0) h4 .lm-type-icon .fa-file').length, 1, 'Shows LM type icon.');
+    let addlProps = find('.lm-search-results > li:eq(0) .learning-material-properties li', container);
+    assert.equal(addlProps.length, 3);
+    assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(0)')),
+      getText('Owner: 0 guy M. Mc0son'));
+    assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(1)')),
+      getText('Content Author: ' + fixtures.learningMaterials[4].originalAuthor));
+    assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(2)')),
+      getText('Upload date: ' + moment(fixtures.learningMaterials[4].uploadDate).format('M-D-YYYY')));
+    await click(searchResults[0]);
+    rows = find('.detail-learningmaterials-content tbody tr', container);
+    assert.equal(rows.length, fixtures.course.learningMaterials.length + 1);
+  }, 1000);
+  await wait();
 });

--- a/tests/acceptance/course/mesh-test.js
+++ b/tests/acceptance/course/mesh-test.js
@@ -52,155 +52,124 @@ module('Acceptance: Course - Mesh Terms', {
   }
 });
 
-test('list mesh', function(assert) {
+test('list mesh', async function(assert) {
   assert.expect(4);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-mesh');
-    var items = find('ul.columnar-list li', container);
-    assert.equal(items.length, 3);
-    assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
-    assert.equal(getElementText(items.eq(1)), getText('descriptor 1'));
-    assert.equal(getElementText(items.eq(2)), getText('descriptor 2'));
-  });
+  await visit(url);
+  var container = find('.detail-mesh');
+  var items = find('ul.columnar-list li', container);
+  assert.equal(items.length, 3);
+  assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
+  assert.equal(getElementText(items.eq(1)), getText('descriptor 1'));
+  assert.equal(getElementText(items.eq(2)), getText('descriptor 2'));
 });
 
-test('manage mesh', function(assert) {
+test('manage mesh', async function(assert) {
   assert.expect(34);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-mesh');
-    click(find('.actions button', container));
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container);
-      let removableItems = find('.removable-list li', meshManager);
-      assert.equal(removableItems.length, 3);
-      assert.equal(
-        getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
-        getText('descriptor 0')
-      );
-      assert.equal(getElementText(find('.content .details', removableItems.eq(0)).eq(0)), getText('1 - tree number 2'));
-      assert.equal(
-        getElementText(find('.content .title', removableItems.eq(1)).eq(0)),
-        getText('descriptor 1')
-      );
-      assert.equal(getElementText(find('.content .details', removableItems.eq(1)).eq(0)), '2');
-      assert.equal(
-        getElementText(find('.content .title', removableItems.eq(2)).eq(0)),
-        getText('descriptor 2')
-      );
-      assert.equal(getElementText(find('.content .details', removableItems.eq(2)).eq(0)), '3');
-      let searchBox = find('.search-box', meshManager);
-      assert.equal(searchBox.length, 1);
-      searchBox = searchBox.eq(0);
-      let searchBoxInput = find('input', searchBox);
-      assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
-      fillIn(searchBoxInput, 'descriptor');
-      click('span.search-icon', searchBox);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results > li', meshManager);
-        assert.equal(searchResults.length, 6);
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(0)).eq(0)), getText('descriptor 0'));
-        assert.equal(getElementText(find('.descriptor-id', searchResults.eq(0)).eq(0)), getText('1 - tree number 2'));
-        let scopeNotes = find('.mesh-concepts li', searchResults.eq(0));
-        assert.equal(scopeNotes.length, 4);
-        for(let i = 0; i < 3; i++) {
-          assert.equal(getElementText(scopeNotes.eq(i)), getText(`scope note ${i}`));
-        }
-        assert.equal(getElementText(scopeNotes.eq(3)), '1234567890'.repeat(25));
-        assert.ok($(scopeNotes.eq(3)).hasClass('truncated'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(1)).eq(0)), getText('descriptor 1'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(2)).eq(0)), getText('descriptor 2'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(3)).eq(0)), getText('descriptor 3'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(4)).eq(0)), getText('descriptor 4'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(5)).eq(0)), getText('descriptor 5'));
-        assert.ok($(searchResults[0]).hasClass('disabled'));
-        assert.ok($(searchResults[1]).hasClass('disabled'));
-        assert.ok($(searchResults[2]).hasClass('disabled'));
-        assert.ok(!$(searchResults[3]).hasClass('disabled'));
-        assert.ok(!$(searchResults[4]).hasClass('disabled'));
-        assert.ok(!$(searchResults[5]).hasClass('disabled'));
+  await visit(url);
+  var container = find('.detail-mesh');
+  await click(find('.actions button', container));
+  let meshManager = find('.mesh-manager', container);
+  let removableItems = find('.removable-list li', meshManager);
+  assert.equal(removableItems.length, 3);
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
+    getText('descriptor 0')
+  );
+  assert.equal(getElementText(find('.content .details', removableItems.eq(0)).eq(0)), getText('1 - tree number 2'));
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(1)).eq(0)),
+    getText('descriptor 1')
+  );
+  assert.equal(getElementText(find('.content .details', removableItems.eq(1)).eq(0)), '2');
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(2)).eq(0)),
+    getText('descriptor 2')
+  );
+  assert.equal(getElementText(find('.content .details', removableItems.eq(2)).eq(0)), '3');
+  let searchBox = find('.search-box', meshManager);
+  assert.equal(searchBox.length, 1);
+  searchBox = searchBox.eq(0);
+  let searchBoxInput = find('input', searchBox);
+  assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('span.search-icon', searchBox);
+  let searchResults = find('.mesh-search-results > li', meshManager);
+  assert.equal(searchResults.length, 6);
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(0)).eq(0)), getText('descriptor 0'));
+  assert.equal(getElementText(find('.descriptor-id', searchResults.eq(0)).eq(0)), getText('1 - tree number 2'));
+  let scopeNotes = find('.mesh-concepts li', searchResults.eq(0));
+  assert.equal(scopeNotes.length, 4);
+  for(let i = 0; i < 3; i++) {
+    assert.equal(getElementText(scopeNotes.eq(i)), getText(`scope note ${i}`));
+  }
+  assert.equal(getElementText(scopeNotes.eq(3)), '1234567890'.repeat(25));
+  assert.ok($(scopeNotes.eq(3)).hasClass('truncated'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(1)).eq(0)), getText('descriptor 1'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(2)).eq(0)), getText('descriptor 2'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(3)).eq(0)), getText('descriptor 3'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(4)).eq(0)), getText('descriptor 4'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(5)).eq(0)), getText('descriptor 5'));
+  assert.ok($(searchResults[0]).hasClass('disabled'));
+  assert.ok($(searchResults[1]).hasClass('disabled'));
+  assert.ok($(searchResults[2]).hasClass('disabled'));
+  assert.ok(!$(searchResults[3]).hasClass('disabled'));
+  assert.ok(!$(searchResults[4]).hasClass('disabled'));
+  assert.ok(!$(searchResults[5]).hasClass('disabled'));
 
-        click('.removable-list li:eq(1)', meshManager).then(function(){
-          assert.ok(!$(find('.mesh-search-results > li:eq(1)', meshManager)).hasClass('disabled'));
-        });
-        click(searchResults[3]);
-        andThen(function(){
-          assert.ok($(find('.mesh-search-results > li:eq(3)', meshManager)).hasClass('disabled'));
-          removableItems = find('.removable-list li', meshManager);
-          assert.equal(
-            getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
-            getText('descriptor 0')
-          );
-          assert.equal(
-            getElementText(find('.content .title', removableItems.eq(1)).eq(0)),
-            getText('descriptor 2')
-          );
-          assert.equal(
-            getElementText(find('.content .title', removableItems.eq(2)).eq(0)),
-            getText('descriptor 3')
-          );
-        });
-      });
-    });
-  });
+  await click('.removable-list li:eq(1)', meshManager);
+  assert.ok(!$(find('.mesh-search-results > li:eq(1)', meshManager)).hasClass('disabled'));
+  await click(searchResults[3]);
+  assert.ok($(find('.mesh-search-results > li:eq(3)', meshManager)).hasClass('disabled'));
+  removableItems = find('.removable-list li', meshManager);
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
+    getText('descriptor 0')
+  );
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(1)).eq(0)),
+    getText('descriptor 2')
+  );
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(2)).eq(0)),
+    getText('descriptor 3')
+  );
 });
 
-test('save mesh changes', function(assert) {
+test('save mesh changes', async function(assert) {
   assert.expect(4);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-mesh');
-    click(find('.actions button', container));
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container);
-      fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');
-      click('.search-box span.search-icon', meshManager);
-      andThen(function(){
-        click('.removable-list li:eq(1)', meshManager).then(()=> {
-          click('.mesh-search-results > li:eq(3)', meshManager).then(()=>{
-            click('button.bigadd', container);
-          });
-        });
-        andThen(function(){
-          var items = find('ul.columnar-list li', container);
-          assert.equal(items.length, 3);
-          assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
-          assert.equal(getElementText(items.eq(1)), getText('descriptor 2'));
-          assert.equal(getElementText(items.eq(2)), getText('descriptor 3'));
-        });
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.detail-mesh');
+  await click(find('.actions button', container));
+  let meshManager = find('.mesh-manager', container);
+  await fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');
+  await click('.search-box span.search-icon', meshManager);
+  await click('.removable-list li:eq(1)', meshManager);
+  await click('.mesh-search-results > li:eq(3)', meshManager);
+  await click('button.bigadd', container);
+  var items = find('ul.columnar-list li', container);
+  assert.equal(items.length, 3);
+  assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
+  assert.equal(getElementText(items.eq(1)), getText('descriptor 2'));
+  assert.equal(getElementText(items.eq(2)), getText('descriptor 3'));
 });
 
 
 
-test('cancel mesh changes', function(assert) {
+test('cancel mesh changes', async function(assert) {
   assert.expect(4);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-mesh');
-    click(find('.actions button', container));
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container);
-      fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');
-      click('.search-box span.search-icon', meshManager);
-      andThen(function(){
-        click('.removable-list li:eq(1)', meshManager).then(()=> {
-          click('.mesh-search-results li:eq(3)', meshManager).then(()=>{
-            click('button.bigcancel', container);
-          });
-        });
+  await visit(url);
+  var container = find('.detail-mesh');
+  await click(find('.actions button', container));
+  let meshManager = find('.mesh-manager', container);
+  await fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');
+  await click('.search-box span.search-icon', meshManager);
+  await click('.removable-list li:eq(1)', meshManager);
+  await click('.mesh-search-results li:eq(3)', meshManager);
+  await click('button.bigcancel', container);
 
-        andThen(function(){
-          var items = find('ul.columnar-list li', container);
-          assert.equal(items.length, 3);
-          assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
-          assert.equal(getElementText(items.eq(1)), getText('descriptor 1'));
-          assert.equal(getElementText(items.eq(2)), getText('descriptor 2'));
-        });
-      });
-    });
-  });
+  var items = find('ul.columnar-list li', container);
+  assert.equal(items.length, 3);
+  assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
+  assert.equal(getElementText(items.eq(1)), getText('descriptor 1'));
+  assert.equal(getElementText(items.eq(2)), getText('descriptor 2'));
 });

--- a/tests/acceptance/course/objectivecreate-test.js
+++ b/tests/acceptance/course/objectivecreate-test.js
@@ -5,8 +5,10 @@ import {
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+import wait from 'ember-test-helpers/wait';
 import Ember from 'ember';
 
+const { run } = Ember;
 var application;
 var fixtures = {};
 var url = '/courses/1?details=true&courseObjectiveDetails=true';
@@ -34,58 +36,46 @@ module('Acceptance: Course - Objective Create', {
   }
 });
 
-test('save new objective', function(assert) {
+test('save new objective', async function(assert) {
   assert.expect(8);
-  visit(url);
+  await visit(url);
   var newObjectiveTitle = 'Test junk 123';
-  andThen(function() {
-    let objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
-    assert.equal(objectiveRows.length, fixtures.course.objectives.length);
-    click('.detail-objectives .detail-objectives-actions button');
-    //wait for the editor to load
-    Ember.run.later(()=>{
-      find('.detail-objectives .newobjective .fr-box').froalaEditor('html.set', newObjectiveTitle);
-      find('.detail-objectives .newobjective .fr-box').froalaEditor('events.trigger', 'contentChanged');
-      Ember.run.later(()=>{
-        click('.detail-objectives .newobjective button.done');
-        andThen(function(){
-          objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
-          assert.equal(objectiveRows.length, fixtures.course.objectives.length + 1);
-          let tds = find('td', objectiveRows.eq(0));
-          assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
-          assert.equal(getElementText(tds.eq(1)), getText('Add New'));
-          assert.equal(getElementText(tds.eq(2)), getText('Add New'));
-          tds = find('td', objectiveRows.eq(1));
-          assert.equal(getElementText(tds.eq(0)), getText(newObjectiveTitle));
-          assert.equal(getElementText(tds.eq(1)), getText('Add New'));
-          assert.equal(getElementText(tds.eq(2)), getText('Add New'));
-        });
-      }, 100);
-    }, 100);
-  });
+  let objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
+  assert.equal(objectiveRows.length, fixtures.course.objectives.length);
+  await click('.detail-objectives .detail-objectives-actions button');
+  find('.detail-objectives .newobjective .fr-box').froalaEditor('html.set', newObjectiveTitle);
+  find('.detail-objectives .newobjective .fr-box').froalaEditor('events.trigger', 'contentChanged');
+  await click('.detail-objectives .newobjective button.done');
+  objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
+  assert.equal(objectiveRows.length, fixtures.course.objectives.length + 1);
+  let tds = find('td', objectiveRows.eq(0));
+  assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
+  assert.equal(getElementText(tds.eq(1)), getText('Add New'));
+  assert.equal(getElementText(tds.eq(2)), getText('Add New'));
+  tds = find('td', objectiveRows.eq(1));
+  assert.equal(getElementText(tds.eq(0)), getText(newObjectiveTitle));
+  assert.equal(getElementText(tds.eq(1)), getText('Add New'));
+  assert.equal(getElementText(tds.eq(2)), getText('Add New'));
 
+  await wait();
 });
 
-test('cancel new objective', function(assert) {
+test('cancel new objective', async function(assert) {
   assert.expect(5);
-  visit(url);
-  andThen(function() {
-    let objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
-    assert.equal(objectiveRows.length, fixtures.course.objectives.length);
-    click('.detail-objectives .detail-objectives-actions button');
-    click('.detail-objectives .newobjective button.cancel');
-  });
-  andThen(function(){
-    let objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
-    assert.equal(objectiveRows.length, fixtures.course.objectives.length);
-    let tds = find('td', objectiveRows.eq(0));
-    assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
-    assert.equal(getElementText(tds.eq(1)), getText('Add New'));
-    assert.equal(getElementText(tds.eq(2)), getText('Add New'));
-  });
+  await visit(url);
+  let objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
+  assert.equal(objectiveRows.length, fixtures.course.objectives.length);
+  await click('.detail-objectives .detail-objectives-actions button');
+  await click('.detail-objectives .newobjective button.cancel');
+  objectiveRows = find('.detail-objectives .course-objective-list tbody tr');
+  assert.equal(objectiveRows.length, fixtures.course.objectives.length);
+  let tds = find('td', objectiveRows.eq(0));
+  assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
+  assert.equal(getElementText(tds.eq(1)), getText('Add New'));
+  assert.equal(getElementText(tds.eq(2)), getText('Add New'));
 });
 
-test('empty objective title can not be created', function(assert) {
+test('empty objective title can not be created', async function(assert) {
   assert.expect(3);
   const container = '.detail-objectives:eq(0)';
   const expandNewObjective = `${container} .detail-objectives-actions button`;
@@ -93,21 +83,17 @@ test('empty objective title can not be created', function(assert) {
   const editor = `${newObjective} .fr-box`;
   const save = `${newObjective} .done`;
   const errorMessage = `${newObjective} .validation-error-message`;
-  visit(url);
-  click(expandNewObjective);
+  await visit(url);
+  await click(expandNewObjective);
 
-  andThen(function() {
-    //wait for the editor to load
-    Ember.run.later(()=>{
-      let editorContents = find(editor).data('froala.editor').$el.text();
-      assert.equal(getText(editorContents), '');
-
-      find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
-      find(editor).froalaEditor('events.trigger', 'contentChanged');
-      Ember.run.later(()=>{
-        assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
-        assert.ok(find(save).is(':disabled'));
-      }, 100);
-    }, 100);
+  let editorContents = find(editor).data('froala.editor').$el.text();
+  assert.equal(getText(editorContents), '');
+  find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
+  find(editor).froalaEditor('events.trigger', 'contentChanged');
+  run.later(() => {
+    assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
+    assert.ok(find(save).is(':disabled'));
   });
+
+  await wait();
 });

--- a/tests/acceptance/course/objectivemesh-test.js
+++ b/tests/acceptance/course/objectivemesh-test.js
@@ -5,6 +5,7 @@ import {
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+import wait from 'ember-test-helpers/wait';
 
 var application;
 var url = '/courses/1?details=true&courseObjectiveDetails=true';
@@ -56,123 +57,98 @@ module('Acceptance: Course - Objective Mesh Descriptors', {
   }
 });
 
-test('manage terms', function(assert) {
+test('manage terms', async function(assert) {
   assert.expect(27);
-  visit(url);
-  andThen(function() {
-    let detailObjectives = find('.detail-objectives').eq(0);
-    click('.course-objective-list tbody tr:eq(1) td:eq(2) .link', detailObjectives).then(function(){
-      assert.equal(getElementText(find('.specific-title', detailObjectives)), 'SelectMeSHDescriptorsforObjective');
-    });
+  await visit(url);
+  let detailObjectives = find('.detail-objectives').eq(0);
+  await click('.course-objective-list tbody tr:eq(1) td:eq(2) .link', detailObjectives);
+  assert.equal(getElementText(find('.specific-title', detailObjectives)), 'SelectMeSHDescriptorsforObjective');
 
-    andThen(function() {
-      let meshManager = find('.mesh-manager', detailObjectives).eq(0);
-      let objective = fixtures.courseObjectives[1];
-      let removableItems = find('.removable-list li', meshManager);
-      assert.equal(removableItems.length, objective.meshDescriptors.length);
-      for (let i = 0; i < objective.meshDescriptors.length; i++){
-        let meshDescriptorName = find('.content .title', removableItems[i]).eq(0);
-        assert.equal(getElementText(meshDescriptorName), getText(fixtures.meshDescriptors[objective.meshDescriptors[i] - 1].name));
-      }
+  let meshManager = find('.mesh-manager', detailObjectives).eq(0);
+  let objective = fixtures.courseObjectives[1];
+  let removableItems = find('.removable-list li', meshManager);
+  assert.equal(removableItems.length, objective.meshDescriptors.length);
+  for (let i = 0; i < objective.meshDescriptors.length; i++){
+    let meshDescriptorName = find('.content .title', removableItems[i]).eq(0);
+    assert.equal(getElementText(meshDescriptorName), getText(fixtures.meshDescriptors[objective.meshDescriptors[i] - 1].name));
+  }
 
-      let searchBox = find('.search-box', meshManager);
-      assert.equal(searchBox.length, 1);
-      searchBox = searchBox.eq(0);
-      let searchBoxInput = find('input', searchBox);
-      assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
-      fillIn(searchBoxInput, 'descriptor');
-      click('span.search-icon', searchBox);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        assert.equal(searchResults.length, fixtures.meshDescriptors.length);
-        for(let i = 0; i < fixtures.meshDescriptors.length; i++){
-          let meshDescriptorName = find('.descriptor-name', searchResults[i]).eq(0);
-          assert.equal(getElementText(meshDescriptorName), getText(fixtures.meshDescriptors[i].name));
-        }
+  let searchBox = find('.search-box', meshManager);
+  assert.equal(searchBox.length, 1);
+  searchBox = searchBox.eq(0);
+  let searchBoxInput = find('input', searchBox);
+  assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('span.search-icon', searchBox);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  assert.equal(searchResults.length, fixtures.meshDescriptors.length);
+  for(let i = 0; i < fixtures.meshDescriptors.length; i++){
+    let meshDescriptorName = find('.descriptor-name', searchResults[i]).eq(0);
+    assert.equal(getElementText(meshDescriptorName), getText(fixtures.meshDescriptors[i].name));
+  }
 
-        for (let i = 0; i < fixtures.meshDescriptors.length; i++){
-          if(objective.meshDescriptors.indexOf(fixtures.meshDescriptors[i].id) !== -1){
-            assert.ok($(searchResults[i]).hasClass('disabled'));
-          } else {
-            assert.ok(!$(searchResults[i]).hasClass('disabled'));
-          }
-        }
-        click('.removable-list li:eq(0)', meshManager).then(function(){
-          assert.ok(!$(find('.mesh-search-results li:eq(1)', meshManager)).hasClass('disabled'));
-        });
-        click(searchResults[0]);
-        andThen(function(){
-          assert.ok($(find('.mesh-search-results li:eq(0)', meshManager)).hasClass('disabled'));
+  for (let i = 0; i < fixtures.meshDescriptors.length; i++){
+    if(objective.meshDescriptors.indexOf(fixtures.meshDescriptors[i].id) !== -1){
+      assert.ok($(searchResults[i]).hasClass('disabled'));
+    } else {
+      assert.ok(!$(searchResults[i]).hasClass('disabled'));
+    }
+  }
+  await click('.removable-list li:eq(0)', meshManager);
+  assert.ok(!$(find('.mesh-search-results li:eq(1)', meshManager)).hasClass('disabled'));
+  await click(searchResults[0]);
+  assert.ok($(find('.mesh-search-results li:eq(0)', meshManager)).hasClass('disabled'));
 
-          let newExpectedMesh = [
-            fixtures.meshDescriptors[0].name,
-            fixtures.meshDescriptors[2].name,
-            fixtures.meshDescriptors[3].name,
-            fixtures.meshDescriptors[4].name,
-            fixtures.meshDescriptors[5].name,
-          ];
-          removableItems = find('.removable-list li', meshManager);
-          assert.equal(removableItems.length, 5);
-          for (let i = 0; i < 2; i++){
-            let meshDescriptorName = find('.content .title', removableItems[i]).eq(0);
-            assert.equal(getElementText(meshDescriptorName), getText(newExpectedMesh[i]));
-          }
-        });
-      });
-    });
-  });
+  let newExpectedMesh = [
+    fixtures.meshDescriptors[0].name,
+    fixtures.meshDescriptors[2].name,
+    fixtures.meshDescriptors[3].name,
+    fixtures.meshDescriptors[4].name,
+    fixtures.meshDescriptors[5].name,
+  ];
+  removableItems = find('.removable-list li', meshManager);
+  assert.equal(removableItems.length, 5);
+  for (let i = 0; i < 2; i++){
+    let meshDescriptorName = find('.content .title', removableItems[i]).eq(0);
+    assert.equal(getElementText(meshDescriptorName), getText(newExpectedMesh[i]));
+  }
+  await wait();
 });
 
-test('save terms', function(assert) {
+test('save terms', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    let detailObjectives = find('.detail-objectives').eq(0);
-    click('.course-objective-list tbody tr:eq(0) td:eq(2) .link', detailObjectives);
-    andThen(function() {
-      let meshManager = find('.mesh-manager', detailObjectives).eq(0);
-      let searchBoxInput = find('.search-box input', meshManager);
-      fillIn(searchBoxInput, 'descriptor');
-      click('.search-box span.search-icon', meshManager);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        click('.removable-list li:eq(0)', meshManager);
-        click(searchResults[1]);
-        click('button.bigadd', detailObjectives);
-        andThen(function(){
-          let expectedMesh = fixtures.meshDescriptors[1].name;
-          let tds = find('.course-objective-list tbody tr:eq(0) td');
-          assert.equal(getElementText(tds.eq(2)), getText(expectedMesh));
-        });
-      });
-    });
-  });
+  await visit(url);
+  let detailObjectives = find('.detail-objectives').eq(0);
+  await click('.course-objective-list tbody tr:eq(0) td:eq(2) .link', detailObjectives);
+  let meshManager = find('.mesh-manager', detailObjectives).eq(0);
+  let searchBoxInput = find('.search-box input', meshManager);
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('.search-box span.search-icon', meshManager);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  await click('.removable-list li:eq(0)', meshManager);
+  await click(searchResults[1]);
+  await click('button.bigadd', detailObjectives);
+  let expectedMesh = fixtures.meshDescriptors[1].name;
+  let tds = find('.course-objective-list tbody tr:eq(0) td');
+  assert.equal(getElementText(tds.eq(2)), getText(expectedMesh));
 });
 
-test('cancel changes', function(assert) {
+test('cancel changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    let detailObjectives = find('.detail-objectives').eq(0);
-    click('.course-objective-list tbody tr:eq(0) td:eq(2) .link', detailObjectives);
-    andThen(function() {
-      let meshManager = find('.mesh-manager', detailObjectives).eq(0);
-      let searchBoxInput = find('.search-box input', meshManager);
-      fillIn(searchBoxInput, 'descriptor');
-      click('.search-box span.search-icon', meshManager);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        click('.removable-list li:eq(0)', meshManager);
-        click(searchResults[1]);
-        click(searchResults[2]);
-        click(searchResults[3]);
-        click('button.bigcancel', detailObjectives);
-        andThen(function(){
-          let tds = find('.course-objective-list tbody tr:eq(0) td');
-          let expectedMesh = fixtures.meshDescriptors[fixtures.courseObjectives[0].meshDescriptors[0] - 1].name;
-          assert.equal(getElementText(tds.eq(2)), getText(expectedMesh));
-        });
-      });
-    });
-  });
+  await visit(url);
+  let detailObjectives = find('.detail-objectives').eq(0);
+  await click('.course-objective-list tbody tr:eq(0) td:eq(2) .link', detailObjectives);
+  let meshManager = find('.mesh-manager', detailObjectives).eq(0);
+  let searchBoxInput = find('.search-box input', meshManager);
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('.search-box span.search-icon', meshManager);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  await click('.removable-list li:eq(0)', meshManager);
+  await click(searchResults[1]);
+  await click(searchResults[2]);
+  await click(searchResults[3]);
+  await click('button.bigcancel', detailObjectives);
+  let tds = find('.course-objective-list tbody tr:eq(0) td');
+  let expectedMesh = fixtures.meshDescriptors[fixtures.courseObjectives[0].meshDescriptors[0] - 1].name;
+  assert.equal(getElementText(tds.eq(2)), getText(expectedMesh));
 });

--- a/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -5,11 +5,6 @@ import {
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
-import Ember from 'ember';
-
-const { RSVP, run } = Ember;
-const { Promise } = RSVP;
-
 var application;
 var url = '/courses/1?details=true&courseObjectiveDetails=true';
 var fixtures = {};
@@ -100,143 +95,111 @@ module('Acceptance: Course with multiple Cohorts - Objective Parents', {
   }
 });
 
-test('list parent objectives by competency', function(assert) {
+test('list parent objectives by competency', async function(assert) {
   assert.expect(27);
-  visit(url);
-  andThen(function() {
-    let tds = find('.course-objective-list tbody tr:eq(0) td');
-    assert.equal(tds.length, 4);
-    click('.link', tds.eq(1));
-    andThen(function() {
-      let objectiveManager = find('.objective-manager').eq(0);
-      let objective = fixtures.courseObjectives[0];
-      assert.equal(getElementText(find('.specific-title')), 'SelectParentObjective');
-      assert.equal(getElementText(find('.objectivetitle', objectiveManager)), getText(objective.title));
-      let expectedCohortTitles = 'Select Parent For: ' +
-        fixtures.program.title + fixtures.cohorts[0].title +
-        fixtures.program.title + fixtures.cohorts[1].title;
-      assert.equal(getElementText(find('.group-picker', objectiveManager)), getText(expectedCohortTitles));
-      let parentPicker = find('.parent-picker', objectiveManager).eq(0);
-      let competencyTitles = find('.competency-title', parentPicker);
-      assert.equal(competencyTitles.length, fixtures.competencies.length);
-      //every competency is in the list
-      assert.equal(getElementText(competencyTitles.eq(0)), getText('competency 0'));
-      assert.ok(competencyTitles.eq(0).hasClass('selected'));
-      assert.equal(getElementText(competencyTitles.eq(1)), getText('competency 1'));
-      assert.ok(!competencyTitles.eq(1).hasClass('selected'));
+  await visit(url);
+  let tds = find('.course-objective-list tbody tr:eq(0) td');
+  assert.equal(tds.length, 4);
+  await click('.link', tds.eq(1));
+  let objectiveManager = find('.objective-manager').eq(0);
+  let objective = fixtures.courseObjectives[0];
+  assert.equal(getElementText(find('.specific-title')), 'SelectParentObjective');
+  assert.equal(getElementText(find('.objectivetitle', objectiveManager)), getText(objective.title));
+  let expectedCohortTitles = 'Select Parent For: ' +
+    fixtures.program.title + fixtures.cohorts[0].title +
+    fixtures.program.title + fixtures.cohorts[1].title;
+  assert.equal(getElementText(find('.group-picker', objectiveManager)), getText(expectedCohortTitles));
+  let parentPicker = find('.parent-picker', objectiveManager).eq(0);
+  let competencyTitles = find('.competency-title', parentPicker);
+  assert.equal(competencyTitles.length, fixtures.competencies.length);
+  //every competency is in the list
+  assert.equal(getElementText(competencyTitles.eq(0)), getText('competency 0'));
+  assert.ok(competencyTitles.eq(0).hasClass('selected'));
+  assert.equal(getElementText(competencyTitles.eq(1)), getText('competency 1'));
+  assert.ok(!competencyTitles.eq(1).hasClass('selected'));
 
-      let items = find('li', parentPicker);
-      assert.equal(getElementText(items.eq(0)), getText('objective 0'));
-      assert.equal(getElementText(items.eq(1)), getText('objective 1'));
-      assert.equal(getElementText(items.eq(2)), getText('objective 2'));
-      assert.ok($(items.eq(0)).hasClass('selected'));
-      assert.ok(!$(items.eq(1)).hasClass('selected'));
-      assert.ok(!$(items.eq(2)).hasClass('selected'));
+  let items = find('li', parentPicker);
+  assert.equal(getElementText(items.eq(0)), getText('objective 0'));
+  assert.equal(getElementText(items.eq(1)), getText('objective 1'));
+  assert.equal(getElementText(items.eq(2)), getText('objective 2'));
+  assert.ok($(items.eq(0)).hasClass('selected'));
+  assert.ok(!$(items.eq(1)).hasClass('selected'));
+  assert.ok(!$(items.eq(2)).hasClass('selected'));
 
-      pickOption(find('.group-picker select', objectiveManager), 'program 0 cohort 1', assert);
-      andThen(()=>{
-        parentPicker = find('.parent-picker', objectiveManager).eq(0);
-        competencyTitles = find('.competency-title', parentPicker);
-        assert.equal(competencyTitles.length, fixtures.competencies.length);
-        //every competency is in the list
-        assert.equal(getElementText(competencyTitles.eq(0)), getText('competency 0'));
-        assert.ok(competencyTitles.eq(0).hasClass('selected'));
-        assert.equal(getElementText(competencyTitles.eq(1)), getText('competency 1'));
-        assert.ok(!competencyTitles.eq(1).hasClass('selected'));
+  await pickOption(find('.group-picker select', objectiveManager), 'program 0 cohort 1', assert);
+  parentPicker = find('.parent-picker', objectiveManager).eq(0);
+  competencyTitles = find('.competency-title', parentPicker);
+  assert.equal(competencyTitles.length, fixtures.competencies.length);
+  //every competency is in the list
+  assert.equal(getElementText(competencyTitles.eq(0)), getText('competency 0'));
+  assert.ok(competencyTitles.eq(0).hasClass('selected'));
+  assert.equal(getElementText(competencyTitles.eq(1)), getText('competency 1'));
+  assert.ok(!competencyTitles.eq(1).hasClass('selected'));
 
-        items = find('li', parentPicker);
-        assert.equal(getElementText(items.eq(0)), getText('objective 3'));
-        assert.equal(getElementText(items.eq(1)), getText('objective 4'));
-        assert.equal(getElementText(items.eq(2)), getText('objective 5'));
-        assert.ok($(items.eq(0)).hasClass('selected'));
-        assert.ok(!$(items.eq(1)).hasClass('selected'));
-        assert.ok(!$(items.eq(2)).hasClass('selected'));
-      });
-    });
-  });
+  items = find('li', parentPicker);
+  assert.equal(getElementText(items.eq(0)), getText('objective 3'));
+  assert.equal(getElementText(items.eq(1)), getText('objective 4'));
+  assert.equal(getElementText(items.eq(2)), getText('objective 5'));
+  assert.ok($(items.eq(0)).hasClass('selected'));
+  assert.ok(!$(items.eq(1)).hasClass('selected'));
+  assert.ok(!$(items.eq(2)).hasClass('selected'));
 });
 
-test('change course objective parent', function(assert) {
-  assert.expect(9);
-  return new Promise(resolve => {
-    visit(url);
-    andThen(() => {
-      let tds = find('.course-objective-list tbody tr:eq(0) td');
-      click('.link', tds.eq(1)).then(() => {
-        let objectiveManager = find('.objective-manager').eq(0);
-        let parentPicker = find('.parent-picker', objectiveManager).eq(0);
-        let groupPicker = find('.group-picker select', objectiveManager).eq(0);
-        click('li:eq(1)', parentPicker).then(() => {
-          assert.ok(find('h5:eq(1)', parentPicker).hasClass('selected'));
-          assert.ok(!find('h5:eq(0)', parentPicker).hasClass('selected'));
-          assert.ok(find('li:eq(1)', parentPicker).hasClass('selected'));
-          assert.ok(!find('li:eq(0)', parentPicker).hasClass('selected'));
-          groupPicker.val('2');
-          groupPicker.trigger('change');
-          run.later(() => {
-            click('li:eq(1)', parentPicker).then(() => {
-              assert.ok(find('h5:eq(1)', parentPicker).hasClass('selected'));
-              assert.ok(!find('h5:eq(0)', parentPicker).hasClass('selected'));
-              assert.ok(find('li:eq(1)', parentPicker).hasClass('selected'));
-              assert.ok(!find('li:eq(0)', parentPicker).hasClass('selected'));
-              assert.ok(!find('li:eq(2)', parentPicker).hasClass('selected'));
-              resolve();
-            });
-          });
-        });
-      });
-    });
-  });
+test('change course objective parent', async function(assert) {
+  assert.expect(10);
+  await visit(url);
+  let tds = find('.course-objective-list tbody tr:eq(0) td');
+  await click('.link', tds.eq(1));
+  let objectiveManager = find('.objective-manager').eq(0);
+  let parentPicker = find('.parent-picker', objectiveManager).eq(0);
+  await click('li:eq(1)', parentPicker);
+  assert.ok(find('h5:eq(1)', parentPicker).hasClass('selected'));
+  assert.notOk(find('h5:eq(0)', parentPicker).hasClass('selected'));
+  assert.ok(find('li:eq(1)', parentPicker).hasClass('selected'));
+  assert.notOk(find('li:eq(0)', parentPicker).hasClass('selected'));
+  await pickOption(find('.group-picker select', objectiveManager), 'program 0 cohort 1', assert);
+  await click('li:eq(1)', parentPicker);
+  assert.ok(find('h5:eq(1)', parentPicker).hasClass('selected'));
+  assert.ok(!find('h5:eq(0)', parentPicker).hasClass('selected'));
+  assert.ok(find('li:eq(1)', parentPicker).hasClass('selected'));
+  assert.ok(!find('li:eq(0)', parentPicker).hasClass('selected'));
+  assert.ok(!find('li:eq(2)', parentPicker).hasClass('selected'));
 });
 
-test('save changes', function(assert) {
+test('save changes', async function(assert) {
   assert.expect(2);
-  visit(url);
-  andThen(function() {
-    click('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
-    click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)').then(()=> {
-      pickOption('.objective-manager:eq(0) .group-picker select', 'program 0 cohort 1', assert);
-      andThen(() => {
-        click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
-        click('.detail-objectives:eq(0) button.bigadd');
-      });
-    });
-  });
-  andThen(function(){
-    let td = find('.course-objective-list tbody tr:eq(0) td:eq(1)');
-    assert.equal(getElementText(td), getText(
-      'program0cohort0' +
-      fixtures.parentObjectives[1].title +
-      '(' + fixtures.competencies[fixtures.parentObjectives[1].competency - 1].title + ')' +
+  await visit(url);
+  await click('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
+  await click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
+  await pickOption('.objective-manager:eq(0) .group-picker select', 'program 0 cohort 1', assert);
+  await click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
+  await click('.detail-objectives:eq(0) button.bigadd');
+  let td = find('.course-objective-list tbody tr:eq(0) td:eq(1)');
+  assert.equal(getElementText(td), getText(
+    'program0cohort0' +
+    fixtures.parentObjectives[1].title +
+    '(' + fixtures.competencies[fixtures.parentObjectives[1].competency - 1].title + ')' +
+    'program0cohort1' +
+    fixtures.parentObjectives[4].title +
+    '(' + fixtures.competencies[fixtures.parentObjectives[4].competency - 1].title + ')'
+  ));
+});
+
+test('cancel changes', async function(assert) {
+  assert.expect(2);
+  await visit(url);
+  await click('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
+  await click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
+  await pickOption('.objective-manager:eq(0) .group-picker select', 'program 0 cohort 1', assert);
+  await click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
+  await click('.detail-objectives:eq(0) button.bigcancel');
+  let td = find('.course-objective-list tbody tr:eq(0) td:eq(1)');
+  assert.equal(getElementText(td), getText(
+    'program0cohort0' +
+    fixtures.parentObjectives[0].title +
+    '(' + fixtures.competencies[fixtures.parentObjectives[0].competency - 1].title + ')' +
       'program0cohort1' +
-      fixtures.parentObjectives[4].title +
-      '(' + fixtures.competencies[fixtures.parentObjectives[4].competency - 1].title + ')'
-    ));
-  });
-});
-
-test('cancel changes', function(assert) {
-  assert.expect(2);
-  visit(url);
-  andThen(function() {
-    click('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
-    click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)').then(()=> {
-      pickOption('.objective-manager:eq(0) .group-picker select', 'program 0 cohort 1', assert);
-      andThen(() => {
-        click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
-        click('.detail-objectives:eq(0) button.bigcancel');
-      });
-    });
-  });
-  andThen(function(){
-    let td = find('.course-objective-list tbody tr:eq(0) td:eq(1)');
-    assert.equal(getElementText(td), getText(
-      'program0cohort0' +
-      fixtures.parentObjectives[0].title +
-      '(' + fixtures.competencies[fixtures.parentObjectives[0].competency - 1].title + ')' +
-        'program0cohort1' +
-        fixtures.parentObjectives[3].title +
-        '(' + fixtures.competencies[fixtures.parentObjectives[3].competency - 1].title + ')'
-    ));
-  });
+      fixtures.parentObjectives[3].title +
+      '(' + fixtures.competencies[fixtures.parentObjectives[3].competency - 1].title + ')'
+  ));
 });

--- a/tests/acceptance/course/objectiveparents-test.js
+++ b/tests/acceptance/course/objectiveparents-test.js
@@ -72,97 +72,79 @@ module('Acceptance: Course - Objective Parents', {
   }
 });
 
-test('list parent objectives by competency', function(assert) {
+test('list parent objectives by competency', async function(assert) {
   assert.expect(16);
-  visit(url);
-  andThen(function() {
-    let tds = find('.course-objective-list tbody tr:eq(0) td');
-    assert.equal(tds.length, 4);
-    click('.link', tds.eq(1));
+  await visit(url);
+  let tds = find('.course-objective-list tbody tr:eq(0) td');
+  assert.equal(tds.length, 4);
+  await click('.link', tds.eq(1));
 
-    andThen(function() {
-      let objectiveManager = find('.objective-manager').eq(0);
-      let objective = fixtures.courseObjectives[0];
-      assert.equal(getElementText(find('.specific-title')), 'SelectParentObjective');
-      assert.equal(getElementText(find('.objectivetitle', objectiveManager)), getText(objective.title));
-      let expectedCohortTitle = 'Select Parent For: ' + fixtures.program.title + fixtures.cohort.title;
-      assert.equal(getElementText(find('.group-picker', objectiveManager)), getText(expectedCohortTitle));
-      let parentPicker = find('.parent-picker', objectiveManager).eq(0);
-      let competencyTitles = find('.competency-title', parentPicker);
-      assert.equal(competencyTitles.length, fixtures.competencies.length);
-      //every competency is in the list
-      for(let i = 0; i < fixtures.programYear.competencies.length; i++){
-        let competency = fixtures.competencies[fixtures.programYear.competencies[i] - 1];
-        assert.equal(getElementText(competencyTitles.eq(i)), getText(competency.title));
-        let ul = find('ul', parentPicker).eq(i);
-        let items = find('li', ul);
-        let cohortObjectives = competency.objectives;
-        assert.equal(cohortObjectives.length, cohortObjectives.length);
-        for (let j = 0; j < cohortObjectives.length; j++){
-          let li = items.eq(j);
-          assert.equal(getElementText(li), getText(fixtures.parentObjectives[cohortObjectives[j] - 1].title));
-          if(objective.parents.indexOf(cohortObjectives[j]) !== -1){
-            assert.ok(competencyTitles.eq(i).hasClass('selected'));
-            assert.ok($(li).hasClass('selected'));
-          } else {
-            assert.ok(!$(li).hasClass('selected'));
-          }
-        }
+  let objectiveManager = find('.objective-manager').eq(0);
+  let objective = fixtures.courseObjectives[0];
+  assert.equal(getElementText(find('.specific-title')), 'SelectParentObjective');
+  assert.equal(getElementText(find('.objectivetitle', objectiveManager)), getText(objective.title));
+  let expectedCohortTitle = 'Select Parent For: ' + fixtures.program.title + fixtures.cohort.title;
+  assert.equal(getElementText(find('.group-picker', objectiveManager)), getText(expectedCohortTitle));
+  let parentPicker = find('.parent-picker', objectiveManager).eq(0);
+  let competencyTitles = find('.competency-title', parentPicker);
+  assert.equal(competencyTitles.length, fixtures.competencies.length);
+  //every competency is in the list
+  for(let i = 0; i < fixtures.programYear.competencies.length; i++){
+    let competency = fixtures.competencies[fixtures.programYear.competencies[i] - 1];
+    assert.equal(getElementText(competencyTitles.eq(i)), getText(competency.title));
+    let ul = find('ul', parentPicker).eq(i);
+    let items = find('li', ul);
+    let cohortObjectives = competency.objectives;
+    assert.equal(cohortObjectives.length, cohortObjectives.length);
+    for (let j = 0; j < cohortObjectives.length; j++){
+      let li = items.eq(j);
+      assert.equal(getElementText(li), getText(fixtures.parentObjectives[cohortObjectives[j] - 1].title));
+      if(objective.parents.indexOf(cohortObjectives[j]) !== -1){
+        assert.ok(competencyTitles.eq(i).hasClass('selected'));
+        assert.ok($(li).hasClass('selected'));
+      } else {
+        assert.ok(!$(li).hasClass('selected'));
       }
-    });
-  });
+    }
+  }
 });
 
-test('change course objective parent', function(assert) {
+test('change course objective parent', async function(assert) {
   assert.expect(4);
-  visit(url);
-  andThen(function() {
-    let tds = find('.course-objective-list tbody tr:eq(0) td');
-    click('.link', tds.eq(1));
-    andThen(function() {
-      let objectiveManager = find('.objective-manager').eq(0);
-      let parentPicker = find('.parent-picker', objectiveManager).eq(0);
-      click('li:eq(1)', parentPicker);
-      andThen(function(){
-        assert.ok(find('h5:eq(1)', parentPicker).hasClass('selected'));
-        assert.ok(!find('h5:eq(0)', parentPicker).hasClass('selected'));
-        assert.ok(find('li:eq(1)', parentPicker).hasClass('selected'));
-        assert.ok(!find('li:eq(0)', parentPicker).hasClass('selected'));
-      });
-    });
-  });
+  await visit(url);
+  let tds = find('.course-objective-list tbody tr:eq(0) td');
+  await click('.link', tds.eq(1));
+  let objectiveManager = find('.objective-manager').eq(0);
+  let parentPicker = find('.parent-picker', objectiveManager).eq(0);
+  await click('li:eq(1)', parentPicker);
+  assert.ok(find('h5:eq(1)', parentPicker).hasClass('selected'));
+  assert.ok(!find('h5:eq(0)', parentPicker).hasClass('selected'));
+  assert.ok(find('li:eq(1)', parentPicker).hasClass('selected'));
+  assert.ok(!find('li:eq(0)', parentPicker).hasClass('selected'));
 });
 
-test('save changes', function(assert) {
+test('save changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    click('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
-    click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
-    click('.detail-objectives:eq(0) button.bigadd');
-  });
-  andThen(function(){
-    let td = find('.course-objective-list tbody tr:eq(0) td:eq(1)');
-    assert.equal(getElementText(td), getText(
-      fixtures.parentObjectives[1].title +
-      '(' + fixtures.competencies[fixtures.parentObjectives[1].competency - 1].title + ')'
-    ));
-  });
+  await visit(url);
+  await click('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
+  await click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
+  await click('.detail-objectives:eq(0) button.bigadd');
+  let td = find('.course-objective-list tbody tr:eq(0) td:eq(1)');
+  assert.equal(getElementText(td), getText(
+    fixtures.parentObjectives[1].title +
+    '(' + fixtures.competencies[fixtures.parentObjectives[1].competency - 1].title + ')'
+  ));
 });
 
-test('cancel changes', function(assert) {
+test('cancel changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    click('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
-    click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
-    click('.detail-objectives:eq(0) button.bigcancel');
-  });
-  andThen(function(){
-    let td = find('.course-objective-list tbody tr:eq(0) td:eq(1)');
-    assert.equal(getElementText(td), getText(
-      fixtures.parentObjectives[0].title +
-      '(' + fixtures.competencies[fixtures.parentObjectives[0].competency - 1].title + ')'
-    ));
-  });
+  await visit(url);
+  await click('.course-objective-list tbody tr:eq(0) td:eq(1) .link');
+  await click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
+  await click('.detail-objectives:eq(0) button.bigcancel');
+  let td = find('.course-objective-list tbody tr:eq(0) td:eq(1)');
+  assert.equal(getElementText(td), getText(
+    fixtures.parentObjectives[0].title +
+    '(' + fixtures.competencies[fixtures.parentObjectives[0].competency - 1].title + ')'
+  ));
 });

--- a/tests/acceptance/course/overview-test.js
+++ b/tests/acceptance/course/overview-test.js
@@ -25,7 +25,7 @@ module('Acceptance: Course - Overview', {
   }
 });
 
-test('check fields', function(assert) {
+test('check fields', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -50,26 +50,23 @@ test('check fields', function(assert) {
   var clerkshipType = server.create('courseClerkshipType', {
     courses: [1]
   });
-  visit(url);
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.index');
-    var container = find('.course-overview');
-    var startDate = moment.utc(course.startDate).format('L');
-    assert.equal(getElementText(find('.coursestartdate', container)), 'Start:' + startDate);
-    assert.equal(getElementText(find('.courseexternalid', container)), 'CourseID:123');
-    assert.equal(getElementText(find('.courselevel', container)), 'Level:3');
-    var endDate = moment.utc(course.endDate).format('L');
-    assert.equal(getElementText(find('.courseenddate', container)), 'End:' + endDate);
-    assert.equal(getElementText(find('.universallocator', container)), 'ILIOS' + course.id);
-    assert.equal(getElementText(find('.clerkshiptype', container)), getText('Clerkship Type:' + clerkshipType.title));
-    assert.equal(getElementText(find('.coursedirectors', container)), getText('Directors: A M. Director'));
-    assert.ok(find('a.rollover', container).prop('href').search(/courses\/1\/rollover/) > -1);
-
-  });
+  assert.equal(currentPath(), 'course.index');
+  var container = find('.course-overview');
+  var startDate = moment.utc(course.startDate).format('L');
+  assert.equal(getElementText(find('.coursestartdate', container)), 'Start:' + startDate);
+  assert.equal(getElementText(find('.courseexternalid', container)), 'CourseID:123');
+  assert.equal(getElementText(find('.courselevel', container)), 'Level:3');
+  var endDate = moment.utc(course.endDate).format('L');
+  assert.equal(getElementText(find('.courseenddate', container)), 'End:' + endDate);
+  assert.equal(getElementText(find('.universallocator', container)), 'ILIOS' + course.id);
+  assert.equal(getElementText(find('.clerkshiptype', container)), getText('Clerkship Type:' + clerkshipType.title));
+  assert.equal(getElementText(find('.coursedirectors', container)), getText('Directors: A M. Director'));
+  assert.ok(find('a.rollover', container).prop('href').search(/courses\/1\/rollover/) > -1);
 });
 
-test('check detail fields', function(assert) {
+test('check detail fields', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -83,22 +80,20 @@ test('check detail fields', function(assert) {
   var clerkshipType = server.create('courseClerkshipType', {
     courses: [1]
   });
-  visit(url + '?details=true');
+  await visit(url + '?details=true');
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.index');
-    var container = find('.course-overview');
-    var startDate = moment.utc(course.startDate).format('L');
-    assert.equal(getElementText(find('.coursestartdate .editable', container)), startDate);
-    assert.equal(getElementText(find('.courseexternalid .editable', container)), 123);
-    assert.equal(getElementText(find('.courselevel .editable', container)), 3);
-    var endDate = moment.utc(course.endDate).format('L');
-    assert.equal(getElementText(find('.courseenddate .editable', container)), endDate);
-    assert.equal(getElementText(find('.clerkshiptype .editable', container)), getText(clerkshipType.title));
-  });
+  assert.equal(currentPath(), 'course.index');
+  var container = find('.course-overview');
+  var startDate = moment.utc(course.startDate).format('L');
+  assert.equal(getElementText(find('.coursestartdate .editable', container)), startDate);
+  assert.equal(getElementText(find('.courseexternalid .editable', container)), 123);
+  assert.equal(getElementText(find('.courselevel .editable', container)), 3);
+  var endDate = moment.utc(course.endDate).format('L');
+  assert.equal(getElementText(find('.courseenddate .editable', container)), endDate);
+  assert.equal(getElementText(find('.clerkshiptype .editable', container)), getText(clerkshipType.title));
 });
 
-test('pick clerkship type', function(assert) {
+test('pick clerkship type', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -106,33 +101,25 @@ test('pick clerkship type', function(assert) {
     year: 2013,
     school: 1,
   });
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(find('.course-overview .clerkshiptype')), getText('Clerkship Type: Not a Clerkship'));
-  });
-  visit(url + '?details=true');
-  andThen(function() {
-    var container = find('.course-overview');
-    assert.equal(getElementText(find('.clerkshiptype .editable', container)), getText('Not a Clerkship'));
-    click(find('.clerkshiptype .editable', container));
-    andThen(function(){
-      let options = find('.clerkshiptype select option', container);
-      //add one for the blank option
-      assert.equal(options.length, fixtures.clerkshipTypes.length + 1);
-      for(let i = 0; i < fixtures.clerkshipTypes.length + 1; i++){
-        let title = i===0?'Not a Clerkship':fixtures.clerkshipTypes[i-1].title;
-        assert.equal(getElementText(options.eq(i)), getText(title));
-      }
-      pickOption(find('.clerkshiptype select', container), fixtures.clerkshipTypes[1].title, assert);
-      click(find('.clerkshiptype .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.clerkshiptype .editable', container)), getText(fixtures.clerkshipTypes[1].title));
-      });
-    });
-  });
+  await visit(url);
+  assert.equal(getElementText(find('.course-overview .clerkshiptype')), getText('Clerkship Type: Not a Clerkship'));
+  await visit(url + '?details=true');
+  var container = find('.course-overview');
+  assert.equal(getElementText(find('.clerkshiptype .editable', container)), getText('Not a Clerkship'));
+  await click(find('.clerkshiptype .editable', container));
+  let options = find('.clerkshiptype select option', container);
+  //add one for the blank option
+  assert.equal(options.length, fixtures.clerkshipTypes.length + 1);
+  for(let i = 0; i < fixtures.clerkshipTypes.length + 1; i++){
+    let title = i===0?'Not a Clerkship':fixtures.clerkshipTypes[i-1].title;
+    assert.equal(getElementText(options.eq(i)), getText(title));
+  }
+  await pickOption(find('.clerkshiptype select', container), fixtures.clerkshipTypes[1].title, assert);
+  await click(find('.clerkshiptype .actions .done', container));
+  assert.equal(getElementText(find('.clerkshiptype .editable', container)), getText(fixtures.clerkshipTypes[1].title));
 });
 
-test('remove clerkship type', function(assert) {
+test('remove clerkship type', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -144,22 +131,16 @@ test('remove clerkship type', function(assert) {
   server.create('courseClerkshipType', {
     courses: [1]
   });
-  visit(url + '?details=true');
+  await visit(url + '?details=true');
 
-  andThen(function() {
-    var container = find('.course-overview');
-    click(find('.clerkshiptype .editable', container));
-    andThen(function(){
-      pickOption(find('.clerkshiptype select', container), 'Not a Clerkship', assert);
-      click(find('.clerkshiptype .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.clerkshiptype .editable', container)), getText('Not a Clerkship'));
-      });
-    });
-  });
+  var container = find('.course-overview');
+  await click(find('.clerkshiptype .editable', container));
+  await pickOption(find('.clerkshiptype select', container), 'Not a Clerkship', assert);
+  await click(find('.clerkshiptype .actions .done', container));
+  assert.equal(getElementText(find('.clerkshiptype .editable', container)), getText('Not a Clerkship'));
 });
 
-test('open and close details', function(assert) {
+test('open and close details', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -168,26 +149,19 @@ test('open and close details', function(assert) {
     school: 1
   });
 
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.index');
-    assert.equal(find('.course-details .title').length, 3);
-    click('.detail-collapsed-control').then(function(){
-      assert.ok(find('.title').length > 2);
-      assert.equal(currentURL(), '/courses/1?details=true');
-    });
-  });
-
-  andThen(function() {
-    assert.ok(find('.course-details .title').length > 2);
-    click('.detail-collapsed-control').then(function(){
-      assert.equal(find('.course-details .title').length, 3);
-      assert.equal(currentURL(), '/courses/1');
-    });
-  });
+  await visit(url);
+  assert.equal(currentPath(), 'course.index');
+  assert.equal(find('.course-details .title').length, 3);
+  await click('.detail-collapsed-control');
+  assert.ok(find('.title').length > 2);
+  assert.equal(currentURL(), '/courses/1?details=true');
+  assert.ok(find('.course-details .title').length > 2);
+  await click('.detail-collapsed-control');
+  assert.equal(find('.course-details .title').length, 3);
+  assert.equal(currentURL(), '/courses/1');
 });
 
-test('change title', function(assert) {
+test('change title', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -195,28 +169,20 @@ test('change title', function(assert) {
     year: 2013,
     school: 1,
   });
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(find('.course-header .title')), getText('course 0 2013-2014'));
-  });
-  visit(url + '?details=true');
-  andThen(function() {
-    let container = find('.course-header .title');
-    assert.equal(getElementText(find('.editable', container)), getText('course 0'));
-    click(find('.editable', container));
-    andThen(function(){
-      let input = find('input', container);
-      assert.equal(getText(input.val()), getText('course 0'));
-      fillIn(input, 'test new title');
-      click(find('.done', container));
-      andThen(function(){
-        assert.equal(getElementText(container), getText('test new title 2013-2014'));
-      });
-    });
-  });
+  await visit(url);
+  assert.equal(getElementText(find('.course-header .title')), getText('course 0 2013-2014'));
+  await visit(url + '?details=true');
+  let container = find('.course-header .title');
+  assert.equal(getElementText(find('.editable', container)), getText('course 0'));
+  await click(find('.editable', container));
+  let input = find('input', container);
+  assert.equal(getText(input.val()), getText('course 0'));
+  await fillIn(input, 'test new title');
+  await click(find('.done', container));
+  assert.equal(getElementText(container), getText('test new title 2013-2014'));
 });
 
-test('change start date', function(assert) {
+test('change start date', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -227,32 +193,23 @@ test('change start date', function(assert) {
     school: 1,
   });
   var startDate = moment.utc(course.startDate).format('L');
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(find('.course-overview .coursestartdate')), getText('Start:' + startDate));
-  });
-  visit(url + '?details=true');
-  andThen(function() {
-    var container = find('.course-overview');
-    assert.equal(getElementText(find('.coursestartdate', container)), getText('Start:' + startDate));
-    click(find('.coursestartdate .editable', container));
-    andThen(function(){
-      var input = find('.coursestartdate .editinplace input', container);
-      assert.equal(getText(input.val()), getText(startDate));
-      var interactor = openDatepicker(find('.coursestartdate input', container));
-      assert.equal(interactor.selectedYear(), moment(course.startDate).format('YYYY'));
-      var newDate = moment(course.startDate).add(1, 'year').add(1, 'month');
-      interactor.selectDate(newDate.toDate());
-      click(find('.coursestartdate .editinplace .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.coursestartdate', container)), getText('Start:' + newDate.format('L')));
-      });
-
-    });
-  });
+  await visit(url);
+  assert.equal(getElementText(find('.course-overview .coursestartdate')), getText('Start:' + startDate));
+  await visit(url + '?details=true');
+  var container = find('.course-overview');
+  assert.equal(getElementText(find('.coursestartdate', container)), getText('Start:' + startDate));
+  await click(find('.coursestartdate .editable', container));
+  var input = find('.coursestartdate .editinplace input', container);
+  assert.equal(getText(input.val()), getText(startDate));
+  var interactor = openDatepicker(find('.coursestartdate input', container));
+  assert.equal(interactor.selectedYear(), moment(course.startDate).format('YYYY'));
+  var newDate = moment(course.startDate).add(1, 'year').add(1, 'month');
+  interactor.selectDate(newDate.toDate());
+  await click(find('.coursestartdate .editinplace .actions .done', container));
+  assert.equal(getElementText(find('.coursestartdate', container)), getText('Start:' + newDate.format('L')));
 });
 
-test('start date validation', function(assert) {
+test('start date validation', async function(assert) {
   assert.expect(2);
   server.create('user', {
     id: 4136
@@ -263,24 +220,18 @@ test('start date validation', function(assert) {
     endDate: new Date('2013-05-22'),
     school: 1,
   });
-  visit(url + '?details=true');
-  andThen(function() {
-    const container = find('.course-overview');
-    click(find('.coursestartdate .editable', container));
-    andThen(function(){
-      assert.notOk(find('.coursestartdate .validation-error-message', container).length, 'no validation error shown.');
-      const interactor = openDatepicker(find('.coursestartdate input', container));
-      const newDate = moment(course.startDate).add(1, 'year');
-      interactor.selectDate(newDate.toDate());
-      click(find('.coursestartdate .editinplace .actions .done', container));
-      andThen(function(){
-        assert.ok(find('.coursestartdate .validation-error-message', container).length, 'validation error shows.');
-      });
-    });
-  });
+  await visit(url + '?details=true');
+  const container = find('.course-overview');
+  await click(find('.coursestartdate .editable', container));
+  assert.notOk(find('.coursestartdate .validation-error-message', container).length, 'no validation error shown.');
+  const interactor = openDatepicker(find('.coursestartdate input', container));
+  const newDate = moment(course.startDate).add(1, 'year');
+  interactor.selectDate(newDate.toDate());
+  await click(find('.coursestartdate .editinplace .actions .done', container));
+  assert.ok(find('.coursestartdate .validation-error-message', container).length, 'validation error shows.');
 });
 
-test('change end date', function(assert) {
+test('change end date', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -291,32 +242,23 @@ test('change end date', function(assert) {
     endDate: new Date('2015-05-22'),
   });
   var endDate = moment.utc(course.endDate).format('L');
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(find('.course-overview .courseenddate')), getText('End:' + endDate));
-  });
-  visit(url + '?details=true');
-  andThen(function() {
-    var container = find('.course-overview');
-    assert.equal(getElementText(find('.courseenddate', container)), getText('End:' + endDate));
-    click(find('.courseenddate .editable', container));
-    andThen(function(){
-      var input = find('.courseenddate .editinplace input', container);
-      assert.equal(getText(input.val()), getText(endDate));
-      var interactor = openDatepicker(find('.courseenddate input', container));
-      assert.equal(interactor.selectedYear(), moment(course.endDate).format('YYYY'));
-      var newDate = moment(course.endDate).add(1, 'year').add(1, 'month');
-      interactor.selectDate(newDate.toDate());
-      click(find('.courseenddate .editinplace .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.courseenddate', container)), getText('End:' + newDate.format('L')));
-      });
-
-    });
-  });
+  await visit(url);
+  assert.equal(getElementText(find('.course-overview .courseenddate')), getText('End:' + endDate));
+  await visit(url + '?details=true');
+  var container = find('.course-overview');
+  assert.equal(getElementText(find('.courseenddate', container)), getText('End:' + endDate));
+  await click(find('.courseenddate .editable', container));
+  var input = find('.courseenddate .editinplace input', container);
+  assert.equal(getText(input.val()), getText(endDate));
+  var interactor = openDatepicker(find('.courseenddate input', container));
+  assert.equal(interactor.selectedYear(), moment(course.endDate).format('YYYY'));
+  var newDate = moment(course.endDate).add(1, 'year').add(1, 'month');
+  interactor.selectDate(newDate.toDate());
+  await click(find('.courseenddate .editinplace .actions .done', container));
+  assert.equal(getElementText(find('.courseenddate', container)), getText('End:' + newDate.format('L')));
 });
 
-test('end date validation', function(assert) {
+test('end date validation', async function(assert) {
   assert.expect(2);
   server.create('user', {
     id: 4136
@@ -327,24 +269,18 @@ test('end date validation', function(assert) {
     endDate: new Date('2013-05-22'),
     school: 1,
   });
-  visit(url + '?details=true');
-  andThen(function() {
-    const container = find('.course-overview');
-    click(find('.courseenddate .editable', container));
-    andThen(function(){
-      assert.notOk(find('.courseenddate .validation-error-message', container).length, 'no validation error shown.');
-      const interactor = openDatepicker(find('.courseenddate input', container));
-      const newDate = moment(course.endDate).subtract(1, 'year');
-      interactor.selectDate(newDate.toDate());
-      click(find('.courseenddate .editinplace .actions .done', container));
-      andThen(function(){
-        assert.ok(find('.courseenddate .validation-error-message', container).length, 'validation error shows.');
-      });
-    });
-  });
+  await visit(url + '?details=true');
+  const container = find('.course-overview');
+  await click(find('.courseenddate .editable', container));
+  assert.notOk(find('.courseenddate .validation-error-message', container).length, 'no validation error shown.');
+  const interactor = openDatepicker(find('.courseenddate input', container));
+  const newDate = moment(course.endDate).subtract(1, 'year');
+  interactor.selectDate(newDate.toDate());
+  await click(find('.courseenddate .editinplace .actions .done', container));
+  assert.ok(find('.courseenddate .validation-error-message', container).length, 'validation error shows.');
 });
 
-test('change externalId', function(assert) {
+test('change externalId', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -353,28 +289,20 @@ test('change externalId', function(assert) {
     school: 1,
     externalId: 'abc123'
   });
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(find('.course-overview .courseexternalid')), getText('CourseID: abc123'));
-  });
-  visit(url + '?details=true');
-  andThen(function() {
-    var container = find('.course-overview');
-    assert.equal(getElementText(find('.courseexternalid', container)), getText('CourseID: abc123'));
-    click(find('.courseexternalid .editable', container));
-    andThen(function(){
-      var input = find('.courseexternalid .editinplace input', container);
-      assert.equal(getText(input.val()), getText('abc123'));
-      fillIn(input, 'testnewid');
-      click(find('.courseexternalid .editinplace .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.courseexternalid', container)), getText('CourseID: testnewid'));
-      });
-    });
-  });
+  await visit(url);
+  assert.equal(getElementText(find('.course-overview .courseexternalid')), getText('CourseID: abc123'));
+  await visit(url + '?details=true');
+  var container = find('.course-overview');
+  assert.equal(getElementText(find('.courseexternalid', container)), getText('CourseID: abc123'));
+  await click(find('.courseexternalid .editable', container));
+  var input = find('.courseexternalid .editinplace input', container);
+  assert.equal(getText(input.val()), getText('abc123'));
+  await fillIn(input, 'testnewid');
+  await click(find('.courseexternalid .editinplace .actions .done', container));
+  assert.equal(getElementText(find('.courseexternalid', container)), getText('CourseID: testnewid'));
 });
 
-test('change level', function(assert) {
+test('change level', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -383,30 +311,22 @@ test('change level', function(assert) {
     school: 1,
     level: 3
   });
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(find('.course-overview .courselevel')), getText('Level: 3'));
-  });
-  visit(url + '?details=true');
-  andThen(function() {
-    var container = find('.course-overview');
-    assert.equal(getElementText(find('.courselevel .editable', container)), 3);
-    click(find('.courselevel .editable', container));
-    andThen(function(){
-      let options = find('.courselevel select option', container);
-      for(let i = 0; i < 5; i++){
-        assert.equal(getElementText(options.eq(i)), i+1);
-      }
-      pickOption(find('.courselevel select', container), '1', assert);
-      click(find('.courselevel .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.course-overview .courselevel')), getText('Level: 1'));
-      });
-    });
-  });
+  await visit(url);
+  assert.equal(getElementText(find('.course-overview .courselevel')), getText('Level: 3'));
+  await visit(url + '?details=true');
+  var container = find('.course-overview');
+  assert.equal(getElementText(find('.courselevel .editable', container)), 3);
+  await click(find('.courselevel .editable', container));
+  let options = find('.courselevel select option', container);
+  for(let i = 0; i < 5; i++){
+    assert.equal(getElementText(options.eq(i)), i+1);
+  }
+  await pickOption(find('.courselevel select', container), '1', assert);
+  await click(find('.courselevel .actions .done', container));
+  assert.equal(getElementText(find('.course-overview .courselevel')), getText('Level: 1'));
 });
 
-test('remove director', function(assert) {
+test('remove director', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -423,15 +343,14 @@ test('remove director', function(assert) {
     directors: [2]
   });
   visit(url);
-  click('.coursedirectors .clickable');
-  click('.coursedirectors li:eq(0)');
-  return click('.coursedirectors .bigadd').then(()=> {
-    assert.equal(getElementText(find('.coursedirectors')), getText('Directors: None'));
-  });
+  await click('.coursedirectors .clickable');
+  await click('.coursedirectors li:eq(0)');
+  await click('.coursedirectors .bigadd');
+  assert.equal(getElementText(find('.coursedirectors')), getText('Directors: None'));
 });
 
 
-test('manage directors', function(assert) {
+test('manage directors', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -468,42 +387,35 @@ test('manage directors', function(assert) {
     level: 3,
     directors: [2]
   });
-  visit(url);
-  click('.coursedirectors .clickable');
+  await visit(url);
+  await click('.coursedirectors .clickable');
 
-  andThen(function() {
-    let directors = find('.coursedirectors');
-    let searchBox = find('.search-box', directors);
-    assert.equal(searchBox.length, 1);
-    searchBox = searchBox.eq(0);
-    let searchBoxInput = find('input', searchBox);
-    fillIn(searchBoxInput, 'guy');
-    click('span.search-icon', searchBox);
-    andThen(function(){
-      let searchResults = find('.live-search li', directors);
-      assert.equal(searchResults.length, 4);
-      assert.equal(getElementText($(searchResults[0])), getText('3 Results'));
-      assert.equal(getElementText($(searchResults[1])), getText('0 guy M. Mc0son'));
-      assert.ok(!$(searchResults[1]).hasClass('inactive'));
-      assert.equal(getElementText($(searchResults[2])), getText('Added M. Guy'));
-      assert.ok($(searchResults[2]).hasClass('inactive'));
-      assert.equal(getElementText($(searchResults[3])), getText('Disabled M. Guy'));
-      assert.ok($(searchResults[3]).hasClass('inactive'));
+  let directors = find('.coursedirectors');
+  let searchBox = find('.search-box', directors);
+  assert.equal(searchBox.length, 1);
+  searchBox = searchBox.eq(0);
+  let searchBoxInput = find('input', searchBox);
+  await fillIn(searchBoxInput, 'guy');
+  await click('span.search-icon', searchBox);
+  let searchResults = find('.live-search li', directors);
+  assert.equal(searchResults.length, 4);
+  assert.equal(getElementText($(searchResults[0])), getText('3 Results'));
+  assert.equal(getElementText($(searchResults[1])), getText('0 guy M. Mc0son'));
+  assert.ok(!$(searchResults[1]).hasClass('inactive'));
+  assert.equal(getElementText($(searchResults[2])), getText('Added M. Guy'));
+  assert.ok($(searchResults[2]).hasClass('inactive'));
+  assert.equal(getElementText($(searchResults[3])), getText('Disabled M. Guy'));
+  assert.ok($(searchResults[3]).hasClass('inactive'));
 
-      click('li:eq(0)', directors).then(function(){
-        assert.ok(!$(find('.live-search li:eq(2)', directors)).hasClass('inactive'));
-        click(searchResults[1]);
-        click('.coursedirectors .bigadd');
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('.coursedirectors')), getText('Directors: 0 guy M. Mc0son'));
-      });
-    });
-  });
+  await click('li:eq(0)', directors);
+  assert.ok(!$(find('.live-search li:eq(2)', directors)).hasClass('inactive'));
+  await click(searchResults[1]);
+  await click('.coursedirectors .bigadd');
+  assert.equal(getElementText(find('.coursedirectors')), getText('Directors: 0 guy M. Mc0son'));
 });
 
 //test for a bug where the search results were not cleared between searches
-test('search twice and list should be correct', function(assert) {
+test('search twice and list should be correct', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -524,39 +436,32 @@ test('search twice and list should be correct', function(assert) {
     level: 3,
     directors: [2]
   });
-  visit(url);
-  click('.coursedirectors .clickable');
-  andThen(function() {
-    let directors = find('.coursedirectors');
-    let searchBox = find('.search-box', directors);
-    assert.equal(searchBox.length, 1);
-    searchBox = searchBox.eq(0);
-    let searchBoxInput = find('input', searchBox);
-    fillIn(searchBoxInput, 'guy');
-    click('span.search-icon', searchBox);
-    andThen(function(){
-      let searchResults = find('.live-search li', directors);
-      assert.equal(searchResults.length, 3);
-      assert.equal(getElementText($(searchResults[0])), getText('2 Results'));
-      assert.equal(getElementText($(searchResults[1])), getText('0 guy M. Mc0son'));
-      assert.equal(getElementText($(searchResults[2])), getText('Added M. Guy'));
-      click(searchResults[1]).then(function(){
-        searchBoxInput = find('input', searchBox);
-        fillIn(searchBoxInput, 'guy');
-        click('span.search-icon', searchBox);
-        andThen(function(){
-          searchResults = find('.live-search li', directors);
-          assert.equal(searchResults.length, 3);
-          assert.equal(getElementText($(searchResults[0])), getText('2 Results'));
-          assert.equal(getElementText($(searchResults[1])), getText('0 guy M. Mc0son'));
-          assert.equal(getElementText($(searchResults[2])), getText('Added M. Guy'));
-        });
-      });
-    });
-  });
+  await visit(url);
+  await click('.coursedirectors .clickable');
+  let directors = find('.coursedirectors');
+  let searchBox = find('.search-box', directors);
+  assert.equal(searchBox.length, 1);
+  searchBox = searchBox.eq(0);
+  let searchBoxInput = find('input', searchBox);
+  await fillIn(searchBoxInput, 'guy');
+  await click('span.search-icon', searchBox);
+  let searchResults = find('.live-search li', directors);
+  assert.equal(searchResults.length, 3);
+  assert.equal(getElementText($(searchResults[0])), getText('2 Results'));
+  assert.equal(getElementText($(searchResults[1])), getText('0 guy M. Mc0son'));
+  assert.equal(getElementText($(searchResults[2])), getText('Added M. Guy'));
+  await click(searchResults[1]);
+  searchBoxInput = find('input', searchBox);
+  await fillIn(searchBoxInput, 'guy');
+  await click('span.search-icon', searchBox);
+  searchResults = find('.live-search li', directors);
+  assert.equal(searchResults.length, 3);
+  assert.equal(getElementText($(searchResults[0])), getText('2 Results'));
+  assert.equal(getElementText($(searchResults[1])), getText('0 guy M. Mc0son'));
+  assert.equal(getElementText($(searchResults[2])), getText('Added M. Guy'));
 });
 
-test('click rollover', function(assert) {
+test('click rollover', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -570,15 +475,13 @@ test('click rollover', function(assert) {
     school: 1,
   });
   const rollover = '.course-overview a.rollover';
-  visit(url);
-  click(rollover);
+  await visit(url);
+  await click(rollover);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.rollover');
-  });
+  assert.equal(currentPath(), 'course.rollover');
 });
 
-test('rollover hidden from instructors', function(assert) {
+test('rollover hidden from instructors', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -591,17 +494,15 @@ test('rollover hidden from instructors', function(assert) {
     year: 2013,
     school: 1,
   });
-  visit(url);
+  await visit(url);
   const container = '.course-overview';
   const rollover = `${container} a.rollover`;
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.index');
-    assert.equal(find(rollover).length, 0);
-  });
+  assert.equal(currentPath(), 'course.index');
+  assert.equal(find(rollover).length, 0);
 });
 
-test('rollover visible to developers', function(assert) {
+test('rollover visible to developers', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -614,17 +515,15 @@ test('rollover visible to developers', function(assert) {
     year: 2013,
     school: 1,
   });
-  visit(url);
+  await visit(url);
   const container = '.course-overview';
   const rollover = `${container} a.rollover`;
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.index');
-    assert.equal(find(rollover).length, 1);
-  });
+  assert.equal(currentPath(), 'course.index');
+  assert.equal(find(rollover).length, 1);
 });
 
-test('rollover visible to course directors', function(assert) {
+test('rollover visible to course directors', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -637,17 +536,15 @@ test('rollover visible to course directors', function(assert) {
     year: 2013,
     school: 1,
   });
-  visit(url);
+  await visit(url);
   const container = '.course-overview';
   const rollover = `${container} a.rollover`;
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.index');
-    assert.equal(find(rollover).length, 1);
-  });
+  assert.equal(currentPath(), 'course.index');
+  assert.equal(find(rollover).length, 1);
 });
 
-test('rollover hidden on rollover route', function(assert) {
+test('rollover hidden on rollover route', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -660,12 +557,10 @@ test('rollover hidden on rollover route', function(assert) {
     year: 2013,
     school: 1,
   });
-  visit(`${url}/rollover`);
+  await visit(`${url}/rollover`);
   const container = '.course-overview';
   const rollover = `${container} a.rollover`;
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.rollover');
-    assert.equal(find(rollover).length, 0);
-  });
+  assert.equal(currentPath(), 'course.rollover');
+  assert.equal(find(rollover).length, 0);
 });

--- a/tests/acceptance/course/printcourse-test.js
+++ b/tests/acceptance/course/printcourse-test.js
@@ -79,18 +79,15 @@ module('Acceptance: Course - Print Course', {
 
 });
 
-test('test print course learning materials', function(assert) {
+test('test print course learning materials', async function(assert) {
+  await visit('/course/1/print');
 
-  visit('/course/1/print');
-
-  andThen(function() {
-    assert.equal(find('.detail-header h2:eq(0)').text(), 'Back to the Future');
-    assert.equal(find('.detail-content ul li:eq(0)').text().trim(), 'Time Travel');
-    assert.equal(find('.detail-content ul li:eq(1)').text(), 'Gigawatt Conversion');
-    assert.equal(find('.detail-view-details .detail-content tbody tr td:eq(0)').text().trim(), 'Save the Clock Tower');
-    assert.equal(find('.detail-view-details .detail-content tbody tr td:eq(1)').text(), 'file');
-    assert.equal(find('.detail-view-details .detail-content tbody tr td:eq(2)').text().trim(), 'No');
-    assert.equal(find('.detail-view-details .detail-content tbody tr td:eq(4)').text().trim(), 'The flux capacitor requires 1.21 gigawatts of electrical power to operate, which is roughly equivalent to the power produced by 15 regular jet engines.Lathrop, Emmett, Flux Capacitor, Journal of Time Travel, 5 Nov 1955');
-    assert.equal(find('.detail-content ul li:eq(2)').text(), 'Flux Capacitor');
-  });
+  assert.equal(find('.detail-header h2:eq(0)').text(), 'Back to the Future');
+  assert.equal(find('.detail-content ul li:eq(0)').text().trim(), 'Time Travel');
+  assert.equal(find('.detail-content ul li:eq(1)').text(), 'Gigawatt Conversion');
+  assert.equal(find('.detail-view-details .detail-content tbody tr td:eq(0)').text().trim(), 'Save the Clock Tower');
+  assert.equal(find('.detail-view-details .detail-content tbody tr td:eq(1)').text(), 'file');
+  assert.equal(find('.detail-view-details .detail-content tbody tr td:eq(2)').text().trim(), 'No');
+  assert.equal(find('.detail-view-details .detail-content tbody tr td:eq(4)').text().trim(), 'The flux capacitor requires 1.21 gigawatts of electrical power to operate, which is roughly equivalent to the power produced by 15 regular jet engines.Lathrop, Emmett, Flux Capacitor, Journal of Time Travel, 5 Nov 1955');
+  assert.equal(find('.detail-content ul li:eq(2)').text(), 'Flux Capacitor');
 });

--- a/tests/acceptance/course/publicationcheck-test.js
+++ b/tests/acceptance/course/publicationcheck-test.js
@@ -50,28 +50,24 @@ module('Acceptance: Course - Publication Check', {
   }
 });
 
-test('full course count', function(assert) {
-  visit('/courses/' + fixtures.fullCourse.id + '/publicationcheck');
-  andThen(function() {
-    assert.equal(currentPath(), 'course.publicationCheck');
-    var items = find('.course-publicationcheck table tbody td');
-    assert.equal(getElementText(items.eq(0)), getText('course 0'));
-    assert.equal(getElementText(items.eq(1)), getText('Yes (1)'));
-    assert.equal(getElementText(items.eq(2)), getText('Yes (1)'));
-    assert.equal(getElementText(items.eq(3)), getText('Yes (1)'));
-    assert.equal(getElementText(items.eq(4)), getText('Yes (1)'));
-  });
+test('full course count', async function(assert) {
+  await visit('/courses/' + fixtures.fullCourse.id + '/publicationcheck');
+  assert.equal(currentPath(), 'course.publicationCheck');
+  var items = find('.course-publicationcheck table tbody td');
+  assert.equal(getElementText(items.eq(0)), getText('course 0'));
+  assert.equal(getElementText(items.eq(1)), getText('Yes (1)'));
+  assert.equal(getElementText(items.eq(2)), getText('Yes (1)'));
+  assert.equal(getElementText(items.eq(3)), getText('Yes (1)'));
+  assert.equal(getElementText(items.eq(4)), getText('Yes (1)'));
 });
 
-test('empty course count', function(assert) {
-  visit('/courses/' + fixtures.emptyCourse.id + '/publicationcheck');
-  andThen(function() {
-    assert.equal(currentPath(), 'course.publicationCheck');
-    var items = find('.course-publicationcheck table tbody td');
-    assert.equal(getElementText(items.eq(0)), getText('course 1'));
-    assert.equal(getElementText(items.eq(1)), getText('No'));
-    assert.equal(getElementText(items.eq(2)), getText('No'));
-    assert.equal(getElementText(items.eq(3)), getText('No'));
-    assert.equal(getElementText(items.eq(4)), getText('No'));
-  });
+test('empty course count', async function(assert) {
+  await visit('/courses/' + fixtures.emptyCourse.id + '/publicationcheck');
+  assert.equal(currentPath(), 'course.publicationCheck');
+  var items = find('.course-publicationcheck table tbody td');
+  assert.equal(getElementText(items.eq(0)), getText('course 1'));
+  assert.equal(getElementText(items.eq(1)), getText('No'));
+  assert.equal(getElementText(items.eq(2)), getText('No'));
+  assert.equal(getElementText(items.eq(3)), getText('No'));
+  assert.equal(getElementText(items.eq(4)), getText('No'));
 });

--- a/tests/acceptance/course/publish-test.js
+++ b/tests/acceptance/course/publish-test.js
@@ -23,7 +23,7 @@ module('Acceptance: Course - Publish', {
   }
 });
 
-test('check published course', function(assert) {
+test('check published course', async function(assert) {
   server.create('course', {
     year: 2013,
     school: 1,
@@ -42,26 +42,24 @@ test('check published course', function(assert) {
     school: 1,
     cohorts: [1],
   });
-  visit('/courses/1');
+  await visit('/courses/1');
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.index');
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Published'));
-    //we have to click the button to create the options
-    click(selector);
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Review 3 Missing Items', 'Mark as Scheduled', 'UnPublish Course'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(currentPath(), 'course.index');
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Published'));
+  //we have to click the button to create the options
+  await click(selector);
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Review 3 Missing Items', 'Mark as Scheduled', 'UnPublish Course'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check scheduled course', function(assert) {
+test('check scheduled course', async function(assert) {
   server.create('course', {
     year: 2013,
     school: 1,
@@ -69,95 +67,83 @@ test('check scheduled course', function(assert) {
     publishedAsTbd: true,
     cohorts: [1],
   });
-  visit('/courses/1');
+  await visit('/courses/1');
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.index');
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Scheduled'));
-    //we have to click the button to create the options
-    click(selector);
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Publish As-is', 'Review 3 Missing Items', 'UnPublish Course'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(currentPath(), 'course.index');
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Scheduled'));
+  //we have to click the button to create the options
+  await click(selector);
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Publish As-is', 'Review 3 Missing Items', 'UnPublish Course'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check draft course', function(assert) {
+test('check draft course', async function(assert) {
   server.create('course', {
     year: 2013,
     school: 1,
     cohorts: [1],
   });
-  visit('/courses/1');
+  await visit('/courses/1');
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.index');
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Not Published'));
-    //we have to click the button to create the options
-    click(selector);
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Publish As-is', 'Review 3 Missing Items', 'Mark as Scheduled'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(currentPath(), 'course.index');
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Not Published'));
+  //we have to click the button to create the options
+  await click(selector);
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Publish As-is', 'Review 3 Missing Items', 'Mark as Scheduled'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check publish draft course', function(assert) {
+test('check publish draft course', async function(assert) {
   server.create('course', {
     year: 2013,
     school: 1,
     cohorts: [1],
   });
-  visit('/courses/1');
+  await visit('/courses/1');
 
 
-  andThen(function() {
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const publish = `${choices}:eq(0)`;
-    click(selector);
-    click(publish);
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const publish = `${choices}:eq(0)`;
+  await click(selector);
+  await click(publish);
 
-    andThen(function(){
-      assert.equal(getElementText(find(selector)), getText('Published'));
-    });
-  });
+  assert.equal(getElementText(find(selector)), getText('Published'));
 });
 
-test('check schedule draft course', function(assert) {
+test('check schedule draft course', async function(assert) {
   server.create('course', {
     year: 2013,
     school: 1,
     cohorts: [1],
   });
-  visit('/courses/1');
-  andThen(function() {
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const schedule = `${choices}:eq(2)`;
-    click(selector);
-    click(schedule);
+  await visit('/courses/1');
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const schedule = `${choices}:eq(2)`;
+  await click(selector);
+  await click(schedule);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Scheduled'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Scheduled'));
 });
 
-test('check publish scheduled course', function(assert) {
+test('check publish scheduled course', async function(assert) {
   server.create('course', {
     year: 2013,
     school: 1,
@@ -165,22 +151,18 @@ test('check publish scheduled course', function(assert) {
     publishedAsTbd: true,
     cohorts: [1],
   });
-  visit('/courses/1');
-  andThen(function() {
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const publish = `${choices}:eq(0)`;
-    click(selector);
-    click(publish);
+  await visit('/courses/1');
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const publish = `${choices}:eq(0)`;
+  await click(selector);
+  await click(publish);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Published'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Published'));
 });
 
-test('check unpublish scheduled course', function(assert) {
+test('check unpublish scheduled course', async function(assert) {
   server.create('course', {
     year: 2013,
     school: 1,
@@ -188,61 +170,49 @@ test('check unpublish scheduled course', function(assert) {
     publishedAsTbd: true,
     cohorts: [1],
   });
-  visit('/courses/1');
-  andThen(function() {
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const unPublish = `${choices}:eq(2)`;
-    click(selector);
-    click(unPublish);
+  await visit('/courses/1');
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const unPublish = `${choices}:eq(2)`;
+  await click(selector);
+  await click(unPublish);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Not Published'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Not Published'));
 });
 
-test('check schedule published course', function(assert) {
+test('check schedule published course', async function(assert) {
   server.create('course', {
     year: 2013,
     school: 1,
     published: true,
     cohorts: [1],
   });
-  visit('/courses/1');
-  andThen(function() {
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const schedule = `${choices}:eq(1)`;
-    click(selector);
-    click(schedule);
+  await visit('/courses/1');
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const schedule = `${choices}:eq(1)`;
+  await click(selector);
+  await click(schedule);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Scheduled'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Scheduled'));
 });
 
-test('check unpublish published course', function(assert) {
+test('check unpublish published course', async function(assert) {
   server.create('course', {
     year: 2013,
     school: 1,
     published: true,
     cohorts: [1],
   });
-  visit('/courses/1');
-  andThen(function() {
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const unPublish = `${choices}:eq(2)`;
-    click(selector);
-    click(unPublish);
+  await visit('/courses/1');
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const unPublish = `${choices}:eq(2)`;
+  await click(selector);
+  await click(unPublish);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Not Published'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Not Published'));
 });

--- a/tests/acceptance/course/publishall-test.js
+++ b/tests/acceptance/course/publishall-test.js
@@ -23,7 +23,7 @@ module('Acceptance: Course - Publish All Sessions', {
   }
 });
 
-test('published sessions do not appear in the cannot publish list #1658', function(assert) {
+test('published sessions do not appear in the cannot publish list #1658', async function(assert) {
   server.create('offering', { session: 1 });
   server.create('offering', { session: 2 });
   server.create('offering', { session: 3 });
@@ -69,14 +69,11 @@ test('published sessions do not appear in the cannot publish list #1658', functi
     meshDescriptors: [1],
     terms: [1],
   });
-  visit('/courses/1/publishall');
+  await visit('/courses/1/publishall');
 
-  andThen(function() {
-    let publishable = find('.publish-all-sessions-publishable');
-    click(find('.clickable', publishable)).then(()=> {
-      assert.equal(getElementText(find('tbody tr:eq(0) td:eq(0)')), getText('session 0'));
-      assert.equal(getElementText(find('tbody tr:eq(1) td:eq(0)')), getText('session 1'));
-      assert.equal(getElementText(find('tbody tr:eq(2) td:eq(0)')), getText('session 2'));
-    });
-  });
+  let publishable = find('.publish-all-sessions-publishable');
+  await click(find('.clickable', publishable));
+  assert.equal(getElementText(find('tbody tr:eq(0) td:eq(0)')), getText('session 0'));
+  assert.equal(getElementText(find('tbody tr:eq(1) td:eq(0)')), getText('session 1'));
+  assert.equal(getElementText(find('tbody tr:eq(2) td:eq(0)')), getText('session 2'));
 });

--- a/tests/acceptance/course/session/ilm-test.js
+++ b/tests/acceptance/course/session/ilm-test.js
@@ -55,258 +55,205 @@ module('Acceptance: Session - Independent Learning', {
   }
 });
 
-test('initial selected instructors', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.detail-instructors');
-    assert.equal(getElementText(find('.title', container)), getText('Instructors(6)'));
-    var selectedGroups = find('.columnar-list:eq(0) li', container);
-    assert.equal(selectedGroups.length, fixtures.ilmSession.instructorGroups.length);
-    for(let i = 0; i < fixtures.ilmSession.instructorGroups.length; i++){
-      let expectedTitle = getText(fixtures.instructorGroups[fixtures.ilmSession.instructorGroups[i] - 1].title);
-      let title = getElementText(selectedGroups.eq(i));
-      assert.equal(title, expectedTitle);
-    }
+test('initial selected instructors', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.detail-instructors');
+  assert.equal(getElementText(find('.title', container)), getText('Instructors(6)'));
+  var selectedGroups = find('.columnar-list:eq(0) li', container);
+  assert.equal(selectedGroups.length, fixtures.ilmSession.instructorGroups.length);
+  for(let i = 0; i < fixtures.ilmSession.instructorGroups.length; i++){
+    let expectedTitle = getText(fixtures.instructorGroups[fixtures.ilmSession.instructorGroups[i] - 1].title);
+    let title = getElementText(selectedGroups.eq(i));
+    assert.equal(title, expectedTitle);
+  }
 
-    var selectedUsers = find('.columnar-list:eq(1) li', container);
-    assert.equal(selectedUsers.length, fixtures.ilmSession.instructors.length);
-    assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
-  });
+  var selectedUsers = find('.columnar-list:eq(1) li', container);
+  assert.equal(selectedUsers.length, fixtures.ilmSession.instructors.length);
+  assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
 });
 
-test('manage instructors lists', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.detail-instructors');
-    click('.actions button', container);
-    andThen(function(){
-      var selectedGroups = find('.removable-list:eq(0) li', container);
-      assert.equal(selectedGroups.length, fixtures.ilmSession.instructorGroups.length);
-      assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2'));
+test('manage instructors lists', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.detail-instructors');
+  await click('.actions button', container);
+  var selectedGroups = find('.removable-list:eq(0) li', container);
+  assert.equal(selectedGroups.length, fixtures.ilmSession.instructorGroups.length);
+  assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2'));
 
-      var selectedUsers = find('.removable-list:eq(1) li', container);
-      assert.equal(selectedUsers.length, fixtures.ilmSession.instructors.length);
-      assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
-    });
-  });
+  var selectedUsers = find('.removable-list:eq(1) li', container);
+  assert.equal(selectedUsers.length, fixtures.ilmSession.instructors.length);
+  assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
 });
 
-test('manage instructors search users', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.detail-instructors');
-    click('.actions button', container);
-    andThen(function(){
-      let searchBox = find('.search-box', container);
-      assert.equal(searchBox.length, 1);
-      searchBox = searchBox.eq(0);
-      let searchBoxInput = find('input', searchBox);
-      assert.equal(searchBoxInput.attr('placeholder'), 'Find Instructor or Group');
-      fillIn(searchBoxInput, 'guy');
-      click('span.search-icon', searchBox).then(()=>{
-        let searchResults = find('.live-search .results li', container);
-        assert.equal(searchResults.length, 8);
-        let expectedResults = '7 Results 0 guy M. Mc0son 1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son 4 guy M. Mc4son 5 guy M. Mc5son 6 guy M. Mc6son';
-        assert.equal(getElementText(searchResults), getText(expectedResults));
+test('manage instructors search users', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.detail-instructors');
+  await click('.actions button', container);
+  let searchBox = find('.search-box', container);
+  assert.equal(searchBox.length, 1);
+  searchBox = searchBox.eq(0);
+  let searchBoxInput = find('input', searchBox);
+  assert.equal(searchBoxInput.attr('placeholder'), 'Find Instructor or Group');
+  await fillIn(searchBoxInput, 'guy');
+  await click('span.search-icon', searchBox);
+  let searchResults = find('.live-search .results li', container);
+  assert.equal(searchResults.length, 8);
+  let expectedResults = '7 Results 0 guy M. Mc0son 1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son 4 guy M. Mc4son 5 guy M. Mc5son 6 guy M. Mc6son';
+  assert.equal(getElementText(searchResults), getText(expectedResults));
 
-        let activeResults = find('.live-search .results li.active', container);
-        assert.equal(getElementText(activeResults), getText('0 guy M. Mc0son 4 guy M. Mc4son 5 guy M. Mc5son 6 guy M. Mc6son'));
+  let activeResults = find('.live-search .results li.active', container);
+  assert.equal(getElementText(activeResults), getText('0 guy M. Mc0son 4 guy M. Mc4son 5 guy M. Mc5son 6 guy M. Mc6son'));
 
-        let inActiveResults = find('.live-search .results li.inactive', container);
-        assert.equal(getElementText(inActiveResults), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
-      });
-    });
-  });
+  let inActiveResults = find('.live-search .results li.inactive', container);
+  assert.equal(getElementText(inActiveResults), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
 });
 
 
-test('manage instructors search groups', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.detail-instructors');
-    click('.actions button', container);
-    andThen(function(){
-      let searchBox = find('.search-box', container);
-      assert.equal(searchBox.length, 1);
-      searchBox = searchBox.eq(0);
-      let searchBoxInput = find('input', searchBox);
-      assert.equal(searchBoxInput.attr('placeholder'), 'Find Instructor or Group');
-      fillIn(searchBoxInput, 'group');
-      click('span.search-icon', searchBox).then(()=>{
-        let searchResults = find('.live-search .results li', container);
-        assert.equal(searchResults.length, 6);
-        let expectedResults = '5 Results instructorgroup 0 instructorgroup 1 instructorgroup 2 instructorgroup 3 instructorgroup 4';
-        assert.equal(getElementText(searchResults), getText(expectedResults));
+test('manage instructors search groups', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.detail-instructors');
+  await click('.actions button', container);
+  let searchBox = find('.search-box', container);
+  assert.equal(searchBox.length, 1);
+  searchBox = searchBox.eq(0);
+  let searchBoxInput = find('input', searchBox);
+  assert.equal(searchBoxInput.attr('placeholder'), 'Find Instructor or Group');
+  await fillIn(searchBoxInput, 'group');
+  await click('span.search-icon', searchBox);
+  let searchResults = find('.live-search .results li', container);
+  assert.equal(searchResults.length, 6);
+  let expectedResults = '5 Results instructorgroup 0 instructorgroup 1 instructorgroup 2 instructorgroup 3 instructorgroup 4';
+  assert.equal(getElementText(searchResults), getText(expectedResults));
 
-        let activeResults = find('.live-search .results li.active', container);
-        assert.equal(getElementText(activeResults), getText('instructorgroup 3 instructorgroup 4'));
+  let activeResults = find('.live-search .results li.active', container);
+  assert.equal(getElementText(activeResults), getText('instructorgroup 3 instructorgroup 4'));
 
-        let inActiveResults = find('.live-search .results li.inactive', container);
-        assert.equal(getElementText(inActiveResults), getText('instructorgroup 0 instructorgroup 1 instructorgroup 2'));
-      });
-    });
-  });
+  let inActiveResults = find('.live-search .results li.inactive', container);
+  assert.equal(getElementText(inActiveResults), getText('instructorgroup 0 instructorgroup 1 instructorgroup 2'));
 });
 
-test('add instructor group', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.detail-instructors');
-    click('.actions button', container).then(function(){
-      let input = find('.search-box input', container);
-      fillIn(input, 'group');
-      click('span.search-icon', container).then(()=>{
-        click('.live-search .results li:eq(4)');
-      });
-    });
-    andThen(function(){
-      let selectedGroups = find('.removable-list:eq(0) li', container);
-      assert.equal(selectedGroups.length, 4);
-      assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2 instructor group 3'));
+test('add instructor group', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.detail-instructors');
+  await click('.actions button', container);
+  let input = find('.search-box input', container);
+  await fillIn(input, 'group');
+  await click('span.search-icon', container);
+  await click('.live-search .results li:eq(4)');
+  let selectedGroups = find('.removable-list:eq(0) li', container);
+  assert.equal(selectedGroups.length, 4);
+  assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2 instructor group 3'));
 
-      let selectedUsers = find('.removable-list:eq(1) li', container);
-      assert.equal(selectedUsers.length, fixtures.ilmSession.instructors.length);
-      assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
-      click('.bigadd', container);
-      andThen(function(){
-        let groups = find('.columnar-list:eq(0) li', container);
-        assert.equal(groups.length, 4);
-        assert.equal(getElementText(groups), getText('instructor group 0 instructor group 1 instructor group 2 instructor group 3'));
+  let selectedUsers = find('.removable-list:eq(1) li', container);
+  assert.equal(selectedUsers.length, fixtures.ilmSession.instructors.length);
+  assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
+  await click('.bigadd', container);
+  let groups = find('.columnar-list:eq(0) li', container);
+  assert.equal(groups.length, 4);
+  assert.equal(getElementText(groups), getText('instructor group 0 instructor group 1 instructor group 2 instructor group 3'));
 
-        let users = find('.columnar-list:eq(1) li', container);
-        assert.equal(users.length, 3);
-        assert.equal(getElementText(users), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
-      });
-    });
-  });
+  let users = find('.columnar-list:eq(1) li', container);
+  assert.equal(users.length, 3);
+  assert.equal(getElementText(users), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
 });
 
-test('add instructor', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.detail-instructors');
-    click('.actions button', container).then(function(){
-      let input = find('.search-box input', container);
-      fillIn(input, 'guy');
-      click('span.search-icon', container).then(()=>{
-        click('.live-search .results li:eq(5)');
-      });
-    });
-    andThen(function(){
-      var selectedGroups = find('.removable-list:eq(0) li', container);
-      assert.equal(selectedGroups.length, fixtures.ilmSession.instructorGroups.length);
-      assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2'));
+test('add instructor', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.detail-instructors');
+  await click('.actions button', container);
+  let input = find('.search-box input', container);
+  await fillIn(input, 'guy');
+  await click('span.search-icon', container);
+  await click('.live-search .results li:eq(5)');
+  var selectedGroups = find('.removable-list:eq(0) li', container);
+  assert.equal(selectedGroups.length, fixtures.ilmSession.instructorGroups.length);
+  assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2'));
 
-      var selectedUsers = find('.removable-list:eq(1) li', container);
-      assert.equal(selectedUsers.length, 4);
-      assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son 4 guy M. Mc4son'));
-      click('.bigadd', container);
-    });
-    andThen(function(){
-      var selectedGroups = find('.columnar-list:eq(0) li', container);
-      assert.equal(selectedGroups.length, 3);
-      assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2'));
+  var selectedUsers = find('.removable-list:eq(1) li', container);
+  assert.equal(selectedUsers.length, 4);
+  assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son 4 guy M. Mc4son'));
+  await click('.bigadd', container);
+  selectedGroups = find('.columnar-list:eq(0) li', container);
+  assert.equal(selectedGroups.length, 3);
+  assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2'));
 
-      var selectedUsers = find('.columnar-list:eq(1) li', container);
-      assert.equal(selectedUsers.length, 4);
-      assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son 4 guy M. Mc4son'));
-    });
-  });
+  selectedUsers = find('.columnar-list:eq(1) li', container);
+  assert.equal(selectedUsers.length, 4);
+  assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son 4 guy M. Mc4son'));
 });
 
-test('remove instructor group', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.detail-instructors');
-    click('.actions button', container).then(function(){
-      click('.removable-list:eq(0) li:eq(0)', container);
-    });
-    andThen(function(){
-      let selectedGroups = find('.removable-list:eq(0) li', container);
-      assert.equal(selectedGroups.length, 2);
-      assert.equal(getElementText(selectedGroups), getText('instructor group 1 instructor group 2'));
+test('remove instructor group', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.detail-instructors');
+  await click('.actions button', container);
+  await click('.removable-list:eq(0) li:eq(0)', container);
+  let selectedGroups = find('.removable-list:eq(0) li', container);
+  assert.equal(selectedGroups.length, 2);
+  assert.equal(getElementText(selectedGroups), getText('instructor group 1 instructor group 2'));
 
-      let selectedUsers = find('.removable-list:eq(1) li', container);
-      assert.equal(selectedUsers.length, 3);
-      assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
-      click('.bigadd', container);
-      andThen(function(){
-        let groups = find('.columnar-list:eq(0) li', container);
-        assert.equal(groups.length, 2);
-        assert.equal(getElementText(groups), getText('instructor group 1 instructor group 2'));
+  let selectedUsers = find('.removable-list:eq(1) li', container);
+  assert.equal(selectedUsers.length, 3);
+  assert.equal(getElementText(selectedUsers), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
+  await click('.bigadd', container);
+  let groups = find('.columnar-list:eq(0) li', container);
+  assert.equal(groups.length, 2);
+  assert.equal(getElementText(groups), getText('instructor group 1 instructor group 2'));
 
-        let users = find('.columnar-list:eq(1) li', container);
-        assert.equal(users.length, 3);
-        assert.equal(getElementText(users), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
-      });
-    });
-  });
+  let users = find('.columnar-list:eq(1) li', container);
+  assert.equal(users.length, 3);
+  assert.equal(getElementText(users), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
 });
 
-test('remove instructor', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.detail-instructors');
-    click('.actions button', container).then(function(){
-      click('.removable-list:eq(1) li:eq(0)', container);
-    });
-    andThen(function(){
-      let selectedGroups = find('.removable-list:eq(0) li', container);
-      assert.equal(selectedGroups.length, 3);
-      assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2'));
+test('remove instructor', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.detail-instructors');
+  await click('.actions button', container);
+  await click('.removable-list:eq(1) li:eq(0)', container);
+  let selectedGroups = find('.removable-list:eq(0) li', container);
+  assert.equal(selectedGroups.length, 3);
+  assert.equal(getElementText(selectedGroups), getText('instructor group 0 instructor group 1 instructor group 2'));
 
-      let selectedUsers = find('.removable-list:eq(1) li', container);
-      assert.equal(selectedUsers.length, 2);
-      assert.equal(getElementText(selectedUsers), getText('2 guy M. Mc2son 3 guy M. Mc3son'));
-      click('.bigadd', container);
-      andThen(function(){
-        let groups = find('.columnar-list:eq(0) li', container);
-        assert.equal(groups.length, 3);
-        assert.equal(getElementText(groups), getText('instructor group 0 instructor group 1 instructor group 2'));
+  let selectedUsers = find('.removable-list:eq(1) li', container);
+  assert.equal(selectedUsers.length, 2);
+  assert.equal(getElementText(selectedUsers), getText('2 guy M. Mc2son 3 guy M. Mc3son'));
+  await click('.bigadd', container);
+  let groups = find('.columnar-list:eq(0) li', container);
+  assert.equal(groups.length, 3);
+  assert.equal(getElementText(groups), getText('instructor group 0 instructor group 1 instructor group 2'));
 
-        let users = find('.columnar-list:eq(1) li', container);
-        assert.equal(users.length, 2);
-        assert.equal(getElementText(users), getText('2 guy M. Mc2son 3 guy M. Mc3son'));
-      });
-    });
-  });
+  let users = find('.columnar-list:eq(1) li', container);
+  assert.equal(users.length, 2);
+  assert.equal(getElementText(users), getText('2 guy M. Mc2son 3 guy M. Mc3son'));
 });
 
-test('undo instructor/group changes', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.detail-instructors');
-    click('.actions button', container).then(function(){
-      click('.removable-list:eq(0) li:eq(0)', container);
-      click('.removable-list:eq(1) li:eq(0)', container);
-    });
-    andThen(function(){
-      let selectedGroups = find('.removable-list:eq(0) li', container);
-      assert.equal(selectedGroups.length, 2);
-      assert.equal(getElementText(selectedGroups), getText('instructor group 1 instructor group 2'));
+test('undo instructor/group changes', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.detail-instructors');
+  await click('.actions button', container);
+  await click('.removable-list:eq(0) li:eq(0)', container);
+  await click('.removable-list:eq(1) li:eq(0)', container);
+  let selectedGroups = find('.removable-list:eq(0) li', container);
+  assert.equal(selectedGroups.length, 2);
+  assert.equal(getElementText(selectedGroups), getText('instructor group 1 instructor group 2'));
 
-      let selectedUsers = find('.removable-list:eq(1) li', container);
-      assert.equal(selectedUsers.length, 2);
-      assert.equal(getElementText(selectedUsers), getText('2 guy M. Mc2son 3 guy M. Mc3son'));
-      click('.bigcancel', container);
-      andThen(function(){
-        let groups = find('.columnar-list:eq(0) li', container);
-        assert.equal(groups.length, 3);
-        assert.equal(getElementText(groups), getText('instructor group 0 instructor group 1 instructor group 2'));
+  let selectedUsers = find('.removable-list:eq(1) li', container);
+  assert.equal(selectedUsers.length, 2);
+  assert.equal(getElementText(selectedUsers), getText('2 guy M. Mc2son 3 guy M. Mc3son'));
+  await click('.bigcancel', container);
+  let groups = find('.columnar-list:eq(0) li', container);
+  assert.equal(groups.length, 3);
+  assert.equal(getElementText(groups), getText('instructor group 0 instructor group 1 instructor group 2'));
 
-        let users = find('.columnar-list:eq(1) li', container);
-        assert.equal(users.length, 3);
-        assert.equal(getElementText(users), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
-      });
-    });
-  });
+  let users = find('.columnar-list:eq(1) li', container);
+  assert.equal(users.length, 3);
+  assert.equal(getElementText(users), getText('1 guy M. Mc1son 2 guy M. Mc2son 3 guy M. Mc3son'));
 });

--- a/tests/acceptance/course/session/learner-groups-test.js
+++ b/tests/acceptance/course/session/learner-groups-test.js
@@ -77,7 +77,7 @@ let setupModels = function(){
   });
 };
 
-test('initial selected learner groups', function(assert) {
+test('initial selected learner groups', async function(assert) {
   setupModels();
   server.create('ilmSession', {
     session: 1,
@@ -95,21 +95,18 @@ test('initial selected learner groups', function(assert) {
   const set3Legend = set3 + ' legend';
   const set3Group1 = set3 + ' li:eq(0)';
 
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    assert.equal(getElementText(find(set1Legend)), getText('learnergroup 0 (program0 cohort0)'));
-    assert.equal(getElementText(find(set2Legend)), getText('learnergroup 1 (program0 cohort0)'));
-    assert.equal(getElementText(find(set3Legend)), getText('learnergroup 3 (program0 cohort0)'));
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.index');
+  assert.equal(getElementText(find(set1Legend)), getText('learnergroup 0 (program0 cohort0)'));
+  assert.equal(getElementText(find(set2Legend)), getText('learnergroup 1 (program0 cohort0)'));
+  assert.equal(getElementText(find(set3Legend)), getText('learnergroup 3 (program0 cohort0)'));
 
-    assert.equal(getElementText(find(set1Group1)), getText('learnergroup 0 (0)'));
-    assert.equal(getElementText(find(set2Group1)), getText('learnergroup 1 (0)'));
-    assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
-
-  });
+  assert.equal(getElementText(find(set1Group1)), getText('learnergroup 0 (0)'));
+  assert.equal(getElementText(find(set2Group1)), getText('learnergroup 1 (0)'));
+  assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
 });
 
-test('learner group manager display', function(assert) {
+test('learner group manager display', async function(assert) {
   setupModels();
   server.create('ilmSession', {
     session: 1,
@@ -126,24 +123,22 @@ test('learner group manager display', function(assert) {
   const set3Legend = set3 + ' legend';
   const set3Group1 = set3 + ' li:eq(0)';
 
-  visit(url + '&isManagingLearnerGroups=true');
+  await visit(url + '&isManagingLearnerGroups=true');
   const availableLearnerGroups = '.detail-learnergroups .tree-groups-list';
-  andThen(function() {
 
-    assert.equal(currentPath(), 'course.session.index');
-    assert.equal(getElementText(find(availableLearnerGroups).children(':visible')), getText('learnergroup 2 learnergroup 3 learnergroup 5  learnergroup 6  learnergroup 4  learnergroup 7'));
+  assert.equal(currentPath(), 'course.session.index');
+  assert.equal(getElementText(find(availableLearnerGroups).children(':visible')), getText('learnergroup 2 learnergroup 3 learnergroup 5  learnergroup 6  learnergroup 4  learnergroup 7'));
 
-    assert.equal(getElementText(find(set1Legend)), getText('learnergroup 0 (program0 cohort0)'));
-    assert.equal(getElementText(find(set2Legend)), getText('learnergroup 1 (program0 cohort0)'));
-    assert.equal(getElementText(find(set3Legend)), getText('learnergroup 3 (program0 cohort0)'));
+  assert.equal(getElementText(find(set1Legend)), getText('learnergroup 0 (program0 cohort0)'));
+  assert.equal(getElementText(find(set2Legend)), getText('learnergroup 1 (program0 cohort0)'));
+  assert.equal(getElementText(find(set3Legend)), getText('learnergroup 3 (program0 cohort0)'));
 
-    assert.equal(getElementText(find(set1Group1)), getText('learnergroup 0 (0)'));
-    assert.equal(getElementText(find(set2Group1)), getText('learnergroup 1 (0)'));
-    assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
-  });
+  assert.equal(getElementText(find(set1Group1)), getText('learnergroup 0 (0)'));
+  assert.equal(getElementText(find(set2Group1)), getText('learnergroup 1 (0)'));
+  assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
 });
 
-test('learner group manager display with no selected groups', function(assert) {
+test('learner group manager display with no selected groups', async function(assert) {
   setupModels();
   server.create('ilmSession', {
     session: 1,
@@ -152,52 +147,44 @@ test('learner group manager display with no selected groups', function(assert) {
   const container = '.detail-learnergroups ';
   const selectedLearnerGroups = container + ' .selected-learner-groups';
 
-  visit(url + '&isManagingLearnerGroups=true');
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    assert.equal(getElementText(find(selectedLearnerGroups)), getText('Selected Learner Groups None'));
-  });
+  await visit(url + '&isManagingLearnerGroups=true');
+  assert.equal(currentPath(), 'course.session.index');
+  assert.equal(getElementText(find(selectedLearnerGroups)), getText('Selected Learner Groups None'));
 });
 
-test('filter learner groups by top group should include all subgroups', function(assert) {
+test('filter learner groups by top group should include all subgroups', async function(assert) {
   setupModels();
   server.create('ilmSession', {
     session: 1,
     learnerGroups: [1, 2, 4]
   });
-  visit(url + '&isManagingLearnerGroups=true');
-  fillIn('.search-box input', 3);
+  await visit(url + '&isManagingLearnerGroups=true');
+  await fillIn('.search-box input', 3);
   const availableLearnerGroups = '.detail-learnergroups .tree-groups-list';
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    assert.equal(getElementText(find(availableLearnerGroups).children(':visible')), getText('learnergroup 3 learnergroup 5 learnergroup 6'));
-  });
+  assert.equal(currentPath(), 'course.session.index');
+  assert.equal(getElementText(find(availableLearnerGroups).children(':visible')), getText('learnergroup 3 learnergroup 5 learnergroup 6'));
 });
 
-test('filter learner groups by subgroup should include top group', function(assert) {
+test('filter learner groups by subgroup should include top group', async function(assert) {
   setupModels();
   server.create('ilmSession', {
     session: 1,
     learnerGroups: [1, 2, 4]
   });
-  visit(url + '&isManagingLearnerGroups=true');
+  await visit(url + '&isManagingLearnerGroups=true');
   const lg3 = '.detail-learnergroups .tree-groups-list li:eq(3)';
   const lg5 = '.detail-learnergroups .tree-groups-list li:eq(4)';
   const lg6 = '.detail-learnergroups .tree-groups-list li:eq(5)';
-  andThen(function() {
-    assert.ok(find(lg3).is(':visible'));
-    assert.ok(find(lg5).is(':visible'));
-    assert.ok(find(lg6).is(':visible'));
-  });
-  fillIn('.search-box input', 5);
-  andThen(function() {
-    assert.ok(find(lg3).is(':visible'));
-    assert.ok(find(lg5).is(':visible'));
-    assert.ok(find(lg6).is(':hidden'));
-  });
+  assert.ok(find(lg3).is(':visible'));
+  assert.ok(find(lg5).is(':visible'));
+  assert.ok(find(lg6).is(':visible'));
+  await fillIn('.search-box input', 5);
+  assert.ok(find(lg3).is(':visible'));
+  assert.ok(find(lg5).is(':visible'));
+  assert.ok(find(lg6).is(':hidden'));
 });
 
-test('add learner group', function(assert) {
+test('add learner group', async function(assert) {
   setupModels();
   server.create('ilmSession', {
     session: 1,
@@ -208,23 +195,18 @@ test('add learner group', function(assert) {
   const set3Legend = set3 + ' legend';
   const set3Group1 = set3 + ' li:eq(0)';
 
-  visit(url + '&isManagingLearnerGroups=true');
+  await visit(url + '&isManagingLearnerGroups=true');
   const lg2 = '.detail-learnergroups .tree-groups-list li:eq(2)';
   const lg2Clicker = lg2 + ' .clickable';
-  andThen(function() {
-    assert.ok(find(lg2).is(':visible'));
-  });
-  click(lg2Clicker);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    assert.equal(getElementText(find(set3Legend)), getText('learnergroup 2 (program0 cohort0)'));
-    assert.equal(getElementText(find(set3Group1)), getText('learnergroup 2 (0)'));
-    assert.ok(find(lg2).is(':hidden'));
-
-  });
+  assert.ok(find(lg2).is(':visible'));
+  await click(lg2Clicker);
+  assert.equal(currentPath(), 'course.session.index');
+  assert.equal(getElementText(find(set3Legend)), getText('learnergroup 2 (program0 cohort0)'));
+  assert.equal(getElementText(find(set3Group1)), getText('learnergroup 2 (0)'));
+  assert.ok(find(lg2).is(':hidden'));
 });
 
-test('add learner sub group', function(assert) {
+test('add learner sub group', async function(assert) {
   setupModels();
   server.create('ilmSession', {
     session: 1,
@@ -237,26 +219,22 @@ test('add learner sub group', function(assert) {
   const lg5 = '.detail-learnergroups .tree-groups-list li:eq(4)';
   const lg5Clicker = lg5 + ' .clickable';
 
-  visit(url + '&isManagingLearnerGroups=true');
-  andThen(function() {
-    assert.ok(find(lg5).is(':visible'));
-  });
-  click(lg5Clicker);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    assert.ok(find(lg5).is(':hidden'));
-    assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
-    assert.equal(getElementText(find(set3Group2)), getText('learnergroup 5 (0)'));
-  });
+  await visit(url + '&isManagingLearnerGroups=true');
+  assert.ok(find(lg5).is(':visible'));
+  await click(lg5Clicker);
+  assert.equal(currentPath(), 'course.session.index');
+  assert.ok(find(lg5).is(':hidden'));
+  assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
+  assert.equal(getElementText(find(set3Group2)), getText('learnergroup 5 (0)'));
 });
 
-test('add learner group with children', function(assert) {
+test('add learner group with children', async function(assert) {
   setupModels();
   server.create('ilmSession', {
     session: 1,
     learnerGroups: [1, 2, 4]
   });
-  visit(url + '&isManagingLearnerGroups=true');
+  await visit(url + '&isManagingLearnerGroups=true');
   const container = '.detail-learnergroups ';
   const set3 = container + 'fieldset:eq(2)';
   const set3Group1 = set3 + ' li:eq(0)';
@@ -266,30 +244,26 @@ test('add learner group with children', function(assert) {
   const lg5 = '.detail-learnergroups .tree-groups-list li:eq(4)';
   const lg6 = '.detail-learnergroups .tree-groups-list li:eq(5)';
   const lg3Clicker = lg3 + ' .clickable';
-  andThen(function() {
-    assert.ok(find(lg3).is(':visible'));
-    assert.ok(find(lg5).is(':visible'));
-    assert.ok(find(lg6).is(':visible'));
-  });
-  click(lg3Clicker);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
-    assert.equal(getElementText(find(set3Group2)), getText('learnergroup 5 (0)'));
-    assert.equal(getElementText(find(set3Group3)), getText('learnergroup 6 (0)'));
-    assert.ok(find(lg3).is(':hidden'));
-    assert.ok(find(lg5).is(':hidden'));
-    assert.ok(find(lg6).is(':hidden'));
-  });
+  assert.ok(find(lg3).is(':visible'));
+  assert.ok(find(lg5).is(':visible'));
+  assert.ok(find(lg6).is(':visible'));
+  await click(lg3Clicker);
+  assert.equal(currentPath(), 'course.session.index');
+  assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
+  assert.equal(getElementText(find(set3Group2)), getText('learnergroup 5 (0)'));
+  assert.equal(getElementText(find(set3Group3)), getText('learnergroup 6 (0)'));
+  assert.ok(find(lg3).is(':hidden'));
+  assert.ok(find(lg5).is(':hidden'));
+  assert.ok(find(lg6).is(':hidden'));
 });
 
-test('add learner group with children and remove one child', function(assert) {
+test('add learner group with children and remove one child', async function(assert) {
   setupModels();
   server.create('ilmSession', {
     session: 1,
     learnerGroups: [1, 2, 4]
   });
-  visit(url + '&isManagingLearnerGroups=true');
+  await visit(url + '&isManagingLearnerGroups=true');
   const container = '.detail-learnergroups ';
   const set3 = container + 'fieldset:eq(2)';
   const set3Group1 = set3 + ' li:eq(0)';
@@ -299,38 +273,31 @@ test('add learner group with children and remove one child', function(assert) {
   const lg5 = '.detail-learnergroups .tree-groups-list li:eq(4)';
   const lg6 = '.detail-learnergroups .tree-groups-list li:eq(5)';
   const lg3Clicker = lg3 + ' .clickable';
-  andThen(function() {
-    assert.ok(find(lg3).is(':visible'));
-    assert.ok(find(lg5).is(':visible'));
-    assert.ok(find(lg6).is(':visible'));
-  });
-  click(lg3Clicker);
-  andThen(function() {
-    assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
-    assert.equal(getElementText(find(set3Group2)), getText('learnergroup 5 (0)'));
-    assert.equal(getElementText(find(set3Group3)), getText('learnergroup 6 (0)'));
-    assert.ok(find(lg3).is(':hidden'));
-    assert.ok(find(lg5).is(':hidden'));
-    assert.ok(find(lg6).is(':hidden'));
-  });
-  click(set3Group2);
-  andThen(function() {
-    assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
-    assert.equal(getElementText(find(set3Group2)), getText('learnergroup 6 (0)'));
-    assert.ok(find(lg3).is(':visible'));
-    assert.ok(find(lg5).is(':visible'));
-    assert.ok(find(lg6).is(':hidden'));
-  });
-
+  assert.ok(find(lg3).is(':visible'));
+  assert.ok(find(lg5).is(':visible'));
+  assert.ok(find(lg6).is(':visible'));
+  await click(lg3Clicker);
+  assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
+  assert.equal(getElementText(find(set3Group2)), getText('learnergroup 5 (0)'));
+  assert.equal(getElementText(find(set3Group3)), getText('learnergroup 6 (0)'));
+  assert.ok(find(lg3).is(':hidden'));
+  assert.ok(find(lg5).is(':hidden'));
+  assert.ok(find(lg6).is(':hidden'));
+  await click(set3Group2);
+  assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
+  assert.equal(getElementText(find(set3Group2)), getText('learnergroup 6 (0)'));
+  assert.ok(find(lg3).is(':visible'));
+  assert.ok(find(lg5).is(':visible'));
+  assert.ok(find(lg6).is(':hidden'));
 });
 
-test('undo learner group change', function(assert) {
+test('undo learner group change', async function(assert) {
   setupModels();
   server.create('ilmSession', {
     session: 1,
     learnerGroups: [1, 2, 4]
   });
-  visit(url + '&isManagingLearnerGroups=true');
+  await visit(url + '&isManagingLearnerGroups=true');
   const container = '.detail-learnergroups ';
   const lg7 = container + '.available-learner-groups li:eq(7) .clickable';
   const cancel = container + '.bigcancel';
@@ -345,29 +312,27 @@ test('undo learner group change', function(assert) {
   const set3Legend = set3 + ' legend';
   const set3Group1 = set3 + ' li:eq(0)';
 
-  click(set1RemoveAll);
-  click(lg7);
-  click(cancel);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
+  await click(set1RemoveAll);
+  await click(lg7);
+  await click(cancel);
+  assert.equal(currentPath(), 'course.session.index');
 
-    assert.equal(getElementText(find(set1Legend)), getText('learnergroup 0 (program0 cohort0)'));
-    assert.equal(getElementText(find(set2Legend)), getText('learnergroup 1 (program0 cohort0)'));
-    assert.equal(getElementText(find(set3Legend)), getText('learnergroup 3 (program0 cohort0)'));
+  assert.equal(getElementText(find(set1Legend)), getText('learnergroup 0 (program0 cohort0)'));
+  assert.equal(getElementText(find(set2Legend)), getText('learnergroup 1 (program0 cohort0)'));
+  assert.equal(getElementText(find(set3Legend)), getText('learnergroup 3 (program0 cohort0)'));
 
-    assert.equal(getElementText(find(set1Group1)), getText('learnergroup 0 (0)'));
-    assert.equal(getElementText(find(set2Group1)), getText('learnergroup 1 (0)'));
-    assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
-  });
+  assert.equal(getElementText(find(set1Group1)), getText('learnergroup 0 (0)'));
+  assert.equal(getElementText(find(set2Group1)), getText('learnergroup 1 (0)'));
+  assert.equal(getElementText(find(set3Group1)), getText('learnergroup 3 (0)'));
 });
 
-test('save learner group change', function(assert) {
+test('save learner group change', async function(assert) {
   setupModels();
   server.create('ilmSession', {
     session: 1,
     learnerGroups: [1, 2, 4]
   });
-  visit(url + '&isManagingLearnerGroups=true');
+  await visit(url + '&isManagingLearnerGroups=true');
   const container = '.detail-learnergroups ';
   const lg7 = container + '.available-learner-groups li:eq(7) .clickable';
   const save = container +  '.bigadd';
@@ -383,22 +348,20 @@ test('save learner group change', function(assert) {
   const set3Group1 = set3 + ' li:eq(0)';
   const set3Group2 = set3 + ' li:eq(1)';
 
-  click(set1RemoveAll);
-  click(lg7);
-  click(save);
-  andThen(function() {
-    assert.equal(getElementText(find(set1Legend)), getText('learnergroup 1 (program0 cohort0)'));
-    assert.equal(getElementText(find(set2Legend)), getText('learnergroup 3 (program0 cohort0)'));
-    assert.equal(getElementText(find(set3Legend)), getText('learnergroup 4 (program0 cohort0)'));
+  await click(set1RemoveAll);
+  await click(lg7);
+  await click(save);
+  assert.equal(getElementText(find(set1Legend)), getText('learnergroup 1 (program0 cohort0)'));
+  assert.equal(getElementText(find(set2Legend)), getText('learnergroup 3 (program0 cohort0)'));
+  assert.equal(getElementText(find(set3Legend)), getText('learnergroup 4 (program0 cohort0)'));
 
-    assert.equal(getElementText(find(set1Group1)), getText('learnergroup 1 (0)'));
-    assert.equal(getElementText(find(set2Group1)), getText('learnergroup 3 (0)'));
-    assert.equal(getElementText(find(set3Group1)), getText('learnergroup 4 (0)'));
-    assert.equal(getElementText(find(set3Group2)), getText('learnergroup 7 (0)'));
-  });
+  assert.equal(getElementText(find(set1Group1)), getText('learnergroup 1 (0)'));
+  assert.equal(getElementText(find(set2Group1)), getText('learnergroup 3 (0)'));
+  assert.equal(getElementText(find(set3Group1)), getText('learnergroup 4 (0)'));
+  assert.equal(getElementText(find(set3Group2)), getText('learnergroup 7 (0)'));
 });
 
-test('collapsed learner groups', function(assert) {
+test('collapsed learner groups', async function(assert) {
   setupModels();
   server.create('programYear', {
     cohort: 2,
@@ -423,19 +386,16 @@ test('collapsed learner groups', function(assert) {
   const cohort2Title = 'table tr:eq(2) td:eq(0)';
   const cohort2Count = 'table tr:eq(2) td:eq(1)';
 
-  visit('/courses/1/sessions/1?sessionLearnergroupDetails=false');
+  await visit('/courses/1/sessions/1?sessionLearnergroupDetails=false');
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    assert.equal(getElementText(find(cohort1Title)), getText('program0 cohort0'));
-    assert.equal(getElementText(find(cohort1Count)), getText('3'));
-    assert.equal(getElementText(find(cohort2Title)), getText('program0 cohort1'));
-    assert.equal(getElementText(find(cohort2Count)), getText('2'));
-
-  });
+  assert.equal(currentPath(), 'course.session.index');
+  assert.equal(getElementText(find(cohort1Title)), getText('program0 cohort0'));
+  assert.equal(getElementText(find(cohort1Count)), getText('3'));
+  assert.equal(getElementText(find(cohort2Title)), getText('program0 cohort1'));
+  assert.equal(getElementText(find(cohort2Count)), getText('2'));
 });
 
-test('initial state with save works as expected #1773', function(assert) {
+test('initial state with save works as expected #1773', async function(assert) {
   server.create('school', {
     courses: [1]
   });
@@ -474,14 +434,10 @@ test('initial state with save works as expected #1773', function(assert) {
   const lg1 = container + '.available-learner-groups li:eq(0) .clickable';
   const save = container +  '.bigadd';
 
-  visit('/courses/1/sessions/1');
-  andThen(function() {
-    assert.equal(find(manageButton).length, 1, 'We are not in a collapsed state');
-  });
-  click(manageButton);
-  click(lg1);
-  click(save);
-  andThen(function() {
-    assert.equal(find(manageButton).length, 1, 'We are not in a collapsed state');
-  });
+  await visit('/courses/1/sessions/1');
+  assert.equal(find(manageButton).length, 1, 'We are not in a collapsed state');
+  await click(manageButton);
+  await click(lg1);
+  await click(save);
+  assert.equal(find(manageButton).length, 1, 'We are not in a collapsed state');
 });

--- a/tests/acceptance/course/session/learningmaterials-test.js
+++ b/tests/acceptance/course/session/learningmaterials-test.js
@@ -7,6 +7,7 @@ import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
 import Ember from 'ember';
 import moment from 'moment';
+import wait from 'ember-test-helpers/wait';
 
 const { isEmpty, isPresent, run } = Ember;
 const { later } = run;
@@ -133,42 +134,40 @@ module('Acceptance: Session - Learning Materials', {
   }
 });
 
-test('list learning materials', function(assert) {
-  visit(url);
-  andThen(function() {
-    const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
-    const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
-    assert.equal(currentPath(), 'course.session.index');
-    let container = find('.detail-learningmaterials');
-    let rows = find('.detail-learningmaterials-content tbody tr', container);
-    assert.equal(rows.length, fixtures.session.learningMaterials.length);
-    for (let i = 0; i < fixtures.session.learningMaterials.length; i++){
-      let row = rows.eq(i);
-      let sessionLm = fixtures.sessionLearningMaterials[fixtures.session.learningMaterials[i] - 1];
-      let lm = fixtures.learningMaterials[sessionLm.learningMaterial - 1];
-      assert.equal(getElementText(find('td:eq(0)', row)), getText(lm.title));
-      // TODO: not checking for exact type icon yet, see comment below [ST 2017/08/01]
-      assert.equal(find('td:eq(0) .lm-type-icon i.fa', row).length, 1, 'LM type icon is present.');
-      //TODO: we are no longer populating for 'type', so we need to pull all these tests out
-      //of the loop and test each fixture individually
-      //assert.equal(getElementText(find('td:eq(1)', row)), getText(lm.type));
-      let required = sessionLm.required?'Yes':'No';
-      assert.equal(getElementText(find('td:eq(2)', row)), getText(userName));
-      assert.equal(getElementText(find('td:eq(3)', row)), getText(required));
-      let notes = sessionLm.notes? 'Yes' : 'No';
-      assert.equal(getElementText(find('td:eq(4)', row)), getText(notes));
-      let notesBool = sessionLm.notes? true : false;
-      let publicNotes = sessionLm.publicNotes ? true : false;
-      assert.equal(find('td:eq(4) i', row).hasClass('fa-eye'), publicNotes && notesBool);
-      let meshTerms = find('td:eq(5) li', row);
-      if('meshDescriptors' in sessionLm){
-        assert.equal(meshTerms.length, sessionLm.meshDescriptors.length);
-        for(let i = 0; i < sessionLm.meshDescriptors.length; i++){
-          assert.equal(getElementText(meshTerms.eq(i)), getText(fixtures.meshDescriptors[sessionLm.meshDescriptors[i] - 1].name));
-        }
+test('list learning materials', async function(assert) {
+  await visit(url);
+  const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
+  const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
+  assert.equal(currentPath(), 'course.session.index');
+  let container = find('.detail-learningmaterials');
+  let rows = find('.detail-learningmaterials-content tbody tr', container);
+  assert.equal(rows.length, fixtures.session.learningMaterials.length);
+  for (let i = 0; i < fixtures.session.learningMaterials.length; i++){
+    let row = rows.eq(i);
+    let sessionLm = fixtures.sessionLearningMaterials[fixtures.session.learningMaterials[i] - 1];
+    let lm = fixtures.learningMaterials[sessionLm.learningMaterial - 1];
+    assert.equal(getElementText(find('td:eq(0)', row)), getText(lm.title));
+    // TODO: not checking for exact type icon yet, see comment below [ST 2017/08/01]
+    assert.equal(find('td:eq(0) .lm-type-icon i.fa', row).length, 1, 'LM type icon is present.');
+    //TODO: we are no longer populating for 'type', so we need to pull all these tests out
+    //of the loop and test each fixture individually
+    //assert.equal(getElementText(find('td:eq(1)', row)), getText(lm.type));
+    let required = sessionLm.required?'Yes':'No';
+    assert.equal(getElementText(find('td:eq(2)', row)), getText(userName));
+    assert.equal(getElementText(find('td:eq(3)', row)), getText(required));
+    let notes = sessionLm.notes? 'Yes' : 'No';
+    assert.equal(getElementText(find('td:eq(4)', row)), getText(notes));
+    let notesBool = sessionLm.notes? true : false;
+    let publicNotes = sessionLm.publicNotes ? true : false;
+    assert.equal(find('td:eq(4) i', row).hasClass('fa-eye'), publicNotes && notesBool);
+    let meshTerms = find('td:eq(5) li', row);
+    if('meshDescriptors' in sessionLm){
+      assert.equal(meshTerms.length, sessionLm.meshDescriptors.length);
+      for(let i = 0; i < sessionLm.meshDescriptors.length; i++){
+        assert.equal(getElementText(meshTerms.eq(i)), getText(fixtures.meshDescriptors[sessionLm.meshDescriptors[i] - 1].name));
       }
     }
-  });
+  }
 });
 
 //we can't upload a file so we cant run this test
@@ -220,435 +219,348 @@ test('list learning materials', function(assert) {
 //   });
 // });
 
-test('create new link learning material', function(assert) {
+test('create new link learning material', async function(assert) {
   const testTitle = 'testsome title';
   const testAuthor = 'testsome author';
   const testDescription = 'testsome description';
   const testUrl = 'http://www.ucsf.edu/';
   const searchBox = '.search-box';
 
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials');
-    let rows = find('.detail-learningmaterials-content tbody tr', container);
+  await visit(url);
+  let container = find('.detail-learningmaterials');
+  let rows = find('.detail-learningmaterials-content tbody tr', container);
 
-    assert.ok(isPresent(find(searchBox)), 'learner-group search box is visible');
-    assert.equal(rows.length, fixtures.session.learningMaterials.length);
-    click('.detail-learningmaterials-actions .button', container).then(function(){
-      //pick the link type
-      click('.detail-learningmaterials-actions ul li:eq(1)');
-    });
-  });
-  andThen(function(){
-    assert.ok(isEmpty(find(searchBox)), 'learner-group search box is hidden while new group are being added');
-    //check that we got the right form
-    let labels = find('.detail-learningmaterials .new-learning-material label');
-    assert.equal(labels.length, 7);
-    const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
-    const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
-    assert.equal(getElementText(find('.detail-learningmaterials .new-learning-material .owninguser')), getText(userName));
-    let newLmContainer = find('.detail-learningmaterials .new-learning-material');
-    let inputs = find('input', newLmContainer);
-    let selectBoxes = find('select', newLmContainer);
-    fillIn(inputs.eq(0), testTitle);
-    fillIn(inputs.eq(1), testAuthor);
-    fillIn(inputs.eq(2), testUrl);
-    pickOption(selectBoxes[0], fixtures.statuses[2].title, assert);
-    pickOption(selectBoxes[1], fixtures.roles[2].title, assert);
-    find('.fr-box', newLmContainer).froalaEditor('html.set', testDescription);
-    find('.fr-box', newLmContainer).froalaEditor('events.trigger', 'contentChanged');
-    click('.detail-learningmaterials .new-learning-material .done');
-    andThen(function(){
-      let container = find('.detail-learningmaterials');
-      let rows = find('.detail-learningmaterials-content tbody tr', container);
-      assert.equal(rows.length, fixtures.session.learningMaterials.length + 1);
-      let row = rows.eq(fixtures.session.learningMaterials.length);
-      assert.equal(getElementText(find('td:eq(0)', row)), getText(testTitle));
-      assert.equal(getElementText(find('td:eq(1)', row)), getText('link'));
-    });
-  });
+  assert.ok(isPresent(find(searchBox)), 'learner-group search box is visible');
+  assert.equal(rows.length, fixtures.session.learningMaterials.length);
+  await click('.detail-learningmaterials-actions .button', container);
+  //pick the link type
+  await click('.detail-learningmaterials-actions ul li:eq(1)');
+  assert.ok(isEmpty(find(searchBox)), 'learner-group search box is hidden while new group are being added');
+  //check that we got the right form
+  let labels = find('.detail-learningmaterials .new-learning-material label');
+  assert.equal(labels.length, 7);
+  const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
+  const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
+  assert.equal(getElementText(find('.detail-learningmaterials .new-learning-material .owninguser')), getText(userName));
+  let newLmContainer = find('.detail-learningmaterials .new-learning-material');
+  let inputs = find('input', newLmContainer);
+  let selectBoxes = find('select', newLmContainer);
+  await fillIn(inputs.eq(0), testTitle);
+  await fillIn(inputs.eq(1), testAuthor);
+  await fillIn(inputs.eq(2), testUrl);
+  await pickOption(selectBoxes[0], fixtures.statuses[2].title, assert);
+  await pickOption(selectBoxes[1], fixtures.roles[2].title, assert);
+  find('.fr-box', newLmContainer).froalaEditor('html.set', testDescription);
+  find('.fr-box', newLmContainer).froalaEditor('events.trigger', 'contentChanged');
+  await click('.detail-learningmaterials .new-learning-material .done');
+  container = find('.detail-learningmaterials');
+  rows = find('.detail-learningmaterials-content tbody tr', container);
+  assert.equal(rows.length, fixtures.session.learningMaterials.length + 1);
+  let row = rows.eq(fixtures.session.learningMaterials.length);
+  assert.equal(getElementText(find('td:eq(0)', row)), getText(testTitle));
+  assert.equal(getElementText(find('td:eq(1)', row)), getText('link'));
 });
 
-test('create new citation learning material', function(assert) {
+test('create new citation learning material', async function(assert) {
   const testTitle = 'testsome title';
   const testAuthor = 'testsome author';
   const testDescription = 'testsome description';
   const testCitation = 'testsome citation';
   const searchBox = '.search-box';
 
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials');
-    let rows = find('.detail-learningmaterials-content tbody tr', container);
+  await visit(url);
+  let container = find('.detail-learningmaterials');
+  let rows = find('.detail-learningmaterials-content tbody tr', container);
 
-    assert.ok(isPresent(find(searchBox)), 'learner-group search box is visible');
-    assert.equal(rows.length, fixtures.session.learningMaterials.length);
-    click('.detail-learningmaterials-actions .button', container).then(function(){
-      //pick the citation type
-      click('.detail-learningmaterials-actions ul li:eq(2)');
-    });
-  });
-  andThen(function(){
-    assert.ok(isEmpty(find(searchBox)), 'learner-group search box is hidden while new group are being added');
-    //check that we got the right form
-    let labels = find('.detail-learningmaterials .new-learning-material label');
-    assert.equal(labels.length, 7);
-    const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
-    const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
-    assert.equal(getElementText(find('.detail-learningmaterials .new-learning-material .owninguser')), getText(userName));
-    let newLmContainer = find('.detail-learningmaterials .new-learning-material');
-    let inputs = find('input', newLmContainer);
-    let selectBoxes = find('select', newLmContainer);
-    fillIn(inputs.eq(0), testTitle);
-    fillIn(inputs.eq(1), testAuthor);
-    fillIn(find('textarea', newLmContainer).eq(0), testCitation);
-    pickOption(selectBoxes[0], fixtures.statuses[2].title, assert);
-    pickOption(selectBoxes[1], fixtures.roles[2].title, assert);
-    find('.fr-box', newLmContainer).froalaEditor('html.set', testDescription);
-    find('.fr-box', newLmContainer).froalaEditor('events.trigger', 'contentChanged');
-    click('.detail-learningmaterials .new-learning-material .done');
-    andThen(function(){
-      let container = find('.detail-learningmaterials');
-      let rows = find('.detail-learningmaterials-content tbody tr', container);
-      assert.equal(rows.length, fixtures.session.learningMaterials.length + 1);
-      let row = rows.eq(fixtures.session.learningMaterials.length);
-      assert.equal(getElementText(find('td:eq(0)', row)), getText(testTitle));
-      assert.equal(getElementText(find('td:eq(1)', row)), getText('citation'));
-    });
-  });
+  assert.ok(isPresent(find(searchBox)), 'learner-group search box is visible');
+  assert.equal(rows.length, fixtures.session.learningMaterials.length);
+  await click('.detail-learningmaterials-actions .button', container);
+  //pick the citation type
+  await click('.detail-learningmaterials-actions ul li:eq(2)');
+  assert.ok(isEmpty(find(searchBox)), 'learner-group search box is hidden while new group are being added');
+  //check that we got the right form
+  let labels = find('.detail-learningmaterials .new-learning-material label');
+  assert.equal(labels.length, 7);
+  const middleInitial = fixtures.user.middleName.charAt(0).toUpperCase();
+  const userName = `${fixtures.user.firstName} ${middleInitial}. ${fixtures.user.lastName}`;
+  assert.equal(getElementText(find('.detail-learningmaterials .new-learning-material .owninguser')), getText(userName));
+  let newLmContainer = find('.detail-learningmaterials .new-learning-material');
+  let inputs = find('input', newLmContainer);
+  let selectBoxes = find('select', newLmContainer);
+  await fillIn(inputs.eq(0), testTitle);
+  await fillIn(inputs.eq(1), testAuthor);
+  await fillIn(find('textarea', newLmContainer).eq(0), testCitation);
+  await pickOption(selectBoxes[0], fixtures.statuses[2].title, assert);
+  await pickOption(selectBoxes[1], fixtures.roles[2].title, assert);
+  find('.fr-box', newLmContainer).froalaEditor('html.set', testDescription);
+  find('.fr-box', newLmContainer).froalaEditor('events.trigger', 'contentChanged');
+  await click('.detail-learningmaterials .new-learning-material .done');
+  container = find('.detail-learningmaterials');
+  rows = find('.detail-learningmaterials-content tbody tr', container);
+  assert.equal(rows.length, fixtures.session.learningMaterials.length + 1);
+  let row = rows.eq(fixtures.session.learningMaterials.length);
+  assert.equal(getElementText(find('td:eq(0)', row)), getText(testTitle));
+  assert.equal(getElementText(find('td:eq(1)', row)), getText('citation'));
 });
 
-test('can only add one learning-material at a time', function(assert) {
+test('can only add one learning-material at a time', async function(assert) {
   const addButton = '.detail-learningmaterials-actions .button';
   const fileButton = '.detail-learningmaterials-actions ul li:eq(0)';
   const collapseButton = '.collapse-button';
   const component = '.new-learning-material';
 
-  visit(url);
-  click(addButton);
-  click(fileButton);
-  andThen(() => {
-    assert.ok(isEmpty(find(addButton)), 'add button is not visible');
-    assert.ok(find(collapseButton).is(':visible'), 'new-add collapse button is visible');
-    assert.ok(find(component).is(':visible'), 'new-add learning-material component is visible');
-  });
+  await visit(url);
+  await click(addButton);
+  await click(fileButton);
+  assert.ok(isEmpty(find(addButton)), 'add button is not visible');
+  assert.ok(find(collapseButton).is(':visible'), 'new-add collapse button is visible');
+  assert.ok(find(component).is(':visible'), 'new-add learning-material component is visible');
 
-  click(collapseButton);
-  andThen(() => {
-    assert.ok(find(addButton).is(':visible'), 'add button is visible');
-    assert.ok(isEmpty(find(collapseButton)), 'new-add collapse button is not visible');
-    assert.ok(isEmpty(find(component)), 'new-add learning-material component is not visible');
-  });
+  await click(collapseButton);
+  assert.ok(find(addButton).is(':visible'), 'add button is visible');
+  assert.ok(isEmpty(find(collapseButton)), 'new-add collapse button is not visible');
+  assert.ok(isEmpty(find(component)), 'new-add learning-material component is not visible');
 });
 
-test('cancel new learning material', function(assert) {
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials');
-    let rows = find('.detail-learningmaterials-content tbody tr', container);
-    assert.equal(rows.length, fixtures.session.learningMaterials.length);
-    click('.detail-learningmaterials-actions .button', container);
-    click('.detail-learningmaterials-actions ul li:eq(0)');
-  });
-  andThen(function(){
-    click('.detail-learningmaterials .new-learning-material .cancel');
-  });
-  andThen(function(){
-    let rows = find('.detail-learningmaterials .detail-learningmaterials-content tbody tr');
-    assert.equal(rows.length, fixtures.session.learningMaterials.length);
-  });
-
+test('cancel new learning material', async function(assert) {
+  await visit(url);
+  let container = find('.detail-learningmaterials');
+  let rows = find('.detail-learningmaterials-content tbody tr', container);
+  assert.equal(rows.length, fixtures.session.learningMaterials.length);
+  await click('.detail-learningmaterials-actions .button', container);
+  await click('.detail-learningmaterials-actions ul li:eq(0)');
+  await click('.detail-learningmaterials .new-learning-material .cancel');
+  rows = find('.detail-learningmaterials .detail-learningmaterials-content tbody tr');
+  assert.equal(rows.length, fixtures.session.learningMaterials.length);
+  await wait();
 });
 
-test('view copyright file learning material details', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
-    andThen(function(){
-      var container = $('.learningmaterial-manager');
-      assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[0].title));
-      assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[0].originalAuthor));
-      assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[0].description));
-      assert.equal(getElementText(find('.copyrightpermission', container)), getText('Yes'));
-      assert.equal(find('.copyrightrationale', container).length, 0);
-    });
-  });
+test('view copyright file learning material details', async function(assert) {
+  await visit(url);
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
+  var container = $('.learningmaterial-manager');
+  assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[0].title));
+  assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[0].originalAuthor));
+  assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[0].description));
+  assert.equal(getElementText(find('.copyrightpermission', container)), getText('Yes'));
+  assert.equal(find('.copyrightrationale', container).length, 0);
 });
 
-test('view rationale file learning material details', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(1) td:eq(0)');
-    andThen(function(){
-      var container = $('.learningmaterial-manager');
-      assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[1].title));
-      assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[1].originalAuthor));
-      assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[1].description));
-      assert.equal(getElementText(find('.copyrightrationale', container)), getText(fixtures.learningMaterials[1].copyrightRationale));
-      assert.equal(find('.citation', container).length, 0);
-      assert.equal(find('.link', container).length, 0);
-    });
-  });
+test('view rationale file learning material details', async function(assert) {
+  await visit(url);
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(1) td:eq(0)');
+  var container = $('.learningmaterial-manager');
+  assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[1].title));
+  assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[1].originalAuthor));
+  assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[1].description));
+  assert.equal(getElementText(find('.copyrightrationale', container)), getText(fixtures.learningMaterials[1].copyrightRationale));
+  assert.equal(find('.citation', container).length, 0);
+  assert.equal(find('.link', container).length, 0);
 });
 
-test('view link learning material details', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(2) td:eq(0)');
-    andThen(function(){
-      var container = $('.learningmaterial-manager');
-      assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[2].title));
-      assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[2].originalAuthor));
-      assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[2].description));
-      assert.equal(getElementText(find('.upload-date', container)),
-        moment(fixtures.learningMaterials[2].uploadDate).format('M-D-YYYY'));
-      assert.equal(getElementText(find('.link', container)), getText(fixtures.learningMaterials[2].link));
-      assert.equal(find('.copyrightpermission', container).length, 1);
-      assert.equal(find('.copyrightrationale', container).length, 0);
-      assert.equal(find('.citation', container).length, 0);
-    });
-  });
+test('view link learning material details', async function(assert) {
+  await visit(url);
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(2) td:eq(0)');
+  var container = $('.learningmaterial-manager');
+  assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[2].title));
+  assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[2].originalAuthor));
+  assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[2].description));
+  assert.equal(getElementText(find('.upload-date', container)),
+    moment(fixtures.learningMaterials[2].uploadDate).format('M-D-YYYY'));
+  assert.equal(getElementText(find('.link', container)), getText(fixtures.learningMaterials[2].link));
+  assert.equal(find('.copyrightpermission', container).length, 1);
+  assert.equal(find('.copyrightrationale', container).length, 0);
+  assert.equal(find('.citation', container).length, 0);
 });
 
-test('view citation learning material details', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(3) td:eq(0)');
-    andThen(function(){
-      var container = $('.learningmaterial-manager');
-      assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[3].title));
-      assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[3].originalAuthor));
-      assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[3].description));
-      assert.equal(getElementText(find('.upload-date', container)),
-        moment(fixtures.learningMaterials[2].uploadDate).format('M-D-YYYY'));
-      assert.equal(getElementText(find('.citation', container)), getText(fixtures.learningMaterials[3].citation));
-      assert.equal(find('.copyrightpermission', container).length, 1);
-      assert.equal(find('.copyrightrationale', container).length, 0);
-      assert.equal(find('.file', container).length, 0);
-    });
-  });
+test('view citation learning material details', async function(assert) {
+  await visit(url);
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(3) td:eq(0)');
+  var container = $('.learningmaterial-manager');
+  assert.equal(getElementText(find('.displayname', container)), getText(fixtures.learningMaterials[3].title));
+  assert.equal(getElementText(find('.originalauthor', container)), getText(fixtures.learningMaterials[3].originalAuthor));
+  assert.equal(getElementText(find('.description', container)), getText(fixtures.learningMaterials[3].description));
+  assert.equal(getElementText(find('.upload-date', container)),
+    moment(fixtures.learningMaterials[2].uploadDate).format('M-D-YYYY'));
+  assert.equal(getElementText(find('.citation', container)), getText(fixtures.learningMaterials[3].citation));
+  assert.equal(find('.copyrightpermission', container).length, 1);
+  assert.equal(find('.copyrightrationale', container).length, 0);
+  assert.equal(find('.file', container).length, 0);
 });
 
-test('edit learning material', function(assert) {
+test('edit learning material', async function(assert) {
   const searchBox = '.search-box';
 
-  visit(url);
-  andThen(function() {
-    assert.ok(isPresent(find(searchBox)), 'learner-gorup search box is visible');
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
-    andThen(function(){
-      let container = $('.learningmaterial-manager');
-      assert.ok(isEmpty(find(searchBox)), 'learner-gorup search box is hidden while in edit mode');
-      click(find('.required .switch-handle', container));
-      click(find('.publicnotes .switch-handle', container));
-      click(find('.status .editable', container)).then(function(){
-        pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
-        click(find('.status .done', container));
-      });
-      let newNote = 'text text.  Woo hoo!';
-      click(find('.notes .editable', container)).then(function(){
-        //wait for the editor to load
-        later(()=>{
-          find('.notes .fr-box', container).froalaEditor('html.set', newNote);
-          find('.notes .fr-box', container).froalaEditor('events.trigger', 'contentChanged');
-          click(find('.notes .done', container));
-          andThen(function(){
-            assert.equal(getElementText(find('.notes', container)), getText(`InstructionalNotes: ${newNote}`));
-          });
-          click('.detail-learningmaterials button.bigadd');
-          andThen(function(){
-            assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(3)')), getText('Yes'));
-            assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4)')), getText('Yes'), 'there is content in notes');
-            assert.ok(isEmpty(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is false and `eye` icon is not visible');
-            assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[2].title));
+  await visit(url);
+  assert.ok(isPresent(find(searchBox)), 'learner-gorup search box is visible');
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
+  let container = $('.learningmaterial-manager');
+  assert.ok(isEmpty(find(searchBox)), 'learner-gorup search box is hidden while in edit mode');
+  await click(find('.required .switch-handle', container));
+  await click(find('.publicnotes .switch-handle', container));
+  await click(find('.status .editable', container));
+  await pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
+  await click(find('.status .done', container));
+  let newNote = 'text text.  Woo hoo!';
+  await click(find('.notes .editable', container));
+  //wait for the editor to load
+  later(async ()=>{
+    find('.notes .fr-box', container).froalaEditor('html.set', newNote);
+    find('.notes .fr-box', container).froalaEditor('events.trigger', 'contentChanged');
+    await click(find('.notes .done', container));
+    assert.equal(getElementText(find('.notes', container)), getText(`InstructionalNotes: ${newNote}`));
+    await click('.detail-learningmaterials button.bigadd');
+    assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(3)')), getText('Yes'));
+    assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4)')), getText('Yes'), 'there is content in notes');
+    assert.ok(isEmpty(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is false and `eye` icon is not visible');
+    assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[2].title));
 
-            click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
-            andThen(function(){
-              container = $('.learningmaterial-manager');
-              assert.equal(getElementText(find('.notes', container)), getText(`InstructionalNotes: ${newNote}`));
-              assert.equal(getElementText(find('.status', container)), getText('Status: status 2'));
-            });
-          });
-        }, 100);
-      });
-    });
-  });
+    await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
+    container = $('.learningmaterial-manager');
+    assert.equal(getElementText(find('.notes', container)), getText(`InstructionalNotes: ${newNote}`));
+    assert.equal(getElementText(find('.status', container)), getText('Status: status 2'));
+  }, 100);
+  await wait();
 });
 
-test('cancel editing learning material', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
-    andThen(function(){
-      var container = $('.learningmaterial-manager');
-      click(find('.required .switch-handle', container));
-      click(find('.publicnotes .switch-handle', container));
-      click(find('.status .editable', container)).then(function(){
-        pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
-        click(find('.status .done', container));
-      });
-      click('.detail-learningmaterials button.bigcancel');
-      andThen(function(){
-        assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(3)')), getText('No'));
-        assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4)')), getText('No'), 'no content is available under notes');
-        assert.ok(isEmpty(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is true but notes are blank so `eye` icon is not visible');
-        assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[0].title));
-      });
-    });
-  });
+test('cancel editing learning material', async function(assert) {
+  await visit(url);
+  await click('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(0)');
+  var container = $('.learningmaterial-manager');
+  await click(find('.required .switch-handle', container));
+  await click(find('.publicnotes .switch-handle', container));
+  await click(find('.status .editable', container));
+  await pickOption(find('.status select', container), fixtures.statuses[2].title, assert);
+  await click(find('.status .done', container));
+  await click('.detail-learningmaterials button.bigcancel');
+  assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(3)')), getText('No'));
+  assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4)')), getText('No'), 'no content is available under notes');
+  assert.ok(isEmpty(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(4) i')), 'publicNotes is true but notes are blank so `eye` icon is not visible');
+  assert.equal(getElementText(find('.detail-learningmaterials .detail-learningmaterials-content tbody tr:eq(0) td:eq(6)')), getText(fixtures.statuses[0].title));
 });
 
-test('manage terms', function(assert) {
+test('manage terms', async function(assert) {
   assert.expect(24);
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials').eq(0);
-    click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container).then(function(){
-      assert.equal(getElementText(find('.specific-title', container)), 'SelectMeSHDescriptorsforLearningMaterials');
-    });
+  await visit(url);
+  let container = find('.detail-learningmaterials').eq(0);
+  await click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container);
+  assert.equal(getElementText(find('.specific-title', container)), 'SelectMeSHDescriptorsforLearningMaterials');
 
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container).eq(0);
-      let material = fixtures.sessionLearningMaterials[0];
-      let removableItems = find('.removable-list li', meshManager);
-      assert.equal(removableItems.length, material.meshDescriptors.length);
-      for (let i = 0; i < material.meshDescriptors.length; i++){
-        let meshDescriptionName = find('.content .title', removableItems[i]).eq(0);
-        assert.equal(getElementText(meshDescriptionName), getText(fixtures.meshDescriptors[material.meshDescriptors[i] - 1].name));
-      }
+  let meshManager = find('.mesh-manager', container).eq(0);
+  let material = fixtures.sessionLearningMaterials[0];
+  let removableItems = find('.removable-list li', meshManager);
+  assert.equal(removableItems.length, material.meshDescriptors.length);
+  for (let i = 0; i < material.meshDescriptors.length; i++){
+    let meshDescriptionName = find('.content .title', removableItems[i]).eq(0);
+    assert.equal(getElementText(meshDescriptionName), getText(fixtures.meshDescriptors[material.meshDescriptors[i] - 1].name));
+  }
 
-      let searchBox = find('.search-box', meshManager);
-      assert.equal(searchBox.length, 1);
-      searchBox = searchBox.eq(0);
-      let searchBoxInput = find('input', searchBox);
-      assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
-      fillIn(searchBoxInput, 'descriptor');
-      click('span.search-icon', searchBox);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        assert.equal(searchResults.length, fixtures.meshDescriptors.length);
+  let searchBox = find('.search-box', meshManager);
+  assert.equal(searchBox.length, 1);
+  searchBox = searchBox.eq(0);
+  let searchBoxInput = find('input', searchBox);
+  assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('span.search-icon', searchBox);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  assert.equal(searchResults.length, fixtures.meshDescriptors.length);
 
-        for(let i = 0; i < fixtures.meshDescriptors.length; i++){
-          let meshDescriptorName = find('.descriptor-name', searchResults[i]).eq(0);
-          assert.equal(getElementText(meshDescriptorName), getText(fixtures.meshDescriptors[i].name));
-        }
+  for(let i = 0; i < fixtures.meshDescriptors.length; i++){
+    let meshDescriptorName = find('.descriptor-name', searchResults[i]).eq(0);
+    assert.equal(getElementText(meshDescriptorName), getText(fixtures.meshDescriptors[i].name));
+  }
 
-        for (let i = 0; i < fixtures.meshDescriptors.length; i++){
-          if(material.meshDescriptors.indexOf(fixtures.meshDescriptors[i].id) !== -1){
-            assert.ok($(searchResults[i]).hasClass('disabled'));
-          } else {
-            assert.ok(!$(searchResults[i]).hasClass('disabled'));
-          }
-        }
-        click('.removable-list li:eq(0)', meshManager).then(function(){
-          assert.ok(!$(find('.mesh-search-results li:eq(1)', meshManager)).hasClass('disabled'));
-        });
-        click(searchResults[0]);
-        andThen(function(){
-          assert.ok($(find('.mesh-search-results li:eq(2)', meshManager)).hasClass('disabled'));
+  for (let i = 0; i < fixtures.meshDescriptors.length; i++){
+    if(material.meshDescriptors.indexOf(fixtures.meshDescriptors[i].id) !== -1){
+      assert.ok($(searchResults[i]).hasClass('disabled'));
+    } else {
+      assert.ok(!$(searchResults[i]).hasClass('disabled'));
+    }
+  }
+  await click('.removable-list li:eq(0)', meshManager);
+  assert.ok(!$(find('.mesh-search-results li:eq(1)', meshManager)).hasClass('disabled'));
+  await click(searchResults[0]);
+  assert.ok($(find('.mesh-search-results li:eq(2)', meshManager)).hasClass('disabled'));
 
-          let newExpectedMesh = [
-            fixtures.meshDescriptors[0],
-            fixtures.meshDescriptors[2]
-          ];
-          removableItems = find('.removable-list li', meshManager);
-          assert.equal(removableItems.length, 2);
-          for (let i = 0; i < 2; i++){
-            let meshDescriptorName = find('.title', removableItems[i]).eq(0);
-            assert.equal(getElementText(meshDescriptorName), getText(newExpectedMesh[i].name));
-          }
-        });
-      });
-    });
-  });
+  let newExpectedMesh = [
+    fixtures.meshDescriptors[0],
+    fixtures.meshDescriptors[2]
+  ];
+  removableItems = find('.removable-list li', meshManager);
+  assert.equal(removableItems.length, 2);
+  for (let i = 0; i < 2; i++){
+    let meshDescriptorName = find('.title', removableItems[i]).eq(0);
+    assert.equal(getElementText(meshDescriptorName), getText(newExpectedMesh[i].name));
+  }
+
+  await wait();
 });
 
-test('save terms', function(assert) {
+test('save terms', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials').eq(0);
-    click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container);
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container).eq(0);
-      let searchBoxInput = find('.search-box input', meshManager);
-      fillIn(searchBoxInput, 'descriptor');
-      click('.search-box span.search-icon', meshManager);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        click('.removable-list li:eq(0)', meshManager);
-        click(searchResults[0]);
-        click('button.bigadd', container);
-        andThen(function(){
-          let expectedMesh = fixtures.meshDescriptors[0].name + fixtures.meshDescriptors[2].name;
-          let tds = find('.detail-learningmaterials-content tbody tr:eq(0) td');
-          assert.equal(getElementText(tds.eq(5)), getText(expectedMesh));
-        });
-      });
-    });
-  });
+  await visit(url);
+  let container = find('.detail-learningmaterials').eq(0);
+  await click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container);
+  let meshManager = find('.mesh-manager', container).eq(0);
+  let searchBoxInput = find('.search-box input', meshManager);
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('.search-box span.search-icon', meshManager);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  await click('.removable-list li:eq(0)', meshManager);
+  await click(searchResults[0]);
+  await click('button.bigadd', container);
+  let expectedMesh = fixtures.meshDescriptors[0].name + fixtures.meshDescriptors[2].name;
+  let tds = find('.detail-learningmaterials-content tbody tr:eq(0) td');
+  assert.equal(getElementText(tds.eq(5)), getText(expectedMesh));
 });
 
-test('cancel term changes', function(assert) {
+test('cancel term changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    let container = find('.detail-learningmaterials').eq(0);
-    click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container);
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container).eq(0);
-      let searchBoxInput = find('.search-box input', meshManager);
-      fillIn(searchBoxInput, 'descriptor');
-      click('.search-box span.search-icon', meshManager);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        click('.removable-list li:eq(0)', meshManager);
-        click(searchResults[2]);
-        click(searchResults[3]);
-        click(searchResults[4]);
-        click('button.bigcancel', container);
-        andThen(function(){
-          let tds = find('.detail-learningmaterials-content tbody tr:eq(0) td');
-          let expectedMesh = fixtures.meshDescriptors[1].name + fixtures.meshDescriptors[2].name;
-          assert.equal(getElementText(tds.eq(5)), getText(expectedMesh));
-        });
-      });
-    });
-  });
+  await visit(url);
+  let container = find('.detail-learningmaterials').eq(0);
+  await click('.detail-learningmaterials-content tbody tr:eq(0) td:eq(5) .link', container);
+  let meshManager = find('.mesh-manager', container).eq(0);
+  let searchBoxInput = find('.search-box input', meshManager);
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('.search-box span.search-icon', meshManager);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  await click('.removable-list li:eq(0)', meshManager);
+  await click(searchResults[2]);
+  await click(searchResults[3]);
+  await click(searchResults[4]);
+  await click('button.bigcancel', container);
+  let tds = find('.detail-learningmaterials-content tbody tr:eq(0) td');
+  let expectedMesh = fixtures.meshDescriptors[1].name + fixtures.meshDescriptors[2].name;
+  assert.equal(getElementText(tds.eq(5)), getText(expectedMesh));
 });
 
-test('find and add learning material', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    let container = find('.detail-learningmaterials');
-    let rows = find('.detail-learningmaterials-content tbody tr', container);
-    assert.equal(rows.length, fixtures.session.learningMaterials.length);
+test('find and add learning material', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.index');
+  let container = find('.detail-learningmaterials');
+  let rows = find('.detail-learningmaterials-content tbody tr', container);
+  assert.equal(rows.length, fixtures.session.learningMaterials.length);
 
-    let searchBoxInput = find('input', container);
-    fillIn(searchBoxInput, 'doc');
-    triggerEvent(searchBoxInput, 'keyup');
-    andThen(function(){
-      later(function(){
-        let searchResults = find('.lm-search-results > li', container);
-        assert.equal(searchResults.length, 1);
-        assert.equal(getElementText($('.lm-search-results > li:eq(0) h4')), getText('Letter to Doc Brown'));
-        assert.equal(find('.lm-search-results > li:eq(0) h4 .lm-type-icon .fa-file').length, 1, 'Shows LM type icon.');
-        let addlProps = find('.lm-search-results > li:eq(0) .learning-material-properties li', container);
-        assert.equal(addlProps.length, 3);
-        assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(0)')),
-          getText('Owner: 0 guy M. Mc0son'));
-        assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(1)')),
-          getText('Content Author: ' + fixtures.learningMaterials[4].originalAuthor));
-        assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(2)')),
-          getText('Upload date: ' + moment(fixtures.learningMaterials[4].uploadDate).format('M-D-YYYY')));
-        click(searchResults[0]);
+  let searchBoxInput = find('input', container);
+  fillIn(searchBoxInput, 'doc');
+  await triggerEvent(searchBoxInput, 'keyup');
+  later(async () => {
+    let searchResults = find('.lm-search-results > li', container);
+    assert.equal(searchResults.length, 1);
+    assert.equal(getElementText($('.lm-search-results > li:eq(0) h4')), getText('Letter to Doc Brown'));
+    assert.equal(find('.lm-search-results > li:eq(0) h4 .lm-type-icon .fa-file').length, 1, 'Shows LM type icon.');
+    let addlProps = find('.lm-search-results > li:eq(0) .learning-material-properties li', container);
+    assert.equal(addlProps.length, 3);
+    assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(0)')),
+      getText('Owner: 0 guy M. Mc0son'));
+    assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(1)')),
+      getText('Content Author: ' + fixtures.learningMaterials[4].originalAuthor));
+    assert.equal(getElementText($('.lm-search-results > li:eq(0) .learning-material-properties li:eq(2)')),
+      getText('Upload date: ' + moment(fixtures.learningMaterials[4].uploadDate).format('M-D-YYYY')));
+    await click(searchResults[0]);
 
-        andThen(function(){
-          rows = find('.detail-learningmaterials-content tbody tr', container);
-          assert.equal(rows.length, fixtures.session.learningMaterials.length + 1);
-        });
-      }, 1000);
-    });
-  });
+    rows = find('.detail-learningmaterials-content tbody tr', container);
+    assert.equal(rows.length, fixtures.session.learningMaterials.length + 1);
+  }, 1000);
+  await wait();
 });

--- a/tests/acceptance/course/session/mesh-test.js
+++ b/tests/acceptance/course/session/mesh-test.js
@@ -35,145 +35,114 @@ module('Acceptance: Session - Mesh Terms', {
   }
 });
 
-test('list mesh', function(assert) {
+test('list mesh', async function(assert) {
   assert.expect(4);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-mesh');
-    var items = find('ul.columnar-list li', container);
-    assert.equal(items.length, 3);
-    assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
-    assert.equal(getElementText(items.eq(1)), getText('descriptor 1'));
-    assert.equal(getElementText(items.eq(2)), getText('descriptor 2'));
-  });
+  await visit(url);
+  var container = find('.detail-mesh');
+  var items = find('ul.columnar-list li', container);
+  assert.equal(items.length, 3);
+  assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
+  assert.equal(getElementText(items.eq(1)), getText('descriptor 1'));
+  assert.equal(getElementText(items.eq(2)), getText('descriptor 2'));
 });
 
-test('manage mesh', function(assert) {
+test('manage mesh', async function(assert) {
   assert.expect(24);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-mesh');
-    click(find('.actions button', container));
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container);
-      let removableItems = find('.removable-list li', meshManager);
-      assert.equal(removableItems.length, 3);
-      assert.equal(
-        getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
-        getText('descriptor 0')
-      );
-      assert.equal(
-        getElementText(find('.content .title', removableItems.eq(1)).eq(0)),
-        getText('descriptor 1')
-      );
-      assert.equal(
-        getElementText(find('.content .title', removableItems.eq(2)).eq(0)),
-        getText('descriptor 2')
-      );
+  await visit(url);
+  var container = find('.detail-mesh');
+  await click(find('.actions button', container));
+  let meshManager = find('.mesh-manager', container);
+  let removableItems = find('.removable-list li', meshManager);
+  assert.equal(removableItems.length, 3);
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
+    getText('descriptor 0')
+  );
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(1)).eq(0)),
+    getText('descriptor 1')
+  );
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(2)).eq(0)),
+    getText('descriptor 2')
+  );
 
-      let searchBox = find('.search-box', meshManager);
-      assert.equal(searchBox.length, 1);
-      searchBox = searchBox.eq(0);
-      let searchBoxInput = find('input', searchBox);
-      assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
-      fillIn(searchBoxInput, 'descriptor');
-      click('span.search-icon', searchBox);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        assert.equal(searchResults.length, 6);
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(0)).eq(0)), getText('descriptor 0'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(1)).eq(0)), getText('descriptor 1'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(2)).eq(0)), getText('descriptor 2'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(3)).eq(0)), getText('descriptor 3'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(4)).eq(0)), getText('descriptor 4'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults.eq(5)).eq(0)), getText('descriptor 5'));
-        assert.ok($(searchResults[0]).hasClass('disabled'));
-        assert.ok($(searchResults[1]).hasClass('disabled'));
-        assert.ok($(searchResults[2]).hasClass('disabled'));
-        assert.ok(!$(searchResults[3]).hasClass('disabled'));
-        assert.ok(!$(searchResults[4]).hasClass('disabled'));
-        assert.ok(!$(searchResults[5]).hasClass('disabled'));
+  let searchBox = find('.search-box', meshManager);
+  assert.equal(searchBox.length, 1);
+  searchBox = searchBox.eq(0);
+  let searchBoxInput = find('input', searchBox);
+  assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('span.search-icon', searchBox);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  assert.equal(searchResults.length, 6);
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(0)).eq(0)), getText('descriptor 0'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(1)).eq(0)), getText('descriptor 1'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(2)).eq(0)), getText('descriptor 2'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(3)).eq(0)), getText('descriptor 3'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(4)).eq(0)), getText('descriptor 4'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults.eq(5)).eq(0)), getText('descriptor 5'));
+  assert.ok($(searchResults[0]).hasClass('disabled'));
+  assert.ok($(searchResults[1]).hasClass('disabled'));
+  assert.ok($(searchResults[2]).hasClass('disabled'));
+  assert.ok(!$(searchResults[3]).hasClass('disabled'));
+  assert.ok(!$(searchResults[4]).hasClass('disabled'));
+  assert.ok(!$(searchResults[5]).hasClass('disabled'));
 
-        click('.removable-list li:eq(1)', meshManager).then(function(){
-          assert.ok(!$(find('.mesh-search-results li:eq(1)', meshManager)).hasClass('disabled'));
-        });
-        click(searchResults[3]);
-        andThen(function(){
-          assert.ok($(find('.mesh-search-results li:eq(3)', meshManager)).hasClass('disabled'));
-          removableItems = find('.removable-list li', meshManager);
-          assert.equal(
-            getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
-            getText('descriptor 0')
-          );
-          assert.equal(
-            getElementText(find('.content .title', removableItems.eq(1)).eq(0)),
-            getText('descriptor 2')
-          );
-          assert.equal(
-            getElementText(find('.content .title', removableItems.eq(2)).eq(0)),
-            getText('descriptor 3')
-          );
-        });
-      });
-    });
-  });
+  await click('.removable-list li:eq(1)', meshManager);
+  assert.ok(!$(find('.mesh-search-results li:eq(1)', meshManager)).hasClass('disabled'));
+  await click(searchResults[3]);
+  assert.ok($(find('.mesh-search-results li:eq(3)', meshManager)).hasClass('disabled'));
+  removableItems = find('.removable-list li', meshManager);
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
+    getText('descriptor 0')
+  );
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(1)).eq(0)),
+    getText('descriptor 2')
+  );
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(2)).eq(0)),
+    getText('descriptor 3')
+  );
 });
 
-test('save mesh changes', function(assert) {
+test('save mesh changes', async function(assert) {
   assert.expect(4);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-mesh');
-    click(find('.actions button', container));
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container);
-      fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');
-      click('.search-box span.search-icon', meshManager);
-      andThen(function(){
-        click('.removable-list li:eq(1)', meshManager).then(()=> {
-          click('.mesh-search-results li:eq(3)', meshManager).then(()=>{
-            click('button.bigadd', container);
-          });
-        });
-        andThen(function(){
-          var items = find('ul.columnar-list li', container);
-          assert.equal(items.length, 3);
-          assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
-          assert.equal(getElementText(items.eq(1)), getText('descriptor 2'));
-          assert.equal(getElementText(items.eq(2)), getText('descriptor 3'));
-        });
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.detail-mesh');
+  await click(find('.actions button', container));
+  let meshManager = find('.mesh-manager', container);
+  await fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');
+  await click('.search-box span.search-icon', meshManager);
+  await click('.removable-list li:eq(1)', meshManager);
+  await click('.mesh-search-results li:eq(3)', meshManager);
+  await click('button.bigadd', container);
+  var items = find('ul.columnar-list li', container);
+  assert.equal(items.length, 3);
+  assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
+  assert.equal(getElementText(items.eq(1)), getText('descriptor 2'));
+  assert.equal(getElementText(items.eq(2)), getText('descriptor 3'));
 });
 
 
 
-test('cancel mesh changes', function(assert) {
+test('cancel mesh changes', async function(assert) {
   assert.expect(4);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-mesh');
-    click(find('.actions button', container));
-    andThen(function() {
-      let meshManager = find('.mesh-manager', container);
-      fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');
-      click('.search-box span.search-icon', meshManager);
-      andThen(function(){
-        click('.removable-list li:eq(1)', meshManager).then(()=> {
-          click('.mesh-search-results li:eq(3)', meshManager).then(()=>{
-            click('button.bigcancel', container);
-          });
-        });
+  await visit(url);
+  var container = find('.detail-mesh');
+  await click(find('.actions button', container));
+  let meshManager = find('.mesh-manager', container);
+  await fillIn(find('.search-box input', meshManager).eq(0), 'descriptor');
+  await click('.search-box span.search-icon', meshManager);
+  await click('.removable-list li:eq(1)', meshManager);
+  await click('.mesh-search-results li:eq(3)', meshManager);
+  await click('button.bigcancel', container);
 
-        andThen(function(){
-          var items = find('ul.columnar-list li', container);
-          assert.equal(items.length, 3);
-          assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
-          assert.equal(getElementText(items.eq(1)), getText('descriptor 1'));
-          assert.equal(getElementText(items.eq(2)), getText('descriptor 2'));
-        });
-      });
-    });
-  });
+  var items = find('ul.columnar-list li', container);
+  assert.equal(items.length, 3);
+  assert.equal(getElementText(items.eq(0)), getText('descriptor 0'));
+  assert.equal(getElementText(items.eq(1)), getText('descriptor 1'));
+  assert.equal(getElementText(items.eq(2)), getText('descriptor 2'));
 });

--- a/tests/acceptance/course/session/objectivecreate-test.js
+++ b/tests/acceptance/course/session/objectivecreate-test.js
@@ -5,7 +5,10 @@ import {
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+import wait from 'ember-test-helpers/wait';
 import Ember from 'ember';
+
+const { run } = Ember;
 
 var application;
 var fixtures = {};
@@ -31,58 +34,46 @@ module('Acceptance: Session - Objective Create', {
   }
 });
 
-test('save new objective', function(assert) {
+test('save new objective', async function(assert) {
   assert.expect(8);
-  visit(url);
+  await visit(url);
   var newObjectiveTitle = 'Test junk 123';
-  andThen(function() {
-    let objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
-    assert.equal(objectiveRows.length, fixtures.session.objectives.length, 'correct number ob initial objectives');
-    click('.detail-objectives .detail-objectives-actions button');
-    //wait for the editor to load
-    Ember.run.later(()=>{
-      find('.detail-objectives .newobjective .fr-box').froalaEditor('html.set', newObjectiveTitle);
-      find('.detail-objectives .newobjective .fr-box').froalaEditor('events.trigger', 'contentChanged');
-      Ember.run.later(()=>{
-        click('.detail-objectives .newobjective button.done');
-        andThen(function(){
-          objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
-          assert.equal(objectiveRows.length, fixtures.session.objectives.length + 1);
-          let tds = find('td', objectiveRows.eq(0));
-          assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
-          assert.equal(getElementText(tds.eq(1)), getText('Add New'));
-          assert.equal(getElementText(tds.eq(2)), getText('Add New'));
-          tds = find('td', objectiveRows.eq(1));
-          assert.equal(getElementText(tds.eq(0)), getText(newObjectiveTitle));
-          assert.equal(getElementText(tds.eq(1)), getText('Add New'));
-          assert.equal(getElementText(tds.eq(2)), getText('Add New'));
-        });
-      }, 100);
-    }, 100);
-  });
+  let objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
+  assert.equal(objectiveRows.length, fixtures.session.objectives.length, 'correct number ob initial objectives');
+  await click('.detail-objectives .detail-objectives-actions button');
+  find('.detail-objectives .newobjective .fr-box').froalaEditor('html.set', newObjectiveTitle);
+  find('.detail-objectives .newobjective .fr-box').froalaEditor('events.trigger', 'contentChanged');
+  await click('.detail-objectives .newobjective button.done');
+  objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
+  assert.equal(objectiveRows.length, fixtures.session.objectives.length + 1);
+  let tds = find('td', objectiveRows.eq(0));
+  assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
+  assert.equal(getElementText(tds.eq(1)), getText('Add New'));
+  assert.equal(getElementText(tds.eq(2)), getText('Add New'));
+  tds = find('td', objectiveRows.eq(1));
+  assert.equal(getElementText(tds.eq(0)), getText(newObjectiveTitle));
+  assert.equal(getElementText(tds.eq(1)), getText('Add New'));
+  assert.equal(getElementText(tds.eq(2)), getText('Add New'));
 
+  await wait();
 });
 
-test('cancel new objective', function(assert) {
+test('cancel new objective', async function(assert) {
   assert.expect(5);
-  visit(url);
-  andThen(function() {
-    let objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
-    assert.equal(objectiveRows.length, fixtures.session.objectives.length);
-    click('.detail-objectives .detail-objectives-actions button');
-    click('.detail-objectives .newobjective button.cancel');
-  });
-  andThen(function(){
-    let objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
-    assert.equal(objectiveRows.length, fixtures.session.objectives.length);
-    let tds = find('td', objectiveRows.eq(0));
-    assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
-    assert.equal(getElementText(tds.eq(1)), getText('Add New'));
-    assert.equal(getElementText(tds.eq(2)), getText('Add New'));
-  });
+  await visit(url);
+  let objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
+  assert.equal(objectiveRows.length, fixtures.session.objectives.length);
+  await click('.detail-objectives .detail-objectives-actions button');
+  await click('.detail-objectives .newobjective button.cancel');
+  objectiveRows = find('.detail-objectives .session-objective-list tbody tr');
+  assert.equal(objectiveRows.length, fixtures.session.objectives.length);
+  let tds = find('td', objectiveRows.eq(0));
+  assert.equal(getElementText(tds.eq(0)), getText(fixtures.objective.title));
+  assert.equal(getElementText(tds.eq(1)), getText('Add New'));
+  assert.equal(getElementText(tds.eq(2)), getText('Add New'));
 });
 
-test('empty objective title can not be created', function(assert) {
+test('empty objective title can not be created', async function(assert) {
   assert.expect(3);
   const container = '.detail-objectives:eq(0)';
   const expandNewObjective = `${container} .detail-objectives-actions button`;
@@ -90,21 +81,18 @@ test('empty objective title can not be created', function(assert) {
   const editor = `${newObjective} .fr-box`;
   const save = `${newObjective} .done`;
   const errorMessage = `${newObjective} .validation-error-message`;
-  visit(url);
-  click(expandNewObjective);
+  await visit(url);
+  await click(expandNewObjective);
 
-  andThen(function() {
-    //wait for the editor to load
-    Ember.run.later(()=>{
-      let editorContents = find(editor).data('froala.editor').$el.text();
-      assert.equal(getText(editorContents), '');
+  let editorContents = find(editor).data('froala.editor').$el.text();
+  assert.equal(getText(editorContents), '');
 
-      find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
-      find(editor).froalaEditor('events.trigger', 'contentChanged');
-      Ember.run.later(()=>{
-        assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
-        assert.ok(find(save).is(':disabled'));
-      }, 100);
-    }, 100);
+  find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
+  find(editor).froalaEditor('events.trigger', 'contentChanged');
+  run.later(()=>{
+    assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
+    assert.ok(find(save).is(':disabled'));
   });
+
+  await wait();
 });

--- a/tests/acceptance/course/session/objectivelist-test.js
+++ b/tests/acceptance/course/session/objectivelist-test.js
@@ -5,7 +5,10 @@ import {
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+import wait from 'ember-test-helpers/wait';
 import Ember from 'ember';
+
+const { run } = Ember;
 
 var application;
 var fixtures = {};
@@ -26,7 +29,7 @@ module('Acceptance: Session - Objective List', {
   }
 });
 
-test('list objectives', function(assert) {
+test('list objectives', async function(assert) {
   assert.expect(40);
   fixtures.parentObjectives = [];
   fixtures.parentObjectives.pushObject(server.create('objective', {
@@ -64,42 +67,39 @@ test('list objectives', function(assert) {
     course: 1,
     objectives: [3,4,5,6,7,8,9,10,11,12,13,14,15]
   });
-  visit(url);
-  andThen(function() {
-    let objectiveRows = find('.session-objective-list tbody tr');
-    assert.equal(objectiveRows.length, fixtures.sessionObjectives.length);
-    var extractParentTitle = function(id){
-      return fixtures.parentObjectives[id - 1].title;
-    };
-    var extractMeshName = function(id){
-      return fixtures.meshDescriptors[id - 1].name;
-    };
-    for(let i = 0; i < fixtures.sessionObjectives.length; i++){
-      let tds = find('td', objectiveRows.eq(i));
-      let objective = fixtures.sessionObjectives[i];
+  await visit(url);
+  let objectiveRows = find('.session-objective-list tbody tr');
+  assert.equal(objectiveRows.length, fixtures.sessionObjectives.length);
+  var extractParentTitle = function(id){
+    return fixtures.parentObjectives[id - 1].title;
+  };
+  var extractMeshName = function(id){
+    return fixtures.meshDescriptors[id - 1].name;
+  };
+  for(let i = 0; i < fixtures.sessionObjectives.length; i++){
+    let tds = find('td', objectiveRows.eq(i));
+    let objective = fixtures.sessionObjectives[i];
 
-      let parentTitle;
-      if('parents' in objective){
-        parentTitle = objective.parents.map(extractParentTitle).join('');
-      } else {
-        parentTitle = 'Add New';
-      }
-
-      let meshTitle;
-      if('meshDescriptors' in objective){
-        meshTitle = objective.meshDescriptors.map(extractMeshName).join('');
-      } else {
-        meshTitle = 'Add New';
-      }
-      assert.equal(getElementText(tds.eq(0)), getText(objective.title));
-      assert.equal(getElementText(tds.eq(1)), getText(parentTitle));
-      assert.equal(getElementText(tds.eq(2)), getText(meshTitle));
+    let parentTitle;
+    if('parents' in objective){
+      parentTitle = objective.parents.map(extractParentTitle).join('');
+    } else {
+      parentTitle = 'Add New';
     }
 
-  });
+    let meshTitle;
+    if('meshDescriptors' in objective){
+      meshTitle = objective.meshDescriptors.map(extractMeshName).join('');
+    } else {
+      meshTitle = 'Add New';
+    }
+    assert.equal(getElementText(tds.eq(0)), getText(objective.title));
+    assert.equal(getElementText(tds.eq(1)), getText(parentTitle));
+    assert.equal(getElementText(tds.eq(2)), getText(meshTitle));
+  }
 });
 
-test('long objective', function(assert) {
+test('long objective', async function(assert) {
   assert.expect(3);
   var longTitle = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam placerat tempor neque ut egestas. In cursus dignissim erat, sed porttitor mauris tincidunt at. Nunc et tortor in purus facilisis molestie. Phasellus in ligula nisi. Nam nec mi in urna mollis pharetra. Suspendisse in nibh ex. Curabitur maximus diam in condimentum pulvinar. Phasellus sit amet metus interdum, molestie turpis vel, bibendum eros. In fermentum elit in odio cursus cursus. Nullam ipsum ipsum, fringilla a efficitur non, vehicula vitae enim. Duis ultrices vitae neque in pulvinar. Nulla molestie vitae quam eu faucibus. Vestibulum tempor, tellus in dapibus sagittis, velit purus maximus lectus, quis ullamcorper sem neque quis sem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed commodo risus sed tellus imperdiet, ac suscipit justo scelerisque. Quisque sit amet nulla efficitur, sollicitudin sem in, venenatis mi. Quisque sit amet neque varius, interdum quam id, condimentum ipsum. Quisque tincidunt efficitur diam ut feugiat. Duis vehicula mauris elit, vel vehicula eros commodo rhoncus. Phasellus ac eros vel turpis egestas aliquet. Nam id dolor rutrum, imperdiet purus ac, faucibus nisi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nam aliquam leo eget quam varius ultricies. Suspendisse pellentesque varius mi eu luctus. Integer lacinia ornare magna, in egestas quam molestie non.';
   server.create('objective', {
@@ -111,19 +111,16 @@ test('long objective', function(assert) {
     course: 1,
     objectives: [1]
   });
-  visit(url);
-  andThen(function() {
-    let objectiveRows = find('.session-objective-list tbody tr');
-    assert.equal(objectiveRows.length, 1);
-    let td = find('.session-objective-list tbody tr:eq(0) td:eq(0)');
-    assert.equal(getElementText(td), getText(longTitle.substring(0,200)));
-    click('i:eq(0)', td).then(function(){
-      assert.equal(getElementText(find('.fr-element', td)), getText(longTitle));
-    });
-  });
+  await visit(url);
+  let objectiveRows = find('.session-objective-list tbody tr');
+  assert.equal(objectiveRows.length, 1);
+  let td = find('.session-objective-list tbody tr:eq(0) td:eq(0)');
+  assert.equal(getElementText(td), getText(longTitle.substring(0,200)));
+  await click('i:eq(0)', td);
+  assert.equal(getElementText(find('.fr-element', td)), getText(longTitle));
 });
 
-test('edit objective title', function(assert) {
+test('edit objective title', async function(assert) {
   assert.expect(3);
   var objective = server.create('objective', {
     courses: [1],
@@ -133,32 +130,23 @@ test('edit objective title', function(assert) {
     course: 1,
     objectives: [1]
   });
-  visit(url);
-  andThen(function() {
-    var container = find('.session-objective-list');
-    let td = find('tbody tr:eq(0) td:eq(0)', container);
-    assert.equal(getElementText(td), getText(objective.title));
-    click('.editable span', td);
+  await visit(url);
+  var container = find('.session-objective-list');
+  let td = find('tbody tr:eq(0) td:eq(0)', container);
+  assert.equal(getElementText(td), getText(objective.title));
+  await click('.editable span', td);
 
-    andThen(function(){
-      //wait for the editor to load
-      Ember.run.later(()=>{
-        let editor = find('.fr-box', td);
-        let editorContents = editor.data('froala.editor').$el.text();
-        assert.equal(getText(editorContents), getText(objective.title));
+  let editor = find('.fr-box', td);
+  let editorContents = editor.data('froala.editor').$el.text();
+  assert.equal(getText(editorContents), getText(objective.title));
 
-        editor.froalaEditor('html.set', 'new title');
-        editor.froalaEditor('events.trigger', 'contentChanged');
-        click(find('.actions .done', td));
-        andThen(function(){
-          assert.equal(getElementText(find('tbody tr:eq(0) td:eq(0)', container)), getText('new title'));
-        });
-      }, 100);
-    });
-  });
+  editor.froalaEditor('html.set', 'new title');
+  editor.froalaEditor('events.trigger', 'contentChanged');
+  await click(find('.actions .done', td));
+  assert.equal(getElementText(find('tbody tr:eq(0) td:eq(0)', container)), getText('new title'));
 });
 
-test('empty objective title can not be saved', function(assert) {
+test('empty objective title can not be saved', async function(assert) {
   assert.expect(4);
   server.create('objective', {
     sessions: [1],
@@ -168,7 +156,7 @@ test('empty objective title can not be saved', function(assert) {
     course: 1,
     objectives: [1]
   });
-  visit(url);
+  await visit(url);
   const container = '.session-objective-list';
   const title = `${container} tbody tr:eq(0) td:eq(0)`;
   const edit = `${title} .editable span`;
@@ -177,23 +165,17 @@ test('empty objective title can not be saved', function(assert) {
   const save = `${title} .done`;
   const errorMessage = `${title} .validation-error-message`;
 
-  andThen(function() {
-    assert.equal(getElementText(title), getText(initialObjectiveTitle));
-    click(edit);
-    andThen(function(){
-      //wait for the editor to load
-      Ember.run.later(()=>{
+  assert.equal(getElementText(title), getText(initialObjectiveTitle));
+  await click(edit);
+  let editorContents = find(editor).data('froala.editor').$el.text();
+  assert.equal(getText(editorContents), getText(initialObjectiveTitle));
 
-        let editorContents = find(editor).data('froala.editor').$el.text();
-        assert.equal(getText(editorContents), getText(initialObjectiveTitle));
+  find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
+  find(editor).froalaEditor('events.trigger', 'contentChanged');
+  run.later(()=>{
+    assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
+    assert.ok(find(save).is(':disabled'));
+  }, 100);
 
-        find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
-        find(editor).froalaEditor('events.trigger', 'contentChanged');
-        Ember.run.later(()=>{
-          assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
-          assert.ok(find(save).is(':disabled'));
-        }, 100);
-      }, 100);
-    });
-  });
+  await wait();
 });

--- a/tests/acceptance/course/session/objectiveparents-test.js
+++ b/tests/acceptance/course/session/objectiveparents-test.js
@@ -55,127 +55,95 @@ module('Acceptance: Session - Objective Parents', {
   }
 });
 
-test('list session objectives', function(assert) {
+test('list session objectives', async function(assert) {
   assert.expect(11);
-  visit(url);
-  andThen(function() {
-    let tds = find('.session-objective-list tbody tr:eq(0) td');
-    assert.equal(tds.length, 4);
-    click('.link', tds.eq(1));
-    andThen(function() {
-      assert.equal(getElementText(find('.specific-title')), 'SelectParentObjectives');
-      let objectiveManager = find('.objective-manager').eq(0);
-      let objective = fixtures.sessionObjectives[0];
-      assert.equal(getElementText(find('.objectivetitle', objectiveManager)), getText(objective.title));
-      let expectedCourseTitle = fixtures.course.title;
-      let parentPicker = find('.parent-picker', objectiveManager).eq(0);
-      assert.equal(getElementText(find('h5', parentPicker)), getText(expectedCourseTitle));
-      //every course objective in the list
-      let ul = find('ul', parentPicker).eq(0);
-      let items = find('li', ul);
-      assert.equal(items.length, fixtures.course.objectives.length);
-      for(let i = 0; i < fixtures.course.objectives.length; i++){
-        let li = items.eq(i);
-        assert.equal(getElementText(li), getText(fixtures.parentObjectives[fixtures.course.objectives[i] - 1].title));
-        if(objective.parents.indexOf(fixtures.course.objectives[i]) !== -1){
-          assert.ok($(li).hasClass('selected'));
-        } else {
-          assert.ok(!$(li).hasClass('selected'));
-        }
-      }
-    });
-  });
+  await visit(url);
+  let tds = find('.session-objective-list tbody tr:eq(0) td');
+  assert.equal(tds.length, 4);
+  await click('.link', tds.eq(1));
+  assert.equal(getElementText(find('.specific-title')), 'SelectParentObjectives');
+  let objectiveManager = find('.objective-manager').eq(0);
+  let objective = fixtures.sessionObjectives[0];
+  assert.equal(getElementText(find('.objectivetitle', objectiveManager)), getText(objective.title));
+  let expectedCourseTitle = fixtures.course.title;
+  let parentPicker = find('.parent-picker', objectiveManager).eq(0);
+  assert.equal(getElementText(find('h5', parentPicker)), getText(expectedCourseTitle));
+  //every course objective in the list
+  let ul = find('ul', parentPicker).eq(0);
+  let items = find('li', ul);
+  assert.equal(items.length, fixtures.course.objectives.length);
+  for(let i = 0; i < fixtures.course.objectives.length; i++){
+    let li = items.eq(i);
+    assert.equal(getElementText(li), getText(fixtures.parentObjectives[fixtures.course.objectives[i] - 1].title));
+    if(objective.parents.indexOf(fixtures.course.objectives[i]) !== -1){
+      assert.ok($(li).hasClass('selected'));
+    } else {
+      assert.ok(!$(li).hasClass('selected'));
+    }
+  }
 });
 
-test('change session objective parent', function(assert) {
+test('change session objective parent', async function(assert) {
   assert.expect(3);
-  visit(url);
-  andThen(function() {
-    click('.session-objective-list tbody tr:eq(0) td:eq(1) .link');
-    andThen(function() {
-      let objectiveManager = find('.objective-manager').eq(0);
-      let parentPicker = find('.parent-picker', objectiveManager).eq(0);
-      click('li:eq(0)', parentPicker);
-      click('li:eq(2)', parentPicker);
-      andThen(function(){
-        assert.ok(find('li:eq(1)', parentPicker).hasClass('selected'));
-        assert.ok(find('li:eq(2)', parentPicker).hasClass('selected'));
-        assert.ok(!find('li:eq(0)', parentPicker).hasClass('selected'));
-      });
-    });
-  });
+  await visit(url);
+  await click('.session-objective-list tbody tr:eq(0) td:eq(1) .link');
+  let objectiveManager = find('.objective-manager').eq(0);
+  let parentPicker = find('.parent-picker', objectiveManager).eq(0);
+  await click('li:eq(0)', parentPicker);
+  await click('li:eq(2)', parentPicker);
+  assert.ok(find('li:eq(1)', parentPicker).hasClass('selected'));
+  assert.ok(find('li:eq(2)', parentPicker).hasClass('selected'));
+  assert.ok(!find('li:eq(0)', parentPicker).hasClass('selected'));
 });
 
-test('deselect all parents for session objective', function(assert) {
+test('deselect all parents for session objective', async function(assert) {
   assert.expect(3);
-  visit(url);
-  andThen(function() {
-    click('.session-objective-list tbody tr:eq(0) td:eq(1) .link');
-    andThen(function() {
-      let objectiveManager = find('.objective-manager').eq(0);
-      let parentPicker = find('.parent-picker', objectiveManager).eq(0);
-      click('li:eq(1)', parentPicker);
-      click('li:eq(0)', parentPicker);
-      andThen(function(){
-        for(let i = 0; i < 3; i++){
-          let item = find('li', parentPicker).eq(i);
-          assert.ok(!item.hasClass('selected'));
-        }
-      });
-
-    });
-  });
+  await visit(url);
+  await click('.session-objective-list tbody tr:eq(0) td:eq(1) .link');
+  let objectiveManager = find('.objective-manager').eq(0);
+  let parentPicker = find('.parent-picker', objectiveManager).eq(0);
+  await click('li:eq(1)', parentPicker);
+  await click('li:eq(0)', parentPicker);
+  for(let i = 0; i < 3; i++){
+    let item = find('li', parentPicker).eq(i);
+    assert.ok(!item.hasClass('selected'));
+  }
 });
 
-test('multiple parents for session objective', function(assert) {
+test('multiple parents for session objective', async function(assert) {
   assert.expect(3);
-  visit(url);
-  andThen(function() {
-    click('.session-objective-list tbody tr:eq(1) td:eq(1) .link');
-    andThen(function() {
-      let objectiveManager = find('.objective-manager').eq(0);
-      let parentPicker = find('.parent-picker', objectiveManager).eq(0);
-      click('li:eq(1)', parentPicker);
-      andThen(function(){
-        assert.ok(find('li:eq(0)', parentPicker).hasClass('selected'));
-        assert.ok(find('li:eq(1)', parentPicker).hasClass('selected'));
-        assert.ok(!find('li:eq(2)', parentPicker).hasClass('selected'));
-      });
-    });
-  });
+  await visit(url);
+  await click('.session-objective-list tbody tr:eq(1) td:eq(1) .link');
+  let objectiveManager = find('.objective-manager').eq(0);
+  let parentPicker = find('.parent-picker', objectiveManager).eq(0);
+  await click('li:eq(1)', parentPicker);
+  assert.ok(find('li:eq(0)', parentPicker).hasClass('selected'));
+  assert.ok(find('li:eq(1)', parentPicker).hasClass('selected'));
+  assert.ok(!find('li:eq(2)', parentPicker).hasClass('selected'));
 });
 
-test('save changes', function(assert) {
+test('save changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    click('.session-objective-list tbody tr:eq(1) td:eq(1) .link');
-    click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(0)');
-    click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
-    click('.detail-objectives:eq(0) button.bigadd');
-    andThen(function(){
-      let td = find('.session-objective-list tbody tr:eq(1) td:eq(1)');
-      assert.equal(getElementText(td), getText(
-        fixtures.parentObjectives[1].title
-      ));
-    });
-  });
-
+  await visit(url);
+  await click('.session-objective-list tbody tr:eq(1) td:eq(1) .link');
+  await click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(0)');
+  await click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
+  await click('.detail-objectives:eq(0) button.bigadd');
+  let td = find('.session-objective-list tbody tr:eq(1) td:eq(1)');
+  assert.equal(getElementText(td), getText(
+    fixtures.parentObjectives[1].title
+  ));
 });
 
-test('cancel changes', function(assert) {
+test('cancel changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    click('.session-objective-list tbody tr:eq(1) td:eq(1) .link');
-    click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
-    click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(0)');
-    click('.detail-objectives:eq(0) button.bigcancel');
-  });
-  andThen(function(){
-    let td = find('.session-objective-list tbody tr:eq(1) td:eq(1)');
-    assert.equal(getElementText(td), getText(
-      fixtures.parentObjectives[0].title
-    ));
-  });
+  await visit(url);
+  await click('.session-objective-list tbody tr:eq(1) td:eq(1) .link');
+  await click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(1)');
+  await click('.objective-manager:eq(0) .parent-picker:eq(0) li:eq(0)');
+  await click('.detail-objectives:eq(0) button.bigcancel');
+  let td = find('.session-objective-list tbody tr:eq(1) td:eq(1)');
+  assert.equal(getElementText(td), getText(
+    fixtures.parentObjectives[0].title
+  ));
 });

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -130,152 +130,131 @@ module('Acceptance: Session - Offerings', {
   }
 });
 
-test('basics', function(assert) {
+test('basics', async function(assert) {
   assert.expect(2);
-  visit(url);
-  andThen(function() {
-    let container = find('.session-offerings');
-    let offeringTitle = 'Offerings (' + fixtures.offerings.length + ')';
-    assert.equal(getElementText(find('.title', container)), getText(offeringTitle));
-    let dateBlocks = find('.offering-block', container);
+  await visit(url);
+  let container = find('.session-offerings');
+  let offeringTitle = 'Offerings (' + fixtures.offerings.length + ')';
+  assert.equal(getElementText(find('.title', container)), getText(offeringTitle));
+  let dateBlocks = find('.offering-block', container);
 
-    assert.equal(dateBlocks.length, fixtures.offerings.length, 'Date blocks count equals offerings fixtures count');
-  });
+  assert.equal(dateBlocks.length, fixtures.offerings.length, 'Date blocks count equals offerings fixtures count');
 });
 
-test('single day offering dates', function(assert) {
+test('single day offering dates', async function(assert) {
   assert.expect(8);
-  visit(url);
-  andThen(function() {
-    let dateBlocks = find('.session-offerings .offering-block');
+  await visit(url);
+  let dateBlocks = find('.session-offerings .offering-block');
 
-    //the first two offerings are single date offerings
-    for(let i = 0; i < 2; i++){
-      let block = dateBlocks.eq(i);
-      let offering = fixtures.offerings[i];
-      assert.equal(getElementText(find('.offering-block-date-dayofweek', block)), getText(moment(offering.startDate).format('dddd')));
-      assert.equal(getElementText(find('.offering-block-date-dayofmonth', block)), getText(moment(offering.startDate).format('MMMM Do')));
-      assert.equal(getElementText(find('.offering-block-time-time-starttime', block)), getText('Starts:' + moment(offering.startDate).format('LT')));
-      assert.equal(getElementText(find('.offering-block-time-time-endtime', block)), getText('Ends:' + moment(offering.endDate).format('LT')));
-    }
-  });
+  //the first two offerings are single date offerings
+  for(let i = 0; i < 2; i++){
+    let block = dateBlocks.eq(i);
+    let offering = fixtures.offerings[i];
+    assert.equal(getElementText(find('.offering-block-date-dayofweek', block)), getText(moment(offering.startDate).format('dddd')));
+    assert.equal(getElementText(find('.offering-block-date-dayofmonth', block)), getText(moment(offering.startDate).format('MMMM Do')));
+    assert.equal(getElementText(find('.offering-block-time-time-starttime', block)), getText('Starts:' + moment(offering.startDate).format('LT')));
+    assert.equal(getElementText(find('.offering-block-time-time-endtime', block)), getText('Ends:' + moment(offering.endDate).format('LT')));
+  }
 });
 
-test('multiday offering dates', function(assert) {
+test('multiday offering dates', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    let dateBlocks = find('.session-offerings .offering-block');
+  await visit(url);
+  let dateBlocks = find('.session-offerings .offering-block');
 
-    //the third offering is multiday
-    for(let i = 2; i < 3; i++){
-      let block = dateBlocks.eq(i);
-      let offering = fixtures.offerings[i];
-      let expectedText = 'Multiday' +
-        'Starts' + moment(offering.startDate).format('dddd MMMM Do [@] LT') +
-        'Ends' + moment(offering.endDate).format('dddd MMMM Do [@] LT');
-      assert.equal(getElementText(find('.multiday-offering-block-time-time', block)), getText(expectedText));
-    }
-  });
+  //the third offering is multiday
+  for(let i = 2; i < 3; i++){
+    let block = dateBlocks.eq(i);
+    let offering = fixtures.offerings[i];
+    let expectedText = 'Multiday' +
+      'Starts' + moment(offering.startDate).format('dddd MMMM Do [@] LT') +
+      'Ends' + moment(offering.endDate).format('dddd MMMM Do [@] LT');
+    assert.equal(getElementText(find('.multiday-offering-block-time-time', block)), getText(expectedText));
+  }
 });
 
-test('learner groups', function(assert) {
+test('learner groups', async function(assert) {
   assert.expect(7);
-  visit(url);
-  andThen(function() {
-    let container = find('.session-offerings');
-    let dateBlocks = find('.offering-block', container);
-    for(let i = 0; i < fixtures.offerings.length; i++){
-      let learnerGroups = find('.offering-block-time-offering-learner_groups li', dateBlocks.eq(i));
-      let offeringLearnerGroups = fixtures.offerings[i].learnerGroups;
-      assert.equal(learnerGroups.length, offeringLearnerGroups.length);
-      for(let i = 0; i < offeringLearnerGroups.length; i++){
-        let learnerGroup = fixtures.learnerGroups[offeringLearnerGroups[i] - 1];
-        assert.equal(getElementText(learnerGroups.eq(i)), getText(learnerGroup.title));
-      }
+  await visit(url);
+  let container = find('.session-offerings');
+  let dateBlocks = find('.offering-block', container);
+  for(let i = 0; i < fixtures.offerings.length; i++){
+    let learnerGroups = find('.offering-block-time-offering-learner_groups li', dateBlocks.eq(i));
+    let offeringLearnerGroups = fixtures.offerings[i].learnerGroups;
+    assert.equal(learnerGroups.length, offeringLearnerGroups.length);
+    for(let i = 0; i < offeringLearnerGroups.length; i++){
+      let learnerGroup = fixtures.learnerGroups[offeringLearnerGroups[i] - 1];
+      assert.equal(getElementText(learnerGroups.eq(i)), getText(learnerGroup.title));
     }
-  });
+  }
 });
 
-test('instructors', function(assert) {
+test('instructors', async function(assert) {
   assert.expect(17);
-  visit(url);
-  andThen(function() {
-    let container = find('.session-offerings');
-    let dateBlocks = find('.offering-block', container);
-    var extractInstructorsFromOffering = function(offeringId){
-      let offering = fixtures.offerings[offeringId];
-      let arr = [];
-      offering.instructors.forEach(function(id){
+  await visit(url);
+  let container = find('.session-offerings');
+  let dateBlocks = find('.offering-block', container);
+  var extractInstructorsFromOffering = function(offeringId){
+    let offering = fixtures.offerings[offeringId];
+    let arr = [];
+    offering.instructors.forEach(function(id){
+      arr.push(id);
+    });
+    offering.instructorGroups.forEach(function(groupId){
+      let instructorGroup = fixtures.instructorGroups[groupId -1];
+      instructorGroup.users.forEach(function(id){
         arr.push(id);
       });
-      offering.instructorGroups.forEach(function(groupId){
-        let instructorGroup = fixtures.instructorGroups[groupId -1];
-        instructorGroup.users.forEach(function(id){
-          arr.push(id);
-        });
-      });
+    });
 
-      return arr.uniq().sort();
-    };
-    for(let i = 0; i < fixtures.offerings.length; i++){
-      let instructors = find('.offering-block-time-offering-instructors li', dateBlocks.eq(i));
-      let offeringInstructors = extractInstructorsFromOffering(i);
-      assert.equal(instructors.length, offeringInstructors.length);
-      for(let i = 0; i < offeringInstructors.length; i++){
-        let instructor = fixtures.users[offeringInstructors[i] - 1];
-        const middleInitial = instructor.middleName.charAt(0).toUpperCase();
-        const instructorTitle = `${instructor.firstName} ${middleInitial}. ${instructor.lastName}`;
-        assert.equal(getElementText(instructors.eq(i)), getText(instructorTitle));
-      }
+    return arr.uniq().sort();
+  };
+  for(let i = 0; i < fixtures.offerings.length; i++){
+    let instructors = find('.offering-block-time-offering-instructors li', dateBlocks.eq(i));
+    let offeringInstructors = extractInstructorsFromOffering(i);
+    assert.equal(instructors.length, offeringInstructors.length);
+    for(let i = 0; i < offeringInstructors.length; i++){
+      let instructor = fixtures.users[offeringInstructors[i] - 1];
+      const middleInitial = instructor.middleName.charAt(0).toUpperCase();
+      const instructorTitle = `${instructor.firstName} ${middleInitial}. ${instructor.lastName}`;
+      assert.equal(getElementText(instructors.eq(i)), getText(instructorTitle));
     }
-  });
+  }
 });
 
-test('confirm removal message', function(assert) {
+test('confirm removal message', async function(assert) {
   assert.expect(2);
-  visit(url);
-  andThen(function() {
-    let offering = find('.offering-block-time-offering:eq(0)');
-    click('.offering-block-time-offering-actions .remove', offering).then(function(){
-      assert.ok(offering.hasClass('offering-confirm-removal'));
-      assert.equal(getElementText(find('.confirm-message', offering)), getText('Are you sure you want to delete this offering with 2 learner groups? This action cannot be undone. Yes Cancel'));
-    });
-  });
+  await visit(url);
+  let offering = find('.offering-block-time-offering:eq(0)');
+  await click('.offering-block-time-offering-actions .remove', offering);
+  assert.ok(offering.hasClass('offering-confirm-removal'));
+  assert.equal(getElementText(find('.confirm-message', offering)), getText('Are you sure you want to delete this offering with 2 learner groups? This action cannot be undone. Yes Cancel'));
 });
 
-test('remove offering', function(assert) {
+test('remove offering', async function(assert) {
   assert.expect(2);
-  visit(url);
-  andThen(function() {
+  await visit(url);
 
-    let offerings = find('.offering-block-time-offering');
-    assert.equal(offerings.length, 3);
-    let offering = find('.offering-block-time-offering').eq(0);
-    click('.offering-block-time-offering-actions .remove', offering).then(function(){
-      click('.confirm-message .remove', offering).then(function(){
-        assert.equal(find('.offering-block-time-offering').length, 2);
-      });
-    });
-  });
+  let offerings = find('.offering-block-time-offering');
+  assert.equal(offerings.length, 3);
+  let offering = find('.offering-block-time-offering').eq(0);
+  await click('.offering-block-time-offering-actions .remove', offering);
+  await click('.confirm-message .remove', offering);
+  assert.equal(find('.offering-block-time-offering').length, 2);
 });
 
-test('cancel remove offering', function(assert) {
+test('cancel remove offering', async function(assert) {
   assert.expect(2);
-  visit(url);
-  andThen(function() {
-    let offerings = find('.offering-block-time-offering');
-    assert.equal(offerings.length, 3);
-    let offering = find('.offering-block-time-offering').eq(0);
-    click('.offering-block-time-offering-actions .remove', offering).then(function(){
-      click('.cancel', offering).then(function(){
-        assert.equal(find('.offering-block-time-offering').length, 3);
-      });
-    });
-  });
+  await visit(url);
+  let offerings = find('.offering-block-time-offering');
+  assert.equal(offerings.length, 3);
+  let offering = find('.offering-block-time-offering').eq(0);
+  await click('.offering-block-time-offering-actions .remove', offering);
+  await click('.cancel', offering);
+  assert.equal(find('.offering-block-time-offering').length, 3);
 });
 
-test('users can create a new offering single day', function(assert) {
+test('users can create a new offering single day', async function(assert) {
   assert.expect(10);
 
   const form = '.offering-form';
@@ -305,41 +284,36 @@ test('users can create a new offering single day', function(assert) {
   const room = '.offering-block-time-offering-location:first';
   const instructor = '.offering-block-time-offering-instructors ul li:eq(0)';
 
-  visit(url);
-  click(expandButton);
-  click(offeringButton);
-  andThen(() => {
-    let startDateInteractor = openDatepicker(find(startDateInput));
-    startDateInteractor.selectDate(new Date(2011, 8, 11));
+  await visit(url);
+  await click(expandButton);
+  await click(offeringButton);
+  let startDateInteractor = openDatepicker(find(startDateInput));
+  startDateInteractor.selectDate(new Date(2011, 8, 11));
 
-    let startBoxes = find(startTimes);
-    pickOption(startBoxes[0], '2', assert);
-    pickOption(startBoxes[1], '15', assert);
+  let startBoxes = find(startTimes);
+  await pickOption(startBoxes[0], '2', assert);
+  await pickOption(startBoxes[1], '15', assert);
 
-  });
-
-  fillIn(durationHours, 15);
-  fillIn(durationMinutes, 15);
-  fillIn(offeringLocation, 'Rm. 111');
-  click(learnerGroupOne);
-  click(learnerGroupTwo);
-  fillIn(searchBox, 'guy');
-  click(searchBoxOption);
-  click(createButton);
-  andThen(() => {
-    assert.equal(find(dayOfWeek).text(), 'Sunday', 'day of the week is correct');
-    assert.equal(find(dayOfMonth).text(), 'September 11th', 'day of month is correct');
-    assert.equal(find(startTime).text().trim(), 'Starts: 2:15 AM', 'start time is correct');
-    assert.equal(find(endTime).text().trim(), 'Ends: 5:30 PM', 'end time is correct');
-    assert.equal(find(learnerGroup1).text().trim(), 'learner group 0', 'correct learner group is picked');
-    assert.equal(find(learnerGroup2).text().trim(), 'learner group 1', 'correct learner group is picked');
-    assert.equal(find(room).text(), 'Rm. 111', 'location/room is correct');
-    assert.equal(find(instructor).text(), '0 guy M. Mc0son', 'instructor is correct');
-  });
+  await fillIn(durationHours, 15);
+  await fillIn(durationMinutes, 15);
+  await fillIn(offeringLocation, 'Rm. 111');
+  await click(learnerGroupOne);
+  await click(learnerGroupTwo);
+  await fillIn(searchBox, 'guy');
+  await click(searchBoxOption);
+  await click(createButton);
+  assert.equal(find(dayOfWeek).text(), 'Sunday', 'day of the week is correct');
+  assert.equal(find(dayOfMonth).text(), 'September 11th', 'day of month is correct');
+  assert.equal(find(startTime).text().trim(), 'Starts: 2:15 AM', 'start time is correct');
+  assert.equal(find(endTime).text().trim(), 'Ends: 5:30 PM', 'end time is correct');
+  assert.equal(find(learnerGroup1).text().trim(), 'learner group 0', 'correct learner group is picked');
+  assert.equal(find(learnerGroup2).text().trim(), 'learner group 1', 'correct learner group is picked');
+  assert.equal(find(room).text(), 'Rm. 111', 'location/room is correct');
+  assert.equal(find(instructor).text(), '0 guy M. Mc0son', 'instructor is correct');
 });
 
 
-test('users can create a new offering multi-day', function(assert) {
+test('users can create a new offering multi-day', async function(assert) {
   assert.expect(9);
 
   const form = '.offering-form';
@@ -369,39 +343,34 @@ test('users can create a new offering multi-day', function(assert) {
   const multiDayStarts = '.multiday-offering-block-time-time-starts:first';
   const multiDayEnds = '.multiday-offering-block-time-time-ends:first';
 
-  visit(url);
-  click(expandButton);
-  click(offeringButton);
-  andThen(() => {
-    let startDateInteractor = openDatepicker(find(startDateInput));
-    startDateInteractor.selectDate(new Date(2011, 8, 11));
+  await visit(url);
+  await click(expandButton);
+  await click(offeringButton);
+  let startDateInteractor = openDatepicker(find(startDateInput));
+  startDateInteractor.selectDate(new Date(2011, 8, 11));
 
-    let startBoxes = find(startTimes);
-    pickOption(startBoxes[0], '2', assert);
-    pickOption(startBoxes[1], '15', assert);
+  let startBoxes = find(startTimes);
+  await pickOption(startBoxes[0], '2', assert);
+  await pickOption(startBoxes[1], '15', assert);
 
-  });
-
-  fillIn(durationHours, 39);
-  fillIn(durationMinutes, 15);
-  fillIn(offeringLocation, 'Rm. 111');
-  click(learnerGroupOne);
-  click(learnerGroupTwo);
-  fillIn(searchBox, 'guy');
-  click(searchBoxOption);
-  click(createButton);
-  andThen(() => {
-    assert.equal(find(multiDayDesc).text().trim(), 'Multiday', 'multi-day statement is correct');
-    assert.equal(find(multiDayStarts).text().trim(), 'Starts Sunday September 11th @ 2:15 AM', 'multi-day statement is correct');
-    assert.equal(find(multiDayEnds).text().trim(), 'Ends Monday September 12th @ 5:30 PM', 'multi-day statement is correct');
-    assert.equal(find(learnerGroup1).text().trim(), 'learner group 0', 'correct learner group is picked');
-    assert.equal(find(learnerGroup2).text().trim(), 'learner group 1', 'correct learner group is picked');
-    assert.equal(find(room).text(), 'Rm. 111', 'location/room is correct');
-    assert.equal(find(instructor).text(), '0 guy M. Mc0son', 'instructor is correct');
-  });
+  await fillIn(durationHours, 39);
+  await fillIn(durationMinutes, 15);
+  await fillIn(offeringLocation, 'Rm. 111');
+  await click(learnerGroupOne);
+  await click(learnerGroupTwo);
+  await fillIn(searchBox, 'guy');
+  await click(searchBoxOption);
+  await click(createButton);
+  assert.equal(find(multiDayDesc).text().trim(), 'Multiday', 'multi-day statement is correct');
+  assert.equal(find(multiDayStarts).text().trim(), 'Starts Sunday September 11th @ 2:15 AM', 'multi-day statement is correct');
+  assert.equal(find(multiDayEnds).text().trim(), 'Ends Monday September 12th @ 5:30 PM', 'multi-day statement is correct');
+  assert.equal(find(learnerGroup1).text().trim(), 'learner group 0', 'correct learner group is picked');
+  assert.equal(find(learnerGroup2).text().trim(), 'learner group 1', 'correct learner group is picked');
+  assert.equal(find(room).text(), 'Rm. 111', 'location/room is correct');
+  assert.equal(find(instructor).text(), '0 guy M. Mc0son', 'instructor is correct');
 });
 
-test('users can create a new small group offering', function(assert) {
+test('users can create a new small group offering', async function(assert) {
   assert.expect(12);
 
   const form = '.offering-form';
@@ -429,39 +398,34 @@ test('users can create a new small group offering', function(assert) {
   const instructors1 = '.offering-block-time-offering-instructors:eq(0) li';
   const instructors2 = '.offering-block-time-offering-instructors:eq(1) li';
 
-  visit(url);
-  click(expandButton);
-  andThen(() => {
-    let startDateInteractor = openDatepicker(find(startDateInput));
-    startDateInteractor.selectDate(new Date(2011, 8, 11));
+  await visit(url);
+  await click(expandButton);
+  let startDateInteractor = openDatepicker(find(startDateInput));
+  startDateInteractor.selectDate(new Date(2011, 8, 11));
 
-    let startBoxes = find(startTimes);
-    pickOption(startBoxes[0], '2', assert);
-    pickOption(startBoxes[1], '15', assert);
+  let startBoxes = find(startTimes);
+  await pickOption(startBoxes[0], '2', assert);
+  await pickOption(startBoxes[1], '15', assert);
 
-  });
-
-  fillIn(durationHours, 15);
-  fillIn(durationMinutes, 15);
-  click(learnerGroupOne);
-  click(learnerGroupTwo);
-  click(createButton);
-  andThen(() => {
-    assert.equal(find(dayOfWeek).text(), 'Sunday', 'day of the week is correct');
-    assert.equal(find(dayOfMonth).text(), 'September 11th', 'day of month is correct');
-    assert.equal(find(startTime).text().trim(), 'Starts: 2:15 AM', 'start time is correct');
-    assert.equal(find(endTime).text().trim(), 'Ends: 5:30 PM', 'end time is correct');
-    assert.equal(find(learnerGroup1).text().trim(), 'learner group 0', 'correct learner group is picked');
-    assert.equal(find(learnerGroup2).text().trim(), 'learner group 1', 'correct learner group is picked');
-    assert.equal(find(location1).text(), 'default 1', 'correct default location is added');
-    assert.equal(find(location2).text(), 'default 2', 'correct default location is added');
-    assert.equal(getElementText(instructors1), '0guyM.Mc0son', 'correct default instructors are added');
-    assert.equal(getElementText(instructors2), '1guyM.Mc1son2guyM.Mc2son5guyM.Mc5son6guyM.Mc6son', 'correct default instructors are added');
-  });
+  await fillIn(durationHours, 15);
+  await fillIn(durationMinutes, 15);
+  await click(learnerGroupOne);
+  await click(learnerGroupTwo);
+  await click(createButton);
+  assert.equal(find(dayOfWeek).text(), 'Sunday', 'day of the week is correct');
+  assert.equal(find(dayOfMonth).text(), 'September 11th', 'day of month is correct');
+  assert.equal(find(startTime).text().trim(), 'Starts: 2:15 AM', 'start time is correct');
+  assert.equal(find(endTime).text().trim(), 'Ends: 5:30 PM', 'end time is correct');
+  assert.equal(find(learnerGroup1).text().trim(), 'learner group 0', 'correct learner group is picked');
+  assert.equal(find(learnerGroup2).text().trim(), 'learner group 1', 'correct learner group is picked');
+  assert.equal(find(location1).text(), 'default 1', 'correct default location is added');
+  assert.equal(find(location2).text(), 'default 2', 'correct default location is added');
+  assert.equal(getElementText(instructors1), '0guyM.Mc0son', 'correct default instructors are added');
+  assert.equal(getElementText(instructors2), '1guyM.Mc1son2guyM.Mc2son5guyM.Mc5son6guyM.Mc6son', 'correct default instructors are added');
 });
 
 
-test('users can edit existing offerings', function(assert) {
+test('users can edit existing offerings', async function(assert) {
   assert.expect(8);
 
   const editButton = '.offering-detail-box i:first';
@@ -488,39 +452,35 @@ test('users can edit existing offerings', function(assert) {
   // const instructor2 = '.offering-block-time-offering-instructors ul li:eq(1)';
   // const instructor3 = '.offering-block-time-offering-instructors ul li:eq(2)';
 
-  visit(url);
-  click(editButton);
-  andThen(() => {
-    let interactor = openDatepicker(find(startDateInput));
-    interactor.selectDate(new Date(2011, 9, 5));
+  await visit(url);
+  await click(editButton);
+  let interactor = openDatepicker(find(startDateInput));
+  interactor.selectDate(new Date(2011, 9, 5));
 
-    let startBoxes = find(startTimes);
-    pickOption(startBoxes[0], '11', assert);
-    pickOption(startBoxes[1], '45', assert);
+  let startBoxes = find(startTimes);
+  await pickOption(startBoxes[0], '11', assert);
+  await pickOption(startBoxes[1], '45', assert);
 
-    fillIn(durationHours, 6);
-    fillIn(durationMinutes, 10);
-    fillIn(offeringLocation, 'Rm. 111');
-    click(removeLearnerGroupOne);
-    click(removeFirstInstructor);
-    click(removeFirstInstructorGroup);
-    click(createButton);
-    andThen(() => {
-      assert.equal(find(dayOfWeek).text(), 'Wednesday', 'day of the week is correct');
-      assert.equal(find(dayOfMonth).text(), 'October 5th', 'day of month is correct');
-      assert.equal(find(startTime).text().trim(), 'Starts: 11:45 AM', 'start time is correct');
-      assert.equal(find(endTime).text().trim(), 'Ends: 5:55 PM', 'end time is correct');
-      assert.equal(find(learnerGroup1).text().trim(), 'learner group 1', 'correct learner group is picked');
-      assert.equal(find(room).text(), 'Rm. 111', 'location/room is correct');
-      //@todo: skipping these, works in real life, but doesn't reload the list in tests
-      // assert.equal(find(instructor1).text(), '6 guy M. Mc6son', 'instructor is correct');
-      // assert.equal(find(instructor2).text(), '8 guy M. Mc5son', 'instructor is correct');
-      // assert.equal(find(instructor3).text(), '9 guy M. Mc5son', 'instructor is correct');
-    });
-  });
+  await fillIn(durationHours, 6);
+  await fillIn(durationMinutes, 10);
+  await fillIn(offeringLocation, 'Rm. 111');
+  await click(removeLearnerGroupOne);
+  await click(removeFirstInstructor);
+  await click(removeFirstInstructorGroup);
+  await click(createButton);
+  assert.equal(find(dayOfWeek).text(), 'Wednesday', 'day of the week is correct');
+  assert.equal(find(dayOfMonth).text(), 'October 5th', 'day of month is correct');
+  assert.equal(find(startTime).text().trim(), 'Starts: 11:45 AM', 'start time is correct');
+  assert.equal(find(endTime).text().trim(), 'Ends: 5:55 PM', 'end time is correct');
+  assert.equal(find(learnerGroup1).text().trim(), 'learner group 1', 'correct learner group is picked');
+  //@todo: skipping these, works in real life, but doesn't reload the list in tests
+  // assert.equal(find(instructor1).text(), '6 guy M. Mc6son', 'instructor is correct');
+  // assert.equal(find(instructor2).text(), '8 guy M. Mc5son', 'instructor is correct');
+  // assert.equal(find(instructor3).text(), '9 guy M. Mc5son', 'instructor is correct');
+  assert.equal(find(room).text(), 'Rm. 111', 'location/room is correct');
 });
 
-test('users can create recurring small groups', function(assert) {
+test('users can create recurring small groups', async function(assert) {
   assert.expect(42);
 
   const form = '.offering-form';
@@ -548,77 +508,72 @@ test('users can create recurring small groups', function(assert) {
   const locations = '.offering-block-time-offering-location';
   const instructors = '.offering-block-time-offering-instructors';
 
-  visit(url);
-  click(expandButton);
-  andThen(() => {
-    let startDateInteractor = openDatepicker(find(startDateInput));
-    startDateInteractor.selectDate(new Date(2015, 4, 22));
+  await visit(url);
+  await click(expandButton);
+  let startDateInteractor = openDatepicker(find(startDateInput));
+  startDateInteractor.selectDate(new Date(2015, 4, 22));
 
-    let startBoxes = find(startTimes);
-    pickOption(startBoxes[0], '2', assert);
-    pickOption(startBoxes[1], '15', assert);
-  });
+  let startBoxes = find(startTimes);
+  await pickOption(startBoxes[0], '2', assert);
+  await pickOption(startBoxes[1], '15', assert);
 
-  fillIn(durationHours, 13);
-  fillIn(durationMinutes, 8);
-  click(makeRecurringButton);
-  fillIn(makeRecurringInput, '4');
-  click(learnerGroupOne);
-  click(learnerGroupTwo);
+  await fillIn(durationHours, 13);
+  await fillIn(durationMinutes, 8);
+  await click(makeRecurringButton);
+  await fillIn(makeRecurringInput, '4');
+  await click(learnerGroupOne);
+  await click(learnerGroupTwo);
 
-  click(createButton);
-  andThen(() => {
-    assert.equal(find(daysOfWeek).eq(0).text(), 'Friday', 'first day of the week is correct');
-    assert.equal(find(daysOfWeek).eq(1).text(), 'Friday', 'second day of the week is correct');
-    assert.equal(find(daysOfWeek).eq(2).text(), 'Friday', 'third day of the week is correct');
-    assert.equal(find(daysOfWeek).eq(3).text(), 'Friday', 'fourth day of the week is correct');
+  await click(createButton);
+  assert.equal(find(daysOfWeek).eq(0).text(), 'Friday', 'first day of the week is correct');
+  assert.equal(find(daysOfWeek).eq(1).text(), 'Friday', 'second day of the week is correct');
+  assert.equal(find(daysOfWeek).eq(2).text(), 'Friday', 'third day of the week is correct');
+  assert.equal(find(daysOfWeek).eq(3).text(), 'Friday', 'fourth day of the week is correct');
 
-    assert.equal(find(daysOfMonth).eq(0).text(), 'May 22nd', 'first day of month is correct');
-    assert.equal(find(daysOfMonth).eq(1).text(), 'May 29th', 'second day of month is correct');
-    assert.equal(find(daysOfMonth).eq(2).text(), 'June 5th', 'third day of month is correct');
-    assert.equal(find(daysOfMonth).eq(3).text(), 'June 12th', 'fourth day of month is correct');
+  assert.equal(find(daysOfMonth).eq(0).text(), 'May 22nd', 'first day of month is correct');
+  assert.equal(find(daysOfMonth).eq(1).text(), 'May 29th', 'second day of month is correct');
+  assert.equal(find(daysOfMonth).eq(2).text(), 'June 5th', 'third day of month is correct');
+  assert.equal(find(daysOfMonth).eq(3).text(), 'June 12th', 'fourth day of month is correct');
 
-    assert.equal(find(startsTime).eq(0).text().trim(), 'Starts: 2:15 AM', 'first start time is correct');
-    assert.equal(find(startsTime).eq(1).text().trim(), 'Starts: 2:15 AM', 'second start time is correct');
-    assert.equal(find(startsTime).eq(2).text().trim(), 'Starts: 2:15 AM', 'third start time is correct');
-    assert.equal(find(startsTime).eq(3).text().trim(), 'Starts: 2:15 AM', 'fourth start time is correct');
+  assert.equal(find(startsTime).eq(0).text().trim(), 'Starts: 2:15 AM', 'first start time is correct');
+  assert.equal(find(startsTime).eq(1).text().trim(), 'Starts: 2:15 AM', 'second start time is correct');
+  assert.equal(find(startsTime).eq(2).text().trim(), 'Starts: 2:15 AM', 'third start time is correct');
+  assert.equal(find(startsTime).eq(3).text().trim(), 'Starts: 2:15 AM', 'fourth start time is correct');
 
-    assert.equal(find(endsTime).eq(0).text().trim(), 'Ends: 3:23 PM', 'first end time is correct');
-    assert.equal(find(endsTime).eq(1).text().trim(), 'Ends: 3:23 PM', 'second end time is correct');
-    assert.equal(find(endsTime).eq(2).text().trim(), 'Ends: 3:23 PM', 'third end time is correct');
-    assert.equal(find(endsTime).eq(3).text().trim(), 'Ends: 3:23 PM', 'fourth end time is correct');
+  assert.equal(find(endsTime).eq(0).text().trim(), 'Ends: 3:23 PM', 'first end time is correct');
+  assert.equal(find(endsTime).eq(1).text().trim(), 'Ends: 3:23 PM', 'second end time is correct');
+  assert.equal(find(endsTime).eq(2).text().trim(), 'Ends: 3:23 PM', 'third end time is correct');
+  assert.equal(find(endsTime).eq(3).text().trim(), 'Ends: 3:23 PM', 'fourth end time is correct');
 
-    assert.equal(find(learnerGroups).eq(0).text().trim(), 'learner group 0', 'first correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(1).text().trim(), 'learner group 1', 'first correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(2).text().trim(), 'learner group 0', 'second correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(3).text().trim(), 'learner group 1', 'second correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(4).text().trim(), 'learner group 0', 'third correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(5).text().trim(), 'learner group 1', 'third correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(6).text().trim(), 'learner group 0', 'fourth correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(7).text().trim(), 'learner group 1', 'fourth correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(0).text().trim(), 'learner group 0', 'first correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(1).text().trim(), 'learner group 1', 'first correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(2).text().trim(), 'learner group 0', 'second correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(3).text().trim(), 'learner group 1', 'second correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(4).text().trim(), 'learner group 0', 'third correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(5).text().trim(), 'learner group 1', 'third correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(6).text().trim(), 'learner group 0', 'fourth correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(7).text().trim(), 'learner group 1', 'fourth correct learner group is picked');
 
-    assert.equal(find(locations).eq(0).text(), 'default 1', 'first correct default location is picked');
-    assert.equal(find(locations).eq(1).text(), 'default 2', 'first correct default location is picked');
-    assert.equal(find(locations).eq(2).text(), 'default 1', 'second correct default location is picked');
-    assert.equal(find(locations).eq(3).text(), 'default 2', 'second correct default location is picked');
-    assert.equal(find(locations).eq(4).text(), 'default 1', 'third correct default location is picked');
-    assert.equal(find(locations).eq(5).text(), 'default 2', 'third correct default location is picked');
-    assert.equal(find(locations).eq(6).text(), 'default 1', 'fourth correct default location is picked');
-    assert.equal(find(locations).eq(7).text(), 'default 2', 'fourth correct default location is picked');
+  assert.equal(find(locations).eq(0).text(), 'default 1', 'first correct default location is picked');
+  assert.equal(find(locations).eq(1).text(), 'default 2', 'first correct default location is picked');
+  assert.equal(find(locations).eq(2).text(), 'default 1', 'second correct default location is picked');
+  assert.equal(find(locations).eq(3).text(), 'default 2', 'second correct default location is picked');
+  assert.equal(find(locations).eq(4).text(), 'default 1', 'third correct default location is picked');
+  assert.equal(find(locations).eq(5).text(), 'default 2', 'third correct default location is picked');
+  assert.equal(find(locations).eq(6).text(), 'default 1', 'fourth correct default location is picked');
+  assert.equal(find(locations).eq(7).text(), 'default 2', 'fourth correct default location is picked');
 
-    assert.equal(getElementText(find(instructors).eq(0)), getText('0 guy M. Mc0son'), 'first correct default instructor is picked');
-    assert.equal(getElementText(find(instructors).eq(1)), getText('1 guy M. Mc1son 2 guy M. Mc2son 5 guy M. Mc5son 6 guy M. Mc6son'), 'first correct default instructor is picked');
-    assert.equal(getElementText(find(instructors).eq(2)), getText('0 guy M. Mc0son'), 'second correct default instructor is picked');
-    assert.equal(getElementText(find(instructors).eq(3)), getText('1 guy M. Mc1son 2 guy M. Mc2son 5 guy M. Mc5son 6 guy M. Mc6son'), 'second correct default instructor is picked');
-    assert.equal(getElementText(find(instructors).eq(4)), getText('0 guy M. Mc0son'), 'third correct default instructor is picked');
-    assert.equal(getElementText(find(instructors).eq(5)), getText('1 guy M. Mc1son 2 guy M. Mc2son 5 guy M. Mc5son 6 guy M. Mc6son'), 'third correct default instructor is picked');
-    assert.equal(getElementText(find(instructors).eq(6)), getText('0 guy M. Mc0son'), 'fourth correct default instructor is picked');
-    assert.equal(getElementText(find(instructors).eq(7)), getText('1 guy M. Mc1son 2 guy M. Mc2son 5 guy M. Mc5son 6 guy M. Mc6son'), 'fourth correct default instructor is picked');
-
-  });
+  assert.equal(getElementText(find(instructors).eq(0)), getText('0 guy M. Mc0son'), 'first correct default instructor is picked');
+  assert.equal(getElementText(find(instructors).eq(1)), getText('1 guy M. Mc1son 2 guy M. Mc2son 5 guy M. Mc5son 6 guy M. Mc6son'), 'first correct default instructor is picked');
+  assert.equal(getElementText(find(instructors).eq(2)), getText('0 guy M. Mc0son'), 'second correct default instructor is picked');
+  assert.equal(getElementText(find(instructors).eq(3)), getText('1 guy M. Mc1son 2 guy M. Mc2son 5 guy M. Mc5son 6 guy M. Mc6son'), 'second correct default instructor is picked');
+  assert.equal(getElementText(find(instructors).eq(4)), getText('0 guy M. Mc0son'), 'third correct default instructor is picked');
+  assert.equal(getElementText(find(instructors).eq(5)), getText('1 guy M. Mc1son 2 guy M. Mc2son 5 guy M. Mc5son 6 guy M. Mc6son'), 'third correct default instructor is picked');
+  assert.equal(getElementText(find(instructors).eq(6)), getText('0 guy M. Mc0son'), 'fourth correct default instructor is picked');
+  assert.equal(getElementText(find(instructors).eq(7)), getText('1 guy M. Mc1son 2 guy M. Mc2son 5 guy M. Mc5son 6 guy M. Mc6son'), 'fourth correct default instructor is picked');
 });
 
-test('users can create recurring single offerings', function(assert) {
+test('users can create recurring single offerings', async function(assert) {
   assert.expect(26);
 
   const form = '.offering-form';
@@ -646,58 +601,53 @@ test('users can create recurring single offerings', function(assert) {
   const endsTime = '.offering-block-time-time-endtime';
   const learnerGroups = '.offering-block-time-offering-learner_groups ul li';
 
-  visit(url);
-  click(expandButton);
-  click(offeringButton);
-  andThen(() => {
-    let startDateInteractor = openDatepicker(find(startDateInput));
-    startDateInteractor.selectDate(new Date(2015, 4, 22));
+  await visit(url);
+  await click(expandButton);
+  await click(offeringButton);
+  let startDateInteractor = openDatepicker(find(startDateInput));
+  startDateInteractor.selectDate(new Date(2015, 4, 22));
 
-    let startBoxes = find(startTimes);
-    pickOption(startBoxes[0], '2', assert);
-    pickOption(startBoxes[1], '15', assert);
-  });
+  let startBoxes = find(startTimes);
+  await pickOption(startBoxes[0], '2', assert);
+  await pickOption(startBoxes[1], '15', assert);
 
-  fillIn(durationHours, 13);
-  fillIn(durationMinutes, 8);
+  await fillIn(durationHours, 13);
+  await fillIn(durationMinutes, 8);
 
-  click(makeRecurringButton);
-  fillIn(makeRecurringInput, '4');
-  click(learnerGroupOne);
-  click(learnerGroupTwo);
+  await click(makeRecurringButton);
+  await fillIn(makeRecurringInput, '4');
+  await click(learnerGroupOne);
+  await click(learnerGroupTwo);
 
-  click(createButton);
-  andThen(() => {
-    assert.equal(find(daysOfWeek).eq(0).text(), 'Friday', 'first day of the week is correct');
-    assert.equal(find(daysOfWeek).eq(1).text(), 'Friday', 'second day of the week is correct');
-    assert.equal(find(daysOfWeek).eq(2).text(), 'Friday', 'third day of the week is correct');
-    assert.equal(find(daysOfWeek).eq(3).text(), 'Friday', 'fourth day of the week is correct');
+  await click(createButton);
+  assert.equal(find(daysOfWeek).eq(0).text(), 'Friday', 'first day of the week is correct');
+  assert.equal(find(daysOfWeek).eq(1).text(), 'Friday', 'second day of the week is correct');
+  assert.equal(find(daysOfWeek).eq(2).text(), 'Friday', 'third day of the week is correct');
+  assert.equal(find(daysOfWeek).eq(3).text(), 'Friday', 'fourth day of the week is correct');
 
-    assert.equal(find(daysOfMonth).eq(0).text(), 'May 22nd', 'first day of month is correct');
-    assert.equal(find(daysOfMonth).eq(1).text(), 'May 29th', 'second day of month is correct');
-    assert.equal(find(daysOfMonth).eq(2).text(), 'June 5th', 'third day of month is correct');
-    assert.equal(find(daysOfMonth).eq(3).text(), 'June 12th', 'fourth day of month is correct');
+  assert.equal(find(daysOfMonth).eq(0).text(), 'May 22nd', 'first day of month is correct');
+  assert.equal(find(daysOfMonth).eq(1).text(), 'May 29th', 'second day of month is correct');
+  assert.equal(find(daysOfMonth).eq(2).text(), 'June 5th', 'third day of month is correct');
+  assert.equal(find(daysOfMonth).eq(3).text(), 'June 12th', 'fourth day of month is correct');
 
-    assert.equal(find(startsTime).eq(0).text().trim(), 'Starts: 2:15 AM', 'first start time is correct');
-    assert.equal(find(startsTime).eq(1).text().trim(), 'Starts: 2:15 AM', 'second start time is correct');
-    assert.equal(find(startsTime).eq(2).text().trim(), 'Starts: 2:15 AM', 'third start time is correct');
-    assert.equal(find(startsTime).eq(3).text().trim(), 'Starts: 2:15 AM', 'fourth start time is correct');
+  assert.equal(find(startsTime).eq(0).text().trim(), 'Starts: 2:15 AM', 'first start time is correct');
+  assert.equal(find(startsTime).eq(1).text().trim(), 'Starts: 2:15 AM', 'second start time is correct');
+  assert.equal(find(startsTime).eq(2).text().trim(), 'Starts: 2:15 AM', 'third start time is correct');
+  assert.equal(find(startsTime).eq(3).text().trim(), 'Starts: 2:15 AM', 'fourth start time is correct');
 
-    assert.equal(find(endsTime).eq(0).text().trim(), 'Ends: 3:23 PM', 'first end time is correct');
-    assert.equal(find(endsTime).eq(1).text().trim(), 'Ends: 3:23 PM', 'second end time is correct');
-    assert.equal(find(endsTime).eq(2).text().trim(), 'Ends: 3:23 PM', 'third end time is correct');
-    assert.equal(find(endsTime).eq(3).text().trim(), 'Ends: 3:23 PM', 'fourth end time is correct');
+  assert.equal(find(endsTime).eq(0).text().trim(), 'Ends: 3:23 PM', 'first end time is correct');
+  assert.equal(find(endsTime).eq(1).text().trim(), 'Ends: 3:23 PM', 'second end time is correct');
+  assert.equal(find(endsTime).eq(2).text().trim(), 'Ends: 3:23 PM', 'third end time is correct');
+  assert.equal(find(endsTime).eq(3).text().trim(), 'Ends: 3:23 PM', 'fourth end time is correct');
 
-    assert.equal(find(learnerGroups).eq(0).text().trim(), 'learner group 0', 'first correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(1).text().trim(), 'learner group 1', 'first correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(2).text().trim(), 'learner group 0', 'second correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(3).text().trim(), 'learner group 1', 'second correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(4).text().trim(), 'learner group 0', 'third correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(5).text().trim(), 'learner group 1', 'third correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(6).text().trim(), 'learner group 0', 'fourth correct learner group is picked');
-    assert.equal(find(learnerGroups).eq(7).text().trim(), 'learner group 1', 'fourth correct learner group is picked');
-
-  });
+  assert.equal(find(learnerGroups).eq(0).text().trim(), 'learner group 0', 'first correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(1).text().trim(), 'learner group 1', 'first correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(2).text().trim(), 'learner group 0', 'second correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(3).text().trim(), 'learner group 1', 'second correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(4).text().trim(), 'learner group 0', 'third correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(5).text().trim(), 'learner group 1', 'third correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(6).text().trim(), 'learner group 0', 'fourth correct learner group is picked');
+  assert.equal(find(learnerGroups).eq(7).text().trim(), 'learner group 1', 'fourth correct learner group is picked');
 });
 
 test('edit offerings twice #2850', async assert => {

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -7,7 +7,6 @@ import {
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
-import Ember from 'ember';
 
 var application;
 var fixtures = {};
@@ -34,7 +33,7 @@ module('Acceptance: Session - Overview', {
   }
 });
 
-test('check fields', function(assert) {
+test('check fields', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -48,18 +47,16 @@ test('check fields', function(assert) {
     sessionType: 1,
     sessionDescription: 1,
   });
-  visit(url);
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.session-overview');
-    assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 0'));
-    assert.equal(getElementText(find('.sessiondescription .content', container)), getText(fixtures.sessionDescription.description));
-    assert.equal(find('.sessionilmhours', container).length, 0);
-  });
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.session-overview');
+  assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 0'));
+  assert.equal(getElementText(find('.sessiondescription .content', container)), getText(fixtures.sessionDescription.description));
+  assert.equal(find('.sessionilmhours', container).length, 0);
 });
 
-test('check remove ilm', function(assert) {
+test('check remove ilm', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -70,25 +67,21 @@ test('check remove ilm', function(assert) {
     course: 1,
     ilmSession: 1
   });
-  visit(url);
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.session-overview');
-    assert.equal(find('.sessionilmhours', container).length, 1);
-    assert.equal(find('.sessionilmduedate', container).length, 1);
-    var dueDate = moment(ilmSession.dueDate).format('L');
-    assert.equal(getElementText(find('.sessionilmhours .content', container)), ilmSession.hours);
-    assert.equal(getElementText(find('.sessionilmduedate .editable', container)), dueDate);
-    click(find('.independentlearningcontrol .switch-handle', container));
-    andThen(function(){
-      assert.equal(find('.sessionilmhours', container).length, 0);
-      assert.equal(find('.sessionilmduedate', container).length, 0);
-    });
-  });
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.session-overview');
+  assert.equal(find('.sessionilmhours', container).length, 1);
+  assert.equal(find('.sessionilmduedate', container).length, 1);
+  var dueDate = moment(ilmSession.dueDate).format('L');
+  assert.equal(getElementText(find('.sessionilmhours .content', container)), ilmSession.hours);
+  assert.equal(getElementText(find('.sessionilmduedate .editable', container)), dueDate);
+  await click(find('.independentlearningcontrol .switch-handle', container));
+  assert.equal(find('.sessionilmhours', container).length, 0);
+  assert.equal(find('.sessionilmduedate', container).length, 0);
 });
 
-test('check add ilm', function(assert) {
+test('check add ilm', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -98,22 +91,18 @@ test('check add ilm', function(assert) {
     sessionType: 1,
     description: 'some text',
   });
-  visit(url);
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    var container = find('.session-overview');
-    click(find('.independentlearningcontrol .switch-handle', container));
-    andThen(function(){
-      assert.equal(find('.sessionilmhours', container).length, 1);
-      assert.equal(find('.sessionilmduedate', container).length, 1);
-      assert.equal(find('.sessionassociatedgroups', container).length, 0);
-      assert.equal(getElementText(find('.sessionilmhours .content', container)), 1);
-    });
-  });
+  assert.equal(currentPath(), 'course.session.index');
+  var container = find('.session-overview');
+  await click(find('.independentlearningcontrol .switch-handle', container));
+  assert.equal(find('.sessionilmhours', container).length, 1);
+  assert.equal(find('.sessionilmduedate', container).length, 1);
+  assert.equal(find('.sessionassociatedgroups', container).length, 0);
+  assert.equal(getElementText(find('.sessionilmhours .content', container)), 1);
 });
 
-test('change ilm hours', function(assert) {
+test('change ilm hours', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -124,27 +113,21 @@ test('change ilm hours', function(assert) {
     course: 1,
     ilmSession: 1
   });
-  visit(url);
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    assert.equal(find('.sessionilmhours', container).length, 1);
-    var container = find('.sessionilmhours');
-    assert.equal(getElementText(find('.content', container)), ilmSession.hours);
-    click(find('.editable', container));
-    andThen(function(){
-      var input = find('.editinplace input', container);
-      assert.equal(getText(input.val()), ilmSession.hours);
-      fillIn(input, 23);
-      click(find('.editinplace .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.content', container)), 23);
-      });
-    });
-  });
+  assert.equal(currentPath(), 'course.session.index');
+  assert.equal(find('.sessionilmhours', container).length, 1);
+  var container = find('.sessionilmhours');
+  assert.equal(getElementText(find('.content', container)), ilmSession.hours);
+  await click(find('.editable', container));
+  var input = find('.editinplace input', container);
+  assert.equal(getText(input.val()), ilmSession.hours);
+  await fillIn(input, 23);
+  await click(find('.editinplace .actions .done', container));
+  assert.equal(getElementText(find('.content', container)), 23);
 });
 
-test('change ilm due date', function(assert) {
+test('change ilm due date', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -155,28 +138,22 @@ test('change ilm due date', function(assert) {
     course: 1,
     ilmSession: 1
   });
-  visit(url);
-  andThen(function() {
-    var container = find('.sessionilmduedate');
-    var dueDate = moment(ilmSession.dueDate).format('L');
-    assert.equal(getElementText(find('.editable', container)), dueDate);
-    click(find('.editable', container));
-    andThen(function(){
-      var input = find('.editinplace input', container);
-      assert.equal(getText(input.val()), getText(dueDate));
-      var interactor = openDatepicker(find('input', container));
-      assert.equal(interactor.selectedYear(), moment(ilmSession.dueDate).format('YYYY'));
-      var newDate = moment(ilmSession.dueDate).add(1, 'year').add(1, 'month');
-      interactor.selectDate(newDate.toDate());
-      click(find('.editinplace .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.editable', container)), newDate.format('L'));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.sessionilmduedate');
+  var dueDate = moment(ilmSession.dueDate).format('L');
+  assert.equal(getElementText(find('.editable', container)), dueDate);
+  await click(find('.editable', container));
+  var input = find('.editinplace input', container);
+  assert.equal(getText(input.val()), getText(dueDate));
+  var interactor = openDatepicker(find('input', container));
+  assert.equal(interactor.selectedYear(), moment(ilmSession.dueDate).format('YYYY'));
+  var newDate = moment(ilmSession.dueDate).add(1, 'year').add(1, 'month');
+  interactor.selectDate(newDate.toDate());
+  await click(find('.editinplace .actions .done', container));
+  assert.equal(getElementText(find('.editable', container)), newDate.format('L'));
 });
 
-test('change title', function(assert) {
+test('change title', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -184,24 +161,18 @@ test('change title', function(assert) {
     course: 1,
     sessionType: 1
   });
-  visit(url);
-  andThen(function() {
-    var container = find('.session-header .title');
-    assert.equal(getElementText(container), getText('session 0'));
-    click(find('.editable', container));
-    andThen(function(){
-      var input = find('.editinplace input', container);
-      assert.equal(getText(input.val()), getText('session 0'));
-      fillIn(input, 'test new title');
-      click(find('.editinplace .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(container), getText('test new title'));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.session-header .title');
+  assert.equal(getElementText(container), getText('session 0'));
+  await click(find('.editable', container));
+  var input = find('.editinplace input', container);
+  assert.equal(getText(input.val()), getText('session 0'));
+  await fillIn(input, 'test new title');
+  await click(find('.editinplace .actions .done', container));
+  assert.equal(getElementText(container), getText('test new title'));
 });
 
-test('change type', function(assert) {
+test('change type', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -209,24 +180,18 @@ test('change type', function(assert) {
     course: 1,
     sessionType: 1
   });
-  visit(url);
-  andThen(function() {
-    var container = find('.session-overview');
-    assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 0'));
-    click(find('.sessiontype .editable', container));
-    andThen(function(){
+  await visit(url);
+  var container = find('.session-overview');
+  assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 0'));
+  await click(find('.sessiontype .editable', container));
 
-      let options = find('.sessiontype select option', container);
-      assert.equal(options.length, 2);
-      assert.equal(getElementText(options.eq(0)), getText('session type 0'));
-      assert.equal(getElementText(options.eq(1)), getText('session type 1'));
-      pickOption(find('.sessiontype select', container), 'session type 1', assert);
-      click(find('.sessiontype .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 1'));
-      });
-    });
-  });
+  let options = find('.sessiontype select option', container);
+  assert.equal(options.length, 2);
+  assert.equal(getElementText(options.eq(0)), getText('session type 0'));
+  assert.equal(getElementText(options.eq(1)), getText('session type 1'));
+  await pickOption(find('.sessiontype select', container), 'session type 1', assert);
+  await click(find('.sessiontype .actions .done', container));
+  assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 1'));
 });
 
 test('session attributes are shown by school config', async assert => {
@@ -386,7 +351,7 @@ test('change attendance required', async assert => {
   await testAttributeToggle(assert, 'showSessionAttendanceRequired', 'sessionattendancerequired');
 });
 
-test('change description', function(assert) {
+test('change description', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -395,30 +360,21 @@ test('change description', function(assert) {
     sessionType: 1,
     sessionDescription: 1
   });
-  visit(url);
-  andThen(function() {
-    var description = getText(fixtures.sessionDescription.description);
-    var container = find('.sessiondescription');
-    assert.equal(getElementText(find('.content', container)), description);
-    click(find('.editable', container));
-    andThen(function(){
-      //wait for the editor to load
-      Ember.run.later(()=>{
-        let editor = find('.sessiondescription .fr-box');
-        let editorContents = editor.data('froala.editor').$el.text();
-        assert.equal(getText(editorContents), description);
-        editor.froalaEditor('html.set', 'test new description');
-        editor.froalaEditor('events.trigger', 'contentChanged');
-        click(find('.editinplace .actions .done', container));
-        andThen(function(){
-          assert.equal(getElementText(find('.content', container)), getText('test new description'));
-        });
-      }, 100);
-    });
-  });
+  await visit(url);
+  var description = getText(fixtures.sessionDescription.description);
+  var container = find('.sessiondescription');
+  assert.equal(getElementText(find('.content', container)), description);
+  await click(find('.editable', container));
+  let editor = find('.sessiondescription .fr-box');
+  let editorContents = editor.data('froala.editor').$el.text();
+  assert.equal(getText(editorContents), description);
+  editor.froalaEditor('html.set', 'test new description');
+  editor.froalaEditor('events.trigger', 'contentChanged');
+  await click(find('.editinplace .actions .done', container));
+  assert.equal(getElementText(find('.content', container)), getText('test new description'));
 });
 
-test('add description', function(assert) {
+test('add description', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -426,29 +382,20 @@ test('add description', function(assert) {
     course: 1,
     sessionType: 1
   });
-  visit(url);
-  andThen(function() {
-    var container = find('.sessiondescription');
-    assert.equal(getElementText(find('.content', container)), getText('Click to edit'));
-    click(find('.editable', container));
-    andThen(function(){
-      //wait for the editor to load
-      Ember.run.later(()=>{
-        let editor = find('.sessiondescription .fr-box');
-        let editorContents = editor.data('froala.editor').$el.text();
-        assert.equal(getText(editorContents), '');
-        editor.froalaEditor('html.set', 'test new description');
-        editor.froalaEditor('events.trigger', 'contentChanged');
-        click(find('.editinplace .actions .done', container));
-        andThen(function(){
-          assert.equal(getElementText(find('.content', container)), getText('test new description'));
-        });
-      }, 100);
-    });
-  });
+  await visit(url);
+  var container = find('.sessiondescription');
+  assert.equal(getElementText(find('.content', container)), getText('Click to edit'));
+  await click(find('.editable', container));
+  let editor = find('.sessiondescription .fr-box');
+  let editorContents = editor.data('froala.editor').$el.text();
+  assert.equal(getText(editorContents), '');
+  editor.froalaEditor('html.set', 'test new description');
+  editor.froalaEditor('events.trigger', 'contentChanged');
+  await click(find('.editinplace .actions .done', container));
+  assert.equal(getElementText(find('.content', container)), getText('test new description'));
 });
 
-test('empty description removes description', function(assert) {
+test('empty description removes description', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -462,27 +409,18 @@ test('empty description removes description', function(assert) {
   const edit = `${container} .editable`;
   const save = `${container} .done`;
 
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(description), getText('Click to edit'));
-    click(edit);
-    andThen(function(){
-      //wait for the editor to load
-      Ember.run.later(()=>{
-        let editor = find(editorElement);
-        assert.equal(editor.data('froala.editor').$el.text(), '');
-        editor.froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
-        editor.froalaEditor('events.trigger', 'contentChanged');
-        click(save);
-        andThen(function(){
-          assert.equal(getElementText(description), getText('Click to edit'));
-        });
-      }, 100);
-    });
-  });
+  await visit(url);
+  assert.equal(getElementText(description), getText('Click to edit'));
+  await click(edit);
+  let editor = find(editorElement);
+  assert.equal(editor.data('froala.editor').$el.text(), '');
+  editor.froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
+  editor.froalaEditor('events.trigger', 'contentChanged');
+  await click(save);
+  assert.equal(getElementText(description), getText('Click to edit'));
 });
 
-test('remove description', function(assert) {
+test('remove description', async function(assert) {
   server.create('user', {
     id: 4136
   });
@@ -497,29 +435,20 @@ test('remove description', function(assert) {
   const edit = `${container} .editable`;
   const save = `${container} .done`;
 
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(description), 'sessiondescription0');
-    click(edit);
-    andThen(function(){
-      //wait for the editor to load
-      Ember.run.later(()=>{
-        let editor = find(editorElement);
-        let editorContents = editor.data('froala.editor').$el.text();
-        assert.equal(getText(editorContents), 'sessiondescription0');
-        editor.froalaEditor('html.set', '');
-        editor.froalaEditor('events.trigger', 'contentChanged');
-        click(save);
-        andThen(function(){
-          assert.equal(getElementText(description), getText('Click to edit'));
-        });
-      }, 100);
-    });
-  });
+  await visit(url);
+  assert.equal(getElementText(description), 'sessiondescription0');
+  await click(edit);
+  let editor = find(editorElement);
+  let editorContents = editor.data('froala.editor').$el.text();
+  assert.equal(getText(editorContents), 'sessiondescription0');
+  editor.froalaEditor('html.set', '');
+  editor.froalaEditor('events.trigger', 'contentChanged');
+  await click(save);
+  assert.equal(getElementText(description), getText('Click to edit'));
 });
 
 
-test('click copy', function(assert) {
+test('click copy', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -534,15 +463,13 @@ test('click copy', function(assert) {
   });
 
   const copy = '.session-overview a.copy';
-  visit(url);
-  click(copy);
+  await visit(url);
+  await click(copy);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.copy');
-  });
+  assert.equal(currentPath(), 'course.session.copy');
 });
 
-test('copy hidden from instructors', function(assert) {
+test('copy hidden from instructors', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -555,17 +482,15 @@ test('copy hidden from instructors', function(assert) {
     course: 1,
     sessionType: 1
   });
-  visit(url);
+  await visit(url);
   const container = '.session-overview';
   const copy = `${container} a.copy`;
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    assert.equal(find(copy).length, 0);
-  });
+  assert.equal(currentPath(), 'course.session.index');
+  assert.equal(find(copy).length, 0);
 });
 
-test('copy visible to developers', function(assert) {
+test('copy visible to developers', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -578,17 +503,15 @@ test('copy visible to developers', function(assert) {
     course: 1,
     sessionType: 1
   });
-  visit(url);
+  await visit(url);
   const container = '.session-overview';
   const copy = `${container} a.copy`;
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    assert.equal(find(copy).length, 1);
-  });
+  assert.equal(currentPath(), 'course.session.index');
+  assert.equal(find(copy).length, 1);
 });
 
-test('copy visible to course directors', function(assert) {
+test('copy visible to course directors', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -601,17 +524,15 @@ test('copy visible to course directors', function(assert) {
     course: 1,
     sessionType: 1
   });
-  visit(url);
+  await visit(url);
   const container = '.session-overview';
   const copy = `${container} a.copy`;
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    assert.equal(find(copy).length, 1);
-  });
+  assert.equal(currentPath(), 'course.session.index');
+  assert.equal(find(copy).length, 1);
 });
 
-test('copy hidden on copy route', function(assert) {
+test('copy hidden on copy route', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -624,12 +545,10 @@ test('copy hidden on copy route', function(assert) {
     course: 1,
     sessionType: 1
   });
-  visit(`${url}/copy`);
+  await visit(`${url}/copy`);
   const container = '.session-overview';
   const copy = `${container} a.copy`;
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.copy');
-    assert.equal(find(copy).length, 0);
-  });
+  assert.equal(currentPath(), 'course.session.copy');
+  assert.equal(find(copy).length, 0);
 });

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -7,8 +7,10 @@ import {
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
 import { openDatepicker } from 'ember-pikaday/helpers/pikaday';
+import wait from 'ember-test-helpers/wait';
 import Ember from 'ember';
 
+const { run } = Ember;
 var application;
 let url = '/courses/1/sessions/1/publicationcheck';
 module('Acceptance: Session - Publication Check', {
@@ -52,7 +54,7 @@ module('Acceptance: Session - Publication Check', {
   }
 });
 
-test('full session count', function(assert) {
+test('full session count', async function(assert) {
   server.create('session', {
     course: 1,
     offerings: [1],
@@ -62,56 +64,49 @@ test('full session count', function(assert) {
     sessionType: 1,
     sessionDescription: 1
   });
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.publicationCheck');
-    var items = find('.session-publicationcheck table tbody td');
-    assert.equal(getElementText(items.eq(0)), getText('session 0'));
-    assert.equal(getElementText(items.eq(1)), getText('Yes (1)'));
-    assert.equal(getElementText(items.eq(2)), getText('Yes (1)'));
-    assert.equal(getElementText(items.eq(3)), getText('Yes (1)'));
-    assert.equal(getElementText(items.eq(4)), getText('Yes (1)'));
-  });
+  await visit(url);
+  assert.equal(currentPath(), 'course.session.publicationCheck');
+  var items = find('.session-publicationcheck table tbody td');
+  assert.equal(getElementText(items.eq(0)), getText('session 0'));
+  assert.equal(getElementText(items.eq(1)), getText('Yes (1)'));
+  assert.equal(getElementText(items.eq(2)), getText('Yes (1)'));
+  assert.equal(getElementText(items.eq(3)), getText('Yes (1)'));
+  assert.equal(getElementText(items.eq(4)), getText('Yes (1)'));
 });
 
-test('empty session count', function(assert) {
+test('empty session count', async function(assert) {
   //create 2 because the second one is empty
   server.createList('session', 2, {
     course: 1
   });
   server.db.courses.update(1, {sessions: [1, 2]});
-  visit('/courses/1/sessions/2/publicationcheck');
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.publicationCheck');
-    var items = find('.session-publicationcheck table tbody td');
-    assert.equal(getElementText(items.eq(0)), getText('session 1'));
-    assert.equal(getElementText(items.eq(1)), getText('No'));
-    assert.equal(getElementText(items.eq(2)), getText('No'));
-    assert.equal(getElementText(items.eq(3)), getText('No'));
-    assert.equal(getElementText(items.eq(4)), getText('No'));
-  });
+  await visit('/courses/1/sessions/2/publicationcheck');
+  assert.equal(currentPath(), 'course.session.publicationCheck');
+  var items = find('.session-publicationcheck table tbody td');
+  assert.equal(getElementText(items.eq(0)), getText('session 1'));
+  assert.equal(getElementText(items.eq(1)), getText('No'));
+  assert.equal(getElementText(items.eq(2)), getText('No'));
+  assert.equal(getElementText(items.eq(3)), getText('No'));
+  assert.equal(getElementText(items.eq(4)), getText('No'));
 });
 
 //also test all the session overview fields (Issue #496)
-test('check fields', function(assert) {
+test('check fields', async function(assert) {
   server.create('session', {
     course: 1,
     sessionType: 1,
     sessionDescription: 1,
   });
-  visit(url);
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.publicationCheck');
-    var container = find('.session-overview');
-    assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 0'));
-    assert.equal(getElementText(find('.sessiondescription .content', container)), getText('session description 0'));
-    assert.equal(find('.sessionilmhours', container).length, 0);
-  });
-
+  assert.equal(currentPath(), 'course.session.publicationCheck');
+  var container = find('.session-overview');
+  assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 0'));
+  assert.equal(getElementText(find('.sessiondescription .content', container)), getText('session description 0'));
+  assert.equal(find('.sessionilmhours', container).length, 0);
 });
 
-test('check remove ilm', function(assert) {
+test('check remove ilm', async function(assert) {
   var ilmSession = server.create('ilmSession', {
     session: 1
   });
@@ -119,46 +114,37 @@ test('check remove ilm', function(assert) {
     course: 1,
     ilmSession: 1
   });
-  visit(url);
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.publicationCheck');
-    var container = find('.session-overview');
-    assert.equal(find('.sessionilmhours', container).length, 1);
-    assert.equal(find('.sessionilmduedate', container).length, 1);
-    var dueDate = moment(ilmSession.dueDate).format('L');
-    assert.equal(getElementText(find('.sessionilmhours .content', container)), ilmSession.hours);
-    assert.equal(getElementText(find('.sessionilmduedate .editable', container)), dueDate);
-    click(find('.independentlearningcontrol .switch-handle', container));
-    andThen(function(){
-      assert.equal(find('.sessionilmhours', container).length, 0);
-      assert.equal(find('.sessionilmduedate', container).length, 0);
-    });
-  });
+  assert.equal(currentPath(), 'course.session.publicationCheck');
+  var container = find('.session-overview');
+  assert.equal(find('.sessionilmhours', container).length, 1);
+  assert.equal(find('.sessionilmduedate', container).length, 1);
+  var dueDate = moment(ilmSession.dueDate).format('L');
+  assert.equal(getElementText(find('.sessionilmhours .content', container)), ilmSession.hours);
+  assert.equal(getElementText(find('.sessionilmduedate .editable', container)), dueDate);
+  await click(find('.independentlearningcontrol .switch-handle', container));
+  assert.equal(find('.sessionilmhours', container).length, 0);
+  assert.equal(find('.sessionilmduedate', container).length, 0);
 });
 
-test('check add ilm', function(assert) {
-
+test('check add ilm', async function(assert) {
   server.create('session', {
     course: 1,
     sessionType: 1,
     description: 'some text',
   });
-  visit(url);
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.publicationCheck');
-    var container = find('.session-overview');
-    click(find('.independentlearningcontrol .switch-handle', container));
-    andThen(function(){
-      assert.equal(find('.sessionilmhours', container).length, 1);
-      assert.equal(find('.sessionilmduedate', container).length, 1);
-      assert.equal(getElementText(find('.sessionilmhours .content', container)), 1);
-    });
-  });
+  assert.equal(currentPath(), 'course.session.publicationCheck');
+  var container = find('.session-overview');
+  await click(find('.independentlearningcontrol .switch-handle', container));
+  assert.equal(find('.sessionilmhours', container).length, 1);
+  assert.equal(find('.sessionilmduedate', container).length, 1);
+  assert.equal(getElementText(find('.sessionilmhours .content', container)), 1);
 });
 
-test('change ilm hours', function(assert) {
+test('change ilm hours', async function(assert) {
   var ilmSession = server.create('ilmSession', {
     session: 1
   });
@@ -166,27 +152,21 @@ test('change ilm hours', function(assert) {
     course: 1,
     ilmSession: 1
   });
-  visit(url);
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.publicationCheck');
-    assert.equal(find('.sessionilmhours', container).length, 1);
-    var container = find('.session-overview .sessionilmhours');
-    assert.equal(getElementText(find('.content', container)), ilmSession.hours);
-    click(find('.editable', container));
-    andThen(function(){
-      var input = find('.editinplace input', container);
-      assert.equal(getText(input.val()), ilmSession.hours);
-      fillIn(input, 23);
-      click(find('.editinplace .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.content', container)), 23);
-      });
-    });
-  });
+  assert.equal(currentPath(), 'course.session.publicationCheck');
+  assert.equal(find('.sessionilmhours', container).length, 1);
+  var container = find('.session-overview .sessionilmhours');
+  assert.equal(getElementText(find('.content', container)), ilmSession.hours);
+  await click(find('.editable', container));
+  var input = find('.editinplace input', container);
+  assert.equal(getText(input.val()), ilmSession.hours);
+  await fillIn(input, 23);
+  await click(find('.editinplace .actions .done', container));
+  assert.equal(getElementText(find('.content', container)), 23);
 });
 
-test('change ilm due date', function(assert) {
+test('change ilm due date', async function(assert) {
   var ilmSession = server.create('ilmSession', {
     session: 1
   });
@@ -194,71 +174,53 @@ test('change ilm due date', function(assert) {
     course: 1,
     ilmSession: 1
   });
-  visit(url);
-  andThen(function() {
-    var container = find('.session-overview .sessionilmduedate');
-    var dueDate = moment(ilmSession.dueDate).format('L');
-    assert.equal(getElementText(find('.editable', container)), dueDate);
-    click(find('.editable', container));
-    andThen(function(){
-      var input = find('.editinplace input', container);
-      assert.equal(getText(input.val()), getText(dueDate));
-      var interactor = openDatepicker(find('input', container));
-      assert.equal(interactor.selectedYear(), moment(ilmSession.dueDate).format('YYYY'));
-      var newDate = moment(ilmSession.dueDate).add(1, 'year').add(1, 'month');
-      interactor.selectDate(newDate.toDate());
-      click(find('.editinplace .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.editable', container)), newDate.format('L'));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.session-overview .sessionilmduedate');
+  var dueDate = moment(ilmSession.dueDate).format('L');
+  assert.equal(getElementText(find('.editable', container)), dueDate);
+  await click(find('.editable', container));
+  var input = find('.editinplace input', container);
+  assert.equal(getText(input.val()), getText(dueDate));
+  var interactor = openDatepicker(find('input', container));
+  assert.equal(interactor.selectedYear(), moment(ilmSession.dueDate).format('YYYY'));
+  var newDate = moment(ilmSession.dueDate).add(1, 'year').add(1, 'month');
+  interactor.selectDate(newDate.toDate());
+  await click(find('.editinplace .actions .done', container));
+  assert.equal(getElementText(find('.editable', container)), newDate.format('L'));
 });
 
-test('change title', function(assert) {
+test('change title', async function(assert) {
   server.create('session', {
     course: 1,
     sessionType: 1
   });
-  visit(url);
-  andThen(function() {
-    let container = find('.session-header .title');
-    assert.equal(getElementText(container), getText('session 0'));
-    click(find('.editable', container));
-    andThen(function(){
-      let input = find('.editinplace input', container);
-      assert.equal(getText(input.val()), getText('session 0'));
-      fillIn(input, 'test new title');
-      click(find('.done', container));
-      andThen(function(){
-        assert.equal(getElementText(container), getText('test new title'));
-      });
-    });
-  });
+  await visit(url);
+  let container = find('.session-header .title');
+  assert.equal(getElementText(container), getText('session 0'));
+  await click(find('.editable', container));
+  let input = find('.editinplace input', container);
+  assert.equal(getText(input.val()), getText('session 0'));
+  await fillIn(input, 'test new title');
+  await click(find('.done', container));
+  assert.equal(getElementText(container), getText('test new title'));
 });
 
-test('change type', function(assert) {
+test('change type', async function(assert) {
   server.create('session', {
     course: 1,
     sessionType: 2
   });
-  visit(url);
-  andThen(function() {
-    var container = find('.session-overview');
-    assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 1'));
-    click(find('.sessiontype .editable', container));
-    andThen(function(){
-      let options = find('.sessiontype select option', container);
-      assert.equal(options.length, 2);
-      assert.equal(getElementText(options.eq(0)), getText('session type 0'));
-      assert.equal(getElementText(options.eq(1)), getText('session type 1'));
-      pickOption(find('.sessiontype select', container), 'session type 0', assert);
-      click(find('.sessiontype .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 0'));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.session-overview');
+  assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 1'));
+  await click(find('.sessiontype .editable', container));
+  let options = find('.sessiontype select option', container);
+  assert.equal(options.length, 2);
+  assert.equal(getElementText(options.eq(0)), getText('session type 0'));
+  assert.equal(getElementText(options.eq(1)), getText('session type 1'));
+  await pickOption(find('.sessiontype select', container), 'session type 0', assert);
+  await click(find('.sessiontype .actions .done', container));
+  assert.equal(getElementText(find('.sessiontype .editable', container)), getText('session type 0'));
 });
 
 
@@ -420,58 +382,47 @@ test('change attendance required', async assert => {
   await testAttributeToggle(assert, 'showSessionAttendanceRequired', 'sessionattendancerequired');
 });
 
-test('change description', function(assert) {
+test('change description', async function(assert) {
   server.create('session', {
     course: 1,
     sessionType: 1,
     sessionDescription: 1
   });
-  visit(url);
-  andThen(function() {
-    let description = getText('session description 0');
-    let container = find('.session-overview .sessiondescription');
-    assert.equal(getElementText(find('.content', container)), description);
-    click(find('.editable .clickable', container));
-    andThen(function(){
-      //wait for the editor to load
-      Ember.run.later(()=>{
-        let editor = find('.sessiondescription .fr-box');
-        let editorContents = editor.data('froala.editor').$el.text();
-        assert.equal(getText(editorContents), description);
-        editor.froalaEditor('html.set', 'test new description');
-        editor.froalaEditor('events.trigger', 'contentChanged');
-        click(find('.editinplace .actions .done', container));
-        andThen(function(){
-          assert.equal(getElementText(find('.content', container)), getText('test new description'));
-        });
-      }, 100);
-    });
-  });
+  await visit(url);
+  let description = getText('session description 0');
+  let container = find('.session-overview .sessiondescription');
+  assert.equal(getElementText(find('.content', container)), description);
+  await click(find('.editable .clickable', container));
+  //wait for the editor to load
+  run.later(async ()=>{
+    let editor = find('.sessiondescription .fr-box');
+    let editorContents = editor.data('froala.editor').$el.text();
+    assert.equal(getText(editorContents), description);
+    editor.froalaEditor('html.set', 'test new description');
+    editor.froalaEditor('events.trigger', 'contentChanged');
+    await click(find('.editinplace .actions .done', container));
+    assert.equal(getElementText(find('.content', container)), getText('test new description'));
+  }, 100);
+  await wait();
 });
 
-test('add description', function(assert) {
+test('add description', async function(assert) {
   server.create('session', {
     course: 1,
     sessionType: 1
   });
-  visit(url);
-  andThen(function() {
-    let container = find('.session-overview .sessiondescription');
-    assert.equal(getElementText(container), getText('Description: Click to edit'));
-    click(find('.editable', container));
-    andThen(function(){
-      //wait for the editor to load
-      Ember.run.later(()=>{
-        let editor = find('.sessiondescription .fr-box');
-        let editorContents = editor.data('froala.editor').$el.text();
-        assert.equal(getText(editorContents), '');
-        editor.froalaEditor('html.set', 'test new description');
-        editor.froalaEditor('events.trigger', 'contentChanged');
-        click(find('.editinplace .actions .done', container));
-        andThen(function(){
-          assert.equal(getElementText(container), getText('Description: test new description'));
-        });
-      }, 100);
-    });
+  await visit(url);
+  let container = find('.session-overview .sessiondescription');
+  assert.equal(getElementText(container), getText('Description: Click to edit'));
+  await click(find('.editable', container));
+  run.later(async () => {
+    let editor = find('.sessiondescription .fr-box');
+    let editorContents = editor.data('froala.editor').$el.text();
+    assert.equal(getText(editorContents), '');
+    editor.froalaEditor('html.set', 'test new description');
+    editor.froalaEditor('events.trigger', 'contentChanged');
+    await click(find('.editinplace .actions .done', container));
+    assert.equal(getElementText(container), getText('Description: test new description'));
   });
+  await wait();
 });

--- a/tests/acceptance/course/session/publish-test.js
+++ b/tests/acceptance/course/session/publish-test.js
@@ -51,175 +51,142 @@ module('Acceptance: Session - Publish', {
   }
 });
 
-test('check published session', function(assert) {
-  visit('/courses/1/sessions/' + fixtures.publishedSession.id);
+test('check published session', async function(assert) {
+  await visit('/courses/1/sessions/' + fixtures.publishedSession.id);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Published'));
-    //we have to click the button to create the options
-    click(selector);
+  assert.equal(currentPath(), 'course.session.index');
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Published'));
+  //we have to click the button to create the options
+  await click(selector);
 
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Review 3 Missing Items', 'Mark as Scheduled', 'UnPublish Session'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Review 3 Missing Items', 'Mark as Scheduled', 'UnPublish Session'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check scheduled session', function(assert) {
-  visit('/courses/1/sessions/' + fixtures.scheduledSession.id);
+test('check scheduled session', async function(assert) {
+  await visit('/courses/1/sessions/' + fixtures.scheduledSession.id);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Scheduled'));
-    //we have to click the button to create the options
-    click(selector);
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Publish As-is', 'Review 3 Missing Items', 'UnPublish Session'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(currentPath(), 'course.session.index');
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Scheduled'));
+  //we have to click the button to create the options
+  await click(selector);
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Publish As-is', 'Review 3 Missing Items', 'UnPublish Session'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check draft session', function(assert) {
-  visit('/courses/1/sessions/' + fixtures.draftSession.id);
+test('check draft session', async function(assert) {
+  await visit('/courses/1/sessions/' + fixtures.draftSession.id);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'course.session.index');
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Not Published'));
-    //we have to click the button to create the options
-    click(selector);
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Publish As-is', 'Review 3 Missing Items', 'Mark as Scheduled'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(currentPath(), 'course.session.index');
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Not Published'));
+  //we have to click the button to create the options
+  await click(selector);
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Publish As-is', 'Review 3 Missing Items', 'Mark as Scheduled'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check publish draft session', function(assert) {
-  visit('/courses/1/sessions/' + fixtures.draftSession.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const publish = `${choices}:eq(0)`;
-    click(selector);
-    click(publish);
+test('check publish draft session', async function(assert) {
+  await visit('/courses/1/sessions/' + fixtures.draftSession.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const publish = `${choices}:eq(0)`;
+  await click(selector);
+  await click(publish);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Published'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Published'));
 });
 
-test('check schedule draft session', function(assert) {
-  visit('/courses/1/sessions/' + fixtures.draftSession.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const schedule = `${choices}:eq(2)`;
-    click(selector);
-    click(schedule);
+test('check schedule draft session', async function(assert) {
+  await visit('/courses/1/sessions/' + fixtures.draftSession.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const schedule = `${choices}:eq(2)`;
+  await click(selector);
+  await click(schedule);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Scheduled'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Scheduled'));
 });
 
-test('check publish scheduled session', function(assert) {
-  visit('/courses/1/sessions/' + fixtures.scheduledSession.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const publish = `${choices}:eq(0)`;
-    click(selector);
-    click(publish);
+test('check publish scheduled session', async function(assert) {
+  await visit('/courses/1/sessions/' + fixtures.scheduledSession.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const publish = `${choices}:eq(0)`;
+  await click(selector);
+  await click(publish);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Published'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Published'));
 });
 
-test('check unpublish scheduled session', function(assert) {
-  visit('/courses/1/sessions/' + fixtures.scheduledSession.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const unPublish = `${choices}:eq(2)`;
-    click(selector);
-    click(unPublish);
+test('check unpublish scheduled session', async function(assert) {
+  await visit('/courses/1/sessions/' + fixtures.scheduledSession.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const unPublish = `${choices}:eq(2)`;
+  await click(selector);
+  await click(unPublish);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Not Published'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Not Published'));
 });
 
-test('check schedule published session', function(assert) {
-  visit('/courses/1/sessions/' + fixtures.publishedSession.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const schedule = `${choices}:eq(1)`;
-    click(selector);
-    click(schedule);
+test('check schedule published session', async function(assert) {
+  await visit('/courses/1/sessions/' + fixtures.publishedSession.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const schedule = `${choices}:eq(1)`;
+  await click(selector);
+  await click(schedule);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Scheduled'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Scheduled'));
 });
 
-test('check unpublish published session', function(assert) {
-  visit('/courses/1/sessions/' + fixtures.publishedSession.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const unPublish = `${choices}:eq(2)`;
-    click(selector);
-    click(unPublish);
+test('check unpublish published session', async function(assert) {
+  await visit('/courses/1/sessions/' + fixtures.publishedSession.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const unPublish = `${choices}:eq(2)`;
+  await click(selector);
+  await click(unPublish);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Not Published'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Not Published'));
 });
 
-test('check publish requirements for ilm session', function(assert) {
-  visit('/courses/1/sessions/' + fixtures.ilmSession.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const firstChoice = `${choices}:eq(0)`;
-    const secondChoice = `${choices}:eq(1)`;
-    click(selector);
+test('check publish requirements for ilm session', async function(assert) {
+  await visit('/courses/1/sessions/' + fixtures.ilmSession.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const firstChoice = `${choices}:eq(0)`;
+  const secondChoice = `${choices}:eq(1)`;
+  await click(selector);
 
-    assert.equal(getElementText(firstChoice), getText('Publish As-is'));
-    assert.equal(getElementText(secondChoice), getText('Review 3 Missing Items'));
-
-  });
+  assert.equal(getElementText(firstChoice), getText('Publish As-is'));
+  assert.equal(getElementText(secondChoice), getText('Review 3 Missing Items'));
 });

--- a/tests/acceptance/course/session/terms-test.js
+++ b/tests/acceptance/course/session/terms-test.js
@@ -48,79 +48,57 @@ module('Acceptance: Session - Terms', {
   }
 });
 
-test('list terms', function(assert) {
+test('list terms', async function(assert) {
   assert.expect(2);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-taxonomies');
-    var items = find('ul.selected-taxonomy-terms li', container);
-    assert.equal(items.length, fixtures.session.terms.length);
-    assert.equal(getElementText(items.eq(0)), getText('term 0'));
-  });
+  await visit(url);
+  var container = find('.detail-taxonomies');
+  var items = find('ul.selected-taxonomy-terms li', container);
+  assert.equal(items.length, fixtures.session.terms.length);
+  assert.equal(getElementText(items.eq(0)), getText('term 0'));
 });
 
-test('manage terms', function(assert) {
+test('manage terms', async function(assert) {
   assert.expect(3);
-  visit(url);
-  andThen(function() {
-    var container = find('.taxonomy-manager');
-    click(find('.actions button', container));
-    andThen(function() {
-      assert.equal(getElementText(find('.removable-list li:eq(0)', container)), getText('term 0'));
-      assert.equal(getElementText(find('.selectable-terms-list li:eq(0)', container)), getText('term 0'));
-      assert.equal(getElementText(find('.selectable-terms-list li:eq(1)', container)), getText('term 1'));
-      /**
-       * SHAMEFUL KLUDGE!
-       * Turns out, the test errors out in 'afterEach()' with the following message:
-       * "Error: Assertion Failed: Cannot call get with 'vocabularies' on an undefined object."
-       * This exception is raised in the course::assignableVocabularies() method.
-       * After stepping through the code, my best guess is that not all calls have been completed by the time
-       * the application is being destroyed.
-       * In other words, the test completes "too fast" for it's own good.
-       * My ham-fisted workaround is to simulate an additional user interaction,
-       * which does nothing else but stall for time.
-       * Lame, but seems to do the trick.
-       * [ST 2016/03/01]
-       */
-      click('button.bigcancel', container);
-    });
-  });
+  await visit(url);
+  var container = find('.taxonomy-manager');
+  await click(find('.actions button', container));
+  assert.equal(getElementText(find('.removable-list li:eq(0)', container)), getText('term 0'));
+  assert.equal(getElementText(find('.selectable-terms-list li:eq(0)', container)), getText('term 0'));
+  assert.equal(getElementText(find('.selectable-terms-list li:eq(1)', container)), getText('term 1'));
+  /**
+   * SHAMEFUL KLUDGE!
+   * Turns out, the test errors out in 'afterEach()' with the following message:
+   * "Error: Assertion Failed: Cannot call get with 'vocabularies' on an undefined object."
+   * This exception is raised in the course::assignableVocabularies() method.
+   * After stepping through the code, my best guess is that not all calls have been completed by the time
+   * the application is being destroyed.
+   * In other words, the test completes "too fast" for it's own good.
+   * My ham-fisted workaround is to simulate an additional user interaction,
+   * which does nothing else but stall for time.
+   * Lame, but seems to do the trick.
+   * [ST 2016/03/01]
+   */
+  await click('button.bigcancel', container);
 });
 
-test('save term changes', function(assert) {
+test('save term changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    var container = find('.taxonomy-manager');
-    click(find('.actions button', container));
-    andThen(function(){
-      click(find('.removable-list li:eq(0)', container)).then(function(){
-        click(find('.selectable-terms-list li:eq(1) > div', container)).then(function(){
-          click('button.bigadd', container);
-        });
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 1'));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.taxonomy-manager');
+  await click(find('.actions button', container));
+  await click(find('.removable-list li:eq(0)', container));
+  await click(find('.selectable-terms-list li:eq(1) > div', container));
+  await click('button.bigadd', container);
+  assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 1'));
 });
 
-test('cancel term changes', function(assert) {
+test('cancel term changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    var container = find('.taxonomy-manager');
-    click(find('.actions button', container));
-    andThen(function(){
-      click(find('.removable-list li:eq(0)', container)).then(function(){
-        click(find('.selectable-terms-list li:eq(1) > div', container)).then(function(){
-          click('button.bigcancel', container);
-        });
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 0'));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.taxonomy-manager');
+  await click(find('.actions button', container));
+  await click(find('.removable-list li:eq(0)', container));
+  await click(find('.selectable-terms-list li:eq(1) > div', container));
+  await click('button.bigcancel', container);
+  assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 0'));
 });

--- a/tests/acceptance/course/terms-test.js
+++ b/tests/acceptance/course/terms-test.js
@@ -44,82 +44,58 @@ module('Acceptance: Course - Terms', {
   }
 });
 
-test('taxonomy summary', function(assert) {
+test('taxonomy summary', async function(assert) {
   assert.expect(7);
-  visit('/courses/1?details=true');
-  andThen(function() {
-    var container = find('.collapsed-taxonomies');
-    var title = find('.title', container);
-    assert.equal(title.text().trim(), 'Terms (' + fixtures.course.terms.length + ')');
-    assert.equal(find('tr:eq(0) th:eq(0)', container).text().trim(), 'Vocabulary');
-    assert.equal(find('tr:eq(0) th:eq(1)', container).text().trim(), 'School');
-    assert.equal(find('tr:eq(0) th:eq(2)', container).text().trim(), 'Assigned Terms');
+  await visit('/courses/1?details=true');
+  var container = find('.collapsed-taxonomies');
+  var title = find('.title', container);
+  assert.equal(title.text().trim(), 'Terms (' + fixtures.course.terms.length + ')');
+  assert.equal(find('tr:eq(0) th:eq(0)', container).text().trim(), 'Vocabulary');
+  assert.equal(find('tr:eq(0) th:eq(1)', container).text().trim(), 'School');
+  assert.equal(find('tr:eq(0) th:eq(2)', container).text().trim(), 'Assigned Terms');
 
-    assert.equal(find('tr:eq(1) td:eq(0)', container).text().trim(), 'Vocabulary 1');
-    assert.equal(find('tr:eq(1) td:eq(1)', container).text().trim(), 'school 0');
-    assert.equal(find('tr:eq(1) td:eq(2)', container).text().trim(), fixtures.course.terms.length);
-  });
+  assert.equal(find('tr:eq(1) td:eq(0)', container).text().trim(), 'Vocabulary 1');
+  assert.equal(find('tr:eq(1) td:eq(1)', container).text().trim(), 'school 0');
+  assert.equal(find('tr:eq(1) td:eq(2)', container).text().trim(), fixtures.course.terms.length);
 });
 
-test('list terms', function(assert) {
+test('list terms', async function(assert) {
   assert.expect(2);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-taxonomies');
-    var items = find('ul.selected-taxonomy-terms li', container);
-    assert.equal(items.length, fixtures.course.terms.length);
-    assert.equal(getElementText(items.eq(0)), getText('term 0'));
-  });
+  await visit(url);
+  var container = find('.detail-taxonomies');
+  var items = find('ul.selected-taxonomy-terms li', container);
+  assert.equal(items.length, fixtures.course.terms.length);
+  assert.equal(getElementText(items.eq(0)), getText('term 0'));
 });
 
-test('manage terms', function(assert) {
+test('manage terms', async function(assert) {
   assert.expect(3);
-  visit(url);
-  andThen(function() {
-    var container = find('.taxonomy-manager');
-    click(find('.actions button', container));
-    andThen(function(){
-      assert.equal(getElementText(find('.removable-list li:eq(0)', container)), getText('term 0'));
-      assert.equal(getElementText(find('.selectable-terms-list li:eq(0)', container)), getText('term 0'));
-      assert.equal(getElementText(find('.selectable-terms-list li:eq(1)', container)), getText('term 1'));
-    });
-  });
+  await visit(url);
+  var container = find('.taxonomy-manager');
+  await click(find('.actions button', container));
+  assert.equal(getElementText(find('.removable-list li:eq(0)', container)), getText('term 0'));
+  assert.equal(getElementText(find('.selectable-terms-list li:eq(0)', container)), getText('term 0'));
+  assert.equal(getElementText(find('.selectable-terms-list li:eq(1)', container)), getText('term 1'));
 });
 
-test('save term changes', function(assert) {
+test('save term changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    var container = find('.taxonomy-manager');
-    click(find('.actions button', container));
-    andThen(function(){
-      click(find('.removable-list li:eq(0)', container)).then(function(){
-        click(find('.selectable-terms-list li:eq(1) > div', container)).then(function(){
-          click('button.bigadd', container);
-        });
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 1'));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.taxonomy-manager');
+  await click(find('.actions button', container));
+  await click(find('.removable-list li:eq(0)', container));
+  await click(find('.selectable-terms-list li:eq(1) > div', container));
+  await click('button.bigadd', container);
+  assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 1'));
 });
 
-test('cancel term changes', function(assert) {
+test('cancel term changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    var container = find('.taxonomy-manager');
-    click(find('.actions button', container));
-    andThen(function(){
-      click(find('.removable-list li:eq(0)', container)).then(function(){
-        click(find('.selectable-terms-list li:eq(1) > div', container)).then(function(){
-          click('button.bigcancel', container);
-        });
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 0'));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.taxonomy-manager');
+  await click(find('.actions button', container));
+  await click(find('.removable-list li:eq(0)', container));
+  await click(find('.selectable-terms-list li:eq(1) > div', container));
+  await click('button.bigcancel', container);
+  assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 0'));
 });

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -4,11 +4,6 @@ import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
 import moment from 'moment';
 
-import Ember from 'ember';
-
-const { run } = Ember;
-const { later } = run;
-
 var application;
 
 module('Acceptance: Courses', {
@@ -23,14 +18,12 @@ module('Acceptance: Courses', {
   }
 });
 
-test('visiting /courses', function(assert) {
-  visit('/courses');
-  andThen(function() {
-    assert.equal(currentPath(), 'courses');
-  });
+test('visiting /courses', async function(assert) {
+  await visit('/courses');
+  assert.equal(currentPath(), 'courses');
 });
 
-test('filters by title', function(assert) {
+test('filters by title', async function(assert) {
   server.create('academicYear', {id: 2014});
   assert.expect(22);
   let firstCourse = server.create('course', {
@@ -59,61 +52,40 @@ test('filters by title', function(assert) {
     school: 1,
     archived: true
   });
-  visit('/courses');
-  andThen(function() {
-    assert.equal(4, find('.list tbody tr').length);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(lastCourse.title));
-    assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')), getText(regularCourse.title));
-    assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')), getText(firstCourse.title));
-    assert.equal(getElementText(find('.list tbody tr:eq(3) td:eq(0)')), getText(secondCourse.title));
+  await visit('/courses');
+  assert.equal(4, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(lastCourse.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')), getText(regularCourse.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')), getText(firstCourse.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(3) td:eq(0)')), getText(secondCourse.title));
 
-    //put these in nested later blocks because there is a 500ms debounce on the title filter
-    fillIn('.titlefilter input', 'first');
-    later(function(){
-      assert.equal(1, find('.list tbody tr').length);
-      assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(firstCourse.title));
-      fillIn('.titlefilter input', 'second');
-      andThen(function(){
-        later(function(){
-          assert.equal(1, find('.list tbody tr').length);
-          assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(secondCourse.title));
-          fillIn('.titlefilter input', 'special');
-          andThen(function(){
-            later(function(){
-              assert.equal(2, find('.list tbody tr').length);
-              assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(firstCourse.title));
-              assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')), getText(secondCourse.title));
+  await fillIn('.titlefilter input', 'first');
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(firstCourse.title));
+  await fillIn('.titlefilter input', 'second');
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(secondCourse.title));
+  await fillIn('.titlefilter input', 'special');
+  assert.equal(2, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(firstCourse.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')), getText(secondCourse.title));
 
-              fillIn('.titlefilter input', 'course');
-              andThen(function(){
-                later(function(){
-                  assert.equal(4, find('.list tbody tr').length);
-                  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(lastCourse.title));
-                  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')), getText(regularCourse.title));
-                  assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')), getText(firstCourse.title));
-                  assert.equal(getElementText(find('.list tbody tr:eq(3) td:eq(0)')), getText(secondCourse.title));
+  await fillIn('.titlefilter input', 'course');
+  assert.equal(4, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(lastCourse.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')), getText(regularCourse.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')), getText(firstCourse.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(3) td:eq(0)')), getText(secondCourse.title));
 
-                  fillIn('.titlefilter input', '');
-                  andThen(function(){
-                    later(function(){
-                      assert.equal(4, find('.list tbody tr').length);
-                      assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(lastCourse.title));
-                      assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')), getText(regularCourse.title));
-                      assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')), getText(firstCourse.title));
-                      assert.equal(getElementText(find('.list tbody tr:eq(3) td:eq(0)')), getText(secondCourse.title));
-                    }, 750);
-                  });
-                }, 750);
-              });
-            }, 750);
-          });
-        }, 750);
-      });
-    }, 750);
-  });
+  await fillIn('.titlefilter input', '');
+  assert.equal(4, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(lastCourse.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')), getText(regularCourse.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')), getText(firstCourse.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(3) td:eq(0)')), getText(secondCourse.title));
 });
 
-test('filters by year', function(assert) {
+test('filters by year', async function(assert) {
   server.create('academicYear', {id: 2013});
   server.create('academicYear', {id: 2014});
   assert.expect(4);
@@ -125,22 +97,14 @@ test('filters by year', function(assert) {
     year: 2014,
     school: 1
   });
-  visit('/courses');
-  andThen(function() {
-    pickOption('.yearsfilter select', '2013 - 2014', assert);
-    andThen(function(){
-      assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(firstCourse.title));
-    });
-  });
-  andThen(function() {
-    pickOption('.yearsfilter select', '2014 - 2015', assert);
-    andThen(function(){
-      assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(secondCourse.title));
-    });
-  });
+  await visit('/courses');
+  await pickOption('.yearsfilter select', '2013 - 2014', assert);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(firstCourse.title));
+  await pickOption('.yearsfilter select', '2014 - 2015', assert);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(secondCourse.title));
 });
 
-test('initial filter by year', function(assert) {
+test('initial filter by year', async function(assert) {
   server.create('academicYear', {id: 2013});
   server.create('academicYear', {id: 2014});
   assert.expect(4);
@@ -152,20 +116,16 @@ test('initial filter by year', function(assert) {
     year: 2014,
     school: 1
   });
-  visit('/courses?year=2014');
-  andThen(function() {
-    assert.equal(find('.list tbody tr').length, 1);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(secondCourse.title));
-  });
+  await visit('/courses?year=2014');
+  assert.equal(find('.list tbody tr').length, 1);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(secondCourse.title));
 
-  visit('/courses?year=2013');
-  andThen(function() {
-    assert.equal(find('.list tbody tr').length, 1);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(firstCourse.title));
-  });
+  await visit('/courses?year=2013');
+  assert.equal(find('.list tbody tr').length, 1);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(firstCourse.title));
 });
 
-test('filters by mycourses', function(assert) {
+test('filters by mycourses', async function(assert) {
   server.create('academicYear', {id: 2014});
   assert.expect(5);
   let firstCourse = server.create('course', {
@@ -177,20 +137,16 @@ test('filters by mycourses', function(assert) {
     school: 1,
     directors: [4136]
   });
-  visit('/courses');
-  andThen(function() {
-    assert.equal(find('.list tbody tr').length, 2);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(firstCourse.title));
-    assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')), getText(secondCourse.title));
-    click('.toggle-mycourses label');
-    andThen(function(){
-      assert.equal(find('.list tbody tr').length, 1);
-      assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(secondCourse.title));
-    });
-  });
+  await visit('/courses');
+  assert.equal(find('.list tbody tr').length, 2);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(firstCourse.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')), getText(secondCourse.title));
+  await click('.toggle-mycourses label');
+  assert.equal(find('.list tbody tr').length, 1);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(secondCourse.title));
 });
 
-test('filters options', function(assert) {
+test('filters options', async function(assert) {
   assert.expect(8);
   server.createList('school', 2);
   server.create('permission', {
@@ -208,25 +164,21 @@ test('filters options', function(assert) {
   const years = `${yearSelect} option`;
   const schools = `${schoolSelect} option`;
 
-  visit('/courses');
-  andThen(function() {
-    let yearOptions = find(years);
-    assert.equal(yearOptions.length, 2);
-    assert.equal(getElementText(yearOptions.eq(0)).substring(0,4), 2014);
-    assert.equal(getElementText(yearOptions.eq(1)).substring(0,4), 2013);
-    assert.equal(find(yearSelect).val(), '2014 - 2015');
+  await visit('/courses');
+  let yearOptions = find(years);
+  assert.equal(yearOptions.length, 2);
+  assert.equal(getElementText(yearOptions.eq(0)).substring(0,4), 2014);
+  assert.equal(getElementText(yearOptions.eq(1)).substring(0,4), 2013);
+  assert.equal(find(yearSelect).val(), '2014 - 2015');
 
-    let schoolOptions = find(schools);
-    assert.equal(schoolOptions.length, 2);
-    assert.equal(getElementText(schoolOptions.eq(0)), 'school0');
-    assert.equal(getElementText(schoolOptions.eq(1)), 'school1');
-    assert.equal(find(schoolSelect).val(), '2');
-
-
-  });
+  let schoolOptions = find(schools);
+  assert.equal(schoolOptions.length, 2);
+  assert.equal(getElementText(schoolOptions.eq(0)), 'school0');
+  assert.equal(getElementText(schoolOptions.eq(1)), 'school1');
+  assert.equal(find(schoolSelect).val(), '2');
 });
 
-test('user can only delete non-published courses with proper privileges', function(assert) {
+test('user can only delete non-published courses with proper privileges', async function(assert) {
   server.create('academicYear', {id: 2014});
   assert.expect(4);
   server.create('course', {
@@ -257,16 +209,14 @@ test('user can only delete non-published courses with proper privileges', functi
   const secondCourseRemove = `${courses}:eq(1) ${remove}`;
   const thirdCourseRemove = `${courses}:eq(2) ${remove}`;
   const fourthCourseRemove = `${courses}:eq(3) ${remove}`;
-  visit('/courses');
-  andThen(function() {
-    assert.equal(find(firstCourseRemove).length, 0, 'non-privileged user cannot delete published course');
-    assert.equal(find(secondCourseRemove).length, 0, 'non-privileged user cannot delete unpublished course');
-    assert.equal(find(thirdCourseRemove).length, 0, 'privileged user cannot delete published course');
-    assert.equal(find(fourthCourseRemove).length, 1, 'privileged user can delete unpublished course');
-  });
+  await visit('/courses');
+  assert.equal(find(firstCourseRemove).length, 0, 'non-privileged user cannot delete published course');
+  assert.equal(find(secondCourseRemove).length, 0, 'non-privileged user cannot delete unpublished course');
+  assert.equal(find(thirdCourseRemove).length, 0, 'privileged user cannot delete published course');
+  assert.equal(find(fourthCourseRemove).length, 1, 'privileged user can delete unpublished course');
 });
 
-test('new course', function(assert) {
+test('new course', async function(assert) {
   const year = moment().year();
   server.create('academicYear', {id: year});
   assert.expect(5);
@@ -278,44 +228,37 @@ test('new course', function(assert) {
   const saveButton = '.done';
   const savedLink = '.saved-result a';
 
-  visit(url);
-  click(expandButton);
-  fillIn(input, 'Course 1');
-  pickOption(selectField, `${year} - ${year + 1}`, assert);
-  click(saveButton);
-  andThen(() => {
-    function getContent(i) {
-      return find(`tbody tr td:eq(${i})`).text().trim();
-    }
+  await visit(url);
+  await click(expandButton);
+  await fillIn(input, 'Course 1');
+  await pickOption(selectField, `${year} - ${year + 1}`, assert);
+  await click(saveButton);
+  function getContent(i) {
+    return find(`tbody tr td:eq(${i})`).text().trim();
+  }
 
-    assert.equal(find(savedLink).text().trim(), 'Course 1', 'link is visible');
-    assert.equal(getContent(0), 'Course 1', 'course is correct');
-    assert.equal(getContent(1), 'school 0', 'school is correct');
-    assert.equal(getContent(2), `${year} - ${year + 1}`, 'year is correct');
-  });
+  assert.equal(find(savedLink).text().trim(), 'Course 1', 'link is visible');
+  assert.equal(getContent(0), 'Course 1', 'course is correct');
+  assert.equal(getContent(1), 'school 0', 'school is correct');
+  assert.equal(getContent(2), `${year} - ${year + 1}`, 'year is correct');
 });
 
-test('new course in another year does not display in list', function(assert) {
+test('new course in another year does not display in list', async function(assert) {
   server.create('academicYear', {id: 2012});
   server.create('academicYear', {id: 2013});
   assert.expect(1);
-  visit('/courses');
+  await visit('/courses');
   let newTitle = 'new course title, woohoo';
-  andThen(function() {
-    let container = find('.courses');
-    click('.actions button', container);
-    andThen(function(){
-      fillIn('.new-course input:eq(0)', newTitle);
+  let container = find('.courses');
+  await click('.actions button', container);
+  await fillIn('.new-course input:eq(0)', newTitle);
 
-      click('.new-course .done', container).then(function(){
-        var rows = find('tbody tr', container);
-        assert.equal(rows.length, 0);
-      });
-    });
-  });
+  await click('.new-course .done', container);
+  var rows = find('tbody tr', container);
+  assert.equal(rows.length, 0);
 });
 
-test('new course does not appear twice when navigating back', function(assert) {
+test('new course does not appear twice when navigating back', async function(assert) {
   const year = moment().year();
   server.create('academicYear', {id: year});
   assert.expect(5);
@@ -329,24 +272,20 @@ test('new course does not appear twice when navigating back', function(assert) {
   const courseTitle = "Course 1";
   const course1InList = `tbody tr:contains("${courseTitle}")`;
 
-  visit(url);
-  click(expandButton);
-  fillIn(input, courseTitle);
-  pickOption(selectField, `${year} - ${year + 1}`, assert);
-  click(saveButton);
-  andThen(() => {
-    assert.equal(find(savedLink).length, 1, 'one copy of the save link');
-    assert.equal(find(course1InList).length, 1, 'one copy of the course in the list');
-  });
-  click(savedLink);
-  visit(url);
-  andThen(() => {
-    assert.equal(find(savedLink).length, 1, 'one copy of the save link');
-    assert.equal(find(course1InList).length, 1, 'one copy of the course in the list');
-  });
+  await visit(url);
+  await click(expandButton);
+  await fillIn(input, courseTitle);
+  await pickOption(selectField, `${year} - ${year + 1}`, assert);
+  await click(saveButton);
+  assert.equal(find(savedLink).length, 1, 'one copy of the save link');
+  assert.equal(find(course1InList).length, 1, 'one copy of the course in the list');
+  await click(savedLink);
+  await visit(url);
+  assert.equal(find(savedLink).length, 1, 'one copy of the save link');
+  assert.equal(find(course1InList).length, 1, 'one copy of the course in the list');
 });
 
-test('new course can be deleted', function(assert) {
+test('new course can be deleted', async function(assert) {
   const year = moment().year();
   server.create('academicYear', {id: year});
   server.create('userRole', {
@@ -366,29 +305,22 @@ test('new course can be deleted', function(assert) {
   const deleteConfirm = `.confirm-buttons .remove`;
   const savedCourse = '.saved-result';
 
-  visit(url);
-  andThen(() => {
-    assert.equal(find(courses).length, 0, 'there are initiall no courses');
-    assert.equal(find(savedCourse).length, 0, 'there are intially no saved courses');
-    click(expandButton);
-    fillIn(input, 'Course 1');
-    pickOption(selectField, `${year} - ${year + 1}`, assert);
-    click(saveButton);
-    andThen(() => {
-      assert.equal(find(courses).length, 1, 'there is one new course');
-      assert.equal(find(savedCourse).length, 1, 'there is one new saved course');
-      click(deleteCourse);
-      click(deleteConfirm);
-      andThen(()=>{
-        assert.equal(find(courses).length, 0, 'the new course has been deleted');
-        assert.equal(find(savedCourse).length, 0, 'the saved course has been deleted');
-      });
-    });
-  });
-
+  await visit(url);
+  assert.equal(find(courses).length, 0, 'there are initiall no courses');
+  assert.equal(find(savedCourse).length, 0, 'there are intially no saved courses');
+  await click(expandButton);
+  await fillIn(input, 'Course 1');
+  await pickOption(selectField, `${year} - ${year + 1}`, assert);
+  await click(saveButton);
+  assert.equal(find(courses).length, 1, 'there is one new course');
+  assert.equal(find(savedCourse).length, 1, 'there is one new saved course');
+  await click(deleteCourse);
+  await click(deleteConfirm);
+  assert.equal(find(courses).length, 0, 'the new course has been deleted');
+  assert.equal(find(savedCourse).length, 0, 'the saved course has been deleted');
 });
 
-test('locked courses', function(assert) {
+test('locked courses', async function(assert) {
   server.create('academicYear', {id: 2014});
   assert.expect(6);
   server.create('course', {
@@ -403,50 +335,45 @@ test('locked courses', function(assert) {
 
   const url = '/courses?year=2014';
 
-  visit(url);
-  andThen(() => {
-    function getContent(row, column) {
-      return find(`tbody tr:eq(${row}) td:eq(${column})`).text().trim();
-    }
+  await visit(url);
+  function getContent(row, column) {
+    return find(`tbody tr:eq(${row}) td:eq(${column})`).text().trim();
+  }
 
-    assert.equal(getContent(0, 0), 'course 0', 'course name is correct');
-    assert.equal(getContent(0, 6), 'Not Published', 'status');
-    assert.ok(find(`tbody tr:eq(0) td:eq(6) i.fa-lock`).length === 0);
+  assert.equal(getContent(0, 0), 'course 0', 'course name is correct');
+  assert.equal(getContent(0, 6), 'Not Published', 'status');
+  assert.ok(find(`tbody tr:eq(0) td:eq(6) i.fa-lock`).length === 0);
 
-    assert.equal(getContent(1, 0), 'course 1', 'course name is correct');
-    assert.equal(getContent(1, 6), 'Not Published', 'status');
-    assert.ok(find(`tbody tr:eq(1) td:eq(6) i.fa-lock`).length === 1);
-
-  });
+  assert.equal(getContent(1, 0), 'course 1', 'course name is correct');
+  assert.equal(getContent(1, 6), 'Not Published', 'status');
+  assert.ok(find(`tbody tr:eq(1) td:eq(6) i.fa-lock`).length === 1);
 });
 
-test('no academic years exist', function(assert) {
+test('no academic years exist', async function(assert) {
   assert.expect(6);
   const expandButton = '.expand-button';
   const newAcademicYearsOptions = '.new-course option';
   const url = '/courses';
 
-  visit(url);
-  click(expandButton);
-  andThen(() => {
-    let thisYear = parseInt(moment().format('YYYY'));
-    let years = [
-      thisYear-2,
-      thisYear-1,
-      thisYear,
-      thisYear+1,
-      thisYear+2
-    ];
+  await visit(url);
+  await click(expandButton);
+  let thisYear = parseInt(moment().format('YYYY'));
+  let years = [
+    thisYear-2,
+    thisYear-1,
+    thisYear,
+    thisYear+1,
+    thisYear+2
+  ];
 
-    var yearOptions = find(newAcademicYearsOptions);
-    assert.equal(yearOptions.length, years.length);
-    for (let i = 0; i < years.length; i++){
-      assert.equal(getElementText(yearOptions.eq(i)).substring(0,4), years[i]);
-    }
-  });
+  var yearOptions = find(newAcademicYearsOptions);
+  assert.equal(yearOptions.length, years.length);
+  for (let i = 0; i < years.length; i++){
+    assert.equal(getElementText(yearOptions.eq(i)).substring(0,4), years[i]);
+  }
 });
 
-test('sort by title', function(assert) {
+test('sort by title', async function(assert) {
   const firstCourseTitle = '.list tbody tr:eq(0) td:eq(0)';
   const secondCourseTitle = '.list tbody tr:eq(1) td:eq(0)';
   server.create('academicYear', {id: 2014});
@@ -459,18 +386,15 @@ test('sort by title', function(assert) {
     year: 2014,
     school: 1,
   });
-  visit('/courses');
-  andThen(function() {
-    assert.equal(getElementText(find(firstCourseTitle)), getText(firstCourse.title));
-    assert.equal(getElementText(find(secondCourseTitle)), getText(secondCourse.title));
-    click('th:eq(0)').then(()=>{
-      assert.equal(getElementText(find(firstCourseTitle)), getText(secondCourse.title));
-      assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
-    });
-  });
+  await visit('/courses');
+  assert.equal(getElementText(find(firstCourseTitle)), getText(firstCourse.title));
+  assert.equal(getElementText(find(secondCourseTitle)), getText(secondCourse.title));
+  await click('th:eq(0)');
+  assert.equal(getElementText(find(firstCourseTitle)), getText(secondCourse.title));
+  assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
 });
 
-test('sort by level', function(assert) {
+test('sort by level', async function(assert) {
   const firstCourseTitle = '.list tbody tr:eq(0) td:eq(0)';
   const secondCourseTitle = '.list tbody tr:eq(1) td:eq(0)';
   const sortingHeader = 'th:eq(3)';
@@ -486,19 +410,16 @@ test('sort by level', function(assert) {
     school: 1,
     level: 2
   });
-  visit('/courses');
-  click(sortingHeader);
-  andThen(function() {
-    assert.equal(getElementText(find(firstCourseTitle)), getText(firstCourse.title));
-    assert.equal(getElementText(find(secondCourseTitle)), getText(secondCourse.title));
-    click(sortingHeader).then(()=>{
-      assert.equal(getElementText(find(firstCourseTitle)), getText(secondCourse.title));
-      assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
-    });
-  });
+  await visit('/courses');
+  await click(sortingHeader);
+  assert.equal(getElementText(find(firstCourseTitle)), getText(firstCourse.title));
+  assert.equal(getElementText(find(secondCourseTitle)), getText(secondCourse.title));
+  await click(sortingHeader);
+  assert.equal(getElementText(find(firstCourseTitle)), getText(secondCourse.title));
+  assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
 });
 
-test('sort by startDate', function(assert) {
+test('sort by startDate', async function(assert) {
   const firstCourseTitle = '.list tbody tr:eq(0) td:eq(0)';
   const secondCourseTitle = '.list tbody tr:eq(1) td:eq(0)';
   const sortingHeader = 'th:eq(4)';
@@ -514,19 +435,16 @@ test('sort by startDate', function(assert) {
     school: 1,
     startDate: moment().add(1, 'day').toDate()
   });
-  visit('/courses');
-  click(sortingHeader);
-  andThen(function() {
-    assert.equal(getElementText(find(firstCourseTitle)), getText(firstCourse.title));
-    assert.equal(getElementText(find(secondCourseTitle)), getText(secondCourse.title));
-    click(sortingHeader).then(()=>{
-      assert.equal(getElementText(find(firstCourseTitle)), getText(secondCourse.title));
-      assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
-    });
-  });
+  await visit('/courses');
+  await click(sortingHeader);
+  assert.equal(getElementText(find(firstCourseTitle)), getText(firstCourse.title));
+  assert.equal(getElementText(find(secondCourseTitle)), getText(secondCourse.title));
+  await click(sortingHeader);
+  assert.equal(getElementText(find(firstCourseTitle)), getText(secondCourse.title));
+  assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
 });
 
-test('sort by endDate', function(assert) {
+test('sort by endDate', async function(assert) {
   const firstCourseTitle = '.list tbody tr:eq(0) td:eq(0)';
   const secondCourseTitle = '.list tbody tr:eq(1) td:eq(0)';
   const sortingHeader = 'th:eq(5)';
@@ -542,19 +460,16 @@ test('sort by endDate', function(assert) {
     school: 1,
     endDate: moment().add(1, 'day').toDate()
   });
-  visit('/courses');
-  click(sortingHeader);
-  andThen(function() {
-    assert.equal(getElementText(find(firstCourseTitle)), getText(firstCourse.title));
-    assert.equal(getElementText(find(secondCourseTitle)), getText(secondCourse.title));
-    click(sortingHeader).then(()=>{
-      assert.equal(getElementText(find(firstCourseTitle)), getText(secondCourse.title));
-      assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
-    });
-  });
+  await visit('/courses');
+  await click(sortingHeader);
+  assert.equal(getElementText(find(firstCourseTitle)), getText(firstCourse.title));
+  assert.equal(getElementText(find(secondCourseTitle)), getText(secondCourse.title));
+  await click(sortingHeader);
+  assert.equal(getElementText(find(firstCourseTitle)), getText(secondCourse.title));
+  assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
 });
 
-test('sort by status', function(assert) {
+test('sort by status', async function(assert) {
   const firstCourseTitle = '.list tbody tr:eq(0) td:eq(0)';
   const secondCourseTitle = '.list tbody tr:eq(1) td:eq(0)';
   const thirdCourseTitle = '.list tbody tr:eq(2) td:eq(0)';
@@ -579,21 +494,18 @@ test('sort by status', function(assert) {
     published: false,
     publishedAsTbd: false
   });
-  visit('/courses');
-  click(sortingHeader);
-  andThen(function() {
-    assert.equal(getElementText(find(firstCourseTitle)), getText(thirdCourse.title));
-    assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
-    assert.equal(getElementText(find(thirdCourseTitle)), getText(secondCourse.title));
-    click(sortingHeader).then(()=>{
-      assert.equal(getElementText(find(firstCourseTitle)), getText(secondCourse.title));
-      assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
-      assert.equal(getElementText(find(thirdCourseTitle)), getText(thirdCourse.title));
-    });
-  });
+  await visit('/courses');
+  await click(sortingHeader);
+  assert.equal(getElementText(find(firstCourseTitle)), getText(thirdCourse.title));
+  assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
+  assert.equal(getElementText(find(thirdCourseTitle)), getText(secondCourse.title));
+  await click(sortingHeader);
+  assert.equal(getElementText(find(firstCourseTitle)), getText(secondCourse.title));
+  assert.equal(getElementText(find(secondCourseTitle)), getText(firstCourse.title));
+  assert.equal(getElementText(find(thirdCourseTitle)), getText(thirdCourse.title));
 });
 
-test('developer users can lock and unlock course', function(assert) {
+test('developer users can lock and unlock course', async function(assert) {
   assert.expect(6);
   const firstCourseRow = '.list tbody tr:eq(0)';
   const secondCourseRow = '.list tbody tr:eq(1)';
@@ -618,22 +530,18 @@ test('developer users can lock and unlock course', function(assert) {
     publishedAsTbd: true,
     locked: false,
   });
-  visit('/courses');
-  andThen(function() {
-    assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
-    assert.ok(find(firstCourseLockedIcon).hasClass('clickable'), 'first course is clickable');
-    assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
-    assert.ok(find(secondCourseLockedIcon).hasClass('clickable'), 'second course is clickable');
-    click(find(firstCourseLockedIcon));
-    click(find(secondCourseLockedIcon));
-    andThen(()=>{
-      assert.ok(find(firstCourseLockedIcon).hasClass('fa-unlock'), 'first course is now unlocked');
-      assert.ok(find(secondCourseLockedIcon).hasClass('fa-lock'), 'second course is now locked');
-    });
-  });
+  await visit('/courses');
+  assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
+  assert.ok(find(firstCourseLockedIcon).hasClass('clickable'), 'first course is clickable');
+  assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
+  assert.ok(find(secondCourseLockedIcon).hasClass('clickable'), 'second course is clickable');
+  await click(find(firstCourseLockedIcon));
+  await click(find(secondCourseLockedIcon));
+  assert.ok(find(firstCourseLockedIcon).hasClass('fa-unlock'), 'first course is now unlocked');
+  assert.ok(find(secondCourseLockedIcon).hasClass('fa-lock'), 'second course is now locked');
 });
 
-test('course directors users can lock but not unlock course', function(assert) {
+test('course directors users can lock but not unlock course', async function(assert) {
   assert.expect(6);
   const firstCourseRow = '.list tbody tr:eq(0)';
   const secondCourseRow = '.list tbody tr:eq(1)';
@@ -656,22 +564,18 @@ test('course directors users can lock but not unlock course', function(assert) {
     locked: false,
     directors: [4136],
   });
-  visit('/courses');
-  andThen(function() {
-    assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
-    assert.notOk(find(firstCourseLockedIcon).hasClass('clickable'), 'first course is not clickable');
-    assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
-    assert.ok(find(secondCourseLockedIcon).hasClass('clickable'), 'second course is clickable');
-    click(find(firstCourseLockedIcon));
-    click(find(secondCourseLockedIcon));
-    andThen(()=>{
-      assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is still locked');
-      assert.ok(find(secondCourseLockedIcon).hasClass('fa-lock'), 'second course is now locked');
-    });
-  });
+  await visit('/courses');
+  assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
+  assert.notOk(find(firstCourseLockedIcon).hasClass('clickable'), 'first course is not clickable');
+  assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
+  assert.ok(find(secondCourseLockedIcon).hasClass('clickable'), 'second course is clickable');
+  await click(find(firstCourseLockedIcon));
+  await click(find(secondCourseLockedIcon));
+  assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is still locked');
+  assert.ok(find(secondCourseLockedIcon).hasClass('fa-lock'), 'second course is now locked');
 });
 
-test('non-privileged users cannot lock and unlock course but can see the icon', function(assert) {
+test('non-privileged users cannot lock and unlock course but can see the icon', async function(assert) {
   assert.expect(6);
   const firstCourseRow = '.list tbody tr:eq(0)';
   const secondCourseRow = '.list tbody tr:eq(1)';
@@ -692,19 +596,15 @@ test('non-privileged users cannot lock and unlock course but can see the icon', 
     publishedAsTbd: true,
     locked: false,
   });
-  visit('/courses');
-  andThen(function() {
-    assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
-    assert.notOk(find(firstCourseLockedIcon).hasClass('clickable'), 'first course is clickable');
-    assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
-    assert.notOk(find(secondCourseLockedIcon).hasClass('clickable'), 'second course is clickable');
-    click(find(firstCourseLockedIcon));
-    click(find(secondCourseLockedIcon));
-    andThen(()=>{
-      assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is still locked');
-      assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is still unlocked');
-    });
-  });
+  await visit('/courses');
+  assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
+  assert.notOk(find(firstCourseLockedIcon).hasClass('clickable'), 'first course is clickable');
+  assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
+  assert.notOk(find(secondCourseLockedIcon).hasClass('clickable'), 'second course is clickable');
+  await click(find(firstCourseLockedIcon));
+  await click(find(secondCourseLockedIcon));
+  assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is still locked');
+  assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is still unlocked');
 });
 
 test('title filter escapes regex', async function(assert) {

--- a/tests/acceptance/curriculum-inventory/report-test.js
+++ b/tests/acceptance/curriculum-inventory/report-test.js
@@ -17,7 +17,7 @@ module('Acceptance: Curriculum Inventory: Report', {
   }
 });
 
-test('create new sequence block Issue #2108', function(assert) {
+test('create new sequence block Issue #2108', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -36,21 +36,18 @@ test('create new sequence block Issue #2108', function(assert) {
   const newBlockForm = '.new-curriculum-inventory-sequence-block';
   const newFormTitle = `${newBlockForm} .new-result-title`;
 
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'curriculumInventoryReport.index');
-    assert.equal(find(newBlockForm).length, 0);
-    assert.equal(find(newFormTitle).length, 0);
-    click(addSequenceBlock).then(()=>{
-      assert.equal(find(newBlockForm).length, 1);
-      assert.equal(find(newFormTitle).length, 1);
-      assert.equal(getElementText(newFormTitle), getText('New Sequence Block'));
-    });
-  });
+  await visit(url);
+  assert.equal(currentPath(), 'curriculumInventoryReport.index');
+  assert.equal(find(newBlockForm).length, 0);
+  assert.equal(find(newFormTitle).length, 0);
+  await click(addSequenceBlock);
+  assert.equal(find(newBlockForm).length, 1);
+  assert.equal(find(newFormTitle).length, 1);
+  assert.equal(getElementText(newFormTitle), getText('New Sequence Block'));
 });
 
 
-test('rollover hidden from instructors', function(assert) {
+test('rollover hidden from instructors', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -70,17 +67,15 @@ test('rollover hidden from instructors', function(assert) {
     description: 'lorem ipsum',
     program: 1,
   });
-  visit(url);
+  await visit(url);
   const container = '.curriculum-inventory-report-overview';
   const rollover = `${container} a.rollover`;
 
-  andThen(function() {
-    assert.equal(currentPath(), 'curriculumInventoryReport.index');
-    assert.equal(find(rollover).length, 0);
-  });
+  assert.equal(currentPath(), 'curriculumInventoryReport.index');
+  assert.equal(find(rollover).length, 0);
 });
 
-test('rollover visible to developers', function(assert) {
+test('rollover visible to developers', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -100,18 +95,15 @@ test('rollover visible to developers', function(assert) {
     description: 'lorem ipsum',
     program: 1,
   });
-  visit(url);
+  await visit(url);
   const container = '.curriculum-inventory-report-overview';
   const rollover = `${container} a.rollover`;
 
-  //return pauseTest();
-  andThen(function() {
-    assert.equal(currentPath(), 'curriculumInventoryReport.index');
-    assert.equal(find(rollover).length, 1);
-  });
+  assert.equal(currentPath(), 'curriculumInventoryReport.index');
+  assert.equal(find(rollover).length, 1);
 });
 
-test('rollover not visible to course directors', function(assert) {
+test('rollover not visible to course directors', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -131,17 +123,15 @@ test('rollover not visible to course directors', function(assert) {
     description: 'lorem ipsum',
     program: 1,
   });
-  visit(url);
+  await visit(url);
   const container = '.curriculum-inventory-report-overview';
   const rollover = `${container} a.rollover`;
 
-  andThen(function() {
-    assert.equal(currentPath(), 'curriculumInventoryReport.index');
-    assert.equal(find(rollover).length, 0);
-  });
+  assert.equal(currentPath(), 'curriculumInventoryReport.index');
+  assert.equal(find(rollover).length, 0);
 });
 
-test('rollover hidden on rollover route', function(assert) {
+test('rollover hidden on rollover route', async function(assert) {
   server.create('user', {
     id: 4136,
     roles: [1],
@@ -161,12 +151,10 @@ test('rollover hidden on rollover route', function(assert) {
     description: 'lorem ipsum',
     program: 1,
   });
-  visit(`${url}/rollover`);
+  await visit(`${url}/rollover`);
   const container = '.curriculum-inventory-report-overview';
   const rollover = `${container} a.rollover`;
 
-  andThen(function() {
-    assert.equal(currentPath(), 'curriculumInventoryReport.rollover');
-    assert.equal(find(rollover).length, 0);
-  });
+  assert.equal(currentPath(), 'curriculumInventoryReport.rollover');
+  assert.equal(find(rollover).length, 0);
 });

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -97,7 +97,7 @@ module('Acceptance: Dashboard Calendar', {
   }
 });
 
-test('load month calendar', function(assert) {
+test('load month calendar', async function(assert) {
   let today = moment().hour(8);
   let startOfMonth = today.clone().startOf('month');
   let endOfMonth = today.clone().endOf('month').hour(22).minute(59);
@@ -113,20 +113,17 @@ test('load month calendar', function(assert) {
     startDate: endOfMonth.format(),
     endDate: endOfMonth.clone().add(1, 'hour').format()
   });
-  visit('/dashboard?show=calendar&view=month');
-  andThen(function() {
-    assert.equal(currentPath(), 'dashboard');
-    let events = find('div.event');
-    assert.equal(events.length, 2);
-    let eventInfo = '';
-    eventInfo += startOfMonth.format('h:mma') + '-' + startOfMonth.clone().add(1, 'hour').format('h:mma') + ': start of month';
-    eventInfo += endOfMonth.format('h:mma') + '-' + endOfMonth.clone().add(1, 'hour').format('h:mma') + ': end of month';
-    assert.equal(getElementText(events), getText(eventInfo));
-
-  });
+  await visit('/dashboard?show=calendar&view=month');
+  assert.equal(currentPath(), 'dashboard');
+  let events = find('div.event');
+  assert.equal(events.length, 2);
+  let eventInfo = '';
+  eventInfo += startOfMonth.format('h:mma') + '-' + startOfMonth.clone().add(1, 'hour').format('h:mma') + ': start of month';
+  eventInfo += endOfMonth.format('h:mma') + '-' + endOfMonth.clone().add(1, 'hour').format('h:mma') + ': end of month';
+  assert.equal(getElementText(events), getText(eventInfo));
 });
 
-test('load week calendar', function(assert) {
+test('load week calendar', async function(assert) {
   let today = moment().hour(8);
   let startOfWeek = today.clone().startOf('week');
   let endOfWeek = today.clone().endOf('week').hour(22).minute(59);
@@ -142,20 +139,17 @@ test('load week calendar', function(assert) {
     startDate: endOfWeek.format(),
     endDate: endOfWeek.clone().add(1, 'hour').format()
   });
-  visit('/dashboard?show=calendar');
-  andThen(function() {
-    assert.equal(currentPath(), 'dashboard');
-    let events = find('div.event');
-    assert.equal(events.length, 2);
-    let eventInfo = '';
-    eventInfo += startOfWeek.format('h:mma') + '-' + startOfWeek.clone().add(1, 'hour').format('h:mma') + ' start of week';
-    eventInfo += endOfWeek.format('h:mma') + '-' + endOfWeek.clone().add(1, 'hour').format('h:mma') + ' end of week';
-    assert.equal(getElementText(events), getText(eventInfo));
-
-  });
+  await visit('/dashboard?show=calendar');
+  assert.equal(currentPath(), 'dashboard');
+  let events = find('div.event');
+  assert.equal(events.length, 2);
+  let eventInfo = '';
+  eventInfo += startOfWeek.format('h:mma') + '-' + startOfWeek.clone().add(1, 'hour').format('h:mma') + ' start of week';
+  eventInfo += endOfWeek.format('h:mma') + '-' + endOfWeek.clone().add(1, 'hour').format('h:mma') + ' end of week';
+  assert.equal(getElementText(events), getText(eventInfo));
 });
 
-test('load day calendar', function(assert) {
+test('load day calendar', async function(assert) {
   let today = moment().hour(8);
   let tomorow = today.clone().add(1, 'day');
   let yesterday = today.clone().subtract(1, 'day');
@@ -177,19 +171,16 @@ test('load day calendar', function(assert) {
     startDate: yesterday.format(),
     endDate: yesterday.clone().add(1, 'hour').format()
   });
-  visit('/dashboard?show=calendar&view=day');
-  andThen(function() {
-    assert.equal(currentPath(), 'dashboard');
-    let events = find('div.event');
-    assert.equal(events.length, 1);
-    let eventInfo = '';
-    eventInfo += today.format('h:mma') + '-' + today.clone().add(1, 'hour').format('h:mma') + ' today';
-    assert.equal(getElementText(events), getText(eventInfo));
-
-  });
+  await visit('/dashboard?show=calendar&view=day');
+  assert.equal(currentPath(), 'dashboard');
+  let events = find('div.event');
+  assert.equal(events.length, 1);
+  let eventInfo = '';
+  eventInfo += today.format('h:mma') + '-' + today.clone().add(1, 'hour').format('h:mma') + ' today';
+  assert.equal(getElementText(events), getText(eventInfo));
 });
 
-test('click month day number and go to day', function(assert) {
+test('click month day number and go to day', async function(assert) {
   let aDayInTheMonth = moment().startOf('month').add(12, 'days').hour(8);
   server.create('userevent', {
     user: 4136,
@@ -197,19 +188,16 @@ test('click month day number and go to day', function(assert) {
     startDate: aDayInTheMonth.format(),
     endDate: aDayInTheMonth.clone().add(1, 'hour').format()
   });
-  visit('/dashboard?show=calendar&view=month');
-  andThen(function() {
-    let dayOfMonth = aDayInTheMonth.date();
-    let link = find('.day .clickable').filter(function(){
-      return parseInt($(this).text()) === dayOfMonth;
-    }).eq(0);
-    click(link).then(()=>{
-      assert.equal(currentURL(), '/dashboard?date=' + aDayInTheMonth.format('YYYY-MM-DD') + '&show=calendar&view=day');
-    });
-  });
+  await visit('/dashboard?show=calendar&view=month');
+  let dayOfMonth = aDayInTheMonth.date();
+  let link = find('.day .clickable').filter(function(){
+    return parseInt($(this).text()) === dayOfMonth;
+  }).eq(0);
+  await click(link);
+  assert.equal(currentURL(), '/dashboard?date=' + aDayInTheMonth.format('YYYY-MM-DD') + '&show=calendar&view=day');
 });
 
-test('click week day title and go to day', function(assert) {
+test('click week day title and go to day', async function(assert) {
   let today = moment().hour(8);
   server.create('userevent', {
     user: 4136,
@@ -217,16 +205,13 @@ test('click week day title and go to day', function(assert) {
     startDate: today.format(),
     endDate: today.clone().add(1, 'hour').format()
   });
-  visit('/dashboard?show=calendar&view=week');
-  andThen(function() {
-    let dayOfWeek = today.day();
-    click(find('.week-titles .clickable').eq(dayOfWeek)).then(()=>{
-      assert.equal(currentURL(), '/dashboard?date=' + today.format('YYYY-MM-DD') + '&show=calendar&view=day');
-    });
-  });
+  await visit('/dashboard?show=calendar&view=week');
+  let dayOfWeek = today.day();
+  await click(find('.week-titles .clickable').eq(dayOfWeek));
+  assert.equal(currentURL(), '/dashboard?date=' + today.format('YYYY-MM-DD') + '&show=calendar&view=day');
 });
 
-test('click forward on a day goes to next day', function(assert) {
+test('click forward on a day goes to next day', async function(assert) {
   let today = moment().hour(8);
   server.create('userevent', {
     user: 4136,
@@ -234,15 +219,12 @@ test('click forward on a day goes to next day', function(assert) {
     startDate: today.format(),
     endDate: today.clone().add(1, 'hour').format()
   });
-  visit('/dashboard?show=calendar&view=day');
-  andThen(function() {
-    click('.calendar-time-picker li:eq(2)').then(()=>{
-      assert.equal(currentURL(), '/dashboard?date=' + today.add(1, 'day').format('YYYY-MM-DD') + '&show=calendar&view=day');
-    });
-  });
+  await visit('/dashboard?show=calendar&view=day');
+  await click('.calendar-time-picker li:eq(2)');
+  assert.equal(currentURL(), '/dashboard?date=' + today.add(1, 'day').format('YYYY-MM-DD') + '&show=calendar&view=day');
 });
 
-test('click forward on a week goes to next week', function(assert) {
+test('click forward on a week goes to next week', async function(assert) {
   let today = moment().hour(8);
   server.create('userevent', {
     user: 4136,
@@ -250,15 +232,12 @@ test('click forward on a week goes to next week', function(assert) {
     startDate: today.format(),
     endDate: today.clone().add(1, 'hour').format()
   });
-  visit('/dashboard?show=calendar&view=week');
-  andThen(function() {
-    click('.calendar-time-picker li:eq(2)').then(()=>{
-      assert.equal(currentURL(), '/dashboard?date=' + today.add(1, 'week').format('YYYY-MM-DD') + '&show=calendar');
-    });
-  });
+  await visit('/dashboard?show=calendar&view=week');
+  await click('.calendar-time-picker li:eq(2)');
+  assert.equal(currentURL(), '/dashboard?date=' + today.add(1, 'week').format('YYYY-MM-DD') + '&show=calendar');
 });
 
-test('click forward on a month goes to next month', function(assert) {
+test('click forward on a month goes to next month', async function(assert) {
   let today = moment().hour(8);
   server.create('userevent', {
     user: 4136,
@@ -266,15 +245,12 @@ test('click forward on a month goes to next month', function(assert) {
     startDate: today.format(),
     endDate: today.clone().add(1, 'hour').format()
   });
-  visit('/dashboard?show=calendar&view=month');
-  andThen(function() {
-    click('.calendar-time-picker li:eq(2)').then(()=>{
-      assert.equal(currentURL(), '/dashboard?date=' + today.add(1, 'month').format('YYYY-MM-DD') + '&show=calendar&view=month');
-    });
-  });
+  await visit('/dashboard?show=calendar&view=month');
+  await click('.calendar-time-picker li:eq(2)');
+  assert.equal(currentURL(), '/dashboard?date=' + today.add(1, 'month').format('YYYY-MM-DD') + '&show=calendar&view=month');
 });
 
-test('click back on a day goes to previous day', function(assert) {
+test('click back on a day goes to previous day', async function(assert) {
   let today = moment().hour(8);
   server.create('userevent', {
     user: 4136,
@@ -282,15 +258,12 @@ test('click back on a day goes to previous day', function(assert) {
     startDate: today.format(),
     endDate: today.clone().add(1, 'hour').format()
   });
-  visit('/dashboard?show=calendar&view=day');
-  andThen(function() {
-    click('.calendar-time-picker li:eq(0)').then(()=>{
-      assert.equal(currentURL(), '/dashboard?date=' + today.subtract(1, 'day').format('YYYY-MM-DD') + '&show=calendar&view=day');
-    });
-  });
+  await visit('/dashboard?show=calendar&view=day');
+  await click('.calendar-time-picker li:eq(0)');
+  assert.equal(currentURL(), '/dashboard?date=' + today.subtract(1, 'day').format('YYYY-MM-DD') + '&show=calendar&view=day');
 });
 
-test('click back on a week goes to previous week', function(assert) {
+test('click back on a week goes to previous week', async function(assert) {
   let today = moment().hour(8);
   server.create('userevent', {
     user: 4136,
@@ -298,15 +271,12 @@ test('click back on a week goes to previous week', function(assert) {
     startDate: today.format(),
     endDate: today.clone().add(1, 'hour').format()
   });
-  visit('/dashboard?show=calendar&view=week');
-  andThen(function() {
-    click('.calendar-time-picker li:eq(0)').then(()=>{
-      assert.equal(currentURL(), '/dashboard?date=' + today.subtract(1, 'week').format('YYYY-MM-DD') + '&show=calendar');
-    });
-  });
+  await visit('/dashboard?show=calendar&view=week');
+  await click('.calendar-time-picker li:eq(0)');
+  assert.equal(currentURL(), '/dashboard?date=' + today.subtract(1, 'week').format('YYYY-MM-DD') + '&show=calendar');
 });
 
-test('click back on a month goes to previous month', function(assert) {
+test('click back on a month goes to previous month', async function(assert) {
   let today = moment().hour(8);
   server.create('userevent', {
     user: 4136,
@@ -314,15 +284,12 @@ test('click back on a month goes to previous month', function(assert) {
     startDate: today.format(),
     endDate: today.clone().add(1, 'hour').format()
   });
-  visit('/dashboard?show=calendar&view=month');
-  andThen(function() {
-    click('.calendar-time-picker li:eq(0)').then(()=>{
-      assert.equal(currentURL(), '/dashboard?date=' + today.subtract(1, 'month').format('YYYY-MM-DD') + '&show=calendar&view=month');
-    });
-  });
+  await visit('/dashboard?show=calendar&view=month');
+  await click('.calendar-time-picker li:eq(0)');
+  assert.equal(currentURL(), '/dashboard?date=' + today.subtract(1, 'month').format('YYYY-MM-DD') + '&show=calendar&view=month');
 });
 
-test('show user events', function(assert) {
+test('show user events', async function(assert) {
   let today = moment().hour(8);
   server.create('userevent', {
     user: 4136,
@@ -336,11 +303,9 @@ test('show user events', function(assert) {
     endDate: today.clone().add(1, 'hour').format(),
     offering: 2
   });
-  visit('/dashboard?show=calendar');
-  andThen(function() {
-    let events = find('div.event');
-    assert.equal(events.length, 2);
-  });
+  await visit('/dashboard?show=calendar');
+  let events = find('div.event');
+  assert.equal(events.length, 2);
 });
 
 let chooseSchoolEvents = async function(){
@@ -582,12 +547,10 @@ test('agenda show next seven days of events', async function(assert) {
     offering: 3
   });
   await visit('/dashboard?show=agenda');
-  andThen(function() {
-    let events = find('tr');
-    assert.equal(events.length, 2);
-    assert.equal(getElementText(events.eq(0)), getText(today.format('dddd, MMMM Do, YYYY h:mma') + 'event 0'));
-    assert.equal(getElementText(events.eq(1)), getText(endOfTheWeek.format('dddd, MMMM Do, YYYY h:mma') + 'event 1'));
-  });
+  let events = find('tr');
+  assert.equal(events.length, 2);
+  assert.equal(getElementText(events.eq(0)), getText(today.format('dddd, MMMM Do, YYYY h:mma') + 'event 0'));
+  assert.equal(getElementText(events.eq(1)), getText(endOfTheWeek.format('dddd, MMMM Do, YYYY h:mma') + 'event 1'));
 });
 
 test('academic year filters cohort', async function(assert) {

--- a/tests/acceptance/four-oh-four-test.js
+++ b/tests/acceptance/four-oh-four-test.js
@@ -23,19 +23,15 @@ module('Acceptance: FourOhFour', {
   }
 });
 
-test('visiting /four-oh-four', function(assert) {
-  visit('/four-oh-four');
+test('visiting /four-oh-four', async function(assert) {
+  await visit('/four-oh-four');
 
-  andThen(function() {
-    assert.equal(currentPath(), 'fourOhFour');
-    assert.equal(getElementText(find('.full-screen-error')), getText("Rats! I couldn't find that. Please check your page address, and try again.Back to Dashboard"));
-  });
+  assert.equal(currentPath(), 'fourOhFour');
+  assert.equal(getElementText(find('.full-screen-error')), getText("Rats! I couldn't find that. Please check your page address, and try again.Back to Dashboard"));
 });
 
-test('visiting /nothing', function(assert) {
-  visit('/nothing');
+test('visiting /nothing', async function(assert) {
+  await visit('/nothing');
 
-  andThen(function() {
-    assert.equal(currentPath(), 'fourOhFour');
-  });
+  assert.equal(currentPath(), 'fourOhFour');
 });

--- a/tests/acceptance/instructorgroup-test.js
+++ b/tests/acceptance/instructorgroup-test.js
@@ -65,118 +65,95 @@ module('Acceptance: Instructor Group Details', {
   }
 });
 
-test('check fields', function(assert) {
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'instructorGroup');
-    let container = find('.instructorgroup-header');
-    assert.equal(getElementText(find('.title .school-title', container)), getText('school 0 > '));
-    assert.equal(getElementText(find('.title .editable', container)), getText('instructor group 0'));
-    assert.equal(getElementText(find('.info')), getText('Members:2'));
-    assert.equal(getElementText(find('.instructorgroup-overview h2')), getText('instructor group 0 Members (2)'));
+test('check fields', async function(assert) {
+  await visit(url);
+  assert.equal(currentPath(), 'instructorGroup');
+  let container = find('.instructorgroup-header');
+  assert.equal(getElementText(find('.title .school-title', container)), getText('school 0 > '));
+  assert.equal(getElementText(find('.title .editable', container)), getText('instructor group 0'));
+  assert.equal(getElementText(find('.info')), getText('Members:2'));
+  assert.equal(getElementText(find('.instructorgroup-overview h2')), getText('instructor group 0 Members (2)'));
 
-    let items = find('.instructorgroup-overview-content .removable-list li');
-    assert.equal(items.length, 2);
-    assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
-    assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
+  let items = find('.instructorgroup-overview-content .removable-list li');
+  assert.equal(items.length, 2);
+  assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
+  assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
 
-    let courses = find('.instructorgroupcourses li');
-    assert.equal(getElementText(courses), getText('course 0 course 1'));
-  });
+  let courses = find('.instructorgroupcourses li');
+  assert.equal(getElementText(courses), getText('course 0 course 1'));
 });
 
-test('change title', function(assert) {
-  visit(url);
-  andThen(function() {
-    let container = find('.instructorgroup-header');
-    assert.equal(getElementText(find('.title .editable', container)), getText('instructor group 0'));
-    click(find('.title .editable', container));
-    andThen(function(){
-      let input = find('.title .editinplace input', container);
-      assert.equal(getText(input.val()), getText('instructor group 0'));
-      fillIn(input, 'test new title');
-      click(find('.title .editinplace .actions .done', container));
-      andThen(function(){
-        assert.equal(getElementText(find('.title .editable', container)), getText('test new title'));
-      });
-    });
-  });
+test('change title', async function(assert) {
+  await visit(url);
+  let container = find('.instructorgroup-header');
+  assert.equal(getElementText(find('.title .editable', container)), getText('instructor group 0'));
+  await click(find('.title .editable', container));
+  let input = find('.title .editinplace input', container);
+  assert.equal(getText(input.val()), getText('instructor group 0'));
+  await fillIn(input, 'test new title');
+  await click(find('.title .editinplace .actions .done', container));
+  assert.equal(getElementText(find('.title .editable', container)), getText('test new title'));
 });
 
-test('search instructors', function(assert) {
-  visit(url);
+test('search instructors', async function(assert) {
+  await visit(url);
   const container = '.instructorgroup-overview-content';
   const search = `${container} .search-box input`;
   const results = `${container} .results li`;
 
-  fillIn(search, 'guy');
-  andThen(function() {
-    let searchResults = find(results);
-    assert.equal(searchResults.length, 6);
-    assert.equal(getElementText(searchResults.eq(0)), getText('5 Results'));
-    assert.equal(getElementText(searchResults.eq(1)), getText('0 guy M. Mc0son'));
-    assert.ok(searchResults.eq(1).hasClass('active'));
-    assert.equal(getElementText(searchResults.eq(2)), getText('1 guy M. Mc1son'));
-    assert.ok(!searchResults.eq(2).hasClass('active'));
-    assert.equal(getElementText(searchResults.eq(3)), getText('2 guy M. Mc2son'));
-    assert.ok(!searchResults.eq(3).hasClass('active'));
-    assert.equal(getElementText(searchResults.eq(4)), getText('3 guy M. Mc3son'));
-    assert.ok(searchResults.eq(4).hasClass('active'));
-    assert.equal(getElementText(searchResults.eq(5)), getText('4 guy M. Mc4son'));
-    assert.ok(searchResults.eq(5).hasClass('active'));
-  });
+  await fillIn(search, 'guy');
+  let searchResults = find(results);
+  assert.equal(searchResults.length, 6);
+  assert.equal(getElementText(searchResults.eq(0)), getText('5 Results'));
+  assert.equal(getElementText(searchResults.eq(1)), getText('0 guy M. Mc0son'));
+  assert.ok(searchResults.eq(1).hasClass('active'));
+  assert.equal(getElementText(searchResults.eq(2)), getText('1 guy M. Mc1son'));
+  assert.ok(!searchResults.eq(2).hasClass('active'));
+  assert.equal(getElementText(searchResults.eq(3)), getText('2 guy M. Mc2son'));
+  assert.ok(!searchResults.eq(3).hasClass('active'));
+  assert.equal(getElementText(searchResults.eq(4)), getText('3 guy M. Mc3son'));
+  assert.ok(searchResults.eq(4).hasClass('active'));
+  assert.equal(getElementText(searchResults.eq(5)), getText('4 guy M. Mc4son'));
+  assert.ok(searchResults.eq(5).hasClass('active'));
 });
 
-test('add instructor', function(assert) {
-  visit(url);
+test('add instructor', async function(assert) {
+  await visit(url);
 
-  andThen(function() {
-    let container = find('.instructorgroup-overview').eq(0);
-    let items = find('.removable-list li', container);
-    assert.equal(items.length, 2);
-    assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
-    assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
+  let container = find('.instructorgroup-overview').eq(0);
+  let items = find('.removable-list li', container);
+  assert.equal(items.length, 2);
+  assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
+  assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
 
-    fillIn(find('.search-box input', container), 'guy').then(function(){
-      click('.results li:eq(4)', container).then(function(){
-        items = find('.removable-list li', container);
-        assert.equal(items.length, 3);
-        assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
-        assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
-        assert.equal(getElementText(items.eq(2)), getText('3 guy M. Mc3son'));
-      });
-    });
-  });
+  await fillIn(find('.search-box input', container), 'guy');
+  await click('.results li:eq(4)', container);
+  items = find('.removable-list li', container);
+  assert.equal(items.length, 3);
+  assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
+  assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
+  assert.equal(getElementText(items.eq(2)), getText('3 guy M. Mc3son'));
 });
 
-test('remove default instructor', function(assert) {
-  visit(url);
+test('remove default instructor', async function(assert) {
+  await visit(url);
 
-  andThen(function() {
-    let container = find('.instructorgroup-overview').eq(0);
-    click('.removable-list li:eq(0)', container).then(function(){
-      let items = find('.removable-list li', container);
-      assert.equal(items.length, 1);
-      assert.equal(getElementText(items.eq(0)), getText('2 guy M. Mc2son'));
-    });
-  });
+  let container = find('.instructorgroup-overview').eq(0);
+  await click('.removable-list li:eq(0)', container);
+  let items = find('.removable-list li', container);
+  assert.equal(items.length, 1);
+  assert.equal(getElementText(items.eq(0)), getText('2 guy M. Mc2son'));
 });
 
-test('follow link to course', function(assert) {
-  visit(url);
-  andThen(function() {
-    click('.instructorgroupcourses li:eq(0) a');
-    andThen(()=>{
-      assert.equal(currentURL(), '/courses/1');
-    });
-  });
+test('follow link to course', async function(assert) {
+  await visit(url);
+  await click('.instructorgroupcourses li:eq(0) a');
+  assert.equal(currentURL(), '/courses/1');
 });
 
-test('no associated courses', function(assert) {
-  visit('/instructorgroups/3');
-  andThen(function() {
-    assert.equal(getElementText(find('.instructorgroup-header .title .school-title')),getText('school 0 >'));
-    assert.equal(getElementText(find('.instructorgroup-header .title .editable')),getText('instructorgroup 2'));
-    assert.equal(getElementText(find('.instructorgroupcourses')), getText('Associated Courses: None'));
-  });
+test('no associated courses', async function(assert) {
+  await visit('/instructorgroups/3');
+  assert.equal(getElementText(find('.instructorgroup-header .title .school-title')),getText('school 0 >'));
+  assert.equal(getElementText(find('.instructorgroup-header .title .editable')),getText('instructorgroup 2'));
+  assert.equal(getElementText(find('.instructorgroupcourses')), getText('Associated Courses: None'));
 });

--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -18,7 +18,7 @@ moduleForAcceptance('Acceptance: Learnergroup', {
 });
 
 
-test('generate new subgroups', function(assert) {
+test('generate new subgroups', async function(assert) {
   server.create('cohort', {
     learnerGroups: [1, 2, 3]
   });
@@ -56,32 +56,28 @@ test('generate new subgroups', function(assert) {
   const parentLearnergroupTitle = `learner group 0`;
   const table = `${subgroupList} .learnergroup-subgroup-list-list table tbody`;
 
-  visit('/learnergroups/1');
+  await visit('/learnergroups/1');
   // add five subgroups
-  click(expandButton);
-  click(multiGroupsButton);
-  fillIn(input, '5');
-  click(done);
+  await click(expandButton);
+  await click(multiGroupsButton);
+  await fillIn(input, '5');
+  await click(done);
   function getCellData(row, cell) {
     return find(`${table} tr:eq(${row}) td:eq(${cell})`).text().trim();
   }
-  andThen(() => {
-    assert.equal(find(`${table} tr`).length, 7, 'all subgroups are displayed.');
-    for (let i = 0; i < 5; i++) {
-      assert.equal(getCellData(i, 0), `${parentLearnergroupTitle} ${i + 1}`, 'new learnergroup title is ok.');
-    }
-    assert.equal(getCellData(5, 0), 'learner group 1');
-    assert.equal(getCellData(6, 0), 'learner group 2');
+  assert.equal(find(`${table} tr`).length, 7, 'all subgroups are displayed.');
+  for (let i = 0; i < 5; i++) {
+    assert.equal(getCellData(i, 0), `${parentLearnergroupTitle} ${i + 1}`, 'new learnergroup title is ok.');
+  }
+  assert.equal(getCellData(5, 0), 'learner group 1');
+  assert.equal(getCellData(6, 0), 'learner group 2');
 
-    // add two more subgroups
-    click(expandButton);
-    click(multiGroupsButton);
-    fillIn(input, '2');
-    click(done);
-    andThen(() => {
-      assert.equal(find(`${table} tr`).length, 9, 'all subgroups are still displayed.');
-      assert.equal(getCellData(5, 0), `${parentLearnergroupTitle} 6`, 'consecutively new learnergroup title is ok.');
-      assert.equal(getCellData(6, 0), `${parentLearnergroupTitle} 7`, 'consecutively new learnergroup title is ok.');
-    });
-  });
+  // add two more subgroups
+  await click(expandButton);
+  await click(multiGroupsButton);
+  await fillIn(input, '2');
+  await click(done);
+  assert.equal(find(`${table} tr`).length, 9, 'all subgroups are still displayed.');
+  assert.equal(getCellData(5, 0), `${parentLearnergroupTitle} 6`, 'consecutively new learnergroup title is ok.');
+  assert.equal(getCellData(6, 0), `${parentLearnergroupTitle} 7`, 'consecutively new learnergroup title is ok.');
 });

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -6,6 +6,7 @@ import {
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
 import Ember from 'ember';
+import wait from 'ember-test-helpers/wait';
 
 const { isEmpty, isPresent } = Ember;
 
@@ -23,16 +24,14 @@ module('Acceptance: Learner Groups', {
   }
 });
 
-test('visiting /learnergroups', function(assert) {
+test('visiting /learnergroups', async function(assert) {
   server.create('user', {id: 4136});
   server.create('school');
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(currentPath(), 'learnerGroups');
-  });
+  await visit('/learnergroups');
+  assert.equal(currentPath(), 'learnerGroups');
 });
 
-test('single option filters', function(assert) {
+test('single option filters', async function(assert) {
   const schoolsFilter = '.schoolsfilter';
   const programsFilter = '.programsfilter';
   const programyearsfilter = '.programyearsfilter';
@@ -52,15 +51,13 @@ test('single option filters', function(assert) {
   server.create('cohort', {
     programYear: 1,
   });
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(getElementText(find(schoolsFilter)), getText('school 0'));
-    assert.equal(getElementText(find(programsFilter)), getText('program 0'));
-    assert.equal(getElementText(find(programyearsfilter)), getText('cohort 0'));
-  });
+  await visit('/learnergroups');
+  assert.equal(getElementText(find(schoolsFilter)), getText('school 0'));
+  assert.equal(getElementText(find(programsFilter)), getText('program 0'));
+  assert.equal(getElementText(find(programyearsfilter)), getText('cohort 0'));
 });
 
-test('multi-option filters', function(assert) {
+test('multi-option filters', async function(assert) {
   const schoolSelect = '.schoolsfilter select';
   const schoolsFilter = `${schoolSelect} option`;
   const programsFilter = '.programsfilter option';
@@ -98,19 +95,17 @@ test('multi-option filters', function(assert) {
   server.create('cohort', {
     programYear: 2,
   });
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(find(schoolsFilter).length, 2);
-    assert.equal(getElementText(find(schoolsFilter)), getText('school 0 school 1'));
-    assert.equal(find(schoolSelect).val(), '1', 'default school is selected');
-    assert.equal(find(programsFilter).length, 3);
-    assert.equal(getElementText(find(programsFilter)), getText('Select a Program program 0 program 1'));
-    assert.equal(find(programyearsfilter).length, 2);
-    assert.equal(getElementText(find(programyearsfilter)), getText('cohort 1 cohort 0'));
-  });
+  await visit('/learnergroups');
+  assert.equal(find(schoolsFilter).length, 2);
+  assert.equal(getElementText(find(schoolsFilter)), getText('school 0 school 1'));
+  assert.equal(find(schoolSelect).val(), '1', 'default school is selected');
+  assert.equal(find(programsFilter).length, 3);
+  assert.equal(getElementText(find(programsFilter)), getText('Select a Program program 0 program 1'));
+  assert.equal(find(programyearsfilter).length, 2);
+  assert.equal(getElementText(find(programyearsfilter)), getText('cohort 1 cohort 0'));
 });
 
-test('primary school is selected by default', function(assert) {
+test('primary school is selected by default', async function(assert) {
   const schoolsFilter = '.schoolsfilter option:selected';
   assert.expect(1);
   server.create('permission', {
@@ -124,13 +119,11 @@ test('primary school is selected by default', function(assert) {
   server.create('school', {
     users: [1]
   });
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(getElementText(find(schoolsFilter)), getText('school 1'));
-  });
+  await visit('/learnergroups');
+  assert.equal(getElementText(find(schoolsFilter)), getText('school 1'));
 });
 
-test('multi-option filters', function(assert) {
+test('multi-option filters', async function(assert) {
   const schoolsFilter = '.schoolsfilter option';
   const programsFilter = '.programsfilter option';
   const programyearsfilter = '.programyearsfilter option';
@@ -167,18 +160,16 @@ test('multi-option filters', function(assert) {
   server.create('cohort', {
     programYear: 2,
   });
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(find(schoolsFilter).length, 2);
-    assert.equal(getElementText(find(schoolsFilter)), getText('school 0 school 1'));
-    assert.equal(find(programsFilter).length, 3);
-    assert.equal(getElementText(find(programsFilter)), getText('Select a Program program 0 program 1'));
-    assert.equal(find(programyearsfilter).length, 2);
-    assert.equal(getElementText(find(programyearsfilter)), getText('cohort 1 cohort 0'));
-  });
+  await visit('/learnergroups');
+  assert.equal(find(schoolsFilter).length, 2);
+  assert.equal(getElementText(find(schoolsFilter)), getText('school 0 school 1'));
+  assert.equal(find(programsFilter).length, 3);
+  assert.equal(getElementText(find(programsFilter)), getText('Select a Program program 0 program 1'));
+  assert.equal(find(programyearsfilter).length, 2);
+  assert.equal(getElementText(find(programyearsfilter)), getText('cohort 1 cohort 0'));
 });
 
-test('multiple programs filter', function(assert) {
+test('multiple programs filter', async function(assert) {
   const selectedProgram = '.programsfilter select option:selected';
   const programOptions = '.programsfilter select option';
   const programSelectList = '.programsfilter select';
@@ -218,25 +209,19 @@ test('multiple programs filter', function(assert) {
   var secondLearnergroup = server.create('learnerGroup', {
     cohort: 2
   });
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(getElementText(find(selectedProgram)), getText('program 0'));
-    andThen(function(){
-      assert.equal(getElementText(find(firstListedLearnerGroup)),getText(firstLearnergroup.title));
-      var options = find(programOptions);
-      assert.equal(options.length, 3);
-      assert.equal(getElementText(options.eq(0)), getText('Select a Program'));
-      assert.equal(getElementText(options.eq(1)), getText('program 0'));
-      assert.equal(getElementText(options.eq(2)), getText('program 1'));
-      pickOption(programSelectList, 'program 1', assert);
-      andThen(() => {
-        assert.equal(getElementText(find(firstListedLearnerGroup)),getText(secondLearnergroup.title));
-      });
-    });
-  });
+  await visit('/learnergroups');
+  assert.equal(getElementText(find(selectedProgram)), getText('program 0'));
+  assert.equal(getElementText(find(firstListedLearnerGroup)),getText(firstLearnergroup.title));
+  var options = find(programOptions);
+  assert.equal(options.length, 3);
+  assert.equal(getElementText(options.eq(0)), getText('Select a Program'));
+  assert.equal(getElementText(options.eq(1)), getText('program 0'));
+  assert.equal(getElementText(options.eq(2)), getText('program 1'));
+  await pickOption(programSelectList, 'program 1', assert);
+  assert.equal(getElementText(find(firstListedLearnerGroup)),getText(secondLearnergroup.title));
 });
 
-test('multiple program years filter', function(assert) {
+test('multiple program years filter', async function(assert) {
   const selectedProgramYear = '.programyearsfilter select option:selected';
   const programYearOptions = '.programyearsfilter select option';
   const programYearSelectList = '.programyearsfilter select';
@@ -272,22 +257,18 @@ test('multiple program years filter', function(assert) {
   var secondLearnergroup = server.create('learnerGroup', {
     cohort: 2
   });
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(getElementText(find(selectedProgramYear)), getText('cohort 1'));
-    assert.equal(getElementText(find(firstListedLearnerGroup)),getText(secondLearnergroup.title));
-    var options = find(programYearOptions);
-    assert.equal(options.length, 2);
-    assert.equal(getElementText(options.eq(0)), getText('cohort 1'));
-    assert.equal(getElementText(options.eq(1)), getText('cohort 0'));
-    pickOption(programYearSelectList, 'cohort 0', assert);
-    andThen(function(){
-      assert.equal(getElementText(find(firstListedLearnerGroup)),getText(firstLearnergroup.title));
-    });
-  });
+  await visit('/learnergroups');
+  assert.equal(getElementText(find(selectedProgramYear)), getText('cohort 1'));
+  assert.equal(getElementText(find(firstListedLearnerGroup)),getText(secondLearnergroup.title));
+  var options = find(programYearOptions);
+  assert.equal(options.length, 2);
+  assert.equal(getElementText(options.eq(0)), getText('cohort 1'));
+  assert.equal(getElementText(options.eq(1)), getText('cohort 0'));
+  await pickOption(programYearSelectList, 'cohort 0', assert);
+  assert.equal(getElementText(find(firstListedLearnerGroup)),getText(firstLearnergroup.title));
 });
 
-test('list groups', function(assert) {
+test('list groups', async function(assert) {
   server.create('user', {id: 4136});
   server.createList('user', 5, {
     learnerGroups: [1]
@@ -339,22 +320,20 @@ test('list groups', function(assert) {
     users: [11,12]
   });
 
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(2, find('.list tbody tr').length);
-    var rows = find('.list tbody tr');
-    assert.equal(getElementText(find('td:eq(0)', rows.eq(0))),getText(firstLearnergroup.title));
-    // Assertion below needs to be fixed (issue #1157)
-    // assert.equal(getElementText(find('td:eq(1)', rows.eq(0))), 11);
-    assert.equal(getElementText(find('td:eq(2)', rows.eq(0))), 2);
+  await visit('/learnergroups');
+  assert.equal(2, find('.list tbody tr').length);
+  var rows = find('.list tbody tr');
+  assert.equal(getElementText(find('td:eq(0)', rows.eq(0))),getText(firstLearnergroup.title));
+  // Assertion below needs to be fixed (issue #1157)
+  // assert.equal(getElementText(find('td:eq(1)', rows.eq(0))), 11);
+  assert.equal(getElementText(find('td:eq(2)', rows.eq(0))), 2);
 
-    assert.equal(getElementText(find('td:eq(0)', rows.eq(1))),getText(secondLearnergroup.title));
-    assert.equal(getElementText(find('td:eq(1)', rows.eq(1))), 0);
-    assert.equal(getElementText(find('td:eq(2)', rows.eq(1))), 0);
-  });
+  assert.equal(getElementText(find('td:eq(0)', rows.eq(1))),getText(secondLearnergroup.title));
+  assert.equal(getElementText(find('td:eq(1)', rows.eq(1))), 0);
+  assert.equal(getElementText(find('td:eq(2)', rows.eq(1))), 0);
 });
 
-test('filters by title', function(assert) {
+test('filters by title', async function(assert) {
   server.create('user', {id: 4136});
   server.create('school', {
     programs: [1]
@@ -384,52 +363,46 @@ test('filters by title', function(assert) {
     cohort: 1
   });
   assert.expect(15);
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(find('.list tbody tr').length, 3);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(regularLearnergroup.title));
-    assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstLearnergroup.title));
-    assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondLearnergroup.title));
+  await visit('/learnergroups');
+  assert.equal(find('.list tbody tr').length, 3);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(regularLearnergroup.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstLearnergroup.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondLearnergroup.title));
 
-    //put these in nested later blocks because there is a 500ms debounce on the title filter
-    fillIn('.titlefilter input', 'first');
-    Ember.run.later(function(){
+  //put these in nested later blocks because there is a 500ms debounce on the title filter
+  await fillIn('.titlefilter input', 'first');
+  Ember.run.later(async () => {
+    assert.equal(1, find('.list tbody tr').length);
+    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstLearnergroup.title));
+    await fillIn('.titlefilter input', 'second');
+    Ember.run.later(async () => {
       assert.equal(1, find('.list tbody tr').length);
-      assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstLearnergroup.title));
-      fillIn('.titlefilter input', 'second');
-      andThen(function(){
-        Ember.run.later(function(){
-          assert.equal(1, find('.list tbody tr').length);
-          assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(secondLearnergroup.title));
-          fillIn('.titlefilter input', 'special');
-          andThen(function(){
-            Ember.run.later(function(){
-              assert.equal(2, find('.list tbody tr').length);
-              assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstLearnergroup.title));
-              assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(secondLearnergroup.title));
+      assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(secondLearnergroup.title));
+      await fillIn('.titlefilter input', 'special');
+      Ember.run.later(async () => {
+        assert.equal(2, find('.list tbody tr').length);
+        assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstLearnergroup.title));
+        assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(secondLearnergroup.title));
 
-              fillIn('.titlefilter input', '');
-              andThen(function(){
-                Ember.run.later(function(){
-                  assert.equal(3, find('.list tbody tr').length);
-                  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(regularLearnergroup.title));
-                  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstLearnergroup.title));
-                  assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondLearnergroup.title));
-                }, 750);
-              });
-            }, 750);
-          });
+        await fillIn('.titlefilter input', '');
+        Ember.run.later(async () => {
+          assert.equal(3, find('.list tbody tr').length);
+          assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(regularLearnergroup.title));
+          assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstLearnergroup.title));
+          assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondLearnergroup.title));
         }, 750);
-      });
+      }, 750);
     }, 750);
-  });
+  }, 750);
+
+  await wait();
 });
 
 function getCellData(row, cell) {
   return find(`.list tbody tr:eq(${row}) td:eq(${cell})`).text().trim();
 }
 
-test('add new learnergroup', function(assert) {
+test('add new learnergroup', async function(assert) {
   assert.expect(3);
 
   server.create('user', { id: 4136 });
@@ -451,18 +424,16 @@ test('add new learnergroup', function(assert) {
   const done = '.new-learnergroup .done';
 
   let newTitle = 'A New Test Title';
-  visit(url);
-  click(expandButton);
-  fillIn(input, newTitle);
-  click(done);
-  andThen(() => {
-    assert.equal(getCellData(0, 0), 'A New Test Title', 'title is correct');
-    assert.equal(getCellData(0, 1), 0, 'member count is correct');
-    assert.equal(getElementText(find('.saved-result')), getText(newTitle + 'Saved Successfully', 'Success message is shown.'));
-  });
+  await visit(url);
+  await click(expandButton);
+  await fillIn(input, newTitle);
+  await click(done);
+  assert.equal(getCellData(0, 0), 'A New Test Title', 'title is correct');
+  assert.equal(getCellData(0, 1), 0, 'member count is correct');
+  assert.equal(getElementText(find('.saved-result')), getText(newTitle + 'Saved Successfully', 'Success message is shown.'));
 });
 
-test('cancel adding new learnergroup', function(assert) {
+test('cancel adding new learnergroup', async function(assert) {
   assert.expect(8);
 
   server.create('user', {id: 4136});
@@ -490,30 +461,24 @@ test('cancel adding new learnergroup', function(assert) {
   const cancelButton = '.new-learnergroup .cancel';
   const component = '.new-learnergroup';
 
-  visit(url);
-  click(expandButton);
-  andThen(() => {
-    assert.ok(isPresent(find(collapseButton)), 'collapse button is visible');
-    assert.ok(isPresent(find(component)), '`new-learnergroup` component is visible');
-  });
+  await visit(url);
+  await click(expandButton);
+  assert.ok(isPresent(find(collapseButton)), 'collapse button is visible');
+  assert.ok(isPresent(find(component)), '`new-learnergroup` component is visible');
 
-  click(cancelButton);
-  andThen(() => {
-    assert.ok(isPresent(find(expandButton)), 'expand button is visible');
-    assert.ok(isEmpty(find(component)), '`new-learnergroup` component is not visible');
-    assert.equal(getCellData(0, 0), 'learner group 0');
-  });
+  await click(cancelButton);
+  assert.ok(isPresent(find(expandButton)), 'expand button is visible');
+  assert.ok(isEmpty(find(component)), '`new-learnergroup` component is not visible');
+  assert.equal(getCellData(0, 0), 'learner group 0');
 
-  click(expandButton);
-  click(collapseButton);
-  andThen(() => {
-    assert.ok(isPresent(find(expandButton)), 'expand button is visible');
-    assert.ok(isEmpty(find(component)), '`new-learnergroup` component is not visible');
-    assert.equal(getCellData(0, 0), 'learner group 0');
-  });
+  await click(expandButton);
+  await click(collapseButton);
+  assert.ok(isPresent(find(expandButton)), 'expand button is visible');
+  assert.ok(isEmpty(find(component)), '`new-learnergroup` component is not visible');
+  assert.equal(getCellData(0, 0), 'learner group 0');
 });
 
-test('remove learnergroup', function(assert) {
+test('remove learnergroup', async function(assert) {
   assert.expect(3);
   server.create('user', {id: 4136});
   server.create('school', {
@@ -534,18 +499,15 @@ test('remove learnergroup', function(assert) {
   server.create('learnerGroup', {
     cohort: 1,
   });
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(1, find('.list tbody tr').length);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText('learnergroup 0'));
-    click('.list tbody tr:eq(0) td:eq(3) .remove');
-    click('.list tbody tr:eq(1) .remove').then(()=>{
-      assert.equal(0, find('.list tbody tr').length);
-    });
-  });
+  await visit('/learnergroups');
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText('learnergroup 0'));
+  await click('.list tbody tr:eq(0) td:eq(3) .remove');
+  await click('.list tbody tr:eq(1) .remove');
+  assert.equal(0, find('.list tbody tr').length);
 });
 
-test('cancel remove learnergroup', function(assert) {
+test('cancel remove learnergroup', async function(assert) {
   assert.expect(4);
   server.create('user', {id: 4136});
   server.create('school', {
@@ -566,19 +528,16 @@ test('cancel remove learnergroup', function(assert) {
   server.create('learnerGroup', {
     cohort: 1,
   });
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(1, find('.list tbody tr').length);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText('learnergroup 0'));
-    click('.list tbody tr:eq(0) td:eq(3) .remove');
-    click('.list tbody tr:eq(1) .done').then(()=>{
-      assert.equal(1, find('.list tbody tr').length);
-      assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText('learnergroup 0'));
-    });
-  });
+  await visit('/learnergroups');
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText('learnergroup 0'));
+  await click('.list tbody tr:eq(0) td:eq(3) .remove');
+  await click('.list tbody tr:eq(1) .done');
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText('learnergroup 0'));
 });
 
-test('confirmation of remove message', function(assert) {
+test('confirmation of remove message', async function(assert) {
   server.create('user', {id: 4136});
   server.createList('user', 5, {
     learnerGroups: [1]
@@ -607,19 +566,16 @@ test('confirmation of remove message', function(assert) {
     parent: 1
   });
   assert.expect(5);
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(1, find('.list tbody tr').length);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText('learnergroup 0'));
-    click('.list tbody tr:eq(0) td:eq(3) .remove').then(()=>{
-      assert.ok(find('.list tbody tr:eq(0)').hasClass('confirm-removal'));
-      assert.ok(find('.list tbody tr:eq(1)').hasClass('confirm-removal'));
-      assert.equal(getElementText(find('.list tbody tr:eq(1)')), getText('Are you sure you want to delete this learner group, with 2 subgroups? This action cannot be undone. Yes Cancel'));
-    });
-  });
+  await visit('/learnergroups');
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText('learnergroup 0'));
+  await click('.list tbody tr:eq(0) td:eq(3) .remove');
+  assert.ok(find('.list tbody tr:eq(0)').hasClass('confirm-removal'));
+  assert.ok(find('.list tbody tr:eq(1)').hasClass('confirm-removal'));
+  assert.equal(getElementText(find('.list tbody tr:eq(1)')), getText('Are you sure you want to delete this learner group, with 2 subgroups? This action cannot be undone. Yes Cancel'));
 });
 
-test('populated learner groups are not deletable', function(assert) {
+test('populated learner groups are not deletable', async function(assert) {
   server.create('user', {id: 4136});
   server.createList('user', 5, {
     learnerGroups: [1]
@@ -646,15 +602,13 @@ test('populated learner groups are not deletable', function(assert) {
   });
 
   assert.expect(3);
-  visit('/learnergroups');
-  andThen(function() {
-    assert.equal(1, find('.list tbody tr').length);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText('learnergroup 0'));
-    assert.notOk(find('.list tbody tr:eq(0) td:eq(3) .remove').length, 'No delete action is available');
-  });
+  await visit('/learnergroups');
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText('learnergroup 0'));
+  assert.notOk(find('.list tbody tr:eq(0) td:eq(3) .remove').length, 'No delete action is available');
 });
 
-test('click title takes you to learnergroup route', function(assert) {
+test('click title takes you to learnergroup route', async function(assert) {
   assert.expect(1);
   server.create('user', {id: 4136});
   server.create('school', {
@@ -675,16 +629,12 @@ test('click title takes you to learnergroup route', function(assert) {
   server.create('learnerGroup', {
     cohort: 1,
   });
-  visit('/learnergroups');
-  andThen(function() {
-    click('.list tbody tr:eq(0) td:eq(0) a');
-  });
-  andThen(function(){
-    assert.equal(currentURL(), '/learnergroups/1');
-  });
+  await visit('/learnergroups');
+  await click('.list tbody tr:eq(0) td:eq(0) a');
+  assert.equal(currentURL(), '/learnergroups/1');
 });
 
-test('add new learnergroup with full cohort', function(assert) {
+test('add new learnergroup with full cohort', async function(assert) {
   assert.expect(2);
 
   server.create('user', { id: 4136 });
@@ -708,27 +658,23 @@ test('add new learnergroup with full cohort', function(assert) {
   const addFullCohort = '.new-learnergroup .clickable:eq(0)';
   const done = '.new-learnergroup .done';
 
-  visit(url);
-  click(expandButton);
-  fillIn(input, 'A New Test Title');
-  click(addFullCohort);
-  click(done);
-  andThen(() => {
-    assert.equal(getCellData(0, 0), 'A New Test Title', 'title is correct');
-    assert.equal(getCellData(0, 1), 5, 'member count is correct');
-  });
+  await visit(url);
+  await click(expandButton);
+  await fillIn(input, 'A New Test Title');
+  await click(addFullCohort);
+  await click(done);
+  assert.equal(getCellData(0, 0), 'A New Test Title', 'title is correct');
+  assert.equal(getCellData(0, 1), 5, 'member count is correct');
 });
 
-test('no add button when there is no cohort', function(assert) {
+test('no add button when there is no cohort', async function(assert) {
   server.create('user', {id: 4136});
   server.create('school');
-  visit('/learnergroups');
+  await visit('/learnergroups');
   const expandNewButton = '.actions .expand-button';
 
-  andThen(function() {
-    assert.equal(currentPath(), 'learnerGroups');
-    assert.equal(find(expandNewButton).length, 0);
-  });
+  assert.equal(currentPath(), 'learnerGroups');
+  assert.equal(find(expandNewButton).length, 0);
 });
 
 test('title filter escapes regex', async function(assert) {

--- a/tests/acceptance/program/overview-test.js
+++ b/tests/acceptance/program/overview-test.js
@@ -20,17 +20,15 @@ module('Acceptance: Program - Overview', {
   }
 });
 
-test('check fields', function(assert) {
+test('check fields', async function(assert) {
   var program = server.create('program', {
     school: 1,
   });
-  visit(url);
-  andThen(function() {
-    assert.equal(currentPath(), 'program.index');
-    var container = find('.program-overview');
-    assert.equal(getElementText(find('.programtitleshort .editable', container)), getText(program.shortTitle));
-    assert.equal(getElementText(find('.programduration .editable', container)), program.duration);
-  });
+  await visit(url);
+  assert.equal(currentPath(), 'program.index');
+  var container = find('.program-overview');
+  assert.equal(getElementText(find('.programtitleshort .editable', container)), getText(program.shortTitle));
+  assert.equal(getElementText(find('.programduration .editable', container)), program.duration);
 });
 
 test('change title', async function(assert) {
@@ -96,7 +94,7 @@ test('change duration', async function(assert) {
   for(let i = 0; i < 10; i++){
     assert.equal(getElementText(durations.eq(i)), i+1);
   }
-  pickOption(select, '9', assert);
+  await pickOption(select, '9', assert);
   await click(done);
   assert.equal(getElementText(duration), '9');
 });

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -24,7 +24,7 @@ module('Acceptance: Program - ProgramYear List', {
   }
 });
 
-test('check list', function(assert) {
+test('check list', async function(assert) {
   server.create('program', {
     school: 1,
     programYears: [1,2,3,4]
@@ -51,21 +51,19 @@ test('check list', function(assert) {
     archived: true
   });
   server.createList('cohort', 4);
-  visit(url);
-  andThen(function() {
-    var container = find('.programyear-list');
-    var rows = find('tbody tr', container);
-    assert.equal(rows.length, 3);
-    assert.equal(getElementText(find('td:eq(0)', rows.eq(0))), getText('2010 - 2011'));
-    assert.equal(getElementText(find('td:eq(1)', rows.eq(0))), getText('cohort1'));
-    assert.equal(getElementText(find('td:eq(0)', rows.eq(1))), getText('2011 - 2012'));
-    assert.equal(getElementText(find('td:eq(1)', rows.eq(1))), getText('cohort2'));
-    assert.equal(getElementText(find('td:eq(0)', rows.eq(2))), getText('2012 - 2013'));
-    assert.equal(getElementText(find('td:eq(1)', rows.eq(2))), getText('cohort0'));
-  });
+  await visit(url);
+  var container = find('.programyear-list');
+  var rows = find('tbody tr', container);
+  assert.equal(rows.length, 3);
+  assert.equal(getElementText(find('td:eq(0)', rows.eq(0))), getText('2010 - 2011'));
+  assert.equal(getElementText(find('td:eq(1)', rows.eq(0))), getText('cohort1'));
+  assert.equal(getElementText(find('td:eq(0)', rows.eq(1))), getText('2011 - 2012'));
+  assert.equal(getElementText(find('td:eq(1)', rows.eq(1))), getText('cohort2'));
+  assert.equal(getElementText(find('td:eq(0)', rows.eq(2))), getText('2012 - 2013'));
+  assert.equal(getElementText(find('td:eq(1)', rows.eq(2))), getText('cohort0'));
 });
 
-test('check competencies', function(assert) {
+test('check competencies', async function(assert) {
   server.create('program', {
     school: 1,
     programYears: [1]
@@ -78,13 +76,11 @@ test('check competencies', function(assert) {
     competencies: [1,2,3,4,5]
   });
   server.create('cohort');
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(find('.programyear-list tbody tr:eq(0) td:eq(2)')), 5);
-  });
+  await visit(url);
+  assert.equal(getElementText(find('.programyear-list tbody tr:eq(0) td:eq(2)')), 5);
 });
 
-test('check objectives', function(assert) {
+test('check objectives', async function(assert) {
   server.create('program', {
     school: 1,
     programYears: [1]
@@ -97,13 +93,11 @@ test('check objectives', function(assert) {
     objectives: [1,2,3,4,5]
   });
   server.create('cohort');
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(find('.programyear-list tbody tr:eq(0) td:eq(3)')), 5);
-  });
+  await visit(url);
+  assert.equal(getElementText(find('.programyear-list tbody tr:eq(0) td:eq(3)')), 5);
 });
 
-test('check directors', function(assert) {
+test('check directors', async function(assert) {
   server.create('program', {
     school: 1,
     programYears: [1]
@@ -116,13 +110,11 @@ test('check directors', function(assert) {
     directors: [2,3,4,5,6]
   });
   server.create('cohort');
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(find('.programyear-list tbody tr:eq(0) td:eq(4)')), 5);
-  });
+  await visit(url);
+  assert.equal(getElementText(find('.programyear-list tbody tr:eq(0) td:eq(4)')), 5);
 });
 
-test('check terms', function(assert) {
+test('check terms', async function(assert) {
   server.create('program', {
     school: 1,
     programYears: [1],
@@ -143,13 +135,11 @@ test('check terms', function(assert) {
     terms: [1,2,3,4,5]
   });
   server.create('cohort');
-  visit(url);
-  andThen(function() {
-    assert.equal(getElementText(find('.programyear-list tbody tr:eq(0) td:eq(5)')), 5);
-  });
+  await visit(url);
+  assert.equal(getElementText(find('.programyear-list tbody tr:eq(0) td:eq(5)')), 5);
 });
 
-test('check warnings', function(assert) {
+test('check warnings', async function(assert) {
   server.create('program', {
     school: 1,
     programYears: [1]
@@ -158,18 +148,16 @@ test('check warnings', function(assert) {
     program: 1,
   });
   server.create('cohort');
-  visit(url);
-  andThen(function() {
-    var tds = find('.programyear-list tbody tr:eq(0) td');
-    for(let i =2; i< 6; i++){
-      let icon = find('i', tds.eq(i));
-      assert.ok(icon);
-      assert.ok(icon.hasClass('warning'));
-    }
-  });
+  await visit(url);
+  var tds = find('.programyear-list tbody tr:eq(0) td');
+  for(let i =2; i< 6; i++){
+    let icon = find('i', tds.eq(i));
+    assert.ok(icon);
+    assert.ok(icon.hasClass('warning'));
+  }
 });
 
-test('check link', function(assert) {
+test('check link', async function(assert) {
   server.create('program', {
     school: 1,
     programYears: [1]
@@ -178,14 +166,12 @@ test('check link', function(assert) {
     program: 1,
   });
   server.create('cohort');
-  visit(url);
-  click('.programyear-list tbody tr:eq(0) td:eq(0) a');
-  andThen(function() {
-    assert.equal(currentPath(), 'program.programYear.index');
-  });
+  await visit(url);
+  await click('.programyear-list tbody tr:eq(0) td:eq(0) a');
+  assert.equal(currentPath(), 'program.programYear.index');
 });
 
-test('can delete a program-year', function(assert) {
+test('can delete a program-year', async function(assert) {
   server.create('program', {
     school: 1,
     programYears: [1]
@@ -204,19 +190,15 @@ test('can delete a program-year', function(assert) {
   const confirmRemovalButton = '.confirm-message button.remove';
   const listRows = '.list tbody tr';
 
-  visit(url);
-  andThen(() => {
-    assert.ok(isPresent(find(listRows)), 'one program-year exists');
-  });
+  await visit(url);
+  assert.ok(isPresent(find(listRows)), 'one program-year exists');
 
-  click(deleteButton);
-  click(confirmRemovalButton);
-  andThen(() => {
-    assert.ok(isEmpty(find(listRows)), 'program was removed');
-  });
+  await click(deleteButton);
+  await click(confirmRemovalButton);
+  assert.ok(isEmpty(find(listRows)), 'program was removed');
 });
 
-test('canceling adding new program-year collapses select menu', function(assert) {
+test('canceling adding new program-year collapses select menu', async function(assert) {
   server.create('program', {
     school: 1,
   });
@@ -225,23 +207,19 @@ test('canceling adding new program-year collapses select menu', function(assert)
   const cancelButton = '.new-programyear .cancel';
   const selectField = '.startyear-select select';
 
-  visit(url);
-  click(expandButton);
-  andThen(() => {
-    assert.ok(isPresent(find(selectField)), 'select menu is shown');
-  });
+  await visit(url);
+  await click(expandButton);
+  assert.ok(isPresent(find(selectField)), 'select menu is shown');
 
-  click(cancelButton);
-  andThen(() => {
-    assert.ok(isEmpty(find(selectField)), 'select menu is hidden');
-  });
+  await click(cancelButton);
+  assert.ok(isEmpty(find(selectField)), 'select menu is hidden');
 });
 
 function getTableDataText(n, i, element = '') {
   return find(`.programyears .list tbody tr:eq(${n}) td:eq(${i}) ${element}`);
 }
 
-test('can add a program-year (with no pre-existing program-years)', function(assert) {
+test('can add a program-year (with no pre-existing program-years)', async function(assert) {
   server.create('program', {
     id: 1,
     school: 1,
@@ -252,31 +230,25 @@ test('can add a program-year (with no pre-existing program-years)', function(ass
   const selectField = '.startyear-select select';
   const saveButton = '.new-programyear .done';
 
-  visit(url);
-  andThen(() => {
-    assert.ok(isEmpty(find(listRows)), 'there are no pre-existing program-years');
-  });
+  await visit(url);
+  assert.ok(isEmpty(find(listRows)), 'there are no pre-existing program-years');
 
-  click(expandButton);
-  andThen(() => {
-    const thisYear = new Date().getFullYear();
-    find(selectField).eq(0).val(thisYear).change();
-    click(saveButton);
-    const academicYear = `${thisYear.toString()} - ${(thisYear + 1).toString()}`;
-    andThen(() => {
-      assert.equal(getTableDataText(0, 0).text().trim(), academicYear, 'academic year shown');
-      const classOfYear = `Class of ${(thisYear + 4).toString()}`;
-      assert.equal(getTableDataText(0, 1).text().trim(), classOfYear, 'cohort class year shown');
-      assert.ok(getTableDataText(0, 2, 'i').hasClass('fa-warning'), 'warning label shown');
-      assert.ok(getTableDataText(0, 3, 'i').hasClass('fa-warning'), 'warning label shown');
-      assert.ok(getTableDataText(0, 4, 'i').hasClass('fa-warning'), 'warning label shown');
-      assert.ok(getTableDataText(0, 5, 'i').hasClass('fa-warning'), 'warning label shown');
-      assert.equal(getTableDataText(0, 6, 'span').text().trim(), 'Not Published', 'unpublished shown');
-    });
-  });
+  await click(expandButton);
+  const thisYear = new Date().getFullYear();
+  find(selectField).eq(0).val(thisYear).change();
+  await click(saveButton);
+  const academicYear = `${thisYear.toString()} - ${(thisYear + 1).toString()}`;
+  assert.equal(getTableDataText(0, 0).text().trim(), academicYear, 'academic year shown');
+  const classOfYear = `Class of ${(thisYear + 4).toString()}`;
+  assert.equal(getTableDataText(0, 1).text().trim(), classOfYear, 'cohort class year shown');
+  assert.ok(getTableDataText(0, 2, 'i').hasClass('fa-warning'), 'warning label shown');
+  assert.ok(getTableDataText(0, 3, 'i').hasClass('fa-warning'), 'warning label shown');
+  assert.ok(getTableDataText(0, 4, 'i').hasClass('fa-warning'), 'warning label shown');
+  assert.ok(getTableDataText(0, 5, 'i').hasClass('fa-warning'), 'warning label shown');
+  assert.equal(getTableDataText(0, 6, 'span').text().trim(), 'Not Published', 'unpublished shown');
 });
 
-test('can add a program-year (with pre-existing program-year)', function(assert) {
+test('can add a program-year (with pre-existing program-year)', async function(assert) {
   server.createList('user', 3, {
     directedProgramYears: [1]
   });
@@ -336,38 +308,32 @@ test('can add a program-year (with pre-existing program-year)', function(assert)
   const saveButton = '.new-programyear .done';
   const thisYear = new Date().getFullYear();
 
-  visit(url);
-  andThen(() => {
-    const academicYear = `${thisYear.toString()} - ${(thisYear + 1).toString()}`;
+  await visit(url);
+  const academicYear = `${thisYear.toString()} - ${(thisYear + 1).toString()}`;
 
-    assert.equal(getTableDataText(0, 0).text().trim(), academicYear, 'academic year shown');
-    assert.equal(getTableDataText(0, 1).text().trim(), 'cohort 0', 'cohort class year shown');
-    assert.equal(getTableDataText(0, 2).text().trim(), '3');
-    assert.equal(getTableDataText(0, 3).text().trim(), '3');
-    assert.equal(getTableDataText(0, 4).text().trim(), '3');
-    assert.equal(getTableDataText(0, 5).text().trim(), '3');
-    assert.equal(getTableDataText(0, 6, 'span').text().trim(), 'Not Published', 'unpublished shown');
-  });
+  assert.equal(getTableDataText(0, 0).text().trim(), academicYear, 'academic year shown');
+  assert.equal(getTableDataText(0, 1).text().trim(), 'cohort 0', 'cohort class year shown');
+  assert.equal(getTableDataText(0, 2).text().trim(), '3');
+  assert.equal(getTableDataText(0, 3).text().trim(), '3');
+  assert.equal(getTableDataText(0, 4).text().trim(), '3');
+  assert.equal(getTableDataText(0, 5).text().trim(), '3');
+  assert.equal(getTableDataText(0, 6, 'span').text().trim(), 'Not Published', 'unpublished shown');
 
-  click(expandButton);
-  andThen(() => {
-    find(selectField).eq(0).val(thisYear + 1).change();
-    click(saveButton);
-    andThen(() => {
-      const academicYear = `${(thisYear + 1).toString()} - ${(thisYear + 2).toString()}`;
-      assert.equal(getTableDataText(1, 0).text().trim(), academicYear, 'academic year shown');
-      const cohortClassYear = `Class of ${(thisYear + 5).toString()}`;
-      assert.equal(getTableDataText(1, 1).text().trim(), cohortClassYear, 'cohort class year shown');
-      assert.equal(getTableDataText(1, 2).text().trim(), '3', 'copied correctly from latest program-year');
-      assert.equal(getTableDataText(1, 3).text().trim(), '3', 'copied correctly from latest program-year');
-      assert.equal(getTableDataText(1, 4).text().trim(), '3', 'copied correctly from latest program-year');
-      assert.equal(getTableDataText(1, 5).text().trim(), '3', 'copied correctly from latest program-year');
-      assert.equal(getTableDataText(1, 6, 'span').text().trim(), 'Not Published', 'unpublished shown');
-    });
-  });
+  await click(expandButton);
+  find(selectField).eq(0).val(thisYear + 1).change();
+  await click(saveButton);
+  const academicYear2 = `${(thisYear + 1).toString()} - ${(thisYear + 2).toString()}`;
+  assert.equal(getTableDataText(1, 0).text().trim(), academicYear2, 'academic year shown');
+  const cohortClassYear = `Class of ${(thisYear + 5).toString()}`;
+  assert.equal(getTableDataText(1, 1).text().trim(), cohortClassYear, 'cohort class year shown');
+  assert.equal(getTableDataText(1, 2).text().trim(), '3', 'copied correctly from latest program-year');
+  assert.equal(getTableDataText(1, 3).text().trim(), '3', 'copied correctly from latest program-year');
+  assert.equal(getTableDataText(1, 4).text().trim(), '3', 'copied correctly from latest program-year');
+  assert.equal(getTableDataText(1, 5).text().trim(), '3', 'copied correctly from latest program-year');
+  assert.equal(getTableDataText(1, 6, 'span').text().trim(), 'Not Published', 'unpublished shown');
 });
 
-test('privileged users can lock and unlock program-year', function(assert) {
+test('privileged users can lock and unlock program-year', async function(assert) {
   assert.expect(6);
   const firstProgramYearRow = '.list tbody tr:eq(0)';
   const secondProgramYearRow = '.list tbody tr:eq(1)';
@@ -400,22 +366,18 @@ test('privileged users can lock and unlock program-year', function(assert) {
   });
   server.db.users.update(4136, {roles: [1]});
 
-  visit(url);
-  andThen(function() {
-    assert.ok(find(firstProgramYearLockedIcon).hasClass('fa-lock'), 'first program year is locked');
-    assert.ok(find(firstProgramYearLockedIcon).hasClass('clickable'), 'first program year is clickable');
-    assert.ok(find(secondProgramYearLockedIcon).hasClass('fa-unlock'), 'second program year is unlocked');
-    assert.ok(find(secondProgramYearLockedIcon).hasClass('clickable'), 'second program year is clickable');
-    click(firstProgramYearLockedIcon);
-    click(secondProgramYearLockedIcon);
-    andThen(()=>{
-      assert.ok(find(firstProgramYearLockedIcon).hasClass('fa-unlock'), 'first program year is now unlocked');
-      assert.ok(find(secondProgramYearLockedIcon).hasClass('fa-lock'), 'second program year is now locked');
-    });
-  });
+  await visit(url);
+  assert.ok(find(firstProgramYearLockedIcon).hasClass('fa-lock'), 'first program year is locked');
+  assert.ok(find(firstProgramYearLockedIcon).hasClass('clickable'), 'first program year is clickable');
+  assert.ok(find(secondProgramYearLockedIcon).hasClass('fa-unlock'), 'second program year is unlocked');
+  assert.ok(find(secondProgramYearLockedIcon).hasClass('clickable'), 'second program year is clickable');
+  await click(firstProgramYearLockedIcon);
+  await click(secondProgramYearLockedIcon);
+  assert.ok(find(firstProgramYearLockedIcon).hasClass('fa-unlock'), 'first program year is now unlocked');
+  assert.ok(find(secondProgramYearLockedIcon).hasClass('fa-lock'), 'second program year is now locked');
 });
 
-test('non-privileged users cannot lock and unlock course but can see the icon', function(assert) {
+test('non-privileged users cannot lock and unlock course but can see the icon', async function(assert) {
   assert.expect(4);
   const firstCourseRow = '.list tbody tr:eq(0)';
   const secondCourseRow = '.list tbody tr:eq(1)';
@@ -436,20 +398,16 @@ test('non-privileged users cannot lock and unlock course but can see the icon', 
     publishedAsTbd: true,
     locked: false,
   });
-  visit('/courses');
-  andThen(function() {
-    assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
-    assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
-    click(find(firstCourseLockedIcon));
-    click(find(secondCourseLockedIcon));
-    andThen(()=>{
-      assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is still locked');
-      assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is still unlocked');
-    });
-  });
+  await visit('/courses');
+  assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is locked');
+  assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is unlocked');
+  await click(find(firstCourseLockedIcon));
+  await click(find(secondCourseLockedIcon));
+  assert.ok(find(firstCourseLockedIcon).hasClass('fa-lock'), 'first course is still locked');
+  assert.ok(find(secondCourseLockedIcon).hasClass('fa-unlock'), 'second course is still unlocked');
 });
 
-test('delete-button is not visible for program years with populated cohorts', function(assert) {
+test('delete-button is not visible for program years with populated cohorts', async function(assert) {
   server.create('user', {
     id: 1,
     cohorts: [1]
@@ -475,9 +433,7 @@ test('delete-button is not visible for program years with populated cohorts', fu
   const firstProgramYearRow = '.list tbody tr:eq(0)';
   const deleteButtonOnFirstRow = `${firstProgramYearRow} .remove`;
 
-  visit(url);
-  andThen(() => {
-    assert.ok(isPresent(find(firstProgramYearRow)), 'program year is visible');
-    assert.ok(isEmpty(find(deleteButtonOnFirstRow)), 'no delete-button is visible');
-  });
+  await visit(url);
+  assert.ok(isPresent(find(firstProgramYearRow)), 'program year is visible');
+  assert.ok(isEmpty(find(deleteButtonOnFirstRow)), 'no delete-button is visible');
 });

--- a/tests/acceptance/program/programyear/competencies-test.js
+++ b/tests/acceptance/program/programyear/competencies-test.js
@@ -50,40 +50,32 @@ module('Acceptance: Program Year - Competencies', {
   }
 });
 
-test('list', function(assert) {
-
-  visit(url);
-  andThen(function() {
-    let container = find('.programyear-competencies');
-    assert.equal(getElementText(find('.title', container)), getText('Competencies (2)'));
-    let competencies = 'competency 0 competency 1 competency 2';
-    assert.equal(getElementText(find('.programyear-competencies-content', container)), getText(competencies));
-  });
+test('list', async function(assert) {
+  await visit(url);
+  let container = find('.programyear-competencies');
+  assert.equal(getElementText(find('.title', container)), getText('Competencies (2)'));
+  let competencies = 'competency 0 competency 1 competency 2';
+  assert.equal(getElementText(find('.programyear-competencies-content', container)), getText(competencies));
 });
 
-test('manager', function(assert) {
-  visit(url);
-  andThen(function() {
-    let container = find('.programyear-competencies');
-    click('.programyear-competencies-actions button', container).then(function(){
-      let checkboxes = find('input[type=checkbox]', container);
-      assert.equal(checkboxes.length, 6);
-      assert.ok(checkboxes.eq(0).prop('indeterminate'));
-      assert.ok(!checkboxes.eq(0).prop('checked'));
-      assert.ok(checkboxes.eq(1).prop('checked'));
-      assert.ok(checkboxes.eq(2).prop('checked'));
-      assert.ok(!checkboxes.eq(3).prop('checked'));
-      assert.ok(!checkboxes.eq(4).prop('checked'));
-      assert.ok(!checkboxes.eq(5).prop('checked'));
+test('manager', async function(assert) {
+  await visit(url);
+  let container = find('.programyear-competencies');
+  await click('.programyear-competencies-actions button', container);
+  let checkboxes = find('input[type=checkbox]', container);
+  assert.equal(checkboxes.length, 6);
+  assert.ok(checkboxes.eq(0).prop('indeterminate'));
+  assert.ok(!checkboxes.eq(0).prop('checked'));
+  assert.ok(checkboxes.eq(1).prop('checked'));
+  assert.ok(checkboxes.eq(2).prop('checked'));
+  assert.ok(!checkboxes.eq(3).prop('checked'));
+  assert.ok(!checkboxes.eq(4).prop('checked'));
+  assert.ok(!checkboxes.eq(5).prop('checked'));
 
-      click('input[type=checkbox]:eq(1)', container);
-      click('input[type=checkbox]:eq(4)', container);
-      click('.bigadd', container);
+  await click('input[type=checkbox]:eq(1)', container);
+  await click('input[type=checkbox]:eq(4)', container);
+  await click('.bigadd', container);
 
-      andThen(function(){
-        let competencies = 'competency 0 competency 2 competency 3 competency 4';
-        assert.equal(getElementText(find('.programyear-competencies-content', container)), getText(competencies));
-      });
-    });
-  });
+  let competencies = 'competency 0 competency 2 competency 3 competency 4';
+  assert.equal(getElementText(find('.programyear-competencies-content', container)), getText(competencies));
 });

--- a/tests/acceptance/program/programyear/objectives-test.js
+++ b/tests/acceptance/program/programyear/objectives-test.js
@@ -6,6 +6,7 @@ import {
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+import wait from 'ember-test-helpers/wait';
 
 var application;
 var url = '/programs/1/programyears/1?pyObjectiveDetails=true';
@@ -76,256 +77,186 @@ module('Acceptance: Program Year - Objectives', {
   }
 });
 
-test('list', function(assert) {
-  visit(url);
-  andThen(function() {
-    let objectiveRows = find('.programyear-objective-list tbody tr');
-    assert.equal(objectiveRows.length, 3);
-    assert.equal(getElementText(find('td:eq(0)', objectiveRows.eq(0))), getText('objective 0'));
-    assert.equal(getElementText(find('td:eq(1)', objectiveRows.eq(0))), getText('competency 1 (competency 0)'));
-    assert.equal(getElementText(find('td:eq(2)', objectiveRows.eq(0))), getText('descriptor 0 descriptor 1'));
+test('list', async function(assert) {
+  await visit(url);
+  let objectiveRows = find('.programyear-objective-list tbody tr');
+  assert.equal(objectiveRows.length, 3);
+  assert.equal(getElementText(find('td:eq(0)', objectiveRows.eq(0))), getText('objective 0'));
+  assert.equal(getElementText(find('td:eq(1)', objectiveRows.eq(0))), getText('competency 1 (competency 0)'));
+  assert.equal(getElementText(find('td:eq(2)', objectiveRows.eq(0))), getText('descriptor 0 descriptor 1'));
 
-    assert.equal(getElementText(find('td:eq(0)', objectiveRows.eq(1))), getText('objective 1'));
-    assert.equal(getElementText(find('td:eq(1)', objectiveRows.eq(1))), getText('competency 3'));
-    assert.equal(getElementText(find('td:eq(2)', objectiveRows.eq(1))), getText('Add New'));
+  assert.equal(getElementText(find('td:eq(0)', objectiveRows.eq(1))), getText('objective 1'));
+  assert.equal(getElementText(find('td:eq(1)', objectiveRows.eq(1))), getText('competency 3'));
+  assert.equal(getElementText(find('td:eq(2)', objectiveRows.eq(1))), getText('Add New'));
 
-    assert.equal(getElementText(find('td:eq(0)', objectiveRows.eq(2))), getText('objective 2'));
-    assert.equal(getElementText(find('td:eq(1)', objectiveRows.eq(2))), getText('Add New'));
-    assert.equal(getElementText(find('td:eq(2)', objectiveRows.eq(2))), getText('Add New'));
-  });
+  assert.equal(getElementText(find('td:eq(0)', objectiveRows.eq(2))), getText('objective 2'));
+  assert.equal(getElementText(find('td:eq(1)', objectiveRows.eq(2))), getText('Add New'));
+  assert.equal(getElementText(find('td:eq(2)', objectiveRows.eq(2))), getText('Add New'));
 });
 
-test('manage terms', function(assert) {
+test('manage terms', async function(assert) {
   assert.expect(21);
-  visit(url);
-  andThen(function() {
-    let detailObjectives = find('.detail-objectives').eq(0);
-    click('.programyear-objective-list tbody tr:eq(0) td:eq(2) .link', detailObjectives).then(function(){
-      assert.equal(getElementText(find('.specific-title', detailObjectives)), 'SelectMeSHDescriptorsforObjective');
-    });
+  await visit(url);
+  let detailObjectives = find('.detail-objectives').eq(0);
+  await click('.programyear-objective-list tbody tr:eq(0) td:eq(2) .link', detailObjectives);
+  assert.equal(getElementText(find('.specific-title', detailObjectives)), 'SelectMeSHDescriptorsforObjective');
 
-    andThen(function() {
-      let meshManager = find('.mesh-manager', detailObjectives).eq(0);
-      let removableItems = find('.removable-list li', meshManager);
-      assert.equal(removableItems.length, 2);
-      assert.equal(getElementText(find('.content .title', removableItems.eq(0)).eq(0)), getText('descriptor 0'));
-      assert.equal(getElementText(find('.content .title', removableItems.eq(1)).eq(0)), getText('descriptor 1'));
+  let meshManager = find('.mesh-manager', detailObjectives).eq(0);
+  let removableItems = find('.removable-list li', meshManager);
+  assert.equal(removableItems.length, 2);
+  assert.equal(getElementText(find('.content .title', removableItems.eq(0)).eq(0)), getText('descriptor 0'));
+  assert.equal(getElementText(find('.content .title', removableItems.eq(1)).eq(0)), getText('descriptor 1'));
 
-      let searchBox = find('.search-box', meshManager);
-      assert.equal(searchBox.length, 1);
-      searchBox = searchBox.eq(0);
-      let searchBoxInput = find('input', searchBox);
-      assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
-      fillIn(searchBoxInput, 'descriptor');
-      click('span.search-icon', searchBox);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        assert.equal(searchResults.length, 4);
+  let searchBox = find('.search-box', meshManager);
+  assert.equal(searchBox.length, 1);
+  searchBox = searchBox.eq(0);
+  let searchBoxInput = find('input', searchBox);
+  assert.equal(searchBoxInput.attr('placeholder'), 'Search MeSH');
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('span.search-icon', searchBox);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  assert.equal(searchResults.length, 4);
 
-        assert.equal(getElementText(find('.descriptor-name', searchResults[0]).eq(0)), getText('descriptor 0'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults[1]).eq(0)), getText('descriptor 1'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults[2]).eq(0)), getText('descriptor 2'));
-        assert.equal(getElementText(find('.descriptor-name', searchResults[3]).eq(0)), getText('descriptor 3'));
-        assert.ok($(searchResults[0]).hasClass('disabled'));
-        assert.ok($(searchResults[1]).hasClass('disabled'));
-        assert.ok(!$(searchResults[2]).hasClass('disabled'));
-        assert.ok(!$(searchResults[3]).hasClass('disabled'));
-        click('.removable-list li:eq(0)', meshManager).then(function(){
-          assert.ok(!$(find('.mesh-search-results li:eq(0)', meshManager)).hasClass('disabled'));
-        });
-        click(searchResults[2]);
-        andThen(function(){
-          assert.ok($(find('.mesh-search-results li:eq(1)', meshManager)).hasClass('disabled'));
-          assert.ok($(find('.mesh-search-results li:eq(2)', meshManager)).hasClass('disabled'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults[0]).eq(0)), getText('descriptor 0'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults[1]).eq(0)), getText('descriptor 1'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults[2]).eq(0)), getText('descriptor 2'));
+  assert.equal(getElementText(find('.descriptor-name', searchResults[3]).eq(0)), getText('descriptor 3'));
+  assert.ok($(searchResults[0]).hasClass('disabled'));
+  assert.ok($(searchResults[1]).hasClass('disabled'));
+  assert.ok(!$(searchResults[2]).hasClass('disabled'));
+  assert.ok(!$(searchResults[3]).hasClass('disabled'));
+  await click('.removable-list li:eq(0)', meshManager);
+  assert.ok(!$(find('.mesh-search-results li:eq(0)', meshManager)).hasClass('disabled'));
+  await click(searchResults[2]);
+  assert.ok($(find('.mesh-search-results li:eq(1)', meshManager)).hasClass('disabled'));
+  assert.ok($(find('.mesh-search-results li:eq(2)', meshManager)).hasClass('disabled'));
 
-          removableItems = find('.removable-list li', meshManager);
-          assert.equal(removableItems.length, 2);
-          assert.equal(
-            getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
-            getText('descriptor 1')
-          );
-          assert.equal(
-            getElementText(find('.content .title', removableItems.eq(1)).eq(0)),
-            getText('descriptor 2')
-          );
-        });
-      });
-    });
-  });
+  removableItems = find('.removable-list li', meshManager);
+  assert.equal(removableItems.length, 2);
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(0)).eq(0)),
+    getText('descriptor 1')
+  );
+  assert.equal(
+    getElementText(find('.content .title', removableItems.eq(1)).eq(0)),
+    getText('descriptor 2')
+  );
 });
 
-test('save terms', function(assert) {
+test('save terms', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    let detailObjectives = find('.detail-objectives').eq(0);
-    click('.programyear-objective-list tbody tr:eq(0) td:eq(2) .link', detailObjectives);
-    andThen(function() {
-      let meshManager = find('.mesh-manager', detailObjectives).eq(0);
-      let searchBoxInput = find('.search-box input', meshManager);
-      fillIn(searchBoxInput, 'descriptor');
-      click('span.search-icon', meshManager);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        click('.removable-list li:eq(0)', meshManager);
-        click(searchResults[2]);
-        click('button.bigadd', detailObjectives);
-        andThen(function(){
-          let tds = find('.programyear-objective-list tbody tr:eq(0) td');
-          assert.equal(getElementText(tds.eq(2)), getText('descriptor 1 descriptor 2'));
-        });
-      });
-    });
-  });
+  await visit(url);
+  let detailObjectives = find('.detail-objectives').eq(0);
+  await click('.programyear-objective-list tbody tr:eq(0) td:eq(2) .link', detailObjectives);
+  let meshManager = find('.mesh-manager', detailObjectives).eq(0);
+  let searchBoxInput = find('.search-box input', meshManager);
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('span.search-icon', meshManager);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  await click('.removable-list li:eq(0)', meshManager);
+  await click(searchResults[2]);
+  await click('button.bigadd', detailObjectives);
+  let tds = find('.programyear-objective-list tbody tr:eq(0) td');
+  assert.equal(getElementText(tds.eq(2)), getText('descriptor 1 descriptor 2'));
 });
 
-test('cancel term changes', function(assert) {
+test('cancel term changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    let detailObjectives = find('.detail-objectives').eq(0);
-    click('.programyear-objective-list tbody tr:eq(0) td:eq(2) .link', detailObjectives);
-    andThen(function() {
-      let meshManager = find('.mesh-manager', detailObjectives).eq(0);
-      let searchBoxInput = find('.search-box input', meshManager);
-      fillIn(searchBoxInput, 'descriptor');
-      click('span.search-icon', meshManager);
-      andThen(function(){
-        let searchResults = find('.mesh-search-results li', meshManager);
-        click('.removable-list li:eq(0)', meshManager);
-        click(searchResults[2]);
-        click(searchResults[3]);
-        click('button.bigcancel', detailObjectives);
-        andThen(function(){
-          let tds = find('.programyear-objective-list tbody tr:eq(0) td');
-          assert.equal(getElementText(tds.eq(2)), getText('descriptor 0 descriptor 1'));
-        });
-      });
-    });
-  });
+  await visit(url);
+  let detailObjectives = find('.detail-objectives').eq(0);
+  await click('.programyear-objective-list tbody tr:eq(0) td:eq(2) .link', detailObjectives);
+  let meshManager = find('.mesh-manager', detailObjectives).eq(0);
+  let searchBoxInput = find('.search-box input', meshManager);
+  await fillIn(searchBoxInput, 'descriptor');
+  await click('span.search-icon', meshManager);
+  let searchResults = find('.mesh-search-results li', meshManager);
+  await click('.removable-list li:eq(0)', meshManager);
+  await click(searchResults[2]);
+  await click(searchResults[3]);
+  await click('button.bigcancel', detailObjectives);
+  let tds = find('.programyear-objective-list tbody tr:eq(0) td');
+  assert.equal(getElementText(tds.eq(2)), getText('descriptor 0 descriptor 1'));
 });
 
-test('manage competencies', function(assert) {
+test('manage competencies', async function(assert) {
   assert.expect(14);
-  visit(url);
-  andThen(function() {
-    let tds = find('.programyear-objective-list tbody tr:eq(0) td');
-    assert.equal(tds.length, 3);
-    click('.link', tds.eq(1));
-    andThen(function() {
-      assert.equal(getElementText(find('.specific-title')), 'SelectParentCompetencyforObjective');
-      let objectiveManager = find('.objective-manage-competency').eq(0);
-      assert.equal(getElementText(find('.objectivetitle', objectiveManager)), getText('objective 0'));
-      assert.equal(getElementText(find('.parent-picker', objectiveManager)), getText('competency0 competency1 competency2 competency3 competency4'));
-      let items = find('.parent-picker .clickable');
-      assert.equal(items.length, 4);
-      assert.ok(find('.parent-picker h5:eq(0)').hasClass('selected'));
-      assert.ok($(items[0]).hasClass('selected'));
-      assert.ok(!$(items[1]).hasClass('selected'));
-      assert.ok(!find('.parent-picker h5:eq(1)').hasClass('selected'));
-      assert.ok(!find('.parent-picker h5:eq(2)').hasClass('selected'));
+  await visit(url);
+  let tds = find('.programyear-objective-list tbody tr:eq(0) td');
+  assert.equal(tds.length, 3);
+  await click('.link', tds.eq(1));
+  assert.equal(getElementText(find('.specific-title')), 'SelectParentCompetencyforObjective');
+  let objectiveManager = find('.objective-manage-competency').eq(0);
+  assert.equal(getElementText(find('.objectivetitle', objectiveManager)), getText('objective 0'));
+  assert.equal(getElementText(find('.parent-picker', objectiveManager)), getText('competency0 competency1 competency2 competency3 competency4'));
+  let items = find('.parent-picker .clickable');
+  assert.equal(items.length, 4);
+  assert.ok(find('.parent-picker h5:eq(0)').hasClass('selected'));
+  assert.ok($(items[0]).hasClass('selected'));
+  assert.ok(!$(items[1]).hasClass('selected'));
+  assert.ok(!find('.parent-picker h5:eq(1)').hasClass('selected'));
+  assert.ok(!find('.parent-picker h5:eq(2)').hasClass('selected'));
 
-      andThen(function(){
-        click('.parent-picker .clickable:eq(2)', objectiveManager).then(function(){
-          items = find('.parent-picker .clickable');
-          assert.ok(!$(items[0]).hasClass('selected'));
-          assert.ok(!$(items[1]).hasClass('selected'));
-          assert.ok($(items[2]).hasClass('selected'));
-          assert.ok(!$(items[3]).hasClass('selected'));
-        });
-      });
-    });
-  });
+  await click('.parent-picker .clickable:eq(2)', objectiveManager);
+  items = find('.parent-picker .clickable');
+  assert.ok(!$(items[0]).hasClass('selected'));
+  assert.ok(!$(items[1]).hasClass('selected'));
+  assert.ok($(items[2]).hasClass('selected'));
+  assert.ok(!$(items[3]).hasClass('selected'));
 });
 
-test('save competency', function(assert) {
+test('save competency', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    click('.programyear-objective-list tbody tr:eq(0) td:eq(1) .link');
-    andThen(function() {
-      let objectiveManager = find('.objective-manage-competency').eq(0);
-      click('.parent-picker .clickable:eq(1)', objectiveManager).then(function(){
-        click('.detail-objectives button.bigadd');
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('.programyear-objective-list tbody tr td:eq(1)')), getText('competency 2 (competency 0)'));
-      });
-    });
-  });
+  await visit(url);
+  await click('.programyear-objective-list tbody tr:eq(0) td:eq(1) .link');
+  let objectiveManager = find('.objective-manage-competency').eq(0);
+  await click('.parent-picker .clickable:eq(1)', objectiveManager);
+  await click('.detail-objectives button.bigadd');
+  assert.equal(getElementText(find('.programyear-objective-list tbody tr td:eq(1)')), getText('competency 2 (competency 0)'));
 });
 
-test('save no competency', function(assert) {
+test('save no competency', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    click('.programyear-objective-list tbody tr:eq(0) td:eq(1) .link');
-    andThen(function() {
-      let objectiveManager = find('.objective-manage-competency').eq(0);
-      click('.parent-picker .clickable:eq(0)', objectiveManager).then(function(){
-        click('.detail-objectives button.bigadd');
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('.programyear-objective-list tbody tr td:eq(1)')), getText('Add New'));
-      });
-    });
-  });
+  await visit(url);
+  await click('.programyear-objective-list tbody tr:eq(0) td:eq(1) .link');
+  let objectiveManager = find('.objective-manage-competency').eq(0);
+  await click('.parent-picker .clickable:eq(0)', objectiveManager);
+  await click('.detail-objectives button.bigadd');
+  assert.equal(getElementText(find('.programyear-objective-list tbody tr td:eq(1)')), getText('Add New'));
 });
 
-test('cancel competency change', function(assert) {
+test('cancel competency change', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    click('.programyear-objective-list tbody tr:eq(0) td:eq(1) .link');
-    andThen(function() {
-      let objectiveManager = find('.objective-manage-competency').eq(0);
-      click('.parent-picker li:eq(1)', objectiveManager).then(function(){
-        click('.detail-objectives button.bigcancel');
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('.programyear-objective-list tbody tr td:eq(1)')), getText('competency 1 (competency 0)'));
-      });
-    });
-  });
+  await visit(url);
+  await click('.programyear-objective-list tbody tr:eq(0) td:eq(1) .link');
+  let objectiveManager = find('.objective-manage-competency').eq(0);
+  await click('.parent-picker li:eq(1)', objectiveManager);
+  await click('.detail-objectives button.bigcancel');
+  assert.equal(getElementText(find('.programyear-objective-list tbody tr td:eq(1)')), getText('competency 1 (competency 0)'));
 });
 
-test('cancel remove competency change', function(assert) {
+test('cancel remove competency change', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    click('.programyear-objective-list tbody tr:eq(0) td:eq(1) .link');
-    andThen(function() {
-      let objectiveManager = find('.objective-manage-competency').eq(0);
-      click('.parent-picker li:eq(0)', objectiveManager).then(function(){
-        click('.detail-objectives button.bigcancel');
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('.programyear-objective-list tbody tr td:eq(1)')), getText('competency 1 (competency 0)'));
-      });
-    });
-  });
+  await visit(url);
+  await click('.programyear-objective-list tbody tr:eq(0) td:eq(1) .link');
+  let objectiveManager = find('.objective-manage-competency').eq(0);
+  await click('.parent-picker li:eq(0)', objectiveManager);
+  await click('.detail-objectives button.bigcancel');
+  assert.equal(getElementText(find('.programyear-objective-list tbody tr td:eq(1)')), getText('competency 1 (competency 0)'));
 });
 
-test('add competency', function(assert) {
+test('add competency', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    click('.programyear-objective-list tbody tr:eq(2) td:eq(1) button');
-    andThen(function() {
-      let objectiveManager = find('.objective-manage-competency').eq(0);
-      click('.parent-picker .clickable:eq(1)', objectiveManager).then(function(){
-        click('.detail-objectives button.bigadd');
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('.programyear-objective-list tbody tr:eq(2) td:eq(1)')), getText('competency 2 (competency 0)'));
-      });
-    });
-  });
+  await visit(url);
+  await click('.programyear-objective-list tbody tr:eq(2) td:eq(1) button');
+  let objectiveManager = find('.objective-manage-competency').eq(0);
+  await click('.parent-picker .clickable:eq(1)', objectiveManager);
+  await click('.detail-objectives button.bigadd');
+  assert.equal(getElementText(find('.programyear-objective-list tbody tr:eq(2) td:eq(1)')), getText('competency 2 (competency 0)'));
 });
 
-test('empty objective title can not be saved', function(assert) {
+test('empty objective title can not be saved', async function(assert) {
   assert.expect(4);
-  visit(url);
+  await visit(url);
   const container = '.programyear-objective-list';
   const title = `${container} tbody tr:eq(0) td:eq(0)`;
   const edit = `${title} .editable span`;
@@ -334,23 +265,17 @@ test('empty objective title can not be saved', function(assert) {
   const save = `${title} .done`;
   const errorMessage = `${title} .validation-error-message`;
 
-  andThen(function() {
-    assert.equal(getElementText(title), getText(initialObjectiveTitle));
-    click(edit);
-    andThen(function(){
-      //wait for the editor to load
-      Ember.run.later(()=>{
+  assert.equal(getElementText(title), getText(initialObjectiveTitle));
+  await click(edit);
+  let editorContents = find(editor).data('froala.editor').$el.text();
+  assert.equal(getText(editorContents), getText(initialObjectiveTitle));
 
-        let editorContents = find(editor).data('froala.editor').$el.text();
-        assert.equal(getText(editorContents), getText(initialObjectiveTitle));
+  find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
+  find(editor).froalaEditor('events.trigger', 'contentChanged');
+  Ember.run.later(()=>{
+    assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
+    assert.ok(find(save).is(':disabled'));
+  }, 100);
 
-        find(editor).froalaEditor('html.set', '<p>&nbsp</p><div></div><span>  </span>');
-        find(editor).froalaEditor('events.trigger', 'contentChanged');
-        Ember.run.later(()=>{
-          assert.equal(getElementText(errorMessage), getText('This field cannot be blank'));
-          assert.ok(find(save).is(':disabled'));
-        }, 100);
-      }, 100);
-    });
-  });
+  await wait();
 });

--- a/tests/acceptance/program/programyear/overview-test.js
+++ b/tests/acceptance/program/programyear/overview-test.js
@@ -32,85 +32,73 @@ module('Acceptance: Program Year - Overview', {
   }
 });
 
-test('list directors', function(assert) {
-  visit(url);
+test('list directors', async function(assert) {
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'program.programYear.index');
-    var container = find('.programyear-overview').eq(0);
-    var items = find('.removable-list li', container);
-    assert.equal(items.length, 3);
-    assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
-    assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
-    assert.equal(getElementText(items.eq(2)), getText('3 guy M. Mc3son'));
+  assert.equal(currentPath(), 'program.programYear.index');
+  var container = find('.programyear-overview').eq(0);
+  var items = find('.removable-list li', container);
+  assert.equal(items.length, 3);
+  assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
+  assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
+  assert.equal(getElementText(items.eq(2)), getText('3 guy M. Mc3son'));
+});
+
+test('search directors', async function(assert) {
+  await visit(url);
+
+  assert.equal(currentPath(), 'program.programYear.index');
+  var container = find('.programyear-overview').eq(0);
+  fillIn(find('.search-box input', container), 'guy').then(function(){
+    var searchResults = find('.results li', container);
+    assert.equal(searchResults.length, 7);
+    assert.equal(getElementText(searchResults.eq(0)), getText('6 Results'));
+    assert.equal(getElementText(searchResults.eq(1)), getText('0 guy M. Mc0son'));
+    assert.ok(searchResults.eq(1).hasClass('active'));
+    assert.equal(getElementText(searchResults.eq(2)), getText('1 guy M. Mc1son'));
+    assert.ok(searchResults.eq(2).hasClass('inactive'));
+    assert.equal(getElementText(searchResults.eq(3)), getText('2 guy M. Mc2son'));
+    assert.ok(searchResults.eq(3).hasClass('inactive'));
+    assert.equal(getElementText(searchResults.eq(4)), getText('3 guy M. Mc3son'));
+    assert.ok(searchResults.eq(4).hasClass('inactive'));
+    assert.equal(getElementText(searchResults.eq(5)), getText('4 guy M. Mc4son'));
+    assert.ok(searchResults.eq(5).hasClass('active'));
+    assert.equal(getElementText(searchResults.eq(6)), getText('5 guy M. Mc5son'));
+    assert.ok(searchResults.eq(6).hasClass('active'));
   });
 });
 
-test('search directors', function(assert) {
-  visit(url);
+test('add director', async function(assert) {
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'program.programYear.index');
-    var container = find('.programyear-overview').eq(0);
-    fillIn(find('.search-box input', container), 'guy').then(function(){
-      var searchResults = find('.results li', container);
-      assert.equal(searchResults.length, 7);
-      assert.equal(getElementText(searchResults.eq(0)), getText('6 Results'));
-      assert.equal(getElementText(searchResults.eq(1)), getText('0 guy M. Mc0son'));
-      assert.ok(searchResults.eq(1).hasClass('active'));
-      assert.equal(getElementText(searchResults.eq(2)), getText('1 guy M. Mc1son'));
-      assert.ok(searchResults.eq(2).hasClass('inactive'));
-      assert.equal(getElementText(searchResults.eq(3)), getText('2 guy M. Mc2son'));
-      assert.ok(searchResults.eq(3).hasClass('inactive'));
-      assert.equal(getElementText(searchResults.eq(4)), getText('3 guy M. Mc3son'));
-      assert.ok(searchResults.eq(4).hasClass('inactive'));
-      assert.equal(getElementText(searchResults.eq(5)), getText('4 guy M. Mc4son'));
-      assert.ok(searchResults.eq(5).hasClass('active'));
-      assert.equal(getElementText(searchResults.eq(6)), getText('5 guy M. Mc5son'));
-      assert.ok(searchResults.eq(6).hasClass('active'));
-    });
-  });
+  assert.equal(currentPath(), 'program.programYear.index');
+  let container = find('.programyear-overview').eq(0);
+  let items = find('.removable-list li', container);
+  assert.equal(items.length, 3);
+  assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
+  assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
+  assert.equal(getElementText(items.eq(2)), getText('3 guy M. Mc3son'));
+
+  await fillIn(find('.search-box input', container), 'guy');
+  await click('.results li:eq(6)', container);
+  items = find('.removable-list li', container);
+  assert.equal(items.length, 4);
+  assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
+  assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
+  assert.equal(getElementText(items.eq(2)), getText('3 guy M. Mc3son'));
+  assert.equal(getElementText(items.eq(3)), getText('5 guy M. Mc5son'));
 });
 
-test('add director', function(assert) {
-  visit(url);
+test('remove director', async function(assert) {
+  await visit(url);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'program.programYear.index');
-    let container = find('.programyear-overview').eq(0);
-    let items = find('.removable-list li', container);
-    assert.equal(items.length, 3);
-    assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
-    assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
-    assert.equal(getElementText(items.eq(2)), getText('3 guy M. Mc3son'));
-
-    fillIn(find('.search-box input', container), 'guy').then(function(){
-      click('.results li:eq(6)', container).then(function(){
-        items = find('.removable-list li', container);
-        assert.equal(items.length, 4);
-        assert.equal(getElementText(items.eq(0)), getText('1 guy M. Mc1son'));
-        assert.equal(getElementText(items.eq(1)), getText('2 guy M. Mc2son'));
-        assert.equal(getElementText(items.eq(2)), getText('3 guy M. Mc3son'));
-        assert.equal(getElementText(items.eq(3)), getText('5 guy M. Mc5son'));
-      });
-
-    });
-  });
-});
-
-test('remove director', function(assert) {
-  visit(url);
-
-  andThen(function() {
-    assert.equal(currentPath(), 'program.programYear.index');
-    var container = find('.programyear-overview').eq(0);
-    click('.removable-list li:eq(0)', container).then(function(){
-      var items = find('.removable-list li', container);
-      assert.equal(items.length, 2);
-      assert.equal(getElementText(items.eq(0)), getText('2 guy M. Mc2son'));
-      assert.equal(getElementText(items.eq(1)), getText('3 guy M. Mc3son'));
-    });
-  });
+  assert.equal(currentPath(), 'program.programYear.index');
+  var container = find('.programyear-overview').eq(0);
+  await click('.removable-list li:eq(0)', container);
+  var items = find('.removable-list li', container);
+  assert.equal(items.length, 2);
+  assert.equal(getElementText(items.eq(0)), getText('2 guy M. Mc2son'));
+  assert.equal(getElementText(items.eq(1)), getText('3 guy M. Mc3son'));
 });
 
 test('first director added is disabled #2770', async function(assert) {

--- a/tests/acceptance/program/programyear/publicationcheck-test.js
+++ b/tests/acceptance/program/programyear/publicationcheck-test.js
@@ -31,26 +31,22 @@ module('Acceptance: Program Year - Publication Check', {
   }
 });
 
-test('full program count', function(assert) {
-  visit('/programs/' + fixtures.fullProgram.id + '/publicationcheck');
-  andThen(function() {
-    assert.equal(currentPath(), 'program.publicationCheck');
-    var items = find('.program-publication-check .detail-content table tbody td');
-    assert.equal(getElementText(items.eq(0)), getText('program 0'));
-    assert.equal(getElementText(items.eq(1)), getText('short_0'));
-    assert.equal(getElementText(items.eq(2)), 4);
-    assert.equal(getElementText(items.eq(3)), getText('Yes (1)'));
-  });
+test('full program count', async function(assert) {
+  await visit('/programs/' + fixtures.fullProgram.id + '/publicationcheck');
+  assert.equal(currentPath(), 'program.publicationCheck');
+  var items = find('.program-publication-check .detail-content table tbody td');
+  assert.equal(getElementText(items.eq(0)), getText('program 0'));
+  assert.equal(getElementText(items.eq(1)), getText('short_0'));
+  assert.equal(getElementText(items.eq(2)), 4);
+  assert.equal(getElementText(items.eq(3)), getText('Yes (1)'));
 });
 
-test('empty program count', function(assert) {
-  visit('/programs/' + fixtures.emptyProgram.id + '/publicationcheck');
-  andThen(function() {
-    assert.equal(currentPath(), 'program.publicationCheck');
-    var items = find('.program-publication-check .detail-content table tbody td');
-    assert.equal(getElementText(items.eq(0)), getText('program 1'));
-    assert.equal(getElementText(items.eq(1)), getText('short_1'));
-    assert.equal(getElementText(items.eq(2)), 4);
-    assert.equal(getElementText(items.eq(3)), getText('No'));
-  });
+test('empty program count', async function(assert) {
+  await visit('/programs/' + fixtures.emptyProgram.id + '/publicationcheck');
+  assert.equal(currentPath(), 'program.publicationCheck');
+  var items = find('.program-publication-check .detail-content table tbody td');
+  assert.equal(getElementText(items.eq(0)), getText('program 1'));
+  assert.equal(getElementText(items.eq(1)), getText('short_1'));
+  assert.equal(getElementText(items.eq(2)), 4);
+  assert.equal(getElementText(items.eq(3)), getText('No'));
 });

--- a/tests/acceptance/program/programyear/publish-test.js
+++ b/tests/acceptance/program/programyear/publish-test.js
@@ -37,164 +37,134 @@ module('Acceptance: Program Year - Publish', {
   }
 });
 
-test('check published program year', function(assert) {
-  visit('/programs/1/programyears/' + fixtures.published.id);
+test('check published program year', async function(assert) {
+  await visit('/programs/1/programyears/' + fixtures.published.id);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'program.programYear.index');
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Published'));
-    //we have to click the button to create the options
-    click(selector);
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Review 4 Missing Items', 'Mark as Scheduled', 'UnPublish Program Year'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(currentPath(), 'program.programYear.index');
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Published'));
+  //we have to click the button to create the options
+  await click(selector);
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Review 4 Missing Items', 'Mark as Scheduled', 'UnPublish Program Year'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check scheduled program year', function(assert) {
-  visit('/programs/1/programyears/' + fixtures.scheduled.id);
+test('check scheduled program year', async function(assert) {
+  await visit('/programs/1/programyears/' + fixtures.scheduled.id);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'program.programYear.index');
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Scheduled'));
-    //we have to click the button to create the options
-    click(selector);
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Publish As-is', 'Review 4 Missing Items', 'UnPublish Program Year'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(currentPath(), 'program.programYear.index');
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Scheduled'));
+  //we have to click the button to create the options
+  await click(selector);
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Publish As-is', 'Review 4 Missing Items', 'UnPublish Program Year'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check draft program year', function(assert) {
-  visit('/programs/1/programyears/' + fixtures.draft.id);
+test('check draft program year', async function(assert) {
+  await visit('/programs/1/programyears/' + fixtures.draft.id);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'program.programYear.index');
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Not Published'));
-    //we have to click the button to create the options
-    click(selector);
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Publish As-is', 'Review 4 Missing Items', 'Mark as Scheduled'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(currentPath(), 'program.programYear.index');
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Not Published'));
+  //we have to click the button to create the options
+  await click(selector);
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Publish As-is', 'Review 4 Missing Items', 'Mark as Scheduled'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check publish draft program year', function(assert) {
-  visit('/programs/1/programyears/' + fixtures.draft.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const publish = `${choices}:eq(0)`;
-    click(selector);
-    click(publish);
+test('check publish draft program year', async function(assert) {
+  await visit('/programs/1/programyears/' + fixtures.draft.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const publish = `${choices}:eq(0)`;
+  await click(selector);
+  await click(publish);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Published'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Published'));
 });
 
-test('check schedule draft program year', function(assert) {
-  visit('/programs/1/programyears/' + fixtures.draft.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const schedule = `${choices}:eq(2)`;
-    click(selector);
-    click(schedule);
+test('check schedule draft program year', async function(assert) {
+  await visit('/programs/1/programyears/' + fixtures.draft.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const schedule = `${choices}:eq(2)`;
+  await click(selector);
+  await click(schedule);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Scheduled'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Scheduled'));
 });
 
-test('check publish scheduled program year', function(assert) {
-  visit('/programs/1/programyears/' + fixtures.scheduled.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const publish = `${choices}:eq(0)`;
-    click(selector);
-    click(publish);
+test('check publish scheduled program year', async function(assert) {
+  await visit('/programs/1/programyears/' + fixtures.scheduled.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const publish = `${choices}:eq(0)`;
+  await click(selector);
+  await click(publish);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Published'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Published'));
 });
 
-test('check unpublish scheduled program year', function(assert) {
-  visit('/programs/1/programyears/' + fixtures.scheduled.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const unPublish = `${choices}:eq(2)`;
-    click(selector);
-    click(unPublish);
+test('check unpublish scheduled program year', async function(assert) {
+  await visit('/programs/1/programyears/' + fixtures.scheduled.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const unPublish = `${choices}:eq(2)`;
+  await click(selector);
+  await click(unPublish);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Not Published'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Not Published'));
 });
 
-test('check schedule published program year', function(assert) {
-  visit('/programs/1/programyears/' + fixtures.published.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const schedule = `${choices}:eq(1)`;
-    click(selector);
-    click(schedule);
+test('check schedule published program year', async function(assert) {
+  await visit('/programs/1/programyears/' + fixtures.published.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const schedule = `${choices}:eq(1)`;
+  await click(selector);
+  await click(schedule);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Scheduled'));
-      let items = find(choices);
-      assert.equal(items.length, 3);
-      let expectedItems = ['Publish As-is', 'Review 4 Missing Items', 'UnPublish Program Year'];
-      for(let i = 0; i < items.length; i++){
-        assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-      }
-    });
-  });
+  assert.equal(getElementText(selector), getText('Scheduled'));
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Publish As-is', 'Review 4 Missing Items', 'UnPublish Program Year'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check unpublish published program year', function(assert) {
-  visit('/programs/1/programyears/' + fixtures.published.id);
-  andThen(function() {
-    const menu = '.publish-menu:eq(1)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    const unPublish = `${choices}:eq(2)`;
-    click(selector);
-    click(unPublish);
+test('check unpublish published program year', async function(assert) {
+  await visit('/programs/1/programyears/' + fixtures.published.id);
+  const menu = '.publish-menu:eq(1)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  const unPublish = `${choices}:eq(2)`;
+  await click(selector);
+  await click(unPublish);
 
-    andThen(function(){
-      assert.equal(getElementText(selector), getText('Not Published'));
-    });
-  });
+  assert.equal(getElementText(selector), getText('Not Published'));
 });

--- a/tests/acceptance/program/programyear/terms-test.js
+++ b/tests/acceptance/program/programyear/terms-test.js
@@ -42,65 +42,43 @@ module('Acceptance: Program Year - Terms', {
   }
 });
 
-test('list terms', function(assert) {
+test('list terms', async function(assert) {
   assert.expect(2);
-  visit(url);
-  andThen(function() {
-    var container = find('.detail-taxonomies');
-    var items = find('ul.selected-taxonomy-terms li', container);
-    assert.equal(items.length, 1);
-    assert.equal(getElementText(items.eq(0)), getText('term 0'));
-  });
+  await visit(url);
+  var container = find('.detail-taxonomies');
+  var items = find('ul.selected-taxonomy-terms li', container);
+  assert.equal(items.length, 1);
+  assert.equal(getElementText(items.eq(0)), getText('term 0'));
 });
 
-test('manage terms', function(assert) {
+test('manage terms', async function(assert) {
   assert.expect(3);
-  visit(url);
-  andThen(function() {
-    var container = find('.taxonomy-manager');
-    click(find('.actions button', container));
-    andThen(function(){
-      assert.equal(getElementText(find('.removable-list li:eq(0)', container)), getText('term 0'));
-      assert.equal(getElementText(find('.selectable-terms-list li:eq(0)', container)), getText('term 0'));
-      assert.equal(getElementText(find('.selectable-terms-list li:eq(1)', container)), getText('term 1'));
-    });
-  });
+  await visit(url);
+  var container = find('.taxonomy-manager');
+  await click(find('.actions button', container));
+  assert.equal(getElementText(find('.removable-list li:eq(0)', container)), getText('term 0'));
+  assert.equal(getElementText(find('.selectable-terms-list li:eq(0)', container)), getText('term 0'));
+  assert.equal(getElementText(find('.selectable-terms-list li:eq(1)', container)), getText('term 1'));
 });
 
-test('save term changes', function(assert) {
+test('save term changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    var container = find('.taxonomy-manager');
-    click(find('.actions button', container));
-    andThen(function(){
-      click(find('.removable-list li:eq(0)', container)).then(function(){
-        click(find('.selectable-terms-list li:eq(1) > div', container)).then(function(){
-          click('button.bigadd', container);
-        });
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 1'));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.taxonomy-manager');
+  await click(find('.actions button', container));
+  await click(find('.removable-list li:eq(0)', container));
+  await click(find('.selectable-terms-list li:eq(1) > div', container));
+  await click('button.bigadd', container);
+  assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 1'));
 });
 
-test('cancel term changes', function(assert) {
+test('cancel term changes', async function(assert) {
   assert.expect(1);
-  visit(url);
-  andThen(function() {
-    var container = find('.taxonomy-manager');
-    click(find('.actions button', container));
-    andThen(function(){
-      click(find('.removable-list li:eq(0)', container)).then(function(){
-        click(find('.selectable-terms-list li:eq(1) > div', container)).then(function(){
-          click('button.bigcancel', container);
-        });
-      });
-      andThen(function(){
-        assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 0'));
-      });
-    });
-  });
+  await visit(url);
+  var container = find('.taxonomy-manager');
+  await click(find('.actions button', container));
+  await click(find('.removable-list li:eq(0)', container));
+  await click(find('.selectable-terms-list li:eq(1) > div', container));
+  await click('button.bigcancel', container);
+  assert.equal(getElementText(find('ul.selected-taxonomy-terms li', container)), getText('term 0'));
 });

--- a/tests/acceptance/program/publicationcheck-test.js
+++ b/tests/acceptance/program/publicationcheck-test.js
@@ -41,28 +41,24 @@ module('Acceptance: Program - Publication Check', {
   }
 });
 
-test('full program count', function(assert) {
-  visit('/programs/1/programyears/' + fixtures.fullProgramYear.id + '/publicationcheck');
-  andThen(function() {
-    assert.equal(currentPath(), 'program.programYear.publicationCheck');
-    var items = find('.programyear-publication-check .detail-content table tbody td');
-    assert.equal(getElementText(items.eq(0)), getText('2013 - 2014'));
-    assert.equal(getElementText(items.eq(1)), getText('Yes (1)'));
-    assert.equal(getElementText(items.eq(2)), getText('Yes (1)'));
-    assert.equal(getElementText(items.eq(3)), getText('Yes (1)'));
-    assert.equal(getElementText(items.eq(4)), getText('Yes (1)'));
-  });
+test('full program count', async function(assert) {
+  await visit('/programs/1/programyears/' + fixtures.fullProgramYear.id + '/publicationcheck');
+  assert.equal(currentPath(), 'program.programYear.publicationCheck');
+  var items = find('.programyear-publication-check .detail-content table tbody td');
+  assert.equal(getElementText(items.eq(0)), getText('2013 - 2014'));
+  assert.equal(getElementText(items.eq(1)), getText('Yes (1)'));
+  assert.equal(getElementText(items.eq(2)), getText('Yes (1)'));
+  assert.equal(getElementText(items.eq(3)), getText('Yes (1)'));
+  assert.equal(getElementText(items.eq(4)), getText('Yes (1)'));
 });
 
-test('empty program count', function(assert) {
-  visit('/programs/1/programyears/' + fixtures.emptyProgramYear.id + '/publicationcheck');
-  andThen(function() {
-    assert.equal(currentPath(), 'program.programYear.publicationCheck');
-    var items = find('.programyear-publication-check .detail-content table tbody td');
-    assert.equal(getElementText(items.eq(0)), getText('2013 - 2014'));
-    assert.equal(getElementText(items.eq(1)), getText('No'));
-    assert.equal(getElementText(items.eq(2)), getText('No'));
-    assert.equal(getElementText(items.eq(3)), getText('No'));
-    assert.equal(getElementText(items.eq(4)), getText('No'));
-  });
+test('empty program count', async function(assert) {
+  await visit('/programs/1/programyears/' + fixtures.emptyProgramYear.id + '/publicationcheck');
+  assert.equal(currentPath(), 'program.programYear.publicationCheck');
+  var items = find('.programyear-publication-check .detail-content table tbody td');
+  assert.equal(getElementText(items.eq(0)), getText('2013 - 2014'));
+  assert.equal(getElementText(items.eq(1)), getText('No'));
+  assert.equal(getElementText(items.eq(2)), getText('No'));
+  assert.equal(getElementText(items.eq(3)), getText('No'));
+  assert.equal(getElementText(items.eq(4)), getText('No'));
 });

--- a/tests/acceptance/program/publish-test.js
+++ b/tests/acceptance/program/publish-test.js
@@ -35,153 +35,135 @@ module('Acceptance: Program - Publish', {
   }
 });
 
-test('check published program', function(assert) {
-  visit('/programs/' + fixtures.published.id);
+test('check published program', async function(assert) {
+  await visit('/programs/' + fixtures.published.id);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'program.index');
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Published'));
-    //we have to click the button to create the options
-    click(selector);
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Review 1 Missing Items', 'Mark as Scheduled', 'UnPublish Program'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(currentPath(), 'program.index');
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Published'));
+  //we have to click the button to create the options
+  await click(selector);
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Review 1 Missing Items', 'Mark as Scheduled', 'UnPublish Program'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check scheduled program', function(assert) {
-  visit('/programs/' + fixtures.scheduled.id);
+test('check scheduled program', async function(assert) {
+  await visit('/programs/' + fixtures.scheduled.id);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'program.index');
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Scheduled'));
-    //we have to click the button to create the options
-    click(selector);
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Publish As-is', 'Review 1 Missing Items', 'UnPublish Program'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(currentPath(), 'program.index');
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Scheduled'));
+  //we have to click the button to create the options
+  await click(selector);
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Publish As-is', 'Review 1 Missing Items', 'UnPublish Program'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check draft program', function(assert) {
-  visit('/programs/' + fixtures.draft.id);
+test('check draft program', async function(assert) {
+  await visit('/programs/' + fixtures.draft.id);
 
-  andThen(function() {
-    assert.equal(currentPath(), 'program.index');
-    const menu = '.publish-menu:eq(0)';
-    const selector = `${menu} .rl-dropdown-toggle`;
-    const choices = `${menu} .rl-dropdown button`;
-    assert.equal(getElementText(selector), getText('Not Published'));
-    //we have to click the button to create the options
-    click(selector);
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Publish As-is', 'Review 1 Missing Items', 'Mark as Scheduled'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(currentPath(), 'program.index');
+  const menu = '.publish-menu:eq(0)';
+  const selector = `${menu} .rl-dropdown-toggle`;
+  const choices = `${menu} .rl-dropdown button`;
+  assert.equal(getElementText(selector), getText('Not Published'));
+  //we have to click the button to create the options
+  await click(selector);
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Publish As-is', 'Review 1 Missing Items', 'Mark as Scheduled'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check publish draft program', function(assert) {
-  visit('/programs/' + fixtures.draft.id);
+test('check publish draft program', async function(assert) {
+  await visit('/programs/' + fixtures.draft.id);
   const menu = '.publish-menu:eq(0)';
   const selector = `${menu} .rl-dropdown-toggle`;
   const choices = `${menu} .rl-dropdown button`;
   const publish = `${choices}:eq(0)`;
-  click(selector);
-  click(publish);
+  await click(selector);
+  await click(publish);
 
-  andThen(function(){
-    assert.equal(getElementText(selector), getText('Published'));
-  });
+  assert.equal(getElementText(selector), getText('Published'));
 });
 
-test('check schedule draft program', function(assert) {
-  visit('/programs/' + fixtures.draft.id);
+test('check schedule draft program', async function(assert) {
+  await visit('/programs/' + fixtures.draft.id);
   const menu = '.publish-menu:eq(0)';
   const selector = `${menu} .rl-dropdown-toggle`;
   const choices = `${menu} .rl-dropdown button`;
   const schedule = `${choices}:eq(2)`;
 
-  click(selector);
-  click(schedule);
+  await click(selector);
+  await click(schedule);
 
-  andThen(function(){
-    assert.equal(getElementText(selector), getText('Scheduled'));
-  });
+  assert.equal(getElementText(selector), getText('Scheduled'));
 });
 
-test('check publish scheduled program', function(assert) {
-  visit('/programs/' + fixtures.scheduled.id);
+test('check publish scheduled program', async function(assert) {
+  await visit('/programs/' + fixtures.scheduled.id);
   const menu = '.publish-menu:eq(0)';
   const selector = `${menu} .rl-dropdown-toggle`;
   const choices = `${menu} .rl-dropdown button`;
   const publish = `${choices}:eq(0)`;
-  click(selector);
-  click(publish);
+  await click(selector);
+  await click(publish);
 
-  andThen(() => {
-    assert.equal(getElementText(selector), getText('Published'));
-  });
+  assert.equal(getElementText(selector), getText('Published'));
 });
 
-test('check unpublish scheduled program', function(assert) {
-  visit('/programs/' + fixtures.scheduled.id);
+test('check unpublish scheduled program', async function(assert) {
+  await visit('/programs/' + fixtures.scheduled.id);
   const menu = '.publish-menu:eq(0)';
   const selector = `${menu} .rl-dropdown-toggle`;
   const choices = `${menu} .rl-dropdown button`;
   const unPublish = `${choices}:eq(2)`;
-  click(selector);
-  click(unPublish);
+  await click(selector);
+  await click(unPublish);
 
-  andThen(() => {
-    assert.equal(getElementText(selector), getText('Not Published'));
-  });
+  assert.equal(getElementText(selector), getText('Not Published'));
 });
 
-test('check schedule published program', function(assert) {
-  visit('/programs/' + fixtures.published.id);
+test('check schedule published program', async function(assert) {
+  await visit('/programs/' + fixtures.published.id);
   const menu = '.publish-menu:eq(0)';
   const selector = `${menu} .rl-dropdown-toggle`;
   const choices = `${menu} .rl-dropdown button`;
   const schedule = `${choices}:eq(1)`;
-  click(selector);
-  click(schedule);
+  await click(selector);
+  await click(schedule);
 
-  andThen(function(){
-    assert.equal(getElementText(selector), getText('Scheduled'));
-    let items = find(choices);
-    assert.equal(items.length, 3);
-    let expectedItems = ['Publish As-is', 'Review 1 Missing Items', 'UnPublish Program'];
-    for(let i = 0; i < items.length; i++){
-      assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
-    }
-  });
+  assert.equal(getElementText(selector), getText('Scheduled'));
+  let items = find(choices);
+  assert.equal(items.length, 3);
+  let expectedItems = ['Publish As-is', 'Review 1 Missing Items', 'UnPublish Program'];
+  for(let i = 0; i < items.length; i++){
+    assert.equal(getElementText(items.eq(i)), getText(expectedItems[i]));
+  }
 });
 
-test('check unpublish published program', function(assert) {
-  visit('/programs/' + fixtures.published.id);
+test('check unpublish published program', async function(assert) {
+  await visit('/programs/' + fixtures.published.id);
   const menu = '.publish-menu:eq(0)';
   const selector = `${menu} .rl-dropdown-toggle`;
   const choices = `${menu} .rl-dropdown button`;
   const unPublish = `${choices}:eq(2)`;
-  click(selector);
-  click(unPublish);
+  await click(selector);
+  await click(unPublish);
 
-  andThen(() => {
-    assert.equal(getElementText(selector), getText('Not Published'));
-  });
+  assert.equal(getElementText(selector), getText('Not Published'));
 });

--- a/tests/acceptance/user-test.js
+++ b/tests/acceptance/user-test.js
@@ -35,7 +35,7 @@ module('Acceptance: User', {
   }
 });
 
-test('can search for users', function(assert) {
+test('can search for users', async function(assert) {
   server.createList('user', 20, { email: 'user@example.edu' });
   server.createList('authentication', 20);
 
@@ -45,17 +45,13 @@ test('can search for users', function(assert) {
   const secondResultEmail = `${secondResult} .email`;
   const name = '.user-display-name';
 
-  visit(url);
-  fillIn(userSearch, 'son');
-  triggerEvent(userSearch, 'keyup');
-  andThen(() => {
-    assert.equal(find(secondResultUsername).text().trim(), '1 guy M. Mc1son', 'user name is correct');
-    assert.equal(find(secondResultEmail).text().trim(), 'user@example.edu', 'user email is correct');
-  });
+  await visit(url);
+  await fillIn(userSearch, 'son');
+  await triggerEvent(userSearch, 'keyup');
+  assert.equal(find(secondResultUsername).text().trim(), '1 guy M. Mc1son', 'user name is correct');
+  assert.equal(find(secondResultEmail).text().trim(), 'user@example.edu', 'user email is correct');
 
-  click(secondResultUsername);
-  andThen(() => {
-    assert.equal(currentURL(), '/users/2', 'new user profile is shown');
-    assert.equal(find(name).text().trim(), '1 guy M. Mc1son', 'user name is shown');
-  });
+  await click(secondResultUsername);
+  assert.equal(currentURL(), '/users/2', 'new user profile is shown');
+  assert.equal(find(name).text().trim(), '1 guy M. Mc1son', 'user name is shown');
 });

--- a/tests/acceptance/users-test.js
+++ b/tests/acceptance/users-test.js
@@ -27,48 +27,36 @@ function getCellContent(i) {
   return find(`tbody tr td:eq(${i})`).text().trim();
 }
 
-test('can see list of users and transition to user route', function(assert) {
+test('can see list of users and transition to user route', async function(assert) {
   const firstStudent = 'tbody tr td:eq(1) a';
 
-  visit(url);
-  andThen(() => {
-    assert.equal(getCellContent(0), '', 'user is a student');
-    assert.equal(getCellContent(1), '0 guy M. Mc0son', 'name is shown');
-    assert.equal(getCellContent(2), '123', 'campus ID is shown');
-    assert.equal(getCellContent(3), 'user@example.edu', 'email is shown');
-    assert.equal(getCellContent(4), 'school 0', 'primary school is shown');
-  });
+  await visit(url);
+  assert.equal(getCellContent(0), '', 'user is a student');
+  assert.equal(getCellContent(1), '0 guy M. Mc0son', 'name is shown');
+  assert.equal(getCellContent(2), '123', 'campus ID is shown');
+  assert.equal(getCellContent(3), 'user@example.edu', 'email is shown');
+  assert.equal(getCellContent(4), 'school 0', 'primary school is shown');
 
-  click(firstStudent);
-  andThen(() => {
-    assert.equal(currentURL(), '/users/4136', 'tranistioned to `user` route');
-  });
+  await click(firstStudent);
+  assert.equal(currentURL(), '/users/4136', 'tranistioned to `user` route');
 });
 
-test('can page through list of users', function(assert) {
+test('can page through list of users', async function(assert) {
   const leftArrow = '.backward';
   const rightArrow = '.forward';
 
-  visit(url);
-  click(rightArrow);
-  andThen(() => {
-    assert.equal(currentURL(), '/users?offset=25', 'query param shown');
-  });
+  await visit(url);
+  await click(rightArrow);
+  assert.equal(currentURL(), '/users?offset=25', 'query param shown');
 
-  click(rightArrow);
-  andThen(() => {
-    assert.equal(currentURL(), '/users?offset=50', 'query param shown');
-  });
+  await click(rightArrow);
+  assert.equal(currentURL(), '/users?offset=50', 'query param shown');
 
-  click(leftArrow);
-  andThen(() => {
-    assert.equal(currentURL(), '/users?offset=25', 'query param shown');
-  });
+  await click(leftArrow);
+  assert.equal(currentURL(), '/users?offset=25', 'query param shown');
 
-  click(leftArrow);
-  andThen(() => {
-    assert.equal(currentURL(), '/users', 'back to first page');
-  });
+  await click(leftArrow);
+  assert.equal(currentURL(), '/users', 'back to first page');
 });
 
 test('can search for a user and transition to user route', async function(assert) {


### PR DESCRIPTION
This is much clearer than `andThen()` for waiting for asynchronous
events in a test.

WIP:
- [x] Need to figure out how to disallow `andThen` global in our tests. This global is set by the `env` `embertest: true` option and comes from https://github.com/sindresorhus/globals/blob/master/globals.json#L1239 but I'm not sure how to unset this. Maybe @Trott knows how to customize an `eslint` environment? Otherwise we can just declare all of those globals (except `andThen`) in our own config.