### PR TITLE
Check for an existing worker before re-loading

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -59,8 +59,12 @@ export default Route.extend(ApplicationRouteMixin, {
 
   activate() {
     if ('serviceWorker' in navigator) {
-      const event = navigator.serviceWorker.addEventListener('controllerchange', () => {
-        window.location.reload();
+      const { controller: currentController } = navigator.serviceWorker;
+      const event = navigator.serviceWorker.addEventListener('controllerchange', async () => {
+        // only reload the page if there was a previously active controller
+        if (currentController) {
+          window.location.reload();
+        }
       });
       this.set('event', event);
     }


### PR DESCRIPTION
Hopefully this solves the issues where visiting ilios for the first time would sometimes cause the page to refresh as soon as it was loaded.