### PR TITLE
Fix loading bar initialization

### DIFF
--- a/app/components/loading-bar.js
+++ b/app/components/loading-bar.js
@@ -17,12 +17,6 @@ export default Component.extend({
     return htmlSafe(`width: ${progress}%;`);
   }),
 
-  didReceiveAttrs() {
-    const incrementProgress = this.get('incrementProgress');
-    incrementProgress.perform();
-  },
-
-
   incrementProgress: task(function * () {
     const removeProgress = this.get('removeProgress');
     const isLoading = this.get('isLoading');
@@ -39,7 +33,7 @@ export default Component.extend({
     } else {
       return removeProgress.perform();
     }
-  }).restartable(),
+  }).restartable().on('init'),
 
   removeProgress: task(function * () {
     const progress = this.get('progress');


### PR DESCRIPTION
Using the on helper with the task ensures the component is fully setup,
in some newer version of ember the task doesn't exist when
didReceiveAttrs is run causing an error.