### PR TITLE
Fix user profile roles checkboxes

### DIFF
--- a/app/components/user-profile-bio.js
+++ b/app/components/user-profile-bio.js
@@ -119,6 +119,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   changeUserPassword: false,
   updatedFieldsFromSync: null,
   showSyncErrorMessage: false,
+  'data-test-user-profile-bio': true,
 
   manage: task(function * (){
     const user = this.get('user');

--- a/app/components/user-profile-roles.js
+++ b/app/components/user-profile-roles.js
@@ -20,6 +20,7 @@ export default Component.extend({
   isFormerStudentFlipped: false,
   isEnabledFlipped: false,
   isUserSyncIgnoredFlipped: false,
+  'data-test-user-profile-roles': true,
 
   save: task(function * (){
     const store = this.get('store');
@@ -83,7 +84,7 @@ export default Component.extend({
     return (originallyYes && !flipped) || (!originallyYes && flipped);
   }),
 
-  isEnabled: computed('user.enabled', 'isEnabledFlipped', async function(){
+  isEnabled: computed('user.enabled', 'isEnabledFlipped', function(){
     const flipped = this.get('isEnabledFlipped');
     const user = this.get('user');
     if (isEmpty(user)) {
@@ -93,8 +94,8 @@ export default Component.extend({
     return (originallyYes && !flipped) || (!originallyYes && flipped);
   }),
 
-  isUserSyncIgnored: computed('user.enabled', 'isEnabledFlipped', async function(){
-    const flipped = this.get('isEnabledFlipped');
+  isUserSyncIgnored: computed('user.userSyncIgnore', 'isUserSyncIgnoredFlipped', function(){
+    const flipped = this.get('isUserSyncIgnoredFlipped');
     const user = this.get('user');
     if (isEmpty(user)) {
       return false;

--- a/app/components/user-profile.js
+++ b/app/components/user-profile.js
@@ -8,4 +8,5 @@ export default Component.extend({
   canUpdate: false,
   canCreate: false,
   classNames: ['user-profile'],
+  'data-test-user-profile': true,
 });

--- a/app/templates/components/user-profile-roles.hbs
+++ b/app/templates/components/user-profile-roles.hbs
@@ -1,9 +1,9 @@
 <div class='actions'>
   {{#if isManaging}}
-    <button class='bigadd' {{action (perform save)}}>{{fa-icon (if save.isRunning 'spinner' 'check') spin=(if save.isRunning true false)}}</button>
+    <button class='bigadd' {{action (perform save)}} data-test-save>{{fa-icon (if save.isRunning 'spinner' 'check') spin=(if save.isRunning true false)}}</button>
     <button disabled={{save.isRunning}} class='bigcancel' {{action 'cancel'}}>{{fa-icon 'undo'}}</button>
   {{else if isManageable}}
-    <button class='manage' {{action setIsManaging true}}>{{fa-icon 'edit'}}</button>
+    <button class='manage' {{action setIsManaging true}} data-test-manage>{{fa-icon 'edit'}}</button>
   {{/if}}
 </div>
 <div class='form'>
@@ -18,7 +18,7 @@
     </span>
   </div>
   <div class='item'>
-    <label onclick={{if isManaging (action (mut isFormerStudentFlipped) (not isFormerStudentFlipped))}}>{{t 'general.formerStudent'}}:</label>
+    <label for='former-student'>{{t 'general.formerStudent'}}:</label>
     {{#unless isManaging}}
       <span class='value {{if (await isFormerStudent) "yes" "no"}}'>
         {{#if (await isFormerStudent)}}
@@ -29,7 +29,8 @@
       </span>
     {{else}}
       <input
-        type="checkbox"
+        id='former-student'
+        type='checkbox'
         checked={{await isFormerStudent}}
         onclick={{action (mut isFormerStudentFlipped) (not isFormerStudentFlipped)}}
       >
@@ -39,7 +40,7 @@
   <hr>
 
   <div class='item'>
-    <label onclick={{if isManaging (action (mut isEnabledFlipped) (not isEnabledFlipped))}}>{{t 'general.accountEnabled'}}:</label>
+    <label for='is-enabled'>{{t 'general.accountEnabled'}}:</label>
     {{#unless isManaging}}
       <span class='value {{if (await isEnabled) "yes" "no"}}'>
         {{#if (await isEnabled)}}
@@ -50,15 +51,16 @@
       </span>
     {{else}}
       <input
-        type="checkbox"
-        checked={{await isEnabled}}
+        id='is-enabled'
+        type='checkbox'
+        checked={{isEnabled}}
         onclick={{action (mut isEnabledFlipped) (not isEnabledFlipped)}}
         disabled={{if (eq user.id currentUser.model.id) true}}
       >
     {{/unless}}
   </div>
   <div class='item'>
-    <label onclick={{if isManaging (action (mut isUserSyncIgnoredFlipped) (not isUserSyncIgnoredFlipped))}}>{{t 'general.excludeFromSync'}}:</label>
+    <label for='exclude-from-sync' >{{t 'general.excludeFromSync'}}:</label>
     {{#unless isManaging}}
       <span class='value {{if (await isUserSyncIgnored) "yes" "no"}}'>
         {{#if (await isUserSyncIgnored)}}
@@ -69,8 +71,9 @@
       </span>
     {{else}}
       <input
-        type="checkbox"
-        checked={{await isUserSyncIgnored}}
+        id='exclude-from-sync'
+        type='checkbox'
+        checked={{isUserSyncIgnored}}
         onclick={{action (mut isUserSyncIgnoredFlipped) (not isUserSyncIgnoredFlipped)}}
       >
     {{/unless}}

--- a/tests/integration/components/user-profile-bio-test.js
+++ b/tests/integration/components/user-profile-bio-test.js
@@ -115,7 +115,7 @@ test('clicking manage sends the action', function(assert) {
   assert.expect(1);
   this.set('user', user);
   this.set('click', (what) =>{
-    assert.ok(what, 'recieved boolean true value');
+    assert.ok(what, 'received boolean true value');
   });
   this.render(hbs`{{user-profile-bio user=user isManageable=true setIsManaging=(action click)}}`);
   return wait().then(()=>{

--- a/tests/pages/user.js
+++ b/tests/pages/user.js
@@ -1,0 +1,43 @@
+import {
+  clickable,
+  create,
+  is,
+  text,
+  visitable,
+} from 'ember-cli-page-object';
+
+export default create({
+  scope: '[data-test-user-profile]',
+  visit: visitable('/users/:userId'),
+  roles: {
+    scope: '[data-test-user-profile-roles]',
+    manage: clickable('[data-test-manage]'),
+    save: clickable('[data-test-save]'),
+    student: {
+      scope: '.item:nth-of-type(1)',
+      label: text('label'),
+      value: text('.value'),
+    },
+    formerStudent: {
+      scope: '.item:nth-of-type(2)',
+      label: text('label'),
+      value: text('.value'),
+      selected: is(':checked', 'input'),
+      click: clickable('input')
+    },
+    enabled: {
+      scope: '.item:nth-of-type(3)',
+      label: text('label'),
+      value: text('.value'),
+      selected: is(':checked', 'input'),
+      click: clickable('input')
+    },
+    excludeFromSync: {
+      scope: '.item:nth-of-type(4)',
+      label: text('label'),
+      value: text('.value'),
+      selected: is(':checked', 'input'),
+      click: clickable('input')
+    },
+  },
+});


### PR DESCRIPTION
The sync ignore box was hooked up wrong, cleaned up the labels as well
by relying on HTML controls to link them instead of actions on the label
element.

Fixes #3887