### PR TITLE
Enable Order Rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
     'ember/no-capital-letters-in-routes': 0,
     'ember/routes-segments-snake-case': 0,
     'ember/avoid-leaking-state-in-components': 0,
-    'ember/order-in-components': 0,
+    'ember/order-in-components': 2,
     'ember/order-in-controllers': 0,
     'ember/order-in-routes': 0,
     'ember/use-brace-expansion': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,7 @@ module.exports = {
     'ember/avoid-leaking-state-in-components': 0,
     'ember/order-in-components': 2,
     'ember/order-in-controllers': 2,
-    'ember/order-in-routes': 0,
+    'ember/order-in-routes': 2,
     'ember/use-brace-expansion': 0,
     'generator-star-spacing': 0,
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
     'ember/routes-segments-snake-case': 0,
     'ember/avoid-leaking-state-in-components': 0,
     'ember/order-in-components': 2,
-    'ember/order-in-controllers': 0,
+    'ember/order-in-controllers': 2,
     'ember/order-in-routes': 0,
     'ember/use-brace-expansion': 0,
     'generator-star-spacing': 0,

--- a/app/components/action-menu.js
+++ b/app/components/action-menu.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import DropdownComponentMixin from 'ember-rl-dropdown/mixins/rl-dropdown-component';
 

--- a/app/components/api-version-check.js
+++ b/app/components/api-version-check.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/assign-students.js
+++ b/app/components/assign-students.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/boolean-check.js
+++ b/app/components/boolean-check.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/bulk-new-users.js
+++ b/app/components/bulk-new-users.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/click-choice-buttons.js
+++ b/app/components/click-choice-buttons.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/collapsed-competencies.js
+++ b/app/components/collapsed-competencies.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import RSVP from 'rsvp';

--- a/app/components/collapsed-learnergroups.js
+++ b/app/components/collapsed-learnergroups.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import RSVP from 'rsvp';
 import { task, timeout } from 'ember-concurrency';

--- a/app/components/collapsed-objectives.js
+++ b/app/components/collapsed-objectives.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 

--- a/app/components/collapsed-stewards.js
+++ b/app/components/collapsed-stewards.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import RSVP from 'rsvp';
 import { isEmpty, isPresent } from '@ember/utils';

--- a/app/components/collapsed-taxonomies.js
+++ b/app/components/collapsed-taxonomies.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/competency-title-editor.js
+++ b/app/components/competency-title-editor.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import RSVP from 'rsvp';
 import { isPresent } from '@ember/utils';

--- a/app/components/connection-status.js
+++ b/app/components/connection-status.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import DomMixin from 'ember-lifeline/mixins/dom';
 import { task, timeout } from 'ember-concurrency';

--- a/app/components/course-director-manager.js
+++ b/app/components/course-director-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { task, timeout } from 'ember-concurrency';
 

--- a/app/components/course-editing.js
+++ b/app/components/course-editing.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 const { not } = computed;

--- a/app/components/course-header.js
+++ b/app/components/course-header.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import RSVP from 'rsvp';

--- a/app/components/course-loading.js
+++ b/app/components/course-loading.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/course-materials.js
+++ b/app/components/course-materials.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import RSVP from 'rsvp';
 import EmberObject, { computed } from '@ember/object';

--- a/app/components/course-objective-list-item.js
+++ b/app/components/course-objective-list-item.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import ObjectiveListItem from 'ilios/mixins/objective-list-item';
 

--- a/app/components/course-objective-list.js
+++ b/app/components/course-objective-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import SortableObjectiveList from 'ilios/mixins/sortable-objective-list';

--- a/app/components/course-objective-manager.js
+++ b/app/components/course-objective-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { isEmpty } from '@ember/utils';

--- a/app/components/course-overview.js
+++ b/app/components/course-overview.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import EmberObject, { computed } from '@ember/object';

--- a/app/components/course-publicationcheck.js
+++ b/app/components/course-publicationcheck.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/course-rollover.js
+++ b/app/components/course-rollover.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/course-sessions.js
+++ b/app/components/course-sessions.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/course-summary-header.js
+++ b/app/components/course-summary-header.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/curriculum-inventory-report-details.js
+++ b/app/components/curriculum-inventory-report-details.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/curriculum-inventory-report-header.js
+++ b/app/components/curriculum-inventory-report-header.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Ember from 'ember';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';

--- a/app/components/curriculum-inventory-report-list.js
+++ b/app/components/curriculum-inventory-report-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import ObjectProxy from '@ember/object/proxy';

--- a/app/components/curriculum-inventory-report-overview.js
+++ b/app/components/curriculum-inventory-report-overview.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/curriculum-inventory-report-rollover.js
+++ b/app/components/curriculum-inventory-report-rollover.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import EmberObject, { computed } from '@ember/object';

--- a/app/components/curriculum-inventory-sequence-block-dates-duration-editor.js
+++ b/app/components/curriculum-inventory-sequence-block-dates-duration-editor.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { validator, buildValidations } from 'ember-cp-validations';

--- a/app/components/curriculum-inventory-sequence-block-details.js
+++ b/app/components/curriculum-inventory-sequence-block-details.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/curriculum-inventory-sequence-block-header.js
+++ b/app/components/curriculum-inventory-sequence-block-header.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/curriculum-inventory-sequence-block-list.js
+++ b/app/components/curriculum-inventory-sequence-block-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import RSVP from 'rsvp';

--- a/app/components/curriculum-inventory-sequence-block-min-max-editor.js
+++ b/app/components/curriculum-inventory-sequence-block-min-max-editor.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { validator, buildValidations } from 'ember-cp-validations';

--- a/app/components/curriculum-inventory-sequence-block-overview.js
+++ b/app/components/curriculum-inventory-sequence-block-overview.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/curriculum-inventory-sequence-block-session-list.js
+++ b/app/components/curriculum-inventory-sequence-block-session-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { task } from 'ember-concurrency';

--- a/app/components/curriculum-inventory-sequence-block-session-manager.js
+++ b/app/components/curriculum-inventory-sequence-block-session-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/dashboard-loading.js
+++ b/app/components/dashboard-loading.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/dashboard-mycourses.js
+++ b/app/components/dashboard-mycourses.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/dashboard-myreports.js
+++ b/app/components/dashboard-myreports.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import Component from '@ember/component';

--- a/app/components/detail-cohort-list.js
+++ b/app/components/detail-cohort-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import EmberObject, { computed } from '@ember/object';

--- a/app/components/detail-cohort-manager.js
+++ b/app/components/detail-cohort-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/detail-cohorts.js
+++ b/app/components/detail-cohorts.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import RSVP from 'rsvp';
 

--- a/app/components/detail-competencies.js
+++ b/app/components/detail-competencies.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import RSVP from 'rsvp';

--- a/app/components/detail-instructors-list.js
+++ b/app/components/detail-instructors-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 const { sort } = computed;

--- a/app/components/detail-instructors.js
+++ b/app/components/detail-instructors.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/detail-learnergroups-list.js
+++ b/app/components/detail-learnergroups-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import EmberObject, { computed } from '@ember/object';
 import RSVP from 'rsvp';

--- a/app/components/detail-learnergroups.js
+++ b/app/components/detail-learnergroups.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';

--- a/app/components/detail-learning-materials.js
+++ b/app/components/detail-learning-materials.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import Component from '@ember/component';

--- a/app/components/detail-mesh.js
+++ b/app/components/detail-mesh.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { oneWay, sort } from '@ember/object/computed';
 import { all } from 'rsvp';
 import { inject as service } from '@ember/service';

--- a/app/components/detail-objectives.js
+++ b/app/components/detail-objectives.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/detail-steward-manager.js
+++ b/app/components/detail-steward-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/detail-stewards.js
+++ b/app/components/detail-stewards.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/detail-taxonomies.js
+++ b/app/components/detail-taxonomies.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/detail-terms-list-item.js
+++ b/app/components/detail-terms-list-item.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/detail-terms-list.js
+++ b/app/components/detail-terms-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';

--- a/app/components/editable-field.js
+++ b/app/components/editable-field.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';

--- a/app/components/error-display.js
+++ b/app/components/error-display.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isPresent } from '@ember/utils';

