### PR TITLE
layout fix for user search results

### DIFF
--- a/app/styles/components/user-search.scss
+++ b/app/styles/components/user-search.scss
@@ -11,7 +11,6 @@
     left: 0;
     max-height: 15rem;
     overflow: scroll;
-    position: absolute;
     top: 2rem;
     transition: all .2s ease-in-out;
     z-index: 100;


### PR DESCRIPTION
fixes #3656 

![selection_011](https://user-images.githubusercontent.com/1410427/38440851-9b0b4798-3997-11e8-9e4c-cc69ff05a840.png)

side-effect of this change is that search results are no longer shrink-wrapped and will claim the entire available width of their containing element. Example from the program year director search:

![selection_010](https://user-images.githubusercontent.com/1410427/38440956-f7dadf74-3997-11e8-8535-c0dea5be165c.png)

IMO, this is an acceptable trade-off for the time being.

 