### PR TITLE
Handle icons in the froala editor

### DIFF
--- a/app/components/html-editor.js
+++ b/app/components/html-editor.js
@@ -3,6 +3,8 @@ import $ from 'jquery';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { dom } from '@fortawesome/fontawesome-svg-core';
+import { next } from '@ember/runloop';
 
 const defaultButtons = [
   'bold',
@@ -26,6 +28,15 @@ export default Component.extend({
     this._super(...arguments);
     $.FE.DT = true;
   },
+  /**
+   * Convert `<i>` tags from froala into SVG icons
+   * Uses: https://fontawesome.com/how-to-use/with-the-api/methods/dom-i2svg
+   */
+  didRender() {
+    next(() => {
+      dom.i2svg({node: this.element});
+    });
+  },
   options: computed('i18n.locale', function(){
     const i18n = this.get('i18n');
     const language = i18n.get('locale');
@@ -46,6 +57,7 @@ export default Component.extend({
       toolbarButtonsXS: defaultButtons,
       quickInsertButtons: false,
       pluginsEnabled: ['lists', 'code_view', 'link'],
+      iconsTemplate: 'font_awesome_5',
     };
   })
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -86,6 +86,7 @@ module.exports = function (environment) {
         // //icons which are used dynamically and cannot be detected at build time
         // 'free-solid-svg-icons': [
         //   'ban',
+        //   'bold',
         //   'check',
         //   'clock',
         //   'cloud',
@@ -99,7 +100,10 @@ module.exports = function (environment) {
         //   'file-video',
         //   'file',
         //   'info-circle',
+        //   'italic',
         //   'link',
+        //   'list-ol',
+        //   'list-ul',
         //   'paragraph',
         //   'sort-alpha-down',
         //   'sort-alpha-up',
@@ -108,7 +112,9 @@ module.exports = function (environment) {
         //   'sort',
         //   'spinner',
         //   'star',
-        //   'star-half-alt'
+        //   'star-half-alt',
+        //   'subscript',
+        //   'superscript',
         // ],
       }
     },

--- a/tests/integration/components/html-editor-test.js
+++ b/tests/integration/components/html-editor-test.js
@@ -1,13 +1,15 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('html-editor', 'Integration | Component | html editor', {
-  integration: true
-});
+module('Integration | Component | html editor', function(hooks) {
+  setupRenderingTest(hooks);
 
-test('it renders', function(assert) {
-  this.render(hbs`{{html-editor}}`);
+  test('it renders', async function(assert) {
+    await render(hbs`{{html-editor}}`);
 
-  assert.equal(this.$().text().trim(), 'BoldItalicSubscriptSuperscriptOrdered ListUnordered ListInsert Link');
-
+    assert.equal(this.element.textContent.trim(), 'BoldItalicSubscriptSuperscriptOrdered ListUnordered ListInsert Link');
+    assert.equal(findAll('svg').length, 7);
+  });
 });


### PR DESCRIPTION
We don't have much control over this UI component. I was able to set the
icon template to work with font awesome 5, but then I needed to add a
method from the fontawesome library to convert the `<i>` tags that the
editor created into the SVG icons we can actually display.