### PR TITLE
dropdown selected value display bug

### DIFF
--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -64,23 +64,25 @@ const PrepositionObject = EmberObject.extend({
     }
 
     return null;
-  }),
+  })
 });
 
 export default Component.extend(Validations, ValidationErrorDisplay, {
-  store: service(),
-  intl: service(),
   currentUser: service(),
   flashMessages: service(),
-  classNames: ['new-myreport', 'mesh-manager'],
-  title: null,
-  selectedSchool: null,
-  schoolChanged: false,
-  currentSubject: 'course',
+  intl: service(),
+  store: service(),
+
+  classNames: ['mesh-manager', 'new-myreport'],
+
   currentPrepositionalObject: null,
   currentPrepositionalObjectId: null,
+  currentSubject: 'course',
   isSaving: false,
+  selectedSchool: null,
   selectedYear: null,
+  schoolChanged: false,
+  title: null,
 
   subjectList: computed('intl.locale', function(){
     let list = [
@@ -349,25 +351,31 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
       this.set('currentPrepositionalObject', null);
       this.set('currentPrepositionalObjectId', null);
     },
+
     changePrepositionalObject(object){
       this.set('currentPrepositionalObject', object);
       this.set('currentPrepositionalObjectId', null);
       this.resetCurrentPrepositionalObjectId.perform();
     },
+
     changeSelectedYear(year){
       this.set('selectedYear', year);
       this.set('currentPrepositionalObjectId', null);
       this.resetCurrentPrepositionalObjectId.perform();
     },
+
     changePrepositionalObjectId(id){
       this.set('currentPrepositionalObjectId', id);
     },
+
     chooseInstructor(user){
       this.set('currentPrepositionalObjectId', user.get('id'));
     },
+
     chooseMeshTerm(term){
       this.set('currentPrepositionalObjectId', term.get('id'));
     },
+
     closeEditor(){
       this.close();
     }

--- a/app/templates/components/new-myreport.hbs
+++ b/app/templates/components/new-myreport.hbs
@@ -74,17 +74,19 @@
   {{#if currentPrepositionalObject class="crossFade"}}
     {{#if (contains currentPrepositionalObject (w "course session"))}}
       <select
-        onchange={{action "changeSelectedYear" value="target.value"}}
         data-test-report-year-filter
-      >
-        <option value="" selected={{is-empty selectedYear}}>{{t "general.allAcademicYears"}}</option>
+        onchange={{action "changeSelectedYear" value="target.value"}}>
+        <option value="" selected={{is-empty selectedYear}}>
+          {{t "general.allAcademicYears"}}
+        </option>
         {{#each (sort-by "academicYearTitle:desc" (await allAcademicYears)) as |year|}}
-          <option value={{year.id}} selected={{is-equal year selectedYear}}>
+          <option value={{year.id}} selected={{is-equal year.id selectedYear}}>
             {{year.academicYearTitle}}
           </option>
         {{/each}}
       </select>
     {{/if}}
+
     <p>
       <label>{{t "general.whichIs"}}</label>
       {{#if (is-equal currentPrepositionalObject "instructor")}}

--- a/app/templates/components/new-myreport.hbs
+++ b/app/templates/components/new-myreport.hbs
@@ -71,16 +71,18 @@
       {{/each}}
     </select>
   </p>
-  {{#if currentPrepositionalObject class="crossFade"}}
-    {{#if (contains currentPrepositionalObject (w "course session"))}}
+  {{#if this.currentPrepositionalObject class="crossFade"}}
+    {{#if (contains this.currentPrepositionalObject (w "course session"))}}
       <select
         data-test-report-year-filter
         onchange={{action "changeSelectedYear" value="target.value"}}>
-        <option value="" selected={{is-empty selectedYear}}>
+        <option selected={{is-empty this.selectedYear}} value="">
           {{t "general.allAcademicYears"}}
         </option>
-        {{#each (sort-by "academicYearTitle:desc" (await allAcademicYears)) as |year|}}
-          <option value={{year.id}} selected={{is-equal year.id selectedYear}}>
+        {{#each (sort-by "academicYearTitle:desc" (await this.allAcademicYears)) as |year|}}
+          <option
+            selected={{is-equal year.id this.selectedYear}}
+            value={{year.id}}>
             {{year.academicYearTitle}}
           </option>
         {{/each}}


### PR DESCRIPTION
**Summary:**
An `option` element (seen below) wasn't registering as the selected value for the dropdown because the `is-equal` helper was comparing `year` object to `selectedYear` property. Should be `year.id`.

Fixes https://github.com/ilios/frontend/issues/4403