### PR TITLE
Don't attempt to deploy cron run builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
     - stage: test
       env: PARTITION=4 FILTER='acceptance' SPLIT=4 PARALLEL=false
     - stage: deploy staging
-      if: branch = master AND NOT type = pull_request
+      if: branch = master AND NOT type = pull_request AND NOT type = cron
       script: node_modules/.bin/ember deploy staging --activate
     - stage: deploy production
       if: tag IS present


### PR DESCRIPTION
Travis runs our tests daily, but if we try and deploy these builds then
there is an error since that version has already been deployed.