### PR TITLE
Add specific titles for second and third snapshots

### DIFF
--- a/tests/acceptance/instructorgroups-test.js
+++ b/tests/acceptance/instructorgroups-test.js
@@ -124,7 +124,7 @@ module('Acceptance: Instructor Groups', function(hooks) {
       percySnapshot(assert);
       await click('.new-instructorgroup .done');
       assert.equal(await getElementText(find('.saved-result')), getText(newTitle + 'Saved Successfully'));
-      percySnapshot(assert);
+      percySnapshot('add new instructorgroup saved');
     });
 
     test('cancel adding new instructorgroup', async function(assert) {

--- a/tests/acceptance/learnergroup-bulk-assign-test.js
+++ b/tests/acceptance/learnergroup-bulk-assign-test.js
@@ -69,7 +69,7 @@ module('Acceptance | learner group bulk assign', function(hooks) {
     await page.visit({ learnerGroupId: 1 });
     percySnapshot(assert);
     await page.activateBulkAssign();
-    percySnapshot(assert);
+    percySnapshot('upload users bulk assign');
     this.server.create('user', {
       firstName: 'jasper',
       lastName: 'johnson',
@@ -88,7 +88,7 @@ module('Acceptance | learner group bulk assign', function(hooks) {
     ];
     await triggerUpload(users, '[data-test-user-upload]');
 
-    percySnapshot(assert);
+    percySnapshot('upload users uploaded');
     assert.equal(page.bulkAssign.validUploadedUsers().count, 2);
     assert.ok(page.bulkAssign.validUploadedUsers(0).isValid);
     assert.equal(page.bulkAssign.validUploadedUsers(0).firstName, 'jasper');

--- a/tests/acceptance/user-test.js
+++ b/tests/acceptance/user-test.js
@@ -84,13 +84,13 @@ module('Acceptance: User', function(hooks) {
     assert.equal(page.roles.excludeFromSync.value, 'Yes');
     assert.equal(page.roles.excludeFromSync.label, 'Exclude From Sync:');
     await page.roles.manage();
-    percySnapshot(assert);
+    percySnapshot('User roles display manage');
     assert.ok(page.roles.formerStudent.selected);
     assert.ok(page.roles.enabled.selected);
     assert.ok(page.roles.excludeFromSync.selected);
 
     await page.visit({ userId: user2.id });
-    percySnapshot(assert);
+    percySnapshot('User roles display user 2');
     assert.equal(page.roles.student.value, 'No');
     assert.equal(page.roles.student.label, 'Student:');
     assert.equal(page.roles.formerStudent.value, 'No');
@@ -100,7 +100,7 @@ module('Acceptance: User', function(hooks) {
     assert.equal(page.roles.excludeFromSync.value, 'No');
     assert.equal(page.roles.excludeFromSync.label, 'Exclude From Sync:');
     await page.roles.manage();
-    percySnapshot(assert);
+    percySnapshot('User roles display user 2 manage');
     assert.notOk(page.roles.formerStudent.selected);
     assert.notOk(page.roles.enabled.selected);
     assert.notOk(page.roles.excludeFromSync.selected);


### PR DESCRIPTION
Sending assert only works for the first snapshot, after that we have to
send a specific title to avoid overwriting the first one.