### PR TITLE
Disable the Froala beacon

### DIFF
--- a/app/components/html-editor.js
+++ b/app/components/html-editor.js
@@ -16,6 +16,15 @@ const defaultButtons = [
 export default Component.extend({
   i18n: service(),
   content: '',
+
+  /**
+   * Disable Froala's built in beacon tracking
+   * Has to be done on the global jQuery plugin object
+   */
+  init() {
+    this._super(...arguments);
+    Ember.$.FE.DT = true;
+  },
   options: computed('i18n.locale', function(){
     const i18n = this.get('i18n');
     const language = i18n.get('locale');


### PR DESCRIPTION
Every time the editor is displayed it sends a ping image request back to
the froala mothership. They were a little bit cagey about what this is
for and we are fully licensed to distribute the editor in our opensource
project so we're going to go ahead and disable this phone home
functionality.