### PR TITLE
Fix waiting in bulk new users test

### DIFF
--- a/tests/integration/components/bulk-new-users-test.js
+++ b/tests/integration/components/bulk-new-users-test.js
@@ -4,7 +4,7 @@ import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, click, findAll, find, triggerEvent, waitUntil } from '@ember/test-helpers';
+import { render, settled, click, findAll, find, triggerEvent, waitUntil, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
 import Response from 'ember-cli-mirage/response';
@@ -76,7 +76,7 @@ module('Integration | Component | bulk new users', function(hooks) {
       'change',
       [file]
     );
-    return settled();
+    await waitFor('[data-test-proposed-new-users]');
   };
 
   test('it renders', async function(assert) {


### PR DESCRIPTION
Instead of waiting for a generic settled we can actually wait for the
table to appear. This should fix issues with tests in this module
failing sporadically.