### PR TITLE
Import Inflector instead of using the Ember.Inflector

### DIFF
--- a/app/initializers/inflector.js
+++ b/app/initializers/inflector.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
+import Inflector from 'ember-inflector';
 
 export function initialize() {
-  var inflector = Ember.Inflector.inflector;
-
-  inflector.irregular('vocabulary', 'vocabularies');
-  inflector.uncountable('aamc-pcrs');
+  Inflector.inflector.irregular('vocabulary', 'vocabularies');
+  Inflector.inflector.uncountable('aamc-pcrs');
 }
 
 export default {

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -7,6 +7,5 @@ window.deprecationWorkflow.config = {
     { handler: "silence", matchId: "ember-metal.run.sync"},
     { handler: "silence", matchId: "ember-simple-auth.session.authorize"},
     { handler: "silence", matchId: "ember-routing.route-router"},
-    { handler: "silence", matchId: "ember-inflector.globals"}, //waiting on https://github.com/emberjs/ember-inflector/issues/146
   ]
 };


### PR DESCRIPTION
The old usage is deprecated.

Refs #3741 