### PR TITLE
Update worker immediately when there is an API update

### DIFF
--- a/app/components/api-version-check.js
+++ b/app/components/api-version-check.js
@@ -2,7 +2,6 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import ENV from 'ilios/config/environment';
-import serviceWorkerHasUpdate from 'ilios/utils/service-worker-has-update';
 
 const { apiVersion } = ENV.APP;
 
@@ -18,9 +17,8 @@ export default Component.extend({
     const serverApiVersion = await iliosConfig.get('apiVersion');
     const versionMismatch = serverApiVersion !== apiVersion;
     if (versionMismatch && 'serviceWorker' in navigator) {
-      const hasUpdate = await serviceWorkerHasUpdate();
-      if (hasUpdate) {
-        const reg = await navigator.serviceWorker.getRegistration();
+      const reg = await navigator.serviceWorker.getRegistration();
+      if (reg && reg.waiting) {
         reg.waiting.postMessage('skipWaiting');
       }
     }


### PR DESCRIPTION
The utility we were loading here doesn't seem to exist, but isn't
necessary we can just ask the worker if it has an update.