### PR TITLE
Remove `this.attrs` from templates

### DIFF
--- a/app/templates/components/assign-students.hbs
+++ b/app/templates/components/assign-students.hbs
@@ -38,8 +38,8 @@
       offset=offset
       limit=limit
       total=totalUnassignedStudents
-      setOffset=(action this.attrs.setOffset)
-      setLimit=(action this.attrs.setLimit)
+      setOffset=(action setOffset)
+      setLimit=(action setLimit)
     }}
     <table>
       <thead>
@@ -78,8 +78,8 @@
       offset=offset
       limit=limit
       total=totalUnassignedStudents
-      setOffset=(action this.attrs.setOffset)
-      setLimit=(action this.attrs.setLimit)
+      setOffset=(action setOffset)
+      setLimit=(action setLimit)
     }}
   </div>
 </section>

--- a/app/templates/components/collapsed-competencies.hbs
+++ b/app/templates/components/collapsed-competencies.hbs
@@ -1,4 +1,4 @@
-<div class='title'  {{action (action this.attrs.expand)}}>
+<div class='title'  {{action (action expand)}}>
   {{t 'general.competencies'}} ({{get (await subject.competencies) 'length'}})
 </div>
 {{#unless (is-fulfilled summary)}}

--- a/app/templates/components/collapsed-objectives.hbs
+++ b/app/templates/components/collapsed-objectives.hbs
@@ -1,4 +1,4 @@
-<div class='title'  {{action (action this.attrs.expand)}}>
+<div class='title'  {{action (action expand)}}>
   {{t 'general.objectives'}} ({{get (await objectives) 'length'}})
 </div>
 {{#if (and (is-fulfilled objectives) (is-fulfilled objectivesWithMesh) (is-fulfilled objectivesWithParents))}}

--- a/app/templates/components/collapsed-taxonomies.hbs
+++ b/app/templates/components/collapsed-taxonomies.hbs
@@ -1,4 +1,4 @@
-<div class='title' {{action (action this.attrs.expand)}}>
+<div class='title' {{action (action expand)}}>
   {{t 'general.terms'}} ({{subject.terms.length}})
 </div>
 {{#if (is-pending subject.associatedVocabularies)}}

--- a/app/templates/components/course-director-manager.hbs
+++ b/app/templates/components/course-director-manager.hbs
@@ -2,7 +2,7 @@
   <button class='bigadd' {{action (perform saveChanges)}}>
     {{fa-icon (if saveChanges.isRunning 'spinner' 'check') spin=(if saveChanges.isRunning true false)}}
   </button>
-  <button class='bigcancel' {{action this.attrs.close}}>{{fa-icon 'undo'}}</button>
+  <button class='bigcancel' {{action close}}>{{fa-icon 'undo'}}</button>
 </div>
 <div class='detail-content'>
   <ul class='removable-list tag-list'>

--- a/app/templates/components/course-editing.hbs
+++ b/app/templates/components/course-editing.hbs
@@ -3,8 +3,8 @@
     subject=course
     isCourse=true
     editable=editable
-    collapse=(action this.attrs.setCourseObjectiveDetails false)
-    expand=(action this.attrs.setCourseObjectiveDetails true)
+    collapse=(action setCourseObjectiveDetails false)
+    expand=(action setCourseObjectiveDetails true)
   }}
 {{else}}
   {{collapsed-objectives subject=course expand=(action setCourseObjectiveDetails true)}}
@@ -16,11 +16,11 @@
   {{detail-competencies
     course=course
     editable=editable
-    collapse=(action this.attrs.setCourseCompetencyDetails false)
-    expand=(action this.attrs.setCourseCompetencyDetails true)
+    collapse=(action setCourseCompetencyDetails false)
+    expand=(action setCourseCompetencyDetails true)
   }}
 {{else}}
-  {{collapsed-competencies subject=course expand=(action this.attrs.setCourseCompetencyDetails true)}}
+  {{collapsed-competencies subject=course expand=(action setCourseCompetencyDetails true)}}
 {{/if}}
 
 {{#if (or (eq course.terms.length 0) courseTaxonomyDetails)}}
@@ -28,11 +28,11 @@
     subject=course
     isCourse=true
     editable=editable
-    collapse=(action this.attrs.setCourseTaxonomyDetails false)
-    expand=(action this.attrs.setCourseTaxonomyDetails true)
+    collapse=(action setCourseTaxonomyDetails false)
+    expand=(action setCourseTaxonomyDetails true)
   }}
 {{else}}
-  {{collapsed-taxonomies subject=course expand=(action this.attrs.setCourseTaxonomyDetails true)}}
+  {{collapsed-taxonomies subject=course expand=(action setCourseTaxonomyDetails true)}}
 {{/if}}
 
 {{detail-mesh

--- a/app/templates/components/course-objective-list-item.hbs
+++ b/app/templates/components/course-objective-list-item.hbs
@@ -34,7 +34,7 @@
           <br>
         {{/if}}
         {{#if editable}}
-          <span class='clickable link' {{action this.attrs.manageParents objective}}>
+          <span class='clickable link' {{action manageParents objective}}>
             {{parent.textTitle}}
           </span>
         {{else}}
@@ -47,7 +47,7 @@
       {{/each}}
     {{else}}
       {{#if editable}}
-        <button {{action this.attrs.manageParents objective}}>{{t 'general.addNew'}}</button>
+        <button {{action manageParents objective}}>{{t 'general.addNew'}}</button>
       {{else}}
         {{t 'general.none'}}
       {{/if}}
@@ -58,7 +58,7 @@
       <ul>
         {{#each objective.meshDescriptors as |descriptor|}}
           {{#if editable}}
-            <li class='clickable link' {{action this.attrs.manageDescriptors objective}}>{{descriptor.name}}</li>
+            <li class='clickable link' {{action manageDescriptors objective}}>{{descriptor.name}}</li>
           {{else}}
             <li>{{descriptor.name}}</li>
           {{/if}}
@@ -66,7 +66,7 @@
       </ul>
     {{else}}
       {{#if editable}}
-        <button {{action this.attrs.manageDescriptors objective}}>{{t 'general.addNew'}}</button>
+        <button {{action manageDescriptors objective}}>{{t 'general.addNew'}}</button>
       {{else}}
         {{t 'general.none'}}
       {{/if}}
@@ -74,6 +74,6 @@
   </td>
   <td class='text-left text-top' colspan=1>
     {{#if editable}}
-      <span class='clickable remove' {{action this.attrs.remove objective}}>{{fa-icon 'trash'}}</span>
+      <span class='clickable remove' {{action remove objective}}>{{fa-icon 'trash'}}</span>
     {{/if}}
   </td>

--- a/app/templates/components/course-objective-list.hbs
+++ b/app/templates/components/course-objective-list.hbs
@@ -27,8 +27,8 @@
               course=course
               showRemoveConfirmation=(is-in objectivesForRemovalConfirmation objective.id)
               remove=(action 'confirmRemoval')
-              manageParents=this.attrs.manageParents
-              manageDescriptors=this.attrs.manageDescriptors
+              manageParents=manageParents
+              manageDescriptors=manageDescriptors
             }}
             {{#if (is-in objectivesForRemovalConfirmation objective.id)}}
               <tr class='confirm-removal'>

--- a/app/templates/components/ilios-course-details.hbs
+++ b/app/templates/components/ilios-course-details.hbs
@@ -8,9 +8,9 @@
     courseObjectiveDetails=courseObjectiveDetails
     courseTaxonomyDetails = courseTaxonomyDetails
     courseCompetencyDetails = courseCompetencyDetails
-    setCourseObjectiveDetails=(action this.attrs.setCourseObjectiveDetails)
-    setCourseTaxonomyDetails=(action this.attrs.setCourseTaxonomyDetails)
-    setCourseCompetencyDetails=(action this.attrs.setCourseCompetencyDetails)
+    setCourseObjectiveDetails=(action setCourseObjectiveDetails)
+    setCourseTaxonomyDetails=(action setCourseTaxonomyDetails)
+    setCourseCompetencyDetails=(action setCourseCompetencyDetails)
   }}
   <div {{action 'collapse'}} class='detail-collapsed-control'><span class='is-expanded'>{{t 'general.collapseDetail'}}{{fa-icon "fa-minus-square"}}</span></div>
 {{/if}}

--- a/app/templates/components/learnergroup-instructor-manager.hbs
+++ b/app/templates/components/learnergroup-instructor-manager.hbs
@@ -2,7 +2,7 @@
   <button class='bigadd' {{action (perform saveChanges)}}>
     {{fa-icon (if saveChanges.isRunning 'spinner' 'check') spin=(if saveChanges.isRunning true false)}}
   </button>
-  <button class='bigcancel' {{action this.attrs.close}}>{{fa-icon 'undo'}}</button>
+  <button class='bigcancel' {{action close}}>{{fa-icon 'undo'}}</button>
 </div>
 <div class='detail-content'>
   <ul class='removable-list tag-list'>

--- a/app/templates/components/learnergroup-summary.hbs
+++ b/app/templates/components/learnergroup-summary.hbs
@@ -16,7 +16,7 @@
         cohortTitle=cohortTitle
         users=usersToPassToManager.lastSuccessful.value
         sortBy=sortUsersBy
-        setSortBy=this.attrs.setSortUsersBy
+        setSortBy=setSortUsersBy
         isEditing=isEditing
         addUserToGroup=(perform addUserToGroup)
         removeUserFromGroup=(perform removeUserToCohort)
@@ -101,7 +101,7 @@
       learnerGroupTitle=learnerGroupTitle
       topLevelGroupTitle=topLevelGroupTitle
       sortBy=sortUsersBy
-      setSortBy=this.attrs.setSortUsersBy
+      setSortBy=setSortUsersBy
       addUserToGroup=(perform addUserToGroup)
       addUsersToGroup=(perform addUsersToGroup)
     }}

--- a/app/templates/components/new-directory-user.hbs
+++ b/app/templates/components/new-directory-user.hbs
@@ -40,7 +40,7 @@
           value=otherId
           update=(action (mut otherId))
           onenter=(perform save)
-          onescape=(action this.attrs.close)
+          onescape=(action close)
           focusOut=(action 'addErrorDisplayFor' 'otherId')
         }}
         {{#if (and (v-get this 'otherId' 'isInvalid') (is-in showErrorsFor 'otherId'))}}
@@ -54,7 +54,7 @@
             value=username
             update=(action (mut username))
             onenter=(perform save)
-            onescape=(action this.attrs.close)
+            onescape=(action close)
             focusOut=(action 'addErrorDisplayFor' 'username')
           }}
           {{#if (and (v-get this 'username' 'isInvalid') (is-in showErrorsFor 'username'))}}
@@ -72,7 +72,7 @@
             value=password
             update=(action (mut password))
             onenter=(perform save)
-            onescape=(action this.attrs.close)
+            onescape=(action close)
             focusOut=(action 'addErrorDisplayFor' 'password')
           }}
           {{#if (and (v-get this 'password' 'isInvalid') (is-in showErrorsFor 'password'))}}

--- a/app/templates/components/new-learnergroup-multiple.hbs
+++ b/app/templates/components/new-learnergroup-multiple.hbs
@@ -10,7 +10,7 @@
         value=numSubGroups
         update=(action (mut numSubGroups))
         onenter=(action 'save')
-        onescape=(action this.attrs.cancel)
+        onescape=(action cancel)
         disabled=isSaving
         focusOut=(action 'addErrorDisplayFor' 'numSubGroups')
         placeholder=(t 'general.numberOfGroupsToGenerate')
@@ -22,6 +22,6 @@
   </label>
   <div class="form-col-6 form-data-submit">
     <button class='done text' {{action 'save'}}>{{t 'general.done'}}</button>
-    <button class='cancel text' {{action this.attrs.cancel}}>{{t 'general.cancel'}}</button>
+    <button class='cancel text' {{action cancel}}>{{t 'general.cancel'}}</button>
   </div>
 {{/if}}

--- a/app/templates/components/new-learnergroup-single.hbs
+++ b/app/templates/components/new-learnergroup-single.hbs
@@ -5,7 +5,7 @@
       value=title
       update=(action (mut title))
       onenter=(action 'save')
-      onescape=(action this.attrs.cancel)
+      onescape=(action cancel)
       disabled=isSaving
       focusOut=(action 'addErrorDisplayFor' 'title')
       placeholder=(t 'general.learnerGroupTitlePlaceholder')
@@ -34,5 +34,5 @@
       {{t 'general.done'}}
     {{/if}}
   </button>
-  <button class='cancel text' {{action this.attrs.cancel}}>{{t 'general.cancel'}}</button>
+  <button class='cancel text' {{action cancel}}>{{t 'general.cancel'}}</button>
 </div>

--- a/app/templates/components/new-myreport.hbs
+++ b/app/templates/components/new-myreport.hbs
@@ -5,7 +5,7 @@
     {{one-way-input
       value=title
       update=(action (mut title))
-      onescape=(action this.attrs.close)
+      onescape=(action close)
       disabled=save.isRunning
       focusOut=(action 'addErrorDisplayFor' 'title')
       keyDown=(action 'addErrorDisplayFor' 'title')
@@ -112,6 +112,6 @@
         {{t 'general.save'}}
       {{/if}}
     </button>
-    <button class='cancel text' {{action this.attrs.close}}>{{t 'general.cancel'}}</button>
+    <button class='cancel text' {{action close}}>{{t 'general.cancel'}}</button>
   </div>
 </div>

--- a/app/templates/components/new-objective.hbs
+++ b/app/templates/components/new-objective.hbs
@@ -23,6 +23,6 @@
         {{t 'general.done'}}
       {{/if}}
     </button>
-    <button class='cancel text' {{action this.attrs.cancel}}>{{t 'general.cancel'}}</button>
+    <button class='cancel text' {{action cancel}}>{{t 'general.cancel'}}</button>
   </div>
 </div>

--- a/app/templates/components/new-program.hbs
+++ b/app/templates/components/new-program.hbs
@@ -7,7 +7,7 @@
         value=title
         update=(action (mut title))
         onenter=(action 'save')
-        onescape=(action this.attrs.cancel)
+        onescape=(action cancel)
         disabled=isSaving
         focusOut=(action 'addErrorDisplayFor' 'title')
         placeholder=(t 'general.programTitlePlaceholder')
@@ -25,6 +25,6 @@
         {{t 'general.done'}}
       {{/if}}
     </button>
-    <button class='cancel text' {{action this.attrs.cancel}}>{{t 'general.cancel'}}</button>
+    <button class='cancel text' {{action cancel}}>{{t 'general.cancel'}}</button>
   </div>
 </div>

--- a/app/templates/components/new-user.hbs
+++ b/app/templates/components/new-user.hbs
@@ -16,7 +16,7 @@
       value=firstName
       update=(action (mut firstName))
       onenter=(perform save)
-      onescape=(action this.attrs.close)
+      onescape=(action close)
       focusOut=(action 'addErrorDisplayFor' 'firstName')
     }}
     {{#if (and (v-get this 'firstName' 'isInvalid') (is-in showErrorsFor 'firstName'))}}
@@ -29,7 +29,7 @@
       value=middleName
       update=(action (mut middleName))
       onenter=(perform save)
-      onescape=(action this.attrs.close)
+      onescape=(action close)
       focusOut=(action 'addErrorDisplayFor' 'middleName')
     }}
     {{#if (and (v-get this 'middleName' 'isInvalid') (is-in showErrorsFor 'middleName'))}}
@@ -42,7 +42,7 @@
       value=lastName
       update=(action (mut lastName))
       onenter=(perform save)
-      onescape=(action this.attrs.close)
+      onescape=(action close)
       focusOut=(action 'addErrorDisplayFor' 'lastName')
     }}
     {{#if (and (v-get this 'lastName' 'isInvalid') (is-in showErrorsFor 'lastName'))}}
@@ -55,7 +55,7 @@
       value=campusId
       update=(action (mut campusId))
       onenter=(perform save)
-      onescape=(action this.attrs.close)
+      onescape=(action close)
       focusOut=(action 'addErrorDisplayFor' 'campusId')
     }}
     {{#if (and (v-get this 'campusId' 'isInvalid') (is-in showErrorsFor 'campusId'))}}
@@ -68,7 +68,7 @@
       value=otherId
       update=(action (mut otherId))
       onenter=(perform save)
-      onescape=(action this.attrs.close)
+      onescape=(action close)
       focusOut=(action 'addErrorDisplayFor' 'otherId')
     }}
     {{#if (and (v-get this 'otherId' 'isInvalid') (is-in showErrorsFor 'otherId'))}}
@@ -81,7 +81,7 @@
       value=email
       update=(action (mut email))
       onenter=(perform save)
-      onescape=(action this.attrs.close)
+      onescape=(action close)
       focusOut=(action 'addErrorDisplayFor' 'email')
     }}
     {{#if (and (v-get this 'email' 'isInvalid') (is-in showErrorsFor 'email'))}}
@@ -94,7 +94,7 @@
       value=phone
       update=(action (mut phone))
       onenter=(perform save)
-      onescape=(action this.attrs.close)
+      onescape=(action close)
       focusOut=(action 'addErrorDisplayFor' 'phone')
     }}
     {{#if (and (v-get this 'phone' 'isInvalid') (is-in showErrorsFor 'phone'))}}
@@ -107,7 +107,7 @@
       value=username
       update=(action (mut username))
       onenter=(perform save)
-      onescape=(action this.attrs.close)
+      onescape=(action close)
       focusOut=(action 'addErrorDisplayFor' 'username')
     }}
     {{#if (and (v-get this 'username' 'isInvalid') (is-in showErrorsFor 'username'))}}
@@ -120,7 +120,7 @@
       value=password
       update=(action (mut password))
       onenter=(perform save)
-      onescape=(action this.attrs.close)
+      onescape=(action close)
       focusOut=(action 'addErrorDisplayFor' 'password')
     }}
     {{#if (and (v-get this 'password' 'isInvalid') (is-in showErrorsFor 'password'))}}
@@ -166,6 +166,6 @@
         {{t 'general.done'}}
       {{/if}}
     </button>
-    <button class='cancel text' {{action (action this.attrs.close)}}>{{t 'general.cancel'}}</button>
+    <button class='cancel text' {{action (action close)}}>{{t 'general.cancel'}}</button>
   </div>
 </div>

--- a/app/templates/components/programyear-objective-list-item.hbs
+++ b/app/templates/components/programyear-objective-list-item.hbs
@@ -22,7 +22,7 @@
 <td class='text-left text-top' colspan=2>
   {{#if (await objective.competency)}}
     {{#if editable}}
-      <span class='clickable link' {{action this.attrs.manageCompetency objective}}>
+      <span class='clickable link' {{action manageCompetency objective}}>
         {{get (await objective.competency) "title"}}
       </span>
     {{else}}
@@ -33,7 +33,7 @@
     {{/if}}
   {{else}}
     {{#if editable}}
-      <button {{action this.attrs.manageCompetency objective}}>{{t 'general.addNew'}}</button>
+      <button {{action manageCompetency objective}}>{{t 'general.addNew'}}</button>
     {{else}}
       {{t 'general.none'}}
     {{/if}}
@@ -44,7 +44,7 @@
     <ul>
       {{#each (await objective.meshDescriptors) as |descriptor|}}
         {{#if editable}}
-          <li class='clickable link' {{action this.attrs.manageDescriptors objective}}>{{descriptor.name}}</li>
+          <li class='clickable link' {{action manageDescriptors objective}}>{{descriptor.name}}</li>
         {{else}}
           <li>{{descriptor.name}}</li>
         {{/if}}
@@ -52,7 +52,7 @@
     </ul>
   {{else}}
     {{#if editable}}
-      <button {{action this.attrs.manageDescriptors objective}}>{{t 'general.addNew'}}</button>
+      <button {{action manageDescriptors objective}}>{{t 'general.addNew'}}</button>
     {{else}}
       {{t 'general.none'}}
     {{/if}}

--- a/app/templates/components/programyear-objective-list.hbs
+++ b/app/templates/components/programyear-objective-list.hbs
@@ -23,8 +23,8 @@
             {{programyear-objective-list-item
               objective=objective
               programYear=programYear
-              manageCompetency=this.attrs.manageCompetency
-              manageDescriptors=this.attrs.manageDescriptors
+              manageCompetency=manageCompetency
+              manageDescriptors=manageDescriptors
               editable=editable
             }}
           {{/each}}

--- a/app/templates/components/school-competencies-manager.hbs
+++ b/app/templates/components/school-competencies-manager.hbs
@@ -2,14 +2,14 @@
   <div class='hierarchical-list'>
     {{competency-title-editor competency=obj.domain}}
     {{#if (eq obj.competencies.length 0)}}
-      {{fa-icon 'trash' class='remove clickable' click=(action this.attrs.remove obj.domain)}}
+      {{fa-icon 'trash' class='remove clickable' click=(action remove obj.domain)}}
     {{/if}}
     <ul>
       {{#each obj.competencies as |competency|}}
         <li>
           {{competency-title-editor competency=competency}}
           {{#if (eq competency.objectives.length 0)}}
-            {{fa-icon 'trash' class='remove clickable' click=(action this.attrs.remove competency)}}
+            {{fa-icon 'trash' class='remove clickable' click=(action remove competency)}}
           {{else}}
             ({{competency.objectives.length}})
           {{/if}}

--- a/app/templates/components/school-vocabularies-collapsed.hbs
+++ b/app/templates/components/school-vocabularies-collapsed.hbs
@@ -1,4 +1,4 @@
-<div class='title clickable'  {{action (action this.attrs.expand)}}>
+<div class='title clickable'  {{action (action expand)}}>
   {{t 'general.vocabularies'}} ({{get (await school.vocabularies) 'length'}})
 </div>
 {{#if (is-pending school.vocabularies)}}

--- a/app/templates/components/school-vocabularies-expanded.hbs
+++ b/app/templates/components/school-vocabularies-expanded.hbs
@@ -6,19 +6,19 @@
     {{school-vocabulary-term-manager
       vocabulary=managedVocabulary
       term=managedTerm
-      manageTerm=this.attrs.setSchoolManagedVocabularyTerm
-      manageVocabulary=this.attrs.setSchoolManagedVocabulary
+      manageTerm=setSchoolManagedVocabularyTerm
+      manageVocabulary=setSchoolManagedVocabulary
     }}
   {{else if managedVocabularyId}}
     {{school-vocabulary-manager
       vocabulary=managedVocabulary
-      manageTerm=this.attrs.setSchoolManagedVocabularyTerm
-      manageVocabulary=this.attrs.setSchoolManagedVocabulary
+      manageTerm=setSchoolManagedVocabularyTerm
+      manageVocabulary=setSchoolManagedVocabulary
     }}
   {{else}}
     {{school-vocabularies-list
       school=school
-      manageVocabulary=this.attrs.setSchoolManagedVocabulary
+      manageVocabulary=setSchoolManagedVocabulary
     }}
   {{/if}}
 </div>

--- a/app/templates/components/school-vocabulary-manager.hbs
+++ b/app/templates/components/school-vocabulary-manager.hbs
@@ -1,5 +1,5 @@
 <div class='breadcrumbs'>
-  <span {{action this.attrs.manageVocabulary null}}>{{t 'general.allVocabularies'}}</span>
+  <span {{action manageVocabulary null}}>{{t 'general.allVocabularies'}}</span>
   <span>{{vocabulary.title}}</span>
 </div><br>
 
@@ -22,7 +22,7 @@
 
 {{#each newTerms as |term|}}
   <div class='saved-result'>
-    <span class='clickable link' {{action this.attrs.manageTerm term.id}}>
+    <span class='clickable link' {{action manageTerm term.id}}>
       {{fa-icon 'external-link-square'}} {{term.title}}
     </span>
     {{t 'general.savedSuccessfully'}}
@@ -54,7 +54,7 @@
   {{#if (is-fulfilled sortedTerms)}}
     <ul>
       {{#each (await sortedTerms) as |term|}}
-        <li {{action this.attrs.manageTerm term.id}}>{{term.title}}</li>
+        <li {{action manageTerm term.id}}>{{term.title}}</li>
       {{/each}}
     </ul>
   {{else}}

--- a/app/templates/components/school-vocabulary-term-manager.hbs
+++ b/app/templates/components/school-vocabulary-term-manager.hbs
@@ -1,9 +1,9 @@
 {{#if (is-fulfilled allParents)}}
   <div class='breadcrumbs'>
     <span {{action 'clearVocabAndTerm'}}>{{t 'general.allVocabularies'}}</span>
-    <span {{action this.attrs.manageTerm null}}>{{vocabulary.title}}</span>
+    <span {{action manageTerm null}}>{{vocabulary.title}}</span>
     {{#each (await allParents) as |parent|}}
-      <span {{action this.attrs.manageTerm parent.id}}>{{parent.title}}</span>
+      <span {{action manageTerm parent.id}}>{{parent.title}}</span>
     {{/each}}
     <span>{{term.title}}</span>
   </div>
@@ -48,7 +48,7 @@
 {{/if}}
 {{#each newTerms as |term|}}
   <div class='saved-result'>
-    <span class='clickable link' {{action this.attrs.manageTerm term.id}}>
+    <span class='clickable link' {{action manageTerm term.id}}>
       {{fa-icon 'external-link-square'}} {{term.title}}
     </span>
     {{t 'general.savedSuccessfully'}}
@@ -79,7 +79,7 @@
   {{#if (is-fulfilled sortedTerms)}}
     <ul>
       {{#each (await sortedTerms) as |term|}}
-        <li {{action this.attrs.manageTerm term.id}}>{{term.title}}</li>
+        <li {{action manageTerm term.id}}>{{term.title}}</li>
       {{/each}}
     </ul>
   {{else}}

--- a/app/templates/components/session-objective-list-item.hbs
+++ b/app/templates/components/session-objective-list-item.hbs
@@ -23,7 +23,7 @@
   {{#if objective.hasParents}}
     {{#each objective.parents as |parent|}}
       {{#if editable}}
-        <span class='clickable link' {{action this.attrs.manageParents objective}}>
+        <span class='clickable link' {{action manageParents objective}}>
           {{parent.textTitle}}
         </span>
       {{else}}
@@ -35,7 +35,7 @@
     {{/each}}
   {{else}}
     {{#if editable}}
-      <button {{action this.attrs.manageParents objective}}>{{t 'general.addNew'}}</button>
+      <button {{action manageParents objective}}>{{t 'general.addNew'}}</button>
     {{else}}
       {{t 'general.none'}}
     {{/if}}
@@ -46,7 +46,7 @@
     <ul>
       {{#each objective.meshDescriptors as |descriptor|}}
         {{#if editable}}
-          <li class='clickable link' {{action this.attrs.manageDescriptors objective}}>{{descriptor.name}}</li>
+          <li class='clickable link' {{action manageDescriptors objective}}>{{descriptor.name}}</li>
         {{else}}
           <li>{{descriptor.name}}</li>
         {{/if}}
@@ -54,7 +54,7 @@
     </ul>
   {{else}}
     {{#if editable}}
-      <button {{action this.attrs.manageDescriptors objective}}>{{t 'general.addNew'}}</button>
+      <button {{action manageDescriptors objective}}>{{t 'general.addNew'}}</button>
     {{else}}
       {{t 'general.none'}}
     {{/if}}
@@ -62,6 +62,6 @@
 </td>
 <td class='text-left text-top' colspan=1>
   {{#if editable}}
-    <span class='clickable remove' {{action this.attrs.remove objective}}>{{fa-icon 'trash'}}</span>
+    <span class='clickable remove' {{action remove objective}}>{{fa-icon 'trash'}}</span>
   {{/if}}
 </td>

--- a/app/templates/components/session-objective-list.hbs
+++ b/app/templates/components/session-objective-list.hbs
@@ -27,8 +27,8 @@
               session=session
               showRemoveConfirmation=(is-in objectivesForRemovalConfirmation objective.id)
               remove=(action 'confirmRemoval')
-              manageParents=this.attrs.manageParents
-              manageDescriptors=this.attrs.manageDescriptors
+              manageParents=manageParents
+              manageDescriptors=manageDescriptors
             }}
             {{#if (is-in objectivesForRemovalConfirmation objective.id)}}
               <tr class='confirm-removal'>


### PR DESCRIPTION
This was never necessary. I misunderstood the way DDAU worked in Ember
initially and thought we needed to include this.