### PR TITLE
Remove actions that don't work anymore

### DIFF
--- a/app/controllers/session/index.js
+++ b/app/controllers/session/index.js
@@ -15,13 +15,4 @@ export default Controller.extend({
   isManagingLearnerGroups: false,
   sessionLearnergroupDetails: false,
   showNewOfferingForm: false,
-
-  actions: {
-    setSessionOffset(offset){
-      this.set('sessionOffset', offset);
-    },
-    setSessionLimit(limit){
-      this.set('sessionLimit', limit);
-    },
-  }
 });


### PR DESCRIPTION
We now display the entire session list at the same time so there is no
paging necessary.