### PR TITLE
Reduce the parallelism in non-acceptance test job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
         - greenkeeper-lockfile-update
         - greenkeeper-lockfile-upload
     - stage: test
-      env: PARTITION=false FILTER='!acceptance' SPLIT=4 PARALLEL=true
+      env: PARTITION=false FILTER='!acceptance' SPLIT=2 PARALLEL=true
     - stage: test
       env: PARTITION=1 FILTER='acceptance' SPLIT=4 PARALLEL=false
     - stage: test


### PR DESCRIPTION
This job seems to fail often with a can't connect to testem error
message. I hope that reducing the number of splits helps with that.