### PR TITLE
Temporarily require sudo for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js: 6
-sudo: false
+sudo: required # set to required instead of false as a temporary workaround for https://github.com/travis-ci/travis-ci/issues/8836
 dist: trusty
 
 addons:


### PR DESCRIPTION
There is an issue with travis and chrome-sandbox that requires this
temporarily.