### PR TITLE
added academic year prefix to dropdown

### DIFF
--- a/app/templates/components/new-myreport.hbs
+++ b/app/templates/components/new-myreport.hbs
@@ -126,18 +126,23 @@
       {{else}}
         {{#if (is-fulfilled filteredPrepositionalObjectIdList) class="crossFade"}}
           <select
-            onchange={{action "changePrepositionalObjectId" value="target.value"}}
             data-test-report-object
-          >
-            {{#each
-              (sort-by "active:desc" "label" (await filteredPrepositionalObjectIdList))
-              as |o|
-            }}
+            onchange={{action "changePrepositionalObjectId" value="target.value"}}>
+            {{#each (sort-by "active:desc" "academicYear" "label"
+              (await this.filteredPrepositionalObjectIdList)) as |o|}}
               <option
-                value={{o.value}}
-                selected={{is-equal o.value currentPrepositionalObjectId}}
-              >
-                {{await o.label}}
+                selected={{is-equal o.value this.currentPrepositionalObjectId}}
+                value={{o.value}}>
+                {{#if o.academicYear}}
+                  {{o.academicYear}} |
+                {{/if}}
+                {{#if (and this.isCourse o.externalId)}}
+                  [{{o.externalId}}] | {{o.label}}
+                {{else if this.isSession}}
+                  {{o.label}} | {{o.courseTitle}}
+                {{else}}
+                  {{o.label}}
+                {{/if}}
                 {{#unless o.active}}
                   ({{t "general.inactive"}})
                 {{/unless}}


### PR DESCRIPTION
**Summary:**
Added the following control flow to the new report dropdown:
- `YYYY |` academic year prefix (top sort priority, if available)
- `[externalId] |` for course (if available)
- Course title for session

**UI:**
_Prepositional Object Course_
<img width="857" alt="Screen Shot 2019-04-23 at 4 21 44 PM" src="https://user-images.githubusercontent.com/7553764/56618181-69e55a00-65e7-11e9-9d60-c9b5d7015d6e.png">

_Prepositional Object Session_
<img width="855" alt="Screen Shot 2019-04-23 at 4 26 58 PM" src="https://user-images.githubusercontent.com/7553764/56618190-710c6800-65e7-11e9-8cbe-123831228378.png">

_All Else_
<img width="672" alt="Screen Shot 2019-04-23 at 4 22 00 PM" src="https://user-images.githubusercontent.com/7553764/56618205-779adf80-65e7-11e9-97b0-b1cb20d7bc28.png">

Fixes https://github.com/ilios/frontend/issues/2837