### PR TITLE
Cleanup some Cruft

### DIFF
--- a/app/routes/course.js
+++ b/app/routes/course.js
@@ -3,8 +3,4 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 
 export default Route.extend(AuthenticatedRouteMixin, {
   titleToken: 'general.coursesAndSessions',
-  setupController(controller, model) {
-    controller.set('model', model);
-    this.controllerFor('course').set('showBackToCourseListLink', true);
-  }
 });

--- a/app/routes/session.js
+++ b/app/routes/session.js
@@ -1,29 +1,5 @@
-import { later } from '@ember/runloop';
-import { defer } from 'rsvp';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Route.extend(AuthenticatedRouteMixin, {
-  sessionTypes: [],
-  afterModel() {
-    var self = this;
-    var course = this.modelFor('course');
-    var deferred = defer();
-    later(deferred.resolve, function() {
-      var resolve = this;
-      course.get('school').then(function(school){
-        school.get('sessionTypes').then(function(sessionTypes){
-          self.set('sessionTypes', sessionTypes);
-          resolve();
-        });
-      });
-
-    }, 500);
-    return deferred.promise;
-  },
-  setupController(controller, model) {
-    controller.set('model', model);
-    controller.set('sessionTypes', this.get('sessionTypes'));
-    this.controllerFor('course').set('showBackToCourseListLink', false);
-  }
 });


### PR DESCRIPTION
The session afterModel hook was doing some weird promise stuff to grab
the session types which it turns out we are not actually even using anymore so I removed the
entire block.

We are no longer using showBackToCourseListLink anywhere to hide this
link so there is no reason to set it.