### PR TITLE
Only load schools once

### DIFF
--- a/app/adapters/school.js
+++ b/app/adapters/school.js
@@ -1,0 +1,16 @@
+import IliosAdapter from 'ilios-common/adapters/ilios';
+
+export default IliosAdapter.extend({
+  /**
+   * Don't reload school records if we have any of them
+   * in the store already. Schools rarely change, but they
+   * are needed all the time, we just don't need to go
+   * back to the API once they are loaded.
+   */
+  shouldReloadAll(store, snapshotRecordArray) {
+    return !snapshotRecordArray.length;
+  },
+  shouldBackgroundReloadAll() {
+    return false;
+  },
+});

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import config from 'ilios/config/environment';
+import { all } from 'rsvp';
 
 export default Route.extend(ApplicationRouteMixin, {
   commonAjax: service(),
@@ -9,6 +10,7 @@ export default Route.extend(ApplicationRouteMixin, {
   intl: service(),
   moment: service(),
   session: service(),
+  store: service(),
 
   init() {
     this._super(...arguments);
@@ -35,7 +37,10 @@ export default Route.extend(ApplicationRouteMixin, {
     const currentUser = this.currentUser;
     const user = await currentUser.get('model');
     if (user) {
-      await user.get('roles');
+      await all([
+        user.get('roles'),
+        this.store.findAll('school')
+      ]);
     }
   },
 

--- a/tests/integration/components/user-profile-cohorts-test.js
+++ b/tests/integration/components/user-profile-cohorts-test.js
@@ -49,6 +49,7 @@ module('Integration | Component | user profile cohorts', function(hooks) {
       },
     });
     this.owner.register('service:currentUser', currentUserMock);
+    await this.owner.lookup('service:store').findAll('school');
   });
 
   test('it renders', async function(assert) {


### PR DESCRIPTION
By loading schools immediately and then preventing a reload during the
same session we save 3-5 requests back to the API in the typical page
load. Since schools are extremely permanent this should be a positive for
every user.