### PR TITLE
added courses column & updated trash icon control flow

### DIFF
--- a/app/components/learnergroup-list.js
+++ b/app/components/learnergroup-list.js
@@ -1,33 +1,40 @@
-/* eslint ember/order-in-components: 0 */
 import Component from '@ember/component';
 
 export default Component.extend({
-  init(){
-    this._super(...arguments);
-    this.set('learnerGroupsForRemovalConfirmation', []);
-    this.set('learnerGroupsForCopy', []);
-  },
-  learnerGroups: null,
-  canDelete: false,
+  classNames: ['learnergroup-list'],
+
   canCreate: false,
-  learnerGroupsForRemovalConfirmation: null,
-  learnerGroupsForCopy: null,
+  canDelete: false,
+  learnerGroups: null,
+  copy() {},
+  remove() {},
+
+  init() {
+    this._super(...arguments);
+    this.set('learnerGroupsForCopy', []);
+    this.set('learnerGroupsForRemovalConfirmation', []);
+  },
+
   actions: {
     cancelRemove(learnerGroup) {
       this.learnerGroupsForRemovalConfirmation.removeObject(learnerGroup);
     },
+
     confirmRemove(learnerGroup) {
       const canDelete = this.canDelete;
       if (canDelete) {
         this.learnerGroupsForRemovalConfirmation.pushObject(learnerGroup);
       }
     },
+
     cancelCopy(learnerGroup) {
       this.learnerGroupsForCopy.removeObject(learnerGroup);
     },
+
     startCopy(learnerGroup) {
       this.learnerGroupsForCopy.pushObject(learnerGroup);
     },
+
     async copy(withLearners, learnerGroup) {
       const copy = this.copy;
       await copy(withLearners, learnerGroup);

--- a/app/components/learnergroup-list.js
+++ b/app/components/learnergroup-list.js
@@ -6,6 +6,7 @@ export default Component.extend({
   canCreate: false,
   canDelete: false,
   learnerGroups: null,
+  query: null,
   copy() {},
   remove() {},
 

--- a/app/templates/components/learnergroup-list.hbs
+++ b/app/templates/components/learnergroup-list.hbs
@@ -109,6 +109,12 @@
           </td>
         </tr>
       {{/if}}
+    {{else}}
+      <tr>
+        <td colspan="6" align="center">
+          {{if @query (t "general.noResultsFound") (t "general.none")}}
+        </td>
+      </tr>
     {{/each}}
   </tbody>
 </table>

--- a/app/templates/components/learnergroup-list.hbs
+++ b/app/templates/components/learnergroup-list.hbs
@@ -1,75 +1,110 @@
 <table>
   <thead>
     <tr>
-      <th class="text-left" colspan="2">{{t "general.learnerGroupTitle"}}</th>
-      <th class="text-center hide-from-small-screen">{{t "general.members"}}</th>
-      <th class="text-center hide-from-small-screen">{{t "general.subgroups"}}</th>
+      <th class="text-left" colspan="2">
+        {{t "general.learnerGroupTitle"}}
+      </th>
+      <th class="text-center hide-from-small-screen">
+        {{t "general.members"}}
+      </th>
+      <th class="text-center hide-from-small-screen">
+        {{t "general.subgroups"}}
+      </th>
+      <th class="text-center hide-from-small-screen">
+        {{t "general.courses"}}
+      </th>
       <th class="text-right">{{t "general.actions"}}</th>
     </tr>
   </thead>
+
   <tbody>
-    {{#each (sort-by "title" learnerGroups) as |learnerGroup|}}
-      <tr
-        class={{if
-          (contains learnerGroup learnerGroupsForRemovalConfirmation)
-          "confirm-removal"
-          ""
-        }}
-      >
+    {{#each (sort-by "title" @learnerGroups) as |learnerGroup|}}
+      <tr class={{if (contains learnerGroup this.learnerGroupsForRemovalConfirmation) "confirm-removal"}}>
         <td class="text-left" colspan="2">
           {{#link-to "learnerGroup" learnerGroup}}
             {{learnerGroup.title}}
           {{/link-to}}
         </td>
-        <td class="text-center hide-from-small-screen">{{learnerGroup.usersCount}}</td>
-        <td class="text-center hide-from-small-screen">{{learnerGroup.childrenCount}}</td>
+        <td class="text-center hide-from-small-screen">
+          {{learnerGroup.usersCount}}
+        </td>
+        <td class="text-center hide-from-small-screen">
+          {{learnerGroup.childrenCount}}
+        </td>
+        <td class="text-center hide-from-small-screen">
+          {{get (await learnerGroup.courses) "length"}}
+        </td>
         <td class="text-right">
           {{#if (is-fulfilled learnerGroup.hasLearnersInGroupOrSubgroups)}}
-            {{#if (or (not canDelete) (await learnerGroup.hasLearnersInGroupOrSubgroups))}}
-              {{fa-icon "trash" class="disabled"}}
-            {{else}}
-              <span class="clickable remove" {{action "confirmRemove" learnerGroup}}>
+            {{#if (and
+              @canDelete
+              (not (await learnerGroup.hasLearnersInGroupOrSubgroups))
+              (eq (get (await learnerGroup.courses) "length") 0))}}
+              <span
+                class="clickable remove"
+                {{action "confirmRemove" learnerGroup}}>
                 {{fa-icon "trash" class="enabled"}}
               </span>
+            {{else}}
+              {{fa-icon "trash" class="disabled"}}
             {{/if}}
           {{else}}
             {{loading-spinner}}
           {{/if}}
-          {{#if canCreate}}
-            {{fa-icon
-              "copy"
+
+          {{#if @canCreate}}
+            {{fa-icon "copy"
               class="clickable enabled"
-              click=(action "startCopy" learnerGroup)
               title=(t "general.copy")
-            }}
+              click=(action "startCopy" learnerGroup)}}
           {{else}}
             {{fa-icon "copy" class="disabled"}}
           {{/if}}
         </td>
       </tr>
-      {{#if (contains learnerGroup learnerGroupsForRemovalConfirmation)}}
+
+      {{#if (contains learnerGroup this.learnerGroupsForRemovalConfirmation)}}
         <tr class="confirm-removal">
           <td colspan="5">
             <div class="confirm-message">
-              {{t
-                "general.confirmRemoveLearnerGroup"
-                subgroupCount=learnerGroup.children.length
-              }} <br>
+              {{t "general.confirmRemoveLearnerGroup"
+                subgroupCount=learnerGroup.children.length}} <br>
               <div class="confirm-buttons">
-                <button {{action remove learnerGroup}} class="remove text">{{t "general.yes"}}</button>
-                <button {{action "cancelRemove" learnerGroup}} class="done text">{{t "general.cancel"}}</button>
+                <button
+                  class="remove text"
+                  onclick={{action @remove learnerGroup}}>
+                  {{t "general.yes"}}
+                </button>
+                <button
+                  class="done text"
+                  onclick={{action "cancelRemove" learnerGroup}}>
+                  {{t "general.cancel"}}
+                </button>
               </div>
             </div>
           </td>
         </tr>
       {{/if}}
-      {{#if (contains learnerGroup learnerGroupsForCopy)}}
+
+      {{#if (contains learnerGroup this.learnerGroupsForCopy)}}
         <tr class="confirm-copy">
           <td colspan="5">
             <div class="confirm-buttons">
-              <button {{action "copy" true learnerGroup}} class="done text">{{t "general.copyWithLearners"}}</button>
-              <button {{action "copy" false learnerGroup}} class="done text">{{t "general.copyWithoutLearners"}}</button>
-              <button {{action "cancelCopy" learnerGroup}} class="cancel text">{{t "general.cancel"}}</button>
+              <button
+                class="done text"
+                onclick={{action "copy" true learnerGroup}}>
+                {{t "general.copyWithLearners"}}
+              </button>
+              <button
+                class="done text"
+                onclick={{action "copy" false learnerGroup}}>
+                {{t "general.copyWithoutLearners"}}
+              </button>
+              <button
+                class="cancel text"
+                onclick={{action "cancelCopy" learnerGroup}}>
+                {{t "general.cancel"}}
+              </button>
             </div>
           </td>
         </tr>

--- a/app/templates/learner-groups.hbs
+++ b/app/templates/learner-groups.hbs
@@ -105,12 +105,12 @@
     <div class="list">
       {{#if (is-fulfilled learnerGroups)}}
         {{learnergroup-list
-          learnerGroups=(await filteredLearnerGroups)
-          remove=(action "removeLearnerGroup")
-          copy=(perform copyGroup)
-          canDelete=(await canDelete)
           canCreate=(await canCreate)
-        }}
+          canDelete=(await canDelete)
+          learnerGroups=(await filteredLearnerGroups)
+          query=titleFilter
+          copy=(perform copyGroup)
+          remove=(action "removeLearnerGroup")}}
       {{else}}
         {{pulse-loader}}
       {{/if}}

--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -161,7 +161,7 @@ module('Acceptance | Learnergroup', function(hooks) {
     const firstLink = `${firstTitle} a`;
     const firstMembers = `${firstGroup} td:nth-of-type(2)`;
     const firstSubgroups = `${firstGroup} td:nth-of-type(3)`;
-    const firstGroupCopy = `${firstGroup} td:nth-of-type(4) .fa-copy`;
+    const firstGroupCopy = `${firstGroup} td:nth-of-type(5) .fa-copy`;
     const firstGroupCopyNoLearners = '.list tbody tr:nth-of-type(2) .done:nth-of-type(2)';
     const secondGroup = `${groups}:nth-of-type(2)`;
     const secondTitle = `${secondGroup} td:nth-of-type(1)`;
@@ -244,7 +244,7 @@ module('Acceptance | Learnergroup', function(hooks) {
     const firstLink = `${firstTitle} a`;
     const firstMembers = `${firstGroup} td:nth-of-type(2)`;
     const firstSubgroups = `${firstGroup} td:nth-of-type(3)`;
-    const firstGroupCopy = `${firstGroup} td:nth-of-type(4) .fa-copy`;
+    const firstGroupCopy = `${firstGroup} td:nth-of-type(5) .fa-copy`;
     const firstGroupCopyWithLearners = '.list tbody tr:nth-of-type(2) .done:nth-of-type(1)';
     const secondGroup = `${groups}:nth-of-type(2)`;
     const secondTitle = `${secondGroup} td:nth-of-type(1)`;

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -329,7 +329,7 @@ module('Acceptance | Learner Groups', function(hooks) {
     assert.equal(await getElementText(find(find('.list tbody tr:nth-of-type(1) td'))), getText('learnergroup 0'));
     await click('.list tbody tr:nth-of-type(1) td:nth-of-type(5) .remove');
     await click('.list tbody tr:nth-of-type(2) .remove');
-    assert.equal(0, findAll('.list tbody tr').length);
+    assert.equal(find('.list tbody tr').textContent.trim(), 'None');
   });
 
   test('cancel remove learnergroup', async function (assert) {

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -327,7 +327,7 @@ module('Acceptance | Learner Groups', function(hooks) {
     await visit('/learnergroups');
     assert.equal(1, findAll('.list tbody tr').length);
     assert.equal(await getElementText(find(find('.list tbody tr:nth-of-type(1) td'))), getText('learnergroup 0'));
-    await click('.list tbody tr:nth-of-type(1) td:nth-of-type(4) .remove');
+    await click('.list tbody tr:nth-of-type(1) td:nth-of-type(5) .remove');
     await click('.list tbody tr:nth-of-type(2) .remove');
     assert.equal(0, findAll('.list tbody tr').length);
   });
@@ -351,7 +351,7 @@ module('Acceptance | Learner Groups', function(hooks) {
     await visit('/learnergroups');
     assert.equal(1, findAll('.list tbody tr').length);
     assert.equal(await getElementText(find(find('.list tbody tr:nth-of-type(1) td'))), getText('learnergroup 0'));
-    await click('.list tbody tr:nth-of-type(1) td:nth-of-type(4) .remove');
+    await click('.list tbody tr:nth-of-type(1) td:nth-of-type(5) .remove');
     await click('.list tbody tr:nth-of-type(2) .done');
     assert.equal(1, findAll('.list tbody tr').length);
     assert.equal(await getElementText(find(find('.list tbody tr:nth-of-type(1) td'))), getText('learnergroup 0'));
@@ -381,7 +381,7 @@ module('Acceptance | Learner Groups', function(hooks) {
     await visit('/learnergroups');
     assert.equal(1, findAll('.list tbody tr').length);
     assert.equal(await getElementText(find(find('.list tbody tr:nth-of-type(1) td'))), getText('learnergroup 0'));
-    await click('.list tbody tr:nth-of-type(1) td:nth-of-type(4) .remove');
+    await click('.list tbody tr:nth-of-type(1) td:nth-of-type(5) .remove');
     assert.dom('.list tbody tr').hasClass('confirm-removal');
     assert.dom(findAll('.list tbody tr')[1]).hasClass('confirm-removal');
     assert.equal(await getElementText(find(findAll('.list tbody tr')[1])), getText('Are you sure you want to delete this learner group, with 2 subgroups? This action cannot be undone. Yes Cancel'));
@@ -410,7 +410,7 @@ module('Acceptance | Learner Groups', function(hooks) {
     await visit('/learnergroups');
     assert.equal(1, findAll('.list tbody tr').length);
     assert.equal(await getElementText(find(find('.list tbody tr:nth-of-type(1) td'))), getText('learnergroup 0'));
-    assert.notOk(findAll('.list tbody tr:nth-of-type(1) td:nth-of-type(4) .remove').length, 'No delete action is available');
+    assert.notOk(findAll('.list tbody tr:nth-of-type(1) td:nth-of-type(5) .remove').length, 'No delete action is available');
   });
 
   test('click title takes you to learnergroup route', async function (assert) {
@@ -538,7 +538,7 @@ module('Acceptance | Learner Groups', function(hooks) {
     const firstLink = `${firstTitle} a`;
     const firstMembers = `${firstGroup} td:nth-of-type(2)`;
     const firstSubgroups = `${firstGroup} td:nth-of-type(3)`;
-    const firstGroupCopy = `${firstGroup} td:nth-of-type(4) .fa-copy`;
+    const firstGroupCopy = `${firstGroup} td:nth-of-type(5) .fa-copy`;
     const firstGroupCopyNoLearners = '.list tbody tr:nth-of-type(2) .done:nth-of-type(2)';
     const secondGroup = `${groups}:nth-of-type(2)`;
     const secondTitle = `${secondGroup} td:nth-of-type(1)`;
@@ -628,7 +628,7 @@ module('Acceptance | Learner Groups', function(hooks) {
     const firstLink = `${firstTitle} a`;
     const firstMembers = `${firstGroup} td:nth-of-type(2)`;
     const firstSubgroups = `${firstGroup} td:nth-of-type(3)`;
-    const firstGroupCopy = `${firstGroup} td:nth-of-type(4) .fa-copy`;
+    const firstGroupCopy = `${firstGroup} td:nth-of-type(5) .fa-copy`;
     const firstGroupCopyWithLearners = '.list tbody tr:nth-of-type(2) .done:nth-of-type(1)';
     const secondGroup = `${groups}:nth-of-type(2)`;
     const secondTitle = `${secondGroup} td:nth-of-type(1)`;
@@ -676,4 +676,3 @@ module('Acceptance | Learner Groups', function(hooks) {
     assert.equal(await getElementText(find(secondSubgroupSubgroups)), getText('0'));
   });
 });
-

--- a/tests/integration/components/learnergroup-subgroup-list-test.js
+++ b/tests/integration/components/learnergroup-subgroup-list-test.js
@@ -32,26 +32,26 @@ module('Integration | Component | learnergroup subgroup list', function(hooks) {
     const parentGroup = await this.owner.lookup('service:store').find('learner-group', parent.id);
 
     this.set('parentGroup', parentGroup);
-
     await render(hbs`{{learnergroup-subgroup-list parentGroup=parentGroup}}`);
-
     assert.dom('th').hasText('Learner Group Title');
     assert.dom(findAll('th')[1]).hasText('Members');
     assert.dom(findAll('th')[2]).hasText('Subgroups');
-    assert.dom(findAll('th')[3]).hasText('Actions');
-
+    assert.dom(findAll('th')[3]).hasText('Courses');
+    assert.dom(findAll('th')[4]).hasText('Actions');
     assert.dom('tbody tr:nth-of-type(1) td').hasText('first');
     assert.dom(findAll('tbody tr:nth-of-type(1) td')[1]).hasText('2');
     assert.dom(findAll('tbody tr:nth-of-type(1) td')[2]).hasText('0');
     assert.dom('tbody tr:nth-of-type(2) td').hasText('second');
     assert.dom(findAll('tbody tr:nth-of-type(2) td')[1]).hasText('0');
     assert.dom(findAll('tbody tr:nth-of-type(2) td')[2]).hasText('2');
-
+    assert.dom(findAll('tbody tr:nth-of-type(1) td')[3]).hasText('0');
+    assert.dom(findAll('tbody tr:nth-of-type(2) td')[3]).hasText('0');
   });
 
   test('can remove group', async function(assert) {
     let subGroup1 = {
       title: 'first',
+      courses: resolve([]),
       users: [1,2],
       children: [],
       destroyRecord(){
@@ -63,16 +63,38 @@ module('Integration | Component | learnergroup subgroup list', function(hooks) {
     };
 
     this.set('parentGroup', parentGroup);
-
-    await render(hbs`{{learnergroup-subgroup-list parentGroup=parentGroup canDelete=true}}`);
-
-    await click('tbody td:nth-of-type(4) .remove');
+    await render(hbs`
+      {{learnergroup-subgroup-list
+        canDelete=true
+        parentGroup=parentGroup}}`);
+    await click('tbody td:nth-of-type(5) .remove');
     await click('tbody tr:nth-of-type(2) .remove');
+  });
+
+  test('cannot remove group (has 1+ courses)', async function(assert) {
+    const subGroup1 = {
+      title: 'first',
+      courses: resolve([1]),
+      users: [1,2],
+      children: [],
+      destroyRecord(){
+        assert.ok(true);
+      }
+    };
+    const parentGroup = { children: resolve([subGroup1]) };
+
+    this.set('parentGroup', parentGroup);
+    await render(hbs`
+      {{learnergroup-subgroup-list
+        canDelete=true
+        parentGroup=parentGroup}}`);
+    assert.notOk(find('tbody td:nth-of-type(5) .remove'));
   });
 
   test('removal confirmation', async function(assert) {
     let subGroup1 = {
       title: 'first',
+      courses: resolve([]),
       users: [1,2],
       children: [],
     };
@@ -81,14 +103,13 @@ module('Integration | Component | learnergroup subgroup list', function(hooks) {
     };
 
     this.set('parentGroup', parentGroup);
-
-    await render(hbs`{{learnergroup-subgroup-list parentGroup=parentGroup canDelete=true}}`);
-
-    await click('tbody td:nth-of-type(4) .remove');
-
+    await render(hbs`
+      {{learnergroup-subgroup-list
+        canDelete=true
+        parentGroup=parentGroup}}`);
+    await click('tbody td:nth-of-type(5) .remove');
     assert.dom('tbody tr').hasClass('confirm-removal');
     assert.equal(find(findAll('tbody tr')[1]).textContent.trim().search(/Are you sure/), 0);
-
   });
 
   test('add new group', async function (assert) {


### PR DESCRIPTION
**Summary:**
- Added `Courses` column
- Refactored the control flow for showing the trash icon for learner-group removal
- Refactors
- Fixed/Added tests
- Added empty learner group list handler
- Added empty filter/query list handler

**UI:**
<img width="1040" alt="Screen Shot 2019-04-05 at 2 42 55 PM" src="https://user-images.githubusercontent.com/7553764/55652458-25695a00-57b1-11e9-8a2a-cb6c35ad8ab0.png">

_No Groups:_
<img width="1045" alt="Screen Shot 2019-04-05 at 8 13 55 PM" src="https://user-images.githubusercontent.com/7553764/55663050-73955200-57df-11e9-8805-04f3777101df.png">

_No Query Results:_
<img width="1046" alt="Screen Shot 2019-04-05 at 8 14 16 PM" src="https://user-images.githubusercontent.com/7553764/55663051-73955200-57df-11e9-89f4-297d37e5ba2a.png">

Fixes https://github.com/ilios/frontend/issues/3249
Fixes https://github.com/ilios/frontend/issues/4475