### PR TITLE
Prefer tasks over observer

### DIFF
--- a/app/controllers/programs.js
+++ b/app/controllers/programs.js
@@ -1,12 +1,11 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import { translationMacro as t } from "ember-i18n";
+import { task, timeout } from 'ember-concurrency';
 import escapeRegExp from '../utils/escape-reg-exp';
 
-const { Controller, computed, inject, isEmpty, isPresent, observer, RSVP, run } = Ember;
+const { Controller, computed, inject, isEmpty, isPresent, RSVP } = Ember;
 const { service } = inject;
 const { gt } = computed;
-const { debounce } = run;
 const { PromiseArray } = DS;
 
 export default Controller.extend({
@@ -18,30 +17,23 @@ export default Controller.extend({
     titleFilter: 'filter'
   },
 
-  placeholderValue: t('general.programTitleFilterPlaceholder'),
-
   schoolId: null,
   titleFilter: null,
 
-  //in order to delay rendering until a user is done typing debounce the title filter
-  debouncedFilter: null,
+  changeTitleFilter: task(function * (value) {
+    const clean = escapeRegExp(value);
+    this.set('titleFilter', clean);
+    yield timeout(250);
 
-  watchFilter: observer('titleFilter', function() {
-    debounce(this, this.setFilter, 500);
-  }),
-
-  setFilter() {
-    const titleFilter = this.get('titleFilter');
-    const clean = escapeRegExp(titleFilter);
-    this.set('debouncedFilter', clean);
-  },
+    return clean;
+  }).restartable(),
 
   hasMoreThanOneSchool: gt('model.schools.length', 1),
 
-  filteredPrograms: computed('debouncedFilter', 'programs.[]', {
+  filteredPrograms: computed('changeTitleFilter.lastSuccessful.value', 'programs.[]', {
     get() {
       let defer = RSVP.defer();
-      let title = this.get('debouncedFilter');
+      let title = this.get('changeTitleFilter.lastSuccessful.value');
       let exp = new RegExp(title, 'gi');
 
       this.get('programs').then(programs => {

--- a/app/templates/courses.hbs
+++ b/app/templates/courses.hbs
@@ -27,7 +27,11 @@
     </div>
 
     <div class="titlefilter">
-      {{input type='text' value=titleFilter placeholder=placeholderValue}}
+      {{one-way-input
+        value=titleFilter
+        update=(perform changeTitleFilter)
+        placeholder=(t 'general.courseTitleFilterPlaceholder')
+      }}
     </div>
   </div>
   <section class='courses'>

--- a/app/templates/instructor-groups.hbs
+++ b/app/templates/instructor-groups.hbs
@@ -15,7 +15,11 @@
       {{/if}}
     </div>
     <div class="titlefilter">
-      {{input type='text' value=titleFilter placeholder=placeholderValue}}
+      {{one-way-input
+        value=titleFilter
+        update=(perform changeTitleFilter)
+        placeholder=(t 'general.instructorGroupTitleFilterPlaceholder')
+      }}
     </div>
   </div>
   <section class='instructorgroups'>

--- a/app/templates/learner-groups.hbs
+++ b/app/templates/learner-groups.hbs
@@ -58,7 +58,11 @@
       {{/if}}
     </div>
     <div class="titlefilter">
-      {{input type='text' value=titleFilter placeholder=placeholderValue}}
+      {{one-way-input
+        value=titleFilter
+        update=(perform changeTitleFilter)
+        placeholder=(t 'general.learnerGroupTitleFilterPlaceholder')
+      }}
     </div>
   </div>
   <section class='learnergroups'>

--- a/app/templates/programs.hbs
+++ b/app/templates/programs.hbs
@@ -15,7 +15,11 @@
       {{/if}}
     </div>
     <div class="titlefilter">
-      {{input type='text' value=titleFilter placeholder=placeholderValue}}
+      {{one-way-input
+        value=titleFilter
+        update=(perform changeTitleFilter)
+        placeholder=(t 'general.programTitleFilterPlaceholder')
+      }}
     </div>
   </div>
 

--- a/tests/acceptance/instructorgroups-test.js
+++ b/tests/acceptance/instructorgroups-test.js
@@ -4,9 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
-import Ember from 'ember';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
-import wait from 'ember-test-helpers/wait';
 
 var application;
 
@@ -103,33 +101,24 @@ test('filters by title', async function(assert) {
   assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstInstructorgroup.title));
   assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondInstructorgroup.title));
 
-  //put these in nested later blocks because there is a 500ms debounce on the title filter
   await fillIn('.titlefilter input', 'first');
-  Ember.run.later(async () =>{
-    assert.equal(1, find('.list tbody tr').length);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstInstructorgroup.title));
-    await fillIn('.titlefilter input', 'second');
-    Ember.run.later(async () =>{
-      assert.equal(1, find('.list tbody tr').length);
-      assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(secondInstructorgroup.title));
-      await fillIn('.titlefilter input', 'special');
-      Ember.run.later(async () =>{
-        assert.equal(2, find('.list tbody tr').length);
-        assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstInstructorgroup.title));
-        assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(secondInstructorgroup.title));
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(firstInstructorgroup.title));
 
-        await fillIn('.titlefilter input', '');
-        Ember.run.later(async () =>{
-          assert.equal(3, find('.list tbody tr').length);
-          assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(regularInstructorgroup.title));
-          assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstInstructorgroup.title));
-          assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondInstructorgroup.title));
-        }, 750);
-      }, 750);
-    }, 750);
-  }, 750);
+  await fillIn('.titlefilter input', 'second');
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')), getText(secondInstructorgroup.title));
 
