### PR TITLE
Defer script loading

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -19,8 +19,8 @@
   <body>
     {{content-for "body"}}
 
-    <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/ilios.js"></script>
+    <script defer src="{{rootURL}}assets/vendor.js"></script>
+    <script defer src="{{rootURL}}assets/ilios.js"></script>
 
     {{content-for "body-footer"}}
   </body>


### PR DESCRIPTION
This allows DOM rendering and loading to happen in the background. It
makes our loading animation smoother and faster to appear since
rendering is not blocked by the script tag.