### PR TITLE
don't show tooltip on top-level groups in offerings list.

### DIFF
--- a/app/templates/components/offering-manager.hbs
+++ b/app/templates/components/offering-manager.hbs
@@ -17,7 +17,7 @@
       {{#each (await offering.learnerGroups) as |learnerGroup|}}
         <li>
           {{learnerGroup.title}}
-          {{#if (is-fulfilled learnerGroup.allParents)}}
+          {{#if (and (not learnerGroup.isTopLevelGroup) (is-fulfilled learnerGroup.allParents))}}
             {{#attach-tooltip lazy-render=true animation='shift'}}
               {{join ' > ' (map-by 'title' (await learnerGroup.allParents))}}
             {{/attach-tooltip}}


### PR DESCRIPTION
fixes #3877