### PR TITLE
Remove default limits from API queries

### DIFF
--- a/app/components/assign-students.js
+++ b/app/components/assign-students.js
@@ -68,7 +68,6 @@ export default Component.extend({
       filters: {
         schools: [school.get('id')],
       },
-      limit: 1000,
     });
 
     //prefetch programYears and programs so that ember data will coalesce these requests.

--- a/app/components/bulk-new-users.js
+++ b/app/components/bulk-new-users.js
@@ -98,7 +98,7 @@ export default Component.extend(NewUser, {
   existingUsernames(){
     const store = this.get('store');
     return new Promise(resolve => {
-      store.query('authentication', {limit: 10000000}).then(authentications => {
+      store.query('authentication').then(authentications => {
         resolve(authentications.mapBy('username'));
       });
     });

--- a/app/components/curriculum-inventory-sequence-block-overview.js
+++ b/app/components/curriculum-inventory-sequence-block-overview.js
@@ -130,7 +130,6 @@ export default Component.extend({
             course: course.get('id'),
             published: true
           },
-          limit: 10000,
         }).then(sessions => {
           // filter out ILM sessions
           let filteredSessions = sessions.toArray().filter(function(session) {
@@ -162,7 +161,6 @@ export default Component.extend({
             published: true,
             year: report.get('year'),
           },
-          limit: 10000
         }).then(allLinkableCourses => {
           report.get('linkedCourses').then(linkedCourses => {
             // Filter out all courses that are linked to (sequence blocks in) this report.

--- a/app/components/new-curriculum-inventory-sequence-block.js
+++ b/app/components/new-curriculum-inventory-sequence-block.js
@@ -168,8 +168,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
             school: [schoolId],
             published: true,
             year: report.get('year'),
-          },
-          limit: 10000
+          }
         }).then(allLinkableCourses => {
           report.get('linkedCourses').then(linkedCourses => {
             // Filter out all courses that are linked to (sequence blocks in) this report.

--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -118,7 +118,6 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     const store = this.get('store');
     const school = await this.get('currentSchool');
     let query = {
-      limit: 1000,
       filters: {}
     };
     if (isPresent(school)) {

--- a/app/components/pending-updates-summary.js
+++ b/app/components/pending-updates-summary.js
@@ -72,7 +72,6 @@ export default Component.extend({
     const store = this.get('store');
     const school = await this.get('selectedSchool');
     const updates = await store.query('pending-user-update', {
-      limit: 1000,
       filters: {
         schools: [school.get('id')]
       }

--- a/app/components/session-copy.js
+++ b/app/components/session-copy.js
@@ -140,8 +140,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
       filters: {
         year,
         school
-      },
-      limit: 10000
+      }
     });
 
     if (isEmpty(this.get('selectedCourse'))) {

--- a/app/components/unassigned-students-summary.js
+++ b/app/components/unassigned-students-summary.js
@@ -42,7 +42,6 @@ export default Component.extend({
     return new Promise(resolve => {
       this.get('selectedSchool').then(school => {
         this.get('store').query('user', {
-          limit: 1000,
           filters: {
             roles: [4],
             school: school.get('id'),

--- a/app/controllers/assign-students.js
+++ b/app/controllers/assign-students.js
@@ -28,7 +28,6 @@ export default Controller.extend({
     return new Promise(resolve => {
       let school = this.get('selectedSchool');
       this.get('store').query('user', {
-        limit: 1000,
         filters: {
           roles: [4],
           school: school.get('id'),

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -51,8 +51,7 @@ export default Controller.extend({
             school: schoolId,
             year: yearTitle,
             archived: false
-          },
-          limit: 500
+          }
         }).then(courses => {
           resolve(courses.toArray());
         });

--- a/app/controllers/instructor-groups.js
+++ b/app/controllers/instructor-groups.js
@@ -29,8 +29,7 @@ export default Controller.extend({
       this.get('store').query('instructor-group', {
         filters: {
           school: schoolId
-        },
-        limit: 500
+        }
       }).then(instructorGroups => {
         defer.resolve(instructorGroups);
       });

--- a/app/controllers/pending-user-updates.js
+++ b/app/controllers/pending-user-updates.js
@@ -35,7 +35,6 @@ export default Controller.extend({
     return new Promise(resolve => {
       let school = this.get('selectedSchool');
       this.get('store').query('pending-user-update', {
-        limit: 1000,
         filters: {
           schools: [school.get('id')]
         }

--- a/app/controllers/programs.js
+++ b/app/controllers/programs.js
@@ -88,8 +88,7 @@ export default Controller.extend({
         this.get('store').query('program', {
           filters: {
             school: schoolId
-          },
-          limit: 500
+          }
         }).then(programs => {
           defer.resolve(programs);
         });

--- a/app/mixins/newuser.js
+++ b/app/mixins/newuser.js
@@ -92,8 +92,7 @@ export default Mixin.create(ValidationErrorDisplay, {
     let cohorts = yield this.get('store').query('cohort', {
       filters: {
         schools: [school.get('id')],
-      },
-      limit: 1000,
+      }
     });
 
     //prefetch programYears and programs so that ember data will coalesce these requests.

--- a/app/routes/course/index.js
+++ b/app/routes/course/index.js
@@ -24,13 +24,13 @@ export default  Route.extend({
     }
 
     return all([
-      store.query('session', {filters: {course}, limit: 1000}),
-      store.query('offering', {filters: {courses}, limit: 1000}),
-      store.query('ilm-session', {filters: {courses}, limit: 1000}),
+      store.query('session', {filters: {course}}),
+      store.query('offering', {filters: {courses}}),
+      store.query('ilm-session', {filters: {courses}}),
       //temporarily disabled to fix #3173
-      // store.query('objective', {filters: {courses}, limit: 1000}),
-      // store.query('objective', {filters: {sessions}, limit: 1000}),
-      store.query('session-type', {filters: {sessions}, limit: 1000}),
+      // store.query('objective', {filters: {courses}}),
+      // store.query('objective', {filters: {sessions}}),
+      store.query('session-type', {filters: {sessions}}),
     ]);
   },
   queryParams: {

--- a/app/services/reporting.js
+++ b/app/services/reporting.js
@@ -56,19 +56,6 @@ export default Service.extend({
       filters: {}
     };
 
-    /**
-     * EXTRAWURST!
-     * For reports targeting users and MeSH terms as their primary subjects,
-     * explicitly do not limit on the returned result record.
-     * Otherwise, unintentional truncation will occur due to query construction on the server side.
-     * [ST 2016/03/31]
-     */
-    if (subject === 'instructor' || subject === 'mesh term') {
-      query.limit = 0;
-    } else {
-      query.limit = 1000;
-    }
-
     if(object && objectId){
       let what = pluralize(object.camelize());
       if(object === 'mesh term'){

--- a/tests/integration/components/assign-students-test.js
+++ b/tests/integration/components/assign-students-test.js
@@ -54,10 +54,8 @@ test('it renders', function(assert) {
   ];
 
   storeMock.reopen({
-    query(what, {filters, limit}){
-
+    query(what, {filters}){
       assert.equal('cohort', what);
-      assert.equal(1000, limit);
       assert.equal(1, filters.schools[0]);
       return resolve([cohort]);
     }

--- a/tests/integration/components/new-curriculum-inventory-sequence-block-test.js
+++ b/tests/integration/components/new-curriculum-inventory-sequence-block-test.js
@@ -22,7 +22,7 @@ moduleForComponent('new-curriculum-inventory-sequence-block', 'Integration | Com
 });
 
 test('it renders', function(assert) {
-  assert.expect(75);
+  assert.expect(74);
   let school = EmberObject.create({ id() { return 1; }});
   let academicLevels = [];
   for (let i = 0; i < 10; i++) {
@@ -45,13 +45,12 @@ test('it renders', function(assert) {
   });
 
   storeMock.reopen({
-    query(what, {limit, filters}){
+    query(what, {filters}){
       assert.equal(what, 'course', 'Store is queried for courses.');
       assert.equal(filters.school.length, 1, 'One school id was passed.');
       assert.equal(filters.school[0], school.id(), 'The correct school id was passed.');
       assert.equal(filters.year, report.get('year'), 'The correct year was passed.');
       assert.equal(filters.published, true, 'The correct published value was passed.');
-      assert.equal(limit, 10000, 'The correct record limit was passed.');
       return resolve([course1, course2, course3 ]);
     },
   });

--- a/tests/integration/components/session-copy-test.js
+++ b/tests/integration/components/session-copy-test.js
@@ -40,11 +40,10 @@ test('it renders', function(assert) {
   });
 
   let storeMock = Service.extend({
-    query(what, {limit, filters}){
+    query(what, {filters}){
       assert.equal(what, 'course');
       assert.equal(filters.school, 1);
       assert.equal(filters.year, lastYear);
-      assert.equal(limit, 10000);
 
       return [course1, course2];
     },

--- a/tests/integration/components/unassigned-students-summary-test.js
+++ b/tests/integration/components/unassigned-students-summary-test.js
@@ -26,8 +26,7 @@ test('it renders', function(assert) {
   });
 
   let storeMock = Service.extend({
-    query(what, {limit, filters}){
-      assert.equal(limit, 1000);
+    query(what, {filters}){
       assert.equal(filters.school, 1);
       assert.equal('user', what);
       return resolve([1, 2, 3, 4, 5]);


### PR DESCRIPTION
All of these limits were in place to ensure we got all data from the API
when it was limiting requests to 20 items by default. As this default
was removed in v1.23 we can remove this code as well.

Fixes #3192