### PR TITLE
Display all users in the tree when managing subgroup

### DIFF
--- a/app/components/learnergroup-summary.js
+++ b/app/components/learnergroup-summary.js
@@ -105,10 +105,10 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     const learnerGroup = this.get('learnerGroup');
     if (isEditing) {
       let topLevelGroup = await learnerGroup.get('topLevelGroup');
-      let users = await topLevelGroup.get('users').toArray();
+      let allDescendantUsers = await topLevelGroup.get('allDescendantUsers');
       let treeGroups = await this.get('treeGroups');
 
-      return await map(users, async user => {
+      return await map(allDescendantUsers.toArray(), async user => {
         let lowestGroupInTree = await user.getLowestMemberGroupInALearnerGroupTree(treeGroups);
         return ObjectProxy.create({
           content: user,

--- a/app/components/learnergroup-user-manager.js
+++ b/app/components/learnergroup-user-manager.js
@@ -44,7 +44,7 @@ export default Component.extend({
     });
   }),
 
-  usersInCurrentGroup: computed('filteredUsers.[]', 'learnerGroupId', function(){
+  usersInCurrentGroup: computed('filteredUsers.[]', 'learnerGroupId', 'isEditing', function(){
     const isEditing = this.get('isEditing');
     const filteredUsers = this.get('filteredUsers');
     if (!isEditing) {


### PR DESCRIPTION
If learner groups are built in-correctly it is possible for a learner to
be in a sub-group and not in the parent. We should account for this be
loading the entire group tree when we need it for editing.

Fixes #3476