### PR TITLE
Update ilios common

### DIFF
--- a/app/components/detail-cohort-manager.js
+++ b/app/components/detail-cohort-manager.js
@@ -28,9 +28,7 @@ export default Component.extend({
       if (cohortSchool === courseSchool) {
         return true;
       }
-      // @todo HACK here. Until we update common to a version with canUpdateAllCoursesInSchool
-      // we have to reach into a permission checker internal method instead.
-      if (await permissionChecker.canDoInSchool(cohortSchool, 'CAN_UPDATE_ALL_COURSES')) {
+      if (await permissionChecker.canUpdateAllCoursesInSchool(cohortSchool)) {
         return true;
       }
       const programYear = await cohort.get('programYear');

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "ember-uploader": "1.2.3",
     "ember-web-app": "^2.2.0",
     "eslint-plugin-ember": "^5.0.1",
-    "ilios-common": "13.0.3",
+    "ilios-common": "13.1.1",
     "loader.js": "^4.2.3",
     "normalize.css": "^8.0.0",
     "pre-commit": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6087,9 +6087,9 @@ ignore@^3.3.3, ignore@^3.3.5, ignore@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
-ilios-common@13.0.3:
-  version "13.0.3"
-  resolved "https://registry.yarnpkg.com/ilios-common/-/ilios-common-13.0.3.tgz#8eb0d79db75b1e68a09e77d523abeece3ae2dbe2"
+ilios-common@13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/ilios-common/-/ilios-common-13.1.1.tgz#f4c14ff1d28ae67a07fa4c236cd3bcaa0c4ba56e"
   dependencies:
     elemental-calendar "^0.1.0"
     ember-cli-babel "^6.6.0"


### PR DESCRIPTION
Updates our version of common and removes a call to an 'internal' permission checker API.