### PR TITLE
improved simple-chart tooltip display

### DIFF
--- a/app/styles/components.scss
+++ b/app/styles/components.scss
@@ -91,6 +91,7 @@
 @import 'components/school-vocabularies-list';
 @import 'components/school-vocabulary-manager';
 @import 'components/school-vocabulary-term-manager';
+@import 'components/simple-chart-tooltip';
 @import 'components/pending-single-user-updates';
 @import 'components/pending-user-updates';
 @import 'components/program-details';

--- a/app/styles/components/simple-chart-tooltip.scss
+++ b/app/styles/components/simple-chart-tooltip.scss
@@ -1,0 +1,10 @@
+.simple-chart-tooltip {
+  left: 13rem !important;
+  width: 45%;
+
+  @include for-smaller-than-laptop {
+    left: 0 !important;
+    margin-left: 2.5%;
+    width: 90%;
+  }
+}


### PR DESCRIPTION
**Summary:**
Improved simple-chart tooltip display. Works for all four visualizations.

**UI:**
_Desktop_
<img width="1280" alt="Screen Shot 2019-06-06 at 1 13 30 PM" src="https://user-images.githubusercontent.com/7553764/59057900-0e062600-8861-11e9-9569-00bf0a9ad1fa.png">

_Smaller Than Desktop_
<img width="617" alt="Screen Shot 2019-06-06 at 1 11 40 PM" src="https://user-images.githubusercontent.com/7553764/59057910-152d3400-8861-11e9-9667-b7bc82d2e03c.png">

Fixes https://github.com/ilios/frontend/issues/4544