### PR TITLE
Remove the ember-service-worker-index addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "ember-rl-dropdown": "0.10.1",
     "ember-service-worker": "^0.6.8",
     "ember-service-worker-asset-cache": "^0.6.1",
-    "ember-service-worker-index": "^0.6.2",
     "ember-simple-charts": "^0.4.0",
     "ember-source": "~2.14.1",
     "ember-truth-helpers": "1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,7 +1694,7 @@ broccoli-merge-trees@^0.2.1:
     debug "^2.2.0"
     symlink-or-copy "^1.0.0"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.1.2, broccoli-merge-trees@^1.2.1, broccoli-merge-trees@^1.2.4:
+broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.1.2, broccoli-merge-trees@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -3989,13 +3989,6 @@ ember-service-worker-asset-cache@^0.6.1:
     broccoli-plugin "^1.3.0"
     ember-cli-babel "^5.1.6"
     glob "^7.1.1"
-
-ember-service-worker-index@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/ember-service-worker-index/-/ember-service-worker-index-0.6.2.tgz#9b2d4a344c56ae74f50863a7213e00b8cb9db657"
-  dependencies:
-    broccoli-merge-trees "^1.2.1"
-    broccoli-plugin "^1.3.0"
 
 ember-service-worker@^0.6.8:
   version "0.6.8"


### PR DESCRIPTION
This is a little bit too aggressive in what it returns as the
`index.html` page. It also traps requests to /Shibboleth.SSO stuff which
the browser needs to be allowed to visit. Since we can't know in advance
what the shib route could be for any school the best choice is just to
remove this addon for now.

Fixes #3206