### PR TITLE
Stop reordering ranked search results

### DIFF
--- a/app/components/manage-users-summary.js
+++ b/app/components/manage-users-summary.js
@@ -34,13 +34,15 @@ export default Component.extend({
         text: intl.t('general.moreInputRequiredPrompt')
       }];
     }
+    let params = { q, limit: 100 };
 
-    let searchResults = yield store.query('user', {
-      q,
-      'order_by[lastName]': 'ASC',
-      'order_by[firstName]': 'ASC',
-      limit: 100
-    });
+    const searchEnabled = yield this.iliosConfig.searchEnabled;
+    if (!searchEnabled) {
+      params['order_by[lastName]'] = 'ASC';
+      params['order_by[firstName]'] = 'ASC';
+    }
+
+    let searchResults = yield store.query('user', params);
     if (searchResults.length === 0) {
       return [{
         type: 'text',


### PR DESCRIPTION
When search results come back from elasticsearch instead of a straight
DB search we should trust their order and not resort them by name.

Requires https://github.com/ilios/common/pull/654

Refs https://github.com/ilios/ilios/issues/2384