### PR TITLE
Fix sentry install in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
     - stage: send release to sentry
       if: tag IS present
       env: COVERAGE=false
-      after_install: npm install -g @sentry/cli
+      before_script: npm install -g @sentry/cli
       script:
        - sentry-cli releases new $TRAVIS_TAG
        - sentry-cli releases set-commits --auto $TRAVIS_TAG


### PR DESCRIPTION
after_install doesn't exist, before script does though.