### PR TITLE
reject upload if user is already present in group hierarchy.

### DIFF
--- a/app/components/learnergroup-bulk-finalize-users.js
+++ b/app/components/learnergroup-bulk-finalize-users.js
@@ -14,7 +14,7 @@ export default Component.extend({
     const users = this.users;
     const learnerGroup = this.learnerGroup;
     const matchedGroups = this.matchedGroups;
-    const finalUsers = users.map(obj => {
+    return users.map(obj => {
       let selectedGroup = learnerGroup;
       if (obj.subGroupName) {
         const match = matchedGroups.findBy('name', obj.subGroupName);
@@ -27,8 +27,6 @@ export default Component.extend({
         learnerGroup: selectedGroup
       };
     });
-
-    return finalUsers;
   }),
 
   save: task(function* () {

--- a/app/components/learnergroup-bulk-finalize-users.js
+++ b/app/components/learnergroup-bulk-finalize-users.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
-import { filter, map } from 'rsvp';
+import { map } from 'rsvp';
 import { inject as service } from '@ember/service';
 import { all } from 'rsvp';
 
@@ -10,14 +10,6 @@ export default Component.extend({
   users: null,
   matchedGroups: null,
   learnerGroup: null,
-  invalidUsers: computed('users.[]', 'learnerGroup', async function () {
-    const users = this.users;
-    const learnerGroup = this.learnerGroup;
-    const allDescendantUsers = await learnerGroup.get('allDescendantUsers');
-    const allDescendantUserIds = allDescendantUsers.mapBy('id');
-
-    return filter(users, async user => allDescendantUserIds.includes(user.userRecord.get('id')));
-  }),
   finalData: computed('users.[]', 'matchedGroups.[]', 'learnerGroup', function(){
     const users = this.users;
     const learnerGroup = this.learnerGroup;

--- a/app/components/learnergroup-upload-data.js
+++ b/app/components/learnergroup-upload-data.js
@@ -120,6 +120,18 @@ export default Component.extend({
           if (user.get('lastName') != lastName) {
             warnings.push(intl.t('general.doesNotMatchUserRecord', {description: intl.t('general.lastName'), record: user.get('lastName')}));
           }
+
+          const topLevelGroup = await learnerGroup.get('topLevelGroup');
+          const allUsersInGroupHierarchy = await topLevelGroup.get('allDescendantUsers');
+          if (allUsersInGroupHierarchy.includes(user)) {
+            errors.push(
+              intl.t(
+                'general.userExistsInGroupHierarchy',
+                {groupTitle: topLevelGroup.get('title')}
+              )
+            );
+          }
+
           userRecord = user;
         }
       }

--- a/app/templates/components/learnergroup-bulk-finalize-users.hbs
+++ b/app/templates/components/learnergroup-bulk-finalize-users.hbs
@@ -1,55 +1,32 @@
-{{#if (is-fulfilled invalidUsers)}}
-  {{#if (await invalidUsers)}}
-    <table data-test-final-error-data>
-      <thead>
-        <tr>
-          <th>{{t "general.name"}}</th>
-          <th>{{t "general.campusId"}}</th>
-          <th>{{t "general.error"}}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{#each (await invalidUsers) as |obj|}}
-          <tr>
-            <td>{{obj.userRecord.fullName}}</td>
-            <td>{{obj.userRecord.campusId}}</td>
-            <td>{{t "general.alreadyInLearnerGroup" learnerGroupTitle=learnerGroup.title}}</td>
-          </tr>
-        {{/each}}
-      </tbody>
-    </table>
+<h3>{{t "general.finalResults"}}</h3>
+<table data-test-final-data>
+  <thead>
+    <tr>
+      <th>{{t "general.name"}}</th>
+      <th>{{t "general.campusId"}}</th>
+      <th>{{t "general.learnerGroups"}}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each finalData as |obj|}}
+      <tr>
+        <td>{{obj.user.fullName}}</td>
+        <td>{{obj.user.campusId}}</td>
+        <td>{{obj.learnerGroup.title}}</td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>
 
+<button
+  disabled={{save.isRunning}}
+  data-test-finalize-users-submit
+  {{action (perform save)}}
+>
+  {{#if save.isRunning}}
+    {{loading-spinner}}
   {{else}}
-    <h3>{{t "general.finalResults"}}</h3>
-    <table data-test-final-data>
-      <thead>
-        <tr>
-          <th>{{t "general.name"}}</th>
-          <th>{{t "general.campusId"}}</th>
-          <th>{{t "general.learnerGroups"}}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{#each finalData as |obj|}}
-          <tr>
-            <td>{{obj.user.fullName}}</td>
-            <td>{{obj.user.campusId}}</td>
-            <td>{{obj.learnerGroup.title}}</td>
-          </tr>
-        {{/each}}
-      </tbody>
-    </table>
-
-    <button
-      disabled={{save.isRunning}}
-      data-test-finalize-users-submit
-      {{action (perform save)}}
-    >
-      {{#if save.isRunning}}
-        {{loading-spinner}}
-      {{else}}
-        {{t "general.save"}}
-      {{/if}}
-    </button>
+    {{t "general.save"}}
   {{/if}}
-{{/if}}
+</button>
+

--- a/tests/acceptance/learnergroup-bulk-assign-test.js
+++ b/tests/acceptance/learnergroup-bulk-assign-test.js
@@ -168,6 +168,13 @@ module('Acceptance | learner group bulk assign', function(hooks) {
       lastName: 'maisel',
       campusId: '123456',
     });
+    this.server.create('user', {
+      firstName: 'dabney',
+      lastName: 'middlefield',
+      campusId: '232323',
+      cohortIds: [1],
+      learnerGroupIds: [1]
+    });
     let users = [
       ['j', 'johnson', '1234567890', '123Test'],
       ['jackson', 'j', '12345'],
@@ -175,16 +182,18 @@ module('Acceptance | learner group bulk assign', function(hooks) {
       ['Magick', '', '101010'],
       ['Missing', 'Person', 'abcd'],
       ['mrs', 'maisel', '123456'],
-      ['j', 'johnson', '1234567890', 'anothergroup' ]
+      ['j', 'johnson', '1234567890', 'anothergroup' ],
+      ['dabney', 'middlefield', '232323' ]
     ];
     await triggerUpload(users, '[data-test-user-upload]');
 
-    assert.equal(page.bulkAssign.invalidUploadedUsers().count, 5);
+    assert.equal(page.bulkAssign.invalidUploadedUsers().count, 6);
     assert.equal(page.bulkAssign.invalidUploadedUsers(0).errors, 'First Name is required');
     assert.equal(page.bulkAssign.invalidUploadedUsers(1).errors, 'Last Name is required');
     assert.equal(page.bulkAssign.invalidUploadedUsers(2).errors, 'Could not find a user with the campusId abcd');
     assert.equal(page.bulkAssign.invalidUploadedUsers(3).errors, "User is not in this group's cohort: class of this year");
     assert.equal(page.bulkAssign.invalidUploadedUsers(4).errors, "This user already exists in the upload.");
+    assert.equal(page.bulkAssign.invalidUploadedUsers(5).errors, "User already exists in top-level group group 1 or one of its subgroups.");
     assert.notOk(page.bulkAssign.showConfirmUploadButton);
   });
 
@@ -257,86 +266,6 @@ module('Acceptance | learner group bulk assign', function(hooks) {
     assert.deepEqual( this.server.db.learnerGroups[0].userIds, ['2', '3']);
     assert.deepEqual( this.server.db.learnerGroups[1].userIds, null);
     assert.deepEqual( this.server.db.learnerGroups[2].userIds, ['3']);
-  });
-
-  test('catch user already in group and do not save', async function (assert) {
-    assert.expect(11);
-    this.server.create('user', {
-      firstName: 'jasper',
-      lastName: 'johnson',
-      campusId: '1234567890',
-      cohortIds: [1],
-      learnerGroupIds: [1],
-    });
-    this.server.create('user', {
-      firstName: 'jackson',
-      lastName: 'johnson',
-      campusId: '12345',
-      cohortIds: [1],
-      learnerGroupIds: [3],
-    });
-    let users = [
-      ['jasper', 'johnson', '1234567890'],
-      ['jackson', 'johnson', '12345', '123Test'],
-    ];
-    await page.visit({ learnerGroupId: 1 });
-    await page.activateBulkAssign();
-
-    await triggerUpload(users, '[data-test-user-upload]');
-    assert.equal(page.bulkAssign.validUploadedUsers().count, 2);
-    await page.bulkAssign.confirmUploadedUsers();
-    assert.equal(page.bulkAssign.groupsToMatch().count, 1);
-    await page.bulkAssign.groupsToMatch(0).chooseGroup('2');
-
-    assert.equal(page.bulkAssign.finalData().count, 0);
-
-    assert.equal(page.bulkAssign.finalErrorData().count, 2);
-    assert.equal(page.bulkAssign.finalErrorData(0).name, 'jasper M. johnson');
-    assert.equal(page.bulkAssign.finalErrorData(0).campusId, '1234567890');
-    assert.equal(page.bulkAssign.finalErrorData(0).error, 'Already in the group 1 group. Please remove them and try again.');
-    assert.equal(page.bulkAssign.finalErrorData(1).name, 'jackson M. johnson');
-    assert.equal(page.bulkAssign.finalErrorData(1).campusId, '12345');
-    assert.equal(page.bulkAssign.finalErrorData(1).error, 'Already in the group 1 group. Please remove them and try again.');
-
-    assert.notOk(page.bulkAssign.canSubmitFinalData);
-
-  });
-
-  test('not in group error only on users not in the group #3668', async function (assert) {
-    assert.expect(7);
-    this.server.create('user', {
-      firstName: 'jasper',
-      lastName: 'johnson',
-      campusId: '1234567890',
-      cohortIds: [1],
-      learnerGroupIds: [1],
-    });
-    this.server.create('user', {
-      firstName: 'jackson',
-      lastName: 'johnson',
-      campusId: '12345',
-      cohortIds: [1],
-    });
-    let users = [
-      ['jasper', 'johnson', '1234567890'],
-      ['jackson', 'johnson', '12345'],
-    ];
-    await page.visit({ learnerGroupId: 1 });
-    await page.activateBulkAssign();
-
-    await triggerUpload(users, '[data-test-user-upload]');
-    assert.equal(page.bulkAssign.validUploadedUsers().count, 2);
-    await page.bulkAssign.confirmUploadedUsers();
-
-    assert.equal(page.bulkAssign.finalData().count, 0);
-
-    assert.equal(page.bulkAssign.finalErrorData().count, 1);
-    assert.equal(page.bulkAssign.finalErrorData(0).name, 'jasper M. johnson');
-    assert.equal(page.bulkAssign.finalErrorData(0).campusId, '1234567890');
-    assert.equal(page.bulkAssign.finalErrorData(0).error, 'Already in the group 1 group. Please remove them and try again.');
-
-    assert.notOk(page.bulkAssign.canSubmitFinalData);
-
   });
 
   test('create a new group when requested', async function (assert) {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -363,6 +363,7 @@ general:
   uploadedGroup: "Uploaded Group"
   uploadGroupAssignments: "Upload Group Assignments"
   uploadUsers: "File with user data (csv, tsv, txt)"
+  userExistsInGroupHierarchy: "User already exists in top-level group {groupTitle} or one of its subgroups."
   userExistsMultipleTimesInUpload: "This user already exists in the upload."
   username: Username
   userNotAddableFromDirectory: "This user is missing required information and cannot be added"

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -16,7 +16,6 @@ general:
   allReports: "All Reports"
   allSchools: "All Schools"
   allVocabularies: "All Vocabularies"
-  alreadyInLearnerGroup: "Already in the {learnerGroupTitle} group. Please remove them and try again."
   anything: Anything
   apiVersionMismatch: "API Version Mismatch"
   apiVersionMismatchDetails: "This frontend does not match the version of the API that it is communicating with. Please notify an administrator or technical owner of the system regarding this error <em>immediately</em>, You cannot work with Ilios until this is resolved"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -363,6 +363,7 @@ general:
   uploadedGroup: "Grupo Subido"
   uploadGroupAssignments: "Cargar Asignaciones de Grupos"
   uploadUsers: "Archivo con datos de usuarios (csv, tsv, tx)"
+  userExistsInGroupHierarchy: "El usuario ya existe en el grupo de nivel superior {groupTitle} o en uno de sus subgrupos."
   userExistsMultipleTimesInUpload: "Este usuario ya existe en la carga."
   username: "Nombre de Usuario"
   userNotAddableFromDirectory: "ste usuario está faltando información requerida y no se puede agregar"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -16,7 +16,6 @@ general:
   allReports: "todos reportes"
   allSchools: "Todas las Escuelas"
   allVocabularies: "Todos los Vocabularios"
-  alreadyInLearnerGroup: "Ya en el grupo {learnerGroupTitle}. Por favor, quítelos e inténtelo de nuevo."
   anything: "Caulquier Cosa"
   apiVersionMismatch: "Incompatibilidad de versión de API"
   apiVersionMismatchDetails: "Este interfaz de usuario no corresponde a la versión del API con el cual se comunica. Por favor notifique a un administrador o el dueño técnico del sistema con respecto a este error <em>inmediatamente</em>, no puede trabajar con Ilios hasta que esto sea resuelto"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -364,6 +364,7 @@ general:
   uploadGroupAssignments: "téléversez travaux des groupes"
   uploadUsers: "fichier de donnée utilisateurs (csv, tsv, txt)"
   username: "Nom d'utilisateur"
+  userExistsInGroupHierarchy: "L'utilisateur existe déjà dans le groupe de niveau supérieur {groupTitle} ou dans l'un de ses sous-groupes."
   userExistsMultipleTimesInUpload: "Cet utilisateur existe déjà dans le téléchargement."
   userNotAddableFromDirectory: "Cette utilisateur manque les informations requises, et ne peut pas être ajouté"
   userNotInGroupCohort: "utilisateur introuvable dans cette groupe de cohorte: {cohortTitle}"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -16,7 +16,6 @@ general:
   allReports: "Tous Rapports"
   allSchools: "Toutes les écoles"
   allVocabularies: "Touts vocabulaires"
-  alreadyInLearnerGroup: "Déjà dans le {learnerGroupTitle} groupe. Enlevez s'il vous plaît l'utilisateur et essayez de nouveau."
   anything: "Quelque chose"
   apiVersionMismatch: "API  conflit de version"
   apiVersionMismatchDetails: "Ce 'frontend' ne correspond pas à la version de l'API avec laquelle il communique. Notifiez S'il vous plaît un administrateur ou un propriétaire technique du système quant à cette erreur immédiatement. Vous ne pouvez pas travailler avec Ilios avant que ce ne soit résolu."


### PR DESCRIPTION
refs #4591 

this expands the scope of the "is user already in group" validation check to entail the entire group-hierarchy (not just the current group and below), and moves the check up from the upload finalization step to the initial upload review step.

![Selection_542](https://user-images.githubusercontent.com/1410427/58918832-bfca1900-86e0-11e9-9ceb-b2fcefadc9d1.png)
