### PR TITLE
Use different browser configuration for dev

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -1,11 +1,20 @@
-// Which browsers are returned can be found at http://browserl.ist/
+'use strict';
+
+const browsers = [
+  'last 1 Chrome versions',
+  'last 1 Firefox versions',
+  'last 1 Safari versions'
+];
+
+const isCI = !!process.env.CI;
+const isProductionLikeBuild = ['production', 'preview'].includes(process.env.EMBER_ENV);
+
+if (isCI || isProductionLikeBuild) {
+  browsers.push('last 1 edge versions');
+  browsers.push('firefox esr'); //actually points to the last 2 ESR releases as they overlap
+  browsers.push('last 1 ios versions');
+}
+
 module.exports = {
-  browsers: [
-    'last 1 edge versions',
-    'last 1 chrome versions',
-    'firefox esr', //actually points to the last 2 ESR releases as they overlap
-    'last 1 safari versions',
-    'last 1 ios versions',
-    'last 1 android versions',
-  ]
+  browsers
 };


### PR DESCRIPTION
Production and CI builds support our full browser matrix, but dev only
gets built for super modern browsers. This makes debugging a bit easier
since more new features are supported and less translpiling from the
original source needs to take place.