--- a/app/components/expand-collapse-button.js
+++ b/app/components/expand-collapse-button.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/file-upload.js
+++ b/app/components/file-upload.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';

--- a/app/components/html-editor.js
+++ b/app/components/html-editor.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import $ from 'jquery';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';

--- a/app/components/ilios-course-details.js
+++ b/app/components/ilios-course-details.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import scrollTo from '../utils/scroll-to';
 

--- a/app/components/ilios-course-list.js
+++ b/app/components/ilios-course-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import RSVP from 'rsvp';

--- a/app/components/ilios-header.js
+++ b/app/components/ilios-header.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/ilios-navigation.js
+++ b/app/components/ilios-navigation.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/ilios-users.js
+++ b/app/components/ilios-users.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/instructor-selection-manager.js
+++ b/app/components/instructor-selection-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { translationMacro as t } from "ember-i18n";

--- a/app/components/instructorgroup-details.js
+++ b/app/components/instructorgroup-details.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/instructorgroup-header.js
+++ b/app/components/instructorgroup-header.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/instructorgroup-list.js
+++ b/app/components/instructorgroup-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import ObjectProxy from '@ember/object/proxy';

--- a/app/components/leadership-collapsed.js
+++ b/app/components/leadership-collapsed.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/leadership-list.js
+++ b/app/components/leadership-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/leadership-manager.js
+++ b/app/components/leadership-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/leadership-search.js
+++ b/app/components/leadership-search.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/learnergroup-cohort-user-manager.js
+++ b/app/components/learnergroup-cohort-user-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';

