### PR TITLE
Print unpublished sessions for privileged users

### DIFF
--- a/app/components/print-course.js
+++ b/app/components/print-course.js
@@ -31,7 +31,7 @@ export default Component.extend(SortableByPosition, {
    * @type {Ember.computed}
    * @public
    */
-  sortedSessionProxies: computed('course.sessions.[]', function(){
+  sortedSessionProxies: computed('course.sessions.[]', 'includeUnpublishedSessions', function(){
     return new Promise(resolve => {
 
       const course = this.get('course');

--- a/app/controllers/print-course.js
+++ b/app/controllers/print-course.js
@@ -1,14 +1,21 @@
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { all } from 'rsvp';
 
 export default Controller.extend({
   currentUser: service(),
   queryParams: ['unpublished'],
   unpublished: false,
-  includeUnpublishedSessions: computed('unpublished', 'currentUser.canPrintUnpublishedCourse', function(){
+  includeUnpublishedSessions: computed('unpublished', 'currentUser.canPrintUnpublishedCourse', async function(){
     const unpublished = this.get('unpublished');
-    const canPrintUnpublishedCourse = this.get('currentUser.canPrintUnpublishedCourse');
+    const currentUser = this.get('currentUser');
+    const hasRole = await all([
+      currentUser.get('userIsCourseDirector'),
+      currentUser.get('userIsFaculty'),
+      currentUser.get('userIsDeveloper'),
+    ]);
+    const canPrintUnpublishedCourse = hasRole.includes(true);
 
     return unpublished && canPrintUnpublishedCourse;
   })

--- a/app/templates/components/print-course.hbs
+++ b/app/templates/components/print-course.hbs
@@ -151,7 +151,7 @@
 </section>
 
 {{#each (await sortedSessionProxies) as |session|}}
-  <div class='header'>
+  <div class='header' data-test-session-header>
     <h2>{{session.title}}</h2>
     {{publication-status item=session}}
   </div>

--- a/app/templates/print-course.hbs
+++ b/app/templates/print-course.hbs
@@ -1,1 +1,1 @@
-{{print-course course=model includeUnpublishedSessions=includeUnpublishedSessions}}
+{{print-course course=model includeUnpublishedSessions=(await includeUnpublishedSessions)}}


### PR DESCRIPTION
Non-students should be able to print a course which includes unpublished
sessions. This was broken for a few reasons, now fixed and with tests.

Fixes #3672