### PR TITLE
Skip empty lines in group upload

### DIFF
--- a/app/components/learnergroup-upload-data.js
+++ b/app/components/learnergroup-upload-data.js
@@ -166,13 +166,17 @@ export default Component.extend({
             subGroupName: isPresent(arr[3])?arr[3]:null,
           });
         });
-        let notHeaderRow = proposedUsers.filter(obj => String(obj.firstName).toLowerCase() !== 'first' || String(obj.lastName).toLowerCase() !== 'last');
+        const notHeaderRow = proposedUsers.filter(obj => String(obj.firstName).toLowerCase() !== 'first' || String(obj.lastName).toLowerCase() !== 'last');
+        const skipEmpty = notHeaderRow.filter(obj => {
+          return !(isEmpty(obj.firstName) && isEmpty(obj.lastName) && isEmpty(obj.campusId) && isEmpty(obj.subGroupName));
+        });
 
-        resolve(notHeaderRow);
+        resolve(skipEmpty);
       };
 
       PapaParse.parse(file, {
-        complete
+        complete,
+        skipEmptyLines: true,
       });
     });
   },

--- a/tests/acceptance/learnergroup-bulk-assign-test.js
+++ b/tests/acceptance/learnergroup-bulk-assign-test.js
@@ -383,4 +383,28 @@ module('Acceptance | learner group bulk assign', function(hooks) {
     await page.bulkAssign.confirmUploadedUsers();
     assert.equal(page.bulkAssign.groupsToMatch().count, 2);
   });
+
+  test('ignore blank lines #3684', async function (assert) {
+    await page.visit({ learnerGroupId: 1 });
+    await page.activateBulkAssign();
+    this.server.create('user', {
+      firstName: 'jasper',
+      lastName: 'johnson',
+      campusId: '1234567890',
+      cohortIds: [1],
+    });
+    let users = [
+      ['jasper', 'johnson', '1234567890', '123Test'],
+      [' ', '   ', '', '  '],
+      [' ', '  ', '', ' '],
+      [' ', '   ', '', '  '],
+      ['', '   ', '', '  '],
+    ];
+    await triggerUpload(users, '[data-test-user-upload]');
+
+    assert.equal(page.bulkAssign.validUploadedUsers().count, 1);
+    assert.ok(page.bulkAssign.validUploadedUsers(0).isValid);
+    assert.equal(page.bulkAssign.invalidUploadedUsers().count, 0);
+    assert.ok(page.bulkAssign.showConfirmUploadButton);
+  });
 });


### PR DESCRIPTION
Sometimes CSV files will have empty sets at the bottom, we can skip
these if they are entirely empty.

Fixes #3684