### PR TITLE
Filter out duplicate locales

### DIFF
--- a/app/components/ilios-header.js
+++ b/app/components/ilios-header.js
@@ -12,7 +12,7 @@ export default Component.extend({
   tagName: 'header',
   title: null,
   locales: computed('i18n.locales', 'i18n.locale', function() {
-    return this.get('i18n.locales').map(locale => {
+    return this.get('i18n.locales').uniq().map(locale => {
       return { id: locale, text: this.get('i18n').t('general.language.' + locale) };
     }).filter(locale => locale.id !== this.get('i18n.locale'));
   }),

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -209,7 +209,7 @@
     'invalidDatetimes': 'Fecha/Hora Inválida',
     'isSelective': 'Es selectivo',
     'isTrack': 'Es la Pista',
-    'language': { 'en': 'Inglés (en)', 'es': 'Español (es)', 'fr': 'Français (fr)' },
+    'language': { 'en': 'English (en)', 'es': 'Español (es)', 'fr': 'Français (fr)' },
     'lastName': 'Apellido',
     'learnerAssignments': '{{groupTitle}} Asignaciónes de Aprendedores',
     'learnerGroups': 'Grupos de Aprendedores',


### PR DESCRIPTION
Because we inject locales from ilios/common they get doubled up in the
list.

Fixes #3098