### PR TITLE
learnergroup-list is sortable

### DIFF
--- a/app/components/learnergroup-list.js
+++ b/app/components/learnergroup-list.js
@@ -1,17 +1,45 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
   classNames: ['learnergroup-list'],
 
+  bubbleSort: true,
   canCreate: false,
   canDelete: false,
   learnerGroups: null,
   query: null,
+  sortBy: 'title',
 
   'data-test-learnergroup-list': true,
 
   copy() {},
   remove() {},
+  setSortBy() {},
+
+  sortedAscending: computed('sortBy', function() {
+    return this.sortBy.search(/desc/) === -1;
+  }),
+
+  sortedLearnerGroups: computed('learnerGroups.[]', 'sortBy', 'sortedAscending', function() {
+    const learnerGroups = this.learnerGroups;
+    const sortedAscending = this.sortedAscending;
+    let sortBy = this.sortBy;
+
+    if (learnerGroups) {
+      if (sortBy.indexOf(':') !== -1) {
+        sortBy = sortBy.split(':', 1)[0];
+      }
+
+      let sortedLearnerGroups = learnerGroups.sortBy(sortBy);
+
+      if (!sortedAscending) {
+        sortedLearnerGroups = sortedLearnerGroups.slice().reverse();
+      }
+
+      return sortedLearnerGroups;
+    }
+  }),
 
   init() {
     this._super(...arguments);
@@ -43,6 +71,20 @@ export default Component.extend({
       const copy = this.copy;
       await copy(withLearners, learnerGroup);
       this.learnerGroupsForCopy.removeObject(learnerGroup);
+    },
+
+    sortBy(what) {
+      const sortBy = this.sortBy;
+
+      if (sortBy === what){
+        what += ':desc';
+      }
+
+      if (this.bubbleSort) {
+        this.setSortBy(what);
+      } else {
+        this.set('sortBy', what);
+      }
     }
   }
 });

--- a/app/controllers/learner-groups.js
+++ b/app/controllers/learner-groups.js
@@ -15,6 +15,7 @@ export default Controller.extend({
     programId: 'program',
     programYearId: 'programYear',
     schoolId: 'school',
+    sortLearnerGroupsBy: 'sortBy',
     titleFilter: 'filter'
   },
 
@@ -25,6 +26,7 @@ export default Controller.extend({
   programYearId: null,
   schoolId: null,
   showNewLearnerGroupForm: false,
+  sortLearnerGroupsBy: 'title',
   titleFilter: null,
   totalGroupsToSave: 0,
 

--- a/app/templates/components/learnergroup-list.hbs
+++ b/app/templates/components/learnergroup-list.hbs
@@ -1,15 +1,30 @@
 <table>
   <thead>
     <tr>
-      <th class="text-left" colspan="2">
+      {{#sortable-th
+        colspan=2
+        sortedAscending=this.sortedAscending
+        click=(action "sortBy" "title")}}
         {{t "general.learnerGroupTitle"}}
-      </th>
-      <th class="text-center hide-from-small-screen">
+      {{/sortable-th}}
+      {{#sortable-th
+        align="center"
+        colspan=1
+        hideFromSmallScreen=true
+        sortedAscending=this.sortedAscending
+        sortType="numeric"
+        click=(action "sortBy" "usersCount")}}
         {{t "general.members"}}
-      </th>
-      <th class="text-center hide-from-small-screen">
+      {{/sortable-th}}
+      {{#sortable-th
+        align="center"
+        colspan=1
+        hideFromSmallScreen=true
+        sortedAscending=this.sortedAscending
+        sortType="numeric"
+        click=(action "sortBy" "childrenCount")}}
         {{t "general.subgroups"}}
-      </th>
+      {{/sortable-th}}
       <th class="text-center hide-from-small-screen">
         {{t "general.courses"}}
       </th>
@@ -18,7 +33,7 @@
   </thead>
 
   <tbody>
-    {{#each (sort-by "title" @learnerGroups) as |learnerGroup|}}
+    {{#each this.sortedLearnerGroups as |learnerGroup|}}
       <tr
         class={{if (contains learnerGroup this.learnerGroupsForRemovalConfirmation) "confirm-removal"}}
         data-test-active-row>

--- a/app/templates/components/learnergroup-subgroup-list.hbs
+++ b/app/templates/components/learnergroup-subgroup-list.hbs
@@ -45,6 +45,7 @@
     {{#if (is-fulfilled parentGroup.children)}}
       {{#if (get (await parentGroup.children) "length")}}
         {{learnergroup-list
+          bubbleSort=false
           learnerGroups=(await parentGroup.children)
           canDelete=canDelete
           canCreate=canCreate

--- a/app/templates/learner-groups.hbs
+++ b/app/templates/learner-groups.hbs
@@ -111,8 +111,10 @@
           canCopyWithLearners=true
           learnerGroups=(await filteredLearnerGroups)
           query=titleFilter
+          sortBy=this.sortLearnerGroupsBy
           copy=(perform copyGroup)
-          remove=(action "removeLearnerGroup")}}
+          remove=(action "removeLearnerGroup")
+          setSortBy=(action (mut this.sortLearnerGroupsBy))}}
       {{else}}
         {{pulse-loader}}
       {{/if}}


### PR DESCRIPTION
**Summary:**
`learnergroup-list` component table is sortable.
- `/learnergroups` route - query param sorted
- `/learnergroups/:id` route - internal sort (no query params for now)

**UI:**
![sort](https://user-images.githubusercontent.com/7553764/60309221-58377000-9912-11e9-91d6-6855635bf238.gif)

Fixes https://github.com/ilios/frontend/issues/2595