### PR TITLE
top-align items in program year overview.

### DIFF
--- a/app/styles/components/programyear-overview.scss
+++ b/app/styles/components/programyear-overview.scss
@@ -26,6 +26,7 @@
 
   .programyear-overview-content {
     @include ilios-overview-content;
+    align-items: start;
     padding-top: 1rem;
 
     .removable-directors {


### PR DESCRIPTION
fixes #3948 

![selection_081](https://user-images.githubusercontent.com/1410427/43554206-04dad33e-95a8-11e8-9668-67487cb5a927.png)
