### PR TITLE
Restore mirage assets

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -112,7 +112,6 @@ module.exports = function (environment) {
     //Remove mirage in developemnt, we only use it in testing
     ENV['ember-cli-mirage'] = {
       enabled: false,
-      excludeFilesFromBuild: true
     };
 
     ENV.IliosFeatures.programYearVisualizations = true;


### PR DESCRIPTION
We need these when using the browser to visit /tests

Reverts a change made in #4375