### PR TITLE
Use new permissions system to enforce course editability

### DIFF
--- a/app/components/course-editing.js
+++ b/app/components/course-editing.js
@@ -1,10 +1,8 @@
 /* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
-import { computed } from '@ember/object';
-const { not } = computed;
 
 export default Component.extend({
-  editable: not('course.locked'),
+  editable: false,
   courseObjectiveDetails: false,
   courseTaxonomyDetails: false,
   courseCompetencyDetails: false,

--- a/app/components/course-header.js
+++ b/app/components/course-header.js
@@ -6,7 +6,7 @@ import Publishable from 'ilios/mixins/publishable';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 
-const { alias, not } = computed;
+const { alias } = computed;
 const { Promise } = RSVP;
 
 const Validations = buildValidations({
@@ -29,7 +29,7 @@ export default Component.extend(Validations, Publishable, ValidationErrorDisplay
   courseTitle: null,
   publishTarget: alias('course'),
 
-  editable: not('course.locked'),
+  editable: false,
   'data-test-course-header': true,
 
   actions: {

--- a/app/components/course-leadership-expanded.js
+++ b/app/components/course-leadership-expanded.js
@@ -4,6 +4,7 @@ import { task, timeout } from 'ember-concurrency';
 
 export default Component.extend({
   course: null,
+  editable: false,
   classNames: ['course-leadership-expanded'],
   directors: null,
   administrators: null,

--- a/app/components/course-overview.js
+++ b/app/components/course-overview.js
@@ -8,7 +8,7 @@ import { task } from 'ember-concurrency';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios/mixins/validation-error-display';
 
-const { not, reads } = computed;
+const { reads } = computed;
 const { Promise, all } = RSVP;
 
 const Validations = buildValidations({
@@ -37,7 +37,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   store: service(),
   currentUser: service(),
   routing: service('-routing'),
-  editable: not('course.locked'),
+  editable: false,
   universalLocator: 'ILIOS',
   'data-test-course-overview': true,
   init(){

--- a/app/components/ilios-course-details.js
+++ b/app/components/ilios-course-details.js
@@ -1,4 +1,3 @@
-/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import scrollTo from '../utils/scroll-to';
 
@@ -6,6 +5,7 @@ export default Component.extend({
   tagName: 'section',
   classNames: ['course-details'],
   course: null,
+  editable: false,
   showDetails: null,
   courseObjectiveDetails: null,
   courseTaxonomyDetails: null,

--- a/app/components/learningmaterial-manager.js
+++ b/app/components/learningmaterial-manager.js
@@ -34,7 +34,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   learningMaterial: null,
   isCourse: false,
   isSession: not('isCourse'),
-  editable: true,
+  editable: false,
   type: null,
   title: null,
   owningUserName: null,

--- a/app/components/mesh-manager.js
+++ b/app/components/mesh-manager.js
@@ -30,7 +30,7 @@ export default Component.extend({
   layout: layout,
   classNames: ['mesh-manager'],
   terms: null,
-  editable: true,
+  editable: false,
   query: '',
   searchResults: null,
   searchPage: 0,

--- a/app/components/mesh-manager.js
+++ b/app/components/mesh-manager.js
@@ -30,6 +30,7 @@ export default Component.extend({
   layout: layout,
   classNames: ['mesh-manager'],
   terms: null,
+  editable: true,
   query: '',
   searchResults: null,
   searchPage: 0,
@@ -107,10 +108,16 @@ export default Component.extend({
       this.set('query', '');
     },
     add(term) {
-      this.sendAction('add', term.get('content'));
+      const editable = this.get('editable');
+      if (editable) {
+        this.sendAction('add', term.get('content'));
+      }
     },
     remove(term) {
-      this.sendAction('remove', term);
+      const editable = this.get('editable');
+      if (editable) {
+        this.sendAction('remove', term);
+      }
     }
   }
 });

--- a/app/controllers/course.js
+++ b/app/controllers/course.js
@@ -11,6 +11,7 @@ export default Controller.extend({
   ],
 
   details: false,
+  editable: false,
   courseLeadershipDetails: false,
   courseObjectiveDetails: false,
   courseTaxonomyDetails: false,

--- a/app/routes/course.js
+++ b/app/routes/course.js
@@ -1,6 +1,29 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { inject as service } from '@ember/service';
+
+import config from '../config/environment';
+const { IliosFeatures: { enforceRelationshipCapabilityPermissions } } = config;
 
 export default Route.extend(AuthenticatedRouteMixin, {
+  permissionChecker: service(),
   titleToken: 'general.coursesAndSessions',
+  editable: false,
+  async afterModel(course) {
+    const permissionChecker = this.get('permissionChecker');
+    const schoolId = course.belongsTo('school').id();
+
+    let editable;
+    if (!enforceRelationshipCapabilityPermissions) {
+      editable = !course.get('locked') && !course.get('archived');
+    } else {
+      editable = await permissionChecker.canUpdateCourse(course, schoolId);
+    }
+
+    this.set('editable', editable);
+  },
+  setupController(controller, model) {
+    this._super(controller, model);
+    controller.set('editable', this.get('editable'));
+  }
 });

--- a/app/routes/course.js
+++ b/app/routes/course.js
@@ -11,13 +11,12 @@ export default Route.extend(AuthenticatedRouteMixin, {
   editable: false,
   async afterModel(course) {
     const permissionChecker = this.get('permissionChecker');
-    const schoolId = course.belongsTo('school').id();
 
     let editable;
     if (!enforceRelationshipCapabilityPermissions) {
       editable = !course.get('locked') && !course.get('archived');
     } else {
-      editable = await permissionChecker.canUpdateCourse(course, schoolId);
+      editable = await permissionChecker.canUpdateCourse(course);
     }
 
     this.set('editable', editable);

--- a/app/styles/components/mesh-manager.scss
+++ b/app/styles/components/mesh-manager.scss
@@ -40,9 +40,17 @@
   }
 
   .selected-terms {
-    @include ilios-removable-list;
-
+    @include ilios-tag-list;
     margin-bottom: 2rem;
+
+    li {
+      display: flex;
+
+      .remove {
+        margin-left: .5em;
+      }
+    }
+
 
     .term-title {
       font-weight: bold;

--- a/app/styles/mixins/ilios-form.scss
+++ b/app/styles/mixins/ilios-form.scss
@@ -59,7 +59,7 @@
   padding: 0;
 
   button {
-    background-color: $white;
+    @include ilios-button;
     border-style: solid;
     border-width: 1px;
     margin-right: 1rem;
@@ -69,6 +69,7 @@
     }
 
     &.done {
+      background-color: $white;
       border-color: $ilios-green;
       color: $ilios-green;
 
@@ -78,6 +79,7 @@
     }
 
     &.cancel {
+      background-color: $white;
       border-color: $ilios-red;
       color: $ilios-red;
 

--- a/app/templates/components/course-editing.hbs
+++ b/app/templates/components/course-editing.hbs
@@ -1,6 +1,7 @@
 {{#if (or (and (eq course.directors.length 0) (eq course.administrators.length 0)) courseLeadershipDetails)}}
   {{course-leadership-expanded
     course=course
+    editable=editable
     collapse=(action setCourseLeadershipDetails false)
     expand=(action setCourseLeadershipDetails true)
     isManaging=courseManageLeadership

--- a/app/templates/components/course-leadership-expanded.hbs
+++ b/app/templates/components/course-leadership-expanded.hbs
@@ -8,7 +8,7 @@
         {{fa-icon (if save.isRunning 'spinner' 'check') spin=(if isSaving true false)}}
       </button>
       <button class='bigcancel' {{action setIsManaging false}}>{{fa-icon 'undo'}}</button>
-    {{else}}
+    {{else if editable}}
       <button {{action setIsManaging true}}>{{t 'general.manageLeadership'}}</button>
     {{/if}}
   </div>

--- a/app/templates/components/course-overview.hbs
+++ b/app/templates/components/course-overview.hbs
@@ -9,7 +9,7 @@
     {{#link-to 'printCourse' course (query-params unpublished=true) class='print'}}
       {{fa-icon 'print' title=(t 'general.printSummary') fixedWidth=true}}
     {{/link-to}}
-    {{#if (and (is-fulfilled showRollover) (await showRollover))}}
+    {{#if (and editable (is-fulfilled showRollover) (await showRollover))}}
       {{#link-to 'course.rollover' course class='rollover'}}
         {{fa-icon 'random' title=(t 'general.courseRollover') fixedWidth=true}}
       {{/link-to}}

--- a/app/templates/components/course-overview.hbs
+++ b/app/templates/components/course-overview.hbs
@@ -9,7 +9,7 @@
     {{#link-to 'printCourse' course (query-params unpublished=true) class='print'}}
       {{fa-icon 'print' title=(t 'general.printSummary') fixedWidth=true}}
     {{/link-to}}
-    {{#if (and editable (is-fulfilled showRollover) (await showRollover))}}
+    {{#if (and (is-fulfilled showRollover) (await showRollover))}}
       {{#link-to 'course.rollover' course class='rollover'}}
         {{fa-icon 'random' title=(t 'general.courseRollover') fixedWidth=true}}
       {{/link-to}}

--- a/app/templates/components/course-summary-header.hbs
+++ b/app/templates/components/course-summary-header.hbs
@@ -9,7 +9,7 @@
     {{#link-to 'printCourse' course (query-params unpublished=true) class='print'}}
       {{fa-icon 'print' title=(t 'general.printSummary') fixedWidth=true}}
     {{/link-to}}
-    {{#if (and (is-fulfilled showRollover) (await showRollover))}}
+    {{#if (and editable (is-fulfilled showRollover) (await showRollover))}}
       {{#link-to 'course.rollover' course class='rollover'}}
         {{fa-icon 'random' title=(t 'general.courseRollover') fixedWidth=true}}
       {{/link-to}}

--- a/app/templates/components/course-summary-header.hbs
+++ b/app/templates/components/course-summary-header.hbs
@@ -9,7 +9,7 @@
     {{#link-to 'printCourse' course (query-params unpublished=true) class='print'}}
       {{fa-icon 'print' title=(t 'general.printSummary') fixedWidth=true}}
     {{/link-to}}
-    {{#if (and editable (is-fulfilled showRollover) (await showRollover))}}
+    {{#if (and (is-fulfilled showRollover) (await showRollover))}}
       {{#link-to 'course.rollover' course class='rollover'}}
         {{fa-icon 'random' title=(t 'general.courseRollover') fixedWidth=true}}
       {{/link-to}}

--- a/app/templates/components/detail-mesh.hbs
+++ b/app/templates/components/detail-mesh.hbs
@@ -21,6 +21,7 @@
 <div class='content'>
   {{#if isManaging}}
     {{mesh-manager
+      editable=editable
       terms=bufferTerms
       add='addTermToBuffer'
       remove='removeTermFromBuffer'

--- a/app/templates/components/detail-objectives.hbs
+++ b/app/templates/components/detail-objectives.hbs
@@ -83,7 +83,7 @@
       {{/if}}
     {{/if}}
     {{#if isManagingDescriptors}}
-      {{objective-manage-descriptors objective=manageDescriptorsObjective}}
+      {{objective-manage-descriptors objective=manageDescriptorsObjective editable=editable}}
     {{/if}}
     {{#if isManagingCompetency}}
       {{objective-manage-competency objective=manageCompetencyObjective}}

--- a/app/templates/components/ilios-course-details.hbs
+++ b/app/templates/components/ilios-course-details.hbs
@@ -1,13 +1,14 @@
 <div class="back-to-courses-list">
   {{#link-to 'courses'}}{{t 'general.backToCourses'}}{{/link-to}}
 </div>
-{{course-header course=course}}
-{{course-overview course=course}}
+{{course-header course=course editable=editable}}
+{{course-overview course=course editable=editable}}
 {{#if (not showDetails)}}
   <div {{action setShowDetails true}} class='detail-collapsed-control'><span>{{t 'general.expandDetail'}}{{fa-icon 'plus-square'}}</span></div>
 {{else}}
   {{course-editing
     course=course
+    editable=editable
     courseLeadershipDetails=courseLeadershipDetails
     courseObjectiveDetails=courseObjectiveDetails
     courseTaxonomyDetails = courseTaxonomyDetails

--- a/app/templates/components/learning-material-table-actions.hbs
+++ b/app/templates/components/learning-material-table-actions.hbs
@@ -1,3 +1,3 @@
-{{#unless row.confirmDelete}}
+{{#unless (or (not extra.editable) row.confirmDelete)}}
   {{fa-icon 'trash' click=(action 'clickTrash')}}
 {{/unless}}

--- a/app/templates/components/learningmaterial-manager.hbs
+++ b/app/templates/components/learningmaterial-manager.hbs
@@ -3,7 +3,7 @@
 {{else}}
   <div class="item displayname">
     <label>{{t 'general.displayName'}}:</label>
-    {{#if (await canEditTitle)}}
+    {{#if (and editable (await canEditTitle))}}
       <input
         type='text'
         value={{title}}
@@ -146,53 +146,79 @@
     {{#if startDate}}
       <div class='item start-date'>
         <label>{{t 'general.startDate'}}:</label>
-        {{pikaday-input value=startDate onSelection=(action 'updateDate' 'startDate') format='M/D/YYYY'}}
+        {{#if editable}}
+          {{pikaday-input value=startDate onSelection=(action 'updateDate' 'startDate') format='M/D/YYYY'}}
+        {{else}}
+          {{moment-format startDate 'L'}}
+        {{/if}}
       </div>
 
       <div class='item start-time'>
         <label>{{t 'general.startTime'}}:</label>
-        {{time-picker date=startDate action=(action 'updateTime' 'startDate')}}
+        {{#if editable}}
+          {{time-picker date=startDate action=(action 'updateTime' 'startDate')}}
+        {{else}}
+          {{moment-format startDate 'h:mm a'}}
+        {{/if}}
       </div>
-      <button class='remove-date' {{action (mut startDate null)}}>{{t 'general.timedReleaseClearStartDate'}}</button>
-    {{else}}
+      {{#if editable}}
+        <button class='remove-date' {{action (mut startDate null)}}>{{t 'general.timedReleaseClearStartDate'}}</button>
+      {{/if}}
+    {{else if editable}}
       <p><button class='add-date' {{action 'addDate' 'startDate'}} data-test-add-start-date>{{t 'general.timedReleaseAddStartDate'}}</button></p>
     {{/if}}
 
     {{#if endDate}}
       <div class='item end-date'>
         <label>{{t 'general.endDate'}}:</label>
-        {{pikaday-input value=endDate onSelection=(action 'updateDate' 'endDate') format='M/D/YYYY'}}
+        {{#if editable}}
+          {{pikaday-input value=endDate onSelection=(action 'updateDate' 'endDate') format='M/D/YYYY'}}
+        {{else}}
+          {{moment-format endDate 'L'}}
+        {{/if}}
       </div>
 
       <div class='item end-time'>
         <label>{{t 'general.endTime'}}:</label>
-        {{time-picker date=endDate action=(action 'updateTime' 'endDate')}}
+        {{#if editable}}
+          {{time-picker date=endDate action=(action 'updateTime' 'endDate')}}
+        {{else}}
+          {{moment-format endDate 'h:mm a'}}
+        {{/if}}
       </div>
-
       {{#if (and (v-get this 'endDate' 'isInvalid') (is-in showErrorsFor 'endDate'))}}
         <span class="validation-error-message" data-test-end-date-validation-error-message>{{v-get this 'endDate' 'message'}}</span>
       {{/if}}
-      <button class='remove-date' {{action (mut endDate null)}}>{{t 'general.timedReleaseClearEndDate'}}</button>
-    {{else}}
+      {{#if editable}}
+        <button class='remove-date' {{action (mut endDate null)}}>{{t 'general.timedReleaseClearEndDate'}}</button>
+      {{/if}}
+    {{else if editable}}
       <p><button class='add-date' {{action 'addDate' 'endDate'}} data-test-add-end-date>{{t 'general.timedReleaseAddEndDate'}}</button></p>
     {{/if}}
+
+
   </div>
 
   {{mesh-manager
     terms=terms
+    editable=editable
     add='addTerm'
     remove='removeTerm'
     targetItemTitle=title
   }}
 
   <div class='buttons'>
-    <button class='done' {{action (perform save)}} disabled={{save.isRunning}}>
-      {{#if save.isRunning}}
-        {{loading-spinner}}
-      {{else}}
-        {{t 'general.done'}}
-      {{/if}}
-    </button>
-    <button class='cancel' {{action (action closeManager)}}>{{t 'general.cancel'}}</button>
+    {{#if editable}}
+      <button class='done' {{action (perform save)}} disabled={{save.isRunning}}>
+        {{#if save.isRunning}}
+          {{loading-spinner}}
+        {{else}}
+          {{t 'general.done'}}
+        {{/if}}
+      </button>
+      <button class='cancel' {{action (action closeManager)}}>{{t 'general.cancel'}}</button>
+    {{else}}
+      <button {{action (action closeManager)}}>{{t 'general.close'}}</button>
+    {{/if}}
   </div>
 {{/if}}

--- a/app/templates/components/mesh-manager.hbs
+++ b/app/templates/components/mesh-manager.hbs
@@ -3,7 +3,7 @@
 {{/if}}
 <ul class='selected-terms'>
   {{#each sortedTerms as |term|}}
-    <li {{action 'remove' term}}>
+    <li class={{if editable 'clickable'}} {{action 'remove' term}}>
       <span class="term-title">{{term.name}}</span>
       <span class="term-details">
         {{term.id}}
@@ -15,11 +15,16 @@
           {{/if}}
         {{/if}}
       </span>
-      {{fa-icon 'remove' class='remove'}}
+      {{#if editable}}
+        {{fa-icon 'remove' class='remove'}}
+      {{/if}}
     </li>
   {{/each}}
 </ul>
-{{search-box placeholder=(t 'general.meshSearchPlaceholder') liveSearch=false search=(action 'search') clear=(action 'clear')}}
+
+{{#if editable}}
+  {{search-box placeholder=(t 'general.meshSearchPlaceholder') liveSearch=false search=(action 'search') clear=(action 'clear')}}
+{{/if}}
 
 {{#if searching}}
   <ul class='results'>

--- a/app/templates/components/new-myreport.hbs
+++ b/app/templates/components/new-myreport.hbs
@@ -94,6 +94,7 @@
         {{else}}
           {{mesh-manager
             add='chooseMeshTerm'
+            editable=true
           }}
         {{/if}}
       {{else}}

--- a/app/templates/components/objective-manage-descriptors.hbs
+++ b/app/templates/components/objective-manage-descriptors.hbs
@@ -1,1 +1,1 @@
-{{mesh-manager add='add' remove='remove' terms=objectiveDescriptors}}
+{{mesh-manager add='add' remove='remove' terms=objectiveDescriptors editable=editable}}

--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -1,5 +1,6 @@
 {{ilios-course-details
   course=model
+  editable=editable
   showDetails=details
   setShowDetails=(action (mut details))
   courseLeadershipDetails=courseLeadershipDetails

--- a/tests/acceptance/course/cohorts-test.js
+++ b/tests/acceptance/course/cohorts-test.js
@@ -12,7 +12,7 @@ module('Acceptance: Course - Cohorts', function(hooks) {
   setupMirage(hooks);
   hooks.beforeEach(async function() {
     const school = this.server.create('school');
-    this.user = await setupAuthentication({ school });
+    this.user = await setupAuthentication({ school, administeredSchools: [school] });
     this.server.create('academicYear', {id: 2013});
     const program = this.server.create('program', { school });
     const cohort1 = this.server.create('cohort');

--- a/tests/acceptance/course/leadership-test.js
+++ b/tests/acceptance/course/leadership-test.js
@@ -12,7 +12,7 @@ module('Acceptance: Course - Leadership', function(hooks) {
   setupMirage(hooks);
   hooks.beforeEach(async function() {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     this.server.create('academicYear', {id: 2013});
 
     const users = this.server.createList('user', 4);

--- a/tests/acceptance/course/learningmaterials-test.js
+++ b/tests/acceptance/course/learningmaterials-test.js
@@ -16,8 +16,8 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const school = this.server.create('school');
-    this.user = await setupAuthentication({ school });
+    this.school = this.server.create('school');
+    this.user = await setupAuthentication({ school: this.school });
     this.server.create('academicYear');
     this.server.create('learningMaterialStatus', {
       learningMaterialIds: [1]
@@ -28,6 +28,10 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
   });
   module('Single Linked Materials', function (hooks) {
     hooks.beforeEach(function () {
+      const course = this.server.create('course', {
+        year: 2013,
+        school: this.school,
+      });
       this.server.create('learningMaterial', {
         originalAuthor: 'Jennifer Johnson',
         owningUserId: this.user.id,
@@ -78,37 +82,33 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
       });
       this.server.create('courseLearningMaterial', {
         learningMaterialId: 1,
-        courseId: 1,
+        course,
         required: false,
         meshDescriptorIds: [2, 3],
         position: 0,
       });
       this.server.create('courseLearningMaterial', {
         learningMaterialId: 2,
-        courseId: 1,
+        course,
         required: false,
         position: 1,
       });
       this.server.create('courseLearningMaterial', {
         learningMaterialId: 3,
-        courseId: 1,
+        course,
         publicNotes: false,
         position: 2,
       });
       this.server.create('courseLearningMaterial', {
         learningMaterialId: 4,
-        courseId: 1,
+        course,
         position: 3,
         notes: 'test notes',
-      });
-
-      this.server.create('course', {
-        year: 2013,
-        schoolId: 1,
       });
     });
 
     test('list learning materials', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(currentRouteName(), 'course.index');
 
@@ -150,6 +150,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('create new link learning material', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       const testTitle = 'testsome title';
       const testAuthor = 'testsome author';
       const testDescription = 'testsome description';
@@ -176,6 +177,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('create new citation learning material', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       const testTitle = 'testsome title';
       const testAuthor = 'testsome author';
       const testDescription = 'testsome description';
@@ -202,6 +204,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('can only add one learning-material at a time', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
       assert.ok(page.learningMaterials.canCreateNew);
@@ -213,7 +216,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('cancel new learning material', async function (assert) {
-
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
       assert.ok(page.learningMaterials.canSearch);
@@ -225,6 +228,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('view copyright file learning material details', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
       await page.learningMaterials.current(0).details();
@@ -241,6 +245,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('view rationale file learning material details', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
       await page.learningMaterials.current(1).details();
@@ -257,6 +262,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('view url file learning material details', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
       await page.learningMaterials.current(1).details();
@@ -273,6 +279,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('view link learning material details', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
       await page.learningMaterials.current(2).details();
@@ -291,6 +298,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('view citation learning material details', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
       await page.learningMaterials.current(3).details();
@@ -309,6 +317,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('edit learning material', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       let newNote = 'text text. Woo hoo!';
 
       await page.visit({ courseId: 1, details: true });
@@ -334,6 +343,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('cancel editing learning material', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       let newNote = 'text text. Woo hoo!';
 
       await page.visit({ courseId: 1, details: true });
@@ -360,6 +370,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('manage terms', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
       await page.learningMaterials.current(0).details();
@@ -391,6 +402,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('save terms', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       assert.expect(5);
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
@@ -410,6 +422,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('cancel term changes', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       assert.expect(5);
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
@@ -429,6 +442,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('find and add learning material', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 4);
       await page.learningMaterials.search('doc');
@@ -445,6 +459,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('add timed release start date', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.notOk(page.learningMaterials.current(0).isTimedRelease);
       await page.learningMaterials.current(0).details();
@@ -462,6 +477,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('add timed release start and end date', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       const newStartDate = moment().add(1, 'day').add(1, 'month').hour(10).minute(10);
       const newEndDate = newStartDate.clone().add(1, 'minute');
 
@@ -490,6 +506,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('add timed release end date', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.notOk(page.learningMaterials.current(0).isTimedRelease);
       await page.learningMaterials.current(0).details();
@@ -507,6 +524,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('end date is after start date', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       const newDate = moment().add(1, 'day').add(1, 'month').hour(10).minute(10);
 
       await page.visit({ courseId: 1, details: true });
@@ -533,6 +551,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('edit learning material with no other links #3617', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       let newTitle = 'text text. Woo hoo!';
 
       await page.visit({ courseId: 1, details: true });
@@ -552,6 +571,14 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
 
   module('Double Linked Materials', function (hooks) {
     hooks.beforeEach(function () {
+      const course1 = this.server.create('course', {
+        year: 2013,
+        school: this.school,
+      });
+      const course2 = this.server.create('course', {
+        year: 2013,
+        school: this.school,
+      });
       this.server.create('learningMaterial', {
         originalAuthor: 'Jennifer Johnson',
         owningUserId: this.user.id,
@@ -564,29 +591,21 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
       });
       this.server.create('courseLearningMaterial', {
         learningMaterialId: 1,
-        courseId: 1,
+        course: course1,
         required: false,
         meshDescriptorIds: [2, 3],
         position: 0,
       });
       this.server.create('courseLearningMaterial', {
         learningMaterialId: 1,
-        courseId: 2,
+        course: course2,
         required: false,
         position: 1,
-      });
-
-      this.server.create('course', {
-        year: 2013,
-        schoolId: 1,
-      });
-      this.server.create('course', {
-        year: 2013,
-        schoolId: 1,
       });
     });
 
     test('list learning materials', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(currentRouteName(), 'course.index');
 
@@ -602,6 +621,7 @@ module('Acceptance: Course - Learning Materials', function(hooks) {
     });
 
     test('view learning material details', async function (assert) {
+      this.user.update({ administeredSchools: [this.school] });
       await page.visit({ courseId: 1, details: true });
       assert.equal(page.learningMaterials.current().count, 1);
       await page.learningMaterials.current(0).details();

--- a/tests/acceptance/course/mesh-test.js
+++ b/tests/acceptance/course/mesh-test.js
@@ -13,7 +13,7 @@ module('Acceptance: Course - Mesh Terms', function(hooks) {
   setupMirage(hooks);
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
-    this.server.create('school');
+    this.school = this.server.create('school');
     this.server.create('academicYear');
     this.server.createList('meshTree', 3);
     this.server.createList('meshConcept', 3);
@@ -48,6 +48,7 @@ module('Acceptance: Course - Mesh Terms', function(hooks) {
   });
 
   test('manage terms', async function (assert) {
+    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, details: true });
     assert.equal(page.meshTerms.current().count, 3);
     await page.meshTerms.manage();
@@ -81,6 +82,7 @@ module('Acceptance: Course - Mesh Terms', function(hooks) {
   });
 
   test('save terms', async function (assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(9);
     await page.visit({ courseId: 1, details: true });
     assert.equal(page.meshTerms.current().count, 3);
@@ -105,6 +107,7 @@ module('Acceptance: Course - Mesh Terms', function(hooks) {
   });
 
   test('cancel term changes', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(11);
     await page.visit({ courseId: 1, details: true });
     assert.equal(page.meshTerms.current().count, 3);

--- a/tests/acceptance/course/objectivecreate-test.js
+++ b/tests/acceptance/course/objectivecreate-test.js
@@ -13,7 +13,7 @@ module('Acceptance: Course - Objective Create', function(hooks) {
   setupMirage(hooks);
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
-    this.server.create('school');
+    this.school = this.server.create('school');
     this.server.create('academicYear', {id: 2013});
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);
@@ -27,6 +27,7 @@ module('Acceptance: Course - Objective Create', function(hooks) {
   });
 
   test('save new objective', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(9);
     const newObjectiveDescription = 'Test junk 123';
 
@@ -47,6 +48,7 @@ module('Acceptance: Course - Objective Create', function(hooks) {
   });
 
   test('cancel new objective', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(6);
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
     assert.equal(page.objectives.current().count, 1);
@@ -62,6 +64,7 @@ module('Acceptance: Course - Objective Create', function(hooks) {
   });
 
   test('empty objective title can not be created', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(5);
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
     assert.equal(page.objectives.current().count, 1);

--- a/tests/acceptance/course/objectivelist-test.js
+++ b/tests/acceptance/course/objectivelist-test.js
@@ -13,7 +13,7 @@ module('Acceptance: Course - Objective List', function(hooks) {
   setupMirage(hooks);
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
-    this.server.create('school');
+    this.school = this.server.create('school');
     this.server.create('academicYear', {id: 2013});
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);
@@ -22,6 +22,7 @@ module('Acceptance: Course - Objective List', function(hooks) {
   });
 
   test('list objectives', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(45);
     assert.expect(45);
     this.server.createList('competency', 2);
@@ -68,6 +69,7 @@ module('Acceptance: Course - Objective List', function(hooks) {
   });
 
   test('long objective', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(3);
     var longTitle = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam placerat tempor neque ut egestas. In cursus dignissim erat, sed porttitor mauris tincidunt at. Nunc et tortor in purus facilisis molestie. Phasellus in ligula nisi. Nam nec mi in urna mollis pharetra. Suspendisse in nibh ex. Curabitur maximus diam in condimentum pulvinar. Phasellus sit amet metus interdum, molestie turpis vel, bibendum eros. In fermentum elit in odio cursus cursus. Nullam ipsum ipsum, fringilla a efficitur non, vehicula vitae enim. Duis ultrices vitae neque in pulvinar. Nulla molestie vitae quam eu faucibus. Vestibulum tempor, tellus in dapibus sagittis, velit purus maximus lectus, quis ullamcorper sem neque quis sem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed commodo risus sed tellus imperdiet, ac suscipit justo scelerisque. Quisque sit amet nulla efficitur, sollicitudin sem in, venenatis mi. Quisque sit amet neque varius, interdum quam id, condimentum ipsum. Quisque tincidunt efficitur diam ut feugiat. Duis vehicula mauris elit, vel vehicula eros commodo rhoncus. Phasellus ac eros vel turpis egestas aliquet. Nam id dolor rutrum, imperdiet purus ac, faucibus nisi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nam aliquam leo eget quam varius ultricies. Suspendisse pellentesque varius mi eu luctus. Integer lacinia ornare magna, in egestas quam molestie non.';
     this.server.create('objective', {
@@ -87,6 +89,7 @@ module('Acceptance: Course - Objective List', function(hooks) {
   });
 
   test('edit objective title', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(4);
     const newDescription = 'test new title';
     this.server.create('objective');
@@ -107,6 +110,7 @@ module('Acceptance: Course - Objective List', function(hooks) {
   });
 
   test('empty objective title can not be saved', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(4);
     this.server.create('objective');
 

--- a/tests/acceptance/course/objectivemesh-test.js
+++ b/tests/acceptance/course/objectivemesh-test.js
@@ -13,7 +13,7 @@ module('Acceptance: Course - Objective Mesh Descriptors', function(hooks) {
   setupMirage(hooks);
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
-    this.server.create('school');
+    this.school = this.server.create('school');
     this.server.create('academicYear', {id: 2013});
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);
@@ -41,6 +41,7 @@ module('Acceptance: Course - Objective Mesh Descriptors', function(hooks) {
   });
 
   test('manage terms', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
     assert.equal(page.objectives.current().count, 3);
 
@@ -87,6 +88,7 @@ module('Acceptance: Course - Objective Mesh Descriptors', function(hooks) {
   });
 
   test('save terms', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
     assert.equal(page.objectives.current().count, 3);
 
@@ -118,6 +120,7 @@ module('Acceptance: Course - Objective Mesh Descriptors', function(hooks) {
   });
 
   test('cancel changes', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
     assert.equal(page.objectives.current().count, 3);
 

--- a/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -13,13 +13,13 @@ module('Acceptance: Course with multiple Cohorts - Objective Parents', function(
   setupMirage(hooks);
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
-    const school = this.server.create('school');
-    const program = this.server.create('program', { school });
+    this.school = this.server.create('school');
+    const program = this.server.create('program', { school: this.school });
 
     const programYears = this.server.createList('programYear', 2, { program });
     const cohort1 = this.server.create('cohort', { programYear: programYears[0]});
     const cohort2 = this.server.create('cohort', { programYear: programYears[1]});
-    const competencies = this.server.createList('competency', 2, { school, programYears });
+    const competencies = this.server.createList('competency', 2, { school: this.school, programYears });
 
     const objective1 = this.server.create('objective', { programYears: [programYears[0]], competency: competencies[0] });
     this.server.create('objective', { programYears: [programYears[0]], competency: competencies[1] });
@@ -33,13 +33,14 @@ module('Acceptance: Course with multiple Cohorts - Objective Parents', function(
     const objective4 = this.server.create('objective');
     this.server.create('course', {
       year: 2013,
-      school,
+      school: this.school,
       objectives: [objective3, objective4],
       cohorts: [cohort1, cohort2]
     });
   });
 
   test('list parent objectives by competency', async function (assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(33);
 
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
@@ -90,6 +91,7 @@ module('Acceptance: Course with multiple Cohorts - Objective Parents', function(
   });
 
   test('save changes', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(13);
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
     assert.equal(page.objectives.current(0).description.text, 'objective 4');
@@ -120,6 +122,7 @@ module('Acceptance: Course with multiple Cohorts - Objective Parents', function(
   });
 
   test('cancel changes', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(13);
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
     assert.equal(page.objectives.current(0).description.text, 'objective 4');

--- a/tests/acceptance/course/objectiveparents-test.js
+++ b/tests/acceptance/course/objectiveparents-test.js
@@ -13,7 +13,7 @@ module('Acceptance: Course - Objective Parents', function(hooks) {
   setupMirage(hooks);
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
-    this.server.create('school');
+    this.school =  this.server.create('school');
     this.server.create('program');
     this.server.create('programYear', {
       programId: 1,
@@ -54,6 +54,7 @@ module('Acceptance: Course - Objective Parents', function(hooks) {
   });
 
   test('list parent objectives by competency', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(19);
 
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
@@ -85,6 +86,7 @@ module('Acceptance: Course - Objective Parents', function(hooks) {
   });
 
   test('save changes', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(11);
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
     assert.equal(page.objectives.current().count, 2);
@@ -110,6 +112,7 @@ module('Acceptance: Course - Objective Parents', function(hooks) {
   });
 
   test('cancel changes', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(11);
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
     assert.equal(page.objectives.current().count, 2);

--- a/tests/acceptance/course/publish-test.js
+++ b/tests/acceptance/course/publish-test.js
@@ -13,12 +13,13 @@ module('Acceptance: Course - Publish', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   hooks.beforeEach(async function () {
-    await setupAuthentication();
-    this.server.create('school');
+    this.user = await setupAuthentication();
+    this.school = this.server.create('school');
     this.server.create('cohort');
   });
 
   test('check published course', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     this.server.create('course', {
       year: 2013,
       schoolId: 1,
@@ -55,6 +56,7 @@ module('Acceptance: Course - Publish', function(hooks) {
   });
 
   test('check scheduled course', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     this.server.create('course', {
       year: 2013,
       schoolId: 1,
@@ -80,6 +82,7 @@ module('Acceptance: Course - Publish', function(hooks) {
   });
 
   test('check draft course', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     this.server.create('course', {
       year: 2013,
       schoolId: 1,
@@ -103,6 +106,7 @@ module('Acceptance: Course - Publish', function(hooks) {
   });
 
   test('check publish draft course', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     this.server.create('course', {
       year: 2013,
       schoolId: 1,
@@ -120,6 +124,7 @@ module('Acceptance: Course - Publish', function(hooks) {
   });
 
   test('check schedule draft course', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     this.server.create('course', {
       year: 2013,
       schoolId: 1,
@@ -136,6 +141,7 @@ module('Acceptance: Course - Publish', function(hooks) {
   });
 
   test('check publish scheduled course', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     this.server.create('course', {
       year: 2013,
       schoolId: 1,
@@ -154,6 +160,7 @@ module('Acceptance: Course - Publish', function(hooks) {
   });
 
   test('check unpublish scheduled course', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     this.server.create('course', {
       year: 2013,
       schoolId: 1,
@@ -172,6 +179,7 @@ module('Acceptance: Course - Publish', function(hooks) {
   });
 
   test('check schedule published course', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     this.server.create('course', {
       year: 2013,
       schoolId: 1,
@@ -189,6 +197,7 @@ module('Acceptance: Course - Publish', function(hooks) {
   });
 
   test('check unpublish published course', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     this.server.create('course', {
       year: 2013,
       schoolId: 1,

--- a/tests/acceptance/course/terms-test.js
+++ b/tests/acceptance/course/terms-test.js
@@ -13,9 +13,9 @@ module('Acceptance: Course - Terms', function(hooks) {
   setupMirage(hooks);
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
-    this.server.create('school');
+    this.school = this.server.create('school');
     this.server.create('vocabulary', {
-      schoolId: 1,
+      school: this.school,
       active: true,
     });
     this.server.create('academicYear', {id: 2013});
@@ -31,7 +31,7 @@ module('Acceptance: Course - Terms', function(hooks) {
 
     this.course = this.server.create('course', {
       year: 2013,
-      schoolId: 1,
+      school: this.school,
       termIds: [1]
     });
   });
@@ -61,6 +61,7 @@ module('Acceptance: Course - Terms', function(hooks) {
   });
 
   test('manage terms', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(8);
     await page.visit({ courseId: 1, details: true, courseTaxonomyDetails: true });
     assert.equal(page.taxonomies.vocabularies().count, 1);
@@ -76,6 +77,7 @@ module('Acceptance: Course - Terms', function(hooks) {
   });
 
   test('save term changes', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(5);
     await page.visit({ courseId: 1, details: true, courseTaxonomyDetails: true });
     assert.equal(page.taxonomies.vocabularies().count, 1);
@@ -92,6 +94,7 @@ module('Acceptance: Course - Terms', function(hooks) {
   });
 
   test('cancel term changes', async function(assert) {
+    this.user.update({ administeredSchools: [this.school] });
     assert.expect(5);
     await page.visit({ courseId: 1, details: true, courseTaxonomyDetails: true });
     assert.equal(page.taxonomies.vocabularies().count, 1);

--- a/tests/integration/components/course-leadership-expanded-test.js
+++ b/tests/integration/components/course-leadership-expanded-test.js
@@ -47,6 +47,7 @@ test('it renders', function(assert) {
   this.set('nothing', parseInt);
   this.render(hbs`{{course-leadership-expanded
     course=course
+    editable=true
     collapse=(action nothing)
     expand=(action nothing)
     isManaging=false
@@ -98,6 +99,7 @@ test('clicking the header collapses', function(assert) {
   this.set('nothing', parseInt);
   this.render(hbs`{{course-leadership-expanded
     course=course
+    editable=true
     collapse=(action click)
     expand=(action nothing)
     isManaging=false
@@ -138,6 +140,7 @@ test('clicking manage fires action', function(assert) {
   this.set('nothing', parseInt);
   this.render(hbs`{{course-leadership-expanded
     course=course
+    editable=true
     collapse=(action nothing)
     expand=(action nothing)
     isManaging=false

--- a/tests/integration/components/course-overview-test.js
+++ b/tests/integration/components/course-overview-test.js
@@ -28,7 +28,7 @@ test('renders with no course id', function(assert) {
     clerkshipType: resolve(EmberObject.create())
   });
   this.set('course', course);
-  this.render(hbs`{{course-overview course=course}}`);
+  this.render(hbs`{{course-overview course=course editable=true}}`);
 
   assert.notEqual(this.$('.courseexternalid').text().search(/Course ID:/), -1);
   assert.notEqual(this.$('.courseexternalid').text().search(/Click to edit/), -1);
@@ -47,7 +47,7 @@ test('course external id validation fails if value is too short', function(asser
     clerkshipType: resolve(EmberObject.create()),
   });
   this.set('course', course);
-  this.render(hbs`{{course-overview course=course}}`);
+  this.render(hbs`{{course-overview course=course editable=true}}`);
 
   const item = '.courseexternalid';
   const error = `${item} .validation-error-message`;
@@ -77,7 +77,7 @@ test('course external id validation fails if value is too long', function(assert
     clerkshipType: resolve(EmberObject.create()),
   });
   this.set('course', course);
-  this.render(hbs`{{course-overview course=course}}`);
+  this.render(hbs`{{course-overview course=course editable=true}}`);
 
   const item = '.courseexternalid';
   const error = `${item} .validation-error-message`;

--- a/tests/integration/components/course-summary-header-test.js
+++ b/tests/integration/components/course-summary-header-test.js
@@ -3,6 +3,7 @@ import EmberObject from '@ember/object';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
+import { resolve } from 'rsvp';
 
 moduleForComponent('course-summary-header', 'Integration | Component | course summary header', {
   integration: true,
@@ -14,9 +15,18 @@ moduleForComponent('course-summary-header', 'Integration | Component | course su
   }
 });
 
-test('it renders', function(assert) {
+test('it renders', function (assert) {
+  let school = EmberObject.create({});
+  let permissionCheckerMock = Service.extend({
+    canCreateCourse(inSchool) {
+      assert.equal(school, inSchool);
+      return resolve(true);
+    }
+  });
+  this.register('service:permissionChecker', permissionCheckerMock);
   let course = EmberObject.create({
     title: 'title',
+    school: resolve(school),
     startDate: new Date(2020, 4, 6, 12),
     endDate: new Date(2020, 11, 11, 12),
     externalId: 'abc',
@@ -25,7 +35,7 @@ test('it renders', function(assert) {
     isSchedule: false,
   });
   this.set('course', course);
-  this.render(hbs`{{course-summary-header course=course editable=true}}`);
+  this.render(hbs`{{course-summary-header course=course}}`);
   const title = 'h2';
   const actions = '.course-summary-actions';
   const materialsIcon = `${actions} i:eq(0)`;
@@ -52,7 +62,15 @@ test('it renders', function(assert) {
 
 });
 
-test('no link to materials when that is the current route', function(assert) {
+test('no link to materials when that is the current route', function (assert) {
+  let school = EmberObject.create({});
+  let permissionCheckerMock = Service.extend({
+    canCreateCourse(inSchool) {
+      assert.equal(school, inSchool);
+      return resolve(true);
+    }
+  });
+  this.register('service:permissionChecker', permissionCheckerMock);
   let routerMock = Service.extend({
     currentRouteName: 'course-materials',
     generateURL(){},
@@ -61,11 +79,12 @@ test('no link to materials when that is the current route', function(assert) {
 
   let course = EmberObject.create({
     title: 'title',
+    school: resolve(school),
     startDate: new Date(2020, 4, 6, 12),
     endDate: new Date(2020, 11, 11, 12),
   });
   this.set('course', course);
-  this.render(hbs`{{course-summary-header course=course editable=true}}`);
+  this.render(hbs`{{course-summary-header course=course}}`);
   const actions = '.course-summary-actions i';
   const printIcon = `${actions}:eq(0)`;
   const rolloverIcon = `${actions}:eq(1)`;
@@ -88,7 +107,7 @@ test('no link to rollover when that is the current route', function(assert) {
     endDate: new Date(2020, 11, 11, 12),
   });
   this.set('course', course);
-  this.render(hbs`{{course-summary-header course=course editable=true}}`);
+  this.render(hbs`{{course-summary-header course=course}}`);
   const actions = '.course-summary-actions i';
   const materialsIcon = `${actions}:eq(0)`;
   const printIcon = `${actions}:eq(1)`;
@@ -98,20 +117,29 @@ test('no link to rollover when that is the current route', function(assert) {
   assert.ok(this.$(materialsIcon).hasClass('fa-archive'));
 });
 
-test('no link to rollover when not editable', function(assert) {
+test('no link to rollover when user cannot edit the course', function (assert) {
+  let school = EmberObject.create({});
   let routerMock = Service.extend({
     currentRouteName: 'course.rollover',
     generateURL(){},
   });
   this.register('service:-routing', routerMock);
+  let permissionCheckerMock = Service.extend({
+    canCreateCourse(inSchool) {
+      assert.equal(school, inSchool);
+      return resolve(false);
+    }
+  });
+  this.register('service:permissionChecker', permissionCheckerMock);
 
   let course = EmberObject.create({
     title: 'title',
+    school: resolve(school),
     startDate: new Date(2020, 4, 6, 12),
     endDate: new Date(2020, 11, 11, 12),
   });
   this.set('course', course);
-  this.render(hbs`{{course-summary-header course=course editable=false}}`);
+  this.render(hbs`{{course-summary-header course=course}}`);
   const actions = '.course-summary-actions i';
   const materialsIcon = `${actions}:eq(0)`;
   const printIcon = `${actions}:eq(1)`;

--- a/tests/integration/components/course-summary-header-test.js
+++ b/tests/integration/components/course-summary-header-test.js
@@ -25,7 +25,7 @@ test('it renders', function(assert) {
     isSchedule: false,
   });
   this.set('course', course);
-  this.render(hbs`{{course-summary-header course=course}}`);
+  this.render(hbs`{{course-summary-header course=course editable=true}}`);
   const title = 'h2';
   const actions = '.course-summary-actions';
   const materialsIcon = `${actions} i:eq(0)`;
@@ -65,7 +65,7 @@ test('no link to materials when that is the current route', function(assert) {
     endDate: new Date(2020, 11, 11, 12),
   });
   this.set('course', course);
-  this.render(hbs`{{course-summary-header course=course}}`);
+  this.render(hbs`{{course-summary-header course=course editable=true}}`);
   const actions = '.course-summary-actions i';
   const printIcon = `${actions}:eq(0)`;
   const rolloverIcon = `${actions}:eq(1)`;
@@ -88,7 +88,30 @@ test('no link to rollover when that is the current route', function(assert) {
     endDate: new Date(2020, 11, 11, 12),
   });
   this.set('course', course);
-  this.render(hbs`{{course-summary-header course=course}}`);
+  this.render(hbs`{{course-summary-header course=course editable=true}}`);
+  const actions = '.course-summary-actions i';
+  const materialsIcon = `${actions}:eq(0)`;
+  const printIcon = `${actions}:eq(1)`;
+
+  assert.ok(this.$(actions).length, 2);
+  assert.ok(this.$(printIcon).hasClass('fa-print'));
+  assert.ok(this.$(materialsIcon).hasClass('fa-archive'));
+});
+
+test('no link to rollover when not editable', function(assert) {
+  let routerMock = Service.extend({
+    currentRouteName: 'course.rollover',
+    generateURL(){},
+  });
+  this.register('service:-routing', routerMock);
+
+  let course = EmberObject.create({
+    title: 'title',
+    startDate: new Date(2020, 4, 6, 12),
+    endDate: new Date(2020, 11, 11, 12),
+  });
+  this.set('course', course);
+  this.render(hbs`{{course-summary-header course=course editable=false}}`);
   const actions = '.course-summary-actions i';
   const materialsIcon = `${actions}:eq(0)`;
   const printIcon = `${actions}:eq(1)`;

--- a/tests/integration/components/learning-material-table-actions-test.js
+++ b/tests/integration/components/learning-material-table-actions-test.js
@@ -13,7 +13,8 @@ test('it renders', function(assert) {
   const deleteIcon = 'i.fa-trash';
 
   this.set('row', row);
-  this.render(hbs`{{learning-material-table-actions row=row}}`);
+  this.set('extra', {editable: true});
+  this.render(hbs`{{learning-material-table-actions row=row extra=extra}}`);
   assert.equal(this.$(deleteIcon).length, 1);
 });
 
@@ -24,7 +25,20 @@ test('it does not display an icon when it should not', function(assert) {
   const deleteIcon = 'i.fa-trash';
 
   this.set('row', row);
-  this.render(hbs`{{learning-material-table-actions row=row}}`);
+  this.set('extra', {editable: true});
+  this.render(hbs`{{learning-material-table-actions row=row extra=extra}}`);
+  assert.equal(this.$(deleteIcon).length, 0);
+});
+
+test('it does not display an icon when not editable', function(assert) {
+  const row = EmberObject.create({
+    confirmDelete: false
+  });
+  const deleteIcon = 'i.fa-trash';
+
+  this.set('row', row);
+  this.set('extra', {editable: false});
+  this.render(hbs`{{learning-material-table-actions row=row extra=extra}}`);
   assert.equal(this.$(deleteIcon).length, 0);
 });
 
@@ -36,7 +50,8 @@ test('clicking delete changes the row property', function(assert) {
   const deleteIcon = 'i.fa-trash';
 
   this.set('row', row);
-  this.render(hbs`{{learning-material-table-actions row=row}}`);
+  this.set('extra', {editable: true});
+  this.render(hbs`{{learning-material-table-actions row=row extra=extra}}`);
   assert.equal(this.$(deleteIcon).length, 1);
   this.$(deleteIcon).click();
   assert.ok(row.get('confirmDelete'));


### PR DESCRIPTION
Depending on the users permissions a lot of data must sometimes be
loaded so this work has to be done in the route before rendering
otherwise users may see an uneditable screen followed by a pop-in of new
actions and colors.

Requires https://github.com/ilios/common/pull/199