### PR TITLE
Remove all associations from mirage factories

### DIFF
--- a/mirage/factories/competency.js
+++ b/mirage/factories/competency.js
@@ -1,6 +1,5 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   title: (i) => `competency ${i}`,
-  school: association(),
 });

--- a/mirage/factories/course-learning-material.js
+++ b/mirage/factories/course-learning-material.js
@@ -1,8 +1,6 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   required: true,
   publicNotes: true,
-  course: association(),
-  learningMaterial: association(),
 });

--- a/mirage/factories/course.js
+++ b/mirage/factories/course.js
@@ -1,10 +1,9 @@
 import moment from 'moment';
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   title: (i) => `course ${i}`,
   year: 2013,
-  school: association(),
   level: 1,
   startDate: () => moment().format(),
   endDate: () => moment().add(7, 'weeks').format(),

--- a/mirage/factories/instructor-group.js
+++ b/mirage/factories/instructor-group.js
@@ -1,6 +1,5 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   title: (i) => `instructor group ${i}`,
-  school: association(),
 });

--- a/mirage/factories/permission.js
+++ b/mirage/factories/permission.js
@@ -1,7 +1,6 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  user:  association(),
   canRead: false,
   canWrite: false,
   tableRowId: null,

--- a/mirage/factories/program.js
+++ b/mirage/factories/program.js
@@ -1,9 +1,8 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   title: (i) => `program ${i}`,
   shortTitle: (i) => `short_${i}`,
-  school: association(),
   duration: 4,
   published: true,
   publishedAsTbd: false,

--- a/mirage/factories/school-config.js
+++ b/mirage/factories/school-config.js
@@ -1,7 +1,6 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  school: association(),
   name: (i) => `key_${i}`,
   value: (i) => `value_${i}`,
 });

--- a/mirage/factories/session.js
+++ b/mirage/factories/session.js
@@ -1,8 +1,7 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   title: (i) => `session ${i}`,
-  sessionType: association(),
   attireRequired : false,
   equipmentRequired : false,
   supplemental : false,

