### PR TITLE
Report on materials for the entire course

### DIFF
--- a/app/services/reporting.js
+++ b/app/services/reporting.js
@@ -87,6 +87,9 @@ export default Service.extend({
           what = 'instructed' + what.capitalize();
         }
       }
+      if(subject === 'learning material' && object === 'course'){
+        what = 'fullCourses';
+      }
       query.filters[what] = objectId;
     } else {
       if(subject !== 'mesh term' && subject !== 'instructor' && subject !== 'learning material' && school){

--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v1.26';
+module.exports = 'v1.27';


### PR DESCRIPTION
Take advantage of the new API filter for learningMaterials to get all of
the materials attached to a course or any of its sessions.

Fixes #2445