### PR TITLE
Fix Mesh Search

### DIFF
--- a/app/components/mesh-manager.js
+++ b/app/components/mesh-manager.js
@@ -2,12 +2,17 @@ import { inject as service } from '@ember/service';
 import ObjectProxy from '@ember/object/proxy';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { isEmpty } from '@ember/utils';
 import { task } from 'ember-concurrency';
 import layout from '../templates/components/mesh-manager';
 
-var ProxiedDescriptors = ObjectProxy.extend({
+const ProxiedDescriptors = ObjectProxy.extend({
   terms: null,
-  isActive: computed('content', 'terms.[]', function(){
+  isActive: computed('content', 'terms.[]', function () {
+    const terms = this.get('terms');
+    if (isEmpty(terms)) {
+      return true;
+    }
     return !this.get('terms').includes(this.get('content'));
   })
 });
@@ -20,6 +25,7 @@ export default Component.extend({
     this.set('searchResults', []);
     this.set('sortTerms', ['name']);
   },
+  'data-test-mesh-manager': true,
   layout: layout,
   classNames: ['detail-block', 'mesh-manager'],
   terms: null,

--- a/app/components/search-box.js
+++ b/app/components/search-box.js
@@ -8,6 +8,7 @@ export default Component.extend({
   classNames: ['search-box'],
   value: '',
   liveSearch: true,
+  'data-test-search-box': true,
   searchTask: task(function * () {
     yield timeout(DEBOUNCE_TIMEOUT);
     const value = this.get('value');

--- a/app/templates/components/mesh-manager.hbs
+++ b/app/templates/components/mesh-manager.hbs
@@ -32,10 +32,10 @@
 {{else}}
   {{#if searchResults.length}}
     <div class='selectable-list'>
-      <ul class='mesh-search-results'>
+      <ul class='mesh-search-results' data-test-search-results>
         {{#each searchResults as |term|}}
           <li class="{{unless term.isActive 'disabled'}}" {{action 'add' term}}>
-            <span class="descriptor-name">{{term.name}}</span>
+            <span class="descriptor-name" data-test-name>{{term.name}}</span>
             <span class="descriptor-id">
               {{term.id}}
               {{#if term.trees }}

--- a/tests/acceptance/dashboard/reports-test.js
+++ b/tests/acceptance/dashboard/reports-test.js
@@ -174,3 +174,31 @@ test('filter session by year in new report form', async function (assert) {
   assert.equal(page.myReports.selectedReport.results().count, 1);
   assert.equal(page.myReports.selectedReport.results(0).text, 'Vocabulary 1 > term 0');
 });
+
+test('get all courses associated with mesh term #3419', async function (assert) {
+  server.create('mesh-descriptor', {
+    id: 'D1234',
+    courseIds: [1, 2]
+  });
+  await page.visit();
+  assert.equal(page.myReports.reports().count, 2);
+  await page.myReports.addNewReport();
+
+  await page.myReports.newReport.chooseSchool('school 0');
+  await page.myReports.newReport.chooseSubject('Courses');
+  await page.myReports.newReport.chooseObjectType('MeSH Term');
+  await page.myReports.newReport.fillMeshSearch('0');
+  await page.myReports.newReport.runMeshSearch();
+  assert.equal(page.myReports.newReport.meshSearchResults().count, 1);
+  assert.equal(page.myReports.newReport.meshSearchResults(0).text, 'descriptor 0 D1234');
+  await page.myReports.newReport.meshSearchResults(0).pick();
+  await page.myReports.newReport.save();
+
+  assert.equal(page.myReports.reports().count, 3);
+  await page.myReports.reports(1).select();
+
+  assert.equal(page.myReports.selectedReport.title, 'All Courses for descriptor 0 in school 0');
+  assert.equal(page.myReports.selectedReport.results().count, 2);
+  assert.equal(page.myReports.selectedReport.results(0).text, '2015 - 2016 course 0');
+  assert.equal(page.myReports.selectedReport.results(1).text, '2016 - 2017 course 1');
+});

--- a/tests/pages/dashboard.js
+++ b/tests/pages/dashboard.js
@@ -45,6 +45,15 @@ export default create({
       chooseObject: selectable('[data-test-report-object]'),
       objectCount: count('[data-test-report-object] option'),
       chooseAcademicYear: selectable('[data-test-report-year-filter]'),
+      fillMeshSearch: fillable('[data-test-mesh-manager] [data-test-search-box] input'),
+      runMeshSearch: clickable('[data-test-mesh-manager] [data-test-search-box] .search-icon'),
+      meshSearchResults: collection({
+        itemScope: '[data-test-search-results] li',
+        item: {
+          name: text('[data-test-name]'),
+          pick: clickable()
+        },
+      }),
       save: clickable('[data-test-report-save]'),
     }
   },


### PR DESCRIPTION
Mesh search was broken when no terms were provided as it was expecting
an array. (broken in #3395 [4a5fa1e3509932a0ed6917583ee136d7eb885b64]).

Fixes #3419