### PR TITLE
one-way-controls replacement in user profile bio form.

### DIFF
--- a/app/components/user-profile-bio.js
+++ b/app/components/user-profile-bio.js
@@ -290,6 +290,28 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     });
   }),
 
+  keyUp(event) {
+    const keyCode = event.keyCode;
+    const target = event.target;
+
+    if (! ['text', 'password'].includes(target.type)) {
+      return;
+    }
+
+    if (13 === keyCode) {
+      this.get('save').perform();
+      return;
+    }
+
+    if(27 === keyCode) {
+      if ('text' === target.type) {
+        this.get('cancel').perform();
+      } else {
+        this.send('cancelChangeUserPassword');
+      }
+    }
+  },
+
   actions: {
     cancelChangeUserPassword(){
       this.set('changeUserPassword', false);

--- a/app/templates/components/user-profile-bio.hbs
+++ b/app/templates/components/user-profile-bio.hbs
@@ -17,13 +17,12 @@
   {{#unless isManaging}}
     <span class='value'>{{user.firstName}}</span>
   {{else}}
-    {{one-way-input
-      value=firstName
-      update=(action (mut firstName))
-      onenter=(perform save)
-      onescape=(perform cancel)
-      focusOut=(action 'addErrorDisplayFor' 'firstName')
-    }}
+    <input
+      type="text"
+      value={{firstName}}
+      oninput={{action (mut firstName) value="target.value"}}
+      onfocusout={{action 'addErrorDisplayFor' 'firstName'}}
+    >
     {{#if (and (v-get this 'firstName' 'isInvalid') (is-in showErrorsFor 'firstName'))}}
       <span class="message error">{{v-get this 'firstName' 'message'}}</span>
     {{/if}}
@@ -34,13 +33,12 @@
   {{#unless isManaging}}
     <span class='value'>{{user.middleName}}</span>
   {{else}}
-    {{one-way-input
-      value=middleName
-      update=(action (mut middleName))
-      onenter=(perform save)
-      onescape=(perform cancel)
-      focusOut=(action 'addErrorDisplayFor' 'middleName')
-    }}
+    <input
+      type="text"
+      value={{middleName}}
+      oninput={{action (mut middleName) value="target.value"}}
+      onfocusout={{action 'addErrorDisplayFor' 'middleName'}}
+    >
     {{#if (and (v-get this 'middleName' 'isInvalid') (is-in showErrorsFor 'middleName'))}}
       <span class="message error">{{v-get this 'middleName' 'message'}}</span>
     {{/if}}
@@ -51,13 +49,12 @@
   {{#unless isManaging}}
     <span class='value'>{{user.lastName}}</span>
   {{else}}
-    {{one-way-input
-      value=lastName
-      update=(action (mut lastName))
-      onenter=(perform save)
-      onescape=(perform cancel)
-      focusOut=(action 'addErrorDisplayFor' 'lastName')
-    }}
+    <input
+      type="text"
+      value={{lastName}}
+      oninput={{action (mut lastName) value="target.value"}}
+      onfocusout={{action 'addErrorDisplayFor' 'lastName'}}
+    >
     {{#if (and (v-get this 'lastName' 'isInvalid') (is-in showErrorsFor 'lastName'))}}
       <span class="message error">{{v-get this 'lastName' 'message'}}</span>
     {{/if}}
@@ -68,13 +65,12 @@
   {{#unless isManaging}}
     <span class='value'>{{user.campusId}}</span>
   {{else}}
-    {{one-way-input
-      value=campusId
-      update=(action (mut campusId))
-      onenter=(perform save)
-      onescape=(perform cancel)
-      focusOut=(action 'addErrorDisplayFor' 'campusId')
-    }}
+    <input
+      type="text"
+      value={{campusId}}
+      oninput={{action (mut campusId) value="target.value"}}
+      onfocusout={{action 'addErrorDisplayFor' 'campusId'}}
+    >
     <button class='directory-sync {{if syncComplete "directory-sync-complete"}}' title={{t 'general.updateUserFromDirectory'}} {{action (perform directorySync)}}>{{fa-icon (if (and (not syncComplete) directorySync.isRunning) 'spinner' 'refresh') spin=(if (and (not syncComplete) directorySync.isRunning) true false)}}</button>
     {{#if (and (v-get this 'campusId' 'isInvalid') (is-in showErrorsFor 'campusId'))}}
       <span class="message error">{{v-get this 'campusId' 'message'}}</span>
@@ -89,13 +85,12 @@
   {{#unless isManaging}}
     <span class='value'>{{user.otherId}}</span>
   {{else}}
-    {{one-way-input
-      value=otherId
-      update=(action (mut otherId))
-      onenter=(perform save)
-      onescape=(perform cancel)
-      focusOut=(action 'addErrorDisplayFor' 'otherId')
-    }}
+    <input
+      type="text"
+      value={{otherId}}
+      oninput={{action (mut otherId) value="target.value"}}
+      onfocusout={{action 'addErrorDisplayFor' 'otherId'}}
+    >
     {{#if (and (v-get this 'otherId' 'isInvalid') (is-in showErrorsFor 'otherId'))}}
       <span class="message error">{{v-get this 'otherId' 'message'}}</span>
     {{/if}}
@@ -106,13 +101,12 @@
   {{#unless isManaging}}
     <span class='value'>{{user.email}}</span>
   {{else}}
-    {{one-way-input
-      value=email
-      update=(action (mut email))
-      onenter=(perform save)
-      onescape=(perform cancel)
-      focusOut=(action 'addErrorDisplayFor' 'email')
-    }}
+    <input
+      type="text"
+      value={{email}}
+      oninput={{action (mut email) value="target.value"}}
+      onfocusout={{action 'addErrorDisplayFor' 'email'}}
+    >
     {{#if (and (v-get this 'email' 'isInvalid') (is-in showErrorsFor 'email'))}}
       <span class="message error">{{v-get this 'email' 'message'}}</span>
     {{/if}}
@@ -123,13 +117,12 @@
   {{#unless isManaging}}
     <span class='value'>{{user.phone}}</span>
   {{else}}
-    {{one-way-input
-      value=phone
-      update=(action (mut phone))
-      onenter=(perform save)
-      onescape=(perform cancel)
-      focusOut=(action 'addErrorDisplayFor' 'phone')
-    }}
+    <input
+      type="text"
+      value={{phone}}
+      oninput={{action (mut phone) value="target.value"}}
+      onfocusout={{action 'addErrorDisplayFor' 'phone'}}
+    >
     {{#if (and (v-get this 'phone' 'isInvalid') (is-in showErrorsFor 'phone'))}}
       <span class="message error">{{v-get this 'phone' 'message'}}</span>
     {{/if}}
@@ -140,14 +133,13 @@
   {{#unless isManaging}}
     <span class='value'>{{get (await user.authentication) 'username'}}</span>
   {{else}}
-    {{one-way-input
-      value=username
-      update=(action (mut username))
-      onenter=(perform save)
-      onescape=(perform cancel)
-      focusOut=(action 'addErrorDisplayFor' 'username')
-      disabled=(not (await canEditUsernameAndPassword))
-    }}
+    <input
+      type="text"
+      value={{username}}
+      oninput={{action (mut username) value="target.value"}}
+      onfocusout={{action 'addErrorDisplayFor' 'username'}}
+      disabled={{not (await canEditUsernameAndPassword)}}
+    >
     {{#if (and (v-get this 'username' 'isInvalid') (is-in showErrorsFor 'username'))}}
       <span class="message error">{{v-get this 'username' 'message'}}</span>
     {{/if}}
@@ -160,14 +152,13 @@
       <span class='value'>{{#unless (await usernameMissing)}} &#42;&#42;&#42;&#42;&#42;&#42;&#42;&#42;&#42;{{/unless}}</span>
     {{else}}
       {{#if changeUserPassword}}
-        {{one-way-password
-          value=password
-          update=(action (mut password))
-          onenter=(perform save)
-          onescape=(action 'cancelChangeUserPassword')
-          onkeypress=(action 'addErrorDisplayFor' 'password')
-          focusOut=(action 'addErrorDisplayFor' 'password')
-        }}
+        <input
+          type="password"
+          value={{password}}
+          oninput={{action (mut password) value="target.value"}}
+          onkeypress={{action 'addErrorDisplayFor' 'password'}}
+          onfocusout={{action 'addErrorDisplayFor' 'password'}}
+        >
         {{#if (and (v-get this 'password' 'isInvalid') (is-in showErrorsFor 'password'))}}
           <span class="message error">{{v-get this 'password' 'message'}}</span>
         {{else if (gt password.length 0)}}

--- a/app/templates/components/user-profile-bio.hbs
+++ b/app/templates/components/user-profile-bio.hbs
@@ -21,7 +21,7 @@
       type="text"
       value={{firstName}}
       oninput={{action (mut firstName) value="target.value"}}
-      onfocusout={{action 'addErrorDisplayFor' 'firstName'}}
+      onkeyup={{action 'addErrorDisplayFor' 'firstName'}}
     >
     {{#if (and (v-get this 'firstName' 'isInvalid') (is-in showErrorsFor 'firstName'))}}
       <span class="message error">{{v-get this 'firstName' 'message'}}</span>
@@ -37,7 +37,7 @@
       type="text"
       value={{middleName}}
       oninput={{action (mut middleName) value="target.value"}}
-      onfocusout={{action 'addErrorDisplayFor' 'middleName'}}
+      onkeyup={{action 'addErrorDisplayFor' 'middleName'}}
     >
     {{#if (and (v-get this 'middleName' 'isInvalid') (is-in showErrorsFor 'middleName'))}}
       <span class="message error">{{v-get this 'middleName' 'message'}}</span>
@@ -53,7 +53,7 @@
       type="text"
       value={{lastName}}
       oninput={{action (mut lastName) value="target.value"}}
-      onfocusout={{action 'addErrorDisplayFor' 'lastName'}}
+      onkeyup={{action 'addErrorDisplayFor' 'lastName'}}
     >
     {{#if (and (v-get this 'lastName' 'isInvalid') (is-in showErrorsFor 'lastName'))}}
       <span class="message error">{{v-get this 'lastName' 'message'}}</span>
@@ -69,7 +69,7 @@
       type="text"
       value={{campusId}}
       oninput={{action (mut campusId) value="target.value"}}
-      onfocusout={{action 'addErrorDisplayFor' 'campusId'}}
+      onkeyup={{action 'addErrorDisplayFor' 'campusId'}}
     >
     <button class='directory-sync {{if syncComplete "directory-sync-complete"}}' title={{t 'general.updateUserFromDirectory'}} {{action (perform directorySync)}}>{{fa-icon (if (and (not syncComplete) directorySync.isRunning) 'spinner' 'refresh') spin=(if (and (not syncComplete) directorySync.isRunning) true false)}}</button>
     {{#if (and (v-get this 'campusId' 'isInvalid') (is-in showErrorsFor 'campusId'))}}
@@ -89,7 +89,7 @@
       type="text"
       value={{otherId}}
       oninput={{action (mut otherId) value="target.value"}}
-      onfocusout={{action 'addErrorDisplayFor' 'otherId'}}
+      onkeyup={{action 'addErrorDisplayFor' 'otherId'}}
     >
     {{#if (and (v-get this 'otherId' 'isInvalid') (is-in showErrorsFor 'otherId'))}}
       <span class="message error">{{v-get this 'otherId' 'message'}}</span>
@@ -105,7 +105,7 @@
       type="text"
       value={{email}}
       oninput={{action (mut email) value="target.value"}}
-      onfocusout={{action 'addErrorDisplayFor' 'email'}}
+      onkeyup={{action 'addErrorDisplayFor' 'email'}}
     >
     {{#if (and (v-get this 'email' 'isInvalid') (is-in showErrorsFor 'email'))}}
       <span class="message error">{{v-get this 'email' 'message'}}</span>
@@ -121,7 +121,7 @@
       type="text"
       value={{phone}}
       oninput={{action (mut phone) value="target.value"}}
-      onfocusout={{action 'addErrorDisplayFor' 'phone'}}
+      onkeyup={{action 'addErrorDisplayFor' 'phone'}}
     >
     {{#if (and (v-get this 'phone' 'isInvalid') (is-in showErrorsFor 'phone'))}}
       <span class="message error">{{v-get this 'phone' 'message'}}</span>
@@ -137,7 +137,7 @@
       type="text"
       value={{username}}
       oninput={{action (mut username) value="target.value"}}
-      onfocusout={{action 'addErrorDisplayFor' 'username'}}
+      onkeyup={{action 'addErrorDisplayFor' 'username'}}
       disabled={{not (await canEditUsernameAndPassword)}}
     >
     {{#if (and (v-get this 'username' 'isInvalid') (is-in showErrorsFor 'username'))}}
@@ -157,7 +157,7 @@
           value={{password}}
           oninput={{action (mut password) value="target.value"}}
           onkeypress={{action 'addErrorDisplayFor' 'password'}}
-          onfocusout={{action 'addErrorDisplayFor' 'password'}}
+          onkeyup={{action 'addErrorDisplayFor' 'password'}}
         >
         {{#if (and (v-get this 'password' 'isInvalid') (is-in showErrorsFor 'password'))}}
           <span class="message error">{{v-get this 'password' 'message'}}</span>

--- a/tests/integration/components/user-profile-bio-test.js
+++ b/tests/integration/components/user-profile-bio-test.js
@@ -163,13 +163,13 @@ test('can edit user bio for ldap config', function(assert) {
     assert.equal(this.$(phone).val().trim(), 'x1234', 'phone is set');
     assert.equal(this.$(username).val().trim(), 'test-username', 'username is set');
     assert.ok(this.$(username).is(':disabled'), 'username is disabled');
-    this.$(firstName).val('new first').change();
-    this.$(middleName).val('new middle').change();
-    this.$(lastName).val('new last').change();
-    this.$(campusId).val('new campusId').change();
-    this.$(otherId).val('new otherId').change();
-    this.$(email).val('e@e.com').change();
-    this.$(phone).val('12345x').change();
+    this.$(firstName).val('new first').trigger('input');
+    this.$(middleName).val('new middle').trigger('input');
+    this.$(lastName).val('new last').trigger('input');
+    this.$(campusId).val('new campusId').trigger('input');
+    this.$(otherId).val('new otherId').trigger('input');
+    this.$(email).val('e@e.com').trigger('input');
+    this.$(phone).val('12345x').trigger('input');
 
     this.$('.bigadd').click();
 
@@ -225,14 +225,14 @@ test('can edit non-ldap without setting a password', function(assert) {
     assert.equal(this.$(phone).val().trim(), 'x1234', 'phone is set');
     assert.equal(this.$(username).val().trim(), 'test-username', 'username is set');
     assert.equal(this.$(activatePasswordField).text().trim(), 'Click here to reset password.');
-    this.$(firstName).val('new first').change();
-    this.$(middleName).val('new middle').change();
-    this.$(lastName).val('new last').change();
-    this.$(campusId).val('new campusId').change();
-    this.$(otherId).val('new otherId').change();
-    this.$(email).val('e@e.com').change();
-    this.$(phone).val('12345x').change();
-    this.$(username).val('new-test-user').change();
+    this.$(firstName).val('new first').trigger('input');
+    this.$(middleName).val('new middle').trigger('input');
+    this.$(lastName).val('new last').trigger('input');
+    this.$(campusId).val('new campusId').trigger('input');
+    this.$(otherId).val('new otherId').trigger('input');
+    this.$(email).val('e@e.com').trigger('input');
+    this.$(phone).val('12345x').trigger('input');
+    this.$(username).val('new-test-user').trigger('input');
     this.$('.bigadd').click();
 
     return wait();
@@ -292,15 +292,15 @@ test('can edit user bio for non-ldap config', function(assert) {
     return wait().then(()=>{
       assert.equal(this.$(inputs).length, 9, 'password input has been added');
       assert.equal(this.$(password).val().trim(), '', 'password is set');
-      this.$(firstName).val('new first').change();
-      this.$(middleName).val('new middle').change();
-      this.$(lastName).val('new last').change();
-      this.$(campusId).val('new campusId').change();
-      this.$(otherId).val('new otherId').change();
-      this.$(email).val('e@e.com').change();
-      this.$(phone).val('12345x').change();
-      this.$(username).val('new-test-user').change();
-      this.$(password).val('new-password').change();
+      this.$(firstName).val('new first').trigger('input');
+      this.$(middleName).val('new middle').trigger('input');
+      this.$(lastName).val('new last').trigger('input');
+      this.$(campusId).val('new campusId').trigger('input');
+      this.$(otherId).val('new otherId').trigger('input');
+      this.$(email).val('e@e.com').trigger('input');
+      this.$(phone).val('12345x').trigger('input');
+      this.$(username).val('new-test-user').trigger('input');
+      this.$(password).val('new-password').trigger('input');
       this.$('.bigadd').click();
 
       return wait();
@@ -334,7 +334,7 @@ test('closing password box clears input', function(assert) {
     return wait().then(()=>{
       assert.equal(this.$(inputs).length, 9, 'password input has been added');
       assert.equal(this.$(password).val().trim(), '', 'password is blank');
-      this.$(password).val('new-password').change();
+      this.$(password).val('new-password').trigger('input');
       return wait().then(()=>{
         this.$(cancelPasswordField).click();
         return wait().then(()=>{
@@ -364,7 +364,7 @@ test('password strength 0 display', function(assert) {
   return wait().then(()=>{
     this.$(activatePasswordField).click();
     return wait().then(()=>{
-      this.$(passwordInput).val('12345').change();
+      this.$(passwordInput).val('12345').trigger('input');
       return wait().then(()=>{
         assert.equal(this.$(passwordStrengthMeter).val(), 0, 'meter is intially at 0');
         assert.equal(this.$(passwordStrengthText).text().trim(), 'Try Harder', 'try harder is displayed for level 0 password');
@@ -389,7 +389,7 @@ test('password strength 1 display', function(assert) {
   return wait().then(()=>{
     this.$(activatePasswordField).click();
     return wait().then(()=>{
-      this.$(passwordInput).val('12345ab').change();
+      this.$(passwordInput).val('12345ab').trigger('input');
       return wait().then(()=>{
         assert.equal(this.$(passwordStrengthMeter).val(), 1, 'meter is intially at 1');
         assert.equal(this.$(passwordStrengthText).text().trim(), 'Bad', 'bad is displayed for level 1 password');
@@ -414,7 +414,7 @@ test('password strength 2 display', function(assert) {
   return wait().then(()=>{
     this.$(activatePasswordField).click();
     return wait().then(()=>{
-      this.$(passwordInput).val('12345ab13&').change();
+      this.$(passwordInput).val('12345ab13&').trigger('input');
       return wait().then(()=>{
         assert.equal(this.$(passwordStrengthMeter).val(), 2, 'meter is intially at 2');
         assert.equal(this.$(passwordStrengthText).text().trim(), 'Weak', 'weak is displayed for level 2 password');
@@ -439,7 +439,7 @@ test('password strength 3 display', function(assert) {
   return wait().then(()=>{
     this.$(activatePasswordField).click();
     return wait().then(()=>{
-      this.$(passwordInput).val('12345ab13&!!').change();
+      this.$(passwordInput).val('12345ab13&!!').trigger('input');
       return wait().then(()=>{
         assert.equal(this.$(passwordStrengthMeter).val(), 3, 'meter is intially at 3');
         assert.equal(this.$(passwordStrengthText).text().trim(), 'Good', 'good is displayed for level 3 password');
@@ -464,7 +464,7 @@ test('password strength 4 display', function(assert) {
   return wait().then(()=>{
     this.$(activatePasswordField).click();
     return wait().then(()=>{
-      this.$(passwordInput).val('12345ab14&HHtB').change();
+      this.$(passwordInput).val('12345ab14&HHtB').trigger('input');
       return wait().then(()=>{
         assert.equal(this.$(passwordStrengthMeter).val(), 4, 'meter is intially at 4');
         assert.equal(this.$(passwordStrengthText).text().trim(), 'Strong', 'strong is displayed for level 4 password');


### PR DESCRIPTION
replaced one-way-controls with markup equivalents in "user profile bio" form.

refs #3466 

this form here:

![selection_454](https://user-images.githubusercontent.com/1410427/35538558-330f9428-0503-11e8-8b69-88161a0dff08.png)
