### PR TITLE
When saving an offering highlight it

### DIFF
--- a/app/components/sessions-grid-offering.js
+++ b/app/components/sessions-grid-offering.js
@@ -17,12 +17,13 @@ const Validations = buildValidations({
 
 export default Component.extend(ValidationErrorDisplay, Validations, {
   tagName: 'tr',
-  classNameBindings: [':sessions-grid-offering', 'firstRow', 'even'],
+  classNameBindings: [':sessions-grid-offering', 'firstRow', 'even', 'wasUpdated'],
   canUpdate: false,
   room: null,
   firstRow: false,
   even: false,
   isEditing: false,
+  wasUpdated: false,
   'data-test-sessions-grid-offering': true,
 
   didReceiveAttrs(){
@@ -59,6 +60,13 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     offering.setProperties({startDate, endDate, room, learnerGroups, instructorGroups, instructors});
 
     yield offering.save();
-    scrollIntoView(this.element);
+    this.updateUi.perform();
   }).drop(),
+  updateUi: task(function* () {
+    yield timeout(10);
+    this.set('wasUpdated', true);
+    scrollIntoView(this.element);
+    yield timeout(4000);
+    this.set('wasUpdated', false);
+  }).restartable(),
 });

--- a/app/styles/components/sessions-grid-offering-table.scss
+++ b/app/styles/components/sessions-grid-offering-table.scss
@@ -52,8 +52,12 @@
   }
 
   .sessions-grid-offering {
+    transition: background-color .5s ease-out;
     &.even {
       background-color: darken($active-background-color, 10);
+    }
+    &.was-updated {
+      background-color: lighten($ilios-green, 30%);
     }
   }
 


### PR DESCRIPTION
By marking the recently updated offering after we scroll it into view it
is much easier to find your place again in a large list.

Fixes #3979