### PR TITLE
Add Validation for Vocabulary and Term Titles

### DIFF
--- a/app/components/school-vocabulary-manager.js
+++ b/app/components/school-vocabulary-manager.js
@@ -1,13 +1,10 @@
-/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isPresent } from '@ember/utils';
-import RSVP from 'rsvp';
+import { Promise } from 'rsvp';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios-common/mixins/validation-error-display';
-
-const { Promise } = RSVP;
 
 const Validations = buildValidations({
   newTermTitle: [
@@ -46,14 +43,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   isSavingNewTerm: false,
   newTerm: null,
   classNames: ['school-vocabulary-manager'],
-  didReceiveAttrs(){
-    this._super(...arguments);
-    const vocabulary = this.vocabulary;
-    if (vocabulary) {
-      this.set('title', vocabulary.get('title'));
-      this.set('isActive', vocabulary.get('active'));
-    }
-  },
+  'data-test-school-vocabulary-manager': true,
   sortedTerms: computed('vocabulary.terms.[]', 'newTerm', function(){
     return new Promise(resolve => {
       const vocabulary = this.vocabulary;
@@ -69,19 +59,14 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
       }
     });
   }),
-  keyUp(event) {
-    const keyCode = event.keyCode;
-    const target = event.target;
-
-    if ('text' !== target.type) {
-      return;
-    }
-
-    if (13 === keyCode) {
-      this.send('createTerm');
+  didReceiveAttrs(){
+    this._super(...arguments);
+    const vocabulary = this.vocabulary;
+    if (vocabulary) {
+      this.set('title', vocabulary.get('title'));
+      this.set('isActive', vocabulary.get('active'));
     }
   },
-
   actions: {
     changeVocabularyTitle(){
       const vocabulary = this.vocabulary;
@@ -112,5 +97,17 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
         this.set('isSavingNewTerm', false);
       });
     }
-  }
+  },
+  keyUp(event) {
+    const keyCode = event.keyCode;
+    const target = event.target;
+
+    if ('text' !== target.type) {
+      return;
+    }
+
+    if (13 === keyCode) {
+      this.send('createTerm');
+    }
+  },
 });

--- a/app/components/school-vocabulary-term-manager.js
+++ b/app/components/school-vocabulary-term-manager.js
@@ -51,6 +51,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   title: null,
   isActive: null,
   classNames: ['school-vocabulary-term-manager'],
+  'data-test-school-vocabulary-term-manager': true,
   didReceiveAttrs(){
     this._super(...arguments);
     const term = this.term;
@@ -75,7 +76,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
       const term = this.term;
       if (isPresent(term)) {
         term.get('allParents').then(allParents => {
-          resolve(allParents.reverse());
+          resolve(allParents);
         });
       }
     });

--- a/app/components/school-vocabulary-term-manager.js
+++ b/app/components/school-vocabulary-term-manager.js
@@ -1,14 +1,10 @@
-/* eslint ember/order-in-components: 0 */
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isEmpty, isPresent } from '@ember/utils';
 import { task } from 'ember-concurrency';
-import RSVP from 'rsvp';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios-common/mixins/validation-error-display';
-
-const { Promise } = RSVP;
 
 const Validations = buildValidations({
   newTermTitle: [
@@ -19,20 +15,17 @@ const Validations = buildValidations({
     }),
     validator('async-exclusion', {
       dependentKeys: ['model.term.children.@each.title'],
-      in: computed('model.term.@each.title', function(){
-        return new Promise(resolve => {
-          const term = this.get('model.term');
-          if (isPresent(term)) {
-            term.get('children').then(children => {
-              resolve(children.mapBy('title'));
-            });
-          } else {
-            resolve([]);
-          }
-        });
+      in: computed('model.term.children.@each.title', async function(){
+        const term = this.get('model.term');
+        if (isPresent(term)) {
+          const children = await term.children;
+          return children.mapBy('title');
+        }
+        return [];
+
       }),
       descriptionKey: 'general.term',
-    })
+    }),
   ],
 });
 
@@ -52,35 +45,80 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
   isActive: null,
   classNames: ['school-vocabulary-term-manager'],
   'data-test-school-vocabulary-term-manager': true,
