### PR TITLE
Remove globals that we no longer support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,9 +64,6 @@ module.exports = {
       excludedFiles: ['tests/dummy/**/*.js'],
       "globals": {
         "$": true,
-        "getElementText": true,
-        "getText": true,
-        "pickOption": true,
       },
     }
   ]


### PR DESCRIPTION
Since we migrated to the new test APIs these globals are no longer
needed