### PR TITLE
Fix ignore on ember-qunit

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
       "ember-cli-htmlbars-inline-precompile",
       "ember-cli-htmlbars",
       "ember-cli-inject-live-reload",
-      "ember-cli-qunit",
+      "ember-qunit",
       "ember-cli-sri",
       "ember-cli-uglify",
       "ember-export-application-global",


### PR DESCRIPTION
A recent release of ember-cli updated this package name, but the ignore
configuration didn't get updated at the same time.

Refs #4119
