### PR TITLE
Prevent subgroups with learners from being copied

### DIFF
--- a/app/components/learnergroup-list.js
+++ b/app/components/learnergroup-list.js
@@ -7,6 +7,9 @@ export default Component.extend({
   canDelete: false,
   learnerGroups: null,
   query: null,
+
+  'data-test-learnergroup-list': true,
+
   copy() {},
   remove() {},
 

--- a/app/components/learnergroup-subgroup-list.js
+++ b/app/components/learnergroup-subgroup-list.js
@@ -24,6 +24,8 @@ export default Component.extend({
   saved: false,
   savedGroup: null,
 
+  'data-test-learnergroup-subgroup-list': true,
+
   didReceiveAttrs(){
     this._super(...arguments);
     this.set('saved', false);

--- a/app/templates/components/learnergroup-list.hbs
+++ b/app/templates/components/learnergroup-list.hbs
@@ -36,7 +36,7 @@
         <td class="text-center hide-from-small-screen">
           {{get (await learnerGroup.courses) "length"}}
         </td>
-        <td class="text-right">
+        <td class="text-right" data-test-actions>
           {{#if (is-fulfilled learnerGroup.hasLearnersInGroupOrSubgroups)}}
             {{#if (and
               @canDelete
@@ -44,7 +44,9 @@
               (eq (get (await learnerGroup.courses) "length") 0))}}
               <span
                 class="clickable remove"
-                {{action "confirmRemove" learnerGroup}}>
+                {{action "confirmRemove" learnerGroup}}
+                data-test-remove
+              >
                 {{fa-icon "trash" class="enabled"}}
               </span>
             {{else}}
@@ -53,12 +55,13 @@
           {{else}}
             {{loading-spinner}}
           {{/if}}
-
           {{#if @canCreate}}
             {{fa-icon "copy"
               class="clickable enabled"
               title=(t "general.copy")
-              click=(action "startCopy" learnerGroup)}}
+              click=(action "startCopy" learnerGroup)
+              data-test-copy=true
+            }}
           {{else}}
             {{fa-icon "copy" class="disabled"}}
           {{/if}}
@@ -66,15 +69,17 @@
       </tr>
 
       {{#if (contains learnerGroup this.learnerGroupsForRemovalConfirmation)}}
-        <tr class="confirm-removal">
+        <tr class="confirm-removal" data-test-confirm-removal>
           <td colspan="5">
-            <div class="confirm-message">
+            <div class="confirm-message" data-test-confirmation>
               {{t "general.confirmRemoveLearnerGroup"
                 subgroupCount=learnerGroup.children.length}} <br>
               <div class="confirm-buttons">
                 <button
                   class="remove text"
-                  onclick={{action @remove learnerGroup}}>
+                  onclick={{action @remove learnerGroup}}
+                  data-test-confirm
+                >
                   {{t "general.yes"}}
                 </button>
                 <button
@@ -89,19 +94,34 @@
       {{/if}}
 
       {{#if (contains learnerGroup this.learnerGroupsForCopy)}}
-        <tr class="confirm-copy">
+        <tr class="confirm-copy" data-test-confirm-copy>
           <td colspan="5">
             <div class="confirm-buttons">
-              <button
-                class="done text"
-                onclick={{action "copy" true learnerGroup}}>
-                {{t "general.copyWithLearners"}}
-              </button>
-              <button
-                class="done text"
-                onclick={{action "copy" false learnerGroup}}>
-                {{t "general.copyWithoutLearners"}}
-              </button>
+              {{#if @canCopyWithLearners}}
+                <button
+                  class="done text"
+                  onclick={{action "copy" true learnerGroup}}
+                  data-test-confirm-with-learners
+                >
+                  {{t "general.copyWithLearners"}}
+                </button>
+                <button
+                  class="done text"
+                  onclick={{action "copy" false learnerGroup}}
+                  data-test-confirm-without-learners
+                >
+                  {{t "general.copyWithoutLearners"}}
+                </button>
+              {{else}}
+                <button
+                    class="done text"
+                    onclick={{action "copy" false learnerGroup}}
+                    data-test-confirm-without-learners
+                  >
+                  {{t "general.copy"}}
+                </button>
+              {{/if}}
+
               <button
                 class="cancel text"
                 onclick={{action "cancelCopy" learnerGroup}}>

--- a/app/templates/components/learnergroup-subgroup-list.hbs
+++ b/app/templates/components/learnergroup-subgroup-list.hbs
@@ -48,6 +48,7 @@
           learnerGroups=(await parentGroup.children)
           canDelete=canDelete
           canCreate=canCreate
+          canCopyWithLearners=false
           remove=(action "removeLearnerGroup")
           copy=(perform copyGroup)
         }}

--- a/app/templates/learner-groups.hbs
+++ b/app/templates/learner-groups.hbs
@@ -108,6 +108,7 @@
         {{learnergroup-list
           canCreate=(await canCreate)
           canDelete=(await canDelete)
+          canCopyWithLearners=true
           learnerGroups=(await filteredLearnerGroups)
           query=titleFilter
           copy=(perform copyGroup)

--- a/tests/integration/components/learnergroup-list-test.js
+++ b/tests/integration/components/learnergroup-list-test.js
@@ -1,0 +1,176 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/learnergroup-list';
+
+module('Integration | Component | learner group list', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it renders', async function (assert) {
+    const users = this.server.createList('user', 2);
+    const firstGroup = this.server.create('learner-group');
+    const secondGroup = this.server.create('learner-group', {
+      users
+    });
+    this.server.createList('learner-group', 2, { parent: firstGroup });
+    const firstGroupModel = await this.owner.lookup('service:store').find('learner-group', firstGroup.id);
+    const secondGroupModel = await this.owner.lookup('service:store').find('learner-group', secondGroup.id);
+
+    this.set('learnerGroups', [firstGroupModel, secondGroupModel]);
+    await render(hbs`{{learnergroup-list learnerGroups=learnerGroups}}`);
+
+    assert.equal(component.headings[0].text, 'Learner Group Title');
+    assert.equal(component.headings[1].text, 'Members');
+    assert.equal(component.headings[2].text, 'Subgroups');
+    assert.equal(component.headings[3].text, 'Courses');
+    assert.equal(component.headings[4].text, 'Actions');
+
+    assert.equal(component.groups.length, 2);
+
+    assert.equal(component.groups[0].title, 'learner group 0');
+    assert.equal(component.groups[0].members, '0');
+    assert.equal(component.groups[0].subgroups, '2');
+    assert.equal(component.groups[0].courses, '0');
+
+    assert.equal(component.groups[1].title, 'learner group 1');
+    assert.equal(component.groups[1].members, '2');
+    assert.equal(component.groups[1].subgroups, '0');
+    assert.equal(component.groups[1].courses, '0');
+  });
+
+  test('can remove group', async function (assert) {
+    assert.expect(4);
+    const parent = this.server.create('learner-group');
+
+    this.server.createList('learner-group', 2, { parent });
+    const model = await this.owner.lookup('service:store').find('learner-group', parent.id);
+
+    this.set('remove', ({ id }) => {
+      assert.equal(id, model.id);
+    });
+    this.set('learnerGroups', [model]);
+    await render(hbs`{{learnergroup-list learnerGroups=learnerGroups remove=remove canDelete=true}}`);
+
+    assert.equal(component.groups.length, 1);
+    assert.ok(component.groups[0].actions.canRemove);
+    await component.groups[0].actions.remove();
+    assert.ok(component.confirmRemoval.confirmation.includes('Are you sure'));
+    await component.confirmRemoval.confirm();
+  });
+
+  test('cannot remove group with users', async function (assert) {
+    assert.expect(2);
+    const users = this.server.createList('user', 2);
+    const parent = this.server.create('learner-group', { users });
+
+    this.server.createList('learner-group', 2, { parent });
+    const model = await this.owner.lookup('service:store').find('learner-group', parent.id);
+    this.set('learnerGroups', [model]);
+    await render(hbs`{{learnergroup-list learnerGroups=learnerGroups remove=remove canDelete=true}}`);
+
+    assert.equal(component.groups.length, 1);
+    assert.notOk(component.groups[0].actions.canRemove);
+  });
+
+  test('cannot remove group with users in subgroup', async function (assert) {
+    assert.expect(2);
+    const users = this.server.createList('user', 2);
+    const parent = this.server.create('learner-group');
+
+    this.server.createList('learner-group', 2, { parent, users });
+    const model = await this.owner.lookup('service:store').find('learner-group', parent.id);
+    this.set('learnerGroups', [model]);
+    await render(hbs`{{learnergroup-list learnerGroups=learnerGroups remove=remove canDelete=true}}`);
+
+    assert.equal(component.groups.length, 1);
+    assert.notOk(component.groups[0].actions.canRemove);
+  });
+
+  test('cannot remove group with courses', async function(assert) {
+    assert.expect(2);
+    const course = this.server.create('course');
+    const session = this.server.create('session', { course });
+    const offering = this.server.create('offering', { session });
+    const parent = this.server.create('learner-group', { offerings: [offering] });
+
+    this.server.createList('learner-group', 2, { parent });
+    const model = await this.owner.lookup('service:store').find('learner-group', parent.id);
+    this.set('learnerGroups', [model]);
+    await render(hbs`{{learnergroup-list learnerGroups=learnerGroups remove=remove canDelete=true}}`);
+
+    assert.equal(component.groups.length, 1);
+    assert.notOk(component.groups[0].actions.canRemove);
+  });
+
+  test('can copy group with learners when canCopyWithLearners is enabled', async function (assert) {
+    assert.expect(5);
+    const group = this.server.create('learner-group');
+    const model = await this.owner.lookup('service:store').find('learner-group', group.id);
+
+    this.set('copy', (withLearners, { id }) => {
+      assert.ok(withLearners);
+      assert.equal(id, model.id);
+    });
+    this.set('learnerGroups', [model]);
+    await render(hbs`{{learnergroup-list learnerGroups=learnerGroups copy=copy canCreate=true canCopyWithLearners=true}}`);
+
+    assert.equal(component.groups.length, 1);
+    assert.ok(component.groups[0].actions.canCopy);
+    await component.groups[0].actions.copy();
+    assert.ok(component.confirmCopy.canCopyWithLearners);
+    await component.confirmCopy.confirmWithLearners();
+  });
+
+  test('can copy group without learners', async function (assert) {
+    assert.expect(5);
+    const group = this.server.create('learner-group');
+    const model = await this.owner.lookup('service:store').find('learner-group', group.id);
+
+    this.set('copy', (withLearners, { id }) => {
+      assert.notOk(withLearners);
+      assert.equal(id, model.id);
+    });
+    this.set('learnerGroups', [model]);
+    await render(hbs`{{learnergroup-list learnerGroups=learnerGroups copy=copy canCreate=true}}`);
+
+    assert.equal(component.groups.length, 1);
+    assert.ok(component.groups[0].actions.canCopy);
+    await component.groups[0].actions.copy();
+    assert.ok(component.confirmCopy.canCopyWithoutLearners);
+    await component.confirmCopy.confirmWithoutLearners();
+  });
+
+  test('can copy group without learners when copyWithLearners is disabled', async function (assert) {
+    assert.expect(3);
+    const group = this.server.create('learner-group');
+    const model = await this.owner.lookup('service:store').find('learner-group', group.id);
+
+    this.set('copy', () => { });
+    this.set('learnerGroups', [model]);
+    await render(hbs`{{learnergroup-list learnerGroups=learnerGroups copy=copy canCreate=true canCopyWithLearners=false}}`);
+
+    assert.equal(component.groups.length, 1);
+    assert.ok(component.groups[0].actions.canCopy);
+    await component.groups[0].actions.copy();
+    assert.ok(component.confirmCopy.canCopyWithoutLearners);
+  });
+
+  test('can not copy group with learners when copyWithLearners is disabled', async function (assert) {
+    assert.expect(3);
+    const users = this.server.createList('user', 2);
+    const group = this.server.create('learner-group', { users });
+    const model = await this.owner.lookup('service:store').find('learner-group', group.id);
+
+    this.set('copy', () => { });
+    this.set('learnerGroups', [model]);
+    await render(hbs`{{learnergroup-list learnerGroups=learnerGroups copy=copy canCreate=true canCopyWithLearners=false}}`);
+
+    assert.equal(component.groups.length, 1);
+    assert.ok(component.groups[0].actions.canCopy);
+    await component.groups[0].actions.copy();
+    assert.notOk(component.confirmCopy.canCopyWithLearners);
+  });
+});

--- a/tests/pages/components/learnergroup-list.js
+++ b/tests/pages/components/learnergroup-list.js
@@ -1,0 +1,44 @@
+import {
+  clickable,
+  create,
+  collection,
+  isPresent,
+  text,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-learnergroup-list]',
+  title: text('[data-test-title]'),
+  headings: collection('thead th', {
+    title: text(),
+  }),
+  groups: collection('tbody tr', {
+    title: text('td', { at: 0 }),
+    members: text('td', { at: 1 }),
+    subgroups: text('td', { at: 2 }),
+    courses: text('td', { at: 3 }),
+    actions: {
+      scope: '[data-test-actions]',
+      canRemove: isPresent('[data-test-remove]'),
+      remove: clickable('[data-test-remove]'),
+      canCopy: isPresent('[data-test-copy]'),
+      copy: clickable('[data-test-copy]'),
+    },
+  }),
+  confirmRemoval: {
+    scope: '[data-test-confirm-removal]',
+    confirm: clickable('[data-test-confirm]'),
+    confirmation: text('[data-test-confirmation]'),
+  },
+  confirmCopy: {
+    scope: '[data-test-confirm-copy]',
+    confirmWithLearners: clickable('[data-test-confirm-with-learners]'),
+    confirmWithoutLearners: clickable('[data-test-confirm-without-learners]'),
+    canCopyWithLearners: isPresent('[data-test-confirm-with-learners]'),
+    canCopyWithoutLearners: isPresent('[data-test-confirm-without-learners]'),
+  },
+
+};
+
+export default definition;
+export const component = create(definition);


### PR DESCRIPTION
This isn't allowed in our group model, users can only be in one branch
of a top level group, allowing subgroups to be copied with learners is
in violation of that.

Fixes #4592