### PR TITLE
Fix version in error reports

### DIFF
--- a/app/services/raven.js
+++ b/app/services/raven.js
@@ -14,5 +14,5 @@ export default RavenService.extend({
     return !this.iliosConfig.errorCaptureEnabled;
   },
 
-  release: config.APP.version.match(versionRegExp),
+  release: config.APP.version.match(versionRegExp)[0],
 });


### PR DESCRIPTION
We need to return a string here, but match() is an array.