### PR TITLE
hide "create school" button from non-developers.

### DIFF
--- a/app/components/school-list.js
+++ b/app/components/school-list.js
@@ -26,6 +26,7 @@ const Validations = buildValidations({
 });
 
 export default Component.extend(ValidationErrorDisplay, Validations, {
+  currentUser: service(),
   store: service(),
   classNames: ['school-list'],
   tagName: 'section',

--- a/app/templates/components/school-list.hbs
+++ b/app/templates/components/school-list.hbs
@@ -3,9 +3,11 @@
     <div class="title">
       <h2>{{t 'general.schools'}}</h2>
     </div>
-    <div class='actions'>
-      {{expand-collapse-button value=showNewSchoolForm action="toggleNewSchoolForm"}}
-    </div>
+    {{#if (await currentUser.userIsDeveloper)}}
+      <div class='actions'>
+        {{expand-collapse-button value=showNewSchoolForm action="toggleNewSchoolForm"}}
+      </div>
+    {{/if}}
   </div>
   <section class='new'>
     {{#if showNewSchoolForm class='vertical'}}

--- a/tests/integration/components/school-list-test.js
+++ b/tests/integration/components/school-list-test.js
@@ -4,7 +4,8 @@ import initializer from "ilios/instance-initializers/ember-i18n";
 import startMirage from '../../helpers/start-mirage';
 import Ember from 'ember';
 
-const { Object:EmberObject } = Ember;
+const { Object:EmberObject, RSVP, Service } = Ember;
+const { resolve } = RSVP;
 
 moduleForComponent('school-list', 'Integration | Component | school list', {
   integration: true,
@@ -24,4 +25,26 @@ test('it renders', function(assert) {
   this.render(hbs`{{school-list schools=schools}}`);
   assert.equal(this.$('tr:eq(1) td:eq(0)').text().trim(), 'school 0');
   assert.equal(this.$('tr:eq(2) td:eq(0)').text().trim(), 'school 1');
+});
+
+test('create school button is visible to developers', function(assert) {
+  assert.expect(1);
+  const currentUserMock = Service.extend({
+    userIsDeveloper: resolve(true)
+  });
+  this.register('service:current-user', currentUserMock);
+  this.set('schools', []);
+  this.render(hbs`{{school-list schools=schools}}`);
+  assert.equal(this.$('.header .actions .expand-button').length, 1);
+});
+
+test('create school button is not visible to non-developers', function(assert) {
+  assert.expect(1);
+  const currentUserMock = Service.extend({
+    userIsDeveloper: resolve(false)
+  });
+  this.register('service:current-user', currentUserMock);
+  this.set('schools', []);
+  this.render(hbs`{{school-list schools=schools}}`);
+  assert.equal(this.$('.header .actions .expand-button').length, 0);
 });


### PR DESCRIPTION
fixes #3114 

according to the rules enforced in the [Ilios backend](https://github.com/ilios/ilios/blob/v3.37.2/src/Ilios/AuthenticationBundle/Voter/Entity/SchoolEntityVoter.php#L45), only users with Developer role can create new schools.