### PR TITLE
Run tests without ember-exam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 install:
   - yarn install --non-interactive
 
-script: ember exam --split=$SPLIT --partition=$PARTITION --filter=$FILTER --parallel=$PARALLEL
+script: yarn test --filter=$FILTER
 
 jobs:
   include:
@@ -34,15 +34,9 @@ jobs:
         - greenkeeper-lockfile-update
         - greenkeeper-lockfile-upload
     - stage: test
-      env: PARTITION=false FILTER='!acceptance' SPLIT=2 PARALLEL=true
+      env: FILTER='!acceptance'
     - stage: test
-      env: PARTITION=1 FILTER='acceptance' SPLIT=4 PARALLEL=false
-    - stage: test
-      env: PARTITION=2 FILTER='acceptance' SPLIT=4 PARALLEL=false
-    - stage: test
-      env: PARTITION=3 FILTER='acceptance' SPLIT=4 PARALLEL=false
-    - stage: test
-      env: PARTITION=4 FILTER='acceptance' SPLIT=4 PARALLEL=false
+      env: FILTER='acceptance'
     - stage: deploy staging
       if: branch = master AND NOT type = pull_request AND NOT type = cron
       script: node_modules/.bin/ember deploy staging --activate

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "ember-d3": "0.3.3",
     "ember-data": "2.17.0",
     "ember-drag-drop": "0.4.7",
-    "ember-exam": "1.0.0",
     "ember-export-application-global": "^2.0.0",
     "ember-font-awesome": "^3.0.5",
     "ember-froala-editor": "2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3718,17 +3718,6 @@ ember-element-resize-detector@0.1.5:
     ember-cli-babel "^5.1.6"
     ember-cli-htmlbars "^1.0.3"
 
-ember-exam@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ember-exam/-/ember-exam-1.0.0.tgz#dd750ea407c05b01e74ee27ba42edb58585ae06b"
-  dependencies:
-    chalk "^2.1.0"
-    cli-table2 "^0.2.0"
-    debug "^3.1.0"
-    ember-cli-babel "^6.3.0"
-    fs-extra "^4.0.2"
-    rimraf "^2.6.2"
-
 ember-export-application-global@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"
@@ -5075,7 +5064,7 @@ fs-extra@^3.0.1:
     jsonfile "^3.0.0"
     universalify "^0.1.0"
 
-fs-extra@^4.0.0, fs-extra@^4.0.1, fs-extra@^4.0.2:
+fs-extra@^4.0.0, fs-extra@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   dependencies:
@@ -7969,7 +7958,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
Ember exam seems to be running our tests at least twice. Maybe more.
Switching it off may yield some actual improvements in test time.