### PR TITLE
added collapsed-objectives-program-years component

### DIFF
--- a/app/components/collapsed-objectives-program-years.js
+++ b/app/components/collapsed-objectives-program-years.js
@@ -1,0 +1,31 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { all } from 'rsvp';
+
+export default Component.extend({
+  classNames: ['collapsed-objectives-program-years'],
+  tagName: 'section',
+
+  subject: null,
+  expand() {},
+
+  objectives: computed('subject.objectives.[]', async function() {
+    return await this.subject.objectives;
+  }),
+
+  objectivesWithCompentency: computed('objectives.[]', async function() {
+    const objectives = await this.objectives;
+    const promises = objectives.mapBy('competency');
+    const competencyArray = await all(promises);
+    return competencyArray.filter((competency) => !!competency);
+  }),
+
+  objectivesWithMesh: computed('objectives.[]', async function() {
+    const objectives = await this.objectives;
+    const promises = objectives.mapBy('meshDescriptors');
+    const meshDescriptorsArray = await all(promises);
+    return meshDescriptorsArray.filter((meshDescriptors) => {
+      return meshDescriptors ? meshDescriptors.length > 0 : false;
+    });
+  })
+});

--- a/app/styles/components.scss
+++ b/app/styles/components.scss
@@ -3,6 +3,7 @@
 @import 'components/assign-students';
 @import 'components/bulk-new-users';
 @import 'components/breadcrumbs';
+@import 'components/collapsed-objectives-program-years';
 @import 'components/collapsed-stewards';
 @import 'components/connection-status';
 @import 'components/course-director-manager';

--- a/app/styles/components/collapsed-objectives-program-years.scss
+++ b/app/styles/components/collapsed-objectives-program-years.scss
@@ -1,0 +1,15 @@
+.collapsed-objectives-program-years {
+  @include collapsed-container($ilios-orange);
+
+  .title {
+    @include collapsed-container-title;
+  }
+
+  .content {
+    @include collapsed-container-content;
+
+    table {
+      @include collapsed-container-table;
+    }
+  }
+}

--- a/app/templates/components/collapsed-objectives-program-years.hbs
+++ b/app/templates/components/collapsed-objectives-program-years.hbs
@@ -1,0 +1,69 @@
+<div {{action @expand}} class="title" role="button">
+  {{t "general.objectives"}} ({{get (await this.objectives) "length"}})
+</div>
+
+{{#if (and
+  (is-fulfilled this.objectives)
+  (is-fulfilled this.objectivesWithMesh)
+  (is-fulfilled this.objectivesWithCompentency))}}
+  <div class="content">
+    <table>
+      <thead>
+        <tr>
+          <th class="text-left">{{t "general.summary"}}</th>
+          <th class="text-center">{{t "general.linkedCompetencies"}}</th>
+          <th class="text-center">{{t "general.meshTerms"}}</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            {{t "general.objectiveCount"
+              count=(get (await this.objectives) "length")}}
+          </td>
+          <td class="text-middle text-center" rowspan="3">
+            {{#if (eq
+              (get (await this.objectivesWithCompentency) "length")
+              (get (await this.objectives) "length"))}}
+              {{fa-icon "circle" class="yes"}}
+            {{else if (gte (get (await this.objectivesWithCompentency) "length") 1)}}
+              {{fa-icon "circle" class="maybe"}}
+            {{else}}
+              {{fa-icon "ban" class="no"}}
+            {{/if}}
+          </td>
+          <td class="text-middle text-center" rowspan="3">
+            {{#if (eq
+              (get (await this.objectivesWithMesh) "length")
+              (get (await this.objectives) "length"))}}
+              {{fa-icon "circle" class="yes"}}
+            {{else if (gte (get (await this.objectivesWithMesh) "length") 1)}}
+              {{fa-icon "circle" class="maybe"}}
+            {{else}}
+              {{fa-icon "ban" class="no"}}
+            {{/if}}
+          </td>
+        </tr>
+        <tr>
+          <td>
+            &nbsp;
+            &nbsp;
+            {{t "general.linkedCompetencyCount"
+              count=(get (await this.objectivesWithCompentency) "length")}}
+          </td>
+        </tr>
+        <tr>
+          <td>
+            &nbsp;
+            &nbsp;
+            {{t "general.meshCount"
+              count=(get (await this.objectivesWithMesh) "length")}}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+{{else}}
+  {{loading-spinner tagName="h3"}}
+{{/if}}

--- a/app/templates/components/programyear-details.hbs
+++ b/app/templates/components/programyear-details.hbs
@@ -23,10 +23,9 @@
     expand=(action setPyObjectiveDetails true)
   }}
 {{else}}
