### PR TITLE
Ensure all objectives are loaded for a course

### DIFF
--- a/app/components/collapsed-objectives.js
+++ b/app/components/collapsed-objectives.js
@@ -1,13 +1,36 @@
 import Ember from 'ember';
 
 const { Component, computed } = Ember;
-const { alias, filterBy } = computed;
 
 export default Component.extend({
   tagName: 'section',
   classNames: ['collapsed-objectives'],
   subject: null,
-  objectives: alias('subject.objectives'),
-  objectivesWithParents: filterBy('objectives', 'hasParents', true),
-  objectivesWithMesh: filterBy('objectives', 'hasMesh', true),
+
+  objectives: computed('subject.objectives.[]', async function(){
+    const subject = this.get('subject');
+    const objectives = await subject.get('objectives');
+
+    return objectives;
+  }),
+  objectivesWithParents: computed('objectives.[]', async function(){
+    const objectives = await this.get('objectives');
+    const objectivesWithParents = objectives.filter(objective => {
+      const parentIds = objective.hasMany('parents').ids();
+
+      return parentIds.length > 0;
+    });
+
+    return objectivesWithParents;
+  }),
+  objectivesWithMesh: computed('objectives.[]', async function(){
+    const objectives = await this.get('objectives');
+    const objectivesWithMesh = objectives.filter(objective => {
+      const meshDescriptorIds = objective.hasMany('meshDescriptors').ids();
+
+      return meshDescriptorIds.length > 0;
+    });
+
+    return objectivesWithMesh;
+  }),
 });

--- a/app/routes/course/index.js
+++ b/app/routes/course/index.js
@@ -27,8 +27,9 @@ export default  Route.extend({
       store.query('session', {filters: {course}, limit: 1000}),
       store.query('offering', {filters: {courses}, limit: 1000}),
       store.query('ilm-session', {filters: {courses}, limit: 1000}),
-      store.query('objective', {filters: {courses}, limit: 1000}),
-      store.query('objective', {filters: {sessions}, limit: 1000}),
+      //temporarily disabled to fix #3173
+      // store.query('objective', {filters: {courses}, limit: 1000}),
+      // store.query('objective', {filters: {sessions}, limit: 1000}),
     ]);
   }
 });

--- a/app/templates/components/collapsed-objectives.hbs
+++ b/app/templates/components/collapsed-objectives.hbs
@@ -1,10 +1,7 @@
 <div class='title'  {{action (action this.attrs.expand)}}>
-  {{t 'general.objectives'}} ({{subject.objectives.length}})
+  {{t 'general.objectives'}} ({{get (await objectives) 'length'}})
 </div>
