### PR TITLE
Remove deprecated router events

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -5,17 +5,20 @@ import config from './config/environment';
 
 const Router = EmberRouter.extend({
   iliosMetrics: service(),
+  router: service(),
 
   location: config.locationType,
   rootURL: config.rootURL,
 
-  didTransition() {
+  init() {
     this._super(...arguments);
-    const iliosMetrics = this.iliosMetrics;
-    const page = this.url;
-    const title = this.getWithDefault('currentRouteName', 'unknown');
 
-    iliosMetrics.track(page, title);
+    this.on('routeDidChange', () => {
+      const page = this.router.currentURL;
+      const title = this.router.currentRouteName || 'unknown';
+
+      this.iliosMetrics.track(page, title);
+    });
   },
 });
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -12,6 +12,15 @@ export default Route.extend(ApplicationRouteMixin, {
   currentUser: service(),
   session: service(),
 
+  init() {
+    this._super(...arguments);
+    this.on('routeWillChange', () => {
+      let controller = this.controllerFor('application');
+      controller.set('errors', []);
+      controller.set('showErrorDisplay', false);
+    });
+  },
+
   //Override the default session invalidator so we can do auth stuff
   sessionInvalidated() {
     if (!Ember.testing) {
@@ -78,11 +87,6 @@ export default Route.extend(ApplicationRouteMixin, {
   },
 
   actions: {
-    willTransition() {
-      let controller = this.controllerFor('application');
-      controller.set('errors', []);
-      controller.set('showErrorDisplay', false);
-    },
     loading(transition) {
       let controller = this.controllerFor('application');
       controller.set('currentlyLoading', true);

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -8,7 +8,7 @@ window.deprecationWorkflow.config = {
     { handler: "silence", matchId: "ember-routing.route-router"},
     { handler: "silence", matchId: "ember-runtime.deprecate-copy-copyable"},
     { handler: "silence", matchId: "ember-polyfills.deprecate-merge"},
-    { handler: "silence", matchId: "deprecate-router-events"},
+    { handler: "silence", matchId: "deprecate-router-events"}, // requires https://github.com/ember-a11y/ember-a11y/issues/73
     { handler: "silence", matchId: "remove-handler-infos"},
   ]
 };


### PR DESCRIPTION
These will be removed in Ember 4.0.0 and this is the recommended
transition plan.