### PR TITLE
Add progress bar for builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11154,6 +11154,48 @@
         }
       }
     },
+    "ember-cli-progress": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ember-cli-progress/-/ember-cli-progress-1.0.10.tgz",
+      "integrity": "sha512-YfEvn85uNcFRQM2S8MfIMHoPAmeAmcTf3qk6Fj84hLSiDZ5SWyeRz/Mhxd29/A7nclGWel2R3pJptAUAZK/EHQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "heimdalljs": "^0.2",
+        "ora": "^3.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "ora": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-3.1.0.tgz",
+          "integrity": "sha512-vRBPaNCclUi8pUxRF/G8+5qEQkc6EgzKK1G2ZNJUIGu088Un5qIxFXeDgymvPRM9nmrcUOGzQgS1Vmtz+NtlMw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-spinners": "^1.3.1",
+            "log-symbols": "^2.2.0",
+            "strip-ansi": "^5.0.0",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
+      }
+    },
     "ember-cli-sass": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-8.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-new-version": "^1.3.0",
     "ember-cli-postcss": "^4.2.0",
+    "ember-cli-progress": "^1.0.10",
     "ember-cli-sentry": "^4.0.0",
     "ember-cli-server-variables": "2.2.0",
     "ember-cli-sri": "^2.1.1",


### PR DESCRIPTION
Makes it a bit easier to tell work is being done when the app is starting. Check it out by running `npm start`.