### PR TITLE
Improve async waiters in bulk new users test

### DIFF
--- a/app/components/wait-saving.js
+++ b/app/components/wait-saving.js
@@ -1,4 +1,3 @@
-/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 
@@ -6,6 +5,7 @@ export default Component.extend({
   showProgress: false,
   totalProgress: null,
   currentProgress: null,
+  'data-test-wait-saving': true,
   progress: computed('totalProgress', 'currentProgress', function(){
     const total = this.get('totalProgress') || 1;
     const current = this.get('currentProgress') || 0;

--- a/app/templates/components/bulk-new-users.hbs
+++ b/app/templates/components/bulk-new-users.hbs
@@ -60,7 +60,7 @@
   {{#if parseFile.isRunning}}
     <div class="file-is-loading">{{loading-spinner}}</div>
   {{else if (gte proposedUsers.length 1)}}
-    <div  class="proposed-new-users">
+    <div class="proposed-new-users" data-test-proposed-new-users>
       <table>
         <thead>
           <tr>

--- a/tests/integration/components/bulk-new-users-test.js
+++ b/tests/integration/components/bulk-new-users-test.js
@@ -4,7 +4,7 @@ import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, click, findAll, find, triggerEvent } from '@ember/test-helpers';
+import { render, settled, click, findAll, find, triggerEvent, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
 import Response from 'ember-cli-mirage/response';
@@ -485,6 +485,8 @@ module('Integration | Component | bulk new users', function(hooks) {
   test('dont create authentication if username is not set', async function(assert) {
     assert.expect(2);
     this.set('nothing', parseInt);
+    const proposedNewUsers = '[data-test-proposed-new-users]';
+    const waitSaving = '[data-test-wait-saving]';
     await render(hbs`{{bulk-new-users close=(action nothing)}}`);
 
     let users = [
@@ -492,6 +494,9 @@ module('Integration | Component | bulk new users', function(hooks) {
     ];
     await triggerUpload(users, find('input[type=file]'));
     await click('.done');
+    await waitUntil(() => {
+      return findAll(proposedNewUsers).length === 0 && findAll(waitSaving).length === 0;
+    });
     await settled();
     assert.equal(this.server.db.users[0].firstName, 'jasper');
     assert.equal(this.server.db.users[0].authenticationId, null);


### PR DESCRIPTION
Sometimes this test fails when the promises settled a bit ahead of when
we check for the data. Instead of using the system wide settled state we
can use the UI to tell us if the data should be saved.