### PR TITLE
Remove remaining schools references

### DIFF
--- a/app/components/detail-cohort-manager.js
+++ b/app/components/detail-cohort-manager.js
@@ -1,7 +1,7 @@
 /* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import { all, map } from 'rsvp';
+import { all, filter } from 'rsvp';
 import EmberObject, { computed } from '@ember/object';
 
 import { translationMacro as t } from "ember-i18n";
@@ -11,6 +11,7 @@ const { sort } = computed;
 export default Component.extend({
   i18n: service(),
   store: service(),
+  permissionChecker: service(),
   init() {
     this._super(...arguments);
     this.set('sortBy', ['title']);
@@ -19,32 +20,46 @@ export default Component.extend({
   classNames: ['detail-cohort-manager'],
   placeholder: t('general.filterPlaceholder'),
   filter: '',
+  school: null,
   selectedCohorts: null,
   sortBy: null,
   sortedCohorts: sort('selectedCohorts', 'sortBy'),
+
+  allCohorts: computed('school', async function () {
+    const store = this.get('store');
+    const permissionChecker = this.get('permissionChecker');
+    const allCohorts = await store.findAll('cohort', { reload: true });
+    const courseSchool = this.get('school');
+
+    return filter(allCohorts.toArray(), async cohort => {
+      const cohortSchool = await cohort.get('school');
+      if (cohortSchool === courseSchool) {
+        return true;
+      }
+      // @todo HACK here. Until we update common to a version with canUpdateAllCoursesInSchool
+      // we have to reach into a permission checker internal method instead.
+      if (await permissionChecker.canDoInSchool(cohortSchool, 'CAN_UPDATE_ALL_COURSES')) {
+        return true;
+      }
+      const programYear = await cohort.get('programYear');
+      if (await permissionChecker.canUpdateProgramYear(programYear)) {
+        return true;
+      }
+
+      return false;
+    });
+  }),
 
   /**
    * @property availableCohorts
    * @type {Ember.computed}
    * @protected
    */
