### PR TITLE
Improve controls when a session type can not be edited

### DIFF
--- a/app/components/school-session-type-form.js
+++ b/app/components/school-session-type-form.js
@@ -55,6 +55,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   canEditAssessment: false,
   canEditAssessmentOption: false,
   canEditActive: false,
+  canUpdate: false,
   saveSessionType: task(function * () {
     this.send('addErrorDisplaysFor', ['title', 'calendarColor', 'selectedAamcMethodId']);
     let {validations} = yield this.validate();

--- a/app/templates/components/school-session-type-form.hbs
+++ b/app/templates/components/school-session-type-form.hbs
@@ -107,13 +107,17 @@
   </div>
 
   <div class='buttons'>
-    <button class='done text' {{action (perform saveSessionType)}} disabled={{saveSessionType.isRunning}}>
-      {{#if saveSessionType.isRunning}}
-        {{loading-spinner}}
-      {{else}}
-        {{t 'general.done'}}
-      {{/if}}
-    </button>
-    <button class='cancel text' {{action close}}>{{t 'general.cancel'}}</button>
+    {{#if canUpdate}}
+      <button class='done text' {{action (perform saveSessionType)}} disabled={{saveSessionType.isRunning}}>
+        {{#if saveSessionType.isRunning}}
+          {{loading-spinner}}
+        {{else}}
+          {{t 'general.done'}}
+        {{/if}}
+      </button>
+      <button class='cancel text' {{action close}}>{{t 'general.cancel'}}</button>
+    {{else}}
+      <button class='text' {{action close}}>{{t 'general.close'}}</button>
+    {{/if}}
   </div>
 </div>

--- a/app/templates/components/school-session-type-manager.hbs
+++ b/app/templates/components/school-session-type-manager.hbs
@@ -13,6 +13,7 @@
     canEditAssessment=(and canUpdate (eq sessionType.sessionCount 0))
     canEditAssessmentOption=(and canUpdate (eq sessionType.sessionCount 0))
     canEditActive=canUpdate
+    canUpdate=canUpdate
     save=(perform save)
     close=close
   }}

--- a/app/templates/components/school-session-types-expanded.hbs
+++ b/app/templates/components/school-session-types-expanded.hbs
@@ -21,6 +21,7 @@
       canEditAssessment=true
       canEditAssessmentOption=true
       canEditActive=true
+      canUpdate=true
       save=(perform save)
       close=(action setSchoolNewSessionType false)
     }}

--- a/tests/integration/components/school-session-type-form-test.js
+++ b/tests/integration/components/school-session-type-form-test.js
@@ -195,6 +195,31 @@ test('assessment option hidden when assessment is false', async function(assert)
   assert.equal(this.$(assessmentOption).length, 0);
 });
 
+test('cancel fires action', async function(assert) {
+  assert.expect(1);
+  this.set('assessmentOptions', []);
+  this.set('nothing', parseInt);
+  this.set('close', ()=>{
+    assert.ok(true, 'action was fired');
+  });
+  this.render(hbs`{{school-session-type-form
+    title='one'
+    calendarColor='#ffffff'
+    assessment=false
+    assessmentOption=null
+    assessmentOptions=assessmentOptions
+    canUpdate=true
+    save=(action nothing)
+    close=(action close)
+  }}`);
+
+  const button = '.cancel';
+
+  await wait();
+
+  this.$(button).click();
+});
+
 test('close fires action', async function(assert) {
   assert.expect(1);
   this.set('assessmentOptions', []);
@@ -208,11 +233,12 @@ test('close fires action', async function(assert) {
     assessment=false
     assessmentOption=null
     assessmentOptions=assessmentOptions
+    canUpdate=false
     save=(action nothing)
     close=(action close)
   }}`);
 
-  const button = '.cancel';
+  const button = '.text';
 
   await wait();
 
@@ -263,6 +289,7 @@ test('save fires save', async function(assert) {
     canEditAssessmentOption=true
     canEditActive=true
     isActive=true
+    canUpdate=true
     save=(action save)
     close=(action nothing)
   }}`);


### PR DESCRIPTION
In this case instead of Save and Cancel we just have a Close button.

Fixes #3781