### PR TITLE
Refactor styles for publicationcheck

### DIFF
--- a/app/components/course-publicationcheck.js
+++ b/app/components/course-publicationcheck.js
@@ -3,6 +3,6 @@ import Ember from 'ember';
 const { Component } = Ember;
 
 export default Component.extend({
-  classNames: ['course-publication-check', 'detail-view'],
+  classNames: ['course-publicationcheck'],
   course: null
 });

--- a/app/components/session-publicationcheck.js
+++ b/app/components/session-publicationcheck.js
@@ -3,6 +3,6 @@ import Ember from 'ember';
 const { Component } = Ember;
 
 export default Component.extend({
-  classNames: ['session-publication-check'],
+  classNames: ['session-publicationcheck'],
   session: null,
 });

--- a/app/styles/components/_detailview.scss
+++ b/app/styles/components/_detailview.scss
@@ -258,12 +258,3 @@ tbody .confirm-removal {
     padding-right: .2em;
   }
 }
-
-.session-publicationcheck-detail-view {
-  .back-to-session {
-    border-top: 1px solid $ilios-orange;
-    font-weight: bold;
-    margin: 1em 1.5em;
-    padding-top: 1.5em;
-  }
-}

--- a/app/styles/newcomponents.scss
+++ b/app/styles/newcomponents.scss
@@ -9,6 +9,7 @@
 @import 'newcomponents/course-header';
 @import 'newcomponents/course-details';
 @import 'newcomponents/course-materials';
+@import 'newcomponents/course-publicationcheck';
 @import 'newcomponents/course-summary-header';
 @import 'newcomponents/dashboard-mycourses';
 @import 'newcomponents/dashboard-myreports';
@@ -86,6 +87,7 @@
 @import 'newcomponents/school-session-attributes-expanded';
 @import 'newcomponents/school-session-types-collapsed';
 @import 'newcomponents/school-session-types-expanded';
+@import 'newcomponents/session-publicationcheck';
 @import 'newcomponents/learning-materials-sort-manager';
 @import 'newcomponents/ilios-users';
 @import 'newcomponents/objective-sort-manager';

--- a/app/styles/newcomponents/course-publicationcheck.scss
+++ b/app/styles/newcomponents/course-publicationcheck.scss
@@ -1,0 +1,11 @@
+.course-publicationcheck {
+  @include detail-container($ilios-orange);
+
+  .title {
+    @include detail-container-title;
+  }
+
+  .course-publicationcheck-content {
+    @include detail-container-content;
+  }
+}

--- a/app/styles/newcomponents/session-publicationcheck.scss
+++ b/app/styles/newcomponents/session-publicationcheck.scss
@@ -1,0 +1,26 @@
+.session-publicationcheck {
+  background-color: $active-background-color;
+
+  .back-to-session {
+    border-top: 1px solid $ilios-orange;
+    padding: 1em 0;
+  }
+
+  .results {
+    background-color: $active-background-color;
+    @include detail-container($ilios-orange);
+
+    .title {
+      @include detail-container-title;
+    }
+
+    .session-publicationcheck-content {
+      @include detail-container-content;
+
+      thead {
+        background-color: $header-blue;
+        color: $white;
+      }
+    }
+  }
+}

