### PR TITLE
Improved tests for api-version-check

### DIFF
--- a/tests/acceptance/api-version-check-test.js
+++ b/tests/acceptance/api-version-check-test.js
@@ -1,6 +1,4 @@
 import { visit } from '@ember/test-helpers';
-/* eslint ember/no-global-jquery: 0 */
-import $ from 'jquery';
 import { module, test } from 'qunit';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
 
@@ -32,7 +30,7 @@ module('Acceptance | API Version Check', function(hooks) {
     const warningOverlay = '.api-version-check-warning';
 
     await visit(url);
-    assert.equal($(warningOverlay).length, 0);
+    assert.equal(document.querySelectorAll(warningOverlay).length, 0);
   });
 
   test('Warning shows up when api versions do not match', async function(assert) {
@@ -47,6 +45,6 @@ module('Acceptance | API Version Check', function(hooks) {
     const warningOverlay = '.api-version-check-warning';
 
     await visit(url);
-    assert.equal($(warningOverlay).length, 1);
+    assert.equal(document.querySelectorAll(warningOverlay).length, 1);
   });
 });

--- a/tests/integration/components/api-version-check-test.js
+++ b/tests/integration/components/api-version-check-test.js
@@ -1,12 +1,11 @@
-/* eslint ember/no-global-jquery: 0 */
 import Service from '@ember/service';
 import { resolve } from 'rsvp';
-import $ from 'jquery';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import ENV from 'ilios/config/environment';
+import { schedule } from '@ember/runloop';
 
 const { apiVersion } = ENV.APP;
 
@@ -20,8 +19,10 @@ module('Integration | Component | api version check', function(hooks) {
     const warningOverlay = '.api-version-check-warning';
     this.owner.register('service:iliosConfig', iliosConfigMock);
     await render(hbs`{{api-version-check}}`);
+    await schedule('afterRender', () => {
+      assert.equal(document.querySelectorAll(warningOverlay).length, 0);
+    });
     await settled();
-    assert.equal($(warningOverlay).length, 0);
   });
 
   test('shows warning on mismatch', async function(assert) {
@@ -31,7 +32,9 @@ module('Integration | Component | api version check', function(hooks) {
     const warningOverlay = '.api-version-check-warning';
     this.owner.register('service:iliosConfig', iliosConfigMock);
     await render(hbs`{{api-version-check}}`);
+    await schedule('afterRender', () => {
+      assert.equal(document.querySelectorAll(warningOverlay).length, 1);
+    });
     await settled();
-    assert.equal($(warningOverlay).length, 1);
   });
 });


### PR DESCRIPTION
Eliminate jquery and use after render to ensure the check isn't run
until the page is done building.