-{{#if objectives.isPending}}
-  <h3>{{fa-icon 'spinner' spin=true}}</h3>
-{{/if}}
-{{#unless objectives.isPending}}
+{{#if (and (is-fulfilled objectives) (is-fulfilled objectivesWithMesh) (is-fulfilled objectivesWithParents))}}
   <div class='content'>
     <table>
       <thead>
@@ -17,21 +14,21 @@
       <tbody>
         <tr>
           <td>
-            {{t 'general.objectiveCount' count=objectives.length}}
+            {{t 'general.objectiveCount' count=(get (await objectives) 'length')}}
           </td>
           <td class='text-middle text-center' rowspan=3>
-            {{#if (eq objectivesWithParents.length objectives.length)}}
+            {{#if (eq (get (await objectivesWithParents) 'length') (get (await objectives) 'length'))}}
               {{fa-icon 'circle' class='yes'}}
-            {{else if (gte objectivesWithParents.length 1)}}
+            {{else if (gte (get (await objectivesWithParents) 'length') 1)}}
               {{fa-icon 'circle' class='maybe'}}
             {{else}}
               {{fa-icon 'ban' class='no'}}
             {{/if}}
           </td>
           <td class='text-middle text-center' rowspan=3>
-            {{#if (eq objectivesWithMesh.length objectives.length)}}
+            {{#if (eq (get (await objectivesWithMesh) 'length') (get (await objectives) 'length'))}}
               {{fa-icon 'circle' class='yes'}}
-            {{else if (gte objectivesWithMesh.length 1)}}
+            {{else if (gte (get (await objectivesWithMesh) 'length') 1)}}
               {{fa-icon 'circle' class='maybe'}}
             {{else}}
               {{fa-icon 'ban' class='no'}}
@@ -39,12 +36,14 @@
           </td>
         </tr>
         <tr>
-          <td>&nbsp;&nbsp;{{t 'general.parentCount' count=objectivesWithParents.length}}</td>
+          <td>&nbsp;&nbsp;{{t 'general.parentCount' count=(get (await objectivesWithParents) 'length')}}</td>
         </tr>
         <tr>
-          <td>&nbsp;&nbsp;{{t 'general.meshCount' count=objectivesWithMesh.length}}</td>
+          <td>&nbsp;&nbsp;{{t 'general.meshCount' count=(get (await objectivesWithMesh) 'length')}}</td>
         </tr>
       </tbody>
     </table>
   </div>
-{{/unless}}
+{{else}}
+  <h3>{{fa-icon 'spinner' spin=true}}</h3>
+{{/if}}

--- a/app/templates/components/course-editing.hbs
+++ b/app/templates/components/course-editing.hbs
@@ -7,7 +7,7 @@
     expand=(action this.attrs.setCourseObjectiveDetails true)
   }}
 {{else}}
-  {{collapsed-objectives subject=course expand=(action this.attrs.setCourseObjectiveDetails true)}}
+  {{collapsed-objectives subject=course expand=(action setCourseObjectiveDetails true)}}
 {{/if}}
 
 {{detail-learning-materials subject=course isCourse=true editable=editable}}

--- a/tests/acceptance/course/objectivelist-test.js
+++ b/tests/acceptance/course/objectivelist-test.js
@@ -52,7 +52,7 @@ test('list objectives', function(assert) {
   }));
   fixtures.courseObjectives = [];
   fixtures.courseObjectives.pushObject(server.create('objective', {
-    courses: [1],
+    courses: [1, 2],
     parents: [1],
     meshDecriptors: [1]
   }));

--- a/tests/integration/components/collapsed-objectives-test.js
+++ b/tests/integration/components/collapsed-objectives-test.js
@@ -1,35 +1,69 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
-import startMirage from '../../helpers/start-mirage';
+import wait from 'ember-test-helpers/wait';
 
-const { Object:EmberObject } = Ember;
+const { Object:EmberObject, RSVP } = Ember;
+const { resolve } = RSVP;
+
+let hasMesh, hasParents, plain;
 
 moduleForComponent('collapsed-objectives', 'Integration | Component | collapsed objectives', {
   integration: true,
-  setup(){
-    startMirage(this.container);
+  beforeEach(){
+    hasMesh = EmberObject.create({
+      id: 1,
+      hasMany(what){
+        return {
+          ids(){
+            if (what === 'meshDescriptors') {
+              return [1];
+            }
+
+            return [];
+          }
+        };
+      }
+    });
+    hasParents = EmberObject.create({
+      id: 1,
+      hasMany(what){
+        return {
+          ids(){
+            if (what === 'parents') {
+              return [1];
+            }
+
+            return [];
+          }
+        };
+      }
+    });
+
+    plain = EmberObject.create({
+      id: 1,
+      hasMany(){
+        return {
+          ids(){
+            return [];
+          }
+        };
+      }
+    });
   }
 });
 
-test('displays summary data', function(assert) {
+test('displays summary data', async function(assert) {
   assert.expect(9);
-  let hasMesh = server.create('objective', {
-    hasMesh: true
-  });
-  let hasParents = server.create('objective', {
-    hasParents: true
-  });
-  let plain = server.create('objective');
-  let objectives = [hasMesh, hasParents, plain].map(obj => Ember.Object.create(obj));
 
   const course = EmberObject.create({
-    objectives
+    objectives: resolve([hasMesh, hasParents, plain])
   });
 
   this.set('subject', course);
   this.on('click', parseInt);
   this.render(hbs`{{collapsed-objectives subject=subject expand=(action 'click')}}`);
+  await wait();
 
   assert.equal(this.$('.title').text().trim(), 'Objectives (3)');
   assert.equal(this.$('table tr').length, 4);
@@ -37,13 +71,13 @@ test('displays summary data', function(assert) {
   assert.equal(this.$('tr:eq(2) td:eq(0)').text().trim(), '1 has a parent');
   assert.equal(this.$('tr:eq(3) td:eq(0)').text().trim(), '1 has MeSH');
 
-  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('fa-circle'));
-  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('maybe'));
-  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('fa-circle'));
-  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('maybe'));
+  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('fa-circle'), 'correct icon for parent objectives');
+  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('maybe'), 'correct class for parent objectives');
+  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('fa-circle'), 'correct icon for mesh links');
+  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('maybe'), 'correct class for mesh links');
 });
 
-test('clicking expand icon opens full view', function(assert) {
+test('clicking expand icon opens full view', async function(assert) {
   assert.expect(2);
 
   const course = EmberObject.create();
@@ -54,95 +88,81 @@ test('clicking expand icon opens full view', function(assert) {
   });
 
   this.render(hbs`{{collapsed-objectives subject=subject expand=(action 'click')}}`);
+  await wait();
 
   assert.equal(this.$('.title').text().trim(), 'Objectives ()');
   this.$('.title').click();
 });
 
-test('icons all parents correctly', function(assert) {
+test('icons all parents correctly', async function(assert) {
   assert.expect(4);
-  let objective = server.create('objective', {
-    hasParents: true
-  });
-  let objectives = [objective].map(obj => Ember.Object.create(obj));
 
   const course = EmberObject.create({
-    objectives
+    objectives: resolve([hasParents])
   });
 
   this.set('subject', course);
   this.on('click', parseInt);
   this.render(hbs`{{collapsed-objectives subject=subject expand=(action 'click')}}`);
+  await wait();
 
   assert.equal(this.$('.title').text().trim(), 'Objectives (1)');
   assert.equal(this.$('table tr').length, 4);
 
-  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('fa-circle'));
-  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('yes'));
+  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('fa-circle'), 'has the correct icon');
+  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('yes'), 'icon has the right class');
 });
 
-test('icons no parents correctly', function(assert) {
+test('icons no parents correctly', async function(assert) {
   assert.expect(4);
-  let objective = server.create('objective', {
-    hasParents: false
-  });
-  let objectives = [objective].map(obj => Ember.Object.create(obj));
-
   const course = EmberObject.create({
-    objectives
+    objectives: resolve([plain])
   });
 
   this.set('subject', course);
   this.on('click', parseInt);
   this.render(hbs`{{collapsed-objectives subject=subject expand=(action 'click')}}`);
+  await wait();
 
   assert.equal(this.$('.title').text().trim(), 'Objectives (1)');
   assert.equal(this.$('table tr').length, 4);
 
-  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('fa-ban'));
-  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('no'));
+  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('fa-ban'), 'has the correct icon');
+  assert.ok(this.$('tr:eq(1) td:eq(1) i').hasClass('no'), 'icon has the right class');
 });
 
-test('icons all mesh correctly', function(assert) {
+test('icons all mesh correctly', async function(assert) {
   assert.expect(4);
-  let objective = server.create('objective', {
-    hasMesh: true
-  });
-  let objectives = [objective].map(obj => Ember.Object.create(obj));
-
   const course = EmberObject.create({
-    objectives
+    objectives: resolve([hasMesh])
   });
 
   this.set('subject', course);
   this.on('click', parseInt);
   this.render(hbs`{{collapsed-objectives subject=subject expand=(action 'click')}}`);
+  await wait();
 
   assert.equal(this.$('.title').text().trim(), 'Objectives (1)');
   assert.equal(this.$('table tr').length, 4);
 
-  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('fa-circle'));
-  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('yes'));
+  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('fa-circle'), 'has the correct icon');
+  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('yes'), 'icon has the right class');
 });
 
-test('icons no mesh correctly', function(assert) {
+test('icons no mesh correctly', async function(assert) {
   assert.expect(4);
-  let objective = server.create('objective', {
-    hasMesh: false
-  });
-  let objectives = [objective].map(obj => Ember.Object.create(obj));
-
   const course = EmberObject.create({
-    objectives
+    objectives: resolve([plain])
   });
 
   this.set('subject', course);
   this.on('click', parseInt);
   this.render(hbs`{{collapsed-objectives subject=subject expand=(action 'click')}}`);
+  await wait();
 
   assert.equal(this.$('.title').text().trim(), 'Objectives (1)');
   assert.equal(this.$('table tr').length, 4);
 
-  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('fa-ban'));
-  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('no'));
+  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('fa-ban'), 'has the correct icon');
+  assert.ok(this.$('tr:eq(1) td:eq(2) i').hasClass('no'), 'icon has the right class');
 });


### PR DESCRIPTION
Ember-data has a bug in the latest version that breaks our pre-loading
of course objective data. As a temporary fix this disables the
pre-loading of objectives.

Ended up refactoring the collapsed objectives component while I was 
debugging this and left those changes in since they are good.

Fixes #3173