### PR TITLE
Fix incorrectly named test

### DIFF
--- a/tests/integration/components/user-profile-calendar-test.js
+++ b/tests/integration/components/user-profile-calendar-test.js
@@ -96,7 +96,7 @@ test('clicking forward goes to next week', async function(assert) {
   await wait();
 });
 
-test('clicking forward goes to next week', async function(assert) {
+test('clicking backward goes to last week', async function(assert) {
   assert.expect(2);
   let called = 0;
   commonAjaxMock.reopen({


### PR DESCRIPTION
This test name was wrong, now it is right. Entropy is still going to
kill us all, but at least this test name will now be correct.