### PR TITLE
Select correct default when a year is selected

### DIFF
--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -323,6 +323,14 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     this.set('schoolChanged', true);
   }),
 
+  resetCurrentPrepositionalObjectId: task(function* () {
+    const list = yield this.get('filteredPrepositionalObjectIdList');
+    const first = list.get('firstObject');
+    if(first){
+      this.set('currentPrepositionalObjectId', first.value);
+    }
+  }).restartable(),
+
   actions: {
     changeSubject(subject){
       this.set('currentSubject', subject);
@@ -332,14 +340,12 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     changePrepositionalObject(object){
       this.set('currentPrepositionalObject', object);
       this.set('currentPrepositionalObjectId', null);
-      this.get('prepositionalObjectIdList').then(list => {
-        if(!this.get('currentPrepositionalObjectId')){
-          let first = list.get('firstObject');
-          if(first){
-            this.set('currentPrepositionalObjectId', first.value);
-          }
-        }
-      });
+      this.get('resetCurrentPrepositionalObjectId').perform();
+    },
+    changeSelectedYear(year){
+      this.set('selectedYear', year);
+      this.set('currentPrepositionalObjectId', null);
+      this.get('resetCurrentPrepositionalObjectId').perform();
     },
     changePrepositionalObjectId(id){
       this.set('currentPrepositionalObjectId', id);

--- a/app/templates/components/new-myreport.hbs
+++ b/app/templates/components/new-myreport.hbs
@@ -55,7 +55,7 @@
   </p>
   {{#liquid-if currentPrepositionalObject class='crossFade'}}
     {{#if (contains currentPrepositionalObject (w 'course session'))}}
-      <select onchange={{action (mut selectedYear) value="target.value"}} data-test-report-year-filter>
+      <select onchange={{action 'changeSelectedYear' value="target.value"}} data-test-report-year-filter>
         <option value='' selected={{is-empty selectedYear}}>{{t 'general.allAcademicYears'}}</option>
         {{#each (sort-by 'academicYearTitle:desc' (await allAcademicYears)) as |year|}}
           <option value={{year.id}} selected={{is-equal year selectedYear}}>

--- a/tests/acceptance/dashboard/reports-test.js
+++ b/tests/acceptance/dashboard/reports-test.js
@@ -202,3 +202,44 @@ test('get all courses associated with mesh term #3419', async function (assert) 
   assert.equal(page.myReports.selectedReport.results(0).text, '2015 - 2016 course 0');
   assert.equal(page.myReports.selectedReport.results(1).text, '2016 - 2017 course 1');
 });
+
+test('Prepositional object resets when a new type is selected', async function (assert) {
+  server.create('course', {
+    year: '2016',
+    schoolId: 1
+  });
+  await page.visit();
+  assert.equal(page.myReports.reports().count, 2);
+  await page.myReports.addNewReport();
+
+  await page.myReports.newReport.chooseSchool('school 0');
+  await page.myReports.newReport.chooseSubject('Terms');
+  await page.myReports.newReport.chooseObjectType('Session');
+  await page.myReports.newReport.chooseObject('session 1');
+  await page.myReports.newReport.chooseObjectType('Course');
+  await page.myReports.newReport.save();
+
+  assert.equal(page.myReports.reports().count, 3);
+  await page.myReports.reports(1).select();
+  assert.equal(page.myReports.selectedReport.title, 'All Terms for course 0 in school 0');
+});
+
+test('Report Selector with Academic Year not selecting correct predicate #3427', async function (assert) {
+  server.create('course', {
+    year: '2016',
+    schoolId: 1
+  });
+  await page.visit();
+  assert.equal(page.myReports.reports().count, 2);
+  await page.myReports.addNewReport();
+
+  await page.myReports.newReport.chooseSchool('school 0');
+  await page.myReports.newReport.chooseSubject('Terms');
+  await page.myReports.newReport.chooseObjectType('Course');
+  await page.myReports.newReport.chooseAcademicYear('2016 - 2017');
+  await page.myReports.newReport.save();
+
+  assert.equal(page.myReports.reports().count, 3);
+  await page.myReports.reports(1).select();
+  assert.equal(page.myReports.selectedReport.title, 'All Terms for course 1 in school 0');
+});


### PR DESCRIPTION
We needed to reset the selected object id anytime the year was changed,
otherwise if a selection wasn't made from the dropdown the wrong default
would be used instead.

Fixes #3427