### PR TITLE
Copy learner groups

### DIFF
--- a/app/components/learnergroup-list.js
+++ b/app/components/learnergroup-list.js
@@ -5,6 +5,7 @@ const { Component } = Ember;
 export default Component.extend({
   learnerGroups: [],
   learnerGroupsForRemovalConfirmation: [],
+  learnerGroupsForCopy: [],
   actions: {
     cancelRemove(learnerGroup) {
       this.get('learnerGroupsForRemovalConfirmation').removeObject(learnerGroup);
@@ -12,5 +13,16 @@ export default Component.extend({
     confirmRemove(learnerGroup) {
       this.get('learnerGroupsForRemovalConfirmation').pushObject(learnerGroup);
     },
+    cancelCopy(learnerGroup) {
+      this.get('learnerGroupsForCopy').removeObject(learnerGroup);
+    },
+    startCopy(learnerGroup) {
+      this.get('learnerGroupsForCopy').pushObject(learnerGroup);
+    },
+    async copy(withLearners, learnerGroup) {
+      const copy = this.get('copy');
+      await copy(withLearners, learnerGroup);
+      this.get('learnerGroupsForCopy').removeObject(learnerGroup);
+    }
   }
 });

--- a/app/components/learnergroup-subgroup-list.js
+++ b/app/components/learnergroup-subgroup-list.js
@@ -11,6 +11,7 @@ const { Promise } = RSVP;
 
 export default Component.extend({
   store: service(),
+  i18n: service(),
   flashMessages: service(),
   parentGroup: null,
   classNames: ['learnergroup-subgroup-list'],
@@ -28,9 +29,12 @@ export default Component.extend({
   copyGroup: task(function * (withLearners, learnerGroup) {
     this.set('saved', false);
     const store = this.get('store');
+    const i18n = this.get('i18n');
     const cohort = yield learnerGroup.get('cohort');
     const parentGroup = yield learnerGroup.get('parent');
     const newGroups = yield cloneLearnerGroup(store, learnerGroup, cohort, withLearners, parentGroup);
+    // indicate that the top group is a copy
+    newGroups[0].set('title', newGroups[0].get('title') + ` (${i18n.t('general.copy')})`);
     this.set('totalGroupsToSave', newGroups.length);
     // save groups one at a time because we need to save in this order so parents are saved before children
     for (let i = 0; i < newGroups.length; i++) {

--- a/app/controllers/learner-groups.js
+++ b/app/controllers/learner-groups.js
@@ -200,9 +200,12 @@ export default Controller.extend({
   copyGroup: task(function * (withLearners, learnerGroup) {
     this.set('saved', false);
     const store = this.get('store');
+    const i18n = this.get('i18n');
     const cohort = yield learnerGroup.get('cohort');
     const newGroups = yield cloneLearnerGroup(store, learnerGroup, cohort, withLearners);
     this.set('totalGroupsToSave', newGroups.length);
+    // indicate that the top group is a copy
+    newGroups[0].set('title', newGroups[0].get('title') + ` (${i18n.t('general.copy')})`);
     // save groups one at a time because we need to save in this order so parents are saved before children
     for (let i = 0; i < newGroups.length; i++) {
       yield newGroups[i].save();

--- a/app/controllers/learner-groups.js
+++ b/app/controllers/learner-groups.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import { task, timeout } from 'ember-concurrency';
 import escapeRegExp from '../utils/escape-reg-exp';
+import cloneLearnerGroup from '../utils/clone-learner-group';
 
 const { computed, Controller, inject, isPresent, isEmpty, RSVP } = Ember;
 const { service } = inject;
@@ -26,6 +27,9 @@ export default Controller.extend({
   titleFilter: null,
   saved: false,
   savedGroup: null,
+  isSaving: false,
+  totalGroupsToSave: 0,
+  currentGroupsSaved: 0,
 
   changeTitleFilter: task(function * (value) {
     const clean = escapeRegExp(value);
@@ -193,6 +197,20 @@ export default Controller.extend({
       promise: defer.promise
     });
   }),
+  copyGroup: task(function * (withLearners, learnerGroup) {
+    this.set('saved', false);
+    const store = this.get('store');
+    const cohort = yield learnerGroup.get('cohort');
+    const newGroups = yield cloneLearnerGroup(store, learnerGroup, cohort, withLearners);
+    this.set('totalGroupsToSave', newGroups.length);
+    // save groups one at a time because we need to save in this order so parents are saved before children
+    for (let i = 0; i < newGroups.length; i++) {
+      yield newGroups[i].save();
+      this.set('currentGroupsSaved', i + 1);
+    }
+    this.set('saved', true);
+    this.set('savedGroup', newGroups[0]);
+  }),
   actions: {
     editLearnerGroup(learnerGroup) {
       this.transitionToRoute('learnerGroup', learnerGroup);
@@ -258,6 +276,6 @@ export default Controller.extend({
       this.set('schoolId', schoolId);
       this.set('programId', null);
       this.set('programYearId', null);
-    }
+    },
   }
 });

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -94,6 +94,7 @@ export default {
     'connectionLost': 'Connection Lost.',
     'contentAuthor': 'Content Author',
     'copiedSuccessfully': 'Copied Successfully',
+    'copy': 'Copy',
     'copyLink': 'Copy link',
     'copyrightAgreement': "The file I am uploading is my own or I have express permission to reproduce and/or distribute this item, or use of it here has been assessed as allowable by the legal doctrine of Fair Use. This file does not contain protected health information, and use of it here is in compliance with Government and University policies on copyright and information security and my institution’s guidelines for professional conduct.",
     'copyrightPermission': 'Copyright Permission',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -101,6 +101,8 @@ export default {
     'copySession': 'Copy Session',
     'copySessionSummary': 'You are about to copy over this session (without schedule data) into the selected course. The new session will include all objectives, terms, and learning materials.  To continue click "done".  To return to your current session click "cancel".',
     'copySuccess': 'Copy Completed Successfully',
+    'copyWithLearners': 'Copy With Learners',
+    'copyWithoutLearners': 'Copy Without Learners',
     'countAsOneOffering': 'Count as one offering',
     'courseDirector': 'Course Director',
     'courseRollover': 'Rollover Course',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -101,6 +101,8 @@
     'copySession': 'Copiar una Sesión',
     'copySessionSummary': 'Usted va a copiar esta sesión (sin datos del horario) en el curso seleccionado. La sesión nueva va a incluir todos los objectivos, terminos, y materiales de aprendizaje.  Para continuar haga click en "cumplido".  Para regresar a su sesión corriente, haga click en "cancelar".',
     'copySuccess': 'La Copia se ha Completado con Éxito',
+    'copyWithLearners': 'Copiar Con Alumnos',
+    'copyWithoutLearners': 'Copiar Sin Alumnos',
     'countAsOneOffering': 'Cuenta como un Ofrecimiento',
     'courseDirector': 'Director del Curso',
     'courseRollover': 'Copiar Curso',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -94,6 +94,7 @@
     'connectionLost': 'Conexión Perdida.',
     'contentAuthor': 'Autor del Contenido',
     'copiedSuccessfully': 'Copiado con Éxito',
+    'copy': 'Copiar',
     'copyLink': 'Copiar el enlace',
     'copyrightAgreement': "El archivo que estoy subiendo es mío o tengo permiso expreso para reproducir y / o distribuir este artículo, o su uso aquí ha sido evaluado como permisible por la doctrina del uso justo. Este archivo no contiene ninguna información protegida de la salud, y su utilización aquí está en conformidad con las políticas del gobierno y Universidad sobre derechos de autor y de seguridad de la información y las directrices de mi institución para la conducta profesional.",
     'copyrightPermission': 'Permisos de Derechos de Autor',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -101,6 +101,8 @@ export default {
     'copySession': 'Copier Séance',
     'copySessionSummary': "Vous êtes sur le point la copie sur cette séance (sans données de calendrier) dans le cours choisi. La nouvelle seéance inclura tous les objectifs, des termes et les matiéres d'étude. Continuer le clic \"oui\". Retourner à votre clic de session actuel \"annul\".",
     'copySuccess': 'Copie achevée avec succès',
+    'copyWithLearners': 'Copiér avec étudiants',
+    'copyWithoutLearners': 'Copiér sans étudiants',
     'countAsOneOffering': 'Comptent pour un séance',
     'courseDirector': 'Directeur de Cours',
     'courseRollover': 'Roulement Cours',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -94,6 +94,7 @@ export default {
     'connectionLost': 'Connexion perdu',
     'contentAuthor': "Auteur",
     'copiedSuccessfully': 'Copié avec succès',
+    'copy': 'Copie',
     'copyLink': 'Copier le lien',
     'copyrightAgreement': "Le fichier J'envoie est ma propre ou j'avoir la permission expresse de reproduire et / ou distribuer cet article, ou l'utilisation de celui-ci ici a été jugée admissible par la doctrine juridique de l'utilisation équitable. Ce fichier ne contient pas protégé information sur la santé, et l'utilisation de celui-ci ici est en conformité avec le gouvernement et l'Université des politiques sur le droit d'auteur et à la sécurité de l'information et les directives de mon institution pour la conduite professionnelle.",
     'copyrightPermission': "Droit d’Auteur",

--- a/app/templates/components/learnergroup-list.hbs
+++ b/app/templates/components/learnergroup-list.hbs
@@ -27,7 +27,7 @@
           {{else}}
             {{fa-icon 'spinner' spin=true}}
           {{/if}}
-          {{fa-icon 'copy' class='clickable' click=(action 'startCopy' learnerGroup)}}
+          {{fa-icon 'copy' class='clickable' click=(action 'startCopy' learnerGroup) title=(t 'general.copy')}}
         </td>
       </tr>
       {{#if (contains learnerGroup learnerGroupsForRemovalConfirmation)}}

--- a/app/templates/components/learnergroup-list.hbs
+++ b/app/templates/components/learnergroup-list.hbs
@@ -27,6 +27,7 @@
           {{else}}
             {{fa-icon 'spinner' spin=true}}
           {{/if}}
+          {{fa-icon 'copy' class='clickable' click=(action 'startCopy' learnerGroup)}}
         </td>
       </tr>
       {{#if (contains learnerGroup learnerGroupsForRemovalConfirmation)}}
@@ -35,9 +36,20 @@
             <div class='confirm-message'>
               {{t 'general.confirmRemoveLearnerGroup' subgroupCount=learnerGroup.children.length}} <br>
               <div class="confirm-buttons">
-                <button {{action this.attrs.remove learnerGroup}} class='remove text'>{{t 'general.yes'}}</button>
+                <button {{action remove learnerGroup}} class='remove text'>{{t 'general.yes'}}</button>
                 <button {{action 'cancelRemove' learnerGroup}} class='done text'>{{t 'general.cancel'}}</button>
               </div>
+            </div>
+          </td>
+        </tr>
+      {{/if}}
+      {{#if (contains learnerGroup learnerGroupsForCopy)}}
+        <tr class='confirm-copy'>
+          <td colspan=5>
+            <div class="confirm-buttons">
+              <button {{action 'copy' true learnerGroup}} class='done text'>{{t 'general.copyWithLearners'}}</button>
+              <button {{action 'copy' false learnerGroup}} class='done text'>{{t 'general.copyWithoutLearners'}}</button>
+              <button {{action 'cancelCopy' learnerGroup}} class='cancel text'>{{t 'general.cancel'}}</button>
             </div>
           </td>
         </tr>

--- a/app/templates/components/learnergroup-subgroup-list.hbs
+++ b/app/templates/components/learnergroup-subgroup-list.hbs
@@ -40,6 +40,7 @@
         {{learnergroup-list
           learnerGroups=(await parentGroup.children)
           remove=(action 'removeLearnerGroup')
+          copy=(perform copyGroup)
         }}
       {{/if}}
     {{else}}

--- a/app/templates/learner-groups.hbs
+++ b/app/templates/learner-groups.hbs
@@ -94,6 +94,7 @@
         {{learnergroup-list
           learnerGroups=filteredLearnerGroups
           remove=(action 'removeLearnerGroup')
+          copy=(perform copyGroup)
         }}
       {{else}}
         {{pulse-loader}}
@@ -101,3 +102,10 @@
     </div>
   </section>
 </section>
+{{#liquid-if copyGroup.isRunning class='crossFade'}}
+  {{wait-saving
+    showProgress=true
+    totalProgress=totalGroupsToSave
+    currentProgress=currentGroupsSaved
+  }}
+{{/liquid-if}}

--- a/app/utils/clone-learner-group.js
+++ b/app/utils/clone-learner-group.js
@@ -1,0 +1,44 @@
+import RSVP from 'rsvp';
+
+const { map } = RSVP;
+
+
+/**
+ * Clones a group and all children returning all the groups in the order they were created
+ * so the first group is the top most group in the tree. If they are saved in order then each parent
+ * will be correctly saved before its children
+ * @method cloneLearnerGroup
+ * @param {Object} store
+ * @param {Object} group
+ * @param {Object} cohort
+ * @param {Boolean} withLearners
+ * @param {Object} | null parent
+ * @return {Promise.<Array>}
+ */
+export default async function cloneLearnerGroup(store, group, cohort, withLearners, parent = null) {
+  let newGroup = store.createRecord('learner-group', group.getProperties(
+    'title',
+    'location'
+  ));
+  newGroup.set('cohort', cohort);
+  if (parent) {
+    newGroup.set('parent', parent);
+  }
+  if (withLearners) {
+    const users = await group.get('users');
+    await map(users.toArray(), async user => {
+      await newGroup.addUserToGroupAndAllParents(user);
+    });
+  }
+  const instructors = await group.get('instructors');
+  newGroup.set('instructors', instructors);
+  const children = await group.get('children');
+  let newChildren = await map(children.toArray(), async child => {
+    return await cloneLearnerGroup(store, child, cohort, withLearners, newGroup);
+  });
+  let flat = newChildren.reduce((flattened, obj) => {
+    return flattened.pushObjects(obj.toArray());
+  }, []);
+
+  return [].concat([newGroup], flat);
+}

--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -81,3 +81,198 @@ test('generate new subgroups', async function(assert) {
   assert.equal(getCellData(5, 0), `${parentLearnergroupTitle} 6`, 'consecutively new learnergroup title is ok.');
   assert.equal(getCellData(6, 0), `${parentLearnergroupTitle} 7`, 'consecutively new learnergroup title is ok.');
 });
+
+test('copy learnergroup without learners', async function(assert) {
+  assert.expect(20);
+  server.create('user', {id: 4136});
+  server.create('school', {
+    programs: [1]
+  });
+  server.create('program', {
+    school: 1,
+    programYears: [1]
+  });
+  server.create('programYear', {
+    program: 1,
+    cohort: 1
+  });
+  server.create('cohort', {
+    programYear: 1,
+    learnerGroups: [1]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    children: [2, 3]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 1,
+    children: [4]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 1,
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 2,
+  });
+  const groups = '.list tbody tr';
+  const firstGroup = `${groups}:eq(0)`;
+  const firstTitle = `${firstGroup} td:eq(0)`;
+  const firstLink = `${firstTitle} a`;
+  const firstMembers = `${firstGroup} td:eq(1)`;
+  const firstSubgroups = `${firstGroup} td:eq(2)`;
+  const firstGroupCopy = `${firstGroup} td:eq(3) .fa-copy`;
+  const firstGroupCopyNoLearners = '.list tbody tr:eq(1) .done:eq(1)';
+  const secondGroup = `${groups}:eq(1)`;
+  const secondTitle = `${secondGroup} td:eq(0)`;
+  const secondLink = `${secondTitle} a`;
+  const secondMembers = `${secondGroup} td:eq(1)`;
+  const secondSubgroups = `${secondGroup} td:eq(2)`;
+
+  const subGroupList = '.learnergroup-subgroup-list-list tbody tr';
+  const firstSubgroup = `${subGroupList}:eq(0)`;
+  const firstSubgroupTitle = `${firstSubgroup} td:eq(0)`;
+  const firstSubgroupMembers = `${firstSubgroup} td:eq(1)`;
+  const firstSubgroupSubgroups = `${firstSubgroup} td:eq(2)`;
+  const secondSubgroup = `${subGroupList}:eq(1)`;
+  const secondSubgroupTitle = `${secondSubgroup} td:eq(0)`;
+  const secondSubgroupMembers = `${secondSubgroup} td:eq(1)`;
+  const secondSubgroupSubgroups = `${secondSubgroup} td:eq(2)`;
+
+
+  await visit('/learnergroups');
+  assert.equal(1, find(groups).length);
+  assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(firstMembers)), getText('0'));
+  assert.equal(getElementText(find(firstSubgroups)), getText('2'));
+  await click(firstGroupCopy);
+  await click(firstGroupCopyNoLearners);
+  assert.equal(2, find(groups).length);
+  assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(firstMembers)), getText('0'));
+  assert.equal(getElementText(find(firstSubgroups)), getText('2'));
+  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(secondMembers)), getText('0'));
+  assert.equal(getElementText(find(secondSubgroups)), getText('2'));
+  await click(firstLink);
+  assert.equal(currentURL(), '/learnergroups/1');
+  await visit('/learnergroups');
+  await click(secondLink);
+  assert.equal(currentURL(), '/learnergroups/5');
+
+  assert.equal(2, find(subGroupList).length);
+
+  assert.equal(getElementText(find(firstSubgroupTitle)), getText('learnergroup 1'));
+  assert.equal(getElementText(find(firstSubgroupMembers)), getText('0'));
+  assert.equal(getElementText(find(firstSubgroupSubgroups)), getText('1'));
+  assert.equal(getElementText(find(secondSubgroupTitle)), getText('learnergroup 2'));
+  assert.equal(getElementText(find(secondSubgroupMembers)), getText('0'));
+  assert.equal(getElementText(find(secondSubgroupSubgroups)), getText('0'));
+});
+
+test('copy learnergroup with learners', async function(assert) {
+  assert.expect(20);
+  server.create('school', {
+    programs: [1]
+  });
+  server.create('program', {
+    school: 1,
+    programYears: [1]
+  });
+  server.create('programYear', {
+    program: 1,
+    cohort: 1
+  });
+  server.create('cohort', {
+    programYear: 1,
+    learnerGroups: [1]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    children: [2, 3],
+    users: [2, 3, 4, 5, 6, 7, 8]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 1,
+    children: [4],
+    users: [8]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 1,
+    users: [5, 6, 7]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 2,
+    users: [8]
+  });
+  server.createList('user', 3, {
+    learnerGroups: [1]
+  });
+  server.createList('user', 3, {
+    learnerGroups: [1, 3]
+  });
+  server.createList('user', 3, {
+    learnerGroups: [1, 4]
+  });
+  server.create('user', {
+    learnerGroups: [1, 2, 5]
+  });
+
+  const groups = '.list tbody tr';
+  const firstGroup = `${groups}:eq(0)`;
+  const firstTitle = `${firstGroup} td:eq(0)`;
+  const firstLink = `${firstTitle} a`;
+  const firstMembers = `${firstGroup} td:eq(1)`;
+  const firstSubgroups = `${firstGroup} td:eq(2)`;
+  const firstGroupCopy = `${firstGroup} td:eq(3) .fa-copy`;
+  const firstGroupCopyWithLearners = '.list tbody tr:eq(1) .done:eq(0)';
+  const secondGroup = `${groups}:eq(1)`;
+  const secondTitle = `${secondGroup} td:eq(0)`;
+  const secondLink = `${secondTitle} a`;
+  const secondMembers = `${secondGroup} td:eq(1)`;
+  const secondSubgroups = `${secondGroup} td:eq(2)`;
+
+  const subGroupList = '.learnergroup-subgroup-list-list tbody tr';
+  const firstSubgroup = `${subGroupList}:eq(0)`;
+  const firstSubgroupTitle = `${firstSubgroup} td:eq(0)`;
+  const firstSubgroupMembers = `${firstSubgroup} td:eq(1)`;
+  const firstSubgroupSubgroups = `${firstSubgroup} td:eq(2)`;
+  const secondSubgroup = `${subGroupList}:eq(1)`;
+  const secondSubgroupTitle = `${secondSubgroup} td:eq(0)`;
+  const secondSubgroupMembers = `${secondSubgroup} td:eq(1)`;
+  const secondSubgroupSubgroups = `${secondSubgroup} td:eq(2)`;
+
+  await visit('/learnergroups');
+  assert.equal(1, find(groups).length);
+  assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(firstMembers)), getText('7'));
+  assert.equal(getElementText(find(firstSubgroups)), getText('2'));
+  await click(firstGroupCopy);
+  await click(firstGroupCopyWithLearners);
+  assert.equal(2, find(groups).length);
+  assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(firstMembers)), getText('7'));
+  assert.equal(getElementText(find(firstSubgroups)), getText('2'));
+  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(secondMembers)), getText('7'));
+  assert.equal(getElementText(find(secondSubgroups)), getText('2'));
+  await click(firstLink);
+  assert.equal(currentURL(), '/learnergroups/1');
+  await visit('/learnergroups');
+  await click(secondLink);
+  assert.equal(currentURL(), '/learnergroups/5');
+
+  assert.equal(2, find(subGroupList).length);
+
+  assert.equal(getElementText(find(firstSubgroupTitle)), getText('learnergroup 1'));
+  assert.equal(getElementText(find(firstSubgroupMembers)), getText('1'));
+  assert.equal(getElementText(find(firstSubgroupSubgroups)), getText('1'));
+  assert.equal(getElementText(find(secondSubgroupTitle)), getText('learnergroup 2'));
+  assert.equal(getElementText(find(secondSubgroupMembers)), getText('3'));
+  assert.equal(getElementText(find(secondSubgroupSubgroups)), getText('0'));
+});

--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -153,7 +153,7 @@ test('copy learnergroup without learners', async function(assert) {
   assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
   assert.equal(getElementText(find(firstMembers)), getText('0'));
   assert.equal(getElementText(find(firstSubgroups)), getText('2'));
-  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0 (Copy)'));
   assert.equal(getElementText(find(secondMembers)), getText('0'));
   assert.equal(getElementText(find(secondSubgroups)), getText('2'));
   await click(firstLink);
@@ -258,7 +258,7 @@ test('copy learnergroup with learners', async function(assert) {
   assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
   assert.equal(getElementText(find(firstMembers)), getText('7'));
   assert.equal(getElementText(find(firstSubgroups)), getText('2'));
-  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0 (Copy)'));
   assert.equal(getElementText(find(secondMembers)), getText('7'));
   assert.equal(getElementText(find(secondSubgroups)), getText('2'));
   await click(firstLink);

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -700,3 +700,199 @@ test('title filter escapes regex', async function(assert) {
   assert.equal(find(groups).length, 1);
   assert.equal(getElementText(firstGroupTitle), 'yes\\no');
 });
+
+test('copy learnergroup without learners', async function(assert) {
+  assert.expect(20);
+  server.create('user', {id: 4136});
+  server.create('school', {
+    programs: [1]
+  });
+  server.create('program', {
+    school: 1,
+    programYears: [1]
+  });
+  server.create('programYear', {
+    program: 1,
+    cohort: 1
+  });
+  server.create('cohort', {
+    programYear: 1,
+    learnerGroups: [1]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    children: [2, 3]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 1,
+    children: [4]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 1,
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 2,
+  });
+  const groups = '.list tbody tr';
+  const firstGroup = `${groups}:eq(0)`;
+  const firstTitle = `${firstGroup} td:eq(0)`;
+  const firstLink = `${firstTitle} a`;
+  const firstMembers = `${firstGroup} td:eq(1)`;
+  const firstSubgroups = `${firstGroup} td:eq(2)`;
+  const firstGroupCopy = `${firstGroup} td:eq(3) .fa-copy`;
+  const firstGroupCopyNoLearners = '.list tbody tr:eq(1) .done:eq(1)';
+  const secondGroup = `${groups}:eq(1)`;
+  const secondTitle = `${secondGroup} td:eq(0)`;
+  const secondLink = `${secondTitle} a`;
+  const secondMembers = `${secondGroup} td:eq(1)`;
+  const secondSubgroups = `${secondGroup} td:eq(2)`;
+
+  const subGroupList = '.learnergroup-subgroup-list-list tbody tr';
+  const firstSubgroup = `${subGroupList}:eq(0)`;
+  const firstSubgroupTitle = `${firstSubgroup} td:eq(0)`;
+  const firstSubgroupMembers = `${firstSubgroup} td:eq(1)`;
+  const firstSubgroupSubgroups = `${firstSubgroup} td:eq(2)`;
+  const secondSubgroup = `${subGroupList}:eq(1)`;
+  const secondSubgroupTitle = `${secondSubgroup} td:eq(0)`;
+  const secondSubgroupMembers = `${secondSubgroup} td:eq(1)`;
+  const secondSubgroupSubgroups = `${secondSubgroup} td:eq(2)`;
+
+
+  await visit('/learnergroups');
+  assert.equal(1, find(groups).length);
+  assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(firstMembers)), getText('0'));
+  assert.equal(getElementText(find(firstSubgroups)), getText('2'));
+  await click(firstGroupCopy);
+  await click(firstGroupCopyNoLearners);
+  assert.equal(2, find(groups).length);
+  assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(firstMembers)), getText('0'));
+  assert.equal(getElementText(find(firstSubgroups)), getText('2'));
+  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(secondMembers)), getText('0'));
+  assert.equal(getElementText(find(secondSubgroups)), getText('2'));
+  await click(firstLink);
+  assert.equal(currentURL(), '/learnergroups/1');
+  await visit('/learnergroups');
+  await click(secondLink);
+  assert.equal(currentURL(), '/learnergroups/5');
+
+  assert.equal(2, find(subGroupList).length);
+
+  assert.equal(getElementText(find(firstSubgroupTitle)), getText('learnergroup 1'));
+  assert.equal(getElementText(find(firstSubgroupMembers)), getText('0'));
+  assert.equal(getElementText(find(firstSubgroupSubgroups)), getText('1'));
+  assert.equal(getElementText(find(secondSubgroupTitle)), getText('learnergroup 2'));
+  assert.equal(getElementText(find(secondSubgroupMembers)), getText('0'));
+  assert.equal(getElementText(find(secondSubgroupSubgroups)), getText('0'));
+});
+
+test('copy learnergroup with learners', async function(assert) {
+  assert.expect(20);
+  server.create('user', {id: 4136});
+  server.create('school', {
+    programs: [1]
+  });
+  server.create('program', {
+    school: 1,
+    programYears: [1]
+  });
+  server.create('programYear', {
+    program: 1,
+    cohort: 1
+  });
+  server.create('cohort', {
+    programYear: 1,
+    learnerGroups: [1]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    children: [2, 3],
+    users: [2, 3, 4, 5, 6, 7, 8]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 1,
+    children: [4],
+    users: [8]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 1,
+    users: [5, 6, 7]
+  });
+  server.create('learnerGroup', {
+    cohort: 1,
+    parent: 2,
+    users: [8]
+  });
+  server.createList('user', 3, {
+    learnerGroups: [1]
+  });
+  server.createList('user', 3, {
+    learnerGroups: [1, 3]
+  });
+  server.createList('user', 3, {
+    learnerGroups: [1, 4]
+  });
+  server.create('user', {
+    learnerGroups: [1, 2, 5]
+  });
+
+  const groups = '.list tbody tr';
+  const firstGroup = `${groups}:eq(0)`;
+  const firstTitle = `${firstGroup} td:eq(0)`;
+  const firstLink = `${firstTitle} a`;
+  const firstMembers = `${firstGroup} td:eq(1)`;
+  const firstSubgroups = `${firstGroup} td:eq(2)`;
+  const firstGroupCopy = `${firstGroup} td:eq(3) .fa-copy`;
+  const firstGroupCopyWithLearners = '.list tbody tr:eq(1) .done:eq(0)';
+  const secondGroup = `${groups}:eq(1)`;
+  const secondTitle = `${secondGroup} td:eq(0)`;
+  const secondLink = `${secondTitle} a`;
+  const secondMembers = `${secondGroup} td:eq(1)`;
+  const secondSubgroups = `${secondGroup} td:eq(2)`;
+
+  const subGroupList = '.learnergroup-subgroup-list-list tbody tr';
+  const firstSubgroup = `${subGroupList}:eq(0)`;
+  const firstSubgroupTitle = `${firstSubgroup} td:eq(0)`;
+  const firstSubgroupMembers = `${firstSubgroup} td:eq(1)`;
+  const firstSubgroupSubgroups = `${firstSubgroup} td:eq(2)`;
+  const secondSubgroup = `${subGroupList}:eq(1)`;
+  const secondSubgroupTitle = `${secondSubgroup} td:eq(0)`;
+  const secondSubgroupMembers = `${secondSubgroup} td:eq(1)`;
+  const secondSubgroupSubgroups = `${secondSubgroup} td:eq(2)`;
+
+  await visit('/learnergroups');
+  assert.equal(1, find(groups).length);
+  assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(firstMembers)), getText('7'));
+  assert.equal(getElementText(find(firstSubgroups)), getText('2'));
+  await click(firstGroupCopy);
+  await click(firstGroupCopyWithLearners);
+  assert.equal(2, find(groups).length);
+  assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(firstMembers)), getText('7'));
+  assert.equal(getElementText(find(firstSubgroups)), getText('2'));
+  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(secondMembers)), getText('7'));
+  assert.equal(getElementText(find(secondSubgroups)), getText('2'));
+  await click(firstLink);
+  assert.equal(currentURL(), '/learnergroups/1');
+  await visit('/learnergroups');
+  await click(secondLink);
+  assert.equal(currentURL(), '/learnergroups/5');
+
+  assert.equal(2, find(subGroupList).length);
+
+  assert.equal(getElementText(find(firstSubgroupTitle)), getText('learnergroup 1'));
+  assert.equal(getElementText(find(firstSubgroupMembers)), getText('1'));
+  assert.equal(getElementText(find(firstSubgroupSubgroups)), getText('1'));
+  assert.equal(getElementText(find(secondSubgroupTitle)), getText('learnergroup 2'));
+  assert.equal(getElementText(find(secondSubgroupMembers)), getText('3'));
+  assert.equal(getElementText(find(secondSubgroupSubgroups)), getText('0'));
+});

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -772,7 +772,7 @@ test('copy learnergroup without learners', async function(assert) {
   assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
   assert.equal(getElementText(find(firstMembers)), getText('0'));
   assert.equal(getElementText(find(firstSubgroups)), getText('2'));
-  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0 (Copy)'));
   assert.equal(getElementText(find(secondMembers)), getText('0'));
   assert.equal(getElementText(find(secondSubgroups)), getText('2'));
   await click(firstLink);
@@ -878,7 +878,7 @@ test('copy learnergroup with learners', async function(assert) {
   assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
   assert.equal(getElementText(find(firstMembers)), getText('7'));
   assert.equal(getElementText(find(firstSubgroups)), getText('2'));
-  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0'));
+  assert.equal(getElementText(find(secondTitle)), getText('learnergroup 0 (Copy)'));
   assert.equal(getElementText(find(secondMembers)), getText('7'));
   assert.equal(getElementText(find(secondSubgroups)), getText('2'));
   await click(firstLink);

--- a/tests/unit/utils/clone-learner-group-test.js
+++ b/tests/unit/utils/clone-learner-group-test.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import RSVP from 'rsvp';
+import cloneLearnerGroup from 'ilios/utils/clone-learner-group';
+import { module, test } from 'qunit';
+
+const { Object: EmberObject } = Ember;
+const { resolve } = RSVP;
+
+module('Unit | Utility | clone learner group');
+
+test('clones empty group', async function (assert) {
+  const store = EmberObject.create({
+    createRecord(what, {title, location:loc}) {
+      assert.equal(what, 'learner-group');
+      assert.equal(title, 'to clone');
+      assert.equal(loc, 'over the rainbow');
+
+      return EmberObject.create({ title, location: loc});
+    }
+  });
+  const instructor = EmberObject.create();
+  const group = EmberObject.create({
+    title: 'to clone',
+    location: 'over the rainbow',
+    children: resolve([]),
+    instructors: resolve([instructor]),
+  });
+  const cohort = EmberObject.create({
+
+  });
+  let groups = await cloneLearnerGroup(store, group, cohort, false);
+  assert.equal(groups.length, 1);
+  const result = groups[0];
+  assert.ok(result);
+  assert.equal(result.get('title'), group.get('title'), 'title was copied');
+  assert.equal(result.get('location'), group.get('location'), 'locationw as copied');
+  assert.equal(result.get('cohort'), cohort, 'cohort was copied');
+  assert.equal(result.get('instructors').length, 1);
+  assert.deepEqual(result.get('instructors'), [instructor], 'instructors were copied');
+  assert.equal(result.get('parent'), null, 'there was no parent');
+});


### PR DESCRIPTION
Groups are copied in place on either the cohort list or a subgroup list.
This makes it easier for users to duplicate structure and even membership
quickly.

Needs:
- [x] Translations
- [x] Review of all the ways groups can be copied to ensure this works