### PR TITLE
Start fetching mirage from upstream again

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-image-transformer": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-js-cookie": "0.1.1",
-    "ember-cli-mirage": "jrjohnson/ember-cli-mirage#multiple-matching-inverse",
+    "ember-cli-mirage": "0.4.6",
     "ember-cli-page-object": "1.15.0-beta.2",
     "ember-cli-password-strength": "2.0.0",
     "ember-cli-qunit": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3716,9 +3716,9 @@ ember-cli-lodash-subset@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
 
-ember-cli-mirage@jrjohnson/ember-cli-mirage#multiple-matching-inverse:
-  version "0.4.3"
-  resolved "https://codeload.github.com/jrjohnson/ember-cli-mirage/tar.gz/0a447f93098012fca7f5ba432945e9cf5dd3bbed"
+ember-cli-mirage@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-0.4.6.tgz#058084609536c339ffed1057ac9db0a0a36ab986"
   dependencies:
     broccoli-funnel "^1.0.2"
     broccoli-merge-trees "^1.1.0"


### PR DESCRIPTION
New versions have been released which contain the fixes we were pulling
in from my fork. We can go back to use the official package again.