### PR TITLE
Invalidate the cloudfront cache when we activate

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -24,18 +24,25 @@ module.exports = function(deployTarget) {
     archive: {
       archiveName: 'frontend.tar.gz',
     },
+    cloudfront: {
+      objectPaths(context){
+        return `/${context.archiveName}`;
+      },
+    }
   };
 
   if (deployTarget === 'staging') {
     ENV.build.environment = 'production';
     ENV['s3-index'].bucket = 'frontend-archive-staging';
     ENV['s3-index'].prefix = API_VERSION;
+    ENV['cloudfront'].distribution = 'E1W0LI6DFZEQOV';
   }
 
   if (deployTarget === 'production') {
     ENV.build.environment = 'production';
     ENV['s3-index'].bucket = 'frontend-archive-production';
     ENV['s3-index'].prefix = API_VERSION;
+    ENV['cloudfront'].distribution = 'E1RJJYSB507IYA';
   }
 
   // Note: if you need to build some configuration asynchronously, you can return

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ember-cli-deploy": "1.0.1",
     "ember-cli-deploy-archive": "^0.2.0",
     "ember-cli-deploy-build": "1.1.0",
+    "ember-cli-deploy-cloudfront": "^1.2.0",
     "ember-cli-deploy-display-revisions": "1.0.0",
     "ember-cli-deploy-json-config": "1.0.0",
     "ember-cli-deploy-revision-data": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -444,6 +444,21 @@ aws-sdk@^2.1.48:
     xml2js "0.4.17"
     xmlbuilder "4.2.1"
 
+aws-sdk@^2.95.0:
+  version "2.110.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.110.0.tgz#ef3a88b08e8100d984c307108e0617a56eb74fdb"
+  dependencies:
+    buffer "4.9.1"
+    crypto-browserify "1.0.9"
+    events "^1.1.1"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.0.1"
+    xml2js "0.4.17"
+    xmlbuilder "4.2.1"
+
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
@@ -2351,7 +2366,7 @@ core-object@^2.0.0, core-object@^2.0.6:
   dependencies:
     chalk "^1.1.3"
 
-core-object@^3.1.3:
+core-object@^3.1.3, core-object@^3.1.4:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/core-object/-/core-object-3.1.5.tgz#fa627b87502adc98045e44678e9a8ec3b9c0d2a9"
   dependencies:
@@ -2992,6 +3007,16 @@ ember-cli-deploy-build@1.1.0:
     glob "^7.1.1"
     rsvp "^3.5.0"
 
+ember-cli-deploy-cloudfront@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-deploy-cloudfront/-/ember-cli-deploy-cloudfront-1.2.0.tgz#9315e80ddc105a6160e5f881ba41f3e71966a6bc"
+  dependencies:
+    aws-sdk "^2.95.0"
+    core-object "^3.1.4"
+    ember-cli-deploy-plugin "~0.2.9"
+    rsvp "^4.0.1"
+    uuid "^3.1.0"
+
 ember-cli-deploy-display-revisions@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-deploy-display-revisions/-/ember-cli-deploy-display-revisions-1.0.0.tgz#72ad8cf74d94e996ae0a52cd1403fd9195db38df"
@@ -3011,7 +3036,7 @@ ember-cli-deploy-json-config@1.0.0:
     ember-cli-deploy-plugin "^0.2.3"
     rsvp "^3.5.0"
 
-ember-cli-deploy-plugin@^0.2.1, ember-cli-deploy-plugin@^0.2.3, ember-cli-deploy-plugin@^0.2.6, ember-cli-deploy-plugin@^0.2.9:
+ember-cli-deploy-plugin@^0.2.1, ember-cli-deploy-plugin@^0.2.3, ember-cli-deploy-plugin@^0.2.6, ember-cli-deploy-plugin@^0.2.9, ember-cli-deploy-plugin@~0.2.9:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/ember-cli-deploy-plugin/-/ember-cli-deploy-plugin-0.2.9.tgz#a3d395b8adad7ef68d8bacdd0b0f4a61bcf9e651"
   dependencies:
@@ -7590,6 +7615,10 @@ rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
+rsvp@^4.0.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.6.1.tgz#fcc3bda359da00fd06fb1f2c517f2051541b05b5"
+
 rsvp@~3.0.6:
   version "3.0.21"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.0.21.tgz#49c588fe18ef293bcd0ab9f4e6756e6ac433359f"
@@ -8480,7 +8509,7 @@ uuid@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 


### PR DESCRIPTION
When a new frontend.tar.gz is activated we need to clear the cloudfront
cached previous version. Without this change users would need to wait
for cloudfront to notice the new version at all.