### PR TITLE
Fix issue with loading spinner

### DIFF
--- a/app/styles/components/learnergroup-bulk-assignment.scss
+++ b/app/styles/components/learnergroup-bulk-assignment.scss
@@ -10,7 +10,11 @@
       width: 100%;
 
       i {
-        @include ilios-heading-h1;
+        color: $header-blue;
+        font-size: 2.25rem;
+        font-weight: 600;
+        margin: 0;
+        padding: 0;
       }
     }
   }


### PR DESCRIPTION
When we import the header style here we end up overwriting the
font-family with our header font which causes font awesome to fail
predictably.

Fixes #3608