### PR TITLE
Apply individual styles to curriculum-inventory

### DIFF
--- a/app/components/curriculum-inventory-sequence-block-list.js
+++ b/app/components/curriculum-inventory-sequence-block-list.js
@@ -10,7 +10,7 @@ const SequenceBlockProxy = ObjectProxy.extend({
 });
 
 export default Component.extend({
-  classNames: ['detail-view', 'curriculum-inventory-sequence-block-list'],
+  classNames: ['curriculum-inventory-sequence-block-list'],
   parent: null,
   report: null,
   sequenceBlocks: [],

--- a/app/styles/newcomponents.scss
+++ b/app/styles/newcomponents.scss
@@ -43,6 +43,7 @@
 @import 'newcomponents/curriculum-inventory-report-overview';
 @import 'newcomponents/curriculum-inventory-report-rollover';
 @import 'newcomponents/curriculum-inventory-sequence-block-header';
+@import 'newcomponents/curriculum-inventory-sequence-block-list';
 @import 'newcomponents/curriculum-inventory-sequence-block-overview';
 @import 'newcomponents/curriculum-inventory-sequence-block-dates-duration-editor';
 @import 'newcomponents/curriculum-inventory-sequence-block-min-max-editor';

--- a/app/styles/newcomponents/curriculum-inventory-report-details.scss
+++ b/app/styles/newcomponents/curriculum-inventory-report-details.scss
@@ -1,4 +1,10 @@
 .curriculum-inventory-report-details {
+  @include detail-container($ilios-orange);
+
+  .title {
+    @include detail-container-title;
+  }
+
   .confirm-finalize {
     @include fill-parent;
     background-color: $remove-background-color;

--- a/app/styles/newcomponents/curriculum-inventory-report-header.scss
+++ b/app/styles/newcomponents/curriculum-inventory-report-header.scss
@@ -9,11 +9,7 @@
   }
 
   .title {
-    @include fill-parent;
-
-    @include media($large-screen) {
-      @include span-columns(8 of 12);
-    }
+    @include detail-container-title;
 
     .editable,
     h4 {
@@ -21,14 +17,7 @@
     }
   }
 
-  .header-actions {
-    @include fill-parent;
-
-    @include media($large-screen) {
-      @include span-columns(3 of 12);
-      @include shift(1);
-      @include omega;
-      text-align: right;
-    }
+  .actions {
+    @include detail-container-actions;
   }
 }

--- a/app/styles/newcomponents/curriculum-inventory-sequence-block-list.scss
+++ b/app/styles/newcomponents/curriculum-inventory-sequence-block-list.scss
@@ -1,0 +1,27 @@
+.curriculum-inventory-sequence-block-list {
+  @include main-list;
+
+  .header {
+    @include main-list-box-header;
+
+    h2 {
+      @include ilios-heading;
+    }
+
+    .title {
+      @include main-list-box-header-title;
+    }
+
+    .actions {
+      @include main-list-box-header-actions;
+    }
+  }
+
+  .list {
+    @include main-list-box-table;
+
+    i {
+      margin-left: .25em;
+    }
+  }
+}

--- a/app/templates/components/curriculum-inventory-report-details.hbs
+++ b/app/templates/components/curriculum-inventory-report-details.hbs
@@ -1,25 +1,19 @@
-<div class='detail-view'>
-  <div class='detail-view-main-title'>
-    {{curriculum-inventory-report-header
-      report=report finalize=(action 'confirmFinalization')
-      isFinalizing=isFinalizing
-    }}
-  </div>
-  {{#if showFinalizeConfirmation}}
-    <div class='confirm-finalize'>
-      <div class='confirm-message'>
-        {{t 'general.finalizeReportConfirmation'}} <br>
-        <div class="confirm-buttons">
-          <button {{action 'finalize'}} class='finalize text'>{{t 'general.yes'}}</button>
-          <button {{action 'cancelFinalization'}} class='done text'>{{t 'general.cancel'}}</button>
-        </div>
+{{curriculum-inventory-report-header
+  report=report finalize=(action 'confirmFinalization')
+  isFinalizing=isFinalizing
+}}
+{{#if showFinalizeConfirmation}}
+  <div class='confirm-finalize'>
+    <div class='confirm-message'>
+      {{t 'general.finalizeReportConfirmation'}} <br>
+      <div class="confirm-buttons">
+        <button {{action 'finalize'}} class='finalize text'>{{t 'general.yes'}}</button>
+        <button {{action 'cancelFinalization'}} class='done text'>{{t 'general.cancel'}}</button>
       </div>
     </div>
-  {{/if}}
-  <div class='detail-view-details'>
-    {{curriculum-inventory-report-overview report=report}}
   </div>
-</div>
+{{/if}}
+{{curriculum-inventory-report-overview report=report}}
 {{#liquid-if isFinalizing class='crossFade'}}
   {{#modal-dialog translucentOverlay=true}}
     {{pulse-loader}}

--- a/app/templates/components/curriculum-inventory-report-header.hbs
+++ b/app/templates/components/curriculum-inventory-report-header.hbs
@@ -24,7 +24,7 @@
     {{/editable-field}}
   {{/if}}
 </div>
-<div class ='header-actions'>
+<div class ='actions'>
   <a class="button" {{action (perform downloadReport report)}}>
     <button class="download">
       {{#if downloadFromSameDomain}}

--- a/app/templates/components/curriculum-inventory-sequence-block-details.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-details.hbs
@@ -1,21 +1,15 @@
-<div class='detail-view'>
-  <div class='detail-view-main-title'>
-    {{curriculum-inventory-sequence-block-header sequenceBlock=sequenceBlock}}
+{{curriculum-inventory-sequence-block-header sequenceBlock=sequenceBlock}}
+{{#if (is-fulfilled sequenceBlock.allParents)}}
+  <div class='breadcrumbs'>
+    <span>
+      {{#link-to 'curriculumInventoryReport' sequenceBlock.report}}
+        {{t 'general.curriculumInventoryReport'}}
+      {{/link-to}}
+    </span>
+    {{#each (reverse (await sequenceBlock.allParents)) as |parent|}}
+      <span>{{#link-to 'curriculumInventorySequenceBlock' parent}}{{parent.title}}{{/link-to}}</span>
+    {{/each}}
+    <span>{{sequenceBlock.title}}</span>
   </div>
-  {{#if (is-fulfilled sequenceBlock.allParents)}}
-    <div class='breadcrumbs'>
-      <span>
-        {{#link-to 'curriculumInventoryReport' sequenceBlock.report}}
-          {{t 'general.curriculumInventoryReport'}}
-        {{/link-to}}
-      </span>
-      {{#each (reverse (await sequenceBlock.allParents)) as |parent|}}
-        <span>{{#link-to 'curriculumInventorySequenceBlock' parent}}{{parent.title}}{{/link-to}}</span>
-      {{/each}}
-      <span>{{sequenceBlock.title}}</span>
-    </div>
-  {{/if}}
-  <div class='detail-view-details'>
-    {{curriculum-inventory-sequence-block-overview sequenceBlock=sequenceBlock sortBy=sortSessionsBy setSortBy=setSortSessionBy}}
-  </div>
-</div>
+{{/if}}
+{{curriculum-inventory-sequence-block-overview sequenceBlock=sequenceBlock sortBy=sortSessionsBy setSortBy=setSortSessionBy}}

--- a/app/templates/components/curriculum-inventory-sequence-block-list.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-list.hbs
@@ -1,121 +1,119 @@
 {{#unless loadAttr.running}}
-  <section class='detail-block'>
-    <div class='detail-title'>
+  <div class='header'>
+    <div class='title'>
       {{t 'general.sequenceBlocks'}} ({{get (await sortedBlocks) 'length'}})
     </div>
 
-    <div class='detail-actions'>
+    <div class='actions'>
       {{#unless report.isFinalized}}
         {{expand-collapse-button value=editorOn action="toggleEditor"}}
       {{/unless}}
     </div>
-    <section class='resultslist'>
-      <section class='resultslist-new'>
-        {{#liquid-if editorOn class='vertical'}}
-          {{new-curriculum-inventory-sequence-block
-            parent=parent
-            report=report
-            save=(action 'save')
-            cancel=(action 'cancel')
-          }}
-        {{/liquid-if}}
-        {{#if saved}}
-          <div class='saved-result'>
-            {{#link-to 'curriculumInventorySequenceBlock' savedBlock}}
-              {{fa-icon 'external-link-square'}} {{savedBlock.title}}
-            {{/link-to}}
-            {{t 'general.savedSuccessfully'}}
-          </div>
-        {{/if}}
-      </section>
-      {{#if (is-fulfilled sortedBlocks)}}
-        {{#if (get (await sortedBlocks) 'length')}}
-          <div class='resultslist-list'>
-            <table>
-              <thead>
-                <tr>
-                  <th class='text-center' colspan=5>{{t 'general.sequenceBlock'}}</th>
-                  <th class='text-center' colspan=1>{{t 'general.level'}}</th>
-                  <th class='text-center' colspan=2>{{t 'general.sequenceNumber'}}</th>
-                  <th class='text-center' colspan=2>{{t 'general.startDate'}}</th>
-                  <th class='text-center' colspan=2>{{t 'general.endDate'}}</th>
-                  <th class='text-center' colspan=2>{{t 'general.course'}}</th>
-                  <th class='text-left' colspan=1>{{t 'general.actions'}}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {{#each (await sortedBlocks) as |block|}}
-                  <tr class="{{if block.showRemoveConfirmation 'confirm-removal'}}">
-                    <td class='text-left' colspan=5>
-                      {{#link-to 'curriculumInventorySequenceBlock' block.content}}
-                        {{block.title}}
-                      {{/link-to}}
-                    </td>
-                    <td class='text-center' colspan=1>{{get (await block.academicLevel) 'level'}}</td>
-                    <td class='text-center' colspan=2>
-                      {{#if isInOrderedSequence}}
-                        {{block.orderInSequence}}
-                      {{else}}
-                        {{t 'general.notApplicableAbbr'}}
-                      {{/if}}
-                    </td>
-                    <td class='text-center' colspan=2>
-                      {{#if block.startDate}}
-                        {{moment-format block.startDate 'L'}}
-                      {{else}}
-                        {{t 'general.notApplicableAbbr'}}
-                      {{/if}}
-                    </td>
-                    <td class='text-center' colspan=2>
-                      {{#if block.endDate}}
-                        {{moment-format block.endDate 'L'}}
-                      {{else}}
-                        {{t 'general.notApplicableAbbr'}}
-                      {{/if}}
-                    </td>
-                    <td class='text-center' colspan=2>
-                      {{#if (await block.course)}}
-                        {{get (await block.course) 'title'}}
-                      {{else}}
-                        {{t 'general.notApplicableAbbr'}}
-                      {{/if}}
-                    </td>
-                    <td class='text-center' colspan=1>
-                      {{#link-to 'curriculumInventorySequenceBlock' block.content class='edit'}}
-                        {{fa-icon 'edit'}}
-                      {{/link-to}}
-                      {{#unless report.isFinalized}}
-                        <span class='clickable remove' {{action 'confirmRemove' block}}>{{fa-icon 'trash'}}</span>
-                      {{/unless}}
-                    </td>
-                  </tr>
-                  {{#if block.showRemoveConfirmation}}
-                    <tr class='confirm-removal'>
-                      <td colspan=15>
-                        <div class='confirm-message'>
-                          {{t 'general.sequenceBlockConfirmRemove'}} <br>
-                          <div class="confirm-buttons">
-                            <button {{action 'remove' block}} class='remove text'>{{t 'general.yes'}}</button>
-                            <button {{action 'cancelRemove' block}} class='done text'>{{t 'general.cancel'}}</button>
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
+  </div>
+  <div class='new'>
+    {{#if editorOn}}
+      {{new-curriculum-inventory-sequence-block
+        parent=parent
+        report=report
+        save=(action 'save')
+        cancel=(action 'cancel')
+      }}
+    {{/if}}
+    {{#if saved}}
+      <div class='saved-result'>
+        {{#link-to 'curriculumInventorySequenceBlock' savedBlock}}
+          {{fa-icon 'external-link-square'}} {{savedBlock.title}}
+        {{/link-to}}
+        {{t 'general.savedSuccessfully'}}
+      </div>
+    {{/if}}
+  </div>
+  {{#if (is-fulfilled sortedBlocks)}}
+    {{#if (get (await sortedBlocks) 'length')}}
+      <div class='list'>
+        <table>
+          <thead>
+            <tr>
+              <th class='text-center' colspan=5>{{t 'general.sequenceBlock'}}</th>
+              <th class='text-center' colspan=1>{{t 'general.level'}}</th>
+              <th class='text-center' colspan=2>{{t 'general.sequenceNumber'}}</th>
+              <th class='text-center hide-from-small-screen' colspan=2>{{t 'general.startDate'}}</th>
+              <th class='text-center hide-from-small-screen' colspan=2>{{t 'general.endDate'}}</th>
+              <th class='text-center hide-from-small-screen' colspan=2>{{t 'general.course'}}</th>
+              <th class='text-left' colspan=1>{{t 'general.actions'}}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each (await sortedBlocks) as |block|}}
+              <tr class="{{if block.showRemoveConfirmation 'confirm-removal'}}">
+                <td class='text-left' colspan=5>
+                  {{#link-to 'curriculumInventorySequenceBlock' block.content}}
+                    {{block.title}}
+                  {{/link-to}}
+                </td>
+                <td class='text-center' colspan=1>{{get (await block.academicLevel) 'level'}}</td>
+                <td class='text-center' colspan=2>
+                  {{#if isInOrderedSequence}}
+                    {{block.orderInSequence}}
+                  {{else}}
+                    {{t 'general.notApplicableAbbr'}}
                   {{/if}}
-                {{/each}}
-              </tbody>
-            </table>
-          </div>
-        {{else}}
-          {{#if parent}}
-            <span class="default-message">{{t 'general.noSubSequenceBlocks'}}</span>
-          {{else}}
-            <span class="default-message">{{t 'general.noSequenceBlocks'}}</span>
-          {{/if}}
-        {{/if}}
+                </td>
+                <td class='text-center hide-from-small-screen' colspan=2>
+                  {{#if block.startDate}}
+                    {{moment-format block.startDate 'L'}}
+                  {{else}}
+                    {{t 'general.notApplicableAbbr'}}
+                  {{/if}}
+                </td>
+                <td class='text-center hide-from-small-screen' colspan=2>
+                  {{#if block.endDate}}
+                    {{moment-format block.endDate 'L'}}
+                  {{else}}
+                    {{t 'general.notApplicableAbbr'}}
+                  {{/if}}
+                </td>
+                <td class='text-center hide-from-small-screen' colspan=2>
+                  {{#if (await block.course)}}
+                    {{get (await block.course) 'title'}}
+                  {{else}}
+                    {{t 'general.notApplicableAbbr'}}
+                  {{/if}}
+                </td>
+                <td class='text-center' colspan=1>
+                  {{#link-to 'curriculumInventorySequenceBlock' block.content class='edit'}}
+                    {{fa-icon 'edit'}}
+                  {{/link-to}}
+                  {{#unless report.isFinalized}}
+                    <span class='clickable remove' {{action 'confirmRemove' block}}>{{fa-icon 'trash'}}</span>
+                  {{/unless}}
+                </td>
+              </tr>
+              {{#if block.showRemoveConfirmation}}
+                <tr class='confirm-removal'>
+                  <td colspan=15>
+                    <div class='confirm-message'>
+                      {{t 'general.sequenceBlockConfirmRemove'}} <br>
+                      <div class="confirm-buttons">
+                        <button {{action 'remove' block}} class='remove text'>{{t 'general.yes'}}</button>
+                        <button {{action 'cancelRemove' block}} class='done text'>{{t 'general.cancel'}}</button>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              {{/if}}
+            {{/each}}
+          </tbody>
+        </table>
+      </div>
+    {{else}}
+      {{#if parent}}
+        <span class="default-message">{{t 'general.noSubSequenceBlocks'}}</span>
       {{else}}
-        <div>{{fa-icon 'spinner' spin=true}}</div>
+        <span class="default-message">{{t 'general.noSequenceBlocks'}}</span>
       {{/if}}
-    </section>
-  </section>
+    {{/if}}
+  {{else}}
+    <div>{{fa-icon 'spinner' spin=true}}</div>
+  {{/if}}
 {{/unless}}

--- a/app/templates/curriculum-inventory-report.hbs
+++ b/app/templates/curriculum-inventory-report.hbs
@@ -1,7 +1,6 @@
 <div class="backtolink">
   {{#link-to 'curriculumInventoryReports'}}{{t 'general.backToReports'}}{{/link-to}}
 </div>
-<section class='full-width curriculum-inventory-report'>
-  {{curriculum-inventory-report-details report=model}}
-  {{liquid-outlet}}
-</section>
+
+{{curriculum-inventory-report-details report=model}}
+{{outlet}}

--- a/app/templates/curriculum-inventory-report/index.hbs
+++ b/app/templates/curriculum-inventory-report/index.hbs
@@ -1,8 +1,6 @@
-<div class='list'>
-  {{#if (is-fulfilled model.topLevelSequenceBlocks)}}
-    {{curriculum-inventory-sequence-block-list
-    report=(await model)
-    remove='removeSequenceBlock'
-    }}
-  {{/if}}
-</div>
+{{#if (is-fulfilled model.topLevelSequenceBlocks)}}
+  {{curriculum-inventory-sequence-block-list
+  report=(await model)
+  remove='removeSequenceBlock'
+  }}
+{{/if}}

--- a/tests/integration/components/curriculum-inventory-report-header-test.js
+++ b/tests/integration/components/curriculum-inventory-report-header-test.js
@@ -21,8 +21,8 @@ test('it renders', function(assert) {
   this.render(hbs`{{curriculum-inventory-report-header report=report}}`);
   assert.equal(this.$('.title').text().trim(), report.name, 'Report name shows.');
   assert.equal(this.$('.editable').length, 1, 'Report name is editable.');
-  assert.equal(this.$(`.header-actions .finalize`).length, 1, 'Finalize button shows.');
-  assert.equal(this.$(`.header-actions .download`).length, 1, 'Download button shows.');
+  assert.equal(this.$(`.actions .finalize`).length, 1, 'Finalize button shows.');
+  assert.equal(this.$(`.actions .download`).length, 1, 'Download button shows.');
 });
 
 test('finalized reports render in read-only mode.', function(assert) {
@@ -35,8 +35,8 @@ test('finalized reports render in read-only mode.', function(assert) {
   this.render(hbs`{{curriculum-inventory-report-header report=report}}`);
   assert.equal(this.$('.title .fa-lock').length, 1, 'Lock icon is showing in title.');
   assert.equal(this.$('.editable').length, 0, 'Report name is not editable.');
-  assert.equal(this.$('.header-actions .download').length, 1, 'Download button shows.');
-  assert.equal(this.$(`.header-actions .finalize`).length, 0, 'Finalize button is not showing.');
+  assert.equal(this.$('.actions .download').length, 1, 'Download button shows.');
+  assert.equal(this.$(`.actions .finalize`).length, 0, 'Finalize button is not showing.');
 });
 
 test('change name', function(assert) {

--- a/tests/integration/components/curriculum-inventory-sequence-block-list-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-list-test.js
@@ -74,10 +74,10 @@ test('it renders with top-level sequence blocks', function(assert) {
   this.set('removeSequenceBlock', function() {});
   this.render(hbs`{{curriculum-inventory-sequence-block-list report=report remove='removeSequenceBlock'}}`);
   return wait().then(() => {
-    assert.equal(this.$('.detail-title').text().trim(), `Sequence Blocks (${blocks.length})`,
+    assert.equal(this.$('.title').text().trim(), `Sequence Blocks (${blocks.length})`,
       'Component title is correct, and show the correct number of blocks.'
     );
-    assert.equal(this.$('.detail-actions .expand-button').length, 1, 'Add new button is visible.');
+    assert.equal(this.$('.actions .expand-button').length, 1, 'Add new button is visible.');
 
     assert.equal(this.$('thead th:eq(0)').text().trim(), 'Sequence Block', 'Table column header has correct label.');
     assert.equal(this.$('thead th:eq(1)').text().trim(), 'Level', 'Table column header has correct label.');
@@ -183,10 +183,10 @@ test('it renders with nested blocks', function(assert) {
   this.set('removeSequenceBlock', function() {});
   this.render(hbs`{{curriculum-inventory-sequence-block-list parent=parent remove='removeSequenceBlock'}}`);
   return wait().then(() => {
-    assert.equal(this.$('.detail-title').text().trim(), `Sequence Blocks (${nestedBlocks.length})`,
+    assert.equal(this.$('.title').text().trim(), `Sequence Blocks (${nestedBlocks.length})`,
       'Component title is correct, and show the correct number of nested blocks.'
     );
-    assert.equal(this.$('.detail-actions .expand-button').length, 1, 'Add new button is visible.');
+    assert.equal(this.$('.actions .expand-button').length, 1, 'Add new button is visible.');
 
     assert.equal(this.$('tbody tr:eq(0) td:eq(0)').text().trim(), block1.get('title'));
     assert.equal(this.$('tbody tr:eq(0) td:eq(1)').text().trim(), academicLevel1.get('level'));
@@ -246,7 +246,7 @@ test('finalized/read-only mode', function(assert){
   this.set('removeSequenceBlock', function() {});
   this.render(hbs`{{curriculum-inventory-sequence-block-list report=report remove='removeSequenceBlock'}}`);
   return wait().then(() => {
-    assert.equal(this.$('.detail-actions .expand-button').length, 0, 'Add new button is not visible.');
+    assert.equal(this.$('.actions .expand-button').length, 0, 'Add new button is not visible.');
     assert.equal(this.$('tbody tr:eq(0) td:eq(6) .edit').length, 1, 'Edit link is visible.');
     assert.equal(this.$('tbody tr:eq(0) td:eq(6) .remove').length, 0, 'Remove link is not visible.');
   });
@@ -374,7 +374,7 @@ test('empty top level blocks list', function(assert) {
   this.set('report', report);
   this.render(hbs`{{curriculum-inventory-sequence-block-list report=report}}`);
   return wait().then(() => {
-    assert.equal(this.$('.detail-title').text().trim(), `Sequence Blocks (0)`,
+    assert.equal(this.$('.title').text().trim(), `Sequence Blocks (0)`,
       'Component title is correct, and show the correct number of blocks.'
     );
     assert.equal(
@@ -423,7 +423,7 @@ test('empty nested blocks list', function(assert) {
   this.set('parent', parentBlock);
   this.render(hbs`{{curriculum-inventory-sequence-block-list parent=parent}}`);
   return wait().then(() => {
-    assert.equal(this.$('.detail-title').text().trim(), `Sequence Blocks (0)`,
+    assert.equal(this.$('.title').text().trim(), `Sequence Blocks (0)`,
       'Component title is correct, and show the correct number of blocks.'
     );
     assert.equal(


### PR DESCRIPTION
Removing the detail-block styles from CI brings us one step closer to
removing them completely.

Refs #1705