### PR TITLE
Drop ember-normalize

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -93,5 +93,7 @@ module.exports = function(defaults) {
     },
   });
 
+  app.import('node_modules/normalize.css/normalize.css');
+
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "ember-load": "0.0.12",
     "ember-load-initializers": "^1.0.0",
     "ember-metrics": "0.12.1",
-    "ember-normalize": "1.0.0",
     "ember-noscript": "^2.0.0",
     "ember-pad": "1.2.2",
     "ember-papaparse": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1473,23 +1473,6 @@ broccoli-funnel@1.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.2.6"
 
-broccoli-funnel@^0.2.3:
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-0.2.15.tgz#4d0c128bef746e02f91038415aac4adbfaae222d"
-  dependencies:
-    array-equal "^1.0.0"
-    blank-object "^1.0.1"
-    broccoli-plugin "^1.0.0"
-    debug "^2.2.0"
-    fast-ordered-set "^1.0.0"
-    fs-tree-diff "^0.3.0"
-    minimatch "^2.0.1"
-    mkdirp "^0.5.0"
-    path-posix "^1.0.0"
-    rimraf "^2.4.3"
-    symlink-or-copy "^1.0.0"
-    walk-sync "^0.2.6"
-
 broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.2, broccoli-funnel@^1.0.3, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
@@ -4111,14 +4094,6 @@ ember-native-dom-helpers@^0.5.3:
   dependencies:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
-
-ember-normalize@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ember-normalize/-/ember-normalize-1.0.0.tgz#f5a0077caa1047321a436dd4f2fa7cf944f3b587"
-  dependencies:
-    broccoli-funnel "^0.2.3"
-    ember-cli-babel "^5.1.6"
-    normalize.css "~4.1.1"
 
 ember-noscript@^2.0.0:
   version "2.5.0"
@@ -7196,7 +7171,7 @@ mimic-response@^1.0.0:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^2.0.1, minimatch@^2.0.3:
+minimatch@^2.0.3:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
   dependencies:
@@ -7486,10 +7461,6 @@ normalize-range@^0.1.2:
 normalize.css@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.0.tgz#14ac5e461612538a4ce9be90a7da23f86e718493"
-
-normalize.css@~4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-4.1.1.tgz#4f0b1d5a235383252b04d8566b866cc5fcad9f0c"
 
 npm-git-info@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
This addon isn't compatible with ember-cli 3.0 and we can drop it and
import the css file directly from NPM anyway.

Refs #3540