### PR TITLE
Give some time for icons to render

### DIFF
--- a/tests/integration/components/html-editor-test.js
+++ b/tests/integration/components/html-editor-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { later } from '@ember/runloop';
 
 module('Integration | Component | html editor', function(hooks) {
   setupRenderingTest(hooks);
@@ -9,7 +10,9 @@ module('Integration | Component | html editor', function(hooks) {
   test('it renders', async function(assert) {
     await render(hbs`{{html-editor}}`);
 
-    assert.equal(this.element.textContent.trim(), 'BoldItalicSubscriptSuperscriptOrdered ListUnordered ListInsert Link');
-    assert.equal(findAll('svg').length, 7);
+    await later(() => {
+      assert.equal(this.element.textContent.trim(), 'BoldItalicSubscriptSuperscriptOrdered ListUnordered ListInsert Link');
+      assert.equal(findAll('svg').length, 7);
+    }, 500);
   });
 });


### PR DESCRIPTION
This build happens in the next run loop and can take an instant to
succeed. Giving it a little delay makes this test more reliable.