### PR TITLE
Prevent terms with associations from being deleted

### DIFF
--- a/app/templates/components/school-vocabulary-term-manager.hbs
+++ b/app/templates/components/school-vocabulary-term-manager.hbs
@@ -31,7 +31,7 @@
       {{else}}
         {{title}}
       {{/if}}
-      {{#if (and canDelete (or (not term.hasChildren) (not term.hasAssociations)))}}
+      {{#if (and canDelete (not term.hasChildren) (not term.hasAssociations))}}
         {{fa-icon 'trash' class='clickable remove' click=(action 'deleteTerm')}}
       {{/if}}
     </div>


### PR DESCRIPTION
Logic issue here was *only* allowing terms with associations to be
deleted.

Fixes #3773