### PR TITLE
Go back to upstream ember-pikaday

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "ember-metrics": "0.12.1",
     "ember-noscript": "^2.0.0",
     "ember-pad": "1.2.3",
-    "ember-pikaday": "jrjohnson/ember-pikaday",
+    "ember-pikaday": "2.2.6",
     "ember-qunit-nice-errors": "^1.2.0",
     "ember-resolver": "^5.0.1",
     "ember-responsive": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3314,10 +3314,15 @@ caniuse-db@^1.0.30000820:
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000887.tgz#9abf538610e3349870ed525f7062de649cc3c570"
   integrity sha512-yOScC1WJ6ihxxPNeWSqYc2nKHqeHzXMY382yvC0mZdi+kWBrlEdCFeR/T1s5Abe5n51HoD6IA/Gho2T8vnRT2g==
 
-caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000884:
+caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000884:
   version "1.0.30000887"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000887.tgz#1769458c27bbdcf61b0cb6b5072bb6cd11fd9c23"
   integrity sha512-AHpONWuGFWO8yY9igdXH94tikM6ERS84286r0cAMAXYFtJBk76lhiMhtCxBJNBZsD6hzlvpWZ2AtbVFEkf4JQA==
+
+caniuse-lite@^1.0.30000844:
+  version "1.0.30000888"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000888.tgz#22edb50d91dd70612b5898e3b36f460600c6492f"
+  integrity sha512-vftg+5p/lPsQGpnhSo/yBuYL36ai/cyjLvU3dOPJY1kkKrekLWIy8SLm+wzjX0hpCUdFTasC4/ZT7uqw4rKOnQ==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -4910,10 +4915,15 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.62:
+electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.62:
   version "1.3.70"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.70.tgz#ded377256d92d81b4257d36c65aa890274afcfd2"
   integrity sha512-WYMjqCnPVS5JA+XvwEnpwucJpVi2+q9cdCFpbhxgWGsCtforFBEkuP9+nCyy/wnU/0SyLcLRIeZct9ayMGcXoQ==
+
+electron-to-chromium@^1.3.47:
+  version "1.3.72"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.72.tgz#b69683081d5b7eee6e1ea07b2f5fa30b3c72252d"
+  integrity sha512-OFbXEC01Lq7A66e3UywkvWYNN00HO1I9MAPereGe0NIXrt2MeaovL1bbY+951HKG0euUdPBe0L7yfKxgqxBMMw==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -5452,7 +5462,7 @@ ember-cli-mirage@0.4.9:
     pretender "^1.6.1"
     route-recognizer "^0.2.3"
 
-ember-cli-moment-shim@^3.1.0:
+ember-cli-moment-shim@^3.1.0, ember-cli-moment-shim@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.7.1.tgz#3ad691c5027c1f38a4890fe47d74b5224cc98e32"
   integrity sha512-U3HHuEU7sXQ78v25ifmIa9w4nQPQ7vK/LZ2bt18pN3aKNvIDYiLe/MDeXGmqfFIq3OfruKG+CF+7dOLqxuzSlQ==
@@ -6219,12 +6229,14 @@ ember-pad@1.2.3:
   dependencies:
     ember-cli-babel "^6.6.0"
 
-ember-pikaday@jrjohnson/ember-pikaday:
-  version "2.2.4"
-  resolved "https://codeload.github.com/jrjohnson/ember-pikaday/tar.gz/e367b56a242fd1cafb1940788bcac2308b31fa53"
+ember-pikaday@2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/ember-pikaday/-/ember-pikaday-2.2.6.tgz#c3dd878af716262fc808f57fbdcc362697008a4c"
+  integrity sha512-QErKt+eFGcGHEmI+mea3sMTGbd2mkTUlAchZaQofsqhqHi9hKaD3qIEME8jXoZO5kmOatNvE8BhV4mQyQ7q22w==
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-cli-htmlbars "^1.1.1"
+    ember-cli-moment-shim "^3.6.0"
     ember-cli-node-assets "^0.2.2"
     fastboot-transform "^0.1.1"
     pikaday "^1.5.1"


### PR DESCRIPTION
The release process for this addon has been sorted out so we can go back
to using the official package instead of my fork.