### PR TITLE
Update ember-service-worker-index

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "ember-service-worker": "^0.6.8",
     "ember-service-worker-asset-cache": "^0.6.1",
     "ember-service-worker-cache-first": "^0.6.2",
-    "ember-service-worker-index": "^0.6.2",
+    "ember-service-worker-index": "^0.6.3",
     "ember-service-worker-update-notify": "^1.0.1",
     "ember-simple-charts": "^0.4.0",
     "ember-source": "~2.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4023,9 +4023,9 @@ ember-service-worker-cache-first@^0.6.2:
     broccoli-merge-trees "^1.2.1"
     broccoli-plugin "^1.3.0"
 
-ember-service-worker-index@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/ember-service-worker-index/-/ember-service-worker-index-0.6.2.tgz#9b2d4a344c56ae74f50863a7213e00b8cb9db657"
+ember-service-worker-index@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/ember-service-worker-index/-/ember-service-worker-index-0.6.3.tgz#c01ea350b13e54ea8555b33403f94549954fbc1b"
   dependencies:
     broccoli-merge-trees "^1.2.1"
     broccoli-plugin "^1.3.0"


### PR DESCRIPTION
This is the minimum version that accepts includeScope configuration and
we need it to work with shibboleth.

This should have been done in #3245 😊 