### PR TITLE
Bump API version to v1.23

### DIFF
--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v1.22';
+module.exports = 'v1.23';


### PR DESCRIPTION
Corresponds to version bump on the API to force a migration.