--- a/app/templates/components/course-publicationcheck.hbs
+++ b/app/templates/components/course-publicationcheck.hbs
@@ -1,43 +1,41 @@
-<section class='detail-block'>
-  <div class='detail-title'>
-    {{t 'general.missingItems'}} ({{course.allPublicationIssuesLength}})
-  </div>
-  <div class='detail-content'>
-    <table>
-      <thead>
-        <tr>
-          <th>{{t 'general.courseTitle'}}</th>
-          <th>{{t 'general.cohorts'}}</th>
-          <th>{{t 'general.terms'}}</th>
-          <th>{{t 'general.objectives'}}</th>
-          <th>{{t 'general.meshTerms'}}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{{course.title}}</td>
-          {{#if course.cohorts.length}}
-            <td class='yes'>{{t 'general.yes'}} ({{course.cohorts.length}})</td>
-          {{else}}
-            <td class='no'>{{t 'general.no'}}</td>
-          {{/if}}
-          {{#if course.terms.length}}
-            <td class='yes'>{{t 'general.yes'}} ({{course.terms.length}})</td>
-          {{else}}
-            <td class='no'>{{t 'general.no'}}</td>
-          {{/if}}
-          {{#if course.objectives.length}}
-            <td class='yes'>{{t 'general.yes'}} ({{course.objectives.length}})</td>
-          {{else}}
-            <td class='no'>{{t 'general.no'}}</td>
-          {{/if}}
-          {{#if course.meshDescriptors.length}}
-            <td class='yes'>{{t 'general.yes'}} ({{course.meshDescriptors.length}})</td>
-          {{else}}
-            <td class='no'>{{t 'general.no'}}</td>
-          {{/if}}
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</section>
+<div class='title'>
+  {{t 'general.missingItems'}} ({{course.allPublicationIssuesLength}})
+</div>
+<div class='course-publicationcheck-content'>
+  <table>
+    <thead>
+      <tr>
+        <th>{{t 'general.courseTitle'}}</th>
+        <th>{{t 'general.cohorts'}}</th>
+        <th>{{t 'general.terms'}}</th>
+        <th>{{t 'general.objectives'}}</th>
+        <th>{{t 'general.meshTerms'}}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>{{course.title}}</td>
+        {{#if course.cohorts.length}}
+          <td class='yes'>{{t 'general.yes'}} ({{course.cohorts.length}})</td>
+        {{else}}
+          <td class='no'>{{t 'general.no'}}</td>
+        {{/if}}
+        {{#if course.terms.length}}
+          <td class='yes'>{{t 'general.yes'}} ({{course.terms.length}})</td>
+        {{else}}
+          <td class='no'>{{t 'general.no'}}</td>
+        {{/if}}
+        {{#if course.objectives.length}}
+          <td class='yes'>{{t 'general.yes'}} ({{course.objectives.length}})</td>
+        {{else}}
+          <td class='no'>{{t 'general.no'}}</td>
+        {{/if}}
+        {{#if course.meshDescriptors.length}}
+          <td class='yes'>{{t 'general.yes'}} ({{course.meshDescriptors.length}})</td>
+        {{else}}
+          <td class='no'>{{t 'general.no'}}</td>
+        {{/if}}
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/templates/components/session-publicationcheck.hbs
+++ b/app/templates/components/session-publicationcheck.hbs
@@ -1,8 +1,20 @@
-<section class='detail-block'>
-  <div class='detail-title'>
+{{session-overview
+  course=(await session.course)
+  session=session
+  showCheckLink=false
+  sessionTypes=(await session.course.school.sessionTypes)
+}}
+<div class='back-to-session'>
+  {{#link-to 'session.index' (await session.course) session}}
+    {{fa-icon 'rotate-left'}} {{t 'general.backToTitle' title=session.title}}
+  {{/link-to}}
+</div>
+
+<div class='results'>
+  <div class='title'>
     {{t 'general.missingItems'}} ({{session.allPublicationIssuesLength}})
   </div>
-  <div class='detail-content'>
+  <div class='session-publicationcheck-content'>
     <table>
       <thead>
         <tr>
@@ -40,4 +52,4 @@
       </tbody>
     </table>
   </div>
-</section>
+</div>

--- a/app/templates/session/publication-check.hbs
+++ b/app/templates/session/publication-check.hbs
@@ -1,18 +1,1 @@
-<div class='detail-view session-publicationcheck-detail-view'>
-  <div class='detail-view-details'>
-    {{session-overview
-      course=(await model.course)
-      session=model
-      showCheckLink=false
-      sessionTypes=(await model.course.school.sessionTypes)
-    }}
-
-    <div class='back-to-session'>
-      {{#link-to 'session.index' (await model.course) model}}
-        {{fa-icon 'rotate-left'}} {{t 'general.backToTitle' title=model.title}}
-      {{/link-to}}
-    </div>
-
-    {{session-publicationcheck session=model}}
-  </div>
-</div>
+{{session-publicationcheck session=model}}

--- a/tests/acceptance/course/publicationcheck-test.js
+++ b/tests/acceptance/course/publicationcheck-test.js
@@ -54,7 +54,7 @@ test('full course count', function(assert) {
   visit('/courses/' + fixtures.fullCourse.id + '/publicationcheck');
   andThen(function() {
     assert.equal(currentPath(), 'course.publicationCheck');
-    var items = find('.course-publication-check .detail-content table tbody td');
+    var items = find('.course-publicationcheck table tbody td');
     assert.equal(getElementText(items.eq(0)), getText('course 0'));
     assert.equal(getElementText(items.eq(1)), getText('Yes (1)'));
     assert.equal(getElementText(items.eq(2)), getText('Yes (1)'));
@@ -67,7 +67,7 @@ test('empty course count', function(assert) {
   visit('/courses/' + fixtures.emptyCourse.id + '/publicationcheck');
   andThen(function() {
     assert.equal(currentPath(), 'course.publicationCheck');
-    var items = find('.course-publication-check .detail-content table tbody td');
+    var items = find('.course-publicationcheck table tbody td');
     assert.equal(getElementText(items.eq(0)), getText('course 1'));
     assert.equal(getElementText(items.eq(1)), getText('No'));
     assert.equal(getElementText(items.eq(2)), getText('No'));

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -65,7 +65,7 @@ test('full session count', function(assert) {
   visit(url);
   andThen(function() {
     assert.equal(currentPath(), 'course.session.publicationCheck');
-    var items = find('.session-publication-check .detail-content table tbody td');
+    var items = find('.session-publicationcheck table tbody td');
     assert.equal(getElementText(items.eq(0)), getText('session 0'));
     assert.equal(getElementText(items.eq(1)), getText('Yes (1)'));
     assert.equal(getElementText(items.eq(2)), getText('Yes (1)'));
@@ -83,7 +83,7 @@ test('empty session count', function(assert) {
   visit('/courses/1/sessions/2/publicationcheck');
   andThen(function() {
     assert.equal(currentPath(), 'course.session.publicationCheck');
-    var items = find('.session-publication-check .detail-content table tbody td');
+    var items = find('.session-publicationcheck table tbody td');
     assert.equal(getElementText(items.eq(0)), getText('session 1'));
     assert.equal(getElementText(items.eq(1)), getText('No'));
     assert.equal(getElementText(items.eq(2)), getText('No'));


### PR DESCRIPTION
Both session and course check were using the inherited detail-view
styles which are on their way out. Now they are styles on their own.

To Test:
- [x] That publication check for course and session still look correct.