### PR TITLE
Turn off code coverage in deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ jobs:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
     - stage: deploy staging
       if: branch = master AND NOT type = pull_request AND NOT type = cron
+      env: COVERAGE=false
       script: node_modules/.bin/ember deploy staging --activate
     - stage: deploy production
       if: tag IS present
+      env: COVERAGE=false
       script: node_modules/.bin/ember deploy production --activate


### PR DESCRIPTION
There appears to be a conflict between code coverage and dynamic auto
imports that is causing our deployed frontend to be missing some files.
This should fix it.

Fixes #4271