### PR TITLE
Use computed properties instead of tasks in learner group management

### DIFF
--- a/app/components/learnergroup-cohort-user-manager.js
+++ b/app/components/learnergroup-cohort-user-manager.js
@@ -16,8 +16,8 @@ export default Component.extend({
   classNames: ['learnergroup-cohort-user-manager'],
   sortBy: 'firstName',
   users: [],
-  usersBeingMoved: [],
-  selectedUsers: [],
+  usersBeingMoved: null,
+  selectedUsers: null,
   sortedAscending: computed('sortBy', function(){
     const sortBy = this.get('sortBy');
     return sortBy.search(/desc/) === -1;
@@ -60,8 +60,8 @@ export default Component.extend({
   }),
 
   setCheckAllState(){
-    const selectedUsers = this.get('selectedUsers').get('length');
-    const filteredUsers = this.get('filteredUsers').get('length');
+    const selectedUsers = this.get('selectedUsers.length');
+    const filteredUsers = this.get('filteredUsers.length');
     let el = this.$('th:eq(0) input');
     if (selectedUsers === 0) {
       el.prop('indeterminate', false);

--- a/app/templates/components/learnergroup-list.hbs
+++ b/app/templates/components/learnergroup-list.hbs
@@ -15,8 +15,8 @@
             {{learnerGroup.title}}
           {{/link-to}}
         </td>
-        <td class='text-center hide-from-small-screen'>{{learnerGroup.users.length}}</td>
-        <td class='text-center hide-from-small-screen'>{{learnerGroup.children.length}}</td>
+        <td class='text-center hide-from-small-screen'>{{has-many-length learnerGroup 'users'}}</td>
+        <td class='text-center hide-from-small-screen'>{{has-many-length learnerGroup 'children'}}</td>
         <td class='text-right'>
           {{#if (is-fulfilled learnerGroup.hasLearnersInGroupOrSubgroups)}}
             {{#if (await learnerGroup.hasLearnersInGroupOrSubgroups)}}

--- a/app/templates/components/learnergroup-summary.hbs
+++ b/app/templates/components/learnergroup-summary.hbs
@@ -2,19 +2,19 @@
 <section class='learnergroup-overview'>
   <div class='learnergroup-overview-actions'>
     {{#if isEditing}}
-      <button {{action (action toggleEditMode)}}>{{t 'general.close'}}</button>
+      <button {{action toggleEditMode}}>{{t 'general.close'}}</button>
     {{else}}
-      <button {{action (pipe (action toggleEditMode) (toggle 'showUserManagerLoader' this) (perform usersToPassToManager))}}>{{t 'general.manage'}}</button>
+      <button {{action toggleEditMode}}>{{t 'general.manage'}}</button>
     {{/if}}
   </div>
-  {{#unless showUserManagerLoader}}
+  {{#if (is-fulfilled usersToPassToManager)}}
     <div class='learnergroup-overview-content'>
       {{learnergroup-user-manager
         learnerGroupId=learnerGroupId
         learnerGroupTitle=learnerGroupTitle
         topLevelGroupTitle=topLevelGroupTitle
         cohortTitle=cohortTitle
-        users=usersToPassToManager.lastSuccessful.value
+        users=(await usersToPassToManager)
         sortBy=sortUsersBy
         setSortBy=setSortUsersBy
         isEditing=isEditing
@@ -26,7 +26,7 @@
     </div>
   {{else}}
     <h1 class='text-center'>{{fa-icon 'spinner' spin=true}}</h1>
-  {{/unless}}
+  {{/if}}
 
   <div class="block defaultlocation">
     <label>{{t 'general.defaultLocation'}}:</label>
@@ -95,9 +95,9 @@
 {{learnergroup-subgroup-list parentGroup=learnerGroup}}
 
 <section class='cohortmembers'>
-  {{#unless showCohortManagerLoader}}
+  {{#if (is-fulfilled usersToPassToCohortManager)}}
     {{learnergroup-cohort-user-manager
-      users=usersToPassToCohortManager.lastSuccessful.value
+      users=(await usersToPassToCohortManager)
       learnerGroupTitle=learnerGroupTitle
       topLevelGroupTitle=topLevelGroupTitle
       sortBy=sortUsersBy
@@ -107,7 +107,7 @@
     }}
   {{else}}
     <span class='cohortmembers-loading'>{{fa-icon 'spinner' spin=true}}</span>
-  {{/unless}}
+  {{/if}}
 </section>
 {{#liquid-if isSaving class='crossFade'}}
   {{wait-saving

--- a/tests/integration/components/learnergroup-subgroup-list-test.js
+++ b/tests/integration/components/learnergroup-subgroup-list-test.js
@@ -11,16 +11,26 @@ moduleForComponent('learnergroup-subgroup-list', 'Integration | Component | lear
   integration: true
 });
 
-test('it renders', function(assert) {
+test('it renders', function (assert) {
+  const hasMany = function (what) {
+    const self = this;
+    return {
+      ids() {
+        return self[what];
+      }
+    };
+  };
   let subGroup1 = {
     title: 'first',
     users: [1,2],
     children: [],
+    hasMany,
   };
   let subGroup2 = {
     title: 'second',
     users: [],
     children: [1,2],
+    hasMany,
   };
   let parentGroup = {
     children: resolve([subGroup1, subGroup2])


### PR DESCRIPTION
Tasks are great for managing some concurency, but they don't manage
keeping themselves up to date when changes are made as well as CPs do.
For displaying this learner group data CPs are the way to go.

Fixes #3374