### PR TITLE
Only display invalid users in the list

### DIFF
--- a/app/templates/components/learnergroup-bulk-finalize-users.hbs
+++ b/app/templates/components/learnergroup-bulk-finalize-users.hbs
@@ -9,10 +9,10 @@
         </tr>
       </thead>
       <tbody>
-        {{#each finalData as |obj|}}
+        {{#each (await invalidUsers) as |obj|}}
           <tr>
-            <td>{{obj.user.fullName}}</td>
-            <td>{{obj.user.campusId}}</td>
+            <td>{{obj.userRecord.fullName}}</td>
+            <td>{{obj.userRecord.campusId}}</td>
             <td>{{t 'general.alreadyInLearnerGroup' learnerGroupTitle=learnerGroup.title}}</td>
           </tr>
         {{/each}}


### PR DESCRIPTION
We were pulling from the wrong list of users so everyone showed up as
invalid if any of the records were wrong.