### PR TITLE
Remove link to slack from our README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Build Status](https://travis-ci.org/ilios/frontend.svg?branch=master)](https://travis-ci.org/ilios/frontend)
 [![Code Climate](https://codeclimate.com/github/ilios/frontend/badges/gpa.svg)](https://codeclimate.com/github/ilios/frontend)
 [![Test Coverage](https://codeclimate.com/github/ilios/frontend/badges/coverage.svg)](https://codeclimate.com/github/ilios/frontend/coverage)
-[![Slack](https://ilios-slack.herokuapp.com/badge.svg)](https://ilios-slack.herokuapp.com/)
 [![Stories in Ready](https://badge.waffle.io/ilios/frontend.png?label=ready&title=Ready)](https://waffle.io/ilios/frontend)
 
 ## Open Source Heroes


### PR DESCRIPTION
This is on the website and having it here causes heroku to stay spun up
overnight which means we run out of free time before the end of the
month.