### PR TITLE
Test for learner group cohort members

### DIFF
--- a/app/components/learnergroup-summary.js
+++ b/app/components/learnergroup-summary.js
@@ -121,7 +121,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
       return await learnerGroup.get('usersOnlyAtThisLevel');
     }
   }),
-  usersToPassToCohortManager: computed('learnerGroup.{topLevelGroup,allDescendantUsers.[]}', 'cohort.users.[]', async function () {
+  usersToPassToCohortManager: computed('learnerGroup.topLevelGroup', 'learnerGroup.allDescendantUsers.[]', async function () {
     const learnerGroup = this.get('learnerGroup');
     const cohort = await learnerGroup.get('cohort');
     const topLevelGroup = await learnerGroup.get('topLevelGroup');

--- a/app/routes/learner-group.js
+++ b/app/routes/learner-group.js
@@ -11,7 +11,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
     return all([
       model.get('usersOnlyAtThisLevel'),
       model.get('allInstructors'),
-      model.get('courses'),
       model.get('allParents'),
       model.get('courses'),
     ]);

--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -243,3 +243,44 @@ test('copy learnergroup with learners', async function(assert) {
   assert.equal(getElementText(find(secondSubgroupMembers)), getText('3'));
   assert.equal(getElementText(find(secondSubgroupSubgroups)), getText('0'));
 });
+
+
+test('Cohort members not in learner group appear after navigating to learner group #3428', async function (assert) {
+  const groups = '.list tbody tr';
+  const firstGroup = `${groups}:eq(0)`;
+  const firstTitle = `${firstGroup} td:eq(0)`;
+  const firstLink = `${firstTitle} a`;
+  const members = '.learnergroup-overview-content table:eq(1) tbody tr';
+  const cohortMembers = `.cohortmembers tbody tr`;
+  assert.expect(5);
+  server.create('school');
+  server.create('program', {
+    schoolId: 1,
+  });
+  server.create('programYear', {
+    programId: 1
+  });
+  const cohort = server.create('cohort', {
+    programYearId: 1,
+  });
+  const learnerGroup = server.create('learnerGroup', {
+    cohort
+  });
+  server.createList('user', 5, {
+    cohorts: [cohort],
+    primaryCohort: cohort
+  });
+  server.createList('user', 5, {
+    cohorts: [cohort],
+    primaryCohort: cohort,
+    learnerGroups: [learnerGroup]
+  });
+
+  await visit('/learnergroups');
+  assert.equal(1, find(groups).length);
+  assert.equal(getElementText(find(firstTitle)), getText('learnergroup 0'));
+  await click(firstLink);
+  assert.equal(currentURL(), '/learnergroups/1');
+  assert.equal(find(members).length, 5, 'lists members');
+  assert.equal(find(cohortMembers).length, 5, 'lists cohort non members');
+});


### PR DESCRIPTION
Couple tiny fixes and a test that checks to ensure that all the
non-members of a group that are in the cohort are listed.

This doesn't actually fix #3428 it just adds a test for it.

Requires ilios/common#128