### PR TITLE
Display full sized session table

### DIFF
--- a/app/components/session-table.js
+++ b/app/components/session-table.js
@@ -99,13 +99,6 @@ export default Component.extend({
 
     return columns;
   }),
-
-  height: computed('sessions.length', function(){
-    const sessions = this.get('sessions');
-    const count = sessions?sessions.length:0;
-
-    return count < 10?'25vh':'75vh';
-  }),
   filteredSessions: computed('sessions.[]', 'filterBy', function(){
     const sessions = this.get('sessions');
     const filterBy = this.get('filterBy');

--- a/app/templates/components/session-table.hbs
+++ b/app/templates/components/session-table.hbs
@@ -5,7 +5,7 @@
     placeholder={{t 'general.sessionTitleFilterPlaceholder'}}
   >
 </div>
-{{#light-table table height=height responsive=true as |t|}}
+{{#light-table table height='75vh' responsive=true as |t|}}
   {{t.head
     onColumnClick=(action 'columnClicked')
     iconAscending='fa fa-sort-asc'


### PR DESCRIPTION
Even when there are only a few sessions we should display a full sized
session block - otherwise it is confusing where a user should scroll.

Fixes #3861