### PR TITLE
Get config from iliosConfig service

### DIFF
--- a/tests/unit/routes/login-test.js
+++ b/tests/unit/routes/login-test.js
@@ -1,7 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:login', 'Unit | Route | login ', {
-  needs: ['service:commonAjax', 'service:currentUser', 'service:iliosMetrics', 'service:headData', 'service:session'],
+  needs: ['service:commonAjax', 'service:currentUser', 'service:iliosConfig', 'service:iliosMetrics', 'service:headData', 'service:session'],
 });
 
 test('it exists', function(assert) {


### PR DESCRIPTION
Instead of pulling it directly from the URL we should get the login
configuration from the iliosConfig service. This prevents loading it
twice and avoids repeating ourselves.

Fixes #3347