--- a/app/components/learnergroup-editor.js
+++ b/app/components/learnergroup-editor.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/learnergroup-header.js
+++ b/app/components/learnergroup-header.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 import { validator, buildValidations } from 'ember-cp-validations';

--- a/app/components/learnergroup-instructor-manager.js
+++ b/app/components/learnergroup-instructor-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { isPresent } from '@ember/utils';
 import { computed } from '@ember/object';

--- a/app/components/learnergroup-list.js
+++ b/app/components/learnergroup-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/learnergroup-selection-manager.js
+++ b/app/components/learnergroup-selection-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/learnergroup-subgroup-list.js
+++ b/app/components/learnergroup-subgroup-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/learnergroup-summary.js
+++ b/app/components/learnergroup-summary.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import RSVP from 'rsvp';
 import { isPresent } from '@ember/utils';

--- a/app/components/learnergroup-tree.js
+++ b/app/components/learnergroup-tree.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import RSVP from 'rsvp';

--- a/app/components/learnergroup-user-manager.js
+++ b/app/components/learnergroup-user-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';

--- a/app/components/learning-material-table-actions.js
+++ b/app/components/learning-material-table-actions.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/learning-material-table-mesh.js
+++ b/app/components/learning-material-table-mesh.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/learning-material-table-notes.js
+++ b/app/components/learning-material-table-notes.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/learning-material-table-status.js
+++ b/app/components/learning-material-table-status.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/learning-material-table-title.js
+++ b/app/components/learning-material-table-title.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/learning-material-table.js
+++ b/app/components/learning-material-table.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import Table from 'ember-light-table';

--- a/app/components/learning-materials-sort-manager.js
+++ b/app/components/learning-materials-sort-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import SortableByPosition from 'ilios-common/mixins/sortable-by-position';
 import { task } from 'ember-concurrency';