+  sortedTerms: computed('term.children.[]', 'newTerm', async function(){
+    if (isPresent(this.term)) {
+      const terms = await this.term.children;
+      return terms.filterBy('isNew', false).filterBy('isDeleted', false).sortBy('title');
+    }
+  }),
+  allParents: computed('term.allParents.[]', async function(){
+    if (isPresent(this.term)) {
+      return await this.term.allParents;
+    }
+
+    return [];
+  }),
   didReceiveAttrs(){
     this._super(...arguments);
-    const term = this.term;
-    if (term) {
-      this.set('description', term.get('description'));
-      this.set('title', term.get('title'));
-      this.set('isActive', term.get('active'));
+    if (this.term) {
+      this.set('description', this.term.description);
+      this.set('title', this.term.title);
+      this.set('isActive', this.term.active);
     }
   },
-  sortedTerms: computed('term.children.[]', 'newTerm', function(){
-    return new Promise(resolve => {
-      const term = this.term;
-      if (isPresent(term)) {
-        term.get('children').then(terms => {
-          resolve(terms.filterBy('isNew', false).filterBy('isDeleted', false).sortBy('title'));
-        });
+
+  actions: {
+    async changeTermTitle(){
+      this.term.set('title', this.title);
+      return this.term.save();
+    },
+    revertTermTitleChanges(){
+      this.set('title', this.term.title);
+    },
+    async changeTermDescription(){
+      this.term.set('description', this.description);
+      return this.term.save();
+    },
+    revertTermDescriptionChanges(){
+      this.set('description', this.term.description);
+    },
+    async createTerm() {
+      this.send('addErrorDisplayFor', 'newTermTitle');
+      this.set('isSavingNewTerm', true);
+      try {
+        await this.validate();
+        if (this.validations.attrs.newTermTitle.isValid) {
+          this.send('removeErrorDisplayFor', 'newTermTitle');
+          let title = this.newTermTitle;
+          let term = this.store.createRecord('term', {
+            title,
+            parent: this.term,
+            vocabulary: this.vocabulary,
+            active: true,
+          });
+
+          const newTerm = await term.save();
+          this.set('newTermTitle', null);
+          this.set('newTerm', newTerm);
+          return true;
+        }
+      } finally {
+        this.set('isSavingNewTerm', false);
       }
-    });
-  }),
-  allParents: computed('term.allParents.[]', function(){
-    return new Promise(resolve => {
-      const term = this.term;
-      if (isPresent(term)) {
-        term.get('allParents').then(allParents => {
-          resolve(allParents);
-        });
-      }
-    });
-  }),
+    },
+    async deleteTerm() {
+      const parent = await this.term.parent;
+      let goTo = isEmpty(parent)?null:parent.id;
+      this.manageTerm(goTo);
+      this.term.deleteRecord();
+      await this.term.save();
+      this.flashMessages.success('general.successfullyRemovedTerm');
+    },
+    clearVocabAndTerm(){
+      this.manageVocabulary(null);
+      this.manageTerm(null);
+    }
+  },
   keyUp(event) {
     const keyCode = event.keyCode;
     const target = event.target;
@@ -93,73 +131,9 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
       this.send('createTerm');
     }
   },
-
   changeIsActive: task(function * (isActive){
-    const term = this.term;
-    term.set('active', isActive);
-    yield term.save();
-    this.set('isActive', term.get('active'));
+    this.term.set('active', isActive);
+    yield this.term.save();
+    this.set('isActive', this.term.active);
   }).drop(),
-
-  actions: {
-    changeTermTitle(){
-      const term = this.term;
-      const title = this.title;
-      term.set('title', title);
-      return term.save();
-    },
-    revertTermTitleChanges(){
-      const term = this.term;
-      this.set('title', term.get('title'));
-    },
-    changeTermDescription(){
-      const term = this.term;
-      const description = this.description;
-      term.set('description', description);
-      return term.save();
-    },
-    revertTermDescriptionChanges(){
-      const term = this.term;
-      this.set('description', term.get('description'));
-    },
-    createTerm(){
-      this.send('addErrorDisplayFor', 'newTermTitle');
-      this.set('isSavingNewTerm', true);
-      this.validate().then(({validations}) => {
-        if (validations.get('isValid')) {
-          this.send('removeErrorDisplayFor', 'newTermTitle');
-          let title = this.newTermTitle;
-          const parent = this.term;
-          const vocabulary = this.vocabulary;
-          const store = this.store;
-          let term = store.createRecord('term', {title, parent, vocabulary, active: true});
-          return term.save().then((newTerm) => {
-            this.set('newTermTitle', null);
-            this.set('newTerm', newTerm);
-          });
-        }
-      }).finally(() => {
-        this.set('isSavingNewTerm', false);
-      });
-    },
-    deleteTerm(){
-      const term = this.term;
-      const manageTerm = this.manageTerm;
-      term.get('parent').then(parent => {
-        let goTo = isEmpty(parent)?null:parent.get('id');
-        manageTerm(goTo);
-        term.deleteRecord();
-        term.save().then(() => {
-          this.flashMessages.success('general.successfullyRemovedTerm');
-        });
-      });
-
-    },
-    clearVocabAndTerm(){
-      const manageVocabulary = this.manageVocabulary;
-      const manageTerm = this.manageTerm;
-      manageVocabulary(null);
-      manageTerm(null);
-    }
-  }
 });

