### PR TITLE
Indicate that all sessions are expanding

### DIFF
--- a/app/components/sessions-grid-header.js
+++ b/app/components/sessions-grid-header.js
@@ -1,8 +1,11 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { task, timeout } from 'ember-concurrency';
+import { next } from '@ember/runloop';
 
 export default Component.extend({
   classNames: ['sessions-grid-header'],
+  isExpanding: false,
   'data-test-sessions-grid-header': true,
   sortedAscending: computed('sortBy', function(){
     const sortBy = this.get('sortBy');
@@ -16,5 +19,15 @@ export default Component.extend({
       }
       this.setSortBy(what);
     },
-  }
+  },
+  expandAll: task(function * () {
+    this.set('isExpanding', true);
+    yield timeout(100);
+    this.toggleExpandAll();
+    // we need to wait for the browser to hand back
+    //control and then swap the icon back
+    yield next(() => {
+      this.set('isExpanding', false);
+    });
+  }).drop()
 });

--- a/app/templates/components/course-sessions.hbs
+++ b/app/templates/components/course-sessions.hbs
@@ -47,7 +47,7 @@
     showExpandAll=(is-fulfilled sessionObjects)
     setSortBy=setSortBy
     sortBy=sortBy
-    allSessionsExpanded=(eq expandedSessionIds.length (get (await sessionsWithOfferings) "length"))
+    allSessionsExpanded=(and (eq expandedSessionIds.length (get (await sessionsWithOfferings) "length")) (gt (get (await sessionsWithOfferings) "length") 0))
     toggleExpandAll=(perform toggleExpandAll)
   }}
   {{#if (is-fulfilled sessionObjects)}}

--- a/app/templates/components/sessions-grid-header.hbs
+++ b/app/templates/components/sessions-grid-header.hbs
@@ -1,14 +1,16 @@
 {{! template-lint-disable attribute-indentation }}
 <span data-test-expand-all
-  {{action toggleExpandAll}}
+  {{action (perform expandAll)}}
   class="expand-collapse-control"
   data-test-expand-collapse-all
 >
   {{#if @showExpandAll}}
-    {{#if @allSessionsExpanded}}
-      {{fa-icon "caret-down"}}
+    {{#if isExpanding}}
+      {{loading-spinner}}
+    {{else if @allSessionsExpanded}}
+      {{fa-icon "caret-down" class="clickable"}}
     {{else}}
-      {{fa-icon "caret-right"}}
+      {{fa-icon "caret-right" class="clickable"}}
     {{/if}}
   {{/if}}
 </span>


### PR DESCRIPTION
In big courses it can take a while for all of the sessions to open. What
I'm doing here is starting a loading indicator and then opening the
sessions. The browser takes a while to render the newly exposed DOM so
we use Ember.run.next() to wait for control to come back from that
process and then kill the spinner.

Fixes #3978