### PR TITLE
Improve our error reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - CC_TEST_REPORTER_ID=8c510ad3aa4b1a2a3d504dfdbcc5605e7966c019dc1e9b68a815de50b946ebc6
     - COVERAGE=true
     - MOZ_HEADLESS=1
+    - SENTRY_ORG=ilios
+    - SENTRY_PROJECT=frontend
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
@@ -49,4 +51,9 @@ jobs:
     - stage: deploy production
       if: tag IS present
       env: COVERAGE=false
-      script: node_modules/.bin/ember deploy production --activate
+      script:
+       - node_modules/.bin/ember deploy production --activate
+       - sentry-cli releases new $TRAVIS_TAG
+       - sentry-cli releases set-commits --auto $TRAVIS_TAG
+       - sentry-cli releases files $TRAVIS_TAG upload-sourcemaps dist/
+       - sentry-cli releases finalize $TRAVIS_TAG

--- a/app/services/raven.js
+++ b/app/services/raven.js
@@ -1,5 +1,7 @@
 import RavenService from 'ember-cli-sentry/services/raven';
 import { inject as service } from '@ember/service';
+import config from '../config/environment';
+import { versionRegExp } from 'ember-cli-app-version/utils/regexp';
 
 export default RavenService.extend({
   iliosConfig: service(),
@@ -8,7 +10,9 @@ export default RavenService.extend({
    * Override default service to add configuration check
    * before attempting to capture anything.
    */
-  ignoreError(){
+  ignoreError() {
     return !this.iliosConfig.errorCaptureEnabled;
   },
+
+  release: config.APP.version.match(versionRegExp),
 });


### PR DESCRIPTION
The default of VERSION-tag isn't working for our sentry github
integration so instead this just sends the tag name.  I've also
configured travis to upload source maps and commit data to sentry to
better attach it to the release itself.  Since our production sourcemaps
are often behind an SSO firewall this ensures the sourcemap is attached
to the error.