### PR TITLE
replaced calls to deprecated method with current equivalent.

### DIFF
--- a/app/components/learnergroup-selection-manager.js
+++ b/app/components/learnergroup-selection-manager.js
@@ -14,7 +14,7 @@ export default Component.extend({
   allLearnerGroups: computed('cohorts.[]', function(){
     return new Promise(resolve => {
       let cohorts = this.get('cohorts');
-      all(cohorts.mapBy('topLevelLearnerGroups')).then(allLearnerGroups => {
+      all(cohorts.mapBy('rootLevelLearnerGroups')).then(allLearnerGroups => {
         let flat = allLearnerGroups.reduce((flattened, arr) => {
           return flattened.pushObjects(arr);
         }, []);

--- a/app/controllers/learner-groups.js
+++ b/app/controllers/learner-groups.js
@@ -90,14 +90,14 @@ export default Controller.extend({
   sortedProgramYears: sort('programYears', 'sortByStartYear'),
   hasMoreThanOneProgramYear: gt('programYears.length', 1),
 
-  learnerGroups: computed('selectedProgramYear.cohort.topLevelLearnerGroups.[]', function(){
+  learnerGroups: computed('selectedProgramYear.cohort.rootLevelLearnerGroups.[]', function(){
     let defer = RSVP.defer();
     this.get('selectedProgramYear').then(programYear => {
       if(isEmpty(programYear)){
         defer.resolve([]);
       } else {
         programYear.get('cohort').then(cohort => {
-          cohort.get('topLevelLearnerGroups').then(groups => {
+          cohort.get('rootLevelLearnerGroups').then(groups => {
             defer.resolve(groups);
           });
         });


### PR DESCRIPTION
replace any calls to `Cohort::topLevelLearnerGroup()` with calls to `Cohort::rootLevelLearnerGroup()`.

refs ilios/common#45.