### PR TITLE
Add integrity to links

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -8,8 +8,8 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/ilios.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/ilios.css">
 
     <!-- Ilios variables set  by the web server -->
     {{content-for 'server-variables'}}


### PR DESCRIPTION
Without this <link> elements are loaded twice in some browsers. This
matches the blueprint from ember-cli 2.15.