### PR TITLE
replace regexp pattern matching with simple in-string search.

### DIFF
--- a/app/components/learnergroup-cohort-user-manager.js
+++ b/app/components/learnergroup-cohort-user-manager.js
@@ -4,7 +4,6 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import { task, timeout } from 'ember-concurrency';
-import escapeRegExp from 'ilios-common/utils/escape-reg-exp';
 
 export default Component.extend({
   currentUser: service(),
@@ -30,21 +29,17 @@ export default Component.extend({
   filter: '',
   filteredUsers: computed('filter', 'users.[]', function() {
     let users = this.users;
-    const filter = escapeRegExp(this.filter);
+    const filter = this.filter.toLowerCase();
 
     if (isEmpty(filter)){
       return users;
     }
-    const exp = new RegExp(filter, 'gi');
 
-    let filteredUsers = users.filter((user) => {
-      return user.get('firstName').match(exp) ||
-        user.get('lastName').match(exp) ||
-        user.get('email').match(exp);
+    return users.filter((user) => {
+      return user.get('firstName').toLowerCase().includes(filter) ||
+        user.get('lastName').toLowerCase().includes(filter) ||
+        user.get('email').toLowerCase().includes(filter);
     });
-
-    return filteredUsers;
-
   }),
 
   addSingleUser: task(function * (user) {

--- a/app/components/learnergroup-user-manager.js
+++ b/app/components/learnergroup-user-manager.js
@@ -4,7 +4,6 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import { task, timeout } from 'ember-concurrency';
-import escapeRegExp from 'ilios-common/utils/escape-reg-exp';
 
 export default Component.extend({
   currentUser: service(),
@@ -33,17 +32,16 @@ export default Component.extend({
   filter: '',
   filteredUsers: computed('filter', 'users.[]', function() {
     let users = this.users?this.users:[];
-    const filter = escapeRegExp(this.filter);
+    const filter = this.filter.toLowerCase();
 
     if (isEmpty(filter)){
       return users;
     }
-    const exp = new RegExp(filter, 'gi');
 
     return users.filter((user) => {
-      return user.get('firstName').match(exp) ||
-        user.get('lastName').match(exp) ||
-        user.get('email').match(exp);
+      return user.get('firstName').toLowerCase().includes(filter) ||
+        user.get('lastName').toLowerCase().includes(filter) ||
+        user.get('email').toLowerCase().includes(filter);
     });
   }),
 

--- a/app/components/my-materials.js
+++ b/app/components/my-materials.js
@@ -3,7 +3,6 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import SortableTable from 'ilios-common/mixins/sortable-table';
-import escapeRegExp from '../utils/escape-reg-exp';
 
 export default Component.extend(SortableTable, {
   classNames: ['my-materials'],
@@ -17,15 +16,13 @@ export default Component.extend(SortableTable, {
       materials = materials.filterBy('course', courseIdFilter);
     }
     if (isPresent(filter)) {
-      let val = escapeRegExp(filter);
-      const exp = new RegExp(val, 'gi');
 
       materials = materials.filter(material => {
         let searchString = material.title + ' ' + material.courseTitle + ' ' + material.sessionTitle + ' ';
         if (isPresent(material.instructors)) {
           searchString += material.instructors.join(' ');
         }
-        return searchString.match(exp);
+        return searchString.toLowerCase().includes(filter.toLowerCase());
       });
     }
 

--- a/app/controllers/assign-students.js
+++ b/app/controllers/assign-students.js
@@ -3,7 +3,6 @@ import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import RSVP from 'rsvp';
 import { isBlank, isEmpty, isPresent } from '@ember/utils';
-import escapeRegExp from 'ilios-common/utils/escape-reg-exp';
 const { gt } = computed;
 const { Promise } = RSVP;
 
@@ -37,11 +36,10 @@ export default Controller.extend({
           enabled: true
         }
       }).then(students => {
-        const filter = escapeRegExp(this.filter);
+        const filter = this.filter;
         if (!isBlank(filter)) {
-          const exp = new RegExp(filter, 'gi');
           students = students.filter(user => {
-            return (isEmpty(user.get('fullName')) || user.get('fullName').match(exp));
+            return (isEmpty(user.get('fullName')) || user.get('fullName').toLowerCase().includes(filter.toLowerCase()));
           });
         }
         students = students.sortBy('lastName', 'firstName');

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -6,7 +6,6 @@ import Controller from '@ember/controller';
 import { isPresent, isEmpty, isBlank } from '@ember/utils';
 import moment from 'moment';
 import { task, timeout } from 'ember-concurrency';
-import escapeRegExp from '../utils/escape-reg-exp';
 
 const { gt, sort } = computed;
 
@@ -77,17 +76,17 @@ export default Controller.extend({
     async function(){
       const titleFilter = this.titleFilter;
       const title = isBlank(titleFilter) ? '' : titleFilter ;
-      const cleanTitle = escapeRegExp(title);
       let filterMyCourses = this.userCoursesOnly;
-      let exp = new RegExp(cleanTitle, 'gi');
       const courses = await this.courses;
       let filteredCourses;
-      if (isEmpty(cleanTitle)) {
+      if (isEmpty(title)) {
         filteredCourses = courses.sortBy('title');
       } else {
         filteredCourses = courses.filter(course => {
-          return (isPresent(course.get('title')) && course.get('title').match(exp)) ||
-            (isPresent(course.get('externalId')) && course.get('externalId').match(exp));
+          return (isPresent(course.get('title')) && course.get('title').toLowerCase().includes(title.toLowerCase())) ||
+            (isPresent(course.get('externalId'))
+              && course.get('externalId').toLowerCase().includes(title.toLowerCase())
+            );
         }).sortBy('title');
       }
       if (filterMyCourses) {

--- a/app/controllers/instructor-groups.js
+++ b/app/controllers/instructor-groups.js
@@ -5,7 +5,6 @@ import Controller from '@ember/controller';
 import { resolve } from 'rsvp';
 import { isPresent, isEmpty, isBlank } from '@ember/utils';
 import { task, timeout } from 'ember-concurrency';
-import escapeRegExp from '../utils/escape-reg-exp';
 
 const { gt } = computed;
 
@@ -48,15 +47,14 @@ export default Controller.extend({
   filteredInstructorGroups: computed('titleFilter', 'instructorGroups.[]', async function(){
     const titleFilter = this.titleFilter;
     const title = isBlank(titleFilter) ? '' : titleFilter ;
-    const cleanTitle = escapeRegExp(title);
-    let exp = new RegExp(cleanTitle, 'gi');
     const instructorGroups = await this.instructorGroups;
     let filteredInstructorGroups;
     if(isEmpty(title)){
       filteredInstructorGroups = instructorGroups;
     } else {
       filteredInstructorGroups = instructorGroups.filter(instructorGroup => {
-        return isPresent(instructorGroup.get('title')) && instructorGroup.get('title').match(exp);
+        return isPresent(instructorGroup.get('title'))
+          && instructorGroup.get('title').toLowerCase().includes(title.toLowerCase());
       });
     }
     return filteredInstructorGroups.sortBy('title');

--- a/app/controllers/learner-groups.js
+++ b/app/controllers/learner-groups.js
@@ -4,7 +4,6 @@ import { computed } from '@ember/object';
 import Controller from '@ember/controller';
 import { isBlank, isEmpty, isPresent } from '@ember/utils';
 import { task, timeout } from 'ember-concurrency';
-import escapeRegExp from '../utils/escape-reg-exp';
 import cloneLearnerGroup from '../utils/clone-learner-group';
 
 export default Controller.extend({
@@ -89,15 +88,14 @@ export default Controller.extend({
   filteredLearnerGroups: computed('titleFilter', 'learnerGroups.[]', async function(){
     const titleFilter = this.titleFilter;
     const title = isBlank(titleFilter) ? '' : titleFilter;
-    const cleanTitle = escapeRegExp(title);
     const learnerGroups = await this.learnerGroups;
-    const exp = new RegExp(cleanTitle, 'gi');
     let filteredGroups;
-    if (isEmpty(cleanTitle)) {
+    if (isEmpty(title)) {
       filteredGroups = learnerGroups.sortBy('title');
     } else {
       filteredGroups = learnerGroups.filter(learnerGroup => {
-        return isPresent(learnerGroup.get('title')) && learnerGroup.get('title').match(exp);
+        return isPresent(learnerGroup.get('title'))
+          && learnerGroup.get('title').toLowerCase().includes(title.toLowerCase());
       });
     }
     return filteredGroups.sortBy('title');

--- a/app/controllers/pending-user-updates.js
+++ b/app/controllers/pending-user-updates.js
@@ -5,7 +5,7 @@ import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import RSVP from 'rsvp';
 import { isEmpty, isPresent } from '@ember/utils';
-import escapeRegExp from 'ilios-common/utils/escape-reg-exp';
+
 const { sort, gt } = computed;
 const { all, Promise } = RSVP;
 
@@ -55,13 +55,13 @@ export default Controller.extend({
     const limit = this.limit;
     const offset = this.offset;
     const end = limit + offset;
-    const exp = new RegExp(escapeRegExp(this.filter), 'gi');
 
     return new Promise(resolve => {
       this.allUpdates.then(allUpdates => {
         let sortedUpdates = allUpdates.sortBy('user.lastName', 'user.firstName').slice(offset, end).filter(update => {
           return !this.deletedUpdates.includes(update) &&
-            (isEmpty(update.get('user.fullName')) || update.get('user.fullName').match(exp));
+            (isEmpty(update.get('user.fullName'))
+              || update.get('user.fullName').toLowerCase().includes(this.filter.toLowerCase()));
         });
         resolve(sortedUpdates);
       });

--- a/app/controllers/programs.js
+++ b/app/controllers/programs.js
@@ -5,7 +5,6 @@ import { computed } from '@ember/object';
 import { isPresent, isEmpty, isBlank } from '@ember/utils';
 import { resolve } from 'rsvp';
 import { task, timeout } from 'ember-concurrency';
-import escapeRegExp from '../utils/escape-reg-exp';
 
 const { gt } = computed;
 
@@ -33,16 +32,14 @@ export default Controller.extend({
   filteredPrograms: computed('titleFilter', 'programs.[]', async function() {
     const titleFilter = this.titleFilter;
     const title = isBlank(titleFilter) ? '' : titleFilter ;
-    const cleanTitle = escapeRegExp(title);
-    let exp = new RegExp(cleanTitle, 'gi');
 
     const programs = await this.programs;
     let filteredPrograms;
-    if(isEmpty(cleanTitle)){
+    if(isEmpty(title)){
       filteredPrograms = programs;
     } else {
       filteredPrograms = programs.filter(program => {
-        return isPresent(program.get('title')) && program.get('title').match(exp);
+        return isPresent(program.get('title')) && program.get('title').toLowerCase().includes(title.toLowerCase());
       });
     }
     return filteredPrograms.sortBy('title');


### PR DESCRIPTION
fixes #4351 

affects:

- user search in admin interface
- user search in "pending updates" page of admin interface
- user search in "unassigned students page of admin interface
- search in courses lists page
- search in instructor groups list page
- search in learner groups list page
- my materials search
- user search in learner groups assignment page