### PR TITLE
Provide an update notification

### DIFF
--- a/app/components/update-notification.js
+++ b/app/components/update-notification.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['update-notification'],
+  click() {
+    window.location.reload();
+  }
+});

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -191,6 +191,7 @@ export default {
     'icsFeed': 'ICS Feed',
     'ignore': 'Ignore',
     'ilios': 'Ilios',
+    'iliosUpdatePending': "Huzzah! We've made Ilios better. You will get the new stuff on your next login, or click to update now.",
     'inactive': 'inactive',
     'include': 'Include',
     'incompleteSessions': 'Sessions Incomplete: cannot publish',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -191,6 +191,7 @@
     'icsFeed': 'Fuente de ICS',
     'ignore': 'Ignorar',
     'ilios': 'Ilios',
+    'iliosUpdatePending': "¡Huzzah, hemos hecho Ilios mejor! Obtendrá las cosas nuevas en su próximo inicio de sesión, o haga clic para actualizar ahora.",
     'inactive': 'inactivo',
     'include': 'Incluir',
     'incompleteSessions': 'Sesiónes Incompletas: No se pueden publicar',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -191,6 +191,7 @@ export default {
     'icsFeed': 'Données de ICS',
     'ignore': 'Ignorer',
     'ilios': 'Ilios',
+    'iliosUpdatePending': "hourra! Nous avons fait Ilios mieux. Vous obtiendrez le nouveau truc sur votre connexion prochaine, ou cliquerez pour mettre à jour maintenant.",
     'inactive': 'inactif',
     'include': 'Inclure',
     'incompleteSessions': "Séances incomplète: ne peut être pas publiée",

--- a/app/styles/mixins.scss
+++ b/app/styles/mixins.scss
@@ -10,3 +10,4 @@
 @import 'mixins/admin-blocks';
 @import 'mixins/sort-manager';
 @import 'mixins/dashboard-block';
+@import 'mixins/critical-notice';

--- a/app/styles/mixins/critical-notice.scss
+++ b/app/styles/mixins/critical-notice.scss
@@ -1,0 +1,11 @@
+@mixin critical-notice ($background-color, $color, $height) {
+  background-color: $background-color;
+  color: $color;
+  display: block;
+  line-height: $height;
+  margin: 0;
+  min-height: $height;
+  padding: 0;
+  text-align: center;
+  width: 100%;
+}

--- a/app/styles/newcomponents.scss
+++ b/app/styles/newcomponents.scss
@@ -104,3 +104,4 @@
 @import 'newcomponents/school-session-types-list';
 @import 'newcomponents/school-session-type-manager';
 @import 'newcomponents/school-session-type-form';
+@import 'newcomponents/update-notification';

--- a/app/styles/newcomponents/connection-status.scss
+++ b/app/styles/newcomponents/connection-status.scss
@@ -1,20 +1,14 @@
 .connection-status {
   $height: $base-font-size * 2.5;
-  background-color: $warning-color;
-  color: $text-grey;
+  @include critical-notice($warning-color, $text-grey, $height);
+
   display: none;
-  margin: 0;
-  min-height: $height;
-  padding: 0;
-  text-align: center;
-  width: 100%;
 
   &.offline {
     display: block;
   }
 
   span {
-    line-height: $height;
     margin-right: $base-font-size * 2;
   }
 

--- a/app/styles/newcomponents/update-notification.scss
+++ b/app/styles/newcomponents/update-notification.scss
@@ -1,0 +1,6 @@
+.update-notification {
+  $height: $base-font-size * 2.5;
+  @include critical-notice($info-color, $super-light-grey, $height);
+
+  cursor: pointer;
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,9 @@
 {{ember-load-remover}}
 {{api-version-check}}
 {{connection-status}}
+{{#service-worker-update-notify}}
+  {{update-notification}}
+{{/service-worker-update-notify}}
 {{#if showHeader}}
   {{ilios-header title=translatedTitle}}
 {{/if}}

--- a/app/templates/components/update-notification.hbs
+++ b/app/templates/components/update-notification.hbs
@@ -1,0 +1,1 @@
+{{t 'general.iliosUpdatePending'}}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "ember-rl-dropdown": "0.10.1",
     "ember-service-worker": "^0.6.8",
     "ember-service-worker-asset-cache": "^0.6.1",
+    "ember-service-worker-update-notify": "^1.0.1",
     "ember-simple-charts": "^0.4.0",
     "ember-source": "~2.14.1",
     "ember-truth-helpers": "1.3.0",

--- a/tests/integration/components/update-notification-test.js
+++ b/tests/integration/components/update-notification-test.js
@@ -1,0 +1,11 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('update-notification', 'Integration | Component | update notification', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  this.render(hbs`{{update-notification}}`);
+  assert.equal(this.$().text().trim(), "Huzzah! We've made Ilios better. You will get the new stuff on your next login, or click to update now.");
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3989,6 +3989,13 @@ ember-service-worker-asset-cache@^0.6.1:
     ember-cli-babel "^5.1.6"
     glob "^7.1.1"
 
+ember-service-worker-update-notify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ember-service-worker-update-notify/-/ember-service-worker-update-notify-1.0.1.tgz#b6b9a38dbe21b8528e6586e1930b7adfb2627a08"
+  dependencies:
+    ember-cli-babel "^6.3.0"
+    ember-cli-htmlbars "^2.0.1"
+
 ember-service-worker@^0.6.8:
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/ember-service-worker/-/ember-service-worker-0.6.8.tgz#2a8de37c46e54b3ef2467a54577c25699113c9a8"


### PR DESCRIPTION
When the app is updated behind a service worker we need to give the user
an indication that they should refresh the page.

![update notice](https://user-images.githubusercontent.com/349624/30174604-798d5170-93b0-11e7-8f08-a70b2a791552.png)

