### PR TITLE
removes checkbox restrictions on ILMs, display correct totals in "count as one offering" mode.

### DIFF
--- a/app/components/curriculum-inventory-sequence-block-session-manager.js
+++ b/app/components/curriculum-inventory-sequence-block-session-manager.js
@@ -37,12 +37,8 @@ export default Component.extend({
   }),
 
   allSelected: computed('linkedSessionsBuffer.[]', 'linkableSessionsBuffer.[]', function(){
-    const linkedSessions = this.get('linkedSessionsBuffer').filter(session => {
-      return ! session.get('isIndependentLearning');
-    });
-    const linkableSessions = this.get('linkableSessionsBuffer').filter(session => {
-      return ! session.get('isIndependentLearning');
-    });
+    const linkedSessions = this.get('linkedSessionsBuffer');
+    const linkableSessions = this.get('linkableSessionsBuffer');
     if (isEmpty(linkedSessions) || isEmpty(linkableSessions) || linkedSessions.length < linkableSessions.length) {
       return false;
     }
@@ -61,12 +57,9 @@ export default Component.extend({
   }),
 
   noneSelected: computed('linkedSessionsBuffer.[]', 'linkableSessionsBuffer.[]', function(){
-    const linkedSessions = this.get('linkedSessionsBuffer').filter(session => {
-      return ! session.get('isIndependentLearning');
-    });
-    const linkableSessions = this.get('linkableSessionsBuffer').filter(session => {
-      return ! session.get('isIndependentLearning');
-    });
+    const linkedSessions = this.get('linkedSessionsBuffer');
+    const linkableSessions = this.get('linkableSessionsBuffer');
+
     if (isEmpty(linkedSessions) || isEmpty(linkableSessions)) {
       return true;
     }
@@ -103,15 +96,10 @@ export default Component.extend({
     toggleSelectAll() {
       const allSelected = this.get('allSelected');
 
-      if (allSelected) { // un-select all sessions, ignoring linked ILMs (leave them as-is)
-        this.set('linkedSessionsBuffer', this.get('linkedSessionsBuffer').filter(session => {
-          return session.get('isIndependentLearning');
-        }));
-      } else { //select all sessions, ignoring un-linked ILMs (leave them as-is)
-        const linkedSessions = this.get('linkedSessionsBuffer');
-        this.set('linkedSessionsBuffer', this.get('linkableSessionsBuffer').filter((session) => {
-          return ! session.get('isIndependentLearning') || linkedSessions.includes(session);
-        }));
+      if (allSelected) { // un-select all sessions
+        this.set('linkedSessionsBuffer', []);
+      } else { //select all sessions
+        this.set('linkedSessionsBuffer', this.get('linkableSessionsBuffer'));
       }
     },
     sortBy(what){

--- a/app/templates/components/curriculum-inventory-sequence-block-session-manager.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-session-manager.hbs
@@ -53,7 +53,6 @@
                 type='checkbox'
                 checked=(is-in linkedSessionsBuffer session)
                 change=(action 'changeSession' session)
-                disabled=session.isIndependentLearning
               }}
             </td>
             <td class='text-left' colspan=3>

--- a/app/templates/components/curriculum-inventory-sequence-block-session-manager.hbs
+++ b/app/templates/components/curriculum-inventory-sequence-block-session-manager.hbs
@@ -64,16 +64,16 @@
             <td class='text-left' colspan=3>{{get (await session.sessionType) "title"}}</td>
             <td class='text-center' colspan=1>
               {{#if (is-in linkedSessionsBuffer session)}}
-                {{#unless (is-fulfilled session.maxSingleOfferingDuration)}}
+                {{#unless (is-fulfilled session.maxDuration)}}
                   {{loading-spinner}}
                 {{else}}
-                  {{await session.maxSingleOfferingDuration}}
+                  {{await session.maxDuration}}
                 {{/unless}}
               {{else}}
-                {{#unless (is-fulfilled session.totalSumOfferingsDuration)}}
+                {{#unless (is-fulfilled session.totalSumDuration)}}
                   {{loading-spinner}}
                 {{else}}
-                  {{await session.totalSumOfferingsDuration}}
+                  {{await session.totalSumDuration}}
                 {{/unless}}
               {{/if}}
             </td>

--- a/tests/integration/components/curriculum-inventory-sequence-block-session-manager-test.js
+++ b/tests/integration/components/curriculum-inventory-sequence-block-session-manager-test.js
@@ -16,7 +16,7 @@ moduleForComponent('curriculum-inventory-sequence-block-session-manager', 'Integ
 });
 
 test('it renders', function(assert) {
-  assert.expect(29);
+  assert.expect(28);
 
   let offering1 = EmberObject.create({id: 1});
   let offering2 = EmberObject.create({id: 2});
@@ -46,7 +46,7 @@ test('it renders', function(assert) {
     offerings: resolve(offerings1),
     sessionType: resolve(sessionType1),
     isIndependentLearning: false,
-    maxSingleOfferingDuration: resolve(totalTime1)
+    maxDuration: resolve(totalTime1)
   });
 
   let session2 = EmberObject.create({
@@ -55,7 +55,7 @@ test('it renders', function(assert) {
     offerings: resolve(offerings2),
     sessionType: resolve(sessionType2),
     isIndependentLearning: false,
-    totalSumOfferingsDuration: resolve(totalTime2)
+    totalSumDuration: resolve(totalTime2)
   });
 
   let session3 = EmberObject.create({
@@ -64,7 +64,7 @@ test('it renders', function(assert) {
     offerings: resolve(offerings3),
     sessionType: resolve(sessionType3),
     isIndependentLearning: false,
-    maxSingleOfferingDuration: resolve(totalTime3)
+    maxDuration: resolve(totalTime3)
   });
 
   let session4 = EmberObject.create({
@@ -73,7 +73,7 @@ test('it renders', function(assert) {
     offerings: resolve(offerings4),
     sessionType: resolve(sessionType4),
     isIndependentLearning: true,
-    totalSumOfferingsDuration: resolve(totalTime4)
+    totalSumDuration: resolve(totalTime4)
   });
 
   let linkedSessions = [session1, session3];
@@ -117,7 +117,6 @@ test('it renders', function(assert) {
   assert.equal(this.$('tbody tr:eq(2) td:eq(3)').text().trim(), totalTime3, 'Total time is shown.');
   assert.equal(this.$('tbody tr:eq(2) td:eq(4)').text().trim(), offerings3.length, 'Number of offerings is shown.');
 
-  assert.ok(this.$('tbody tr:eq(3) td:eq(0) input').is(':disabled'), 'Checkbox is disabled.');
   assert.notOk(this.$('tbody tr:eq(3) td:eq(0) input').is(':checked'), 'Count offerings as one is un-checked.');
   assert.ok(this.$('tbody tr:eq(3) td:eq(1)').text().trim().startsWith('(ILM)'), 'ILM is labeled as such.');
   assert.ok(this.$('tbody tr:eq(3) td:eq(1)').text().trim().endsWith(session4.get('title')), 'Title is visible.');
@@ -150,7 +149,7 @@ test('sort by title', function(assert) {
     title: 'Zeppelin',
     offerings: resolve([]),
     sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
-    maxSingleOfferingDuration: resolve(0)
+    maxDuration: resolve(0)
   });
 
   let block = EmberObject.create({
@@ -175,7 +174,7 @@ test('sort by session type', function(assert) {
     title: 'Zeppelin',
     offerings: resolve([]),
     sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
-    maxSingleOfferingDuration: resolve(0)
+    maxDuration: resolve(0)
   });
 
   let block = EmberObject.create({
@@ -200,7 +199,7 @@ test('sort by offerings total', function(assert) {
     title: 'Zeppelin',
     offerings: resolve([]),
     sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
-    maxSingleOfferingDuration: resolve(0)
+    maxDuration: resolve(0)
   });
 
   let block = EmberObject.create({
@@ -220,15 +219,15 @@ test('sort by offerings total', function(assert) {
 
 test('change count as one offering', function(assert) {
   assert.expect(3);
-  let maxSingleOfferingDuration = (20).toFixed(2);
-  let totalSumOfferingsDuration = (15).toFixed(2);
+  let maxDuration = (20).toFixed(2);
+  let totalSumDuration = (15).toFixed(2);
   let session = EmberObject.create({
     id: 1,
     title: 'Zeppelin',
     offerings: resolve([]),
     sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
-    maxSingleOfferingDuration: resolve(maxSingleOfferingDuration),
-    totalSumOfferingsDuration: resolve(totalSumOfferingsDuration)
+    maxDuration: resolve(maxDuration),
+    totalSumDuration: resolve(totalSumDuration)
   });
 
   let block = EmberObject.create({
@@ -241,24 +240,24 @@ test('change count as one offering', function(assert) {
   this.set('sortBy', 'id');
   this.set('setSortBy', function(){});
   this.render(hbs`{{curriculum-inventory-sequence-block-session-manager sessions=sessions sequenceBlock=sequenceBlock sortBy=sortBy setSortBy=setSortBy}}`);
-  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxSingleOfferingDuration);
+  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxDuration);
   this.$('tbody tr:eq(0) td:eq(0) input').prop('checked', false).trigger('click');
-  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), totalSumOfferingsDuration);
+  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), totalSumDuration);
   this.$('tbody tr:eq(0) td:eq(0) input').prop('checked', true).trigger('click');
-  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxSingleOfferingDuration);
+  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxDuration);
 });
 
 test('change count as one offering for all sessions', function(assert) {
   assert.expect(6);
-  let maxSingleOfferingDuration = (20).toFixed(2);
-  let totalSumOfferingsDuration = (15).toFixed(2);
+  let maxDuration = (20).toFixed(2);
+  let totalSumDuration = (15).toFixed(2);
   let session1 = EmberObject.create({
     id: 1,
     title: 'Alpha',
     offerings: resolve([]),
     sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
-    maxSingleOfferingDuration: resolve(maxSingleOfferingDuration),
-    totalSumOfferingsDuration: resolve(totalSumOfferingsDuration)
+    maxDuration: resolve(maxDuration),
+    totalSumDuration: resolve(totalSumDuration)
   });
 
   let session2 = EmberObject.create({
@@ -266,8 +265,8 @@ test('change count as one offering for all sessions', function(assert) {
     title: 'Omega',
     offerings: resolve([]),
     sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
-    maxSingleOfferingDuration: resolve(maxSingleOfferingDuration),
-    totalSumOfferingsDuration: resolve(totalSumOfferingsDuration)
+    maxDuration: resolve(maxDuration),
+    totalSumDuration: resolve(totalSumDuration)
   });
 
   let block = EmberObject.create({
@@ -280,16 +279,16 @@ test('change count as one offering for all sessions', function(assert) {
 
   this.render(hbs`{{curriculum-inventory-sequence-block-session-manager sessions=sessions sequenceBlock=sequenceBlock }}`);
 
-  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxSingleOfferingDuration);
-  assert.equal(this.$('tbody tr:eq(1) td:eq(3)').text().trim(), totalSumOfferingsDuration);
+  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxDuration);
+  assert.equal(this.$('tbody tr:eq(1) td:eq(3)').text().trim(), totalSumDuration);
 
   this.$('thead tr:eq(0) th:eq(0) input').prop('checked', true).trigger('click');
-  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxSingleOfferingDuration);
-  assert.equal(this.$('tbody tr:eq(1) td:eq(3)').text().trim(), maxSingleOfferingDuration);
+  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), maxDuration);
+  assert.equal(this.$('tbody tr:eq(1) td:eq(3)').text().trim(), maxDuration);
 
   this.$('thead tr:eq(0) th:eq(0) input').prop('checked', false).trigger('click');
-  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), totalSumOfferingsDuration);
-  assert.equal(this.$('tbody tr:eq(1) td:eq(3)').text().trim(), totalSumOfferingsDuration);
+  assert.equal(this.$('tbody tr:eq(0) td:eq(3)').text().trim(), totalSumDuration);
+  assert.equal(this.$('tbody tr:eq(1) td:eq(3)').text().trim(), totalSumDuration);
 });
 
 test('save', function(assert) {
@@ -300,8 +299,8 @@ test('save', function(assert) {
     title: 'Alpha',
     offerings: resolve([]),
     sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
-    maxSingleOfferingDuration: resolve(0),
-    totalSumOfferingsDuration: resolve(0)
+    maxDuration: resolve(0),
+    totalSumDuration: resolve(0)
   });
 
   let session2 = EmberObject.create({
@@ -309,8 +308,8 @@ test('save', function(assert) {
     title: 'Omega',
     offerings: resolve([]),
     sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
-    maxSingleOfferingDuration: resolve(0),
-    totalSumOfferingsDuration: resolve(0)
+    maxDuration: resolve(0),
+    totalSumDuration: resolve(0)
   });
 
   let block = EmberObject.create({
@@ -339,8 +338,8 @@ test('cancel', function(assert) {
     title: 'Alpha',
     offerings: resolve([]),
     sessionType: resolve(EmberObject.create({ title: 'Lecture'})),
-    maxSingleOfferingDuration: resolve(0),
-    totalSumOfferingsDuration: resolve(0)
+    maxDuration: resolve(0),
+    totalSumDuration: resolve(0)
   });
 
   let block = EmberObject.create({
@@ -370,7 +369,7 @@ test('check all/uncheck all', function(assert) {
     offerings: resolve([]),
     sessionType: resolve(sessionType),
     isIndependentLearning: false,
-    totalSumOfferingsDuration: resolve(0)
+    totalSumDuration: resolve(0)
   });
 
   let session2 = EmberObject.create({
@@ -379,7 +378,7 @@ test('check all/uncheck all', function(assert) {
     offerings: resolve([]),
     sessionType: resolve(sessionType),
     isIndependentLearning: false,
-    totalSumOfferingsDuration: resolve(0)
+    totalSumDuration: resolve(0)
   });
 
   let session3 = EmberObject.create({
@@ -388,7 +387,7 @@ test('check all/uncheck all', function(assert) {
     offerings: resolve([]),
     sessionType: resolve(sessionType),
     isIndependentLearning: false,
-    totalSumOfferingsDuration: resolve(0)
+    totalSumDuration: resolve(0)
   });
 
   let session4 = EmberObject.create({
@@ -397,7 +396,7 @@ test('check all/uncheck all', function(assert) {
     offerings: resolve([]),
     sessionType: resolve(sessionType),
     isIndependentLearning: true,
-    totalSumOfferingsDuration: resolve(0)
+    totalSumDuration: resolve(0)
   });
 
   let session5 = EmberObject.create({
@@ -406,7 +405,7 @@ test('check all/uncheck all', function(assert) {
     offerings: resolve([]),
     sessionType: resolve(sessionType),
     isIndependentLearning: true,
-    totalSumOfferingsDuration: resolve(0)
+    totalSumDuration: resolve(0)
   });
 
   let sessions = [session1, session2, session3, session4, session5];
@@ -432,7 +431,7 @@ test('check all/uncheck all', function(assert) {
   assert.ok(this.$('tbody tr:eq(0) td:eq(0) input').is(':checked'), 'Count offerings as one is checked.');
   assert.ok(this.$('tbody tr:eq(1) td:eq(0) input').is(':checked'), 'Count offerings as one is checked.');
   assert.ok(this.$('tbody tr:eq(2) td:eq(0) input').is(':checked'), 'Count offerings as one is checked.');
-  assert.notOk(this.$('tbody tr:eq(3) td:eq(0) input').is(':checked'), 'ILM checkbox remains un-checked');
+  assert.ok(this.$('tbody tr:eq(3) td:eq(0) input').is(':checked'), 'Count offerings as one is checked.');
   assert.ok(this.$('tbody tr:eq(4) td:eq(0) input').is(':checked'), 'Count offerings as one is checked.');
 
   this.$('thead tr:eq(0) th:eq(0) input').prop('checked', false).trigger('click');
@@ -440,6 +439,6 @@ test('check all/uncheck all', function(assert) {
   assert.notOk(this.$('tbody tr:eq(1) td:eq(0) input').is(':checked'), 'Count offerings as one is un-checked.');
   assert.notOk(this.$('tbody tr:eq(2) td:eq(0) input').is(':checked'), 'Count offerings as one is un-checked.');
   assert.notOk(this.$('tbody tr:eq(3) td:eq(0) input').is(':checked'), 'Count offerings as one is un-checked.');
-  assert.ok(this.$('tbody tr:eq(4) td:eq(0) input').is(':checked'), 'Count offerings remains checked.');
+  assert.notOk(this.$('tbody tr:eq(4) td:eq(0) input').is(':checked'), 'Count offerings as one is un-checked.');
 
 });


### PR DESCRIPTION
fixes #3831 

![selection_016](https://user-images.githubusercontent.com/1410427/40260908-471ac5d2-5ab2-11e8-87c2-81b0a6f9243e.png)
