### PR TITLE
Fix sessions filter on list to wait for input

### DIFF
--- a/app/templates/components/session-table.hbs
+++ b/app/templates/components/session-table.hbs
@@ -1,7 +1,7 @@
 <div class="filter">
   {{one-way-input
-    value=filterBy
-    update=(action 'cleanFilter')
+    value=filterByDebounced
+    update=(perform changeFilterBy)
     placeholder=(t 'general.sessionTitleFilterPlaceholder')
   }}
 </div>


### PR DESCRIPTION
Debouncing this filter and caching the value locally ensures that every
typed character doesn't cause the table to re-render which is slow and
very intensive. Instead we record each char as it is typed so the input
field stays up to date, but we only send the value up to be processed if
there is a 250ms delay.

Fixes #3184