### PR TITLE
Update ember-data and remove temp fix

### DIFF
--- a/app/routes/course/index.js
+++ b/app/routes/course/index.js
@@ -27,9 +27,8 @@ export default  Route.extend({
       store.query('session', {filters: {course}}),
       store.query('offering', {filters: {courses}}),
       store.query('ilm-session', {filters: {courses}}),
-      //temporarily disabled to fix #3173
-      // store.query('objective', {filters: {courses}}),
-      // store.query('objective', {filters: {sessions}}),
+      store.query('objective', {filters: {courses}}),
+      store.query('objective', {filters: {sessions}}),
       store.query('session-type', {filters: {sessions}}),
     ]);
   },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-cp-validations": "^3.3.1",
     "ember-cryptojs-shim": "^4.0.0",
     "ember-d3": "0.3.3",
-    "ember-data": "~2.14.6",
+    "ember-data": "2.14.11",
     "ember-drag-drop": "0.4.5",
     "ember-exam": "0.7.0",
     "ember-export-application-global": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3561,9 +3561,9 @@ ember-d3@0.3.3:
     ember-cli-babel "^5.1.6"
     recast "^0.11.13"
 
-ember-data@~2.14.6:
-  version "2.14.10"
-  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-2.14.10.tgz#acf66ffffb062a7fc999f9d989d0e0d2e3858cd3"
+ember-data@2.14.11:
+  version "2.14.11"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-2.14.11.tgz#b03247b3f35523e2b3bd8cff0ce098d6bc069b1c"
   dependencies:
     amd-name-resolver "0.0.7"
     babel-plugin-feature-flags "^0.3.1"


### PR DESCRIPTION
This update contains a fix for many2many relationships that allows us to
remove our hack from the course route.