--- a/app/components/learningmaterial-manager.js
+++ b/app/components/learningmaterial-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/learningmaterial-search.js
+++ b/app/components/learningmaterial-search.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import $ from 'jquery';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';

--- a/app/components/loading-bar.js
+++ b/app/components/loading-bar.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';

--- a/app/components/loading-part.js
+++ b/app/components/loading-part.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import layout from '../templates/components/loading-part';
 

--- a/app/components/manage-users-summary.js
+++ b/app/components/manage-users-summary.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { isBlank } from '@ember/utils';

--- a/app/components/mesh-manager.js
+++ b/app/components/mesh-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import ObjectProxy from '@ember/object/proxy';
 import Component from '@ember/component';

--- a/app/components/my-materials.js
+++ b/app/components/my-materials.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isPresent } from '@ember/utils';

--- a/app/components/my-profile.js
+++ b/app/components/my-profile.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/myreports-list-item.js
+++ b/app/components/myreports-list-item.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import ReportTitleMixin from 'ilios/mixins/report-title';
 import { task } from 'ember-concurrency';

--- a/app/components/new-competency.js
+++ b/app/components/new-competency.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';

--- a/app/components/new-course.js
+++ b/app/components/new-course.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { isPresent } from '@ember/utils';

--- a/app/components/new-curriculum-inventory-report.js
+++ b/app/components/new-curriculum-inventory-report.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import EmberObject from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';

--- a/app/components/new-curriculum-inventory-sequence-block.js
+++ b/app/components/new-curriculum-inventory-sequence-block.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { isPresent } from '@ember/utils';

--- a/app/components/new-directory-user.js
+++ b/app/components/new-directory-user.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/new-instructorgroup.js
+++ b/app/components/new-instructorgroup.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { validator, buildValidations } from 'ember-cp-validations';

--- a/app/components/new-learnergroup-multiple.js
+++ b/app/components/new-learnergroup-multiple.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';

--- a/app/components/new-learnergroup-single.js
+++ b/app/components/new-learnergroup-single.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';

--- a/app/components/new-learnergroup.js
+++ b/app/components/new-learnergroup.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/new-learningmaterial.js
+++ b/app/components/new-learningmaterial.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { set, computed } from '@ember/object';

--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/new-objective.js
+++ b/app/components/new-objective.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';

--- a/app/components/new-offering.js
+++ b/app/components/new-offering.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 

--- a/app/components/new-program.js
+++ b/app/components/new-program.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { validator, buildValidations } from 'ember-cp-validations';

--- a/app/components/new-programyear.js
+++ b/app/components/new-programyear.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { isEmpty } from '@ember/utils';
 import { task } from 'ember-concurrency';

--- a/app/components/new-session.js
+++ b/app/components/new-session.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import Component from '@ember/component';

--- a/app/components/new-user.js
+++ b/app/components/new-user.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { validator, buildValidations } from 'ember-cp-validations';
 import NewUser from 'ilios/mixins/newuser';

--- a/app/components/not-found.js
+++ b/app/components/not-found.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/objective-manage-competency.js
+++ b/app/components/objective-manage-competency.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import RSVP from 'rsvp';
 import { computed } from '@ember/object';

--- a/app/components/objective-manage-descriptors.js
+++ b/app/components/objective-manage-descriptors.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import layout from '../templates/components/objective-manage-descriptors';

--- a/app/components/objective-sort-manager.js
+++ b/app/components/objective-sort-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import SortableByPosition from 'ilios-common/mixins/sortable-by-position';
 import { task } from 'ember-concurrency';

--- a/app/components/offering-block.js
+++ b/app/components/offering-block.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import layout from '../templates/components/offering-block';
 

--- a/app/components/offering-calendar.js
+++ b/app/components/offering-calendar.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import RSVP from 'rsvp';

--- a/app/components/offering-editor-learnergroups.js
+++ b/app/components/offering-editor-learnergroups.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isPresent, isEmpty } from '@ember/utils';

