### PR TITLE
Cache index.html with a service worker

### DIFF
--- a/app/components/connection-status.js
+++ b/app/components/connection-status.js
@@ -13,7 +13,7 @@ export default Component.extend(DomMixin, {
   didInsertElement() {
     this._super(...arguments);
     if (!navigator.onLine) {
-      this.wentOffline();
+      this.get('changeConnectionState').perform(false);
     }
     this.addEventListener(window, 'online', () => {
       this.get('changeConnectionState').perform(true);

--- a/app/components/error-display.js
+++ b/app/components/error-display.js
@@ -7,10 +7,14 @@ export default Component.extend({
   errors: null,
   now: null,
   showDetails: true,
+  isOffline: false,
 
   didReceiveAttrs(){
     this._super(...arguments);
     this.set('now', new Date());
+    if (!navigator.onLine) {
+      this.set('isOffline', true);
+    }
   },
 
   is404: computed('errors.[]', function(){
@@ -28,6 +32,9 @@ export default Component.extend({
   actions: {
     toggleDetails() {
       this.set('showDetails', !this.get('showDetails'));
+    },
+    refresh() {
+      window.location.reload();
     }
   }
 });

--- a/app/instance-initializers/error.js
+++ b/app/instance-initializers/error.js
@@ -84,11 +84,14 @@ export default {
   /**
    * Only send an error condition to the server every a second
    * Otherwise we can DDOS ourselfes with a bad browser error loop
+   * Since it is possible to load the app offline with a service worker
+   * we also need to check to ensure the browser is even online before attempting
+   * to send errors.
    * @return boolean
    */
-  shouldWeSendAnotherError(){
+  shouldWeSendAnotherError() {
     let diff = moment().unix() - this.lastErrorSent;
-    return diff > 1;
+    return navigator.onLine && diff > 1;
   },
 
   logError(error, commonAjax) {

--- a/app/styles/components/_error-display.scss
+++ b/app/styles/components/_error-display.scss
@@ -2,6 +2,10 @@
   margin-bottom: 25px;
   margin-left: 1em;
 
+  h2 {
+    @include ilios-heading-h1;
+  }
+
   .error-detail-action {
     color: $text-blue;
     cursor: pointer;

--- a/app/templates/components/error-display.hbs
+++ b/app/templates/components/error-display.hbs
@@ -1,6 +1,9 @@
 {{! template-lint-disable bare-strings }}
 <div class="error-main">
-  {{#if is404}}
+  {{#if isOffline}}
+    <h2>{{t 'general.connectionLost'}}</h2>
+    <p class='clear-errors'><button {{action 'refresh'}}>{{fa-icon 'refresh'}} {{t 'general.reconnectNow'}}</button></p>
+  {{else if is404}}
     {{not-found}}
   {{else}}
     <h2>{{t 'general.errorDisplayMessage'}}</h2>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -38,7 +38,13 @@ module.exports = function(defaults) {
       version: '3',
       include: [
         'assets/**/*',
-        'ilios-prerender/*'
+        'ilios-prerender/*',
+      ]
+    },
+    'esw-cache-first': {
+      version: '1',
+      patterns: [
+        'fonts/fontawesome(.+)',
       ]
     },
     'esw-index': {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -35,10 +35,31 @@ module.exports = function(defaults) {
       versionStrategy: 'every-build',
     },
     'asset-cache': {
-      version: '2',
+      version: '3',
       include: [
         'assets/**/*',
-        'ilios-prerender/*'
+        'ilios-prerender/*',
+        'fonts/**/*',
+      ]
+    },
+    'esw-index': {
+      version: '2',
+      includeScope: [
+        /\/course(\/.*)?$/,
+        /\/course-materials(\/.*)?$/,
+        /\/instructorgroups(\/.*)?$/,
+        /\/learnergroups(\/.*)?$/,
+        /\/programs(\/.*)?$/,
+        /\/admin(\/.*)?$/,
+        /\/logout(\/.*)?$/,
+        /\/schools(\/.*)?$/,
+        /\/myprofile(\/.*)?$/,
+        /\/mymaterials(\/.*)?$/,
+        /\/course-rollover(\/.*)?$/,
+        /\/curriculum-inventory-reports(\/.*)?$/,
+        /\/curriculum-inventory-sequence-block(\/.*)?$/,
+        /\/data(\/.*)?$/,
+        /\/weeklyevents(\/.*)?$/,
       ]
     },
   });

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -38,8 +38,7 @@ module.exports = function(defaults) {
       version: '3',
       include: [
         'assets/**/*',
-        'ilios-prerender/*',
-        'fonts/**/*',
+        'ilios-prerender/*'
       ]
     },
     'esw-index': {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "ember-rl-dropdown": "0.10.1",
     "ember-service-worker": "^0.6.8",
     "ember-service-worker-asset-cache": "^0.6.1",
+    "ember-service-worker-cache-first": "^0.6.2",
     "ember-service-worker-index": "^0.6.2",
     "ember-service-worker-update-notify": "^1.0.1",
     "ember-simple-charts": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "ember-rl-dropdown": "0.10.1",
     "ember-service-worker": "^0.6.8",
     "ember-service-worker-asset-cache": "^0.6.1",
+    "ember-service-worker-index": "^0.6.2",
     "ember-service-worker-update-notify": "^1.0.1",
     "ember-simple-charts": "^0.4.0",
     "ember-source": "~2.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4016,6 +4016,13 @@ ember-service-worker-asset-cache@^0.6.1:
     ember-cli-babel "^5.1.6"
     glob "^7.1.1"
 
+ember-service-worker-cache-first@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/ember-service-worker-cache-first/-/ember-service-worker-cache-first-0.6.2.tgz#413cd940e5b0ef2cac13f438882d18fe914b0b43"
+  dependencies:
+    broccoli-merge-trees "^1.2.1"
+    broccoli-plugin "^1.3.0"
+
 ember-service-worker-index@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/ember-service-worker-index/-/ember-service-worker-index-0.6.2.tgz#9b2d4a344c56ae74f50863a7213e00b8cb9db657"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1711,7 +1711,7 @@ broccoli-merge-trees@^0.2.1:
     debug "^2.2.0"
     symlink-or-copy "^1.0.0"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.1.2, broccoli-merge-trees@^1.2.4:
+broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.1.2, broccoli-merge-trees@^1.2.1, broccoli-merge-trees@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -4015,6 +4015,13 @@ ember-service-worker-asset-cache@^0.6.1:
     broccoli-plugin "^1.3.0"
     ember-cli-babel "^5.1.6"
     glob "^7.1.1"
+
+ember-service-worker-index@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/ember-service-worker-index/-/ember-service-worker-index-0.6.2.tgz#9b2d4a344c56ae74f50863a7213e00b8cb9db657"
+  dependencies:
+    broccoli-merge-trees "^1.2.1"
+    broccoli-plugin "^1.3.0"
 
 ember-service-worker-update-notify@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This brings us several steps closer to offline support, but more importantly it avoids a network request when visiting the app which will speed up initial rendering.

Includes a modified error page that notices if a user is offline and replaces all error data with an offline message since errors are almost certainly coming from that anyway.