### PR TITLE
Standalone is the preferred display for web apps

### DIFF
--- a/config/manifest.js
+++ b/config/manifest.js
@@ -11,7 +11,7 @@ module.exports = function (/* environment, appConfig */) {
     short_name: "Ilios",
     description: "Curriculum management for the health professions",
     start_url: "/dashboard",
-    display: "fullscreen",
+    display: "standalone",
     background_color: "#ffffff",
     theme_color: "#cc6600",
     icons: [


### PR DESCRIPTION
Fullscreen is apparently more useful for games.

This may resolve issues with navigating back to the home screen on some android devices.