### PR TITLE
Manually specify asset path

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -120,6 +120,9 @@ module.exports = function(defaults) {
         ]
       }
     },
+    autoImport: {
+      publicAssetURL: '/assets'
+    },
   });
 
   app.import('node_modules/normalize.css/normalize.css');


### PR DESCRIPTION
Since we load our app and vendor.js files asynchronously using the defer
flag we need to pay special attention to the final path of our assets.
Otherwise ember-auto-import detects it automatically based on the last
script loaded (which for us is probably our custom build error, which is
wrong).

Fixes #4271 🤞 