### PR TITLE
Remove animations between routes

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -22,6 +22,6 @@
   {{#if showErrorDisplay}}
     {{error-display errors=errors clearErrors=(action 'clearErrors')}}
   {{else}}
-    {{liquid-outlet}}
+    {{outlet}}
   {{/if}}
 </div>

--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -12,4 +12,4 @@
   setCourseTaxonomyDetails=(action (mut courseTaxonomyDetails))
   setCourseCompetencyDetails=(action (mut courseCompetencyDetails))
 }}
-{{liquid-outlet}}
+{{outlet}}

--- a/app/templates/program.hbs
+++ b/app/templates/program.hbs
@@ -2,4 +2,4 @@
 {{program-details
   program=model
 }}
-{{liquid-outlet class='horizontal'}}
+{{outlet}}

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -22,24 +22,4 @@ export default function(){
     this.toValue(true),
     this.use('crossFade', {duration: getDuration(1000)})
   );
-  this.transition(
-    this.toRoute(function(){
-      var topRoutes = [];
-      topRoutes.push('dashboard');
-      topRoutes.push('courses');
-      topRoutes.push('learnerGroups');
-      topRoutes.push('learnerGroup');
-      topRoutes.push('instructorGroups');
-      topRoutes.push('instructorGroup');
-      topRoutes.push('programs');
-      return topRoutes.includes(this);
-    }),
-    this.use('crossFade', {duration: getDuration(500)})
-  );
-  this.transition(
-    this.fromRoute('course.index', 'session.index'),
-    this.toRoute('session.index', 'session.publicationCheck'),
-    this.use('toLeft', {duration: getDuration(1000)}),
-    this.reverse('toRight', {duration: getDuration(1000)})
-  );
 }


### PR DESCRIPTION
These have not been working for a while due to our loading states and
some route restructuring. They break other stuff so let's get rid of
them.