-  availableCohorts: computed('selectedCohorts.[]', async function(){
-    const store = this.get('store');
-    const schools = await store.findAll('school', { reload: true });
+  availableCohorts: computed('allCohorts.[]', 'selectedCohorts.[]', async function(){
+    const cohorts = await this.get('allCohorts');
+    const selectedCohorts = this.get('selectedCohorts') || [];
 
-    const cohorts = await map(schools.toArray(), async school => {
-      return school.get('cohorts');
-    });
-
-    const usableCohorts =  cohorts.reduce((array, set) => {
-      return array.pushObjects(set.toArray());
-    }, []);
-
-    return usableCohorts.filter(cohort => {
-      return (
-        this.get('selectedCohorts') && !this.get('selectedCohorts').includes(cohort)
-      );
-    });
+    return cohorts.filter(cohort => !selectedCohorts.includes(cohort));
   }),
 
   /**

--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -221,20 +221,15 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     }
   }),
   /**
-   * A list of schools that the current user is associated with, sorted by title.
+   * All schools, sorted by title.
    * @property schoolList
    * @type {Ember.computed}
    * @public
    */
-  schoolList: computed('currentUser.schools.[]', async function(){
-    const currentUser = this.get('currentUser');
-    const user = await currentUser.get('model');
+  schoolList: computed(async function(){
+    const store = this.get('store');
 
-    if (isEmpty(user)) {
-      return [];
-    }
-
-    const schools = await user.get('schools');
+    const schools = await store.findAll('school');
     return schools.sortBy('title');
   }),
 

--- a/app/templates/components/course-rollover.hbs
+++ b/app/templates/components/course-rollover.hbs
@@ -77,6 +77,7 @@
         <span class='title'>{{t 'general.selectCohortsToAttach'}}:</span>
         {{detail-cohort-manager
           selectedCohorts=selectedCohorts
+          school=(await course.school)
           add='addCohort'
           remove='removeCohort'
         }}

--- a/app/templates/components/detail-cohorts.hbs
+++ b/app/templates/components/detail-cohorts.hbs
@@ -23,6 +23,7 @@
 <div class='detail-cohorts-content'>
   {{#if isManaging class="horizontal"}}
     {{detail-cohort-manager
+      school=(await course.school)
       selectedCohorts=bufferedCohorts
       add='addCohortToBuffer'
       remove='removeCohortFromBuffer'

--- a/app/templates/components/user-profile-cohorts.hbs
+++ b/app/templates/components/user-profile-cohorts.hbs
@@ -10,7 +10,7 @@
       {{/if}}
     </div>
   </div>
-  <p>
+  <p data-test-primary-cohort>
     <h4>{{t 'general.primaryCohort'}}: </h4>
     {{#if primaryCohort}}
       {{#if (and (is-fulfilled primaryCohort.school) (is-fulfilled primaryCohort.program))}}
@@ -24,7 +24,7 @@
     {{/if}}
   </p>
 
-  <p>
+  <p data-test-secondary-cohorts>
     <h4>{{t 'general.secondaryCohorts'}}:</h4>
     {{#if (gt secondaryCohorts.length 0)}}
       <ul>
@@ -46,12 +46,12 @@
   </p>
 
   {{#if isManaging}}
-    <p class='select-available-cohort'>
+    <p class='select-available-cohort' >
       <h4>{{t 'general.availableCohorts'}}</h4>
       <div class="schoolsfilter">
         {{fa-icon 'university' fixedWidth=true}}
         {{#if (gt schools.length 1)}}
-          <select onchange={{action (mut selectedSchoolId) value="target.value"}}>
+          <select onchange={{action (mut selectedSchoolId) value="target.value"}} data-test-school>
             {{#each (sort-by 'title' schools) as |school|}}
               <option value={{school.id}} selected={{is-equal school selectedSchool}}>
                 {{school.title}}
@@ -64,7 +64,7 @@
       </div>
       {{#if (is-fulfilled assignableCohortsForSelectedSchool)}}
         {{#if (gt (get (await assignableCohortsForSelectedSchool) 'length') 0)}}
-          <ul>
+          <ul data-test-assignable-cohorts>
             {{#each (sort-by 'programYear.program.school.title' 'programYear.program.title' 'title' (await assignableCohortsForSelectedSchool)) as |cohort|}}
               <li>
                 {{fa-icon 'plus' class='clickable add' title=(t 'general.addCohort') click=(action 'addSelectedCohort' cohort)}}

--- a/tests/acceptance/assignstudents-test.js
+++ b/tests/acceptance/assignstudents-test.js
@@ -11,7 +11,7 @@ module('Acceptance: assign students', function(hooks) {
   setupMirage(hooks);
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
-    await setupAuthentication({ school });
+    await setupAuthentication({ school, administeredSchools: [this.school] });
     this.server.create('school');
   });
 

--- a/tests/acceptance/course/session/terms-test.js
+++ b/tests/acceptance/course/session/terms-test.js
@@ -12,7 +12,6 @@ module('Acceptance: Session - Terms', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   hooks.beforeEach(async function () {
-    this.server.logging = true;
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school});
     const vocabulary = this.server.create('vocabulary', {

--- a/tests/acceptance/dashboard/calendar-test.js
+++ b/tests/acceptance/dashboard/calendar-test.js
@@ -16,7 +16,6 @@ module('Acceptance: Dashboard Calendar', function(hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    this.server.logging = true;
     this.school = this.server.create('school');
     this.user = await setupAuthentication( { school: this.school } );
     const program = this.server.create('program', {

--- a/tests/integration/components/course-rollover-test.js
+++ b/tests/integration/components/course-rollover-test.js
@@ -590,7 +590,7 @@ test('changing the title looks for new matching courses', function(assert) {
 });
 
 test('rollover course with cohorts', async function(assert) {
-  assert.expect(2);
+  assert.expect(3);
   let som = EmberObject.create({
     id: '1',
     title: 'SOM'
@@ -614,7 +614,8 @@ test('rollover course with cohorts', async function(assert) {
   som.set('cohorts', resolve([cohort]));
   let course = EmberObject.create({
     id: 1,
-    title: 'old course'
+    title: 'old course',
+    school: som
   });
   let ajaxMock = Service.extend({
     request(url, { data }) {
@@ -636,16 +637,16 @@ test('rollover course with cohorts', async function(assert) {
     pushPayload(){},
     peekRecord(){},
     query() { return []; },
-    findAll() {
-      return resolve([som]);
+    findAll(what) {
+      assert.equal(what, 'cohort');
+      return resolve([cohort]);
     }
   });
   getOwner(this).lookup('service:flash-messages').registerTypes(['success']);
   const mockCurrentUser = EmberObject.create({});
 
   const currentUserMock = Service.extend({
-    model: resolve(mockCurrentUser),
-    cohortsInAllAssociatedSchools: resolve([cohort])
+    model: resolve(mockCurrentUser)
   });
   this.register('service:currentUser', currentUserMock);
 

--- a/tests/integration/components/course-rollover-test.js
+++ b/tests/integration/components/course-rollover-test.js
@@ -255,7 +255,8 @@ test('rollover course with new start date', function(assert) {
   storeMock.reopen({
     pushPayload(){},
     peekRecord(){},
-    query(){return [];}
+    query(){return [];},
+    findAll() { return [];},
   });
   getOwner(this).lookup('service:flash-messages').registerTypes(['success']);
 
@@ -348,7 +349,8 @@ test('rollover course prohibit non-matching day-of-week date selection', functio
   storeMock.reopen({
     pushPayload(){},
     peekRecord(){},
-    query(){return [];}
+    query(){return [];},
+    findAll(){return [];},
   });
   getOwner(this).lookup('service:flash-messages').registerTypes(['success']);
 
@@ -414,7 +416,8 @@ test('rollover start date adjustment with former year course start date', functi
   storeMock.reopen({
     pushPayload(){},
     peekRecord(){},
-    query(){return [];}
+    query(){return [];},
+    findAll(){return [];},
   });
   getOwner(this).lookup('service:flash-messages').registerTypes(['success']);
 
@@ -483,7 +486,8 @@ test('rollover course with no offerings', function(assert) {
   storeMock.reopen({
     pushPayload(){},
     peekRecord(){},
-    query(){return [];}
+    query(){return [];},
+    findAll(){return [];},
   });
   getOwner(this).lookup('service:flash-messages').registerTypes(['success']);
 
@@ -513,9 +517,8 @@ test('rollover course with no offerings', function(assert) {
 
 test('errors do not show up initially', function(assert) {
   storeMock.reopen({
-    query(){
-      return [];
-    }
+    query(){return [];},
+    findAll(){return [];},
   });
   let course = EmberObject.create({
     id: 1
@@ -531,9 +534,8 @@ test('errors do not show up initially', function(assert) {
 
 test('errors show up', function(assert) {
   storeMock.reopen({
-    query(){
-      return [];
-    }
+    query(){return [];},
+    findAll(){return [];},
   });
   let course = EmberObject.create({
     id: 1
@@ -609,6 +611,7 @@ test('rollover course with cohorts', async function(assert) {
     program: resolve(program1),
     school: resolve(som)
   });
+  som.set('cohorts', resolve([cohort]));
   let course = EmberObject.create({
     id: 1,
     title: 'old course'
@@ -632,7 +635,10 @@ test('rollover course with cohorts', async function(assert) {
   storeMock.reopen({
     pushPayload(){},
     peekRecord(){},
-    query() { return []; }
+    query() { return []; },
+    findAll() {
+      return resolve([som]);
+    }
   });
   getOwner(this).lookup('service:flash-messages').registerTypes(['success']);
   const mockCurrentUser = EmberObject.create({});

--- a/tests/integration/components/new-myreport-test.js
+++ b/tests/integration/components/new-myreport-test.js
@@ -1,313 +1,282 @@
-import { getOwner } from '@ember/application';
-import RSVP from 'rsvp';
+import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import EmberObject from '@ember/object';
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import initializer from "ilios/instance-initializers/load-common-translations";
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-const { resolve } = RSVP;
+module('Integration | Component | new myreport', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
 
-import wait from 'ember-test-helpers/wait';
+  test('it renders', async function(assert) {
+    assert.expect(35);
+    this.server.create('school', { title: 'first' });
+    const school2 = this.server.create('school', { title: 'second' });
+    this.server.create('school', { title: 'third' });
 
-moduleForComponent('new-myreport', 'Integration | Component | new myreport', {
-  integration: true,
-  setup(){
-    initializer.initialize(getOwner(this));
-  }
-});
+    const mockUser = EmberObject.create({
+      school: resolve(school2)
+    });
 
-test('it renders', async function(assert) {
-  assert.expect(35);
+    const currentUserMock = Service.extend({
+      model: resolve(mockUser)
+    });
+    this.owner.register('service:current-user', currentUserMock);
 
-  const mockSchools = [
-    {id: 2, title: 'second'},
-    {id: 1, title: 'first'},
-    {id: 3, title: 'third'},
-  ];
-  const mockUser = EmberObject.create({
-    schools: resolve(mockSchools),
-    school: resolve(EmberObject.create(mockSchools[0]))
+
+    this.set('close', ()=>{});
+    await render(hbs`{{new-myreport close=(action close)}}`);
+    const title = '.title';
+    const schools = 'select:eq(0)';
+    const schoolOptions = `${schools} option`;
+    const allSchools = `${schoolOptions}:eq(0)`;
+    const firstSchool = `${schoolOptions}:eq(1)`;
+    const secondSchool = `${schoolOptions}:eq(2)`;
+    const thirdSchool = `${schoolOptions}:eq(3)`;
+
+    const subjects = 'select:eq(1) option';
+    const firstSubject = `${subjects}:eq(0)`;
+    const secondSubject = `${subjects}:eq(1)`;
+    const thirdSubject = `${subjects}:eq(2)`;
+    const fourthSubject = `${subjects}:eq(3)`;
+    const fifthSubject = `${subjects}:eq(4)`;
+    const sixthSubject = `${subjects}:eq(5)`;
+    const seventhSubject = `${subjects}:eq(6)`;
+    const eighthSubject = `${subjects}:eq(7)`;
+    const ninthSubject = `${subjects}:eq(8)`;
+    const tenthSubject = `${subjects}:eq(9)`;
+    const eleventhSubject = `${subjects}:eq(10)`;
+
+    await settled();
+    assert.equal(this.$(title).text(), 'New Report');
+    assert.notEqual(this.$(allSchools).text().search(/All Schools/), -1);
+    assert.equal(this.$(allSchools).val(), "null");
+    assert.ok(this.$(allSchools).not(':selected'), 'all schools is not selected');
+    assert.notEqual(this.$(firstSchool).text().search(/first/), -1);
+    assert.equal(this.$(firstSchool).val(), 1);
+    assert.ok(this.$(firstSchool).not(':selected'), 'first school is not selected');
+    assert.notEqual(this.$(secondSchool).text().search(/second/), -1);
+    assert.equal(this.$(secondSchool).val(), 2);
+    assert.ok(this.$(secondSchool).is(':selected'), 'users primary school is selected');
+    assert.notEqual(this.$(thirdSchool).text().search(/third/), -1);
+    assert.equal(this.$(thirdSchool).val(), 3);
+    assert.ok(this.$(thirdSchool).not(':selected'), 'third school is not selected');
+
+    assert.equal(this.$(firstSubject).text().trim(), 'Courses');
+    assert.equal(this.$(firstSubject).val(), 'course');
+    assert.equal(this.$(secondSubject).text().trim(), 'Sessions');
+    assert.equal(this.$(secondSubject).val(), 'session');
+    assert.equal(this.$(thirdSubject).text().trim(), 'Programs');
+    assert.equal(this.$(thirdSubject).val(), 'program');
+    assert.equal(this.$(fourthSubject).text().trim(), 'Program Years');
+    assert.equal(this.$(fourthSubject).val(), 'program year');
+    assert.equal(this.$(fifthSubject).text().trim(), 'Instructors');
+    assert.equal(this.$(fifthSubject).val(), 'instructor');
+    assert.equal(this.$(sixthSubject).text().trim(), 'Instructor Groups');
+    assert.equal(this.$(sixthSubject).val(), 'instructor group');
+    assert.equal(this.$(seventhSubject).text().trim(), 'Learning Materials');
+    assert.equal(this.$(seventhSubject).val(), 'learning material');
+    assert.equal(this.$(eighthSubject).text().trim(), 'Competencies');
+    assert.equal(this.$(eighthSubject).val(), 'competency');
+    assert.equal(this.$(ninthSubject).text().trim(), 'MeSH Terms');
+    assert.equal(this.$(ninthSubject).val(), 'mesh term');
+    assert.equal(this.$(tenthSubject).text().trim(), 'Terms');
+    assert.equal(this.$(tenthSubject).val(), 'term');
+    assert.equal(this.$(eleventhSubject).text().trim(), 'Session Types');
+    assert.equal(this.$(eleventhSubject).val(), 'session type');
   });
 
-  const currentUserMock = Service.extend({
-    model: resolve(mockUser)
-  });
-  this.register('service:current-user', currentUserMock);
+  let checkObjects = async function(context, assert, subjectNum, subjectVal, expectedObjects){
+    assert.expect(expectedObjects.length + 2);
+    const school = context.server.create('school', { title: 'first' });
+    const mockUser = EmberObject.create({
+      school: resolve(school)
+    });
 
+    const currentUserMock = Service.extend({
+      model: resolve(mockUser)
+    });
+    context.owner.register('service:current-user', currentUserMock);
+    context.set('close', ()=>{});
+    await render(hbs`{{new-myreport close=(action close)}}`);
 
-  this.on('close', parseInt);
-  this.render(hbs`{{new-myreport close=(action 'close')}}`);
-  const title = '.title';
-  const schools = 'select:eq(0)';
-  const schoolOptions = `${schools} option`;
-  const allSchools = `${schoolOptions}:eq(0)`;
-  const firstSchool = `${schoolOptions}:eq(1)`;
-  const secondSchool = `${schoolOptions}:eq(2)`;
-  const thirdSchool = `${schoolOptions}:eq(3)`;
+    const schoolSelect = `select:eq(0)`;
+    const select = `select:eq(1)`;
+    const subjects = `${select} option`;
+    const targetSubject = `${subjects}:eq(${subjectNum})`;
 
-  const subjects = 'select:eq(1) option';
-  const firstSubject = `${subjects}:eq(0)`;
-  const secondSubject = `${subjects}:eq(1)`;
-  const thirdSubject = `${subjects}:eq(2)`;
-  const fourthSubject = `${subjects}:eq(3)`;
-  const fifthSubject = `${subjects}:eq(4)`;
-  const sixthSubject = `${subjects}:eq(5)`;
-  const seventhSubject = `${subjects}:eq(6)`;
-  const eighthSubject = `${subjects}:eq(7)`;
-  const ninthSubject = `${subjects}:eq(8)`;
-  const tenthSubject = `${subjects}:eq(9)`;
-  const eleventhSubject = `${subjects}:eq(10)`;
+    const objectsOptions = 'select:eq(2) option';
 
-  await wait();
-  assert.equal(this.$(title).text(), 'New Report');
-  assert.notEqual(this.$(allSchools).text().search(/All Schools/), -1);
-  assert.equal(this.$(allSchools).val(), "null");
-  assert.ok(this.$(allSchools).not(':selected'), 'all schools is not selected');
-  assert.notEqual(this.$(firstSchool).text().search(/first/), -1);
-  assert.equal(this.$(firstSchool).val(), 1);
-  assert.ok(this.$(firstSchool).not(':selected'), 'first school is not selected');
-  assert.notEqual(this.$(secondSchool).text().search(/second/), -1);
-  assert.equal(this.$(secondSchool).val(), 2);
-  assert.ok(this.$(secondSchool).is(':selected'), 'users primary school is selected');
-  assert.notEqual(this.$(thirdSchool).text().search(/third/), -1);
-  assert.equal(this.$(thirdSchool).val(), 3);
-  assert.ok(this.$(thirdSchool).not(':selected'), 'third school is not selected');
+    await settled();
+    context.$(schoolSelect).val(null).change();
+    await settled();
+    assert.equal(context.$(targetSubject).val(), subjectVal, `${subjectVal} is in the list where we expect it.`);
+    context.$(select).val(subjectVal).change();
+    await settled();
 
-  assert.equal(this.$(firstSubject).text().trim(), 'Courses');
-  assert.equal(this.$(firstSubject).val(), 'course');
-  assert.equal(this.$(secondSubject).text().trim(), 'Sessions');
-  assert.equal(this.$(secondSubject).val(), 'session');
-  assert.equal(this.$(thirdSubject).text().trim(), 'Programs');
-  assert.equal(this.$(thirdSubject).val(), 'program');
-  assert.equal(this.$(fourthSubject).text().trim(), 'Program Years');
-  assert.equal(this.$(fourthSubject).val(), 'program year');
-  assert.equal(this.$(fifthSubject).text().trim(), 'Instructors');
-  assert.equal(this.$(fifthSubject).val(), 'instructor');
-  assert.equal(this.$(sixthSubject).text().trim(), 'Instructor Groups');
-  assert.equal(this.$(sixthSubject).val(), 'instructor group');
-  assert.equal(this.$(seventhSubject).text().trim(), 'Learning Materials');
-  assert.equal(this.$(seventhSubject).val(), 'learning material');
-  assert.equal(this.$(eighthSubject).text().trim(), 'Competencies');
-  assert.equal(this.$(eighthSubject).val(), 'competency');
-  assert.equal(this.$(ninthSubject).text().trim(), 'MeSH Terms');
-  assert.equal(this.$(ninthSubject).val(), 'mesh term');
-  assert.equal(this.$(tenthSubject).text().trim(), 'Terms');
-  assert.equal(this.$(tenthSubject).val(), 'term');
-  assert.equal(this.$(eleventhSubject).text().trim(), 'Session Types');
-  assert.equal(this.$(eleventhSubject).val(), 'session type');
-});
+    assert.equal(context.$(`${objectsOptions}:eq(0)`).val(), '', 'first option is blank');
+    expectedObjects.forEach((val, i) => {
+      assert.equal(context.$(`${objectsOptions}:eq(${i+1})`).val(), val, `${val} is object option`);
+    });
+  };
 
-let checkObjects = async function(context, assert, subjectNum, subjectVal, expectedObjects){
-  assert.expect(expectedObjects.length + 2);
-  const mockSchools = [{id: 2, title: 'second'}];
-  const mockUser = EmberObject.create({
-    schools: resolve(mockSchools),
-    school: resolve(EmberObject.create(mockSchools[0]))
+  test('choosing course selects correct objects', function(assert) {
+    return checkObjects(this, assert, 0, 'course', [
+      'session',
+      'program',
+      'instructor',
+      'instructor group',
+      'learning material',
+      'competency',
+      'mesh term',
+    ]);
   });
 
-  const currentUserMock = Service.extend({
-    model: resolve(mockUser)
+  test('choosing session selects correct objects', function(assert) {
+    return checkObjects(this, assert, 1, 'session', [
+      'course',
+      'program',
+      'instructor',
+      'instructor group',
+      'learning material',
+      'competency',
+      'mesh term',
+      'session type',
+    ]);
   });
-  context.register('service:current-user', currentUserMock);
-  context.on('close', parseInt);
-  context.render(hbs`{{new-myreport close=(action 'close')}}`);
 
-  const schoolSelect = `select:eq(0)`;
-  const select = `select:eq(1)`;
-  const subjects = `${select} option`;
-  const targetSubject = `${subjects}:eq(${subjectNum})`;
-
-  const objectsOptions = 'select:eq(2) option';
-
-  await wait();
-  context.$(schoolSelect).val(null).change();
-  await wait();
-  assert.equal(context.$(targetSubject).val(), subjectVal, `${subjectVal} is in the list where we expect it.`);
-  context.$(select).val(subjectVal).change();
-  await wait();
-
-  assert.equal(context.$(`${objectsOptions}:eq(0)`).val(), '', 'first option is blank');
-  expectedObjects.forEach((val, i) => {
-    assert.equal(context.$(`${objectsOptions}:eq(${i+1})`).val(), val, `${val} is object option`);
+  test('choosing programs selects correct objects', function(assert) {
+    return checkObjects(this, assert, 2, 'program', ['course', 'session']);
   });
-};
 
-test('choosing course selects correct objects', function(assert) {
-  return checkObjects(this, assert, 0, 'course', [
-    'session',
-    'program',
-    'instructor',
-    'instructor group',
-    'learning material',
-    'competency',
-    'mesh term',
-  ]);
-});
-
-test('choosing session selects correct objects', function(assert) {
-  return checkObjects(this, assert, 1, 'session', [
-    'course',
-    'program',
-    'instructor',
-    'instructor group',
-    'learning material',
-    'competency',
-    'mesh term',
-    'session type',
-  ]);
-});
-
-test('choosing programs selects correct objects', function(assert) {
-  return checkObjects(this, assert, 2, 'program', ['course', 'session']);
-});
-
-test('choosing program years selects correct objects', function(assert) {
-  return checkObjects(this, assert, 3, 'program year', ['course', 'session']);
-});
-
-test('choosing instructor selects correct objects', function(assert) {
-  return checkObjects(this, assert, 4, 'instructor', [
-    'course',
-    'session',
-    'instructor group',
-    'learning material',
-    'session type',
-  ]);
-});
-
-test('choosing instructor group selects correct objects', function(assert) {
-  return checkObjects(this, assert, 5, 'instructor group', [
-    'course',
-    'session',
-    'instructor',
-    'learning material',
-    'session type',
-  ]);
-});
-
-test('choosing learning material selects correct objects', function(assert) {
-  return checkObjects(this, assert, 6, 'learning material', [
-    'course',
-    'session',
-    'instructor',
-    'instructor group',
-    'mesh term',
-    'session type',
-  ]);
-});
-
-test('choosing competency selects correct objects', function(assert) {
-  return checkObjects(this, assert, 7, 'competency', [
-    'course',
-    'session',
-    'session type',
-  ]);
-});
-
-test('choosing mesh term selects correct objects', function(assert) {
-  return checkObjects(this, assert, 8, 'mesh term', [
-    'course',
-    'session',
-    'learning material',
-    'session type',
-  ]);
-});
-
-test('choosing term selects correct objects', function(assert) {
-  return checkObjects(this, assert, 9, 'term', [
-    'course',
-    'session',
-    'program year',
-    'program',
-    'instructor',
-    'learning material',
-    'competency',
-    'mesh term',
-  ]);
-});
-
-test('choosing session type selects correct objects', function(assert) {
-  return checkObjects(this, assert, 10, 'session type', [
-    'course',
-    'program',
-    'instructor',
-    'instructor group',
-    'learning material',
-    'competency',
-    'mesh term',
-    'term'
-  ]);
-});
-
-
-test('can search for user #2506', async function(assert) {
-  assert.expect(8);
-
-  const mockSchools = [
-    {id: 1, title: 'first'},
-  ];
-  const mockUser = EmberObject.create({
-    schools: resolve(mockSchools),
-    school: resolve(EmberObject.create(mockSchools[0]))
+  test('choosing program years selects correct objects', function(assert) {
+    return checkObjects(this, assert, 3, 'program year', ['course', 'session']);
   });
-  const currentUserMock = Service.extend({
-    model: resolve(mockUser)
+
+  test('choosing instructor selects correct objects', function(assert) {
+    return checkObjects(this, assert, 4, 'instructor', [
+      'course',
+      'session',
+      'instructor group',
+      'learning material',
+      'session type',
+    ]);
   });
-  this.register('service:current-user', currentUserMock);
 
-
-  const user = EmberObject.create({
-    id: 1,
-    fullName: 'Test Person',
-    email: 'test@sample.com',
-    enabled: true
+  test('choosing instructor group selects correct objects', function(assert) {
+    return checkObjects(this, assert, 5, 'instructor group', [
+      'course',
+      'session',
+      'instructor',
+      'learning material',
+      'session type',
+    ]);
   });
-  let storeMock = Service.extend({
-    query(what, {limit, q}){
-      assert.equal('user', what);
-      assert.equal(limit, 100);
-      assert.equal(q, 'abcd');
-      return resolve([user]);
-    },
-    peekRecord(what, userId){
-      assert.equal('user', what);
-      assert.equal(user.get('id'), userId);
 
-      return user;
-    }
+  test('choosing learning material selects correct objects', function(assert) {
+    return checkObjects(this, assert, 6, 'learning material', [
+      'course',
+      'session',
+      'instructor',
+      'instructor group',
+      'mesh term',
+      'session type',
+    ]);
   });
-  this.register('service:store', storeMock);
+
+  test('choosing competency selects correct objects', function(assert) {
+    return checkObjects(this, assert, 7, 'competency', [
+      'course',
+      'session',
+      'session type',
+    ]);
+  });
+
+  test('choosing mesh term selects correct objects', function(assert) {
+    return checkObjects(this, assert, 8, 'mesh term', [
+      'course',
+      'session',
+      'learning material',
+      'session type',
+    ]);
+  });
+
+  test('choosing term selects correct objects', function(assert) {
+    return checkObjects(this, assert, 9, 'term', [
+      'course',
+      'session',
+      'program year',
+      'program',
+      'instructor',
+      'learning material',
+      'competency',
+      'mesh term',
+    ]);
+  });
+
+  test('choosing session type selects correct objects', function(assert) {
+    return checkObjects(this, assert, 10, 'session type', [
+      'course',
+      'program',
+      'instructor',
+      'instructor group',
+      'learning material',
+      'competency',
+      'mesh term',
+      'term'
+    ]);
+  });
 
 
+  test('can search for user #2506', async function(assert) {
+    assert.expect(3);
 
-  const schoolSelect = 'select:eq(0)';
-  const subjects = `select:eq(1) option`;
-  const objectSelect = 'select:eq(2)';
-  const targetSubject = `${subjects}:eq(0)`;
-  const targetObject = `instructor`;
-  const userSearch = '.user-search';
-  const input = `${userSearch} input`;
-  const results = `${userSearch} li`;
-  const firstResult = `${results}:eq(1)`;
-  const selectedUser = `.removable-list`;
+    const school = this.server.create('school', { title: 'first' });
+    const mockUser = EmberObject.create({
+      school: resolve(school)
+    });
+    const currentUserMock = Service.extend({
+      model: resolve(mockUser)
+    });
+    this.owner.register('service:current-user', currentUserMock);
+    this.server.create('user', {
+      firstName: 'Test',
+      lastName: 'Person',
+      middleName: '',
+      email: 'test@example.com',
+    });
 
-  this.on('close', parseInt);
-  this.render(hbs`{{new-myreport close=(action 'close')}}`);
-  await wait();
-  this.$(schoolSelect).val(null).change();
-  await wait();
-  assert.equal(this.$(targetSubject).val(), 'course');
-  this.$(objectSelect).val(targetObject).change();
-  await wait();
+    const schoolSelect = 'select:eq(0)';
+    const subjects = `select:eq(1) option`;
+    const objectSelect = 'select:eq(2)';
+    const targetSubject = `${subjects}:eq(0)`;
+    const targetObject = `instructor`;
+    const userSearch = '.user-search';
+    const input = `${userSearch} input`;
+    const results = `${userSearch} li`;
+    const firstResult = `${results}:eq(1)`;
+    const selectedUser = `.removable-list`;
 
-  assert.equal(this.$(userSearch).length, 1);
-  this.$(input).val('abcd').trigger('input');
-  await wait();
+    this.set('close', ()=>{});
+    await render(hbs`{{new-myreport close=(action close)}}`);
+    await settled();
+    this.$(schoolSelect).val(null).change();
+    await settled();
+    assert.equal(this.$(targetSubject).val(), 'course');
+    this.$(objectSelect).val(targetObject).change();
+    await settled();
 
-  await this.$(firstResult).click();
-  await wait();
-  assert.equal(this.$(selectedUser).text().trim(), 'Test Person');
+    assert.equal(this.$(userSearch).length, 1);
+    this.$(input).val('test').trigger('input');
+    await settled();
 
-  await wait();
+    await this.$(firstResult).click();
+    await settled();
+    assert.equal(this.$(selectedUser).text().trim(), 'Test Person');
+
+    await settled();
+  });
 });


### PR DESCRIPTION
Found a few more places where we were using school references that required a permissions lookup that no longer exists.
Wip:
- [x] Validate permission to use cohort
- [x] No need to traverse schools to cohorts if we're going to display them all.