### PR TITLE
Add and configure ember-qunit-nice-errors

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -62,6 +62,10 @@ module.exports = function (environment) {
       includeLocales: ['es', 'fr'],
       includeTimezone: 'all',
     },
+    'ember-qunit-nice-errors': {
+      completeExistingMessages: true,
+      showFileInfo: true,
+    },
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "ember-papaparse": "1.0.0",
     "ember-pikaday": "2.2.4",
     "ember-promise-helpers": "1.0.3",
+    "ember-qunit-nice-errors": "^1.2.0",
     "ember-resolver": "^4.0.0",
     "ember-responsive": "^2.0.4",
     "ember-rl-dropdown": "0.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -321,6 +321,10 @@ ast-traverse@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ast-traverse/-/ast-traverse-0.1.1.tgz#69cf2b8386f19dcda1bb1e05d68fe359d8897de6"
 
+ast-types@0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.10.1.tgz#f52fca9715579a14f841d67d7f8d25432ab6a3dd"
+
 ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
@@ -480,7 +484,7 @@ babel-core@^5.0.0:
     trim-right "^1.0.0"
     try-resolve "^1.0.0"
 
-babel-core@^6.14.0, babel-core@^6.24.1, babel-core@^6.26.0:
+babel-core@^6.10.4, babel-core@^6.14.0, babel-core@^6.24.1, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -3960,6 +3964,15 @@ ember-promise-helpers@1.0.3, ember-promise-helpers@^1.0.3:
   dependencies:
     ember-cli-babel "^5.1.5"
 
+ember-qunit-nice-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-qunit-nice-errors/-/ember-qunit-nice-errors-1.2.0.tgz#8db4468fbe761f42bec9adcddfd21efa31237267"
+  dependencies:
+    babel-core "^6.10.4"
+    broccoli-persistent-filter "^1.4.3"
+    ember-cli-babel "^6.6.0"
+    recast "^0.13.0"
+
 ember-qunit@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.2.2.tgz#96c8818ecfa3894580a3dc805f7e7f1e82e07c4a"
@@ -4543,7 +4556,7 @@ esprima@^3.1.3, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
@@ -7883,6 +7896,15 @@ recast@^0.11.13, recast@^0.11.17, recast@^0.11.3:
     esprima "~3.1.0"
     private "~0.1.5"
     source-map "~0.5.0"
+
+recast@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.13.0.tgz#a343a394a37d24668d700f88ed04b8d2c314d40d"
+  dependencies:
+    ast-types "0.10.1"
+    esprima "~4.0.0"
+    private "~0.1.5"
+    source-map "~0.6.1"
 
 redent@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This makes it easier to see exactly what assertion in a test is failing
even if we forget to add our own assertion message.