--- a/tests/acceptance/course/objectivelist-test.js
+++ b/tests/acceptance/course/objectivelist-test.js
@@ -14,18 +14,13 @@ module('Acceptance: Course - Objective List', function(hooks) {
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
     this.school = this.server.create('school');
-    this.server.create('academicYear', {id: 2013});
-    this.server.createList('program', 2);
-    this.server.createList('programYear', 2);
-    this.server.createList('cohort', 2);
-
+    this.server.create('academicYear', { id: 2013 });
   });
 
   test('list objectives', async function(assert) {
     this.user.update({ administeredSchools: [this.school] });
     assert.expect(45);
-    assert.expect(45);
-    this.server.createList('competency', 2);
+    this.server.createList('competency', 2, { school: this.school });
     this.server.create('objective', {
       competencyId: 1
     });
@@ -42,7 +37,7 @@ module('Acceptance: Course - Objective List', function(hooks) {
     this.server.createList('objective', 11);
     this.server.create('course', {
       year: 2013,
-      schoolId: 1,
+      school: this.school,
       objectiveIds: [3,4,5,6,7,8,9,10,11,12,13,14,15]
     });
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
@@ -78,7 +73,7 @@ module('Acceptance: Course - Objective List', function(hooks) {
 
     this.server.create('course', {
       year: 2013,
-      schoolId: 1,
+      school: this.school,
       objectiveIds: [1]
     });
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
@@ -96,7 +91,7 @@ module('Acceptance: Course - Objective List', function(hooks) {
 
     this.server.create('course', {
       year: 2013,
-      schoolId: 1,
+      school: this.school,
       objectiveIds: [1]
     });
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });
@@ -116,7 +111,7 @@ module('Acceptance: Course - Objective List', function(hooks) {
 
     this.server.create('course', {
       year: 2013,
-      schoolId: 1,
+      school: this.school,
       objectiveIds: [1]
     });
     await page.visit({ courseId: 1, details: true, courseObjectiveDetails: true });

--- a/tests/acceptance/course/objectiveparents-test.js
+++ b/tests/acceptance/course/objectiveparents-test.js
@@ -14,7 +14,7 @@ module('Acceptance: Course - Objective Parents', function(hooks) {
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
     this.school =  this.server.create('school');
-    this.server.create('program');
+    this.server.create('program', { school: this.school });
     this.server.create('programYear', {
       programId: 1,
     });

--- a/tests/acceptance/course/session/offerings-test.js
+++ b/tests/acceptance/course/session/offerings-test.js
@@ -14,7 +14,7 @@ module('Acceptance: Session - Offerings', function(hooks) {
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
-    this.server.create('program');
+    this.server.create('program', { school: this.school });
     this.server.create('programYear', { programId: 1});
     this.server.create('cohort', {
       programYearId: 1

--- a/tests/acceptance/course/session/publicationcheck-test.js
+++ b/tests/acceptance/course/session/publicationcheck-test.js
@@ -14,12 +14,13 @@ module('Acceptance: Session - Publication Check', function(hooks) {
   setupMirage(hooks);
   hooks.beforeEach(async function () {
     await setupAuthentication();
-    this.server.create('course');
+    const school = this.server.create('school');
+    this.server.create('course', { school });
     this.server.create('vocabulary', {
-      schoolId: 1,
+      school,
     });
     this.server.createList('sessionType', 2, {
-      schoolId: 1
+      school
     });
     this.server.create('sessionDescription');
     this.server.create('objective');

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -16,67 +16,69 @@ module('Acceptance: Dashboard Calendar', function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const school = this.server.create('school');
-    this.user = await setupAuthentication( { school } );
-    this.server.create('program', {
-      schoolId: 1,
+    this.server.logging = true;
+    this.school = this.server.create('school');
+    this.user = await setupAuthentication( { school: this.school } );
+    const program = this.server.create('program', {
+      school: this.school,
     });
-    this.server.create('programYear', {
-      programId: 1,
+    const programYear1 = this.server.create('programYear', {
+      program,
       startYear: 2015,
     });
-    this.server.create('programYear', {
-      programId: 1,
+    const programYear2 = this.server.create('programYear', {
+      program,
       startYear: 2015,
     });
-    this.server.create('cohort', {
-      programYearId: 1,
+    const cohort1 = this.server.create('cohort', {
+      programYear: programYear1,
     });
-    this.server.create('cohort', {
-      programYearId: 2,
+    const cohort2 = this.server.create('cohort', {
+      programYear: programYear2,
+    });
+    const sessionType1 = this.server.create('sessionType', {
+      school: this.school,
+    });
+    const sessionType2 = this.server.create('sessionType', {
+      school: this.school,
     });
     this.server.create('sessionType', {
-      schoolId: 1,
+      school: this.school,
     });
-    this.server.create('sessionType', {
-      schoolId: 1,
-    });
-    this.server.create('sessionType', {
-      schoolId: 1,
-    });
-    this.server.create('course', {
-      schoolId: 1,
+    const course1 = this.server.create('course', {
+      school: this.school,
       year: 2015,
-      cohortIds: [1],
+      cohorts: [cohort1],
     });
-    this.server.create('course', {
+    const course2 = this.server.create('course', {
       year: 2015,
-      schoolId: 1,
-      cohortIds: [1],
+      school: this.school,
+      cohorts: [cohort2],
     });
-    this.server.create('session', {
-      courseId: 1,
-      sessionTypeId: 1,
+    const session1 = this.server.create('session', {
+      course: course1,
+      sessionType: sessionType1,
     });
-    this.server.create('session', {
-      courseId: 1,
-      sessionTypeId: 2,
+    const session2 = this.server.create('session', {
+      course: course1,
+      sessionType: sessionType2,
     });
-    this.server.create('session', {
-      courseId: 2,
+    const session3 = this.server.create('session', {
+      course: course2,
+      sessionType: sessionType2
     });
     this.server.create('academicYear', {
       id: 2015,
       title: 2015
     });
     this.server.create('offering', {
-      sessionId: 1
+      session: session1
     });
     this.server.create('offering', {
-      sessionId: 2
+      session: session2
     });
     this.server.create('offering', {
-      sessionId: 3
+      session: session3
     });
   });
 
@@ -536,7 +538,7 @@ module('Acceptance: Dashboard Calendar', function(hooks) {
       title: 2014
     });
     this.server.create('program', {
-      schoolId: 1,
+      school: this.school,
     });
     this.server.create('programYear', {
       startYear: 2014,
@@ -563,7 +565,7 @@ module('Acceptance: Dashboard Calendar', function(hooks) {
     });
     this.server.create('course', {
       year: 2014,
-      schoolId: 1
+      school: this.school
     });
     await visit('/dashboard?show=calendar');
     await showFilters();
@@ -579,7 +581,7 @@ module('Acceptance: Dashboard Calendar', function(hooks) {
 
   test('clear all filters', async function (assert) {
     const vocabulary = this.server.create('vocabulary', {
-      schoolId: 1
+      school: this.school
     });
     this.server.createList('term', 2, {
       vocabulary
@@ -740,7 +742,7 @@ module('Acceptance: Dashboard Calendar', function(hooks) {
 
   test('test term filter', async function(assert) {
     const vocabulary = this.server.create('vocabulary', {
-      schoolId: 1
+      school: this.school
     });
     this.server.create('term', {
       vocabulary,
@@ -778,7 +780,7 @@ module('Acceptance: Dashboard Calendar', function(hooks) {
 
   test('clear vocab filter #3450', async function(assert) {
     const vocabulary = this.server.create('vocabulary', {
-      schoolId: 1
+      school: this.school
     });
     this.server.create('term', {
       vocabulary,

--- a/tests/acceptance/program/programyear/stewards-test.js
+++ b/tests/acceptance/program/programyear/stewards-test.js
@@ -16,14 +16,15 @@ module('Acceptance: Program Year - Stewards', function(hooks) {
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
-    this.server.create('school');
+    const school2 = this.server.create('school');
+    const school3 = this.server.create('school');
     this.server.create('program', {
       school: this.school,
     });
     this.server.create('programYear', {
       programId: 1,
     });
-    this.server.create('cohort', { programId: 1});
+    this.server.create('cohort', { programYearId: 1});
     this.server.create('department', {
       school: this.school,
     });
@@ -31,10 +32,10 @@ module('Acceptance: Program Year - Stewards', function(hooks) {
       school: this.school,
     });
     this.server.create('department', {
-      schoolId: 2,
+      school: school2,
     });
     this.server.create('department', {
-      schoolId: 3
+      school: school3
     });
     this.server.createList('department', 5, {
       school: this.school,
@@ -46,12 +47,12 @@ module('Acceptance: Program Year - Stewards', function(hooks) {
     });
     this.server.create('programYearSteward', {
       programYearId: 1,
-      schoolId: 2,
+      school: school2,
       departmentId: 3
     });
     this.server.create('programYearSteward', {
       programYearId: 1,
-      schoolId: 3
+      school: school3
     });
   });
 

--- a/tests/acceptance/program/publicationcheck-test.js
+++ b/tests/acceptance/program/publicationcheck-test.js
@@ -18,11 +18,10 @@ module('Acceptance: Program - Publication Check', function(hooks) {
     this.server.create('school');
     this.server.create('objective');
     this.server.create('term');
-    this.server.create('competency');
-    this.server.create('program');
+    this.server.create('competency', { school });
+    this.server.create('program', { school });
     this.fullProgramYear = this.server.create('programYear', {
       startYear: 2013,
-      schoolId: 1,
       programId: 1,
       directors: [user],
       objectiveIds: [1],
@@ -31,7 +30,6 @@ module('Acceptance: Program - Publication Check', function(hooks) {
     });
     this.emptyProgramYear = this.server.create('programYear', {
       startYear: 2013,
-      schoolId: 1,
       programId: 1
     });
     this.server.createList('cohort', 2);


### PR DESCRIPTION
These auto create the related entities and can cause mysterious test
failures, we shouldn't be relying on them so lets just take them out.