### PR TITLE
Activate Prework for testing

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -141,6 +141,9 @@ module.exports = function (environment) {
     //Hide a feature while it is in development
     IliosFeatures: {
       programYearVisualizations: false
+    },
+    featureFlags: {
+      sessionLinkingAdminUi: false
     }
   };
 
@@ -159,6 +162,7 @@ module.exports = function (environment) {
     };
 
     ENV.IliosFeatures.programYearVisualizations = true;
+    ENV.featureFlags.sessionLinkingAdminUi = true;
 
     //put ember concurrency tasks into debug mode to make errors much easier to spot
     ENV.EmberENV.DEBUG_TASKS = true;
@@ -191,6 +195,7 @@ module.exports = function (environment) {
   if (environment === 'preview') {
     // here you can enable a preview-specific feature
     ENV.IliosFeatures.programYearVisualizations = true;
+    ENV.featureFlags.sessionLinkingAdminUi = true;
     ENV['ember-a11y-testing'].componentOptions.turnAuditOff = true;
 
     //Remove mirage


### PR DESCRIPTION
For development and preview, but not in production we need to see this
feature and be able to use it.

Since everything is available in the API this makes it possible to preview this work in Netlify.