### PR TITLE
Improve test waiting for api-version-check

### DIFF
--- a/app/components/api-version-check.js
+++ b/app/components/api-version-check.js
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import ENV from 'ilios/config/environment';
 import { task, timeout } from 'ember-concurrency';
+import { readOnly } from '@ember/object/computed';
 
 const { apiVersion } = ENV.APP;
 
@@ -12,6 +13,7 @@ export default Component.extend({
   countdownToUpdate: null,
   updatePending: false,
   unableToFindUpdate: false,
+  'data-test-load-finished': readOnly('loadAttributes.lastSuccessful.value'),
 
   didInsertElement() {
     this.loadAttributes.perform();
@@ -34,6 +36,7 @@ export default Component.extend({
       }
     }
     this.set('versionMismatch', versionMismatch);
+    return true; //always return true to update data-test-load-finished property
   }).drop(),
   countdown: task(function* () {
     this.set('updateAvailable', true);

--- a/tests/integration/components/api-version-check-test.js
+++ b/tests/integration/components/api-version-check-test.js
@@ -2,10 +2,9 @@ import Service from '@ember/service';
 import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled } from '@ember/test-helpers';
+import { render, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import ENV from 'ilios/config/environment';
-import { schedule } from '@ember/runloop';
 
 const { apiVersion } = ENV.APP;
 
@@ -19,10 +18,9 @@ module('Integration | Component | api version check', function(hooks) {
     const warningOverlay = '.api-version-check-warning';
     this.owner.register('service:iliosConfig', iliosConfigMock);
     await render(hbs`{{api-version-check}}`);
-    await schedule('afterRender', () => {
-      assert.equal(document.querySelectorAll(warningOverlay).length, 0);
-    });
+    await waitFor('[data-test-load-finished]');
     await settled();
+    assert.equal(document.querySelectorAll(warningOverlay).length, 0);
   });
 
   test('shows warning on mismatch', async function(assert) {
@@ -32,9 +30,8 @@ module('Integration | Component | api version check', function(hooks) {
     const warningOverlay = '.api-version-check-warning';
     this.owner.register('service:iliosConfig', iliosConfigMock);
     await render(hbs`{{api-version-check}}`);
-    await schedule('afterRender', () => {
-      assert.equal(document.querySelectorAll(warningOverlay).length, 1);
-    });
+    await waitFor('[data-test-load-finished]');
     await settled();
+    assert.equal(document.querySelectorAll(warningOverlay).length, 1);
   });
 });


### PR DESCRIPTION
All of my attempts to get this test to wait for the task to finish have
load to flaky tests. Instead this change defines a property that will be
set on the UI when the task is done and then the test waits for that
property to show up before running the test.