-  await wait();
+  await fillIn('.titlefilter input', 'special');
+  assert.equal(2, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstInstructorgroup.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(secondInstructorgroup.title));
+
+  await fillIn('.titlefilter input', '');
+  assert.equal(3, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(regularInstructorgroup.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstInstructorgroup.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondInstructorgroup.title));
 });
 
 test('filters options', async function(assert) {

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -6,7 +6,6 @@ import {
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
 import Ember from 'ember';
-import wait from 'ember-test-helpers/wait';
 
 const { isEmpty, isPresent } = Ember;
 
@@ -369,33 +368,24 @@ test('filters by title', async function(assert) {
   assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstLearnergroup.title));
   assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondLearnergroup.title));
 
-  //put these in nested later blocks because there is a 500ms debounce on the title filter
   await fillIn('.titlefilter input', 'first');
-  Ember.run.later(async () => {
-    assert.equal(1, find('.list tbody tr').length);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstLearnergroup.title));
-    await fillIn('.titlefilter input', 'second');
-    Ember.run.later(async () => {
-      assert.equal(1, find('.list tbody tr').length);
-      assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(secondLearnergroup.title));
-      await fillIn('.titlefilter input', 'special');
-      Ember.run.later(async () => {
-        assert.equal(2, find('.list tbody tr').length);
-        assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstLearnergroup.title));
-        assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(secondLearnergroup.title));
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstLearnergroup.title));
 
-        await fillIn('.titlefilter input', '');
-        Ember.run.later(async () => {
-          assert.equal(3, find('.list tbody tr').length);
-          assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(regularLearnergroup.title));
-          assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstLearnergroup.title));
-          assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondLearnergroup.title));
-        }, 750);
-      }, 750);
-    }, 750);
-  }, 750);
+  await fillIn('.titlefilter input', 'second');
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(secondLearnergroup.title));
 
-  await wait();
+  await fillIn('.titlefilter input', 'special');
+  assert.equal(2, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstLearnergroup.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(secondLearnergroup.title));
+
+  await fillIn('.titlefilter input', '');
+  assert.equal(3, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(regularLearnergroup.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstLearnergroup.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondLearnergroup.title));
 });
 
 function getCellData(row, cell) {

--- a/tests/acceptance/programs-test.js
+++ b/tests/acceptance/programs-test.js
@@ -5,8 +5,6 @@ import {
 } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
-import wait from 'ember-test-helpers/wait';
-import Ember from 'ember';
 
 var application;
 
@@ -52,33 +50,22 @@ test('filters by title', async function(assert) {
   assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstProgram.title));
   assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondProgram.title));
 
-  //put these in nested later blocks because there is a 500ms debounce on the title filter
   await fillIn('.titlefilter input', 'first');
-  Ember.run.later(async () => {
-    assert.equal(1, find('.list tbody tr').length);
-    assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstProgram.title));
-    await fillIn('.titlefilter input', 'second');
-    Ember.run.later(async () => {
-      assert.equal(1, find('.list tbody tr').length);
-      assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(secondProgram.title));
-      await fillIn('.titlefilter input', 'special');
-      Ember.run.later(async () => {
-        assert.equal(2, find('.list tbody tr').length);
-        assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstProgram.title));
-        assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(secondProgram.title));
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstProgram.title));
+  await fillIn('.titlefilter input', 'second');
+  assert.equal(1, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(secondProgram.title));
+  await fillIn('.titlefilter input', 'special');
+  assert.equal(2, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(firstProgram.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(secondProgram.title));
 
-        await fillIn('.titlefilter input', '');
-        Ember.run.later(async () => {
-          assert.equal(3, find('.list tbody tr').length);
-          assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(regularProgram.title));
-          assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstProgram.title));
-          assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondProgram.title));
-        }, 750);
-      }, 750);
-    }, 750);
-  }, 750);
-
-  await wait();
+  await fillIn('.titlefilter input', '');
+  assert.equal(3, find('.list tbody tr').length);
+  assert.equal(getElementText(find('.list tbody tr:eq(0) td:eq(0)')),getText(regularProgram.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(1) td:eq(0)')),getText(firstProgram.title));
+  assert.equal(getElementText(find('.list tbody tr:eq(2) td:eq(0)')),getText(secondProgram.title));
 });
 
 test('filters options', async function(assert) {


### PR DESCRIPTION
Attaching a debounced observer to a property is so last year, instead we
can use a task to debounce the keyboard input and remove some issues
from our test suite at the same time.

These are the last of our non-helper observers. I'm saying this fixes #2619.