### PR TITLE
Avoid destroying the offering form when attributes change

### DIFF
--- a/app/components/offering-form.js
+++ b/app/components/offering-form.js
@@ -107,6 +107,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   offeringsToSave: 0,
   savedOfferings: 0,
   recurringDayOptions: null,
+  loaded: false,
   associatedSchools: computed('cohorts.[]', function(){
     return new Promise(resolve => {
       const cohorts = this.get('cohorts');
@@ -267,7 +268,11 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   }),
 
 
-  loadDefaultAttrs(){
+  loadDefaultAttrs() {
+    let loaded = this.get('loaded');
+    if (loaded) {
+      return;
+    }
     let startDate = moment(this.get('defaultStartDate')).hour(8).minute(0).second(0).toDate();
     let endDate = moment(this.get('defaultStartDate')).hour(9).minute(0).second(0).toDate();
     const room = 'TBD';
@@ -275,11 +280,16 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     const recurringDays = [];
     const instructors = [];
     const instructorGroups = [];
+    loaded = true;
 
-    this.setProperties({startDate, endDate, room, learnerGroups, recurringDays, instructors, instructorGroups});
+    this.setProperties({startDate, endDate, room, learnerGroups, recurringDays, instructors, instructorGroups, loaded});
   },
 
   loadAttrsFromOffering: task(function * (offering) {
+    let loaded = this.get('loaded');
+    if (loaded) {
+      return;
+    }
     const startDate = offering.get('startDate');
     const endDate = offering.get('endDate');
     const room = offering.get('room');
@@ -292,9 +302,10 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     const learnerGroups = obj.learnerGroups.toArray();
     const instructors = obj.instructors.toArray();
     const instructorGroups = obj.instructorGroups.toArray();
+    loaded = true;
 
-    this.setProperties({startDate, endDate, room, learnerGroups, recurringDays, instructors, instructorGroups});
-  }),
+    this.setProperties({startDate, endDate, room, learnerGroups, recurringDays, instructors, instructorGroups, loaded});
+  }).drop(),
   saveOffering: task(function * () {
     this.set('offeringsToSave', 0);
     this.set('savedOfferings', 0);

--- a/app/templates/components/instructor-selection-manager.hbs
+++ b/app/templates/components/instructor-selection-manager.hbs
@@ -10,7 +10,7 @@
 
 {{#if (get (await instructors) 'length')}}
   <ul class='removable-list tag-list'>
-    {{#each (sort-by 'title' (await instructors)) as |user|}}
+    {{#each (sort-by 'fullName' (await instructors)) as |user|}}
       <li {{action 'removeInstructor' user}}>
         {{user.fullName}} {{fa-icon 'times'}}
       </li>

--- a/app/templates/components/offering-form.hbs
+++ b/app/templates/components/offering-form.hbs
@@ -1,4 +1,4 @@
-{{#unless loadAttrsFromOffering.isRunning}}
+{{#if loaded}}
   <p class='toggle-offering-calendar'>
     {{toggle-buttons
       firstOptionSelected=(not showOfferingCalendar)
@@ -167,7 +167,7 @@
     </button>
     <button class='cancel text' {{action close}}>{{t 'general.cancel'}}</button>
   </div>
-{{/unless}}
+{{/if}}
 
 {{#if saveOffering.isRunning}}
   {{wait-saving

--- a/mirage/factories/offering.js
+++ b/mirage/factories/offering.js
@@ -1,6 +1,9 @@
 import { Factory } from 'ember-cli-mirage';
+import moment from 'moment';
 
 export default Factory.extend({
   room:  (i) => `room ${i}`,
   site: (i) => `site ${i}`,
+  startDate: moment().toDate(),
+  endDate: moment().add(1, 'hour').toDate(),
 });

--- a/tests/acceptance/course/session/offerings-management-test.js
+++ b/tests/acceptance/course/session/offerings-management-test.js
@@ -1,0 +1,105 @@
+import destroyApp from '../../../helpers/destroy-app';
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from 'ilios/tests/helpers/start-app';
+import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+
+let application;
+module('Acceptance: Session - Offering Management', {
+  beforeEach: function() {
+    application = startApp();
+    setupAuthentication(application);
+  },
+
+  afterEach: function() {
+    destroyApp(application);
+  }
+});
+
+test('search for instructor who is a course director #2838', async function(assert) {
+  assert.expect(1);
+
+  const school = server.create('school');
+  const permission1 = server.create('permission', {
+    tableRowId: '1',
+    tableName: 'school'
+  });
+  const users = server.createList('user', 3, {
+    school,
+    permissions: [permission1],
+  });
+  const course = server.create('course', {
+    school,
+    directors: [users[0], users[1], users[2]],
+  });
+  const session = server.create('session', {
+    course,
+  });
+  server.create('offering', {
+    session,
+  });
+
+
+  const editButton = '.offering-detail-box .edit';
+  const form = '.offering-form';
+  const search = `${form} .search-box`;
+  const searchBox = `${search} input`;
+  const results = `${form} .results li`;
+
+  await visit('/courses/1/sessions/1');
+  await click(editButton);
+  await fillIn(searchBox, 'guy 3');
+  assert.equal(find(results).length, 2);
+});
+
+test('searching for course directors as instructors does not remove existing instructors #3479', async function(assert) {
+  assert.expect(7);
+
+  const school = server.create('school');
+  const permission1 = server.create('permission', {
+    tableRowId: '1',
+    tableName: 'school'
+  });
+  const users = server.createList('user', 3, {
+    school,
+    permissions: [permission1],
+  });
+  const course = server.create('course', {
+    school,
+    directors: [users[0], users[1]],
+  });
+  const session = server.create('session', {
+    course,
+  });
+  server.create('offering', {
+    session
+  });
+
+
+  const editButton = '.offering-detail-box .edit';
+  const form = '.offering-form';
+  const instructors = `${form} .instructors`;
+  const search = `${instructors} .search-box`;
+  const searchBox = `${search} input`;
+  const results = `${instructors} .results li`;
+  const firstResult = `${results}:eq(1)`;
+  const selectedInstructors = `${instructors} .tag-list li`;
+  const firstSelectedInstructor = `${selectedInstructors}:eq(0)`;
+  const secondSelectedInstructor = `${selectedInstructors}:eq(1)`;
+
+  await visit('/courses/1/sessions/1');
+  await click(editButton);
+  await fillIn(searchBox, 'guy 2');
+  assert.equal(find(results).length, 2);
+  await click(firstResult);
+  assert.equal(find(selectedInstructors).length, 1);
+  assert.equal(find(firstSelectedInstructor).text().trim(), '2 guy M. Mc2son');
+  await fillIn(searchBox, 'guy 3');
+  assert.equal(find(selectedInstructors).length, 1);
+  assert.equal(find(firstSelectedInstructor).text().trim(), '2 guy M. Mc2son');
+  await click(firstResult);
+  assert.equal(find(selectedInstructors).length, 2);
+  assert.equal(find(secondSelectedInstructor).text().trim(), '3 guy M. Mc3son');
+});


### PR DESCRIPTION
By removing this check we avoid a re-render anytime something is loaded
or changed. Specifically this was an issue when some users attached to a
course as a director were queried from the API. It would cause a
re-render which destroyed the search box.

Fixes #2838