### PR TITLE
Drop babel polyfill

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -21,7 +21,6 @@ module.exports = function(defaults) {
     tests: env.EMBER_CLI_TEST_COMMAND || !isProductionLikeBuild,
     hinting: env.EMBER_CLI_TEST_COMMAND || !isProductionLikeBuild,
     'ember-cli-babel': {
-      includePolyfill: true,
       sourceMaps: isProductionLikeBuild?false:'inline'
     },
     'ember-cli-image-transformer': {


### PR DESCRIPTION
We needed this to support async / await and other promise syntax, but
this is handled for us by ember-maybe-regenerator now so we can drop the
polyfill and save some file size.

Needs to be tested in all of our supported browsers:
- [x] Chrome 64
- [x] Firefox 58
- [x] Safari11
- [x] Edge16
- [x] iOS Safari11.0-11.2
- [ ] Firefox52 
- [x] Opera 51