--- a/app/templates/components/school-vocabulary-manager.hbs
+++ b/app/templates/components/school-vocabulary-manager.hbs
@@ -38,7 +38,7 @@
     </div>
   {{/if}}
   {{#if canCreate}}
-    <div class="form">
+    <div class="form" data-test-new-term-form>
       <input
         type="text"
         value={{newTermTitle}}
@@ -56,7 +56,7 @@
       {{#if
         (and (v-get this "newTermTitle" "isInvalid") (is-in showErrorsFor "newTermTitle"))
       }}
-        <span class="validation-error-message">{{v-get this "newTermTitle" "message"}}</span>
+        <span class="validation-error-message" data-test-error-message>{{v-get this "newTermTitle" "message"}}</span>
       {{/if}}
     </div>
   {{/if}}

--- a/app/templates/components/school-vocabulary-manager.hbs
+++ b/app/templates/components/school-vocabulary-manager.hbs
@@ -7,21 +7,28 @@
   <h4>{{t "general.title"}}: </h4>
   {{#if canUpdate}}
     {{#editable-field
-      value=(if title title (t "general.clickToEdit"))
+      value=(if vocabularyTitle vocabularyTitle (t "general.clickToEdit"))
       save=(action "changeVocabularyTitle")
       close=(action "revertVocabularyTitleChanges")
+      isSaveDisabled=(and (v-get this "vocabularyTitle" "isInvalid") (is-in showErrorsFor "vocabularyTitle"))
       saveOnEnter=true
       closeOnEscape=true
       as |isSaving|
     }}
       <input
-        value={{title}}
-        oninput={{action (mut title) value="target.value"}}
+        value={{vocabularyTitle}}
+        oninput={{action (mut vocabularyTitle) value="target.value"}}
         disabled={{isSaving}}
+        onkeyup={{action "addErrorDisplayFor" "vocabularyTitle"}}
       >
     {{/editable-field}}
+    {{#if
+      (and (v-get this "vocabularyTitle" "isInvalid") (is-in showErrorsFor "vocabularyTitle"))
+    }}
+      <span class="validation-error-message" data-test-title-error-message>{{v-get this "vocabularyTitle" "message"}}</span>
+    {{/if}}
   {{else}}
-    {{title}}
+    {{vocabularyTitle}}
   {{/if}}
 </div>
 

--- a/app/templates/components/school-vocabulary-manager.hbs
+++ b/app/templates/components/school-vocabulary-manager.hbs
@@ -1,10 +1,9 @@
-{{! template-lint-disable attribute-indentation }}
-<div class="breadcrumbs">
-  <span {{action manageVocabulary null}}>{{t "general.allVocabularies"}}</span>
-  <span>{{vocabulary.title}}</span>
+<div class="breadcrumbs" data-test-breadcrumbs>
+  <span {{action manageVocabulary null}} data-test-all>{{t "general.allVocabularies"}}</span>
+  <span data-test-vocabulary>{{vocabulary.title}}</span>
 </div><br>
 
-<div class="school-vocabulary-manager-title">
+<div class="school-vocabulary-manager-title" data-test-title>
   <h4>{{t "general.title"}}: </h4>
   {{#if canUpdate}}
     {{#editable-field
@@ -29,7 +28,7 @@
 <h5>{{t "general.terms"}}:</h5>
 
 
-<div class="terms">
+<div class="terms" data-test-terms>
   {{#if newTerm}}
     <div class="saved-result">
       <span class="clickable link" {{action manageTerm newTerm.id}}>
@@ -62,9 +61,9 @@
     </div>
   {{/if}}
   {{#if (is-fulfilled sortedTerms)}}
-    <ul>
+    <ul data-test-term-list>
       {{#each (await sortedTerms) as |term|}}
-        <li {{action manageTerm term.id}}>
+        <li {{action manageTerm term.id}} data-test-term>
           {{term.title}}{{#if (not term.active)}} <em>({{t "general.inactive"}})</em>{{/if}}
         </li>
       {{/each}}

--- a/app/templates/components/school-vocabulary-term-manager.hbs
+++ b/app/templates/components/school-vocabulary-term-manager.hbs
@@ -89,7 +89,7 @@
     </div>
   {{/if}}
   {{#if canCreate}}
-    <div>
+    <div data-test-new-term-form>
       <input
         type="text"
         value={{newTermTitle}}
@@ -106,7 +106,7 @@
       {{#if
         (and (v-get this "newTermTitle" "isInvalid") (is-in showErrorsFor "newTermTitle"))
       }}
-        <span class="validation-error-message">{{v-get this "newTermTitle" "message"}}</span>
+        <span class="validation-error-message" data-test-error-message>{{v-get this "newTermTitle" "message"}}</span>
       {{/if}}
     </div>
   {{/if}}

--- a/app/templates/components/school-vocabulary-term-manager.hbs
+++ b/app/templates/components/school-vocabulary-term-manager.hbs
@@ -1,18 +1,18 @@
 {{! template-lint-disable attribute-indentation }}
 {{#if (is-fulfilled allParents)}}
-  <div class="breadcrumbs">
-    <span {{action "clearVocabAndTerm"}}>{{t "general.allVocabularies"}}</span>
-    <span {{action manageTerm null}}>{{vocabulary.title}}</span>
+  <div class="breadcrumbs" data-test-breadcrumbs>
+    <span {{action "clearVocabAndTerm"}} data-test-all>{{t "general.allVocabularies"}}</span>
+    <span {{action manageTerm null}} data-test-vocabulary>{{vocabulary.title}}</span>
     {{#each (await allParents) as |parent|}}
-      <span {{action manageTerm parent.id}}>{{parent.title}}</span>
+      <span {{action manageTerm parent.id}} data-test-term>{{parent.title}}</span>
     {{/each}}
-    <span>{{term.title}}</span>
+    <span data-test-term>{{term.title}}</span>
   </div>
 {{/if}}
 
 {{#if term}}
   <div class="school-vocabulary-term-manager-properties">
-    <div class="block term-title">
+    <div class="block term-title" data-test-title>
       <h4>{{t "general.title"}}:</h4>
       {{#if canUpdate}}
         {{#editable-field
@@ -36,7 +36,7 @@
         {{fa-icon "trash" class="clickable remove" click=(action "deleteTerm")}}
       {{/if}}
     </div>
-    <div class="block is-active">
+    <div class="block is-active" data-test-is-active>
       <label>{{t "general.active"}}:</label>
       {{#if canUpdate}}
         {{toggle-yesno
@@ -52,7 +52,7 @@
         {{/if}}
       {{/if}}
     </div>
-    <div class="block term-description">
+    <div class="block term-description" data-test-description>
       <label>{{t "general.description"}}:</label>
       {{#if canUpdate}}
         {{#editable-field
@@ -79,7 +79,7 @@
 
 <h5>{{t "general.subTerms"}}:</h5>
 
-<div class="terms">
+<div class="terms" data-test-sub-terms>
   {{#if newTerm}}
     <div class="saved-result">
       <span class="clickable link" {{action manageTerm newTerm.id}}>
@@ -112,9 +112,9 @@
   {{/if}}
 
   {{#if (is-fulfilled sortedTerms)}}
-    <ul>
+    <ul data-test-term-list>
       {{#each (await sortedTerms) as |term|}}
-        <li {{action manageTerm term.id}}>
+        <li {{action manageTerm term.id}} data-test-term>
           {{term.title}}{{#if (not term.active)}} <em>({{t "general.inactive"}})</em>{{/if}}
         </li>
       {{/each}}

--- a/app/templates/components/school-vocabulary-term-manager.hbs
+++ b/app/templates/components/school-vocabulary-term-manager.hbs
@@ -1,4 +1,3 @@
-{{! template-lint-disable attribute-indentation }}
 {{#if (is-fulfilled allParents)}}
   <div class="breadcrumbs" data-test-breadcrumbs>
     <span {{action "clearVocabAndTerm"}} data-test-all>{{t "general.allVocabularies"}}</span>
@@ -16,7 +15,7 @@
       <h4>{{t "general.title"}}:</h4>
       {{#if canUpdate}}
         {{#editable-field
-          value=(if title title (t "general.clickToEdit"))
+          value=(if termTitle termTitle (t "general.clickToEdit"))
           save=(action "changeTermTitle")
           close=(action "revertTermTitleChanges")
           saveOnEnter=true
@@ -24,13 +23,18 @@
           as |isSaving|
         }}
           <input
-            value={{title}}
-            oninput={{action (mut title) value="target.value"}}
+            value={{termTitle}}
+            oninput={{action (mut termTitle) value="target.value"}}
             disabled={{isSaving}}
           >
         {{/editable-field}}
       {{else}}
-        {{title}}
+        {{termTitle}}
+      {{/if}}
+      {{#if
+        (and (v-get this "termTitle" "isInvalid") (is-in showErrorsFor "termTitle"))
+      }}
+        <span class="validation-error-message" data-test-title-error-message>{{v-get this "termTitle" "message"}}</span>
       {{/if}}
       {{#if (and canDelete (not term.hasChildren) (not term.hasAssociations))}}
         {{fa-icon "trash" class="clickable remove" click=(action "deleteTerm")}}

--- a/tests/integration/components/school-vocabulary-manager-test.js
+++ b/tests/integration/components/school-vocabulary-manager-test.js
@@ -1,17 +1,16 @@
 import EmberObject from '@ember/object';
-import RSVP from 'rsvp';
+import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, findAll } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-
-const { resolve } = RSVP;
+import { component } from 'ilios/tests/pages/components/school-vocabulary-manager';
 
 module('Integration | Component | school vocabulary manager', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    assert.expect(4);
+    assert.expect(6);
     let vocabulary = EmberObject.create({
       title: 'fake vocab',
       terms: resolve([
@@ -27,13 +26,11 @@ module('Integration | Component | school vocabulary manager', function(hooks) {
       manageTerm=(action nothing)
       manageVocabulary=(action nothing)
     }}`);
-
-    const all = '.breadcrumbs span:nth-of-type(1)';
-    const vocab = '.breadcrumbs span:nth-of-type(2)';
-
-    assert.dom(all).hasText('All Vocabularies');
-    assert.dom(vocab).hasText(vocabulary.title);
-    assert.dom('.terms ul li').hasText('first (inactive)');
-    assert.dom(findAll('.terms ul li')[1]).hasText('second');
+    assert.equal(component.title, `Title: ${vocabulary.title}`);
+    assert.equal(component.breadcrumbs.all, 'All Vocabularies');
+    assert.equal(component.breadcrumbs.vocabulary, vocabulary.title);
+    assert.equal(component.terms.list.length, 2);
+    assert.equal(component.terms.list[0].text, 'first (inactive)');
+    assert.equal(component.terms.list[1].text, 'second');
   });
 });

--- a/tests/pages/components/school-vocabulary-manager.js
+++ b/tests/pages/components/school-vocabulary-manager.js
@@ -1,12 +1,18 @@
 import {
+  clickable,
   create,
   collection,
+  isPresent,
+  fillable,
   text,
 } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-school-vocabulary-manager]',
   title: text('[data-test-title]'),
+  editTitle: clickable('[data-test-title] .clickable'),
+  changeTitle: fillable('[data-test-title] input'),
+  saveTitle: clickable('[data-test-title] .done'),
   breadcrumbs: {
     scope: '[data-test-breadcrumbs]',
     all: text('[data-test-all]'),
@@ -17,6 +23,13 @@ const definition = {
     list: collection('[data-test-term-list] [data-test-term]', {
       title: text(),
     }),
+    newTermForm: {
+      scope: '[data-test-new-term-form]',
+      setTitle: fillable('input'),
+      save: clickable('.save'),
+      hasError: isPresent('[data-test-error-message]'),
+      errorMessage: text('[data-test-error-message]'),
+    }
   },
 
 };

--- a/tests/pages/components/school-vocabulary-manager.js
+++ b/tests/pages/components/school-vocabulary-manager.js
@@ -13,6 +13,8 @@ const definition = {
   editTitle: clickable('[data-test-title] .clickable'),
   changeTitle: fillable('[data-test-title] input'),
   saveTitle: clickable('[data-test-title] .done'),
+  hasError: isPresent('[data-test-title-error-message]'),
+  errorMessage: text('[data-test-title-error-message]'),
   breadcrumbs: {
     scope: '[data-test-breadcrumbs]',
     all: text('[data-test-all]'),

--- a/tests/pages/components/school-vocabulary-manager.js
+++ b/tests/pages/components/school-vocabulary-manager.js
@@ -1,0 +1,25 @@
+import {
+  create,
+  collection,
+  text,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-school-vocabulary-manager]',
+  title: text('[data-test-title]'),
+  breadcrumbs: {
+    scope: '[data-test-breadcrumbs]',
+    all: text('[data-test-all]'),
+    vocabulary: text('[data-test-vocabulary]'),
+  },
+  terms: {
+    scope: '[data-test-terms]',
+    list: collection('[data-test-term-list] [data-test-term]', {
+      title: text(),
+    }),
+  },
+
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/school-vocabulary-term-manager.js
+++ b/tests/pages/components/school-vocabulary-term-manager.js
@@ -1,0 +1,50 @@
+import {
+  clickable,
+  create,
+  collection,
+  is,
+  isPresent,
+  fillable,
+  text,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-school-vocabulary-term-manager]',
+  title: text('[data-test-title]'),
+  editTitle: clickable('[data-test-title] .clickable'),
+  changeTitle: fillable('[data-test-title] input'),
+  saveTitle: clickable('[data-test-title] .done'),
+  hasError: isPresent('[data-test-title-error-message]'),
+  errorMessage: text('[data-test-title-error-message]'),
+  description: text('[data-test-description]'),
+  breadcrumbs: {
+    scope: '[data-test-breadcrumbs]',
+    all: text('[data-test-all]'),
+    vocabulary: text('[data-test-vocabulary]'),
+    terms: collection('[data-test-term]', {
+      title: text(),
+    }),
+  },
+  isActive: {
+    scope: '[data-test-is-active]',
+    active: is(':checked', 'input'),
+    toggle: clickable('[data-test-toggle-yesno]'),
+  },
+  subTerms: {
+    scope: '[data-test-sub-terms]',
+    list: collection('[data-test-term-list] [data-test-term]', {
+      title: text(),
+    }),
+    newTermForm: {
+      scope: '[data-test-new-term-form]',
+      setTitle: fillable('input'),
+      save: clickable('.save'),
+      hasError: isPresent('[data-test-error-message]'),
+      errorMessage: text('[data-test-error-message]'),
+    }
+  },
+
+};
+
+export default definition;
+export const component = create(definition);


### PR DESCRIPTION
Fixes #4296 

Includes tests for things we wern't testing before as well as a refactor of two components. Left it in (hopefully parseable) individual commits.