### PR TITLE
Improve our unsupported browser error experience

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -22,7 +22,7 @@ module.exports = function (environment) {
       'script-src':   ["'self'", "'unsafe-eval'", 'www.google-analytics.com'],
       'font-src':     ["'self'", 'fonts.gstatic.com'],
       'connect-src':  ["'self'", 'www.google-analytics.com'],
-      'img-src':      ["'self'", 'data:', 'www.google-analytics.com'],
+      'img-src':      ["'self'", 'data:', 'www.google-analytics.com', 'cdnjs.cloudflare.com/ajax/libs/browser-logos/'],
       'style-src':    ["'self'", "'unsafe-inline'", 'fonts.googleapis.com'],
       'media-src':    ["'self'"],
       'manifest-src': ["'self'"],

--- a/lib/ilios-error/index.js
+++ b/lib/ilios-error/index.js
@@ -1,6 +1,9 @@
 /* eslint-env node */
 'use strict';
 
+const browserslist = require('browserslist');
+const caniuse = require('caniuse-db/data.json').agents;
+
 module.exports = {
   name: 'ilios-error',
 
@@ -10,13 +13,21 @@ module.exports = {
         <style type="text/css">
           #ilios-loading-error {
             padding: 2em;
+          }
+          #ilios-loading-error h1,
+          #ilios-loading-error h2 {
             text-align: center;
           }
-          #ilios-loading-error table {
-            margin: 2rem auto;
+          #ilios-loading-error .supported-browsers {
+            border: 1px solid blue;
+            margin-top: 1rem;
+            padding: 1rem 2rem;
           }
-          #ilios-loading-error table caption {
-            font-weight: bold;
+          #ilios-loading-error ul {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-around;
+            list-style-type: none;
           }
         </style>
       `;
@@ -25,46 +36,77 @@ module.exports = {
       return `<script src="${config.rootURL}ilios-error/scripts.js"></script>`;
     }
 
-    if( type === 'body') {
+    if (type === 'body') {
+      const supportedBrowsers = this.getSupportedBrowsers().join('');
       return `
         <div id='ilios-loading-error' data-deploy class='hidden ember-load-indicator'>
           <h1>
             It is possible that your browser is not supported by Ilios.
             Please refresh this page or try a different browser.
           </h1>
-          <table>
-          <caption>Supported Browsers</caption>
-          <thead>
-            <tr>
-              <th>Chrome</th>
-              <th>Firefox ESR</th>
-              <th>Edge</th>
-              <th>Safari</th>
-              <th>Android</th>
-              <th>Safari iOS</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/chrome/chrome_48x48.png" alt="Chrome"></td>
-              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/firefox/firefox_48x48.png" alt="Firefox"></td>
-              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/edge/edge_48x48.png" alt="Edge"></td>
-              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari/safari_48x48.png" alt="Safari"></td>
-              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/android/android_48x48.png" alt="Android"></td>
-              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari-ios/safari-ios_48x48.png" alt="Safari iOS"></td>
-            </tr>
-            <tr>
-              <td>Latest ✔</td>
-              <td>Latest ✔</td>
-              <td>Latest ✔</td>
-              <td>Latest ✔</td>
-              <td>Latest ✔</td>
-              <td>Latest ✔</td>
-            </tr>
-          </tbody>
-        </table>
+          <div class='supported-browsers'>
+            <h2>Supported Browsers</h2>
+            <ul>${supportedBrowsers}</ul>
+          </div>
         </div>
       `;
     }
+  },
+
+  getBrowserLogo(id) {
+    if (id === 'ios_saf') {
+      id = 'safari-ios';
+    }
+    if (id === 'samsung') {
+      id = 'samsung-internet';
+    }
+    if (id === 'op_mini') {
+      id = 'opera-mini';
+    }
+
+    const same = ['chrome', 'firefox', 'edge', 'safari', 'safari-ios', 'samsung-internet', 'opera-mini'];
+    if (same.includes(id)) {
+      return `https://cdnjs.cloudflare.com/ajax/libs/browser-logos/44.0.0/${id}/${id}_16x16.png`;
+    }
+
+    if (id === 'ie') {
+      return `https://cdnjs.cloudflare.com/ajax/libs/browser-logos/44.0.0/archive/internet-explorer_9-11/internet-explorer_9-11_16x16.png`;
+    }
+
+    if (id === 'and_chr') {
+      return `https://cdnjs.cloudflare.com/ajax/libs/browser-logos/44.0.0/archive/android/android_16x16.png`;
+    }
+
+    if (id === 'and_uc') {
+      return `https://cdnjs.cloudflare.com/ajax/libs/browser-logos/44.0.0/archive/uc/uc_16x16.png`;
+    }
+  },
+
+  getSupportedBrowsers() {
+    const targets = this.project.targets && this.project.targets.browsers;
+    const query = targets.join(', ');
+    const list = browserslist(query);
+
+    const mappedList = list.map(browser => {
+      const arr = browser.split(' ');
+      const id = arr[0];
+      const version = arr[1];
+
+      const db = caniuse[id];
+
+      return {
+        "version": version,
+        "id": id,
+        "name": db.browser,
+        "logo": this.getBrowserLogo(id)
+      };
+    });
+
+    mappedList.sort((a, b) => a.name.localeCompare(b.name));
+
+    return mappedList.map(obj => {
+      let logo = obj.logo ? `<img src="${obj.logo}" alt="${obj.name} logo">` : '';
+      return `<li>${logo} ${obj.name} ${obj.version}</li>`;
+    });
   }
 };

