### PR TITLE
Don't override font-face

### DIFF
--- a/app/styles/components/_reset.scss
+++ b/app/styles/components/_reset.scss
@@ -1,7 +1,6 @@
 body {
   background-color: $white;
   color: $base-font-color;
-  font-family: $helvetica;
   font-size: $base-font-size;
   line-height: $base-line-height;
 }


### PR DESCRIPTION
Ilios/common is providing a nice set of default system fonts that we
don't need to override here.