### PR TITLE
Add stylelint explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "loader.js": "^4.2.3",
     "normalize.css": "^8.0.0",
     "pre-commit": "^1.2.2",
+    "stylelint": "^9.1.3",
     "stylelint-config-recommended-scss": "^3.1.0",
     "stylelint-scss": "^2.5.0",
     "validator": "^9.0.0"


### PR DESCRIPTION
This ends up getting installed from ember-cli-stylelint, but we're
getting a lot of errors because yarn isn't sure we have it. Let's just
add it as a dependency and take away all doubt.