### PR TITLE
Simplify rendering of learner groups in offering form

### DIFF
--- a/app/components/learnergroup-selection-manager.js
+++ b/app/components/learnergroup-selection-manager.js
@@ -1,37 +1,11 @@
 /* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { computed } from '@ember/object';
-import RSVP from 'rsvp';
-const { Promise, all } = RSVP;
 
 export default Component.extend({
   i18n: service(),
-  init(){
-    this._super(...arguments);
-    this.set('sortBy', ['title']);
-  },
   classNames: ['learnergroup-selection-manager'],
   filter: '',
-  sortBy: null,
   cohorts: null,
   learnerGroups: null,
-  allLearnerGroups: computed('cohorts.[]', function(){
-    return new Promise(resolve => {
-      let cohorts = this.get('cohorts');
-      all(cohorts.mapBy('rootLevelLearnerGroups')).then(allLearnerGroups => {
-        let flat = allLearnerGroups.reduce((flattened, arr) => {
-          return flattened.pushObjects(arr);
-        }, []);
-
-        resolve(flat);
-      });
-    });
-
-  }),
-  actions: {
-    compareCohorts(cohort1, cohort2){
-      return cohort1.get('id') === cohort2.get('id');
-    }
-  }
 });

--- a/app/components/offering-manager.js
+++ b/app/components/offering-manager.js
@@ -6,7 +6,6 @@ import { isEmpty } from '@ember/utils';
 import RSVP from 'rsvp';
 const { Promise } = RSVP;
 
-
 export default Component.extend({
   currentUser: service(),
   classNames: ['offering-manager'],

--- a/app/templates/components/learnergroup-selection-manager.hbs
+++ b/app/templates/components/learnergroup-selection-manager.hbs
@@ -13,22 +13,19 @@
     {{t 'general.availableLearnerGroups'}}
     {{#unless (and (is-fulfilled allLearnerGroups) (is-fulfilled cohorts))}}{{fa-icon 'spinner' spin=true}}{{/unless}}
   </h4>
-  {{#if (and (is-fulfilled allLearnerGroups) (is-fulfilled cohorts))}}
-    {{search-box search=(action (mut filter)) placeholder=(t 'general.filterPlaceholder')}}
-    {{#each (sort-by 'title' (await cohorts)) as |cohort|}}
-      <div class='cohort-learner-groups'>
-        {{#if (and (is-fulfilled cohort.programYear) (is-fulfilled cohort.programYear.program))}}
-          <h5 class='cohort-title'>{{cohort.programYear.program.title}} {{cohort.title}}</h5>
-          <ul class='tree-groups-list'>
-            {{#each (sort-by 'title' (filter-by 'cohort' (await (action 'compareCohorts' cohort)) (await allLearnerGroups))) as |learnerGroup|}}
-              {{learnergroup-tree learnerGroup=learnerGroup selectedGroups=learnerGroups filter=filter add=(action add)}}
-            {{/each}}
-          </ul>
-        {{else}}
-          {{fa-icon 'spinner' spin=true}}
-        {{/if}}
-      </div>
-    {{/each}}
-  {{/if}}
-
+  {{search-box search=(action (mut filter)) placeholder=(t 'general.filterPlaceholder')}}
+  {{#each (sort-by 'title' (await cohorts)) as |cohort|}}
+    <div class='cohort-learner-groups'>
+      {{#if (and (is-fulfilled cohort.programYear) (is-fulfilled cohort.programYear.program) (is-fulfilled cohort.rootLevelLearnerGroups))}}
+        <h5 class='cohort-title'>{{cohort.programYear.program.title}} {{cohort.title}}</h5>
+        <ul class='tree-groups-list'>
+          {{#each (sort-by 'title' (await cohort.rootLevelLearnerGroups)) as |learnerGroup|}}
+            {{learnergroup-tree learnerGroup=learnerGroup selectedGroups=learnerGroups filter=filter add=(action add)}}
+          {{/each}}
+        </ul>
+      {{else}}
+        {{fa-icon 'spinner' spin=true}}
+      {{/if}}
+    </div>
+  {{/each}}
 </div>

--- a/app/templates/components/offering-manager.hbs
+++ b/app/templates/components/offering-manager.hbs
@@ -1,4 +1,4 @@
-{{#liquid-if (and isEditing (is-fulfilled offering.session.course.cohorts)) class='horizontal'}}
+{{#if (and isEditing (is-fulfilled offering.session.course.cohorts)) class='horizontal'}}
   {{offering-form
     showRoom=true
     showInstructors=true
@@ -61,4 +61,4 @@
   </div>
 
 
-{{/liquid-if}}
+{{/if}}


### PR DESCRIPTION
We're bumping up against an infinite rendering limit in ember that is
alleviated by simplifying this data and the template.

Fixes #2850 and unblocks updating ember-concurrency.

There is already a test in place for this issue, but offering management, specifically learner group selection, should be click tested.