### PR TITLE
dashboard report menu to preserve state and scroll

### DIFF
--- a/app/components/dashboard-myreports.js
+++ b/app/components/dashboard-myreports.js
@@ -42,7 +42,6 @@ export default Component.extend(DomMixin, ReportTitleMixin, {
     const yPos = this.preserveScroll[this.scrollKey];
 
     if (yPos > 0) {
-      const element = document.querySelector('.dashboard-block-body');
       element.scrollTop = yPos;
     }
 
@@ -79,7 +78,7 @@ export default Component.extend(DomMixin, ReportTitleMixin, {
   }),
 
   reportResultsList: computed('selectedReport', 'selectedYear', async function() {
-    const report = await this.selectedReport;
+    const report = this.selectedReport;
     const year = this.selectedYear;
     return report ? await this.reporting.getResults(report, year) : [];
   }),

--- a/app/components/dashboard-myreports.js
+++ b/app/components/dashboard-myreports.js
@@ -1,31 +1,63 @@
 /* eslint ember/order-in-components: 0 */
-import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
 import Component from '@ember/component';
-import RSVP from 'rsvp';
+import { computed } from '@ember/object';
+import { next } from '@ember/runloop';
+import { inject as service } from '@ember/service';
+import { Promise } from 'rsvp';
 import { task, timeout } from 'ember-concurrency';
+import DomMixin from 'ember-lifeline/mixins/dom';
 import ReportTitleMixin from 'ilios/mixins/report-title';
 import PapaParse from 'papaparse';
 import createDownloadFile from '../utils/create-download-file';
+import { runDisposables } from 'ember-lifeline';
 
-const { Promise, resolve } = RSVP;
-
-export default Component.extend(ReportTitleMixin, {
+export default Component.extend(DomMixin, ReportTitleMixin, {
   currentUser: service(),
+  preserveScroll: service(),
   reporting: service(),
   store: service(),
-  tagName: 'div',
+
   classNames: ['dashboard-myreports'],
+  tagName: 'div',
+
+  scrollKey: 'reportList',
+
+  'data-test-dashboard-myreports': true,
+  finishedBuildingReport: false,
   myReportEditorOn: false,
   selectedReport: null,
   selectedYear: null,
   user: null,
-  finishedBuildingReport: false,
-  'data-test-dashboard-myreports': true,
+  onReportSelect() {},
+  onReportYearSelect() {},
 
   didReceiveAttrs() {
     this._super(...arguments);
     this.loadAttr.perform();
+  },
+
+  didRender() {
+    this._super(...arguments);
+    const element = document.querySelector('.dashboard-block-body');
+    const yPos = this.preserveScroll[this.scrollKey];
+
+    if (yPos > 0) {
+      const element = document.querySelector('.dashboard-block-body');
+      element.scrollTop = yPos;
+    }
+
+    if (element) {
+      next(() => {
+        this.addEventListener('.dashboard-block-body', 'scroll', () => {
+          this.preserveScroll.set(this.scrollKey, element.scrollTop);
+        });
+      });
+    }
+  },
+
+  destroy() {
+    runDisposables(this);
+    this._super(...arguments);
   },
 
   loadAttr: task(function * () {
@@ -45,34 +77,34 @@ export default Component.extend(ReportTitleMixin, {
       });
     });
   }),
-  reportResultsList: computed('selectedReport', 'selectedYear', function(){
-    const report = this.selectedReport;
+
+  reportResultsList: computed('selectedReport', 'selectedYear', async function() {
+    const report = await this.selectedReport;
     const year = this.selectedYear;
-    if(!report){
-      return resolve([]);
-    }
-    return this.reporting.getResults(report, year);
+    return report ? await this.reporting.getResults(report, year) : [];
   }),
+
   allAcademicYears: computed(async function () {
     const store = this.store;
     const years = await store.findAll('academic-year');
-
     return years;
   }),
+
   showAcademicYearFilter: computed('selectedReport', function(){
     const report = this.selectedReport;
     if(!report){
       return false;
     }
-    const subject = report.get('subject');
-    const prepositionalObject = report.get('prepositionalObject');
-
+    const subject = report.subject;
+    const prepositionalObject = report.prepositionalObject;
     return prepositionalObject != 'course' && ['course', 'session'].includes(subject);
   }),
+
   selectedReportTitle: computed('selectedReport', async function(){
     const report = this.selectedReport;
     return this.getReportTitle(report);
   }),
+
   downloadReport: task(function* () {
     const report = this.selectedReport;
     const title = yield this.getReportTitle(report);
@@ -84,19 +116,19 @@ export default Component.extend(ReportTitleMixin, {
     yield timeout(2000);
     this.set('finishedBuildingReport', false);
   }).drop(),
+
   actions: {
     toggleEditor() {
       this.set('myReportEditorOn', !this.myReportEditorOn);
     },
+
     closeEditor() {
       this.set('myReportEditorOn', false);
     },
-    selectReport(report){
-      this.set('selectedReport', report);
-    },
+
     deleteReport(report){
       report.deleteRecord();
       report.save();
-    },
+    }
   }
 });

--- a/app/components/myreports-list-item.js
+++ b/app/components/myreports-list-item.js
@@ -3,11 +3,12 @@ import Component from '@ember/component';
 import ReportTitleMixin from 'ilios/mixins/report-title';
 import { task } from 'ember-concurrency';
 
-
 export default Component.extend(ReportTitleMixin, {
   reporttitle: null,
   classNames: ['myreports-list-item'],
   tagName: 'span',
+
+  onReportSelect() {},
 
   didReceiveAttrs() {
     this._super(...arguments);
@@ -18,11 +19,5 @@ export default Component.extend(ReportTitleMixin, {
   loadTitle: task(function * (report) {
     const title = yield this.getReportTitle(report);
     this.set('reporttitle', title);
-  }).restartable(),
-
-  actions: {
-    selectReport(report) {
-      this.selectReport(report);
-    }
-  }
+  }).restartable()
 });

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -1,4 +1,20 @@
 import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 import DashboardController from 'ilios-common/mixins/dashboard-controller';
 
-export default Controller.extend(DashboardController);
+export default Controller.extend(DashboardController, {
+  queryParams: ['report', 'reportYear'],
+
+  report: null,
+  reportYear: '',
+
+  selectedReport: computed('report', async function() {
+    const reportId = this.report;
+    const store = this.store;
+
+    if (reportId) {
+      const report = store.peekRecord('report', reportId);
+      return report ? report : await store.findRecord('report', reportId);
+    }
+  })
+});

--- a/app/mixins/report-title.js
+++ b/app/mixins/report-title.js
@@ -7,17 +7,17 @@ export default Mixin.create({
   report: null,
 
   async getReportTitle(report){
-    const title = report.get('title');
+    const title = report.title;
     if (title) {
       return title;
     }
     const intl = this.intl;
     const store = this.store;
-    const subject = report.get('subject');
+    const subject = report.subject;
     const subjectTranslation = intl.t(this.subjectTranslations[subject]);
-    const prepositionalObject = report.get('prepositionalObject');
+    const prepositionalObject = report.prepositionalObject;
 
-    const school = await report.get('school');
+    const school = await report.school;
     const schoolTitle = school?school.get('title'):intl.t('general.allSchools');
 
     if (prepositionalObject) {
@@ -39,11 +39,11 @@ export default Mixin.create({
 
       let object;
       if(model === 'user'){
-        object = record.get('fullName');
+        object = record.fullName;
       } else if(model === 'mesh-descriptor'){
-        object = record.get('name');
+        object = record.name;
       } else {
-        object = record.get('title');
+        object = record.title;
       }
 
       return intl.t('general.reportDisplayTitleWithObject', {

--- a/app/services/reporting.js
+++ b/app/services/reporting.js
@@ -27,24 +27,21 @@ export default Service.extend({
 
   async findResults(report){
     const store = this.store;
-    const subject = report.get('subject');
-    const object = report.get('prepositionalObject');
-    const objectId = report.get('prepositionalObjectTableRowId');
-    const school = await report.get('school');
-
+    const subject = report.subject;
+    const object = report.prepositionalObject;
+    const objectId = report.prepositionalObjectTableRowId;
+    const school = await report.school;
     return store.query(
       this.getModel(subject),
       this.getQuery(subject, object, objectId, school)
     );
   },
 
-  async getResults(report, year){
-    const subject = report.get('subject');
-
+  async getResults(report, year) {
+    const subject = report.subject;
     const results = await this.findResults(report);
     let mapper = pluralize(subject.camelize()) + 'Results';
     const mappedResults = await this[mapper](results, year);
-
     return mappedResults.sortBy('value');
   },
 
@@ -97,7 +94,7 @@ export default Service.extend({
       query.filters[what] = objectId;
     } else {
       if(subject !== 'mesh term' && subject !== 'instructor' && subject !== 'learning material' && school){
-        query.filters['schools'] = [school.get('id')];
+        query.filters['schools'] = [school.id];
       }
     }
 

--- a/app/templates/components/dashboard-myreports.hbs
+++ b/app/templates/components/dashboard-myreports.hbs
@@ -2,8 +2,10 @@
   <div class="dashboard-block-header">
     <h3 data-test-title>{{t "general.myReports"}}</h3>
     <div class="dashboard-block-actions">
-      {{#liquid-if selectedReport class="crossFade"}}
-        <button {{action "selectReport" null}}>{{t "general.allReports"}}</button>
+      {{#liquid-if @selectedReport class="crossFade"}}
+        <button onclick={{action @onReportSelect null}}>
+          {{t "general.allReports"}}
+        </button>
         <button
           disabled={{downloadReport.isRunning}}
           {{action (perform downloadReport)}}
@@ -27,25 +29,29 @@
     </div>
   </div>
 
-  {{#liquid-if selectedReport class="crossFade"}}
+  {{#liquid-if @selectedReport class="crossFade"}}
     <div class="dashboard-block-body" data-test-selected-report>
       <h3 data-test-report-title>{{await selectedReportTitle}}</h3>
 
       {{#if showAcademicYearFilter}}
         <div class="years-filter">
           <select
-            onchange={{action (mut selectedYear) value="target.value"}}
             data-test-year-filter
-          >
-            <option value="" selected={{is-empty selectedYear}}>{{t "general.allAcademicYears"}}</option>
+            onchange={{action @onReportYearSelect value="target.value"}}>
+            <option
+              selected={{is-empty @selectedYear}}
+              value="">
+              {{t "general.allAcademicYears"}}
+            </option>
             {{#each (sort-by "academicYearTitle:desc" (await allAcademicYears)) as |year|}}
-              <option value={{year.id}} selected={{is-equal year.id selectedYear}}>
+              <option value={{year.id}} selected={{is-equal year.id @selectedYear}}>
                 {{year.academicYearTitle}}
               </option>
             {{/each}}
           </select>
         </div>
       {{/if}}
+
       {{#if (is-fulfilled reportResultsList)}}
         {{#if (get (await reportResultsList) "length")}}
           <ul data-test-results>
@@ -64,7 +70,6 @@
                 </li>
               {{else}}
                 <li>{{item.value}}</li>
-
               {{/if}}
             {{/each}}
           </ul>
@@ -84,7 +89,9 @@
         <ul class="saved-reports" data-test-saved-reports>
           {{#each (await sortedReports) as |report|}}
             <li>
-              {{myreports-list-item report=report selectReport=(action "selectReport")}}
+              {{myreports-list-item
+                report=report
+                onReportSelect=@onReportSelect}}
               {{fa-icon
                 "trash"
                 class="clickable remove enabled"

--- a/app/templates/components/myreports-list-item.hbs
+++ b/app/templates/components/myreports-list-item.hbs
@@ -1,6 +1,6 @@
 {{#unless loadTitle.isRunning}}
   {{#if reporttitle}}
-    <span {{action "selectReport" report}} class="link clickable">
+    <span class="link clickable" {{action @onReportSelect report.id}}>
       {{fa-icon "external-link-square-alt"}}
       {{reporttitle}}
     </span>

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -30,7 +30,12 @@
     onUpdateSessionTypes=(action "updateSessionTypes")
     onUpdateTerms=(action "updateTerms")}}
   <div class="dashboard-blocks">
-    {{dashboard-myreports data-test-myreports}}
+    {{dashboard-myreports
+      data-test-myreports
+      selectedReport=(await this.selectedReport)
+      selectedYear=this.reportYear
+      onReportSelect=(action (mut this.report))
+      onReportYearSelect=(action (mut this.reportYear))}}
     {{dashboard-mycourses}}
   </div>
 </div>

--- a/tests/acceptance/dashboard/reports-test.js
+++ b/tests/acceptance/dashboard/reports-test.js
@@ -1,4 +1,4 @@
-import { currentRouteName } from '@ember/test-helpers';
+import { currentRouteName, currentURL } from '@ember/test-helpers';
 import {
   module,
   test
@@ -78,6 +78,7 @@ module('Acceptance | Dashboard Reports', function(hooks) {
     assert.equal(page.myReports.selectedReport.title, 'my report 0');
     assert.equal(page.myReports.selectedReport.results.length, 1);
     assert.equal(page.myReports.selectedReport.results[0].text, '2015 - 2016 course 0 session 0');
+    assert.equal(currentURL(), '/dashboard?report=1', 'report query param works');
   });
 
   test('no year filter on reports with a course prepositional object', async function(assert) {
@@ -96,10 +97,12 @@ module('Acceptance | Dashboard Reports', function(hooks) {
     assert.equal(page.myReports.selectedReport.results.length, 2);
     assert.equal(page.myReports.selectedReport.results[0].text, '2015 - 2016 course 0 session 0');
     assert.equal(page.myReports.selectedReport.results[1].text, '2016 - 2017 course 1 session 1');
+    assert.equal(currentURL(), '/dashboard?report=2', 'report query param works');
   });
 
   test('year filter works', async function (assert) {
     await page.visit();
+    assert.equal(currentURL(), '/dashboard');
     assert.equal(page.myReports.reports.length, 2);
     await page.myReports.reports[0].select();
     assert.equal(page.myReports.selectedReport.title, 'All Sessions for term 0 in school 0');
@@ -108,6 +111,7 @@ module('Acceptance | Dashboard Reports', function(hooks) {
     await page.myReports.selectedReport.chooseYear('2016');
     assert.equal(page.myReports.selectedReport.results.length, 1);
     assert.equal(page.myReports.selectedReport.results[0].text, '2016 - 2017 course 1 session 1');
+    assert.equal(currentURL(), '/dashboard?report=2&reportYear=2016', 'reportYear query param works');
   });
 
   test('create new report', async function (assert) {

--- a/tests/integration/components/dashboard-myreports-test.js
+++ b/tests/integration/components/dashboard-myreports-test.js
@@ -39,8 +39,14 @@ module('Integration | Component | dashboard myreports', function(hooks) {
       prepositionalObjectTableRowId: session.id,
       user: this.user,
     });
-    await render(hbs`{{dashboard-myreports}}`);
-
+    this.setProperties({ selectedReport: null, selectedYear: '' });
+    this.setProperties({ setReport: () => {}, setReportYear: () => {} });
+    await render(hbs`
+      {{dashboard-myreports
+        selectedReport=this.selectedReport
+        selectedYear=this.selectedYear
+        onReportSelect=(action this.setReport)
+        onReportYearSelect=(action this.setReportYear)}}`);
     assert.equal(component.title, 'My Reports');
     assert.equal(component.reports.length, 2);
     assert.equal(component.reports[0].title, 'report 0');
@@ -56,7 +62,7 @@ module('Integration | Component | dashboard myreports', function(hooks) {
   });
 
   test('year filter works', async function(assert) {
-    assert.expect(7);
+    assert.expect(9);
     this.server.create('academic-year', {
       id: 2015
     });
@@ -72,7 +78,7 @@ module('Integration | Component | dashboard myreports', function(hooks) {
       school,
       year: 2016,
     });
-    this.server.create('report', {
+    const report = this.server.create('report', {
       title: 'my report 0',
       subject: 'course',
       prepositionalObject: 'school',
@@ -85,8 +91,21 @@ module('Integration | Component | dashboard myreports', function(hooks) {
       return schema.courses.all();
     });
 
-    await render(hbs`{{dashboard-myreports}}`);
-
+    this.setProperties({ selectedReport: null, selectedYear: '' });
+    this.set('setReport', (reportId) => {
+      this.set('selectedReport', report);
+      assert.equal(reportId, '1', 'report id bubbles up for query params');
+    });
+    this.set('setReportYear', (year) => {
+      this.set('selectedYear', year);
+      assert.equal(year, '2016', 'report year bubbles up for query params');
+    });
+    await render(hbs`
+      {{dashboard-myreports
+        selectedReport=this.selectedReport
+        selectedYear=this.selectedYear
+        onReportSelect=(action this.setReport)
+        onReportYearSelect=(action this.setReportYear)}}`);
     assert.equal(component.title, 'My Reports');
     assert.equal(component.reports.length, 1);
     assert.equal(component.reports[0].title, 'my report 0');
@@ -108,7 +127,7 @@ module('Integration | Component | dashboard myreports', function(hooks) {
       school,
       year: 2015,
     });
-    this.server.create('report', {
+    const report = this.server.create('report', {
       title: 'my report 0',
       subject: 'course',
       user: this.user,
@@ -119,8 +138,15 @@ module('Integration | Component | dashboard myreports', function(hooks) {
       return schema.courses.all();
     });
 
-    await render(hbs`{{dashboard-myreports}}`);
-
+    this.setProperties({ selectedReport: null, selectedYear: '' });
+    this.set('setReport', () => this.set('selectedReport', report));
+    this.set('setReportYear', (year) => this.set('selectedYear', year));
+    await render(hbs`
+      {{dashboard-myreports
+        selectedReport=this.selectedReport
+        selectedYear=this.selectedYear
+        onReportSelect=(action this.setReport)
+        onReportYearSelect=(action this.setReportYear)}}`);
     await component.reports[0].select();
     assert.ok(component.selectedReport.yearsFilterExists);
     assert.equal(component.selectedReport.currentYear, '');

--- a/tests/integration/components/myreports-list-item-test.js
+++ b/tests/integration/components/myreports-list-item-test.js
@@ -14,9 +14,7 @@ module('Integration | Component | myreports list item', function(hooks) {
       title: 'Lorem Ipsum'
     });
 
-    const reportModel = await this.owner
-      .lookup('service:store')
-      .find('report', report.id);
+    const reportModel = await this.owner.lookup('service:store').find('report', report.id);
     this.set('report', reportModel);
     this.set('selectReport', (param) => assert.equal(param, reportModel.id));
     await render(hbs`
@@ -34,9 +32,7 @@ module('Integration | Component | myreports list item', function(hooks) {
       subject: 'competency'
     });
 
-    const reportModel = await this.owner
-      .lookup('service:store')
-      .find('report', report.id);
+    const reportModel = await this.owner.lookup('service:store').find('report', report.id);
     this.set('report', reportModel);
     this.set('selectReport', (param) => assert.equal(param, reportModel.id));
     await render(hbs`
@@ -56,9 +52,7 @@ module('Integration | Component | myreports list item', function(hooks) {
       subject: 'competency',
     });
 
-    const reportModel = await this.owner
-      .lookup('service:store')
-      .find('report', report.id);
+    const reportModel = await this.owner.lookup('service:store').find('report', report.id);
     this.setProperties({ report: reportModel, selectReport: () => {} });
     await render(hbs`
       {{myreports-list-item
@@ -82,12 +76,8 @@ module('Integration | Component | myreports list item', function(hooks) {
       prepositionalObjectTableRowId: user.id,
     });
 
-    const reportModel = await this.owner
-      .lookup('service:store')
-      .find('report', report.id);
-    const userModel = await this.owner
-      .lookup('service:store')
-      .find('user', user.id);
+    const reportModel = await this.owner.lookup('service:store').find('report', report.id);
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
     this.setProperties({ report: reportModel, selectReport: () => {} });
     await render(hbs`
       {{myreports-list-item

--- a/tests/integration/components/myreports-list-item-test.js
+++ b/tests/integration/components/myreports-list-item-test.js
@@ -14,13 +14,15 @@ module('Integration | Component | myreports list item', function(hooks) {
       title: 'Lorem Ipsum'
     });
 
-    const reportModel = await this.owner.lookup('service:store').find('report', report.id);
+    const reportModel = await this.owner
+      .lookup('service:store')
+      .find('report', report.id);
     this.set('report', reportModel);
-    this.set('selectReport', (param) => {
-      assert.equal(param, reportModel);
-    });
-    await render(hbs`{{myreports-list-item report=report selectReport=(action selectReport)}}`);
-
+    this.set('selectReport', (param) => assert.equal(param, reportModel.id));
+    await render(hbs`
+      {{myreports-list-item
+        report=this.report
+        onReportSelect=(action this.selectReport)}}`);
     assert.dom(this.element).hasText(report.title);
     assert.dom('.clickable').exists({ count: 1 });
     await click('.clickable');
@@ -32,13 +34,15 @@ module('Integration | Component | myreports list item', function(hooks) {
       subject: 'competency'
     });
 
-    const reportModel = await this.owner.lookup('service:store').find('report', report.id);
+    const reportModel = await this.owner
+      .lookup('service:store')
+      .find('report', report.id);
     this.set('report', reportModel);
-    this.set('selectReport', (param) => {
-      assert.equal(param, reportModel);
-    });
-    await render(hbs`{{myreports-list-item report=report selectReport=(action selectReport)}}`);
-
+    this.set('selectReport', (param) => assert.equal(param, reportModel.id));
+    await render(hbs`
+      {{myreports-list-item
+        report=this.report
+        onReportSelect=(action this.selectReport)}}`);
     assert.dom(this.element).hasText('All Competencies in All Schools');
     assert.dom('.clickable').exists({ count: 1 });
     await click('.clickable');
@@ -52,9 +56,14 @@ module('Integration | Component | myreports list item', function(hooks) {
       subject: 'competency',
     });
 
-    const reportModel = await this.owner.lookup('service:store').find('report', report.id);
-    this.set('report', reportModel);
-    await render(hbs`{{myreports-list-item report=report}}`);
+    const reportModel = await this.owner
+      .lookup('service:store')
+      .find('report', report.id);
+    this.setProperties({ report: reportModel, selectReport: () => {} });
+    await render(hbs`
+      {{myreports-list-item
+        report=this.report
+        onReportSelect=(action this.selectReport)}}`);
     assert.dom(this.element).hasText('All Competencies in ' + school.title);
     assert.dom('.clickable').exists({ count: 1 });
   });
@@ -73,11 +82,17 @@ module('Integration | Component | myreports list item', function(hooks) {
       prepositionalObjectTableRowId: user.id,
     });
 
-    const reportModel = await this.owner.lookup('service:store').find('report', report.id);
-    const userModel = await this.owner.lookup('service:store').find('user', user.id);
-    this.set('report', reportModel);
-    await render(hbs`{{myreports-list-item report=report}}`);
-
+    const reportModel = await this.owner
+      .lookup('service:store')
+      .find('report', report.id);
+    const userModel = await this.owner
+      .lookup('service:store')
+      .find('user', user.id);
+    this.setProperties({ report: reportModel, selectReport: () => {} });
+    await render(hbs`
+      {{myreports-list-item
+        report=this.report
+        onReportSelect=(action this.selectReport)}}`);
     assert.dom(this.element).hasText(
       'All Competencies for ' + userModel.get('fullName') +  ' in ' + school.title
     );


### PR DESCRIPTION
**Summary:**
Dashboard report list now keeps its report-setting state via query params and also preserves its scroll.
- Report ID - `/dashboard?report=1`
- Report Year - `/dashboard?reportYear=2016`

**UI:**
<img width="538" alt="Screen Shot 2019-05-14 at 11 24 44 AM" src="https://user-images.githubusercontent.com/7553764/57714815-eee9ef00-763a-11e9-954b-b8783c1b5485.png">

Fixes https://github.com/ilios/frontend/issues/4541