### PR TITLE
Run tests in headless chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ install:
 
 before_script:
   - greenkeeper-lockfile-update
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 
 script:
   - ember exam --split=$SPLIT --partition=$PARTITION --filter=$FILTER --parallel=$PARALLEL

--- a/testem.js
+++ b/testem.js
@@ -8,5 +8,13 @@ module.exports = {
   ],
   "launch_in_dev": [
     "Chrome"
-  ]
+  ],
+  "browser_args": {
+    "Chrome": [
+      '--headless',
+      '--disable-gpu',
+      '--remote-debugging-port=9222',
+      '--window-size=1440,900'
+    ]
+  }
 };


### PR DESCRIPTION
This is a little bit more reliable that using the framebuffer and
simpler too.

If you want to see what headless chrome is doing you can just connect to
it at http://localhost:9222.