### PR TITLE
added code for allowing/resetting preserved scroll

### DIFF
--- a/app/routes/course/index.js
+++ b/app/routes/course/index.js
@@ -1,6 +1,22 @@
-/* eslint ember/order-in-routes: 0 */
 import Route from '@ember/routing/route';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 import IndexRouteMixin from 'ilios-common/mixins/course/index-route';
 
 export default Route.extend(IndexRouteMixin, {
+  preserveScroll: service(),
+
+  beforeModel(transition) {
+    const isFromSessionIndex = get(transition, 'from.name') === 'session.index';
+    this.preserveScroll.set('shouldScrollDown', isFromSessionIndex);
+  },
+
+  actions: {
+    willTransition(transition) {
+      this.preserveScroll.set('isListenerOn', false);
+      if (transition.targetName !== 'session.index') {
+        this.preserveScroll.set('yPos', null);
+      }
+    }
+  }
 });


### PR DESCRIPTION
**Summary:**
Custom code to enable preserve scrolling and reseting variables upon leaving the route.

Accompanies https://github.com/ilios/common/pull/623
Fixes https://github.com/ilios/frontend/issues/3813