### PR TITLE
Fix class declarations for icons

### DIFF
--- a/app/templates/components/instructorgroup-details.hbs
+++ b/app/templates/components/instructorgroup-details.hbs
@@ -11,7 +11,7 @@
       <span>
         <ul class='removable-list tag-list'>
           {{#each (sort-by 'lastName' 'firstName' (await instructorGroup.users)) as |user|}}
-            <li {{action 'removeUser' user}}>{{user.fullName}}{{fa-icon 'remove' classNames='removex'}}</li>
+            <li {{action 'removeUser' user}}>{{user.fullName}}{{fa-icon 'remove' class='removex'}}</li>
           {{/each}}
         </ul>
       </span>

--- a/app/templates/components/programyear-list.hbs
+++ b/app/templates/components/programyear-list.hbs
@@ -54,28 +54,28 @@
                   {{#if programYearProxy.competencies.length}}
                     {{programYearProxy.competencies.length}}
                   {{else}}
-                    {{fa-icon 'warning' classNames='warning'}}
+                    {{fa-icon 'warning' class='warning'}}
                   {{/if}}
                 </td>
                 <td class='text-left'>
                   {{#if programYearProxy.objectives.length}}
                     {{programYearProxy.objectives.length}}
                   {{else}}
-                    {{fa-icon 'warning' classNames='warning'}}
+                    {{fa-icon 'warning' class='warning'}}
                   {{/if}}
                 </td>
                 <td class='text-left'>
                   {{#if programYearProxy.directors.length}}
                     {{programYearProxy.directors.length}}
                   {{else}}
-                    {{fa-icon 'warning' classNames='warning'}}
+                    {{fa-icon 'warning' class='warning'}}
                   {{/if}}
                 </td>
                 <td class='text-left'>
                   {{#if programYearProxy.terms.length}}
                     {{programYearProxy.terms.length}}
                   {{else}}
-                    {{fa-icon 'warning' classNames='warning'}}
+                    {{fa-icon 'warning' class='warning'}}
                   {{/if}}
                 </td>
 

--- a/app/templates/components/programyear-overview.hbs
+++ b/app/templates/components/programyear-overview.hbs
@@ -5,7 +5,7 @@
     {{#if editable}}
       <ul class='removable-list tag-list'>
         {{#each sortedDirectors as |user|}}
-          <li {{action 'removeDirector' user}}>{{user.fullName}}{{fa-icon 'remove' classNames='removex'}}</li>
+          <li {{action 'removeDirector' user}}>{{user.fullName}}{{fa-icon 'remove' class='removex'}}</li>
         {{/each}}
       </ul>
     {{else}}


### PR DESCRIPTION
The API for ember-font-awesome is to send classes as `class` not
`classNames`.