### PR TITLE
Notify users when a new version is available

### DIFF
--- a/app/components/update-notification.js
+++ b/app/components/update-notification.js
@@ -11,7 +11,13 @@ export default Component.extend({
   async click() {
     if ('serviceWorker' in navigator) {
       const reg = await navigator.serviceWorker.getRegistration();
-      reg.waiting.postMessage('skipWaiting');
+      if (reg && reg.waiting) {
+        reg.waiting.postMessage('skipWaiting');
+      }
+    }
+    const reload = this.get('reload');
+    if (reload) {
+      reload();
     }
   }
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -2,6 +2,9 @@
 {{#service-worker-update-notify}}
   {{update-notification}}
 {{/service-worker-update-notify}}
+{{#new-version-notifier as |version lastVersion reload|}}
+  {{update-notification reload=(action reload)}}
+{{/new-version-notifier}}
 <div class='application-wrapper {{if currentUser.performsNonLearnerFunction "show-navigation"}}'>
   {{ilios-header title=translatedTitle currentlyLoading=currentlyLoading}}
   {{#if session.isAuthenticated}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -91,6 +91,10 @@ module.exports = function(defaults) {
         /\/weeklyevents(\/.*)?$/,
       ]
     },
+    newVersion: {
+      enabled: true,
+      useAppVersion: true
+    },
   });
 
   app.import('node_modules/normalize.css/normalize.css');

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ember-cli-image-transformer": "^2.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mirage": "0.4.7",
+    "ember-cli-new-version": "^1.3.0",
     "ember-cli-page-object": "1.15.0-beta.2",
     "ember-cli-password-strength": "2.0.0",
     "ember-cli-qunit": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4191,7 +4191,7 @@ ember-cli-htmlbars-inline-precompile@^1.0.0:
     heimdalljs-logger "^0.1.9"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.1.1:
+ember-cli-htmlbars@^1.0.1, ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.1.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz#461289724b34af372a6a0c4b6635819156963353"
   dependencies:
@@ -4275,6 +4275,15 @@ ember-cli-moment-shim@^3.1.0:
     lodash.defaults "^4.2.0"
     moment "^2.19.3"
     moment-timezone "^0.5.13"
+
+ember-cli-new-version@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-new-version/-/ember-cli-new-version-1.3.0.tgz#e1453e88be5a0d4756801ce7f417e8bd2faec1b0"
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^6.6.0"
+    ember-cli-htmlbars "^1.0.1"
+    ember-concurrency "^0.8.12"
 
 ember-cli-node-assets@^0.1.4:
   version "0.1.6"
@@ -4590,7 +4599,7 @@ ember-composable-helpers@^2.0.1, ember-composable-helpers@^2.0.2, ember-composab
     broccoli-funnel "^1.0.1"
     ember-cli-babel "^6.6.0"
 
-ember-concurrency@0.8.19:
+ember-concurrency@0.8.19, ember-concurrency@^0.8.12:
   version "0.8.19"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.19.tgz#71b9c175ba077865310029cb4bdb880e17d5155e"
   dependencies:


### PR DESCRIPTION
If a user leaves their session open for a long time they might want to
know that a new version of ilios is available to use. This notifies them
by polling the server to see what our latest build is.

I used the same UI we use when a background service worker update is detected. These are different cases, but users will see them as the same and the UI should be the same.