--- a/app/components/offering-form.js
+++ b/app/components/offering-form.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/offering-manager.js
+++ b/app/components/offering-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/pagedlist-controls.js
+++ b/app/components/pagedlist-controls.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 const { lte } = computed;

--- a/app/components/pending-single-user-update.js
+++ b/app/components/pending-single-user-update.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import RSVP from 'rsvp';

--- a/app/components/pending-updates-summary.js
+++ b/app/components/pending-updates-summary.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/pre-fill.js
+++ b/app/components/pre-fill.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 

--- a/app/components/print-course.js
+++ b/app/components/print-course.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { sort } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';

--- a/app/components/program-details.js
+++ b/app/components/program-details.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/program-header.js
+++ b/app/components/program-header.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import RSVP from 'rsvp';

--- a/app/components/program-list.js
+++ b/app/components/program-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import ObjectProxy from '@ember/object/proxy';

--- a/app/components/program-overview.js
+++ b/app/components/program-overview.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import EmberObject, { computed } from '@ember/object';
 import RSVP from 'rsvp';

--- a/app/components/programyear-competencies.js
+++ b/app/components/programyear-competencies.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import RSVP from 'rsvp';
 import { computed } from '@ember/object';

--- a/app/components/programyear-details.js
+++ b/app/components/programyear-details.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/programyear-header.js
+++ b/app/components/programyear-header.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import Publishable from 'ilios/mixins/publishable';

--- a/app/components/programyear-list.js
+++ b/app/components/programyear-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/programyear-objective-list-item.js
+++ b/app/components/programyear-objective-list-item.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import ObjectiListItem from 'ilios/mixins/objective-list-item';
 

--- a/app/components/programyear-objective-list.js
+++ b/app/components/programyear-objective-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import SortableObjectiveList from 'ilios/mixins/sortable-objective-list';

--- a/app/components/programyear-overview.js
+++ b/app/components/programyear-overview.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 const { filterBy, sort, not } = computed;

--- a/app/components/progress-bar.js
+++ b/app/components/progress-bar.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/string';

--- a/app/components/publication-status.js
+++ b/app/components/publication-status.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 const { alias } = computed;

--- a/app/components/publish-all-sessions.js
+++ b/app/components/publish-all-sessions.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/publish-menu.js
+++ b/app/components/publish-menu.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/recently-updated-display.js
+++ b/app/components/recently-updated-display.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';

