### PR TITLE
Drop support for unsupported browsers

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -13,7 +13,6 @@ if (isCI || isProductionLikeBuild) {
   browsers.push('last 1 edge versions');
   browsers.push('firefox esr'); //sometimes points to the last 2 ESR releases when they overlap
   browsers.push('last 1 ios versions');
-  browsers.push('> 1%'); // any browser with more than 1% global market share
 }
 
 module.exports = {


### PR DESCRIPTION
This set of browsers that we target did not match our published support
matrix and was including IE11 which does not have CSS Grid support and
looks terrible. Instead we should only target browsers that we actually
support.