### PR TITLE
Add an Academic Year filter to course and session reports

### DIFF
--- a/app/components/dashboard-myreports.js
+++ b/app/components/dashboard-myreports.js
@@ -10,10 +10,12 @@ const { Promise, resolve } = RSVP;
 export default Component.extend({
   currentUser: service(),
   reporting: service(),
+  store: service(),
   tagName: 'div',
   classNames: ['dashboard-myreports'],
   myReportEditorOn: false,
   selectedReport: null,
+  selectedYear: null,
   user: null,
 
   didReceiveAttrs() {
@@ -38,12 +40,29 @@ export default Component.extend({
       });
     });
   }),
-  reportResultsList: computed('selectedReport', function(){
+  reportResultsList: computed('selectedReport', 'selectedYear', function(){
     const report = this.get('selectedReport');
+    const year = this.get('selectedYear');
     if(!report){
       return resolve([]);
     }
-    return this.get('reporting').getResults(report);
+    return this.get('reporting').getResults(report, year);
+  }),
+  allAcademicYears: computed(async function () {
+    const store = this.get('store');
+    const years = await store.findAll('academic-year');
+
+    return years;
+  }),
+  showAcademicYearFilter: computed('selectedReport', function(){
+    const report = this.get('selectedReport');
+    if(!report){
+      return false;
+    }
+    const subject = report.get('subject');
+    const prepositionalObject = report.get('prepositionalObject');
+
+    return prepositionalObject != 'course' && ['course', 'session'].includes(subject);
   }),
   actions: {
     toggleEditor() {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -16,6 +16,7 @@ export default {
     'administrators': 'Administrators',
     'advancedOptions': 'Advanced Options',
     'all': 'All',
+    'allAcademicYears': 'All Academic Years',
     'allCourses': 'All Courses',
     'allOtherMembers': 'All other members of {{topLevelGroupTitle}}',
     'allReports': 'All Reports',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -16,6 +16,7 @@
     'administrators': 'Administradores',
     'advancedOptions': 'Opciones Avanzadas',
     'all': 'Todos',
+    'allAcademicYears': 'Todos Los Años Académicos',
     'allCourses': 'Todos Los Cursos',
     'allOtherMembers': 'Todos otros miembros de {{topLevelGroupTitle}}',
     'allReports': 'todos reportes',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -16,6 +16,7 @@ export default {
     'administrators': 'Administrateurs',
     'advancedOptions': 'Options avancées',
     'all': "Tous",
+    'allAcademicYears': 'Toutes Années Scolaires',
     'allCourses': "Tous les Cours",
     'allOtherMembers': 'Tous les autres membres du {{topLevelGroupTitle}}',
     'allReports': "Tous Rapports",

--- a/app/services/reporting.js
+++ b/app/services/reporting.js
@@ -127,7 +127,7 @@ export default Service.extend({
       return rhett;
     });
 
-    return mappedResults.filter(obj => isEmpty(year) || parseInt(obj.course.get('year')) === parseInt(year));
+    return mappedResults.filter(obj => isEmpty(year) || parseInt(obj.course.get('year'), 10) === parseInt(year), 10);
   },
   async sessionsResults(results, year){
     const canView = await this.get('canViewCourses');
@@ -144,7 +144,7 @@ export default Service.extend({
       return rhett;
     });
 
-    return mappedResults.filter(obj => isEmpty(year) || parseInt(obj.course.get('year')) === parseInt(year));
+    return mappedResults.filter(obj => isEmpty(year) || parseInt(obj.course.get('year'), 10) === parseInt(year), 10);
   },
   async programsResults(results){
     const canView = await this.get('canViewPrograms');

--- a/app/styles/newcomponents/dashboard-myreports.scss
+++ b/app/styles/newcomponents/dashboard-myreports.scss
@@ -1,6 +1,10 @@
 .dashboard-myreports {
   @include dashboard-block;
 
+  h3 {
+    margin: 0;
+  }
+
   .form-title {
     color: $ilios-orange;
     font-weight: bold;
@@ -31,5 +35,12 @@
     border: $header-grey 2px solid;
     margin: 10px;
     padding: 10px;
+  }
+
+  .years-filter {
+    margin: .5em 0 1em;
+    padding-right: .5em;
+    text-align: right;
+    width: 100%;
   }
 }

--- a/app/templates/components/dashboard-myreports.hbs
+++ b/app/templates/components/dashboard-myreports.hbs
@@ -11,11 +11,24 @@
   </div>
 
   {{#liquid-if selectedReport class='crossFade'}}
-    <div class='dashboard-block-body'>
-      <h3>{{report-title selectedReport}}</h3>
+    <div class='dashboard-block-body' data-test-selected-report>
+      <h3 data-test-report-title>{{report-title selectedReport}}</h3>
+
+      {{#if showAcademicYearFilter}}
+        <div class="years-filter">
+          <select onchange={{action (mut selectedYear) value="target.value"}} data-test-year-filter>
+            <option value='' selected={{is-empty selectedYear}}>{{t 'general.allAcademicYears'}}</option>
+            {{#each (sort-by 'academicYearTitle:desc' (await allAcademicYears)) as |year|}}
+              <option value={{year.id}} selected={{is-equal year selectedYear}}>
+                {{year.academicYearTitle}}
+              </option>
+            {{/each}}
+          </select>
+        </div>
+      {{/if}}
       {{#if (is-fulfilled reportResultsList)}}
         {{#if (get (await reportResultsList) 'length')}}
-          <ul>
+          <ul data-test-results>
             {{#each (await reportResultsList) as |item|}}
               {{#if item.model2}}
                 <li>
@@ -50,7 +63,7 @@
       {{#if (is-fulfilled sortedReports)}}
         {{#if (get (await sortedReports) 'length')}}
           <table>
-            <tbody>
+            <tbody data-test-saved-reports>
               {{#each (await sortedReports) as |report|}}
                 <tr>
                   <td colspan=4>

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -1,21 +1,23 @@
-{{common-dashboard
-  show=show
-  setShow=(action (mut show))
-  selectedDate=selectedDate
-  selectedView=selectedView
-  mySchedule=mySchedule
-  showFilters=showFilters
-  changeDate=(action 'changeDate')
-  changeView=(action (mut view))
-  selectEvent=(action 'selectEvent')
-  toggleMySchedule=(action 'toggleMySchedule')
-  toggleShowFilters=(action 'toggleShowFilters')
-  selectedAcademicYear=selectedAcademicYear
-  selectedSchool=selectedSchool
-  changeAcademicYear=(action (mut academicYear))
-  changeSchool=(action (mut school))
-  courseFilters=courseFilters
-  toggleCourseFilters=(action (toggle 'courseFilters' this))
-}}
-{{dashboard-myreports}}
-{{dashboard-mycourses}}
+<div data-test-dashboard>
+  {{common-dashboard
+    show=show
+    setShow=(action (mut show))
+    selectedDate=selectedDate
+    selectedView=selectedView
+    mySchedule=mySchedule
+    showFilters=showFilters
+    changeDate=(action 'changeDate')
+    changeView=(action (mut view))
+    selectEvent=(action 'selectEvent')
+    toggleMySchedule=(action 'toggleMySchedule')
+    toggleShowFilters=(action 'toggleShowFilters')
+    selectedAcademicYear=selectedAcademicYear
+    selectedSchool=selectedSchool
+    changeAcademicYear=(action (mut academicYear))
+    changeSchool=(action (mut school))
+    courseFilters=courseFilters
+    toggleCourseFilters=(action (toggle 'courseFilters' this))
+  }}
+  {{dashboard-myreports data-test-myreports}}
+  {{dashboard-mycourses}}
+</div>

--- a/mirage/factories/report.js
+++ b/mirage/factories/report.js
@@ -1,0 +1,7 @@
+import { Factory } from 'ember-cli-mirage';
+import moment from 'moment';
+
+export default Factory.extend({
+  title: (i) => `my report ${i}`,
+  createdAt: () => moment().format(),
+});

--- a/mirage/helpers/get-all.js
+++ b/mirage/helpers/get-all.js
@@ -106,6 +106,11 @@ const filterByFilterParams = function(all, filterParams){
           if(obj[param].id.toString() !== value.toString()){
             match = false;
           }
+        } else if (obj[param] instanceof Collection) {
+          let result = obj[param].filter(model => {
+            return model.id.toString() === value.toString();
+          });
+          match = result.length > 0;
         } else
         //convert everything to a string and do a strict comparison
         if(obj[param].toString() !== value.toString()){

--- a/tests/acceptance/dashboard/reports-test.js
+++ b/tests/acceptance/dashboard/reports-test.js
@@ -1,0 +1,112 @@
+import destroyApp from '../../helpers/destroy-app';
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from 'ilios/tests/helpers/start-app';
+import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+import page from 'ilios/tests/pages/dashboard';
+
+var application;
+
+module('Acceptance: Dashboard Reports', {
+  beforeEach: function() {
+    application = startApp();
+    const school = server.create('school');
+    const user = setupAuthentication(application, { id: 4136, schoolId: 1 });
+    const vocabulary = server.create('vocabulary');
+    const term = server.create('term', { vocabulary });
+    server.create('academic-year', {
+      id: 2015
+    });
+    server.create('academic-year', {
+      id: 2016
+    });
+    const firstCourse = server.create('course', {
+      school,
+      year: 2015,
+    });
+    server.create('session', {
+      course: firstCourse,
+      terms: [term],
+    });
+    const secondCourse = server.create('course', {
+      school,
+      year: 2016,
+    });
+    server.create('session', {
+      course: secondCourse,
+      terms: [term],
+    });
+    server.create('report', {
+      subject: 'session',
+      prepositionalObject: 'course',
+      prepositionalObjectTableRowId: firstCourse.id,
+      user,
+      school,
+    });
+    server.create('report', {
+      title: null,
+      subject: 'session',
+      prepositionalObject: 'term',
+      prepositionalObjectTableRowId: term.id,
+      user,
+      school,
+    });
+  },
+
+  afterEach: function() {
+    destroyApp(application);
+  }
+});
+
+test('visiting /dashboard', async function(assert) {
+  await page.visit();
+  assert.equal(currentPath(), 'dashboard');
+});
+
+test('shows reports', async function(assert) {
+  await page.visit();
+  assert.equal(page.myReports.reports().count, 2);
+  assert.equal(page.myReports.reports(0).title, 'All Sessions for term 0 in school 0');
+  assert.equal(page.myReports.reports(1).title, 'my report 0');
+});
+
+test('first report works', async function(assert) {
+  await page.visit();
+  assert.equal(page.myReports.reports().count, 2);
+  await page.myReports.reports(1).select();
+  assert.equal(page.myReports.selectedReport.title, 'my report 0');
+  assert.equal(page.myReports.selectedReport.results().count, 1);
+  assert.equal(page.myReports.selectedReport.results(0).text, '2015 - 2016 course 0 session 0');
+});
+
+test('no year filter on reports with a course prepositional object', async function(assert) {
+  await page.visit();
+  assert.equal(page.myReports.reports().count, 2);
+  await page.myReports.reports(1).select();
+  assert.equal(page.myReports.selectedReport.title, 'my report 0');
+  assert.notOk(page.myReports.selectedReport.yearsFilterExists);
+});
+
+test('second report works', async function (assert) {
+  await page.visit();
+  assert.equal(page.myReports.reports().count, 2);
+  await page.myReports.reports(0).select();
+  assert.equal(page.myReports.selectedReport.title, 'All Sessions for term 0 in school 0');
+  assert.equal(page.myReports.selectedReport.results().count, 2);
+  assert.equal(page.myReports.selectedReport.results(0).text, '2015 - 2016 course 0 session 0');
+  assert.equal(page.myReports.selectedReport.results(1).text, '2016 - 2017 course 1 session 1');
+});
+
+test('year filter works', async function (assert) {
+  await page.visit();
+  assert.equal(page.myReports.reports().count, 2);
+  await page.myReports.reports(0).select();
+  assert.equal(page.myReports.selectedReport.title, 'All Sessions for term 0 in school 0');
+  assert.ok(page.myReports.selectedReport.yearsFilterExists);
+  assert.equal(page.myReports.selectedReport.results().count, 2);
+  await page.myReports.selectedReport.chooseYear('2016 - 2017');
+  assert.equal(page.myReports.selectedReport.results().count, 1);
+  assert.equal(page.myReports.selectedReport.results(0).text, '2016 - 2017 course 1 session 1');
+});

--- a/tests/pages/dashboard.js
+++ b/tests/pages/dashboard.js
@@ -1,0 +1,37 @@
+import {
+  clickable,
+  create,
+  collection,
+  isPresent,
+  text,
+  visitable
+} from 'ember-cli-page-object';
+
+import selectable from '../helpers/selectable';
+
+export default create({
+  scope: '[data-test-dashboard]',
+  visit: visitable('/dashboard'),
+  myReports: {
+    scope: '[data-test-myreports]',
+    reports: collection({
+      itemScope: '[data-test-saved-reports] tr',
+      item: {
+        title: text('td:eq(0)'),
+        select: clickable('.clickable', { scope: 'td:eq(0)' })
+      },
+    }),
+    selectedReport: {
+      scope: '[data-test-selected-report]',
+      title: text('[data-test-report-title]'),
+      yearsFilterExists: isPresent('[data-test-year-filter]'),
+      chooseYear: selectable('[data-test-year-filter]'),
+      results: collection({
+        itemScope: '[data-test-results] li',
+        item: {
+          title: text(),
+        },
+      }),
+    },
+  },
+});


### PR DESCRIPTION
This allows a user to limit the displayed results to only a specific year.

Refs #1520

WIP:
- [x] Needs translation for `'allAcademicYears': 'All Academic Years',`.