### PR TITLE
Bust the service worker cache on every build

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -31,6 +31,9 @@ module.exports = function(defaults) {
       plugins: ['lists', 'code_view', 'link'],
       themes: 'gray'
     },
+    'ember-service-worker': {
+      versionStrategy: 'every-build',
+    },
     'asset-cache': {
       version: '2',
       include: [


### PR DESCRIPTION
Builds result in new fingerprinted assets and a new index.html file so
we need to bust the service worker cache anytime this happens.

WIP:
- [x] Waiting on some feedback from the ember elders on this setting.