### PR TITLE
Add 48 and 96 pixel icons for android

### DIFF
--- a/config/manifest.js
+++ b/config/manifest.js
@@ -22,12 +22,12 @@ module.exports = function (/* environment, appConfig */) {
         type: "image/png",
         targets: ['favicon'],
       })),
-      {
-        src: "/assets/icons/sunburst-white-background192.png",
-        sizes: "192x192",
+      ...[48, 96, 192].map(size => ({
+        src: `/assets/icons/sunburst-white-background${size}.png`,
+        sizes: `${size}x${size}`,
         type: "image/png",
         targets: ['manifest'],
-      },
+      })),
       {
         src: "/assets/icons/sunburst-transparent512.png",
         sizes: "512x512",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -31,7 +31,7 @@ module.exports = function(defaults) {
           inputFilename: 'lib/images/sunburst.svg',
           outputFileName: 'sunburst-white-background',
           convertTo: 'png',
-          sizes: [180, 192],
+          sizes: [48, 96, 180, 192],
         },
         {
           inputFilename: 'lib/images/sunburst.svg',


### PR DESCRIPTION
The transparent favicon is currently being used since we aren't
providing a small enough icon for the android launcher.