### PR TITLE
Update ember-cli-template-lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-string-helpers": "^1.5.0",
     "ember-cli-stylelint": "^2.0.0",
-    "ember-cli-template-lint": "0.7.6",
+    "ember-cli-template-lint": "1.0.0-beta.1",
     "ember-cli-uglify": "^2.0.0",
     "ember-click-outside": "^1.0.0",
     "ember-composable-helpers": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,7 +1739,7 @@ broccoli-clean-css@^1.1.0:
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
 
-broccoli-concat@^3.2.2:
+broccoli-concat@^3.2.2, broccoli-concat@^3.4.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-3.5.1.tgz#25d5bff467e451a03ae2a93b3fc8701b3955a732"
   dependencies:
@@ -4487,17 +4487,17 @@ ember-cli-stylelint@^2.0.0:
     ember-cli-version-checker "^2.1.0"
     js-string-escape "^1.0.1"
 
-ember-cli-template-lint@0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/ember-cli-template-lint/-/ember-cli-template-lint-0.7.6.tgz#33e55efa460fbfa2f108775318460ba9d6bf8667"
+ember-cli-template-lint@1.0.0-beta.1:
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-template-lint/-/ember-cli-template-lint-1.0.0-beta.1.tgz#8cffc1939885216135d627621d6e02fd485d1978"
   dependencies:
     aot-test-generators "^0.1.0"
-    broccoli-concat "^3.2.2"
+    broccoli-concat "^3.4.0"
     broccoli-persistent-filter "^1.2.0"
-    chalk "^2.0.1"
+    chalk "^2.4.1"
     debug "^3.0.0"
-    ember-cli-version-checker "^2.1.0"
-    ember-template-lint "^0.8.16"
+    ember-cli-version-checker "^2.1.2"
+    ember-template-lint "^1.0.0-beta.2"
     json-stable-stringify "^1.0.1"
     md5-hex "^2.0.0"
     strip-ansi "^4.0.0"
@@ -5296,13 +5296,13 @@ ember-string-ishtmlsafe-polyfill@^2.0.0:
   dependencies:
     ember-cli-version-checker "^2.1.0"
 
-ember-template-lint@^0.8.16:
-  version "0.8.23"
-  resolved "https://registry.yarnpkg.com/ember-template-lint/-/ember-template-lint-0.8.23.tgz#45170d6f2fe6336635df1d1067cabab6b5eb02d0"
+ember-template-lint@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/ember-template-lint/-/ember-template-lint-1.0.0-beta.2.tgz#ee06ec5c463471cb34d3ef59f6432396e77deb70"
   dependencies:
     "@glimmer/compiler" "^0.35.5"
     chalk "^2.0.0"
-    glob "^7.0.0"
+    globby "^8.0.1"
     minimatch "^3.0.4"
     resolve "^1.1.3"
     strip-bom "^3.0.0"
@@ -6521,7 +6521,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-globby@^8.0.0:
+globby@^8.0.0, globby@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.1.tgz#b5ad48b8aa80b35b814fc1281ecc851f1d2b5b50"
   dependencies:


### PR DESCRIPTION
This beta release includes a fix needed for broccoli updates and some
build speed improvements that are worth taking advantage of.