### PR TITLE
removes new course notification on route transition

### DIFF
--- a/app/routes/courses.js
+++ b/app/routes/courses.js
@@ -1,12 +1,18 @@
-/* eslint ember/order-in-routes: 0 */
-import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   currentUser: service(),
   store: service(),
+
+  queryParams: {
+    titleFilter: {
+      replace: true
+    }
+  },
+
   model() {
     let defer = RSVP.defer();
     let model = {};
@@ -23,12 +29,12 @@ export default Route.extend(AuthenticatedRouteMixin, {
         });
       });
     });
-
     return defer.promise;
   },
-  queryParams: {
-    titleFilter: {
-      replace: true
+
+  actions: {
+    willTransition() {
+      this.controller.set('newCourse', null);
     }
   }
 });

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -319,14 +319,13 @@ module('Acceptance | Courses', function(hooks) {
     await page.newCourseForm.title(courseTitle);
     await page.newCourseForm.chooseYear(year);
     await page.newCourseForm.save();
-
     assert.equal(page.courses().count, 1);
     assert.equal(page.newCourseLink, 'Course 1');
+
     await page.visitNewCourse();
     await page.visit({ year });
-
     assert.equal(page.courses().count, 1);
-    assert.equal(page.newCourseLink, 'Course 1');
+    assert.ok(page.newCourseLinkIsHidden);
   });
 
   test('new course can be deleted', async function(assert) {
@@ -338,7 +337,7 @@ module('Acceptance | Courses', function(hooks) {
     });
     this.server.db.users.update(this.user.id, {roleIds: [1]});
 
-    assert.expect(11);
+    assert.expect(10);
 
     await page.visit({ year });
     assert.equal(page.courses().count, 0);
@@ -354,9 +353,8 @@ module('Acceptance | Courses', function(hooks) {
 
     await page.visitNewCourse();
     await page.visit({ year });
-    assert.equal(page.courses().count, 1);
     assert.equal(page.savedCoursesCount, 1);
-    assert.equal(page.newCourseLink, 'Course 1');
+    assert.ok(page.newCourseLinkIsHidden);
 
     await page.courses(0).remove();
     await page.confirmCourseRemoval();

--- a/tests/pages/courses.js
+++ b/tests/pages/courses.js
@@ -5,6 +5,7 @@ import {
   count,
   fillable,
   hasClass,
+  isHidden,
   isVisible,
   property,
   text,
@@ -48,7 +49,8 @@ export default create({
     }),
   },
   newCourseLink: text('[data-test-new-course] a'),
-  savedCoursesCount: count('[data-test-new-course] a'),
+  newCourseLinkIsHidden: isHidden('[data-test-new-course] a'),
+  savedCoursesCount: count('[data-test-courses] [data-test-active-row]'),
   visitNewCourse: clickable('[data-test-new-course] a'),
   courses: collection({
     scope: '[data-test-ilios-course-list]',


### PR DESCRIPTION
**Summary:**
Removes new course creation notification when user transitions away.

Fixes https://github.com/ilios/frontend/issues/4490