### PR TITLE
render translation string with unescaped html.

### DIFF
--- a/app/templates/components/my-profile.hbs
+++ b/app/templates/components/my-profile.hbs
@@ -55,7 +55,7 @@
 
 <section class="token-maintenance">
   <h3>{{t "general.manageAPITokens"}}</h3>
-  <p>{{t "general.tokenInfo" apiDocsUrl=apiDocsUrl}}</p>
+  <p>{{t "general.tokenInfo" apiDocsUrl=apiDocsUrl htmlSafe=true}}</p>
   {{#unless (or showInvalidateTokens showCreateNewToken)}}
     <button
       class="new-token done text"


### PR DESCRIPTION
fixes #4182 

![selection_208](https://user-images.githubusercontent.com/1410427/49242335-51b63980-f3bf-11e8-8112-e0d3aaaa87d9.png)
