### PR TITLE
Remove annoying error in tests

### DIFF
--- a/lib/ilios-error/index.js
+++ b/lib/ilios-error/index.js
@@ -51,6 +51,15 @@ module.exports = {
         </div>
       `;
     }
+
+    if (type === 'test-body-footer') {
+      return `<script type='application/javascript'>
+        var errorContainer = document.getElementById('ilios-loading-error');
+        if (errorContainer) {
+          errorContainer.parentNode.removeChild(errorContainer);
+        }
+      </script>`;
+    }
   },
 
   getBrowserLogo(id) {


### PR DESCRIPTION
Integration tests don't use all of our initializers and styles so the
browser error message which is only supposed to show up if there is a
critical error shows up at the top of the tests.  We can just remove
that from all test pages with a little bit of JS.