--- a/lib/ilios-error/index.js
+++ b/lib/ilios-error/index.js
@@ -12,6 +12,12 @@ module.exports = {
             padding: 2em;
             text-align: center;
           }
+          #ilios-loading-error table {
+            margin: 2rem auto;
+          }
+          #ilios-loading-error table caption {
+            font-weight: bold;
+          }
         </style>
       `;
     }
@@ -26,6 +32,37 @@ module.exports = {
             It is possible that your browser is not supported by Ilios.
             Please refresh this page or try a different browser.
           </h1>
+          <table>
+          <caption>Supported Browsers</caption>
+          <thead>
+            <tr>
+              <th>Chrome</th>
+              <th>Firefox ESR</th>
+              <th>Edge</th>
+              <th>Safari</th>
+              <th>Android</th>
+              <th>Safari iOS</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/chrome/chrome_48x48.png" alt="Chrome"></td>
+              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/firefox/firefox_48x48.png" alt="Firefox"></td>
+              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/edge/edge_48x48.png" alt="Edge"></td>
+              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari/safari_48x48.png" alt="Safari"></td>
+              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/android/android_48x48.png" alt="Android"></td>
+              <td><img src="https://cdnjs.cloudflare.com/ajax/libs/browser-logos/42.6.0/safari-ios/safari-ios_48x48.png" alt="Safari iOS"></td>
+            </tr>
+            <tr>
+              <td>Latest ✔</td>
+              <td>Latest ✔</td>
+              <td>Latest ✔</td>
+              <td>Latest ✔</td>
+              <td>Latest ✔</td>
+              <td>Latest ✔</td>
+            </tr>
+          </tbody>
+        </table>
         </div>
       `;
     }

--- a/lib/ilios-error/public/scripts.js
+++ b/lib/ilios-error/public/scripts.js
@@ -1,13 +1,13 @@
-/* global document */
+/* global document, window */
 
-//after 20 seconds display the error message
-setTimeout(function(){
-  const loadingIndicator = document.getElementById('ilios-loading-indicator');
+// if there is an uncaught runtime error show the error message
+window.addEventListener('error', function () {
+  var loadingIndicator = document.getElementById('ilios-loading-indicator');
   if (loadingIndicator) {
-    loadingIndicator.remove();
+    loadingIndicator.parentNode.removeChild(loadingIndicator);
   }
-  const errorContainer = document.getElementById('ilios-loading-error');
+  var errorContainer = document.getElementById('ilios-loading-error');
   if (errorContainer) {
     errorContainer.classList.remove('hidden');
   }
-}, 20000);
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "browserslist": "^3.2.3",
+    "caniuse-db": "^1.0.30000820",
     "ember-ajax": "^3.0.0",
     "ember-chrome-devtools": "^0.2.0",
     "ember-cli": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1834,6 +1834,13 @@ browserslist@^3.1.1:
     caniuse-lite "^1.0.30000815"
     electron-to-chromium "^1.3.39"
 
+browserslist@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.3.tgz#ad36e56a43daeacf4d2b7bb16441b7ac30be4510"
+  dependencies:
+    caniuse-lite "^1.0.30000819"
+    electron-to-chromium "^1.3.40"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -1935,9 +1942,17 @@ can-symlink@^1.0.0:
   dependencies:
     tmp "0.0.28"
 
+caniuse-db@^1.0.30000820:
+  version "1.0.30000820"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000820.tgz#7c20e25cea1768b261b724f82e3a6a253aaa1468"
+
 caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000810, caniuse-lite@^1.0.30000815:
   version "1.0.30000815"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000815.tgz#3a4258e6850362185adb11b0d754a48402d35bf6"
+
+caniuse-lite@^1.0.30000819:
+  version "1.0.30000820"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000820.tgz#6e36ee75187a2c83d26d6504a1af47cc580324d2"
 
 capture-exit@^1.1.0:
   version "1.2.0"
@@ -3173,6 +3188,10 @@ ee-first@1.1.1:
 electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.39:
   version "1.3.39"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.39.tgz#d7a4696409ca0995e2750156da612c221afad84d"
+
+electron-to-chromium@^1.3.40:
+  version "1.3.40"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.40.tgz#1fbd6d97befd72b8a6f921dc38d22413d2f6fddf"
 
 element-resize-detector@1.1.4:
   version "1.1.4"


### PR DESCRIPTION
Instead of just waiting to display the error message we can display it
as soon as we trap a runtime exception. Since Ember will trap these for
us once the app is booted this will only show up for pre-load errors.

Builds the list of support browsers from our targets.js file and
displays them when there is an error.  This isn't the same as our
official support matrix, but it is dynamic and will always be correct.

Fixes #3311

Example of the error page:
<img width="1525" alt="ie11-error" src="https://user-images.githubusercontent.com/349624/37885861-689e00ea-306c-11e8-8865-997258c5a060.png">
