### PR TITLE
Remove deprecated authorize calls

### DIFF
--- a/app/components/file-upload.js
+++ b/app/components/file-upload.js
@@ -25,11 +25,13 @@ export default FileField.extend({
   iliosConfig: service(),
   i18n: service(),
   url: '',
-  headers: computed('session.isAuthenticated', function(){
+  headers: computed('session.isAuthenticated', function () {
+    const session = this.get('session');
+    const { jwt } = session.data.authenticated;
     let headers = {};
-    this.get('session').authorize('authorizer:token', (headerName, headerValue) => {
-      headers[headerName] = headerValue;
-    });
+    if (jwt) {
+      headers['X-JWT-Authorization'] = `Token ${jwt}`;
+    }
 
     return headers;
   }),

--- a/app/components/programyear-objective-list.js
+++ b/app/components/programyear-objective-list.js
@@ -19,10 +19,12 @@ export default Component.extend(FileSaverMixin, SortableObjectiveList, {
   programYear: alias('subject'),
 
   authHeaders: computed('session.isAuthenticated', function(){
+    const session = this.get('session');
+    const { jwt } = session.data.authenticated;
     let headers = {};
-    this.get('session').authorize('authorizer:token', (headerName, headerValue) => {
-      headers[headerName] = headerValue;
-    });
+    if (jwt) {
+      headers['X-JWT-Authorization'] = `Token ${jwt}`;
+    }
 
     return headers;
   }),

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -5,7 +5,6 @@ window.deprecationWorkflow.config = {
   workflow: [
     { handler: "silence", matchId: "ember-cli-page-object.old-collection-api"},
     { handler: "silence", matchId: "ember-metal.run.sync"},
-    { handler: "silence", matchId: "ember-simple-auth.session.authorize"},
     { handler: "silence", matchId: "ember-routing.route-router"},
   ]
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -32,9 +32,6 @@ module.exports = function (environment) {
       extendedTimeout: 1000,
       types: [ 'success', 'warning', 'info', 'alert' ]
     },
-    'ember-simple-auth': {
-      authorizer: 'authorizer:token'
-    },
     'ember-simple-auth-token': {
       serverTokenEndpoint: '/auth/login',
       serverTokenRefreshEndpoint: '/auth/token',


### PR DESCRIPTION
This methods is deprecated from ember-simple-auth and we have to put the
headers together manually.