### PR TITLE
Immediately load new worker if there is an API update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   global:
     # See https://git.io/vdao3 for details.
     - JOBS=1
+    - SW_DISABLED=true
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/app/components/api-version-check.js
+++ b/app/components/api-version-check.js
@@ -1,22 +1,29 @@
 /* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import RSVP from 'rsvp';
-import { computed } from '@ember/object';
 import ENV from 'ilios/config/environment';
-
-const { Promise } = RSVP;
+import serviceWorkerHasUpdate from 'ilios/utils/service-worker-has-update';
 
 const { apiVersion } = ENV.APP;
 
 export default Component.extend({
   iliosConfig: service(),
-  versionMismatch: computed('iliosConfig.apiVersion', function(){
+  versionMismatch: false,
+
+  didInsertElement() {
+    this.loadAttributes();
+  },
+  async loadAttributes() {
     const iliosConfig = this.get('iliosConfig');
-    return new Promise(resolve => {
-      iliosConfig.get('apiVersion').then(serverApiVersion => {
-        resolve(serverApiVersion !== apiVersion);
-      });
-    });
-  }),
+    const serverApiVersion = await iliosConfig.get('apiVersion');
+    const versionMismatch = serverApiVersion !== apiVersion;
+    if (versionMismatch && 'serviceWorker' in navigator) {
+      const hasUpdate = await serviceWorkerHasUpdate();
+      if (hasUpdate) {
+        const reg = await navigator.serviceWorker.getRegistration();
+        reg.waiting.postMessage('skipWaiting');
+      }
+    }
+    this.set('versionMismatch', versionMismatch);
+  },
 });

--- a/app/templates/components/api-version-check.hbs
+++ b/app/templates/components/api-version-check.hbs
@@ -1,4 +1,4 @@
-{{#if (await versionMismatch)}}
+{{#if versionMismatch}}
   {{#modal-dialog
     alignmentTarget='body'
     attachment='middle center'

--- a/tests/integration/components/api-version-check-test.js
+++ b/tests/integration/components/api-version-check-test.js
@@ -5,6 +5,7 @@ import $ from 'jquery';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import ENV from 'ilios/config/environment';
+import wait from 'ember-test-helpers/wait';
 
 const { apiVersion } = ENV.APP;
 
@@ -14,24 +15,24 @@ moduleForComponent('api-version-check', 'Integration | Component | api version c
   integration: true
 });
 
-test('shows no warning when versions match', function(assert) {
+test('shows no warning when versions match', async function(assert) {
   const iliosConfigMock = Service.extend({
     apiVersion: resolve(apiVersion)
   });
   const warningOverlay = '.api-version-check-warning';
   this.register('service:iliosConfig', iliosConfigMock);
   this.render(hbs`{{api-version-check}}`);
+  await wait();
   assert.equal($(warningOverlay).length, 0);
-
 });
 
-test('shows warning on mismatch', function(assert) {
+test('shows warning on mismatch', async function(assert) {
   const iliosConfigMock = Service.extend({
     apiVersion: resolve('bad')
   });
   const warningOverlay = '.api-version-check-warning';
   this.register('service:iliosConfig', iliosConfigMock);
   this.render(hbs`{{api-version-check}}`);
+  await wait();
   assert.equal($(warningOverlay).length, 1);
-
 });


### PR DESCRIPTION
The user should not need to take any action in this case. We should
immediately load any new workers that are waiting.