### PR TITLE
replaces {{one-way-input}} inside {{editable-field}} with markup.

### DIFF
--- a/app/components/editable-field.js
+++ b/app/components/editable-field.js
@@ -12,7 +12,7 @@ export default Component.extend({
   renderHtml: false,
   classNames: ['editinplace'],
   saveOnEnter: false,
-  cancelOnEscape: false,
+  closeOnEscape: false,
   clickPrompt: null,
   looksEmpty: computed('value', function(){
     let value = this.get('value') || '';

--- a/app/components/editable-field.js
+++ b/app/components/editable-field.js
@@ -11,6 +11,8 @@ export default Component.extend({
   isSaveDisabled: false,
   renderHtml: false,
   classNames: ['editinplace'],
+  saveOnEnter: false,
+  cancelOnEscape: false,
   clickPrompt: null,
   looksEmpty: computed('value', function(){
     let value = this.get('value') || '';
@@ -40,4 +42,20 @@ export default Component.extend({
 
     control.focus();
   }).drop(),
+
+  keyUp(event) {
+    const keyCode = event.keyCode;
+    const target = event.target;
+
+    // make sure that they key was pressed only on input element that we're supporting
+    if (! ['text', 'textarea'].includes(target.type)) {
+      return;
+    }
+
+    if (13 === keyCode && this.get('saveOnEnter')) {
+      this.get('saveData').perform();
+    } else if(27 === keyCode && this.get('closeOnEscape')) {
+      this.get('closeEditor').perform();
+    }
+  }
 });

--- a/app/components/editable-field.js
+++ b/app/components/editable-field.js
@@ -47,7 +47,7 @@ export default Component.extend({
     const keyCode = event.keyCode;
     const target = event.target;
 
-    // make sure that they key was pressed only on input element that we're supporting
+    // only process key events coming from text input/textarea.
     if (! ['text', 'textarea'].includes(target.type)) {
       return;
     }

--- a/app/templates/components/bulk-new-users.hbs
+++ b/app/templates/components/bulk-new-users.hbs
@@ -68,11 +68,12 @@
           {{#each proposedUsers as |obj|}}
             <tr>
               <td>
-                {{one-way-checkbox
-                  checked=(and (v-get obj 'isValid') (contains obj selectedUsers))
-                  update=(action 'toggleUserSelection' obj)
-                  disabled=(v-get obj 'isInvalid')
-                }}
+                <input
+                  type="checkbox"
+                  checked={{and (v-get obj 'isValid') (contains obj selectedUsers)}}
+                  onclick={{action 'toggleUserSelection' obj}}
+                  disabled={{v-get obj 'isInvalid'}}
+                >
               </td>
               <td class="{{if (v-get obj 'firstName' 'isInvalid') 'error'}}">{{obj.firstName}}</td>
               <td class="{{if (v-get obj 'lastName' 'isInvalid') 'error'}}">{{obj.lastName}}</td>

--- a/app/templates/components/competency-title-editor.hbs
+++ b/app/templates/components/competency-title-editor.hbs
@@ -2,16 +2,16 @@
   value=title
   save=(perform save)
   close=(action 'revert')
-  as |isSaving save close|
+  saveOnEnter=true
+  closeOnEscape=true
+  as |isSaving|
 }}
-  {{one-way-input
-    value=title
-    update=(action (mut title))
-    onenter=save
-    onescape=close
-    disabled=isSaving
-    focusOut=(action 'addErrorDisplayFor' 'title')
-  }}
+  <input
+    value={{title}}
+    oninput={{action (mut title) value="target.value"}}
+    disabled={{isSaving}}
+    onfocusout={{action 'addErrorDisplayFor' 'title'}}
+  >
 {{/editable-field}}
 {{#if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}}
   <span class="validation-error-message">{{v-get this 'title' 'message'}}</span>

--- a/app/templates/components/course-header.hbs
+++ b/app/templates/components/course-header.hbs
@@ -6,17 +6,17 @@
         value=courseTitle
         save=(action 'changeTitle')
         close=(action 'revertTitleChanges')
-        as |isSaving save close|
+        saveOnEnter=true
+        closeOnEscape=true
+        as |isSaving|
       }}
-        {{one-way-input
-          value=courseTitle
-          update=(action (mut courseTitle))
-          onenter=save
-          onescape=close
-          disabled=isSaving
-          focusOut=(action 'addErrorDisplayFor' 'courseTitle')
-          keyPress=(action 'addErrorDisplayFor' 'courseTitle')
-        }}
+        <input
+          value={{courseTitle}}
+          disabled={{isSaving}}
+          oninput={{action (mut courseTitle) value="target.value"}}
+          onfocusout={{action 'addErrorDisplayFor' 'courseTitle'}}
+          onkeypress={{action 'addErrorDisplayFor' 'courseTitle'}}
+        >
         {{#if (and (v-get this 'courseTitle' 'isInvalid') (is-in showErrorsFor 'courseTitle'))}}
           <span class="validation-error-message">{{v-get this 'courseTitle' 'message'}}</span>
         {{/if}}

--- a/app/templates/components/course-overview.hbs
+++ b/app/templates/components/course-overview.hbs
@@ -26,16 +26,16 @@
           value=(if externalId externalId (t 'general.clickToEdit'))
           save=(action 'changeExternalId')
           close=(action 'revertExternalIdChanges')
-          as |isSaving save close|
+          saveOnEnter=true
+          closeOnEscape=true
+          as |isSaving|
         }}
-          {{one-way-input
-            value=externalId
-            update=(action (mut externalId))
-            onenter=save
-            onescape=close
-            disabled=isSaving
-            focusOut=(action 'addErrorDisplayFor' 'externalId')
-          }}
+          <input
+            value={{externalId}}
+            oninput={{action (mut externalId) value="target.value"}}
+            disabled={{isSaving}}
+            onfocusout={{action 'addErrorDisplayFor' 'externalId'}}
+          >
           {{#if (and (v-get this 'externalId' 'isInvalid') (is-in showErrorsFor 'externalId'))}}
             <span class="validation-error-message">{{v-get this 'externalId' 'message'}}</span>
           {{/if}}

--- a/app/templates/components/course-rollover.hbs
+++ b/app/templates/components/course-rollover.hbs
@@ -65,10 +65,11 @@
       <div class='included'>
         <span class='title'>{{t 'general.include'}}:</span>
         <div class='include'>
-          {{one-way-checkbox
-            checked=(not skipOfferings)
-            update=(toggle 'skipOfferings' this)
-          }}
+          <input
+            type="checkbox"
+            checked={{not skipOfferings}}
+            onclick={{toggle 'skipOfferings' this}}
+          >
           <span>{{t 'general.offerings'}}</span>
         </div>
       </div>

--- a/app/templates/components/curriculum-inventory-report-header.hbs
+++ b/app/templates/components/curriculum-inventory-report-header.hbs
@@ -7,17 +7,17 @@
     value=reportName
     save=(action 'changeName')
     close=(action 'revertNameChanges')
-    as |isSaving save close|
+    saveOnEnter=true
+    closeOnEscape=true
+    as |isSaving|
     }}
-      {{one-way-input
-      value=reportName
-      update=(action (mut reportName))
-      onenter=save
-      onescape=close
-      disabled=isSaving
-      focusOut=(action 'addErrorDisplayFor' 'reportName')
-      keyPress=(action 'addErrorDisplayFor' 'reportName')
-      }}
+      <input
+        value={{reportName}}
+        oninput={{action (mut reportName) value="target.value"}}
+        disabled={{isSaving}}
+        onfocusout={{action 'addErrorDisplayFor' 'reportName'}}
+        onkeypress={{action 'addErrorDisplayFor' 'reportName'}}
+      >
       {{#if (and (v-get this 'reportName' 'isInvalid') (is-in showErrorsFor 'reportName'))}}
         <span class="validation-error-message">{{v-get this 'reportName' 'message'}}</span>
       {{/if}}

--- a/app/templates/components/curriculum-inventory-report-overview.hbs
+++ b/app/templates/components/curriculum-inventory-report-overview.hbs
@@ -92,10 +92,11 @@
           save=(action 'changeDescription')
           close=(action 'revertDescriptionChanges')
           clickPrompt=(if description description (t 'general.clickToEdit'))
+          closeOnEscape=true
           as |isSaving|
           }}
             <textarea
-              onchange={{action (mut description) value="target.value"}}
+              oninput={{action (mut description) value="target.value"}}
               value={{description}}
               disabled={{isSaving}}
               onkeypress={{action 'addErrorDisplayFor' 'description'}}

--- a/app/templates/components/curriculum-inventory-report-rollover.hbs
+++ b/app/templates/components/curriculum-inventory-report-rollover.hbs
@@ -21,12 +21,12 @@
 
   <div class="item description">
     <label>{{t 'general.description'}}:</label>
-    {{one-way-textarea
-      value=description
-      update=(action (mut description))
-      disabled=isSaving
-      placeholder=(t 'general.reportDescriptionPlaceholder')
-    }}
+    <textarea
+      value={{description}}
+      oninput={{action (mut description) value="target.value"}}
+      disabled={{if isSaving true}}
+      placeholder={{t 'general.reportDescriptionPlaceholder'}}
+    ></textarea>
   </div>
 
   <div class="item years">

--- a/app/templates/components/curriculum-inventory-report-rollover.hbs
+++ b/app/templates/components/curriculum-inventory-report-rollover.hbs
@@ -24,7 +24,7 @@
     <textarea
       value={{description}}
       oninput={{action (mut description) value="target.value"}}
-      disabled={{if isSaving true}}
+      disabled={{isSaving}}
       placeholder={{t 'general.reportDescriptionPlaceholder'}}
     ></textarea>
   </div>

--- a/app/templates/components/curriculum-inventory-sequence-block-header.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-header.hbs
@@ -7,17 +7,17 @@
       value=blockTitle
       save=(action 'changeTitle')
       close=(action 'revertTitleChanges')
-      as |isSaving save close|
+      saveOnEnter=true
+      closeOnEscape=true
+      as |isSaving|
     }}
-      {{one-way-input
-        value=blockTitle
-        update=(action (mut blockTitle))
-        onenter=save
-        onescape=close
-        disabled=isSaving
-        focusOut=(action 'addErrorDisplayFor' 'blockTitle')
-        keyPress=(action 'addErrorDisplayFor' 'blockTitle')
-      }}
+      <input
+        value={{blockTitle}}
+        oninput={{action (mut blockTitle) value="target.value"}}
+        disabled={{isSaving}}
+        onfocusout={{action 'addErrorDisplayFor' 'blockTitle'}}
+        onkeypress={{action 'addErrorDisplayFor' 'blockTitle'}}
+      >
       {{#if (and (v-get this 'blockTitle' 'isInvalid') (is-in showErrorsFor 'blockTitle'))}}
         <span class="validation-error-message">{{v-get this 'blockTitle' 'message'}}</span>
       {{/if}}

--- a/app/templates/components/curriculum-inventory-sequence-block-overview.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-overview.hbs
@@ -42,15 +42,16 @@
           value=(if description description (t 'general.clickToAddDescription'))
           save=(action 'changeDescription')
           close=(action 'revertDescriptionChanges')
-          as |isSaving save close|
+          closeOnEscape=true
+          as |isSaving|
         }}
-          {{one-way-textarea
-            value=description
-            update=(action (mut description))
-            onenter=save
-            onescape=close
-            disabled=isSaving
-          }}
+          <textarea
+            value={{description}}
+            oninput={{action (mut description) value="target.value"}}
+            disabled={{isSaving}}
+          >
+            {{description}}
+          </textarea>
         {{/editable-field}}
       {{/if}}
     </div>

--- a/app/templates/components/curriculum-inventory-sequence-block-session-manager.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-session-manager.hbs
@@ -10,12 +10,12 @@
       <thead>
         <tr>
           <th class='text-center' colspan=2>
-            {{input
-            type='checkbox'
-            checked=allSelected
-            change=(action 'toggleSelectAll')
-            indeterminate=someSelected
-            }}{{t 'general.countAsOneOffering'}}
+            <input
+            type="checkbox"
+            checked={{allSelected}}
+            onclick={{action 'toggleSelectAll' value="target.value"}}
+            indeterminate={{someSelected}}
+            >{{t 'general.countAsOneOffering'}}
           </th>
           {{#sortable-th
             colspan=3

--- a/app/templates/components/instructorgroup-header.hbs
+++ b/app/templates/components/instructorgroup-header.hbs
@@ -4,17 +4,17 @@
      value=title
      save=(action 'changeTitle')
      close=(action 'revertTitleChanges')
-     as |isSaving save close|
+     saveOnEnter=true
+     closeOnEscape=true
+     as |isSaving|
   }}
-    {{one-way-input
-      value=title
-      update=(action (mut title))
-      onenter=save
-      onescape=close
-      disabled=isSaving
-      focusOut=(action 'addErrorDisplayFor' 'title')
-      keyPress=(action 'addErrorDisplayFor' 'title')
-    }}
+    <input
+      value={{title}}
+      oninput={{action (mut title) value="target.value"}}
+      disabled={{isSaving}}
+      onfocusout={{action 'addErrorDisplayFor' 'title'}}
+      onkeypress={{action 'addErrorDisplayFor' 'title'}}
+    >
     {{#if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}}
       <span class="validation-error-message">{{v-get this 'title' 'message'}}</span>
     {{/if}}

--- a/app/templates/components/learnergroup-cohort-user-manager.hbs
+++ b/app/templates/components/learnergroup-cohort-user-manager.hbs
@@ -42,10 +42,11 @@
           <tr class="{{unless user.enabled 'disabled-user-account'}}">
             <td class='text-left' colspan=1>
               {{#if user.enabled}}
-                {{one-way-checkbox
-                  checked=(contains user selectedUsers)
-                  update=(action 'toggleUserSelection' user)
-                }}
+                <input
+                  type="checkbox"
+                  checked={{contains user selectedUsers}}
+                  onclick={{action 'toggleUserSelection' user}}
+                >
               {{else}}
                 {{fa-icon 'user-times' title=(t 'general.disabled') class='error'}}
               {{/if}}

--- a/app/templates/components/learnergroup-header.hbs
+++ b/app/templates/components/learnergroup-header.hbs
@@ -5,17 +5,17 @@
         value=(if title title (t 'general.clickToEdit'))
         save=(perform changeTitle)
         close=(action 'revertTitleChanges')
-        as |isSaving save close|
+        saveOnEnter=true
+        closeOnEscape=true
+        as |isSaving|
       }}
-        {{one-way-input
-          value=title
-          update=(action (mut title))
-          onenter=save
-          onescape=close
-          disabled=isSaving
-          focusOut=(action 'addErrorDisplayFor' 'title')
-          keyPress=(action 'addErrorDisplayFor' 'title')
-        }}
+        <input
+          value={{title}}
+          oninput={{action (mut title) value="target.value"}}
+          disabled={{isSaving}}
+          onfocusout={{action 'addErrorDisplayFor' 'title'}}
+          onkeypress={{action 'addErrorDisplayFor' 'title'}}
+        >
         {{#if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}}
           <span class="validation-error-message">{{v-get this 'title' 'message'}}</span>
         {{/if}}

--- a/app/templates/components/learnergroup-summary.hbs
+++ b/app/templates/components/learnergroup-summary.hbs
@@ -35,16 +35,16 @@
         value=(if location location (t 'general.clickToEdit'))
         save=(action 'changeLocation')
         close=(action 'revertLocationChanges')
-        as |isSaving save close|
+        saveOnEnter=true
+        closeOnEscape=true
+        as |isSaving|
       }}
-        {{one-way-input
-          value=location
-          update=(action (mut location))
-          onenter=save
-          onescape=close
-          disabled=isSaving
-          focusOut=(action 'addErrorDisplayFor' 'location')
-        }}
+        <input
+          value={{location}}
+          oninput={{action (mut location) value="target.value"}}
+          disabled={{isSaving}}
+          onfocusout={{action 'addErrorDisplayFor' 'location'}}
+        >
         {{#if (and (v-get this 'location' 'isInvalid') (is-in showErrorsFor 'location'))}}
           <span class="validation-error-message">{{v-get this 'location' 'message'}}</span>
         {{/if}}

--- a/app/templates/components/learnergroup-user-manager.hbs
+++ b/app/templates/components/learnergroup-user-manager.hbs
@@ -65,10 +65,11 @@
               <td class='text-left' colspan=1>
                 {{#if user.enabled}}
                   {{#if isEditing}}
-                    {{one-way-checkbox
-                      checked=(contains user.content selectedUsers)
-                      update=(action 'toggleUserSelection' user.content)
-                    }}
+                    <input
+                      type="checkbox"
+                      checked={{contains user.content selectedUsers}}
+                      onclick={{action 'toggleUserSelection' user.content}}
+                    >
                   {{/if}}
                 {{else}}
                   {{fa-icon 'user-times' title=(t 'general.disabled') class='error'}}
@@ -121,10 +122,11 @@
                 <td class='text-left' colspan=1>
                   {{#if user.enabled}}
                     {{#if isEditing}}
-                      {{one-way-checkbox
-                        checked=(contains user.content selectedUsers)
-                        update=(action 'toggleUserSelection' user.content)
-                      }}
+                      <input
+                        type="checkbox"
+                        checked={{contains user.content selectedUsers}}
+                        onclick={{action 'toggleUserSelection' user.content}}
+                      >
                     {{/if}}
                   {{else}}
                     {{fa-icon 'user-times' title=(t 'general.disabled') class='error'}}

--- a/app/templates/components/new-curriculum-inventory-report.hbs
+++ b/app/templates/components/new-curriculum-inventory-report.hbs
@@ -24,12 +24,12 @@
       <div class="form-col form-col-12 description">
         <label class="form-label">{{t 'general.description'}}:</label>
         <div class="form-data form-data-text form-input-row">
-          {{one-way-textarea
-            value=description
-            update=(action (mut description))
-            disabled=isSaving
-            placeholder=(t 'general.reportDescriptionPlaceholder')
-          }}
+          <textarea
+            value={{description}}
+            oninput={{action (mut description) value="target.value"}}
+            disabled={{if isSaving true}}
+            placeholder={{t 'general.reportDescriptionPlaceholder'}}
+          ></textarea>
         </div>
       </div>
 

--- a/app/templates/components/new-curriculum-inventory-report.hbs
+++ b/app/templates/components/new-curriculum-inventory-report.hbs
@@ -27,7 +27,7 @@
           <textarea
             value={{description}}
             oninput={{action (mut description) value="target.value"}}
-            disabled={{if isSaving true}}
+            disabled={{isSaving}}
             placeholder={{t 'general.reportDescriptionPlaceholder'}}
           ></textarea>
         </div>

--- a/app/templates/components/new-curriculum-inventory-sequence-block.hbs
+++ b/app/templates/components/new-curriculum-inventory-sequence-block.hbs
@@ -40,12 +40,12 @@
   </div>
   <div class="item description">
     <label>{{t 'general.description'}}:</label>
-    {{one-way-textarea
-      value=description
-      update=(action (mut description))
-      disabled=isSaving
-      placeholder=(t 'general.sequenceBlockDescriptionPlaceholder')
-    }}
+    <textarea
+      value={{description}}
+      oninput={{action (mut description) value="target.value"}}
+      disabled={{if isSaving true}}
+      placeholder={{t 'general.sequenceBlockDescriptionPlaceholder'}}
+    ></textarea>
   </div>
 
   <div class="item required">

--- a/app/templates/components/new-curriculum-inventory-sequence-block.hbs
+++ b/app/templates/components/new-curriculum-inventory-sequence-block.hbs
@@ -43,7 +43,7 @@
     <textarea
       value={{description}}
       oninput={{action (mut description) value="target.value"}}
-      disabled={{if isSaving true}}
+      disabled={{isSaving}}
       placeholder={{t 'general.sequenceBlockDescriptionPlaceholder'}}
     ></textarea>
   </div>

--- a/app/templates/components/new-learningmaterial.hbs
+++ b/app/templates/components/new-learningmaterial.hbs
@@ -104,10 +104,11 @@
     <label>{{t 'general.copyrightPermission'}}:</label>
     <span>
       <p id="lm-copyright-agreement-text">
-        {{one-way-checkbox
-            checked=copyrightPermission
-            update=(action (mut copyrightPermission))
-        }}
+        <input
+          type="checkbox"
+          checked={{copyrightPermission}}
+          onclick={{action (mut copyrightPermission)}}
+        >
         {{t 'general.copyrightAgreement'}}
       </p>
     </span>

--- a/app/templates/components/offering-form.hbs
+++ b/app/templates/components/offering-form.hbs
@@ -75,7 +75,7 @@
                   type="checkbox"
                   checked={{or (is-in recurringDays obj.day) (eq (moment-format startDate 'd') obj.day)}}
                   onclick={{action 'toggleRecurringDay' obj.day}}
-                  disabled={{if (eq (moment-format startDate 'd') obj.day) true}}
+                  disabled={{eq (moment-format startDate 'd') obj.day}}
                 >
                 <label class="day-of-week">{{t obj.t}}</label>
               </div>

--- a/app/templates/components/offering-form.hbs
+++ b/app/templates/components/offering-form.hbs
@@ -71,11 +71,12 @@
           <div class="make-recurring-days">
             {{#each recurringDayOptions as |obj|}}
               <div>
-                {{one-way-checkbox
-                  checked=(or (is-in recurringDays obj.day) (eq (moment-format startDate 'd') obj.day))
-                  click=(action 'toggleRecurringDay' obj.day)
-                  disabled=(eq (moment-format startDate 'd') obj.day)
-                }}
+                <input
+                  type="checkbox"
+                  checked={{or (is-in recurringDays obj.day) (eq (moment-format startDate 'd') obj.day)}}
+                  onclick={{action 'toggleRecurringDay' obj.day}}
+                  disabled={{if (eq (moment-format startDate 'd') obj.day) true}}
+                >
                 <label class="day-of-week">{{t obj.t}}</label>
               </div>
             {{/each}}

--- a/app/templates/components/program-header.hbs
+++ b/app/templates/components/program-header.hbs
@@ -4,17 +4,17 @@
     value=programTitle
     save=(action 'changeTitle')
     close=(action 'revertTitleChanges')
-    as |isSaving save close|
+    saveOnEnter=true
+    closeOnEscape=true
+    as |isSaving|
   }}
-    {{one-way-input
-      value=programTitle
-      update=(action (mut programTitle))
-      onenter=save
-      onescape=close
-      disabled=isSaving
-      focusOut=(action 'addErrorDisplayFor' 'programTitle')
-      keyPress=(action 'addErrorDisplayFor' 'programTitle')
-    }}
+    <input
+      value={{programTitle}}
+      oninput={{action (mut programTitle) value="target.value"}}
+      disabled={{isSaving}}
+      onfocusout={{action 'addErrorDisplayFor' 'programTitle'}}
+      onkeypress={{action 'addErrorDisplayFor' 'programTitle'}}
+    >
     {{#if (and (v-get this 'programTitle' 'isInvalid') (is-in showErrorsFor 'programTitle'))}}
       <span class="validation-error-message">{{v-get this 'programTitle' 'message'}}</span>
     {{/if}}

--- a/app/templates/components/program-overview.hbs
+++ b/app/templates/components/program-overview.hbs
@@ -8,17 +8,17 @@
          save=(action 'changeShortTitle')
          close=(action 'revertShortTitleChanges')
          clickPrompt=(t 'general.clickToEdit')
-         as |isSaving save close|
+         saveOnEnter=true
+         closeOnEscape=true
+         as |isSaving|
       }}
-        {{one-way-input
-          value=shortTitle
-          update=(action (mut shortTitle))
-          onenter=save
-          onescape=close
-          disabled=isSaving
-          focusOut=(action 'addErrorDisplayFor' 'shortTitle')
-          keyPress=(action 'addErrorDisplayFor' 'shortTitle')
-        }}
+        <input
+          value={{shortTitle}}
+          oninput={{action (mut shortTitle) value="target.value"}}
+          disabled={{isSaving}}
+          onfocusout={{action 'addErrorDisplayFor' 'shortTitle'}}
+          onkeypress={{action 'addErrorDisplayFor' 'shortTitle'}}
+        >
         {{#if (and (v-get this 'shortTitle' 'isInvalid') (is-in showErrorsFor 'shortTitle'))}}
           <span class="validation-error-message">{{v-get this 'shortTitle' 'message'}}</span>
         {{/if}}

--- a/app/templates/components/programyear-competencies.hbs
+++ b/app/templates/components/programyear-competencies.hbs
@@ -32,14 +32,9 @@
                 <input type='checkbox' checked>
                 {{domain.title}}
               </span>
-            {{else if (contains domain (await competenciesWithSelectedChildren))}}
-              <span class='clickable' onclick={{action 'addCompetencyToBuffer' domain}}>
-                <input type="checkbox" indeterminate={{true}}>
-                {{domain.title}}
-              </span>
             {{else}}
               <span class='clickable' onclick={{action 'addCompetencyToBuffer' domain}}>
-                <input type='checkbox'>
+                <input type="checkbox" indeterminate={{contains domain (await competenciesWithSelectedChildren)}}>
                 {{domain.title}}
               </span>
             {{/if}}

--- a/app/templates/components/programyear-competencies.hbs
+++ b/app/templates/components/programyear-competencies.hbs
@@ -34,7 +34,7 @@
               </span>
             {{else if (contains domain (await competenciesWithSelectedChildren))}}
               <span class='clickable' onclick={{action 'addCompetencyToBuffer' domain}}>
-                {{input type="checkbox" indeterminate=true}}
+                <input type="checkbox" indeterminate={{true}}>
                 {{domain.title}}
               </span>
             {{else}}

--- a/app/templates/components/programyear-competencies.hbs
+++ b/app/templates/components/programyear-competencies.hbs
@@ -34,7 +34,7 @@
               </span>
             {{else if (contains domain (await competenciesWithSelectedChildren))}}
               <span class='clickable' onclick={{action 'addCompetencyToBuffer' domain}}>
-                {{one-way-checkbox indeterminate=true}}
+                {{input type="checkbox" indeterminate=true}}
                 {{domain.title}}
               </span>
             {{else}}

--- a/app/templates/components/publish-all-sessions.hbs
+++ b/app/templates/components/publish-all-sessions.hbs
@@ -131,11 +131,19 @@
               <td>
                 <ul>
                   <li>
-                    {{one-way-checkbox checked=(is-in sessionsToOverride session) click=(action 'toggleSession' session)}}
+                    <input
+                      type="checkbox"
+                      checked={{is-in sessionsToOverride session}}
+                      onclick={{action 'toggleSession' session}}
+                    >
                     <span class='clickable' {{action 'toggleSession' session}}>{{t 'general.publishAsIs'}}</span>
                   </li>
                   <li>
-                    {{one-way-checkbox checked=(not-in sessionsToOverride session) click=(action 'toggleSession' session)}}
+                    <input
+                      type="checkbox"
+                      checked={{not-in sessionsToOverride session}}
+                      onclick={{action 'toggleSession' session}}
+                    >
                     <span class='clickable' {{action 'toggleSession' session}}>{{t 'general.markAsScheduled'}}</span>
                   </li>
                 </ul>

--- a/app/templates/components/school-manager.hbs
+++ b/app/templates/components/school-manager.hbs
@@ -8,17 +8,17 @@
     value=title
     save=(action 'changeTitle')
     close=(action 'revertTitleChanges')
-    as |isSaving save close|
+    saveOnEnter=true
+    closeOnEscape=true
+    as |isSaving|
   }}
-    {{one-way-input
-      value=title
-      update=(action (mut title))
-      onenter=save
-      onescape=close
-      disabled=isSaving
-      focusOut=(action 'addErrorDisplayFor' 'title')
-      keyPress=(action 'addErrorDisplayFor' 'title')
-    }}
+    <input
+      value={{title}}
+      oninput={{action (mut title) value="target.value"}}
+      disabled={{isSaving}}
+      onfocusout={{action 'addErrorDisplayFor' 'title'}}
+      onkeypress={{action 'addErrorDisplayFor' 'title'}}
+    >
     {{#if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}}
       <span class="validation-error-message">{{v-get this 'title' 'message'}}</span>
     {{/if}}

--- a/app/templates/components/school-vocabulary-manager.hbs
+++ b/app/templates/components/school-vocabulary-manager.hbs
@@ -8,15 +8,15 @@
     value=(if title title (t 'general.clickToEdit'))
     save=(action 'changeVocabularyTitle')
     close=(action 'revertVocabularyTitleChanges')
-    as |isSaving save close|
+    saveOnEnter=true
+    closeOnEscape=true
+    as |isSaving|
   }}
-    {{one-way-input
-      value=title
-      update=(action (mut title))
-      onenter=save
-      onescape=close
-      disabled=isSaving
-    }}
+    <input
+      value={{title}}
+      oninput={{action (mut title) value="target.value"}}
+      disabled={{isSaving}}
+    >
   {{/editable-field}}
 </p>
 

--- a/app/templates/components/school-vocabulary-term-manager.hbs
+++ b/app/templates/components/school-vocabulary-term-manager.hbs
@@ -15,15 +15,15 @@
       value=(if title title (t 'general.clickToEdit'))
       save=(action 'changeTermTitle')
       close=(action 'revertTermTitleChanges')
-      as |isSaving save close|
+      saveOnEnter=true
+      closeOnEscape=true
+      as |isSaving|
     }}
-      {{one-way-input
-      	value=title
-      	update=(action (mut title))
-      	onenter=save
-      	onescape=close
-      	disabled=isSaving
-      }}
+      <input
+        value={{title}}
+        oninput={{action (mut title) value="target.value"}}
+        disabled={{isSaving}}
+      >
     {{/editable-field}}
     {{#unless (or term.hasChildren term.hasAssociations)}}
       {{fa-icon 'trash' class='clickable remove' click=(action 'deleteTerm')}}
@@ -34,15 +34,16 @@
       value=(if description description (t 'general.clickToAddTermDescription'))
       save=(action 'changeTermDescription')
       close=(action 'revertTermDescriptionChanges')
-      as |isSaving save close|
+      closeOnEscape=true
+      as |isSaving|
     }}
-      {{one-way-textarea
-        value=description
-        update=(action (mut description))
-        onenter=save
-        onescape=close
-        disabled=isSaving
-      }}
+      <textarea
+        value={{description}}
+        oninput={{action (mut description) value="target.value"}}
+        disabled={{isSaving}}
+      >
+        {{description}}
+      </textarea>
     {{/editable-field}}
   </p>
 {{/if}}

--- a/app/templates/components/session-overview.hbs
+++ b/app/templates/components/session-overview.hbs
@@ -5,16 +5,16 @@
         value=title
         save=(action 'changeTitle')
         close=(action 'revertTitleChanges')
-      as |isSaving save close|
+        saveOnEnter=true
+        closeOnEscape=true
+      as |isSaving|
       }}
-        {{one-way-input
-          value=title
-          update=(action (mut title))
-          onenter=save
-          onescape=close
-          disabled=isSaving
-          focusOut=(action 'addErrorDisplayFor' 'title')
-        }}
+        <input
+          value={{title}}
+          disabled={{isSaving}}
+          oninput={{action (mut title) value="target.value"}}
+          onfocusout={{action 'addErrorDisplayFor' 'title'}}
+        >
         {{#if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}}
           <span class="validation-error-message">{{v-get this 'title' 'message'}}</span>
         {{/if}}

--- a/app/templates/components/user-profile-roles.hbs
+++ b/app/templates/components/user-profile-roles.hbs
@@ -18,10 +18,11 @@
       {{/if}}
     </span>
   {{else}}
-    {{one-way-checkbox
-      checked=(await isCourseDirector)
-      update=(action (mut isCourseDirectorFlipped) (not isCourseDirectorFlipped))
-    }}
+    <input
+      type="checkbox"
+      checked={{await isCourseDirector}}
+      onclick={{action (mut isCourseDirectorFlipped) (not isCourseDirectorFlipped)}}
+    >
   {{/unless}}
 </div>
 <div class='item'>
@@ -35,10 +36,11 @@
       {{/if}}
     </span>
   {{else}}
-    {{one-way-checkbox
-      checked=(await isFaculty)
-      update=(action (mut isFacultyFlipped) (not isFacultyFlipped))
-    }}
+    <input
+      type="checkbox"
+      checked={{await isFaculty}}
+      onclick={{action (mut isFacultyFlipped) (not isFacultyFlipped)}}
+    >
   {{/unless}}
 </div>
 <div class='item'>
@@ -52,10 +54,11 @@
       {{/if}}
     </span>
   {{else}}
-    {{one-way-checkbox
-      checked=(await isDeveloper)
-      update=(action (mut isDeveloperFlipped) (not isDeveloperFlipped))
-    }}
+    <input
+      type="checkbox"
+      checked={{await isDeveloper}}
+      onclick={{action (mut isDeveloperFlipped) (not isDeveloperFlipped)}}
+    >
   {{/unless}}
 </div>
 <div class='item'>
@@ -69,10 +72,11 @@
       {{/if}}
     </span>
   {{else}}
-    {{one-way-checkbox
-      checked=(await isFormerStudent)
-      update=(action (mut isFormerStudentFlipped) (not isFormerStudentFlipped))
-    }}
+    <input
+      type="checkbox"
+      checked={{await isFormerStudent}}
+      onclick={{action (mut isFormerStudentFlipped) (not isFormerStudentFlipped)}}
+    >
   {{/unless}}
 </div>
 
@@ -89,11 +93,12 @@
       {{/if}}
     </span>
   {{else}}
-    {{one-way-checkbox
-      checked=(await isEnabled)
-      update=(action (mut isEnabledFlipped) (not isEnabledFlipped))
-      disabled=(eq user.id currentUser.model.id)
-    }}
+    <input
+      type="checkbox"
+      checked={{await isEnabled}}
+      onclick={{action (mut isEnabledFlipped) (not isEnabledFlipped)}}
+      disabled={{if (eq user.id currentUser.model.id) true}}
+    >
   {{/unless}}
 </div>
 <div class='item'>
@@ -107,9 +112,10 @@
       {{/if}}
     </span>
   {{else}}
-    {{one-way-checkbox
-      checked=(await isUserSyncIgnored)
-      update=(action (mut isUserSyncIgnoredFlipped) (not isUserSyncIgnoredFlipped))
-    }}
+    <input
+      type="checkbox"
+      checked={{await isUserSyncIgnored}}
+      onclick={{action (mut isUserSyncIgnoredFlipped) (not isUserSyncIgnoredFlipped)}}
+    >
   {{/unless}}
 </div>

--- a/app/templates/components/user-profile-schools.hbs
+++ b/app/templates/components/user-profile-schools.hbs
@@ -26,11 +26,12 @@
           <td colspan="3">{{school.title}}</td>
           <td>
             {{#if isManaging}}
-              {{one-way-checkbox
-                checked=(is-in (await readAndWriteSchoolIds) school.id)
-                update=(action 'toggleReadSchool' school)
-                disabled=(is-in (await writeSchoolIds) school.id)
-              }}
+              <input
+                type="checkbox"
+                checked={{is-in (await readAndWriteSchoolIds) school.id}}
+                onclick={{action 'toggleReadSchool' school}}
+                disabled={{if (is-in (await writeSchoolIds) school.id) true}}
+              >
             {{else}}
               {{fa-icon
                 (if (or (contains school.id (map-by 'id' (await readSchools))) (contains school.id (map-by 'id' (await writeSchools)))) 'check' 'ban')
@@ -40,10 +41,11 @@
           </td>
           <td>
             {{#if isManaging}}
-              {{one-way-checkbox
-                checked=(contains school.id (map-by 'id' (await writeSchools)))
-                update=(action 'toggleWriteSchool' school)
-              }}
+              <input
+                type="checkbox"
+                checked={{contains school.id (map-by 'id' (await writeSchools))}}
+                onclick={{action 'toggleWriteSchool' school}}
+              >
             {{else}}
               {{fa-icon
                 (if (contains school.id (map-by 'id' (await writeSchools))) 'check' 'ban')

--- a/tests/integration/components/competency-title-editor-test.js
+++ b/tests/integration/components/competency-title-editor-test.js
@@ -27,7 +27,7 @@ test('validation errors show up when saving', function(assert) {
   this.set('competency', competency);
   this.render(hbs`{{competency-title-editor competency=competency}}`);
   this.$('.content span:eq(0)').click();
-  this.$('input').val('').change();
+  this.$('input').val('').trigger('input');
   this.$('button.done').click();
   return wait().then(()=>{
     assert.equal(this.$('.validation-error-message').length, 1);

--- a/tests/integration/components/course-overview-test.js
+++ b/tests/integration/components/course-overview-test.js
@@ -57,7 +57,7 @@ test('course external id validation fails if value is too short', function(asser
   this.$(button).click();
   return wait().then(()=>{
     assert.equal(this.$(error).length, 0, 'No validation errors shown initially.');
-    this.$(input).val('a').change();
+    this.$(input).val('a').trigger('input');
     this.$(save).click();
     wait().then(() => {
       assert.equal(this.$(error).length, 1, 'Validation failed, error message shows.');
@@ -87,7 +87,7 @@ test('course external id validation fails if value is too long', function(assert
   this.$(button).click();
   return wait().then(()=>{
     assert.equal(this.$(error).length, 0, 'No validation errors shown initially.');
-    this.$(input).val('tooLong'.repeat(50)).change();
+    this.$(input).val('tooLong'.repeat(50)).trigger('input');
     this.$(save).click();
     wait().then(() => {
       assert.equal(this.$(error).length, 1, 'Validation failed, error message shows.');
@@ -128,7 +128,7 @@ test('course external id validation passes on changed value within boundaries', 
   this.$(button).click();
   return wait().then(()=>{
     assert.equal(this.$(error).length, 0, 'No validation errors shown initially.');
-    this.$(input).val('legit').change();
+    this.$(input).val('legit').trigger('input');
     this.$(save).click();
     wait().then(() => {
       assert.equal(this.$(error).length, 0, 'No validation errors, no messages shown.');
@@ -169,7 +169,7 @@ test('course external id validation passes on empty value', function(assert) {
   this.$(button).click();
   return wait().then(()=>{
     assert.equal(this.$(error).length, 0, 'No validation errors shown initially.');
-    this.$(input).val('').change();
+    this.$(input).val('').trigger('input');
     this.$(save).click();
     wait().then(() => {
       assert.equal(this.$(error).length, 0, 'No validation errors, no messages shown.');

--- a/tests/integration/components/curriculum-inventory-report-header-test.js
+++ b/tests/integration/components/curriculum-inventory-report-header-test.js
@@ -56,7 +56,7 @@ test('change name', function(assert) {
   assert.equal(this.$('.editinplace').text().trim(), report.name);
   this.$('.editable').click();
   this.$('.editinplace input').val(newName);
-  this.$('.editinplace input').trigger('change');
+  this.$('.editinplace input').trigger('input');
   this.$('.editinplace .done').click();
   return wait().then(() => {
     assert.equal(this.$('.editinplace').text().trim(), newName);
@@ -78,7 +78,7 @@ test('change name fails on empty value', function(assert) {
   this.$('.editable').click();
   assert.equal(this.$('.validation-error-message').length, 0, 'No validation error shown initially.');
   this.$('.editinplace input').val('');
-  this.$('.editinplace input').trigger('change');
+  this.$('.editinplace input').trigger('input');
   this.$('.editinplace .done').click();
   return wait().then(() => {
     assert.ok(this.$('.validation-error-message').length, 1, 'Validation error shows.');

--- a/tests/integration/components/curriculum-inventory-report-overview-test.js
+++ b/tests/integration/components/curriculum-inventory-report-overview-test.js
@@ -612,7 +612,7 @@ test('change description', function (assert) {
     this.$('.description .editinplace .editable').click();
     return wait().then(() => {
       const newDescription = 'Quidquid luce fuit, tenebris agit.';
-      this.$('.description textarea').val(newDescription).trigger('change');
+      this.$('.description textarea').val(newDescription).trigger('input');
       this.$('.description .actions .done').click();
       return wait().then(() => {
         assert.equal(this.$('.description .editinplace').text().trim(), newDescription);
@@ -668,7 +668,7 @@ test('description validation fails if text is too long', function (assert) {
         'Validation error is initially not shown.'
       );
       const newDescription = '0123456789'.repeat(5000);
-      this.$('.description textarea').val(newDescription).trigger('change');
+      this.$('.description textarea').val(newDescription).trigger('input');
       this.$('.description .actions .done').click();
       return wait().then(() => {
         assert.equal(this.$('.description .validation-error-message').length, 1, 'Validation error message is visible.');

--- a/tests/integration/components/curriculum-inventory-report-rollover-test.js
+++ b/tests/integration/components/curriculum-inventory-report-rollover-test.js
@@ -177,7 +177,7 @@ test('rollover report with new name, description and year', async function(asser
   this.$(input).val(newName);
   this.$(input).trigger('change');
   this.$(textarea).val(newDescription);
-  this.$(textarea).trigger('change');
+  this.$(textarea).trigger('input');
   this.$(lastOption).prop('selected', true);
   this.$(lastOption).trigger('change');
   await this.$('.done').click();

--- a/tests/integration/components/curriculum-inventory-sequence-block-header-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-header-test.js
@@ -48,7 +48,7 @@ test('change title', function(assert) {
   assert.equal(this.$('.editinplace').text().trim(), block.title);
   this.$('.editable').click();
   this.$('.editinplace input').val(newTitle);
-  this.$('.editinplace input').trigger('change');
+  this.$('.editinplace input').trigger('input');
   this.$('.editinplace .done').click();
   return wait().then(() => {
     assert.equal(this.$('.editinplace').text().trim(), newTitle);
@@ -68,7 +68,7 @@ test('change title fails on empty value', function(assert) {
   this.$('.editable').click();
   assert.equal(this.$('.validation-error-message').length, 0, 'No validation error shown initially.');
   this.$('.editinplace input').val('');
-  this.$('.editinplace input').trigger('change');
+  this.$('.editinplace input').trigger('input');
   this.$('.editinplace .done').click();
   return wait().then(() => {
     assert.ok(this.$('.validation-error-message').length, 1, 'Validation error shows.');
@@ -88,7 +88,7 @@ test('change title fails on too-short value', function(assert) {
   this.$('.editable').click();
   assert.equal(this.$('.validation-error-message').length, 0, 'No validation error shown initially.');
   this.$('.editinplace input').val('ab');
-  this.$('.editinplace input').trigger('change');
+  this.$('.editinplace input').trigger('input');
   this.$('.editinplace .done').click();
   return wait().then(() => {
     assert.ok(this.$('.validation-error-message').length, 1, 'Validation error shows.');
@@ -108,7 +108,7 @@ test('change title fails on overlong value', function(assert) {
   this.$('.editable').click();
   assert.equal(this.$('.validation-error-message').length, 0, 'No validation error shown initially.');
   this.$('.editinplace input').val('0123456789'.repeat(21));
-  this.$('.editinplace input').trigger('change');
+  this.$('.editinplace input').trigger('input');
   this.$('.editinplace .done').click();
   return wait().then(() => {
     assert.ok(this.$('.validation-error-message').length, 1, 'Validation error shows.');

--- a/tests/integration/components/curriculum-inventory-sequence-block-overview-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-overview-test.js
@@ -556,7 +556,7 @@ test('change description', function(assert) {
     this.$('.description .editinplace .clickable').click();
     return wait().then(() => {
       const newDescription = 'Lorem Ipsum';
-      this.$('.description textarea').val(newDescription).trigger('change');
+      this.$('.description textarea').val(newDescription).trigger('input');
       this.$('.description .actions .done').click();
       return wait().then(() => {
         assert.equal(this.$('.description .editinplace').text().trim(), newDescription);

--- a/tests/integration/components/curriculum-inventory-sequence-block-session-manager-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-session-manager-test.js
@@ -218,9 +218,9 @@ test('change count as one offering', function(assert) {
   this.set('setSortBy', function(){});
   this.render(hbs`{{curriculum-inventory-sequence-block-session-manager linkableSessions=linkableSessions sequenceBlock=sequenceBlock sortBy=sortBy setSortBy=setSortBy}}`);
   assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxSingleOfferingDuration);
-  this.$('tbody tr:eq(0) td:eq(0) input').prop('checked', false).trigger('change');
+  this.$('tbody tr:eq(0) td:eq(0) input').prop('checked', false).trigger('click');
   assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), totalSumOfferingsDuration);
-  this.$('tbody tr:eq(0) td:eq(0) input').prop('checked', true).trigger('change');
+  this.$('tbody tr:eq(0) td:eq(0) input').prop('checked', true).trigger('click');
   assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxSingleOfferingDuration);
 });
 
@@ -259,11 +259,11 @@ test('change count as one offering for all sessions', function(assert) {
   assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxSingleOfferingDuration);
   assert.equal(this.$('tbody tr:eq(1) td:eq(3)').text().trim(), totalSumOfferingsDuration);
 
-  this.$('thead tr:eq(0) th:eq(0) input').prop('checked', true).trigger('change');
+  this.$('thead tr:eq(0) th:eq(0) input').prop('checked', true).trigger('click');
   assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxSingleOfferingDuration);
   assert.equal(this.$('tbody tr:eq(1) td:eq(3)').text().trim(), maxSingleOfferingDuration);
 
-  this.$('thead tr:eq(0) th:eq(0) input').prop('checked', false).trigger('change');
+  this.$('thead tr:eq(0) th:eq(0) input').prop('checked', false).trigger('click');
   assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), totalSumOfferingsDuration);
   assert.equal(this.$('tbody tr:eq(1) td:eq(3)').text().trim(), totalSumOfferingsDuration);
 });
@@ -303,7 +303,7 @@ test('save', function(assert) {
     assert.ok(sessions.includes(session2));
   });
   this.render(hbs`{{curriculum-inventory-sequence-block-session-manager linkableSessions=linkableSessions sortBy=sortBy sequenceBlock=sequenceBlock save=(action 'save')}}`);
-  this.$('tbody tr:eq(1) td:eq(0) input').prop('checked', true).trigger('change');
+  this.$('tbody tr:eq(1) td:eq(0) input').prop('checked', true).trigger('click');
   this.$('.detail-actions .bigadd').click();
 });
 

--- a/tests/integration/components/editable-field-test.js
+++ b/tests/integration/components/editable-field-test.js
@@ -39,3 +39,31 @@ test('it renders an edit icon when it looks empty', function(assert) {
   assert.equal(this.$().text().trim(), '');
   assert.equal(this.$(icon).length, 1);
 });
+
+test('save on enter', function(assert) {
+  assert.expect(1);
+  this.set('value', 'lorem');
+  this.on('save', () => {
+    assert.ok(true, 'save action fired.');
+  });
+  this.render(hbs`{{#editable-field save=(action 'save') saveOnEnter=true value=value}}<input value={{value}} oninput={{action (mut value) value="target.value"}}>{{/editable-field}}`);
+  this.$('.editable').click();
+  const e = $.Event("keyup");
+  e.which = 13;
+  e.keyCode = 13;
+  this.$('.editinplace input').trigger(e);
+});
+
+test('close on escape', function(assert) {
+  assert.expect(1);
+  this.set('value', 'lorem');
+  this.on('revert', () => {
+    assert.ok(true, 'revert action fired.');
+  });
+  this.render(hbs`{{#editable-field close=(action 'revert') closeOnEscape=true value=value}}<input value={{value}} oninput={{action (mut value) value="target.value"}}>{{/editable-field}}`);
+  this.$('.editable').click();
+  const e = $.Event("keyup");
+  e.which = 27;
+  e.keyCode = 27;
+  this.$('.editinplace input').trigger(e);
+});

--- a/tests/integration/components/instructorgroup-header-test.js
+++ b/tests/integration/components/instructorgroup-header-test.js
@@ -42,7 +42,7 @@ test('can change title', function(assert) {
   assert.equal(this.$('.editinplace').text().trim(), 'lorem ipsum');
   this.$('.editable').click();
   this.$('.editinplace input').val('new title');
-  this.$('.editinplace input').trigger('change');
+  this.$('.editinplace input').trigger('input');
   this.$('.editinplace .done').click();
   return wait().then(() => {
     assert.equal(this.$('.editinplace').text().trim(), 'new title');

--- a/tests/integration/components/learnergroup-header-test.js
+++ b/tests/integration/components/learnergroup-header-test.js
@@ -37,7 +37,7 @@ test('can change title', async function(assert) {
   assert.equal(this.$('h2').text().trim(), 'our group');
   this.$('h2 .editable').click();
   this.$('h2 input').val('new title');
-  this.$('h2 input').trigger('change');
+  this.$('h2 input').trigger('input');
   this.$('h2 .done').click();
   await wait();
 });
@@ -87,7 +87,7 @@ test('validate title length', async function(assert) {
   assert.equal(this.$(errors).length, 0, 'there are no errors');
   this.$(edit).click();
   const longTitle = 'x'.repeat(61);
-  this.$(input).val(longTitle).change();
+  this.$(input).val(longTitle).trigger('input');
   this.$(done).click();
   await wait();
   assert.equal(this.$(errors).length, 1, 'there is now an error');

--- a/tests/integration/components/learnergroup-summary-test.js
+++ b/tests/integration/components/learnergroup-summary-test.js
@@ -125,7 +125,7 @@ test('Update location', function(assert) {
     assert.equal(this.$(defaultLocation).text().trim(), 'test location');
     this.$(editLocation).click();
     return wait().then(()=> {
-      this.$(input).val('new location name').change();
+      this.$(input).val('new location name').trigger('input');
       this.$(save).click();
       return wait().then(()=> {
         assert.equal(this.$(defaultLocation).text().trim(), 'new location name');

--- a/tests/integration/components/new-curriculum-inventory-report-test.js
+++ b/tests/integration/components/new-curriculum-inventory-report-test.js
@@ -105,7 +105,7 @@ test('save', function(assert) {
 
   this.render(hbs`{{new-curriculum-inventory-report currentProgram=program save=(action saveReport)}}`);
   this.$('.name input').val('new report').change();
-  this.$('.description textarea').val('lorem ipsum').change();
+  this.$('.description textarea').val('lorem ipsum').trigger('input');
   this.$('.academic-year option:eq(0)').prop('selected', true).change();
   this.$('button.done').click();
 });

--- a/tests/integration/components/new-curriculum-inventory-sequence-block-test.js
+++ b/tests/integration/components/new-curriculum-inventory-sequence-block-test.js
@@ -273,7 +273,7 @@ test('save with defaults', function(assert) {
 
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report save=(action saveBlock)}}`);
   this.$('.title input').val(newTitle).change();
-  this.$('.description textarea').val(newDescription).change();
+  this.$('.description textarea').val(newDescription).trigger('input');
   let interactor = openDatepicker(this.$('.start-date input'));
   interactor.selectDate(newStartDate.toDate());
   interactor = openDatepicker(this.$('.end-date input'));
@@ -335,7 +335,7 @@ test('save with non-defaults', function(assert) {
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report save=(action saveBlock)}}`);
   return wait().then(() => {
     this.$('.title input').val('foo bar').change();
-    this.$('.description textarea').val('lorem ipsum').change();
+    this.$('.description textarea').val('lorem ipsum').trigger('input');
     this.$('.duration input').val(duration).change();
     this.$('.minimum input').val(minimum).change();
     this.$('.maximum input').val(maximum).change();
@@ -393,7 +393,7 @@ test('save nested block in ordered sequence', function(assert) {
 
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report parent=parentBlock save=(action saveBlock)}}`);
   this.$('.title input').val('Foo Bar').change();
-  this.$('.description textarea').val('Lorem Ipsum').change();
+  this.$('.description textarea').val('Lorem Ipsum').trigger('input');
   this.$('.order-in-sequence option:eq(1)').prop('selected', true).change();
   this.$('.duration input').val('19').change();
   this.$('button.done').click();
@@ -500,7 +500,7 @@ test('save fails when minimum is larger than maximum', function(assert) {
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
     this.$('.title input').val('Foo Bar').change();
-    this.$('.description text').val('Lorem Ipsum').change();
+    this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
     let interactor = openDatepicker(startDateInput);
@@ -542,7 +542,7 @@ test('save fails when minimum is less than zero', function(assert) {
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
     this.$('.title input').val('Foo Bar').change();
-    this.$('.description text').val('Lorem Ipsum').change();
+    this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
     let interactor = openDatepicker(startDateInput);
@@ -583,7 +583,7 @@ test('save fails when minimum is empty', function(assert) {
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
     this.$('.title input').val('Foo Bar').change();
-    this.$('.description text').val('Lorem Ipsum').change();
+    this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
     let interactor = openDatepicker(startDateInput);
@@ -624,7 +624,7 @@ test('save fails when maximum is empty', function(assert) {
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
     this.$('.title input').val('Foo Bar').change();
-    this.$('.description text').val('Lorem Ipsum').change();
+    this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
     let interactor = openDatepicker(startDateInput);
@@ -672,7 +672,7 @@ test('save with date range and a zero duration', function(assert) {
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report save=(action saveBlock)}}`);
   return wait().then(() => {
     this.$('.title input').val('Foo Bar').change();
-    this.$('.description text').val('Lorem Ipsum').change();
+    this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
     let interactor = openDatepicker(startDateInput);
@@ -718,7 +718,7 @@ test('save with non-zero duration and no date range', function(assert) {
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report save=(action saveBlock)}}`);
   return wait().then(() => {
     this.$('.title input').val('Foo Bar').change();
-    this.$('.description text').val('Lorem Ipsum').change();
+    this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     this.$('.duration input').val(duration).change();
     this.$('button.done').click();
   });
@@ -749,7 +749,7 @@ test('save fails if end-date is older than start-date', function(assert) {
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
     this.$('.title input').val('Foo Bar').change();
-    this.$('.description text').val('Lorem Ipsum').change();
+    this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
     let interactor = openDatepicker(startDateInput);
@@ -790,7 +790,7 @@ test('save fails on missing duration', function(assert) {
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
     this.$('.title input').val('Foo Bar').change();
-    this.$('.description text').val('Lorem Ipsum').change();
+    this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
     let interactor = openDatepicker(startDateInput);
@@ -831,7 +831,7 @@ test('save fails on invalid duration', function(assert) {
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
     this.$('.title input').val('Foo Bar').change();
-    this.$('.description text').val('Lorem Ipsum').change();
+    this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
     let interactor = openDatepicker(startDateInput);
@@ -872,7 +872,7 @@ test('save fails if neither date range nor non-zero duration is provided', funct
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
     this.$('.title input').val('Foo Bar').change();
-    this.$('.description text').val('Lorem Ipsum').change();
+    this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     this.$('.duration text').val('Lorem Ipsum').change();
     this.$('button.done').click();
     return wait().then(() => {
@@ -906,7 +906,7 @@ test('save fails if start-date is given but no end-date is provided', function(a
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
     this.$('.title input').val('Foo Bar').change();
-    this.$('.description text').val('Lorem Ipsum').change();
+    this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     this.$('.duration text').val('Lorem Ipsum').change();
     let startDateInput = this.$('.start-date input');
     let interactor = openDatepicker(startDateInput);


### PR DESCRIPTION
refs #3466

Update: this PR now also contains replacements for all `{{one-way-checkbox}}` components.
Update 2: this PR now contains replacements for all remaining `{{one-way-textbox}}` components.