--- a/app/components/removeable-row.js
+++ b/app/components/removeable-row.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Row from 'ember-light-table/components/lt-row';
 
 export default Row.extend({

--- a/app/components/school-competencies-collapsed.js
+++ b/app/components/school-competencies-collapsed.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 

--- a/app/components/school-competencies-expanded.js
+++ b/app/components/school-competencies-expanded.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/school-competencies-list.js
+++ b/app/components/school-competencies-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/school-competencies-manager.js
+++ b/app/components/school-competencies-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';

--- a/app/components/school-leadership-expanded.js
+++ b/app/components/school-leadership-expanded.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';

--- a/app/components/school-list.js
+++ b/app/components/school-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { sort } from '@ember/object/computed';

--- a/app/components/school-manager.js
+++ b/app/components/school-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/school-session-attributes-collapsed.js
+++ b/app/components/school-session-attributes-collapsed.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/school-session-attributes-expanded.js
+++ b/app/components/school-session-attributes-expanded.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import EmberObject from '@ember/object';
 import { isEmpty } from '@ember/utils';

--- a/app/components/school-session-attributes-manager.js
+++ b/app/components/school-session-attributes-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/school-session-attributes.js
+++ b/app/components/school-session-attributes.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/school-session-type-form.js
+++ b/app/components/school-session-type-form.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import Component from '@ember/component';

--- a/app/components/school-session-type-manager.js
+++ b/app/components/school-session-type-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import EmberObject, { computed } from '@ember/object';

--- a/app/components/school-session-types-collapsed.js
+++ b/app/components/school-session-types-collapsed.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 

--- a/app/components/school-session-types-expanded.js
+++ b/app/components/school-session-types-expanded.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/school-session-types-list.js
+++ b/app/components/school-session-types-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { timeout, task } from 'ember-concurrency';
 

--- a/app/components/school-vocabularies-collapsed.js
+++ b/app/components/school-vocabularies-collapsed.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/school-vocabularies-expanded.js
+++ b/app/components/school-vocabularies-expanded.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/school-vocabularies-list.js
+++ b/app/components/school-vocabularies-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/school-vocabulary-manager.js
+++ b/app/components/school-vocabulary-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/school-vocabulary-term-manager.js
+++ b/app/components/school-vocabulary-term-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/search-box.js
+++ b/app/components/search-box.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { isPresent } from '@ember/utils';
 import { task, timeout } from 'ember-concurrency';

--- a/app/components/selectable-search-result.js
+++ b/app/components/selectable-search-result.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { A } from '@ember/array';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/selectable-terms-list-item.js
+++ b/app/components/selectable-terms-list-item.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 

--- a/app/components/selectable-terms-list.js
+++ b/app/components/selectable-terms-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/separated-list.js
+++ b/app/components/separated-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/session-copy.js
+++ b/app/components/session-copy.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/session-details.js
+++ b/app/components/session-details.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import scrollTo from '../utils/scroll-to';

--- a/app/components/session-objective-list-item.js
+++ b/app/components/session-objective-list-item.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import ObjectiListItem from 'ilios/mixins/objective-list-item';
 

--- a/app/components/session-objective-list.js
+++ b/app/components/session-objective-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import SortableObjectiveList from 'ilios/mixins/sortable-objective-list';

--- a/app/components/session-objective-manager.js
+++ b/app/components/session-objective-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import ObjectProxy from '@ember/object/proxy';

--- a/app/components/session-offerings-list.js
+++ b/app/components/session-offerings-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/session-offerings.js
+++ b/app/components/session-offerings.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/session-overview.js
+++ b/app/components/session-overview.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/session-publicationcheck.js
+++ b/app/components/session-publicationcheck.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/session-table-actions.js
+++ b/app/components/session-table-actions.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/session-table-expand.js
+++ b/app/components/session-table-expand.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/session-table-first-offering.js
+++ b/app/components/session-table-first-offering.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/session-table-status.js
+++ b/app/components/session-table-status.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/session-table-title.js
+++ b/app/components/session-table-title.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/session-table.js
+++ b/app/components/session-table.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';

--- a/app/components/sortable-th.js
+++ b/app/components/sortable-th.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 

--- a/app/components/taxonomy-manager.js
+++ b/app/components/taxonomy-manager.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/time-picker.js
+++ b/app/components/time-picker.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import moment from 'moment';
 import momentFormat from 'ember-moment/computeds/format';

--- a/app/components/toggle-mycourses.js
+++ b/app/components/toggle-mycourses.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import layout from '../templates/components/toggle-mycourses';
 

--- a/app/components/toggle-onoff.js
+++ b/app/components/toggle-onoff.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/toggle-yesno.js
+++ b/app/components/toggle-yesno.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/unassigned-students-summary.js
+++ b/app/components/unassigned-students-summary.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { gt } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';

--- a/app/components/update-notification.js
+++ b/app/components/update-notification.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/user-list.js
+++ b/app/components/user-list.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/components/user-profile-bio.js
+++ b/app/components/user-profile-bio.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/user-profile-calendar.js
+++ b/app/components/user-profile-calendar.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';

--- a/app/components/user-profile-cohorts.js
+++ b/app/components/user-profile-cohorts.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/user-profile-ics.js
+++ b/app/components/user-profile-ics.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { isEmpty, isPresent } from '@ember/utils';

--- a/app/components/user-profile-learnergroups.js
+++ b/app/components/user-profile-learnergroups.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import RSVP from 'rsvp';
 import EmberObject, { computed } from '@ember/object';

--- a/app/components/user-profile-roles.js
+++ b/app/components/user-profile-roles.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/user-profile-schools.js
+++ b/app/components/user-profile-schools.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import RSVP from 'rsvp';

--- a/app/components/user-profile.js
+++ b/app/components/user-profile.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 

--- a/app/components/user-search.js
+++ b/app/components/user-search.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import ObjectProxy from '@ember/object/proxy';
 import Component from '@ember/component';

--- a/app/components/visualizer-course-objectives.js
+++ b/app/components/visualizer-course-objectives.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import RSVP from 'rsvp';
 import { computed } from '@ember/object';

--- a/app/components/wait-saving.js
+++ b/app/components/wait-saving.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 

--- a/app/components/yesno-table-cell.js
+++ b/app/components/yesno-table-cell.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-controllers: 0 */
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-controllers: 0 */
 /* eslint ember/avoid-leaking-state-in-ember-objects: 0 */
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';

--- a/app/controllers/curriculum-inventory-reports.js
+++ b/app/controllers/curriculum-inventory-reports.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-controllers: 0 */
 /* eslint ember/avoid-leaking-state-in-ember-objects: 0 */
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';

--- a/app/controllers/instructor-groups.js
+++ b/app/controllers/instructor-groups.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-controllers: 0 */
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import Controller from '@ember/controller';

--- a/app/controllers/learner-groups.js
+++ b/app/controllers/learner-groups.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-controllers: 0 */
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import Controller from '@ember/controller';

--- a/app/controllers/pending-user-updates.js
+++ b/app/controllers/pending-user-updates.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-controllers: 0 */
 /* eslint ember/avoid-leaking-state-in-ember-objects: 0 */
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';

--- a/app/controllers/programs.js
+++ b/app/controllers/programs.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-controllers: 0 */
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-routes: 0 */
 import Ember from 'ember';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';

--- a/app/routes/assign-students.js
+++ b/app/routes/assign-students.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-routes: 0 */
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';

--- a/app/routes/course/index.js
+++ b/app/routes/course/index.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-routes: 0 */
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';

--- a/app/routes/courses.js
+++ b/app/routes/courses.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-routes: 0 */
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';

--- a/app/routes/instructor-groups.js
+++ b/app/routes/instructor-groups.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-routes: 0 */
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';

--- a/app/routes/learner-groups.js
+++ b/app/routes/learner-groups.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-routes: 0 */
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-routes: 0 */
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { isPresent } from '@ember/utils';

--- a/app/routes/pending-user-updates.js
+++ b/app/routes/pending-user-updates.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-routes: 0 */
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 

--- a/app/routes/programs.js
+++ b/app/routes/programs.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-routes: 0 */
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';

--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -1,3 +1,4 @@
+/* eslint ember/order-in-routes: 0 */
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 

--- a/tests/integration/components/course-summary-header-test.js
+++ b/tests/integration/components/course-summary-header-test.js
@@ -54,8 +54,8 @@ test('it renders', function(assert) {
 
 test('no link to materials when that is the current route', function(assert) {
   let routerMock = Service.extend({
-    generateURL(){},
     currentRouteName: 'course-materials',
+    generateURL(){},
   });
   this.register('service:-routing', routerMock);
 
@@ -77,8 +77,8 @@ test('no link to materials when that is the current route', function(assert) {
 
 test('no link to rollover when that is the current route', function(assert) {
   let routerMock = Service.extend({
-    generateURL(){},
     currentRouteName: 'course.rollover',
+    generateURL(){},
   });
   this.register('service:-routing', routerMock);
 


### PR DESCRIPTION
Enabled three rules that enforce consistent property ordering in ember component, controller, and route objects. Fixing these all at once seemed like a big job so instead I added an exclude comment to each file so we can fix these as we edit the file or when we have some time, but still enforce the rules on all new files.