### PR TITLE
Added Error to Group Tool Translations refs #3655

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -168,6 +168,7 @@ export default {
     'ends': 'Ends',
     'endTime': 'End Time',
     'errorDisplayMessage': 'Sorry! Something went wrong with your request. Please try refreshing or check back later.',
+    'error': 'Error',
     'errors': 'Errors',
     'errorSavingAuthentication': 'Accounts were created for these users, but they will not be able to login.  This usually happens when the username already exists, but belongs to another user.  Please click on each user in the list and create a username and password for them.',
     'errorSavingUser': 'These users were unable to be saved.  Please verify that they do not already exist.',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -168,6 +168,7 @@
     'ends': 'Termina',
     'endTime': 'Hora de Cumplir',
     'errorDisplayMessage': 'Lo sentimos! Algo salió mal con su pedido. Por favor, trate de actualizar la página o revise de nuevo más tarde.',
+    'error': 'Error',
     'errors': 'Errores',
     'errorSavingAuthentication': 'Las cuentas fueron creadas para estos usuarios, pero no podrán iniciar sesión.  Esto generalmente sucede cuando el nombre de usuario ya existe, pero pertenece a otro usuario.  Por favor seleccione cada usuario y crear un nombre de usuario y contraseña.',
     'errorSavingUser': 'Estos usuarios fueron incapaces de salvarse. Por favor, compruebe que no existen.',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -168,6 +168,7 @@ export default {
     'ends': "Terminé",
     'endTime': "Heure Terminé",
     'errorDisplayMessage': "Désolé! Quelque chose s'est passé mal avec votre demande. Essayez s'il vous plaît de rafraîchir ou vérifier en arrière plus tard.",
+    'error': 'Erreur',
     'errors': 'Erreurs',
     'errorSavingAuthentication': "Les comptes ont été créés pour ces utilisateurs, mais ils ne pourront pas à la connexion. Ceci arrive d'habitude quand le nom d'utilisateur existe déjà, mais appartient à un autre utilisateur. Cliquez S'il vous plaît sur chaque utilisateur et créez un nom d'utilisateur et un mot de passe pour eux.",
     'errorSavingUser': "Ces utilisateurs n'avait pas été sauvé. Vérifiez qu'ils n'existent pas déjà.",


### PR DESCRIPTION
This fixes the missing `Error` message that should have been displayed when there is an "error" using the Learner Group upload tool.  

Fixes #3655 

