### PR TITLE
Display the users current timezone in the offering editor

### DIFF
--- a/app/helpers/browser-timezone.js
+++ b/app/helpers/browser-timezone.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import moment from 'moment';
+
+export function browserTimezone() {
+  return moment.tz.guess();
+}
+
+export default Ember.Helper.helper(browserTimezone);

--- a/app/styles/newcomponents/offering-form.scss
+++ b/app/styles/newcomponents/offering-form.scss
@@ -94,4 +94,10 @@
   .buttons {
     @include ilios-form-buttons;
   }
+
+  .timezone {
+    color: $darker-grey;
+    font-size: .8 * $base-font-size;
+    margin-left: 1em;
+  }
 }

--- a/app/templates/components/offering-form.hbs
+++ b/app/templates/components/offering-form.hbs
@@ -5,7 +5,7 @@
   </div>
 
   <div class='item start-time'>
-    <label>{{t 'general.startTime'}}:</label>
+    <label>{{t 'general.startTime'}}: <span class='timezone'>({{browser-timezone}})</span></label>
     {{time-picker date=startDate action='updateStartTime'}}
   </div>
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -50,7 +50,8 @@ module.exports = function(environment) {
     },
     moment: {
       // Full list of locales: https://github.com/moment/moment/tree/2.10.3/locale
-      includeLocales: ['es', 'fr']
+      includeLocales: ['es', 'fr'],
+      includeTimezone: 'all',
     },
     EmberENV: {
       FEATURES: {

--- a/tests/integration/helpers/browser-timezone-test.js
+++ b/tests/integration/helpers/browser-timezone-test.js
@@ -1,0 +1,17 @@
+
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
+
+moduleForComponent('browser-timezone', 'helper:browser-timezone', {
+  integration: true
+});
+
+test('it renders current timezone as guessed by moment', function(assert) {
+  this.set('inputValue', '1234');
+
+  this.render(hbs`{{browser-timezone}}`);
+
+  assert.equal(this.$().text().trim(), moment.tz.guess());
+});
+


### PR DESCRIPTION
This makes it easier for users to notice if they are changing a time
incorrectly because their browsers timezone isn't what they expect it to
be.

Fixes #3291