### PR TITLE
Lock time at 8am in tests

### DIFF
--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -298,8 +298,8 @@ test('learner group calendar', async function(assert) {
   const session = server.create('session', { course });
   server.create('offering', {
     session,
-    startDate: moment().toDate(),
-    endDate: moment().add(1, 'hour').toDate(),
+    startDate: moment().hour(8).toDate(),
+    endDate: moment().hour(8).add(1, 'hour').toDate(),
     learnerGroups: [learnerGroup],
   });
 
@@ -330,14 +330,14 @@ test('learner group calendar with subgroup events', async function(assert) {
   });
   server.create('offering', {
     session,
-    startDate: moment().toDate(),
-    endDate: moment().add(1, 'hour').toDate(),
+    startDate: moment().hour(8).toDate(),
+    endDate: moment().hour(8).add(1, 'hour').toDate(),
     learnerGroups: [learnerGroup],
   });
   server.create('offering', {
     session,
-    startDate: moment().toDate(),
-    endDate: moment().add(1, 'hour').toDate(),
+    startDate: moment().hour(8).toDate(),
+    endDate: moment().hour(8).add(1, 'hour').toDate(),
     learnerGroups: [subgroup],
   });
 

--- a/tests/integration/components/learnergroup-calendar-test.js
+++ b/tests/integration/components/learnergroup-calendar-test.js
@@ -9,11 +9,9 @@ moduleForComponent('learnergroup-calendar', 'Integration | Component | learnergr
   integration: true,
 });
 
-
-
 test('shows events', async function(assert) {
   assert.expect(1);
-  const today = moment();
+  const today = moment().hour(8);
   const course = EmberObject.create({
     title: 'course title'
   });
@@ -56,7 +54,7 @@ test('shows events', async function(assert) {
 
 test('shows subgroup events', async function(assert) {
   assert.expect(1);
-  const today = moment();
+  const today = moment().hour(8);
   const course = EmberObject.create({
     title: 'course title'
   });


### PR DESCRIPTION
This prevents errors when adding an hour makes it tomorrow which makes
tests flakey around midnight.

Fixes #3529