### PR TITLE
Remove ember-cli-clipboard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-autoprefixer": "0.8.1",
     "ember-cli-babel": "^6.6.0",
-    "ember-cli-clipboard": "0.8.0",
     "ember-cli-code-coverage": "^0.4.1",
     "ember-cli-content-security-policy": "1.0.0",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2968,7 +2968,7 @@ ember-cli-broccoli-sane-watcher@^2.0.4:
     rsvp "^3.0.18"
     sane "^1.1.1"
 
-ember-cli-clipboard@0.8.0, ember-cli-clipboard@^0.8.0:
+ember-cli-clipboard@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/ember-cli-clipboard/-/ember-cli-clipboard-0.8.0.tgz#c2e91290b2746c1a4903097f5d7a55406de539b1"
   dependencies:


### PR DESCRIPTION
We inherit this from ilios-common and don't need to include it
ourselves.

Supersedes #3372