### PR TITLE
added scroll to CI report rollover transition

### DIFF
--- a/app/components/curriculum-inventory-report-overview.js
+++ b/app/components/curriculum-inventory-report-overview.js
@@ -4,6 +4,7 @@ import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { validator, buildValidations } from 'ember-cp-validations';
 import ValidationErrorDisplay from 'ilios-common/mixins/validation-error-display';
+import scrollTo from 'ilios-common/utils/scroll-to';
 
 const Validations = buildValidations({
   description: [
@@ -30,6 +31,7 @@ const Validations = buildValidations({
 export default Component.extend(Validations, ValidationErrorDisplay, {
   currentUser: service(),
   permissionChecker: service(),
+  router: service(),
   routing: service('-routing'),
 
   classNames: ['curriculum-inventory-report-overview'],
@@ -177,6 +179,11 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     revertDescriptionChanges(){
       const report = this.report;
       this.set('description', report.get('description'));
+    },
+
+    transitionToRollover() {
+      this.router.transitionTo('curriculumInventoryReport.rollover', this.report);
+      scrollTo('.rollover-form');
     }
   }
 });

--- a/app/styles/components/curriculum-inventory-report-overview.scss
+++ b/app/styles/components/curriculum-inventory-report-overview.scss
@@ -13,15 +13,13 @@
     .report-overview-actions {
       @include ilios-overview-actions;
 
-      a {
+      a, span {
         color: $header-blue;
         font-size: 1.2rem;
         margin-right: .5rem;
       }
     }
   }
-
-
 
   .block {
     @include ilios-overview-block;

--- a/app/templates/components/curriculum-inventory-report-overview.hbs
+++ b/app/templates/components/curriculum-inventory-report-overview.hbs
@@ -4,13 +4,14 @@
     <div class="title">{{t "general.overview"}}</div>
     <div class="report-overview-actions">
       {{#if (and (is-fulfilled showRollover) (await showRollover))}}
-        {{#link-to "curriculumInventoryReport.rollover" report class="rollover"}}
-          {{fa-icon
-            "random"
-            title=(t "general.curriculumInventoryReportRollover")
+        <span
+          class="link rollover"
+          role="button"
+          {{action "transitionToRollover"}}>
+          {{fa-icon "random"
             fixedWidth=true
-          }}
-        {{/link-to}}
+            title=(t "general.curriculumInventoryReportRollover")}}
+        </span>
       {{/if}}
     </div>
   </div>

--- a/tests/acceptance/curriculum-inventory/report-test.js
+++ b/tests/acceptance/curriculum-inventory/report-test.js
@@ -78,8 +78,7 @@ module('Acceptance | Curriculum Inventory: Report', function(hooks) {
     });
     await visit(url);
     const container = '.curriculum-inventory-report-overview';
-    const rollover = `${container} a.rollover`;
-
+    const rollover = `${container} span.rollover`;
     assert.equal(currentRouteName(), 'curriculumInventoryReport.index');
     assert.dom(rollover).exists({ count: 1 });
   });


### PR DESCRIPTION
**Summary:**
Rollover icon enables scroll to Rollover form.

Fixes https://github.com/ilios/frontend/issues/4636