### PR TITLE
Add a calendar to learner groups

### DIFF
--- a/app/components/learnergroup-calendar.js
+++ b/app/components/learnergroup-calendar.js
@@ -1,0 +1,58 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import RSVP from 'rsvp';
+import moment from 'moment';
+const { map } = RSVP;
+
+export default Component.extend({
+  classNames: ['learnergroup-calendar'],
+
+  learnerGroup: null,
+  selectedDate: null,
+
+  calendarEvents: computed('learnerGroup.offerings.[]', async function () {
+    const learnerGroup = this.get('learnerGroup');
+    if (!learnerGroup) {
+      return [];
+    }
+    const offerings = await learnerGroup.get('offerings');
+    const events = await map(offerings.toArray(), async offering => {
+      const session = await offering.get('session');
+      const course = await session.get('course');
+      return {
+        startDate: offering.get('startDate'),
+        endDate: offering.get('endDate'),
+        courseTitle: course.get('title'),
+        name: session.get('title'),
+        offering: offering.get("id"),
+        location: offering.get("location"),
+        color: "#84c444"
+      };
+    });
+
+    return events;
+  }),
+
+  init() {
+    this._super(...arguments);
+    const today = moment();
+    this.set('selectedDate', today.toDate());
+  },
+
+  actions: {
+    goForward(){
+      const selectedDate = this.get('selectedDate');
+      let newDate = moment(selectedDate).add(1, 'week').toDate();
+      this.set('selectedDate', newDate);
+    },
+    goBack(){
+      const selectedDate = this.get('selectedDate');
+      let newDate = moment(selectedDate).subtract(1, 'week').toDate();
+      this.set('selectedDate', newDate);
+    },
+    gotoToday(){
+      let newDate = moment().toDate();
+      this.set('selectedDate', newDate);
+    },
+  }
+});

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -467,6 +467,7 @@ export default {
     'showMore': 'Show more',
     'showNotesToStudents': 'Show Notes to Students',
     'showSessionEvents': 'Show all other <em>{{sessionTitle}}</em> events',
+    'showSubgroupEvents': 'Show events for all subgroups',
     'singleDay': 'Single Day',
     'singleGroup': 'Single Group',
     'smallGroupMessage': "Please select at least one learner group to attach to your small group offering. If you wish to schedule this offering without groups, please select the 'offering' button above.",

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -467,6 +467,7 @@
     'showMore': 'Mostrar más',
     'showNotesToStudents': 'Mostrar Notas a Los Estudiantes',
     'showSessionEvents': 'Mostrar todos los <em>{{sessionTitle}}</em> eventos',
+    'showSubgroupEvents': 'Mostrar eventos para todos los grupos subordinados',
     'singleDay': 'Un Solo Día',
     'singleGroup': 'Solo grupo',
     'smallGroupMessage': "Por favor seleccione al menos un grupo de alumnos para adjuntar a su ofrecimiento de grupos pequeños. Si usted desea programar este ofrecimiento sin grupos, favor de seleccionar el botón de 'ofrecimiento' de arriba.",

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -467,6 +467,7 @@ export default {
     'showMore': "Afficher plus",
     'showNotesToStudents': "Afficher notes aux étudiantes",
     'showSessionEvents': 'Montrez tous les autres <em>{{sessionTitle}}</em> événements',
+    'showSubgroupEvents': 'Afficher les événements pour tous les sous-groupes',
     'singleDay': "Seule Journée",
     'singleGroup': 'Seul groupe',
     'smallGroupMessage': "S'il vous plaît choisir au moins un groupe d'apprenants à joindre à votre offrande de 'small groups'. Si vous souhaitez programmer cette offrande sans groupes, s'il vous plaît choisir le bouton 'offre' au-dessus.",

--- a/app/styles/newcomponents.scss
+++ b/app/styles/newcomponents.scss
@@ -52,6 +52,7 @@
 @import 'newcomponents/leadership-collapsed';
 @import 'newcomponents/leadership-manager';
 @import 'newcomponents/leadership-search';
+@import 'newcomponents/learnergroup-calendar';
 @import 'newcomponents/learnergroup-cohort-user-manager';
 @import 'newcomponents/learnergroup-header';
 @import 'newcomponents/learnergroup-selection-manager';

--- a/app/styles/newcomponents/learnergroup-calendar.scss
+++ b/app/styles/newcomponents/learnergroup-calendar.scss
@@ -1,0 +1,33 @@
+.learnergroup-calendar {
+  @include fill-parent;
+  @include omega;
+  border: 1px solid $black;
+  border-radius: 5px;
+  box-sizing: border-box;
+  clear: both;
+  margin-bottom: 1em;
+  min-height: 5em;
+  padding: .25em 2em .75em;
+  position: relative;
+
+  h2 {
+    @include ilios-heading;
+    font-size: 1.25 * $base-font-size;
+    margin-bottom: 1em;
+    text-align: center;
+    width: 100%;
+  }
+
+  .loding-indicator {
+    @include ilios-heading-h1;
+    left: 4em;
+    opacity: 75;
+    position: absolute;
+    top: 5em;
+    transition: all .5s ease-in-out;
+
+    &.loaded {
+      opacity: 0;
+    }
+  }
+}

--- a/app/templates/components/learnergroup-calendar.hbs
+++ b/app/templates/components/learnergroup-calendar.hbs
@@ -1,0 +1,15 @@
+<ul class='inline learnergroup-calendar-time-picker'>
+  <li class='clickable' {{action 'goBack'}}>{{fa-icon 'backward'}}</li>
+  <li class='clickable' {{action 'gotoToday'}}>{{t 'general.today'}}</li>
+  <li class='clickable' {{action 'goForward'}}>{{fa-icon 'forward'}}</li>
+</ul>
+
+<div class='ilios-calendar'>
+  {{ilios-calendar-week
+    calendarEvents=(await calendarEvents)
+    date=selectedDate
+    areEventsSelectable=false
+    areDaysSelectable=false
+  }}
+</div>
+<span class="loding-indicator {{if (is-fulfilled calendarEvents) 'loaded'}}">{{fa-icon 'spinner' spin=true}} {{t 'general.loadingEvents'}}...</span>

--- a/app/templates/components/learnergroup-calendar.hbs
+++ b/app/templates/components/learnergroup-calendar.hbs
@@ -1,3 +1,9 @@
+<p class='learnergroup-calendar-filter-options'>
+  <span class='filter' data-test-learnergroup-calendar-toggle-subgroup-events>
+    {{toggle-yesno yes=showSubgroupEvents toggle=(action (mut showSubgroupEvents))}}
+    <label onclick={{toggle 'showSubgroupEvents' this}}>{{t 'general.showSubgroupEvents'}}</label>
+  </span>
+</p>
 <ul class='inline learnergroup-calendar-time-picker'>
   <li class='clickable' {{action 'goBack'}}>{{fa-icon 'backward'}}</li>
   <li class='clickable' {{action 'gotoToday'}}>{{t 'general.today'}}</li>

--- a/app/templates/components/learnergroup-summary.hbs
+++ b/app/templates/components/learnergroup-summary.hbs
@@ -89,6 +89,18 @@
       {{/if}}
     </div>
   </div>
+
+  <p class='block' data-test-toggle-learnergroup-calendar>
+    {{toggle-buttons
+      firstOptionSelected=(not showLearnerGroupCalendar)
+      firstLabel=(t 'general.hideCalendar')
+      secondLabel=(t 'general.showCalendar')
+      toggle=(toggle 'showLearnerGroupCalendar' this)
+    }}
+  </p>
+  {{#if showLearnerGroupCalendar}}
+    {{learnergroup-calendar learnerGroup=learnerGroup}}
+  {{/if}}
 </section>
 
 

--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -2,6 +2,7 @@ import { test, module } from 'qunit';
 import startApp from 'ilios/tests/helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+import moment from 'moment';
 
 let application;
 
@@ -283,4 +284,32 @@ test('Cohort members not in learner group appear after navigating to learner gro
   assert.equal(currentURL(), '/learnergroups/1');
   assert.equal(find(members).length, 5, 'lists members');
   assert.equal(find(cohortMembers).length, 5, 'lists cohort non members');
+});
+
+test('learner group calendar', async function(assert) {
+  assert.expect(2);
+  const program = server.create('program', {
+    schoolId: 1,
+  });
+  const programYear = server.create('programYear', { program });
+  const cohort = server.create('cohort', { programYear });
+  const learnerGroup = server.create('learnerGroup', { cohort });
+  const course = server.create('course', { cohorts: [cohort] });
+  const session = server.create('session', { course });
+  server.create('offering', {
+    session,
+    startDate: moment().toDate(),
+    endDate: moment().add(1, 'hour').toDate(),
+    learnerGroups: [learnerGroup],
+  });
+
+  server.create('offering');
+
+  const calendarToggle = '[data-test-toggle-learnergroup-calendar] label:eq(1)';
+  const event = '.event';
+
+  await visit('/learnergroups/1');
+  assert.equal(find(event).length, 0);
+  await click(calendarToggle);
+  assert.equal(find(event).length, 1);
 });

--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -313,3 +313,44 @@ test('learner group calendar', async function(assert) {
   await click(calendarToggle);
   assert.equal(find(event).length, 1);
 });
+
+test('learner group calendar with subgroup events', async function(assert) {
+  assert.expect(3);
+  const program = server.create('program', {
+    schoolId: 1,
+  });
+  const programYear = server.create('programYear', { program });
+  const cohort = server.create('cohort', { programYear });
+  const learnerGroup = server.create('learnerGroup', { cohort });
+  const course = server.create('course', { cohorts: [cohort] });
+  const session = server.create('session', { course });
+  const subgroup = server.create('learnerGroup', {
+    cohort,
+    parent: learnerGroup
+  });
+  server.create('offering', {
+    session,
+    startDate: moment().toDate(),
+    endDate: moment().add(1, 'hour').toDate(),
+    learnerGroups: [learnerGroup],
+  });
+  server.create('offering', {
+    session,
+    startDate: moment().toDate(),
+    endDate: moment().add(1, 'hour').toDate(),
+    learnerGroups: [subgroup],
+  });
+
+  server.create('offering');
+
+  const calendarToggle = '[data-test-toggle-learnergroup-calendar] label:eq(1)';
+  const subgroupEventsToggle = '[data-test-learnergroup-calendar-toggle-subgroup-events] input:eq(0)';
+  const event = '.event';
+
+  await visit('/learnergroups/1');
+  assert.equal(find(event).length, 0);
+  await click(calendarToggle);
+  assert.equal(find(event).length, 1);
+  await click(subgroupEventsToggle);
+  assert.equal(find(event).length, 2);
+});

--- a/tests/integration/components/learnergroup-calendar-test.js
+++ b/tests/integration/components/learnergroup-calendar-test.js
@@ -1,25 +1,102 @@
+import EmberObject from '@ember/object';
+import { resolve } from 'rsvp';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
+import wait from 'ember-test-helpers/wait';
 
 moduleForComponent('learnergroup-calendar', 'Integration | Component | learnergroup calendar', {
-  integration: true
+  integration: true,
 });
 
-test('it renders', function(assert) {
 
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{learnergroup-calendar}}`);
+test('shows events', async function(assert) {
+  assert.expect(1);
+  const today = moment();
+  const course = EmberObject.create({
+    title: 'course title'
+  });
+  const session = EmberObject.create({
+    title: 'session title',
+    course: resolve(course)
+  });
 
-  assert.equal(this.$().text().trim(), '');
+  const offering1 = EmberObject.create({
+    id: 1,
+    startDate: today.format(),
+    endDate: today.clone().add('1', 'hour').format(),
+    location: 123,
+    session: resolve(session)
+  });
+  const offering2 = EmberObject.create({
+    id: 2,
+    startDate: today.format(),
+    endDate: today.clone().add('1', 'hour').format(),
+    location: 123,
+    session: resolve(session)
+  });
+  const subGroup = EmberObject.create({
+    id: 1,
+    offerings: resolve([offering2]),
+    allDescendants: resolve([])
+  });
+  const learnerGroup = EmberObject.create({
+    id: 1,
+    offerings: resolve([offering1]),
+    allDescendants: resolve([subGroup])
+  });
+  this.set('learnerGroup', learnerGroup);
+  this.render(hbs`{{learnergroup-calendar learnerGroup=learnerGroup}}`);
+  const events = '.ilios-calendar-event';
+  await wait();
 
-  // Template block usage:
-  this.render(hbs`
-    {{#learnergroup-calendar}}
-      template block text
-    {{/learnergroup-calendar}}
-  `);
+  assert.equal(this.$(events).length, 1);
+});
 
-  assert.equal(this.$().text().trim(), 'template block text');
+test('shows subgroup events', async function(assert) {
+  assert.expect(1);
+  const today = moment();
+  const course = EmberObject.create({
+    title: 'course title'
+  });
+  const session = EmberObject.create({
+    title: 'session title',
+    course: resolve(course)
+  });
+
+  const offering1 = EmberObject.create({
+    id: 1,
+    startDate: today.format(),
+    endDate: today.clone().add('1', 'hour').format(),
+    location: 123,
+    session: resolve(session)
+  });
+  const offering2 = EmberObject.create({
+    id: 2,
+    startDate: today.format(),
+    endDate: today.clone().add('1', 'hour').format(),
+    location: 123,
+    session: resolve(session)
+  });
+  const subGroup = EmberObject.create({
+    id: 1,
+    offerings: resolve([offering2]),
+    allDescendants: resolve([])
+  });
+  const learnerGroup = EmberObject.create({
+    id: 1,
+    offerings: resolve([offering1]),
+    allDescendants: resolve([subGroup])
+  });
+
+  this.set('learnerGroup', learnerGroup);
+  this.render(hbs`{{learnergroup-calendar learnerGroup=learnerGroup}}`);
+  const events = '.ilios-calendar-event';
+  const subgroupEventsToggle = '[data-test-learnergroup-calendar-toggle-subgroup-events] label:eq(0)';
+  await wait();
+
+  this.$(subgroupEventsToggle).click();
+  await wait();
+  assert.equal(this.$(events).length, 2);
 });

--- a/tests/integration/components/learnergroup-calendar-test.js
+++ b/tests/integration/components/learnergroup-calendar-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('learnergroup-calendar', 'Integration | Component | learnergroup calendar', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{learnergroup-calendar}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#learnergroup-calendar}}
+      template block text
+    {{/learnergroup-calendar}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/user-profile-calendar-test.js
+++ b/tests/integration/components/user-profile-calendar-test.js
@@ -15,7 +15,7 @@ moduleForComponent('user-profile-calendar', 'Integration | Component | user prof
     commonAjaxMock = Service.extend({});
     this.register('service:commonAjax', commonAjaxMock);
     const iliosConfigMock = Service.extend({
-      namesapce: ''
+      namespace: ''
     });
     this.register('service:iliosConfig', iliosConfigMock);
   }


### PR DESCRIPTION
This calendar displays all of the offerings that are attached to a
group.

Fixes #3401 

wip:
- [x] needs functional review
- [x] component needs tests
- [x] should we display subgroup's offerings in this calendar?