### PR TITLE
Lint before committing

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "ilios-common": "11.1.0",
     "loader.js": "^4.2.3",
     "normalize.css": "^8.0.0",
+    "pre-commit": "^1.2.2",
     "stylelint-config-recommended-scss": "^3.1.0",
     "stylelint-scss": "^2.5.0",
     "validator": "^9.0.0"
@@ -119,5 +120,9 @@
       "ember-tether"
     ]
   },
+  "pre-commit": [
+    "lint:js",
+    "lint:style"
+  ],
   "private": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7963,6 +7963,14 @@ postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.17, postcss@^6.0.19, postcss@^6.0.
     source-map "^0.6.1"
     supports-color "^5.2.0"
 
+pre-commit@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
+  dependencies:
+    cross-spawn "^5.0.1"
+    spawn-sync "^1.0.15"
+    which "1.2.x"
+
 prebuild-install@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.5.1.tgz#0f234140a73760813657c413cdccdda58296b1da"
@@ -9977,6 +9985,12 @@ which-pm-runs@^1.0.0:
 which@1, which@^1.1.1, which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
+which@1.2.x:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
Avoid issues with committing poorly formatted JS or SCSS by linting
before each commit.  Takes about 15 seconds, but it is worth it I think.

This can always be skipped with `--no-verify`.