### PR TITLE
Use new password-strengh async loading strategy

### DIFF
--- a/app/components/user-profile-bio.js
+++ b/app/components/user-profile-bio.js
@@ -6,7 +6,6 @@ import RSVP from 'rsvp';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 import { task, timeout } from 'ember-concurrency';
-import strength from 'password-strength';
 
 const { Promise } = RSVP;
 
@@ -82,6 +81,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   currentUser: service(),
   iliosConfig: service(),
   commonAjax: service(),
+  passwordStrength: service(),
 
   init(){
     this._super(...arguments);
@@ -273,9 +273,11 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     });
   }),
 
-  passwordStrength: computed('password', function () {
+  passwordStrengthScore: computed('password', async function () {
+    const passwordStrength = this.get('passwordStrength');
     const password = isEmpty(this.get('password'))?'':this.get('password');
-    return strength(password);
+    const obj = await passwordStrength.strength(password);
+    return obj.score;
   }),
 
   usernameMissing: computed('user.authentication', function(){

--- a/app/templates/components/user-profile-bio.hbs
+++ b/app/templates/components/user-profile-bio.hbs
@@ -171,20 +171,20 @@
         {{#if (and (v-get this 'password' 'isInvalid') (is-in showErrorsFor 'password'))}}
           <span class="message error">{{v-get this 'password' 'message'}}</span>
         {{else if (gt password.length 0)}}
-          <span class='password-strength {{concat "strength-" passwordStrength.score}}'>
-            {{#if (eq passwordStrength.score 0)}}
+          <span class='password-strength {{concat "strength-" (await passwordStrengthScore)}}'>
+            {{#if (eq (await passwordStrengthScore) 0)}}
               {{t 'general.tryHarder'}}
-            {{else if (eq passwordStrength.score 1)}}
+            {{else if (eq (await passwordStrengthScore) 1)}}
               {{t 'general.bad'}}
-            {{else if (eq passwordStrength.score 2)}}
+            {{else if (eq (await passwordStrengthScore) 2)}}
               {{t 'general.weak'}}
-            {{else if (eq passwordStrength.score 3)}}
+            {{else if (eq (await passwordStrengthScore) 3)}}
               {{t 'general.good'}}
-            {{else if (eq passwordStrength.score 4)}}
+            {{else if (eq (await passwordStrengthScore) 4)}}
               {{t 'general.strong'}}
             {{/if}}
           </span>
-          <meter max="4" value={{passwordStrength.score}}></meter>
+          <meter max="4" value={{await passwordStrengthScore}}></meter>
         {{/if}}
         <span class='cancel-password-field clickable link' onclick={{action 'cancelChangeUserPassword'}}>{{t 'general.cancel'}}</span>
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -23,6 +23,9 @@ module.exports = function(defaults) {
       includePolyfill: true,
       sourceMaps: isProductionLikeBuild?false:'inline'
     },
+    'ember-cli-password-strength': {
+      bundleZxcvbn: false
+    },
     'ember-cli-qunit': {
       useLintTree: false
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-cli-mirage": "0.1.14",
     "ember-cli-neat": "0.0.6",
     "ember-cli-page-object": "^1.11.0",
-    "ember-cli-password-strength": "1.1.0",
+    "ember-cli-password-strength": "2.0.0",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-sass": "7.0.0",
     "ember-cli-sass-lint": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3328,9 +3328,9 @@ ember-cli-page-object@^1.11.0:
     ember-test-helpers "^0.6.3"
     rsvp "^3.2.1"
 
-ember-cli-password-strength@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-password-strength/-/ember-cli-password-strength-1.1.0.tgz#fda9f922011a234c66ef347d32fcbc1c51b5d527"
+ember-cli-password-strength@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-password-strength/-/ember-cli-password-strength-2.0.0.tgz#f6f16d5c42ac16a4605305244f15f092f15224b3"
   dependencies:
     broccoli-funnel "^1.1.0"
     broccoli-merge-trees "^2.0.0"


### PR DESCRIPTION
This avoids us needing to include the 400kb Zxcvbn in our vendor.js file
and slims down our initial application load by 25%.