### PR TITLE
Add title for truncated values

### DIFF
--- a/app/templates/components/sessions-grid-offering.hbs
+++ b/app/templates/components/sessions-grid-offering.hbs
@@ -56,13 +56,13 @@
     {{/if}}
   </td>
   <td class="text-center">{{get (await @offering.allLearners) "length"}}</td>
-  <td colspan="2">
+  <td colspan="2" title={{join ", " (map-by "title" (sort-by "title" (await @offering.learnerGroups)))}}>
     {{truncate
       (join ", " (map-by "title" (sort-by "title" (await @offering.learnerGroups))))
       30
     }}
   </td>
-  <td colspan="2">
+  <td colspan="2" title={{join ", " (map-by "fullName" (sort-by "fullName" (await @offering.allInstructors)))}}>
     {{truncate
       (join ", " (map-by "fullName" (sort-by "fullName" (await @offering.allInstructors))))
       30


### PR DESCRIPTION
When learner groups and instructors are truncated a hover over title
makes it easy to see the whole list.

Fixes #3985