### PR TITLE
replace {{one-way-input}} with raw markup equivalent

### DIFF
--- a/app/templates/assign-students.hbs
+++ b/app/templates/assign-students.hbs
@@ -21,7 +21,11 @@
     </div>
 
     <div id='titlefilter' class="filter">
-      {{one-way-input filter placeholder=(t 'general.pendingUserUpdates.filterBy') update=(action (mut filter))}}
+      <input
+        value={{filter}}
+        oninput={{action (mut filter) value="target.value"}}
+        placeholder={{t 'general.pendingUserUpdates.filterBy'}}
+      >
     </div>
   </div>
 

--- a/app/templates/components/course-materials.hbs
+++ b/app/templates/components/course-materials.hbs
@@ -33,11 +33,11 @@
   <h2 class='session-material-title'>{{t 'general.sessionLearningMaterials'}} ({{get (await sessionLearningMaterials) 'length'}})</h2>
   {{#if (gt (get (await sessionLearningMaterials) 'length') 0)}}
     <span class="filter-session-lms">
-      {{one-way-input
-        value=filter
-        update=(action (mut filter))
-        placeholder=(t 'general.filterPlaceholder')
-      }}
+      <input
+        value={{filter}}
+        oninput={{action (mut filter) value="target.value"}}
+        placeholder={{t 'general.filterPlaceholder'}}
+      >
     </span>
     <table>
       <thead>

--- a/app/templates/components/learnergroup-cohort-user-manager.hbs
+++ b/app/templates/components/learnergroup-cohort-user-manager.hbs
@@ -2,11 +2,11 @@
   {{t 'general.cohortMembersNotInGroup' groupTitle=topLevelGroupTitle}} ({{users.length}})
 </div>
 <div class="actions">
-  {{one-way-input
-    value=filter
-    update=(action (mut filter))
-    placeholder=(t 'general.filterByNameOrEmail')
-  }}
+  <input
+    value={{filter}}
+    oninput={{action (mut filter) value="target.value"}}
+    placeholder={{t 'general.filterByNameOrEmail'}}
+  >
 </div>
 <div class='learnergroup-cohort-user-manager-content'>
   <div class='list'>

--- a/app/templates/components/learnergroup-user-manager.hbs
+++ b/app/templates/components/learnergroup-user-manager.hbs
@@ -5,11 +5,11 @@
 </div>
 {{#if users.length}}
   <div class="actions">
-    {{one-way-input
-      value=filter
-      update=(action (mut filter))
-      placeholder=(t 'general.filterByNameOrEmail')
-    }}
+    <input
+      value={{filter}}
+      oninput={{action (mut filter) value="target.value"}}
+      placeholder={{t 'general.filterByNameOrEmail'}}
+    >
   </div>
   <div class='learnergroup-user-manager-content'>
     <div class='list'>

--- a/app/templates/components/my-materials.hbs
+++ b/app/templates/components/my-materials.hbs
@@ -13,11 +13,11 @@
       </select>
     </span>
     <span class="filter">
-      {{one-way-input
-        update=(action setFilter)
-        value=filter
-        placeholder=(t 'general.filterPlaceholder')
-      }}
+      <input
+        value={{filter}}
+        oninput={{action (action setFilter) value="target.value"}}
+        placeholder={{t 'general.filterPlaceholder'}}
+      >
     </span>
     <table>
       <thead>

--- a/app/templates/components/new-learningmaterial.hbs
+++ b/app/templates/components/new-learningmaterial.hbs
@@ -1,12 +1,12 @@
 <div class="item">
   <label>{{t 'general.displayName'}}:</label>
   <span>
-    {{one-way-input
-      value=title
-      update=(action (mut title))
-      disabled=prepareSave.isRunning
-      focusOut=(action 'addErrorDisplayFor' 'title')
-    }}
+    <input
+      value={{title}}
+      oninput={{action (mut title) value="target.value"}}
+      disabled={{prepareSave.isRunning}}
+      onfocusout={{action 'addErrorDisplayFor' 'title'}}
+    >
     {{#if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}}
       <span class="validation-error-message">{{v-get this 'title' 'message'}}</span>
     {{/if}}
@@ -34,12 +34,12 @@
 <div class="item">
   <label>{{t 'general.contentAuthor'}}:</label>
   <span>
-    {{one-way-input
-      value=originalAuthor
-      update=(action (mut originalAuthor))
-      disabled=prepareSave.isRunning
-      focusOut=(action 'addErrorDisplayFor' 'originalAuthor')
-    }}
+    <input
+      value={{originalAuthor}}
+      oninput={{action (mut originalAuthor) value="target.value"}}
+      disabled={{prepareSave.isRunning}}
+      onfocusout={{action 'addErrorDisplayFor' 'originalAuthor'}}
+    >
     {{#if (and (v-get this 'originalAuthor' 'isInvalid') (is-in showErrorsFor 'originalAuthor'))}}
       <span class="validation-error-message">{{v-get this 'originalAuthor' 'message'}}</span>
     {{/if}}
@@ -63,13 +63,13 @@
   <div class="item">
     <label>{{t 'general.url'}}:</label>
     <span>
-      {{one-way-input
-        value=link
-        update=(action (mut link))
-        disabled=prepareSave.isRunning
-        focusOut=(action 'addErrorDisplayFor' 'link')
-        keyDown=(action 'addErrorDisplayFor' 'link')
-      }}
+      <input
+        value={{link}}
+        oninput={{action (mut link) value="target.value"}}
+        disabled={{prepareSave.isRunning}}
+        onfocusout={{action 'addErrorDisplayFor' 'link'}}
+        onkeydown={{action 'addErrorDisplayFor' 'link'}}
+      >
       {{#if (and (v-get this 'link' 'isInvalid') (is-in showErrorsFor 'link'))}}
         <span class="validation-error-message">{{v-get this 'link' 'message'}}</span>
       {{/if}}

--- a/app/templates/components/offering-form.hbs
+++ b/app/templates/components/offering-form.hbs
@@ -24,26 +24,26 @@
   <div class='item offering-duration'>
     <label>{{t 'general.duration'}}:</label> <br>
     <div class='hours'>
-      {{one-way-input
-        value=durationHours
-        update=(perform updateDurationHours)
-        focusOut=(action 'addErrorDisplayFor' 'durationHours')
-        keyUp=(action 'addErrorDisplayFor' 'durationHours')
-        class=(if (and (v-get this 'durationHours' 'isInvalid') (is-in showErrorsFor 'durationHours')) 'has-error')
-      }}
+      <input
+        value={{durationHours}}
+        oninput={{action (perform updateDurationHours) value="target.value"}}
+        onfocusout={{action 'addErrorDisplayFor' 'durationHours'}}
+        onkeyup={{action 'addErrorDisplayFor' 'durationHours'}}
+        class={{if (and (v-get this 'durationHours' 'isInvalid') (is-in showErrorsFor 'durationHours')) 'has-error'}}
+      >
       {{#if (and (v-get this 'durationHours' 'isInvalid') (is-in showErrorsFor 'durationHours'))}}
         <span class="validation-error-message">{{v-get this 'durationHours' 'message'}}</span>
       {{/if}}
       <label>{{t 'general.hours'}}</label>
     </div>
     <div class='minutes'>
-      {{one-way-input
-        value=durationMinutes
-        update=(perform updateDurationMinutes)
-        focusOut=(action 'addErrorDisplayFor' 'durationMinutes')
-        keyUp=(action 'addErrorDisplayFor' 'durationMinutes')
-        class=(if (and (v-get this 'durationMinutes' 'isInvalid') (is-in showErrorsFor 'durationMinutes')) 'has-error')
-      }}
+      <input
+        value={{durationMinutes}}
+          oninput={{action (perform updateDurationMinutes) value="target.value"}}
+          onfocusout={{action 'addErrorDisplayFor' 'durationMinutes'}}
+          onkeyup={{action 'addErrorDisplayFor' 'durationMinutes'}}
+          class={{if (and (v-get this 'durationMinutes' 'isInvalid') (is-in showErrorsFor 'durationMinutes')) 'has-error'}}
+      >
       {{#if (and (v-get this 'durationMinutes' 'isInvalid') (is-in showErrorsFor 'durationMinutes'))}}
         <span class="validation-error-message">{{v-get this 'durationMinutes' 'message'}}</span>
       {{/if}}
@@ -82,13 +82,13 @@
           </div>
 
           <div class="make-recurring-input-container">
-            {{one-way-input
-              value=numberOfWeeks
-              update=(action (mut numberOfWeeks))
-              focusOut=(action 'addErrorDisplayFor' 'numberOfWeeks')
-              keyUp=(action 'addErrorDisplayFor' 'numberOfWeeks')
-              class=(concat 'make-recurring-input ' (if (and (v-get this 'numberOfWeeks' 'isInvalid') (is-in showErrorsFor 'numberOfWeeks')) 'has-error'))
-            }}
+            <input
+              value={{numberOfWeeks}}
+              oninput={{action (mut numberOfWeeks) value="target.value"}}
+              onfocusout={{action 'addErrorDisplayFor' 'numberOfWeeks'}}
+              onkeyup={{action 'addErrorDisplayFor' 'numberOfWeeks'}}
+              class={{concat 'make-recurring-input ' (if (and (v-get this 'numberOfWeeks' 'isInvalid') (is-in showErrorsFor 'numberOfWeeks')) 'has-error')}}
+            >
             <label class="make-recurring-input-label">{{t 'general.weeks'}}</label>
             {{#if (and (v-get this 'numberOfWeeks' 'isInvalid') (is-in showErrorsFor 'numberOfWeeks'))}}
               <span class="validation-error-message">{{v-get this 'numberOfWeeks' 'message'}}</span>
@@ -107,12 +107,12 @@
           {{t 'general.defaultLocationNotLoaded'}}
         {{/unless}}
       </label>
-      {{one-way-input
-        value=room
-        update=(action (mut room))
-        keyUp=(action 'addErrorDisplayFor' 'room')
-        focusOut=(action 'addErrorDisplayFor' 'room')
-      }}
+      <input
+        value={{room}}
+        oninput={{action (mut room) value="target.value"}}
+        onkeyup={{action 'addErrorDisplayFor' 'room'}}
+        onfocusout={{action 'addErrorDisplayFor' 'room'}}
+      >
       {{#if (and (v-get this 'room' 'isInvalid') (is-in showErrorsFor 'room'))}}
         <span class="validation-error-message">{{v-get this 'room' 'message'}}</span>
       {{/if}}

--- a/app/templates/components/school-session-type-form.hbs
+++ b/app/templates/components/school-session-type-form.hbs
@@ -43,12 +43,12 @@
   <div class='item calendar-color'>
     <label>{{t 'general.color'}}:</label>
     {{#if canEditCalendarColor}}
-      {{one-way-input
-        type='color'
-        value=calendarColor
-        update=(action (mut calendarColor))
-        focusOut=(action 'addErrorDisplayFor' 'calendarColor')
-      }}
+      <input
+        type="color"
+        value={{calendarColor}}
+        onfocusout={{action 'addErrorDisplayFor' 'calendarColor'}}
+        oninput={{action (mut calendarColor) value="target.value"}}
+      >
       {{#if (and (v-get this 'calendarColor' 'isInvalid') (is-in showErrorsFor 'calendarColor'))}}
         <span class="message error">{{v-get this 'calendarColor' 'message'}}</span>
       {{/if}}

--- a/app/templates/components/session-table.hbs
+++ b/app/templates/components/session-table.hbs
@@ -1,9 +1,9 @@
 <div class="filter">
-  {{one-way-input
-    value=filterByDebounced
-    update=(perform changeFilterBy)
-    placeholder=(t 'general.sessionTitleFilterPlaceholder')
-  }}
+  <input
+    value={{filterByDebounced}}
+    oninput={{action (perform changeFilterBy) value="target.value"}}
+    placeholder={{t 'general.sessionTitleFilterPlaceholder'}}
+  >
 </div>
 {{#light-table table height=height responsive=true as |t|}}
   {{t.head

--- a/app/templates/courses.hbs
+++ b/app/templates/courses.hbs
@@ -27,12 +27,12 @@
     </div>
 
     <div class="titlefilter">
-      {{one-way-input
+      <input
         data-test-title-filter
-        value=titleFilter
-        update=(perform changeTitleFilter)
-        placeholder=(t 'general.courseTitleFilterPlaceholder')
-      }}
+        value={{titleFilter}}
+        oninput={{action (perform changeTitleFilter) value="target.value"}}
+        placeholder={{t 'general.courseTitleFilterPlaceholder'}}
+      >
     </div>
   </div>
   <section class='courses'>

--- a/app/templates/instructor-groups.hbs
+++ b/app/templates/instructor-groups.hbs
@@ -15,11 +15,11 @@
       {{/if}}
     </div>
     <div class="titlefilter">
-      {{one-way-input
-        value=titleFilter
-        update=(perform changeTitleFilter)
-        placeholder=(t 'general.instructorGroupTitleFilterPlaceholder')
-      }}
+      <input
+        value={{titleFilter}}
+        oninput={{action (perform changeTitleFilter) value="target.value"}}
+        placeholder={{t 'general.instructorGroupTitleFilterPlaceholder'}}
+      >
     </div>
   </div>
   <section class='instructorgroups'>

--- a/app/templates/learner-groups.hbs
+++ b/app/templates/learner-groups.hbs
@@ -55,11 +55,11 @@
       {{/if}}
     </div>
     <div class="titlefilter">
-      {{one-way-input
-        value=titleFilter
-        update=(perform changeTitleFilter)
-        placeholder=(t 'general.learnerGroupTitleFilterPlaceholder')
-      }}
+      <input
+        value={{titleFilter}}
+        oninput={{action (perform changeTitleFilter) value="target.value"}}
+        placeholder={{t 'general.learnerGroupTitleFilterPlaceholder'}}
+      >
     </div>
   </div>
   <section class='learnergroups'>

--- a/app/templates/programs.hbs
+++ b/app/templates/programs.hbs
@@ -15,11 +15,11 @@
       {{/if}}
     </div>
     <div class="titlefilter">
-      {{one-way-input
-        value=titleFilter
-        update=(perform changeTitleFilter)
-        placeholder=(t 'general.programTitleFilterPlaceholder')
-      }}
+      <input
+        value={{titleFilter}}
+        oninput={{action (perform changeTitleFilter) value="target.value"}}
+        placeholder={{t 'general.programTitleFilterPlaceholder'}}
+      >
     </div>
   </div>
 

--- a/tests/integration/components/course-materials-test.js
+++ b/tests/integration/components/course-materials-test.js
@@ -208,7 +208,8 @@ test('filter by title', function(assert) {
   const filter = '.filter-session-lms input';
 
   assert.equal(this.$(sessionMaterials).length, 3);
-  this.$(filter).val('title1').change();
+  this.$(filter).val('title1');
+  this.$(filter).trigger('input');
   assert.equal(this.$(sessionMaterials).length, 1);
   assert.equal(this.$(firstSessionLmTitle).text().trim(), 'title1');
 
@@ -232,7 +233,8 @@ test('filter by type', function(assert) {
   const filter = '.filter-session-lms input';
 
   assert.equal(this.$(sessionMaterials).length, 3);
-  this.$(filter).val('file').change();
+  this.$(filter).val('file');
+  this.$(filter).trigger('input');
   assert.equal(this.$(sessionMaterials).length, 1);
   assert.equal(this.$(firstSessionLmTitle).text().trim(), 'title2');
 
@@ -256,7 +258,8 @@ test('filter by author', function(assert) {
   const filter = '.filter-session-lms input';
 
   assert.equal(this.$(sessionMaterials).length, 3);
-  this.$(filter).val('author2').change();
+  this.$(filter).val('author2');
+  this.$(filter).trigger('input');
   assert.equal(this.$(sessionMaterials).length, 1);
   assert.equal(this.$(firstSessionLmTitle).text().trim(), 'title2');
 
@@ -280,7 +283,8 @@ test('filter by citation', function(assert) {
   const filter = '.filter-session-lms input';
 
   assert.equal(this.$(sessionMaterials).length, 3);
-  this.$(filter).val('citationtext').change();
+  this.$(filter).val('citationtext');
+  this.$(filter).trigger('input');
   assert.equal(this.$(sessionMaterials).length, 1);
   assert.equal(this.$(firstSessionLmTitle).text().replace(/[\t\n\s]+/g, ""), 'title3citationtext');
 

--- a/tests/integration/components/offering-form-test.js
+++ b/tests/integration/components/offering-form-test.js
@@ -55,8 +55,8 @@ test('room validation errors show up when typing', function(assert) {
   const error = `${item} .validation-error-message`;
   const save = '.buttons .done';
   this.$(input).val(padStart('a', 300, 'a'));
-  this.$(input).trigger('change');
 
+  this.$(input).trigger('input');
   this.$(save).click();
 
   return wait().then(()=>{
@@ -128,7 +128,7 @@ test('recurring numberOfWeeks validation errors show up when saving', function(a
 
   this.$(toggle).click();
   const save = '.buttons .done';
-  this.$(input).val(0).trigger('change');
+  this.$(input).val(0).trigger('input');
 
   this.$(save).click();
 
@@ -378,7 +378,7 @@ test('save recurring 3 weeks should get lots of days', function(assert) {
   this.render(hbs`{{offering-form close=(action nothing) showMakeRecurring=true save=(action save)}}`);
 
   this.$(toggle).click();
-  this.$(weeks).val(3).trigger('change');
+  this.$(weeks).val(3).trigger('input');
   let interactor = openDatepicker(this.$(startDateInput));
   interactor.selectDate(newStartDate);
   this.$(inputs).eq(thursday).click().change();
@@ -431,9 +431,11 @@ test('changing duration changes end date', function(assert) {
   const endDate = '.end-date-time .text';
   const format = 'M/D/YYYY h:mm a';
   assert.equal(moment().hour(9).minute(0).format(format), this.$(endDate).text().trim());
-  this.$(durationHour).val('2').change();
+  this.$(durationHour).val('2');
+  this.$(durationHour).trigger('input');
   return wait().then(()=>{
-    this.$(durationMinute).val('15').change();
+    this.$(durationMinute).val('15');
+    this.$(durationMinute).trigger('input');
     return wait().then(()=>{
       assert.equal(moment().hour(10).minute(15).format(format), this.$(endDate).text().trim());
     });
@@ -454,11 +456,15 @@ test('changing duration and start time changes end date', function(assert) {
   const format = 'M/D/YYYY h:mm a';
   assert.equal(moment().hour(9).minute(0).format(format), this.$(endDate).text().trim());
   this.$(startHour).val('2').change();
+  this.$(startHour).val('2').change();
   this.$(startMinute).val('10').change();
   this.$(startAmPm).val('pm').change();
-  this.$(durationHour).val('2').change();
+  this.$(durationHour).val('2');
+  this.$(durationHour).trigger('input');
+
   return wait().then(()=>{
     this.$(durationMinute).val('50').change();
+    this.$(durationMinute).trigger('input');
     return wait().then(()=>{
       assert.equal(moment().hour(17).minute(0).format(format), this.$(endDate).text().trim());
     });

--- a/tests/integration/components/school-session-type-form-test.js
+++ b/tests/integration/components/school-session-type-form-test.js
@@ -281,9 +281,11 @@ test('save fires save', async function(assert) {
 
   assert.ok(this.$(isActiveInput).is(':checked'), 'active is selected');
 
-  this.$(titleInput).val('new title').change();
+  this.$(titleInput).val('new title');
+  this.$(titleInput).trigger('input');
   this.$(aamcMethodSelect).val(aamcMethodMock.get('id')).change();
-  this.$(colorInput).val('#a1b2c3').change();
+  this.$(colorInput).val('#a1b2c3');
+  this.$(colorInput).trigger('input');
   this.$(assessmentOptionSelect).val('1').change();
 
   assert.ok(this.$(isActiveInput).is(':checked'), 'active is selected');


### PR DESCRIPTION
refs #3469 

first batch of replacements, these are the easy ones (without `onenter` and `onescape` custom events). 