### PR TITLE
replaces {{one-way-input}} with markup equivalent

### DIFF
--- a/app/components/new-course.js
+++ b/app/components/new-course.js
@@ -59,6 +59,24 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   selectedYear: null,
   isSaving: false,
 
+  keyUp(event) {
+    const keyCode = event.keyCode;
+    const target = event.target;
+
+    if ('text' !== target.type) {
+      return;
+    }
+
+    if (13 === keyCode) {
+      this.send('save');
+      return;
+    }
+
+    if(27 === keyCode) {
+      this.sendAction('cancel');
+    }
+  },
+
   actions: {
     setYear(year) {
       this.set('selectedYear', year);

--- a/app/components/new-curriculum-inventory-sequence-block.js
+++ b/app/components/new-curriculum-inventory-sequence-block.js
@@ -192,6 +192,24 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     });
   }),
 
+  keyUp(event) {
+    const keyCode = event.keyCode;
+    const target = event.target;
+
+    if (! ['text', 'textarea'].includes(target.type)) {
+      return;
+    }
+
+    if (13 === keyCode && 'text' === target.type) {
+      this.send('save');
+      return;
+    }
+
+    if(27 === keyCode) {
+      this.send('cancel');
+    }
+  },
+
   actions: {
     save() {
       this.set('isSaving', true);

--- a/app/components/new-learnergroup-multiple.js
+++ b/app/components/new-learnergroup-multiple.js
@@ -19,6 +19,24 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   numSubGroups: null,
   isSaving: false,
 
+  keyUp(event) {
+    const keyCode = event.keyCode;
+    const target = event.target;
+
+    if ('text' !== target.type) {
+      return;
+    }
+
+    if (13 === keyCode) {
+      this.send('save');
+      return;
+    }
+
+    if(27 === keyCode) {
+      this.sendAction('cancel');
+    }
+  },
+
   actions: {
     save() {
       this.send('addErrorDisplayFor', 'numSubGroups');

--- a/app/components/new-learnergroup-single.js
+++ b/app/components/new-learnergroup-single.js
@@ -19,6 +19,24 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   fillWithCohort: false,
   isSaving: false,
 
+  keyUp(event) {
+    const keyCode = event.keyCode;
+    const target = event.target;
+
+    if ('text' !== target.type) {
+      return;
+    }
+
+    if (13 === keyCode) {
+      this.send('save');
+      return;
+    }
+
+    if(27 === keyCode) {
+      this.sendAction('cancel');
+    }
+  },
+
   actions: {
     save() {
       this.send('addErrorDisplayFor', 'title');

--- a/app/components/new-program.js
+++ b/app/components/new-program.js
@@ -20,6 +20,23 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   title: null,
   isSaving: false,
   classNames: ['new-program'],
+  keyUp(event) {
+    const keyCode = event.keyCode;
+    const target = event.target;
+
+    if ('text' !== target.type) {
+      return;
+    }
+
+    if (13 === keyCode) {
+      this.send('save');
+      return;
+    }
+
+    if(27 === keyCode) {
+      this.sendAction('cancel');
+    }
+  },
   actions: {
     save() {
       this.set('isSaving', true);

--- a/app/components/new-session.js
+++ b/app/components/new-session.js
@@ -76,4 +76,22 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
       this.sendAction('cancel');
     }
   }),
+
+  keyUp(event) {
+    const keyCode = event.keyCode;
+    const target = event.target;
+
+    if ('text' !== target.type) {
+      return;
+    }
+
+    if (13 === keyCode) {
+      this.get('saveNewSession').perform();
+      return;
+    }
+
+    if(27 === keyCode) {
+      this.sendAction('cancel');
+    }
+  },
 });

--- a/app/templates/components/new-course.hbs
+++ b/app/templates/components/new-course.hbs
@@ -5,17 +5,15 @@
     <div class="form-label">{{t 'general.title'}}:</div>
 
     <div class="form-data form-data-text form-input-row">
-      {{one-way-input
+      <input
+        type="text"
         data-test-title
-        value=title
-        update=(action (mut title))
-        onenter=(action 'save')
-        onescape=(action 'cancel')
-        disabled=isSaving
-        focusOut=(action 'addErrorDisplayFor' 'title')
-        keyDown=(action 'addErrorDisplayFor' 'title')
-        placeholder=(t 'general.courseTitlePlaceholder')
-      }}
+        value={{title}}
+        oninput={{action (mut title) value="target.value"}}
+        disabled={{isSaving}}
+        onkeyup={{action 'addErrorDisplayFor' 'title'}}
+        placeholder={{t 'general.courseTitlePlaceholder'}}
+      >
       {{#if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}}
         <span class="validation-error-message">{{v-get this 'title' 'message'}}</span>
       {{/if}}

--- a/app/templates/components/new-curriculum-inventory-sequence-block.hbs
+++ b/app/templates/components/new-curriculum-inventory-sequence-block.hbs
@@ -2,16 +2,14 @@
 {{#if isLoaded}}
   <div class="item title">
     <label>{{t 'general.title'}}:</label>
-    {{one-way-input
-      value=title
-      update=(action (mut title))
-      onenter=(action 'save')
-      onescape=(action 'cancel')
-      disabled=isSaving
-      focusOut=(action 'addErrorDisplayFor' 'title')
-      keyDown=(action 'addErrorDisplayFor' 'title')
-      placeholder=(t 'general.sequenceBlockTitlePlaceholder')
-    }}
+    <input
+      type="text"
+      value={{title}}
+      oninput={{action (mut title) value="target.value"}}
+      disabled={{isSaving}}
+      onkeyup={{action 'addErrorDisplayFor' 'title'}}
+      placeholder={{t 'general.sequenceBlockTitlePlaceholder'}}
+    >
     {{#if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}}
       <span class="validation-error-message">{{v-get this 'title' 'message'}}</span>
     {{/if}}
@@ -83,15 +81,13 @@
 
   <div class="item duration">
     <label>{{t 'general.durationInDays'}}:</label>
-    {{one-way-input
-      value=duration
-      update=(action (mut duration))
-      onenter=(action 'save')
-      onescape=(action 'cancel')
-      disabled=isSaving
-      focusOut=(action 'addErrorDisplayFor' 'duration')
-      keyDown=(action 'addErrorDisplayFor' 'duration')
-    }}
+    <input
+      type="text"
+      value={{duration}}
+      oninput={{action (mut duration) value="target.value"}}
+      disabled={{isSaving}}
+      onkeyup={{action 'addErrorDisplayFor' 'duration'}}
+    >
     {{#if (and (v-get this 'duration' 'isInvalid') (is-in showErrorsFor 'duration'))}}
       <span class="validation-error-message">{{v-get this 'duration' 'message'}}</span>
     {{/if}}
@@ -107,15 +103,13 @@
 
   <div class="item minimum">
     <label>{{t 'general.minimum'}}:</label>
-    {{one-way-input
-      value=minimum
-      update=(action (mut minimum))
-      onenter=(action 'save')
-      onescape=(action 'cancel')
-      disabled=isSaving
-      focusOut=(action 'addErrorDisplayFor' 'minimum')
-      keyDown=(action 'addErrorDisplayFor' 'minimum')
-    }}
+    <input
+      type="text"
+      value={{minimum}}
+      oninput={{action (mut minimum) value="target.value"}}
+      disabled={{isSaving}}
+      onkeyup={{action 'addErrorDisplayFor' 'minimum'}}
+    >
     {{#if (and (v-get this 'minimum' 'isInvalid') (is-in showErrorsFor 'minimum'))}}
       <span class="validation-error-message">{{v-get this 'minimum' 'message'}}</span>
     {{/if}}
@@ -123,15 +117,13 @@
 
   <div class="item maximum">
     <label>{{t 'general.maximum'}}:</label>
-    {{one-way-input
-      value=maximum
-      update=(action (mut maximum))
-      onenter=(action 'save')
-      onescape=(action 'cancel')
-      disabled=isSaving
-      focusOut=(action 'addErrorDisplayFor' 'maximum')
-      keyDown=(action 'addErrorDisplayFor' 'maximum')
-    }}
+    <input
+      type="text"
+      value={{maximum}}
+      oninput={{action (mut maximum) value="target.value"}}
+      disabled={{isSaving}}
+      onkeyup={{action 'addErrorDisplayFor' 'maximum'}}
+    >
     {{#if (and (v-get this 'maximum' 'isInvalid') (is-in showErrorsFor 'maximum'))}}
       <span class="validation-error-message">{{v-get this 'maximum' 'message'}}</span>
     {{/if}}

--- a/app/templates/components/new-learnergroup-multiple.hbs
+++ b/app/templates/components/new-learnergroup-multiple.hbs
@@ -6,15 +6,14 @@
   <label class="form-col form-col-12">
     <div class="form-label">{{t 'general.numberOfGroups'}}:</div>
     <div class="form-data form-data-text form-input-row">
-      {{one-way-input
-        value=numSubGroups
-        update=(action (mut numSubGroups))
-        onenter=(action 'save')
-        onescape=(action cancel)
-        disabled=isSaving
-        focusOut=(action 'addErrorDisplayFor' 'numSubGroups')
-        placeholder=(t 'general.numberOfGroupsToGenerate')
-      }}
+      <input
+        type="text"
+        value={{numSubGroups}}
+        oninput={{action (mut numSubGroups) value="target.value"}}
+        disabled={{isSaving}}
+        onkeyup={{action 'addErrorDisplayFor' 'numSubGroups'}}
+        placeholder={{t 'general.numberOfGroupsToGenerate'}}
+      >
       {{#if (and (v-get this 'numSubGroups' 'isInvalid') (is-in showErrorsFor 'numSubGroups'))}}
         <span class="validation-error-message">{{v-get this 'numSubGroups' 'message'}}</span>
       {{/if}}

--- a/app/templates/components/new-learnergroup-single.hbs
+++ b/app/templates/components/new-learnergroup-single.hbs
@@ -1,15 +1,14 @@
 <div class="form-col form-col-12">
   <div class="form-label">{{t 'general.title'}}:</div>
   <div class="form-data form-data-text form-input-row">
-    {{one-way-input
-      value=title
-      update=(action (mut title))
-      onenter=(action 'save')
-      onescape=(action cancel)
-      disabled=isSaving
-      focusOut=(action 'addErrorDisplayFor' 'title')
-      placeholder=(t 'general.learnerGroupTitlePlaceholder')
-    }}
+    <input
+      type="text"
+      value={{title}}
+      oninput={{action (mut title) value="target.value"}}
+      disabled={{isSaving}}
+      onkeyup={{action 'addErrorDisplayFor' 'title'}}
+      placeholder={{t 'general.learnerGroupTitlePlaceholder'}}
+    >
     {{#if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}}
       <span class="validation-error-message">{{v-get this 'title' 'message'}}</span>
     {{/if}}

--- a/app/templates/components/new-program.hbs
+++ b/app/templates/components/new-program.hbs
@@ -4,15 +4,14 @@
     <div class="form-col form-col-12">
       <label class="form-label">{{t 'general.title'}}:</label>
       <div class="form-data form-data-text form-data-input-row newinstructorgroup-title">
-        {{one-way-input
-          value=title
-          update=(action (mut title))
-          onenter=(action 'save')
-          onescape=(action cancel)
-          disabled=isSaving
-          focusOut=(action 'addErrorDisplayFor' 'title')
-          placeholder=(t 'general.programTitlePlaceholder')
-        }}
+        <input
+          type="text"
+          value={{title}}
+          oninput={{action (mut title) value="target.value"}}
+          disabled={{isSaving}}
+          onkeyup={{action 'addErrorDisplayFor' 'title'}}
+          placeholder={{t 'general.programTitlePlaceholder'}}
+        >
         {{#if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}}
           <span class="validation-error-message">{{v-get this 'title' 'message'}}</span>
         {{/if}}

--- a/app/templates/components/new-session.hbs
+++ b/app/templates/components/new-session.hbs
@@ -3,14 +3,13 @@
 <div class="new-session-content">
   <div class="item">
     <label>{{t 'general.title'}}:</label>
-    {{one-way-input
-      value=title
-      update=(action (mut title))
-      onenter=(perform saveNewSession)
-      onescape=(action cancel)
-      focusOut=(action 'addErrorDisplayFor' 'title')
-      class=(if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title')) 'has-error')
-    }}
+    <input
+      type="text"
+      value={{title}}
+      oninput={{action (mut title) value="target.value"}}
+      onkeyup={{action 'addErrorDisplayFor' 'title'}}
+      class={{if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title')) 'has-error'}}
+    >
     {{#if (and (v-get this 'title' 'isInvalid') (is-in showErrorsFor 'title'))}}
       <span class="validation-error-message">{{v-get this 'title' 'message'}}</span>
     {{/if}}

--- a/tests/integration/components/learnergroup-subgroup-list-test.js
+++ b/tests/integration/components/learnergroup-subgroup-list-test.js
@@ -139,7 +139,7 @@ test('add new group', function(assert) {
   let newTitle = 'new group';
   return wait().then(()=>{
     this.$('input').val(newTitle);
-    this.$('input').trigger('change');
+    this.$('input').trigger('input');
     this.$('.done').click();
     return wait().then(() => {
       assert.equal(this.$('.saved-result').text().trim().replace(/[\t\n\s]+/g, ''),
@@ -212,7 +212,7 @@ test('add multiple new groups', async function(assert) {
   await wait();
   this.$(multiGroupButton).click();
 
-  this.$(multiGroupCount).val(1).change();
+  this.$(multiGroupCount).val(1).trigger('input');
   this.$(done).click();
   await wait();
 
@@ -278,7 +278,7 @@ test('truncates multiple group with long name', async function(assert) {
   this.$(multiGroupButton).click();
 
 
-  this.$(multiGroupCount).val(1).change();
+  this.$(multiGroupCount).val(1).trigger('input');
   this.$(done).click();
   await wait();
 

--- a/tests/integration/components/new-curriculum-inventory-sequence-block-test.js
+++ b/tests/integration/components/new-curriculum-inventory-sequence-block-test.js
@@ -198,7 +198,7 @@ test('selecting course reveals additional course info', function(assert) {
     let courseOption = this.$('.course option:eq(1)');
     this.$('.course select').val('1').trigger('change');
     courseOption.prop('selected', true);
-    courseOption.trigger('change');
+    courseOption.trigger('input');
     return wait().then(() => {
       let details = this.$('.course .details').text().trim();
       assert.ok(details.indexOf('Level: ' + course.get('level')) === 0);
@@ -272,7 +272,7 @@ test('save with defaults', function(assert) {
   });
 
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report save=(action saveBlock)}}`);
-  this.$('.title input').val(newTitle).change();
+  this.$('.title input').val(newTitle).trigger('input');
   this.$('.description textarea').val(newDescription).trigger('input');
   let interactor = openDatepicker(this.$('.start-date input'));
   interactor.selectDate(newStartDate.toDate());
@@ -334,11 +334,11 @@ test('save with non-defaults', function(assert) {
 
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report save=(action saveBlock)}}`);
   return wait().then(() => {
-    this.$('.title input').val('foo bar').change();
+    this.$('.title input').val('foo bar').trigger('input');
     this.$('.description textarea').val('lorem ipsum').trigger('input');
-    this.$('.duration input').val(duration).change();
-    this.$('.minimum input').val(minimum).change();
-    this.$('.maximum input').val(maximum).change();
+    this.$('.duration input').val(duration).trigger('input');
+    this.$('.minimum input').val(minimum).trigger('input');
+    this.$('.maximum input').val(maximum).trigger('input');
     this.$('.course option:eq(1)').prop('selected', true).change();
     this.$('.child-sequence-order option:eq(1)').prop('selected', true).change();
     this.$('.required option:eq(2)').prop('selected', true).change();
@@ -392,10 +392,10 @@ test('save nested block in ordered sequence', function(assert) {
   });
 
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report parent=parentBlock save=(action saveBlock)}}`);
-  this.$('.title input').val('Foo Bar').change();
+  this.$('.title input').val('Foo Bar').trigger('input');
   this.$('.description textarea').val('Lorem Ipsum').trigger('input');
   this.$('.order-in-sequence option:eq(1)').prop('selected', true).change();
-  this.$('.duration input').val('19').change();
+  this.$('.duration input').val('19').trigger('input');
   this.$('button.done').click();
 });
 
@@ -499,7 +499,7 @@ test('save fails when minimum is larger than maximum', function(assert) {
   this.set('report', report);
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
-    this.$('.title input').val('Foo Bar').change();
+    this.$('.title input').val('Foo Bar').trigger('input');
     this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
@@ -508,8 +508,8 @@ test('save fails when minimum is larger than maximum', function(assert) {
     interactor = openDatepicker(endDateInput);
     interactor.selectDate(moment('2016-12-30').toDate());
     assert.equal(this.$('.validation-error-message').length, 0, 'Initially, no validation error is shown.');
-    this.$('.maximum input').val('5').change();
-    this.$('.minimum input').val('10').change();
+    this.$('.maximum input').val('5').trigger('input');
+    this.$('.minimum input').val('10').trigger('input');
     this.$('button.done').click();
     return wait().then(() => {
       assert.equal(this.$('.validation-error-message').length, 1, 'Validation error shows.');
@@ -541,7 +541,7 @@ test('save fails when minimum is less than zero', function(assert) {
   this.set('report', report);
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
-    this.$('.title input').val('Foo Bar').change();
+    this.$('.title input').val('Foo Bar').trigger('input');
     this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
@@ -550,7 +550,7 @@ test('save fails when minimum is less than zero', function(assert) {
     interactor = openDatepicker(endDateInput);
     interactor.selectDate(moment('2016-12-30').toDate());
     assert.equal(this.$('.validation-error-message').length, 0, 'Initially, no validation error is shown.');
-    this.$('.minimum input').val('-1').change();
+    this.$('.minimum input').val('-1').trigger('input');
     this.$('button.done').click();
     return wait().then(() => {
       assert.equal(this.$('.validation-error-message').length, 1, 'Validation error shows.');
@@ -582,7 +582,7 @@ test('save fails when minimum is empty', function(assert) {
   this.set('report', report);
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
-    this.$('.title input').val('Foo Bar').change();
+    this.$('.title input').val('Foo Bar').trigger('input');
     this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
@@ -591,7 +591,7 @@ test('save fails when minimum is empty', function(assert) {
     interactor = openDatepicker(endDateInput);
     interactor.selectDate(moment('2016-12-30').toDate());
     assert.equal(this.$('.validation-error-message').length, 0, 'Initially, no validation error is shown.');
-    this.$('.minimum input').val('').change();
+    this.$('.minimum input').val('').trigger('input');
     this.$('button.done').click();
     return wait().then(() => {
       assert.equal(this.$('.validation-error-message').length, 1, 'Validation error shows.');
@@ -623,7 +623,7 @@ test('save fails when maximum is empty', function(assert) {
   this.set('report', report);
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
-    this.$('.title input').val('Foo Bar').change();
+    this.$('.title input').val('Foo Bar').trigger('input');
     this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
@@ -632,7 +632,7 @@ test('save fails when maximum is empty', function(assert) {
     interactor = openDatepicker(endDateInput);
     interactor.selectDate(moment('2016-12-30').toDate());
     assert.equal(this.$('.validation-error-message').length, 0, 'Initially, no validation error is shown.');
-    this.$('.maximum input').val('-1').change();
+    this.$('.maximum input').val('-1').trigger('input');
     this.$('button.done').click();
     return wait().then(() => {
       assert.equal(this.$('.validation-error-message').length, 1, 'Validation error shows.');
@@ -671,7 +671,7 @@ test('save with date range and a zero duration', function(assert) {
   this.set('report', report);
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report save=(action saveBlock)}}`);
   return wait().then(() => {
-    this.$('.title input').val('Foo Bar').change();
+    this.$('.title input').val('Foo Bar').trigger('input');
     this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
@@ -679,7 +679,7 @@ test('save with date range and a zero duration', function(assert) {
     interactor.selectDate(moment('2016-11-12').toDate());
     interactor = openDatepicker(endDateInput);
     interactor.selectDate(moment('2016-12-30').toDate());
-    this.$('.duration input').val('0').change();
+    this.$('.duration input').val('0').trigger('input');
     this.$('button.done').click();
   });
 });
@@ -717,9 +717,9 @@ test('save with non-zero duration and no date range', function(assert) {
   this.set('report', report);
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report save=(action saveBlock)}}`);
   return wait().then(() => {
-    this.$('.title input').val('Foo Bar').change();
+    this.$('.title input').val('Foo Bar').trigger('input');
     this.$('.description textarea').val('Lorem Ipsum').trigger('input');
-    this.$('.duration input').val(duration).change();
+    this.$('.duration input').val(duration).trigger('input');
     this.$('button.done').click();
   });
 });
@@ -748,7 +748,7 @@ test('save fails if end-date is older than start-date', function(assert) {
   this.set('report', report);
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
-    this.$('.title input').val('Foo Bar').change();
+    this.$('.title input').val('Foo Bar').trigger('input');
     this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
@@ -789,7 +789,7 @@ test('save fails on missing duration', function(assert) {
   this.set('report', report);
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
-    this.$('.title input').val('Foo Bar').change();
+    this.$('.title input').val('Foo Bar').trigger('input');
     this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
@@ -798,7 +798,7 @@ test('save fails on missing duration', function(assert) {
     interactor = openDatepicker(endDateInput);
     interactor.selectDate(moment('2016-12-30').toDate());
     assert.equal(this.$('.validation-error-message').length, 0, 'Initially, no validation error is shown.');
-    this.$('.duration input').val('').change();
+    this.$('.duration input').val('').trigger('input');
     this.$('button.done').click();
     return wait().then(() => {
       assert.equal(this.$('.validation-error-message').length, 1, 'Validation error shows.');
@@ -830,7 +830,7 @@ test('save fails on invalid duration', function(assert) {
   this.set('report', report);
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
-    this.$('.title input').val('Foo Bar').change();
+    this.$('.title input').val('Foo Bar').trigger('input');
     this.$('.description textarea').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let endDateInput = this.$('.end-date input');
@@ -839,7 +839,7 @@ test('save fails on invalid duration', function(assert) {
     interactor = openDatepicker(endDateInput);
     interactor.selectDate(moment('2016-12-30').toDate());
     assert.equal(this.$('.validation-error-message').length, 0, 'Initially, no validation error is shown.');
-    this.$('.duration input').val('WRONG').change();
+    this.$('.duration input').val('WRONG').trigger('input');
     this.$('button.done').click();
     return wait().then(() => {
       assert.equal(this.$('.validation-error-message').length, 1, 'Validation error shows.');
@@ -871,9 +871,9 @@ test('save fails if neither date range nor non-zero duration is provided', funct
   this.set('report', report);
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
-    this.$('.title input').val('Foo Bar').change();
+    this.$('.title input').val('Foo Bar').trigger('input');
     this.$('.description textarea').val('Lorem Ipsum').trigger('input');
-    this.$('.duration text').val('Lorem Ipsum').change();
+    this.$('.duration text').val('Lorem Ipsum').trigger('input');
     this.$('button.done').click();
     return wait().then(() => {
       assert.equal(this.$('.validation-error-message').length, 2, 'Validation errors show.');
@@ -905,9 +905,9 @@ test('save fails if start-date is given but no end-date is provided', function(a
   this.set('report', report);
   this.render(hbs`{{new-curriculum-inventory-sequence-block report=report}}`);
   return wait().then(() => {
-    this.$('.title input').val('Foo Bar').change();
+    this.$('.title input').val('Foo Bar').trigger('input');
     this.$('.description textarea').val('Lorem Ipsum').trigger('input');
-    this.$('.duration text').val('Lorem Ipsum').change();
+    this.$('.duration text').val('Lorem Ipsum').trigger('input');
     let startDateInput = this.$('.start-date input');
     let interactor = openDatepicker(startDateInput);
     interactor.selectDate(moment('2016-11-12').toDate());


### PR DESCRIPTION
refs #3466

affects the following forms:

- new program
- new session
- new course
- new curriculum inventory sequence block
- new sub-learnergroup (single)
- new sub-learnergroup (multiple)