### PR TITLE
Show the loading bar anytime it's needed

### DIFF
--- a/app/components/loading-bar.js
+++ b/app/components/loading-bar.js
@@ -33,7 +33,7 @@ export default Component.extend({
     } else {
       return removeProgress.perform();
     }
-  }).restartable().on('init'),
+  }).restartable().on('didReceiveAttrs'),
 
   removeProgress: task(function * () {
     const progress = this.progress;


### PR DESCRIPTION
By using init here we were only showing the loading bar once, on initial
page boot. Changing this ensures that it is checked anytime the
`isLoading` attr gets updated.

Fixes #4650