### PR TITLE
Limit scope of styles for new-offering

### DIFF
--- a/app/styles/newcomponents/new-offering.scss
+++ b/app/styles/newcomponents/new-offering.scss
@@ -1,7 +1,7 @@
 .new-offering {
   margin-top: 2em;
 
-  .title {
+  .new-offering-title {
     @include fill-parent;
     @include ilios-heading-h5;
     text-align: center;

--- a/app/templates/components/new-offering.hbs
+++ b/app/templates/components/new-offering.hbs
@@ -1,4 +1,4 @@
-<div class="title">{{t 'general.newOffering'}}</div>
+<div class="new-offering-title">{{t 'general.newOffering'}}</div>
 
 <div class='choose-offering-type'>
   {{click-choice-buttons

--- a/tests/integration/components/new-offering-test.js
+++ b/tests/integration/components/new-offering-test.js
@@ -24,5 +24,5 @@ test('it renders', function(assert) {
     close=(action nothing)
   }}`);
 
-  assert.equal(this.$('.title:eq(0)').text().trim(), 'New Offering');
+  assert.equal(this.$('.new-offering-title:eq(0)').text().trim(), 'New Offering');
 });


### PR DESCRIPTION
This .title class was getting applied to deeply and messing up the
offering calendar.

Fixes #3350