### PR TITLE
Use new permissions system when creating a course

### DIFF
--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -7,12 +7,16 @@ import { isPresent, isEmpty, isBlank } from '@ember/utils';
 import moment from 'moment';
 import { task, timeout } from 'ember-concurrency';
 import escapeRegExp from '../utils/escape-reg-exp';
+import config from '../config/environment';
+
+const { IliosFeatures: { enforceRelationshipCapabilityPermissions } } = config;
 
 const { gt, sort } = computed;
 
 export default Controller.extend({
   i18n: service(),
   currentUser: service(),
+  permissionChecker: service(),
   queryParams: {
     schoolId: 'school',
     yearTitle: 'year',
@@ -122,6 +126,14 @@ export default Controller.extend({
     }
 
     return defaultYear;
+  }),
+  canCreateCourse: computed('selectedSchool', 'currentUser', async function () {
+    if (!enforceRelationshipCapabilityPermissions) {
+      return true;
+    }
+    const permissionChecker = this.get('permissionChecker');
+    const selectedSchool = this.get('selectedSchool');
+    return permissionChecker.canCreateCourse(selectedSchool.get('id'));
   }),
 
   actions: {

--- a/app/templates/courses.hbs
+++ b/app/templates/courses.hbs
@@ -46,7 +46,9 @@
     <div class="header">
       <h2 class="title">{{t 'general.courses'}}</h2>
       <div class='actions'>
-        {{expand-collapse-button data-test-toggle-new-course-form value=showNewCourseForm action="toggleNewCourseForm"}}
+        {{#if (await canCreateCourse)}}
+          {{expand-collapse-button data-test-toggle-new-course-form value=showNewCourseForm action="toggleNewCourseForm"}}
+        {{/if}}
       </div>
     </div>
     <section class='new'>

--- a/config/environment.js
+++ b/config/environment.js
@@ -89,6 +89,7 @@ module.exports = function (environment) {
       allowAddNewUser: true,
       schoolSessionAttributes: true,
       accessCourseVisualizations: true,
+      enforceRelationshipCapabilityPermissions: false,
     }
   };
 
@@ -107,6 +108,7 @@ module.exports = function (environment) {
     };
 
     ENV.IliosFeatures.accessCourseVisualizations = true;
+    ENV.IliosFeatures.enforceRelationshipCapabilityPermissions = true;
   }
 
   if (environment === 'test') {


### PR DESCRIPTION
Check if a user is allowed to create a course before displaying the
control. Currently behind a feature flag so this can be merged before the new system is released. This is meant to be a validation of our approach.

Requires:
- [x] https://github.com/ilios/common/pull/193

Needs to be tested with an API that supports the new permissions system.