-  {{collapsed-objectives
+  {{collapsed-objectives-program-years
     subject=programYear
-    expand=(action setPyObjectiveDetails true)
-  }}
+    expand=(action setPyObjectiveDetails true)}}
 {{/liquid-if}}
 
 {{#liquid-if (or (eq programYear.terms.length 0) pyTaxonomyDetails)}}

--- a/tests/integration/components/collapsed-objectives-program-years-test.js
+++ b/tests/integration/components/collapsed-objectives-program-years-test.js
@@ -1,0 +1,126 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, settled } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+import { resolve } from 'rsvp';
+
+module('Integration | Component | collapsed-objectives-program-years', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const hasMesh = EmberObject.create({
+    meshDescriptors: resolve([1, 2])
+  });
+  const hasCompetency = EmberObject.create({
+    competency: resolve(EmberObject.create())
+  });
+  const plain = EmberObject.create();
+
+  test('displays summary data', async function(assert) {
+    assert.expect(9);
+
+    const subject = EmberObject.create({
+      objectives: resolve([hasMesh, hasCompetency, plain])
+    });
+    this.setProperties({ subject, click: () => {} });
+    await render(hbs`
+      {{collapsed-objectives-program-years
+        subject=subject
+        expand=(action click)}}`);
+    assert.dom('.title').hasText('Objectives (3)');
+    assert.dom('table tr').exists({ count: 4 });
+    assert.dom('tr td').hasText('There are 3 objectives');
+    assert.dom('tr:nth-of-type(2) td').includesText("1 has a linked competency");
+    assert.dom('tr:nth-of-type(3) td').includesText("1 has MeSH");
+    assert.dom('tr td:nth-of-type(2) svg').hasClass('fa-circle', 'correct icon for parent objectives');
+    assert.dom('tr td:nth-of-type(2) svg').hasClass('maybe', 'correct class for parent objectives');
+    assert.dom('tr td:nth-of-type(3) svg').hasClass('fa-circle', 'correct icon for mesh links');
+    assert.dom('tr td:nth-of-type(3) svg').hasClass('maybe', 'correct class for mesh links');
+  });
+
+  test('clicking expand icon opens full view', async function(assert) {
+    assert.expect(2);
+
+    const subject = EmberObject.create();
+    this.setProperties({ subject, click: () => assert.ok(true) });
+    await render(hbs`
+      {{collapsed-objectives-program-years
+        subject=subject
+        expand=(action click)}}`);
+    await settled();
+    assert.dom('.title').hasText('Objectives ()');
+    await click('.title');
+  });
+
+  test('icons all linked competencies correctly', async function(assert) {
+    assert.expect(4);
+
+    const subject = EmberObject.create({
+      objectives: resolve([hasCompetency])
+    });
+    this.setProperties({ subject, click: () => {} });
+    await render(hbs`
+      {{collapsed-objectives-program-years
+        subject=subject
+        expand=(action click)}}`);
+    await settled();
+    assert.dom('.title').hasText('Objectives (1)');
+    assert.dom('table tr').exists({ count: 4 });
+    assert.dom('tr td:nth-of-type(2) svg').hasClass('fa-circle', 'has the correct icon');
+    assert.dom('tr td:nth-of-type(2) svg').hasClass('yes', 'icon has the right class');
+  });
+
+  test('icons no parents correctly', async function(assert) {
+    assert.expect(4);
+
+    const subject = EmberObject.create({
+      objectives: resolve([plain])
+    });
+    this.setProperties({ subject, click: () => {} });
+    await render(hbs`
+      {{collapsed-objectives-program-years
+        subject=subject
+        expand=(action click)}}`);
+    await settled();
+    assert.dom('.title').hasText('Objectives (1)');
+    assert.dom('table tr').exists({ count: 4 });
+    assert.dom('tr td:nth-of-type(2) svg').hasClass('fa-ban', 'has the correct icon');
+    assert.dom('tr td:nth-of-type(2) svg').hasClass('no', 'icon has the right class');
+  });
+
+  test('icons all mesh correctly', async function(assert) {
+    assert.expect(4);
+
+    const subject = EmberObject.create({
+      objectives: resolve([hasMesh])
+    });
+    this.setProperties({ subject, click: () => {} });
+    await render(hbs`
+      {{collapsed-objectives-program-years
+        subject=subject
+        expand=(action click)}}`);
+    await settled();
+    assert.dom('.title').hasText('Objectives (1)');
+    assert.dom('table tr').exists({ count: 4 });
+    assert.dom('tr td:nth-of-type(3) svg').hasClass('fa-circle', 'has the correct icon');
+    assert.dom('tr td:nth-of-type(3) svg').hasClass('yes', 'icon has the right class');
+  });
+
+  test('icons no mesh correctly', async function(assert) {
+    assert.expect(4);
+
+    const subject = EmberObject.create({
+      objectives: resolve([plain])
+    });
+    this.setProperties({ subject, click: () => {} });
+    await render(hbs`
+      {{collapsed-objectives-program-years
+        subject=subject
+        expand=(action click)}}`);
+    await settled();
+    assert.dom('.title').hasText('Objectives (1)');
+    assert.dom('table tr').exists({ count: 4 });
+    assert.dom('tr td:nth-of-type(3) svg').hasClass('fa-ban', 'has the correct icon');
+    assert.dom('tr td:nth-of-type(3) svg').hasClass('no', 'icon has the right class');
+  });
+});


### PR DESCRIPTION
**Summary:**
Program years should now use `collapsed-objectives-program-years` component for the collapsed summary as they relate to competencies and not parents.

**UI:**
<img width="1067" alt="Screen Shot 2019-04-02 at 3 26 36 PM" src="https://user-images.githubusercontent.com/7553764/55434789-66216300-5566-11e9-8f23-27e3311244a1.png">

Accompanies https://github.com/ilios/common/pull/608
Fixes https://github.com/ilios/frontend/issues/4463