### PR TITLE
new group message does not stick after route transition

### DIFF
--- a/app/routes/learner-groups.js
+++ b/app/routes/learner-groups.js
@@ -6,6 +6,7 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 
 export default Route.extend(AuthenticatedRouteMixin, {
   store: service(),
+
   model() {
     let defer = RSVP.defer();
     let model = {};
@@ -16,9 +17,16 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
     return defer.promise;
   },
+
   queryParams: {
     titleFilter: {
       replace: true
+    }
+  },
+
+  actions: {
+    willTransition() {
+      this.controller.set('newGroup', null);
     }
   }
 });

--- a/app/templates/learner-groups.hbs
+++ b/app/templates/learner-groups.hbs
@@ -92,10 +92,11 @@
           fillModeSupported=true
         }}
       {{/liquid-if}}
-      {{#if newGroup}}
+
+      {{#if this.newGroup}}
         <div class="saved-result">
-          {{#link-to "learnerGroup" newGroup}}
-            {{fa-icon "external-link-square-alt"}} {{newGroup.title}}
+          {{#link-to "learnerGroup" this.newGroup}}
+            {{fa-icon "external-link-square-alt"}} {{this.newGroup.title}}
           {{/link-to}}
           {{t "general.savedSuccessfully"}}
         </div>


### PR DESCRIPTION
**Summary:**
New learner group creation message disappears if user transitions out of the route.