### PR TITLE
Add automated accessibility checks

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -11,7 +11,7 @@
     {{#if showErrorDisplay}}
       {{error-display errors=errors clearErrors=(action 'clearErrors')}}
     {{else}}
-      {{outlet}}
+      {{focusing-outlet}}
     {{/if}}
   </main>
   <footer class='ilios-footer'>

--- a/app/templates/course.hbs
+++ b/app/templates/course.hbs
@@ -14,4 +14,4 @@
   setCourseCompetencyDetails=(action (mut courseCompetencyDetails))
   setCourseManageLeadership=(action (mut courseManageLeadership))
 }}
-{{outlet}}
+{{focusing-outlet}}

--- a/app/templates/curriculum-inventory-report.hbs
+++ b/app/templates/curriculum-inventory-report.hbs
@@ -10,4 +10,4 @@
   manageLeadership=manageLeadership
   setManageLeadership=(action (mut manageLeadership))
 }}
-{{outlet}}
+{{focusing-outlet}}

--- a/app/templates/program-year.hbs
+++ b/app/templates/program-year.hbs
@@ -1,3 +1,3 @@
 {{programyear-header programYear=model canUpdate=canUpdate}}
 {{programyear-overview programYear=model canUpdate=canUpdate}}
-{{outlet}}
+{{focusing-outlet}}

--- a/app/templates/program.hbs
+++ b/app/templates/program.hbs
@@ -6,4 +6,4 @@
   manageLeadership=manageLeadership
   setManageLeadership=(action (mut manageLeadership))
 }}
-{{outlet}}
+{{focusing-outlet}}

--- a/app/templates/session.hbs
+++ b/app/templates/session.hbs
@@ -1,1 +1,1 @@
-{{outlet}}
+{{focusing-outlet}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -66,6 +66,12 @@ module.exports = function (environment) {
       completeExistingMessages: true,
       showFileInfo: true,
     },
+    'ember-a11y-testing': {
+      componentOptions: {
+        turnAuditOff: process.env.SKIP_A11Y || false,
+        visualNoiseLevel: 1,
+      }
+    },
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
@@ -134,6 +140,7 @@ module.exports = function (environment) {
   if (environment === 'preview') {
     // here you can enable a preview-specific feature
     ENV.IliosFeatures.programYearVisualizations = true;
+    ENV['ember-a11y-testing'].componentOptions.turnAuditOff = true;
   }
 
   //add our API host to the list of acceptable data sources

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "browserslist": "^4.0.0",
     "caniuse-db": "^1.0.30000820",
     "crypto-js": "^3.1.9-1",
+    "ember-a11y": "^0.1.15",
+    "ember-a11y-testing": "^0.5.2",
     "ember-ajax": "^3.0.0",
     "ember-auto-import": "^1.0.0",
     "ember-chrome-devtools": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,6 +797,10 @@ aws4@^1.2.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
+axe-core@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.6.1.tgz#28772c4f76966d373acda35b9a409299dc00d1b5"
+
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -1877,7 +1881,7 @@ broccoli-funnel@1.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.2.6"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.2, broccoli-funnel@^1.0.3, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.2, broccoli-funnel@^1.0.3, broccoli-funnel@^1.0.7, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -1952,7 +1956,7 @@ broccoli-merge-trees@1.1.1:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.2.1:
+broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.1.4, broccoli-merge-trees@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -3874,6 +3878,27 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+ember-a11y-testing@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/ember-a11y-testing/-/ember-a11y-testing-0.5.2.tgz#0ee555824a8e8181c55470e261b88dad4fdac721"
+  dependencies:
+    axe-core "^2.6.1"
+    broccoli-funnel "^2.0.1"
+    ember-cli-babel "^6.8.2"
+    ember-cli-version-checker "^2.1.0"
+    ember-get-config "^0.2.4"
+
+ember-a11y@^0.1.15:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ember-a11y/-/ember-a11y-0.1.15.tgz#10729ec8ebc6183470cf460d9919863f4d499856"
+  dependencies:
+    broccoli-funnel "^1.0.7"
+    broccoli-merge-trees "^1.1.4"
+    broccoli-string-replace "^0.1.1"
+    ember-cli-babel "^6.0.0"
+    ember-cli-version-checker "^1.1.7"
+    ember-getowner-polyfill "^1.0.1"
+
 ember-ajax@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ember-ajax/-/ember-ajax-3.1.0.tgz#3db36e67357ef447639517656aeac4bb13e73a9c"
@@ -4488,7 +4513,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@^1.0.2:
+ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:
@@ -4730,7 +4755,7 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-factory-for-polyfill@^1.3.1:
+ember-factory-for-polyfill@^1.1.0, ember-factory-for-polyfill@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
   dependencies:
@@ -4772,6 +4797,14 @@ ember-get-config@^0.2.2, ember-get-config@^0.2.3, ember-get-config@^0.2.4:
   dependencies:
     broccoli-file-creator "^1.1.1"
     ember-cli-babel "^6.3.0"
+
+ember-getowner-polyfill@^1.0.1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.5.tgz#ceff8a09897d0d7e05c821bb71666a95eb26dc92"
+  dependencies:
+    ember-cli-babel "^5.1.6"
+    ember-cli-version-checker "^1.2.0"
+    ember-factory-for-polyfill "^1.1.0"
 
 "ember-getowner-polyfill@^1.1.0 || ^2.0.0", ember-getowner-polyfill@^2.0.0, ember-getowner-polyfill@^2.0.1, ember-getowner-polyfill@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
This will decorate our application with indications where accessibility
is failing and put pressure on us to make it better. Once we get some of
the basics under control we can add some automated checks to the
rendering tests as well.

Also does some automated work on route changes to focus screen readers
on the correct content.

Not enabled on netlify preview builds.

**is enabled** in development unless `SKIP_A11Y=true ember serve` is specified.

Fixes #1930