### PR TITLE
All course objectives to be linked to multiple parents

### DIFF
--- a/app/templates/components/course-objective-manager.hbs
+++ b/app/templates/components/course-objective-manager.hbs
@@ -25,12 +25,12 @@
             {{#each (await competency.objectives) as |objective|}}
               {{#if objective.selected}}
                 <li class='selected clickable' {{action 'removeParent' objective}}>
-                  <input type='radio' checked="checked">
+                  <input type={{if (await (get (await currentCohort) 'allowMultipleParents')) 'checkbox' 'radio'}} checked="checked">
                   {{objective.textTitle}}
                 </li>
               {{else}}
-                <li class='clickable' {{action 'addParent' objective}}>
-                  <input type='radio'>
+                <li class='clickable' {{action (perform addParent objective)}}>
+                  <input type={{if (await (get (await currentCohort) 'allowMultipleParents')) 'checkbox' 'radio'}}>
                   {{objective.textTitle}}
                 </li>
               {{/if}}


### PR DESCRIPTION
When a school has configured this behavior a course objective can be
connected to multiple program year objectives at the same time. The
default is to maintain the current one to one requirement.

Fixes #2126