### PR TITLE
Fix cancel editing of empty session description

### DIFF
--- a/app/components/session-overview.js
+++ b/app/components/session-overview.js
@@ -9,6 +9,7 @@ import Publishable from 'ilios/mixins/publishable';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 import config from '../config/environment';
+import { task } from 'ember-concurrency';
 
 const { IliosFeatures: { schoolSessionAttributes } } = config;
 const { oneWay, sort } = computed;
@@ -140,6 +141,16 @@ export default Component.extend(Publishable, Validations, ValidationErrorDisplay
     }
     const school = await this.get('school');
     return await school.getConfigValue('showSessionSpecialEquipmentRequired');
+  }),
+
+  revertDescriptionChanges: task(function * (){
+    const session = this.get('session');
+    const sessionDescription = yield session.get('sessionDescription');
+    if (sessionDescription) {
+      this.set('description', sessionDescription.get('description'));
+    } else {
+      this.set('description', null);
+    }
   }),
 
   actions: {
@@ -330,13 +341,6 @@ export default Component.extend(Publishable, Validations, ValidationErrorDisplay
       }
 
       this.set('description', html);
-    },
-    revertDescriptionChanges(){
-      this.get('session').get('sessionDescription').then(sessionDescription => {
-        if (sessionDescription) {
-          this.set('description', sessionDescription.get('description'));
-        }
-      });
     },
   }
 });

--- a/app/templates/components/session-overview.hbs
+++ b/app/templates/components/session-overview.hbs
@@ -236,7 +236,7 @@
           {{#editable-field
             value=description
             save=(action 'saveDescription')
-            close=(action 'revertDescriptionChanges')
+            close=(perform revertDescriptionChanges)
             renderHtml=true
             isSaveDisabled=(and (v-get this 'description' 'isInvalid') (is-in showErrorsFor 'description'))
             clickPrompt=(t 'general.clickToEdit')

--- a/tests/acceptance/course/session/overview-test.js
+++ b/tests/acceptance/course/session/overview-test.js
@@ -438,6 +438,27 @@ test('remove description', async function(assert) {
   assert.equal(getElementText(description), getText('Click to edit'));
 });
 
+test('cancel editing empty description #3210', async function(assert) {
+  server.create('user', {
+    id: 4136
+  });
+  server.create('session', {
+    courseId: 1,
+    sessionTypeId: 1
+  });
+  await visit(url);
+  const container = find('.sessiondescription');
+  assert.equal(getElementText(find('.content', container)), getText('Click to edit'));
+  await click(find('.editable', container));
+  let editor = find('.sessiondescription .fr-box');
+  let editorContents = editor.data('froala.editor').$el.text();
+  assert.equal(getText(editorContents), '');
+  editor.froalaEditor('html.set', 'test new description');
+  editor.froalaEditor('events.trigger', 'contentChanged');
+  await click(find('.editinplace .actions .cancel', container));
+  assert.equal(getElementText(find('.content', container)), getText('Click to edit'));
+});
+
 
 test('click copy', async function(assert) {
   server.create('userRole', {


### PR DESCRIPTION
When there is no description originally and we cancel editing we should
revert the description to null otherwise the user has to refresh the
page.

Fixes #3210