### PR TITLE
Deploy noscript, loading, and error code

### DIFF
--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v1.24';
+module.exports = 'v1.25';

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -28,6 +28,28 @@ module.exports = function(deployTarget) {
       objectPaths(context){
         return `/${context.archiveName}`;
       },
+    },
+    'json-config': {
+      jsonBlueprint(context, pluginHelper) {
+        var jsonBlueprint = pluginHelper.readConfigDefault('jsonBlueprint');
+        jsonBlueprint.style = {
+          selector: 'style',
+          attributes: ['type'],
+          includeContent: true,
+        };
+        jsonBlueprint.noScript = {
+          selector: 'noscript',
+          attributes: false,
+          includeHtmlContent: true,
+        };
+        jsonBlueprint.div = {
+          selector: '[data-deploy]',
+          attributes: ['id', 'class'],
+          includeHtmlContent: true,
+        };
+
+        return jsonBlueprint;
+      }
     }
   };
 

--- a/lib/ilios-error/index.js
+++ b/lib/ilios-error/index.js
@@ -21,10 +21,12 @@ module.exports = {
 
     if( type === 'body') {
       return `
-        <h1 id='ilios-loading-error' class='hidden ember-load-indicator'>
-          It is possible that your browser is not supported by Ilios.
-          Please refresh this page or try a different browser.
-        </h1>
+        <div id='ilios-loading-error' data-deploy class='hidden ember-load-indicator'>
+          <h1>
+            It is possible that your browser is not supported by Ilios.
+            Please refresh this page or try a different browser.
+          </h1>
+        </div>
       `;
     }
   }

--- a/lib/ilios-loading/index.js
+++ b/lib/ilios-loading/index.js
@@ -76,7 +76,7 @@ module.exports = {
     }
 
     if (type === 'body') {
-      return `<div id='ilios-loading-indicator' class='ember-load-indicator'>
+      return `<div id='ilios-loading-indicator' data-deploy class='ember-load-indicator'>
         <h1>
           <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 392.11 392.11">
             <title>Ilios Is Loading</title>

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-cli-deploy-build": "1.1.1",
     "ember-cli-deploy-cloudfront": "^1.2.0",
     "ember-cli-deploy-display-revisions": "1.0.0",
-    "ember-cli-deploy-json-config": "1.0.0",
+    "ember-cli-deploy-json-config": "1.0.1",
     "ember-cli-deploy-revision-data": "1.0.0",
     "ember-cli-deploy-s3-index": "1.0.0",
     "ember-cli-deprecation-workflow": "0.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3063,9 +3063,9 @@ ember-cli-deploy-display-revisions@1.0.0:
     moment "^2.18.0"
     rsvp "^3.5.0"
 
-ember-cli-deploy-json-config@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-deploy-json-config/-/ember-cli-deploy-json-config-1.0.0.tgz#10a39c5a03800624da91ec29dd49f59d77c7112f"
+ember-cli-deploy-json-config@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-deploy-json-config/-/ember-cli-deploy-json-config-1.0.1.tgz#ef1df38eaef4c96b5bcd5e93aabc3f304095bd04"
   dependencies:
     chalk "^1.0.0"
     cheerio "^0.22.0"


### PR DESCRIPTION
New configuration available in our deployment plugins lets us include
this data in our deployed JSON file so we can use it on the API.