### PR TITLE
course-materials component query param flow update

### DIFF
--- a/app/routes/course-materials.js
+++ b/app/routes/course-materials.js
@@ -2,5 +2,4 @@ import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import CourseMaterialsRouteMixin from 'ilios-common/mixins/course-materials-route';
 
-export default Route.extend(AuthenticatedRouteMixin, CourseMaterialsRouteMixin, {
-});
+export default Route.extend(AuthenticatedRouteMixin, CourseMaterialsRouteMixin);

--- a/app/templates/course-materials.hbs
+++ b/app/templates/course-materials.hbs
@@ -1,5 +1,12 @@
 <div class="backtolink">
   {{#link-to "course" model}}{{t "general.backToCourse"}}{{/link-to}}
 </div>
+
 {{course-summary-header course=model}}
-{{course-materials course=model sortBy=sortBy setSortBy=(action (mut sortBy))}}
+
+{{course-materials
+  course=model
+  clmSortBy=clmSortBy
+  slmSortBy=slmSortBy
+  onClmSort=(action (mut clmSortBy))
+  onSlmSort=(action (mut slmSortBy))}}

--- a/app/templates/course-materials.hbs
+++ b/app/templates/course-materials.hbs
@@ -6,7 +6,7 @@
 
 {{course-materials
   course=model
-  clmSortBy=clmSortBy
-  slmSortBy=slmSortBy
-  onClmSort=(action (mut clmSortBy))
-  onSlmSort=(action (mut slmSortBy))}}
+  courseSort=courseSort
+  sessionSort=sessionSort
+  onCourseSort=(action (mut courseSort))
+  onSessionSort=(action (mut sessionSort))}}


### PR DESCRIPTION
**Summary:**
Since query params are used for session learning materials sorting, we need to update the query params to handle course learning materials as well.

Accompanies https://github.com/ilios/common/pull/596
Fixes https://github.com/ilios/frontend/issues/4402