### PR TITLE
move inactive terms to bottom of list and label them as such.

### DIFF
--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -47,7 +47,7 @@ const PrepositionObject = EmberObject.extend({
   }),
   active: computed('model', 'type', function() {
     const type = this.get('type');
-    if (type === 'session type') {
+    if (['session type', 'term'].contains(type)) {
       return this.get('model').get('active');
     }
     return true;


### PR DESCRIPTION
![selection_487](https://user-images.githubusercontent.com/1410427/36455491-1cdf2b88-1655-11e8-9efe-03d790bae7b4.png)

fixes #3407 

this follows the pattern already established for inactive session-types.