### PR TITLE
Build javascript for all browsers with more than 1% market share

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -11,8 +11,9 @@ const isProductionLikeBuild = ['production', 'preview'].includes(process.env.EMB
 
 if (isCI || isProductionLikeBuild) {
   browsers.push('last 1 edge versions');
-  browsers.push('firefox esr'); //actually points to the last 2 ESR releases as they overlap
+  browsers.push('firefox esr'); //sometimes points to the last 2 ESR releases when they overlap
   browsers.push('last 1 ios versions');
+  browsers.push('> 1%'); // any browser with more than 1% global market share
 }
 
 module.exports = {


### PR DESCRIPTION
This is more than our officially supported browsers, but it gives us the
cleanest build for the most devices while we work on some issues with
promises and our transpiled build.