### PR TITLE
Show loading bar when navigation is present

### DIFF
--- a/app/styles/newcomponents/loading-bar.scss
+++ b/app/styles/newcomponents/loading-bar.scss
@@ -4,6 +4,11 @@
   text-align: left;
   width: 100%;
 
+  @include media($giant-screen) {
+    // get out of the way of the navigation block on huge screens
+    padding-left: 180px;
+  }
+
   .bar {
     background-color: $ilios-blue;
     border: 0;


### PR DESCRIPTION
One huge screens the navigation sits flush against the top left edge
blocking the loading bar. We can work around this be just making some
space for it.