### PR TITLE
Use the API version data from common

### DIFF
--- a/app/components/api-version-check.js
+++ b/app/components/api-version-check.js
@@ -1,13 +1,10 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import ENV from 'ilios/config/environment';
 import { task, timeout } from 'ember-concurrency';
 import { readOnly } from '@ember/object/computed';
 
-const { apiVersion } = ENV.APP;
-
 export default Component.extend({
-  iliosConfig: service(),
+  apiVersion: service(),
   versionMismatch: false,
   updateAvailable: false,
   countdownToUpdate: null,
@@ -19,9 +16,7 @@ export default Component.extend({
     this.loadAttributes.perform();
   },
   loadAttributes: task(function* () {
-    const iliosConfig = this.iliosConfig;
-    const serverApiVersion = yield iliosConfig.get('apiVersion');
-    const versionMismatch = serverApiVersion !== apiVersion;
+    const versionMismatch = yield this.apiVersion.isMismatched;
     if (versionMismatch && 'serviceWorker' in navigator) {
       yield (1000); //wait a second to let the new service worker get fetched if it is available
       const reg = yield navigator.serviceWorker.getRegistration();

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,15 +1,12 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
-import ENV from 'ilios/config/environment';
-
-const { apiVersion } = ENV.APP;
 
 export default Controller.extend({
+  apiVersion: service(),
   currentUser: service(),
   intl: service(),
   session: service(),
 
-  apiVersion,
   currentlyLoading: false,
   errors: null,
   showErrorDisplay: null,

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -18,7 +18,7 @@
   </main>
   <footer class="ilios-footer">
     <div class="version">
-      {{apiVersion}}
+      {{apiVersion.version}}
       {{app-version versionOnly=true}}
     </div>
   </footer>

--- a/config/api-version.js
+++ b/config/api-version.js
@@ -1,3 +1,0 @@
-/* eslint-env node */
-
-module.exports = 'v1.37';

--- a/config/environment.js
+++ b/config/environment.js
@@ -7,8 +7,6 @@ if (existsSync(dotEnvPath)) {
   dotenv.config({ path: dotEnvPath });
 }
 
-const API_VERSION = require('./api-version.js');
-
 module.exports = function (environment) {
 
   let ENV = {
@@ -87,7 +85,6 @@ module.exports = function (environment) {
     },
 
     APP: {
-      apiVersion: API_VERSION,
       // Here you can pass flags/options to your application instance
       // when it is created
     },

--- a/tests/acceptance/admin-test.js
+++ b/tests/acceptance/admin-test.js
@@ -7,9 +7,7 @@ import {
   waitFor
 } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import ENV from 'ilios/config/environment';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
-const { apiVersion } = ENV.APP;
 
 let url = '/admin';
 
@@ -56,6 +54,7 @@ module('Acceptance | Admin', function(hooks) {
 
   test('ordered by when search is disabled', async function (assert) {
     assert.expect(4);
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
     this.server.get('application/config', function() {
       return { config: {
         type: 'form',
@@ -84,6 +83,7 @@ module('Acceptance | Admin', function(hooks) {
 
   test('no order by when search is enabled', async function (assert) {
     assert.expect(2);
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
     this.server.get('application/config', function() {
       return { config: {
         type: 'form',

--- a/tests/acceptance/api-version-check-test.js
+++ b/tests/acceptance/api-version-check-test.js
@@ -2,9 +2,6 @@ import { visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
 
-import ENV from 'ilios/config/environment';
-const { apiVersion } = ENV.APP;
-
 let url = '/';
 
 import { setupApplicationTest } from 'ember-qunit';
@@ -19,7 +16,9 @@ module('Acceptance | API Version Check', function(hooks) {
   });
 
   test('No warning shows up when api versions match', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    assert.ok(apiVersion);
     this.server.get('application/config', function() {
       assert.ok(true, 'our config override was called');
       return { config: {

--- a/tests/acceptance/footer-test.js
+++ b/tests/acceptance/footer-test.js
@@ -5,7 +5,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
 import ENV from 'ilios/config/environment';
 import { versionRegExp } from 'ember-cli-app-version/utils/regexp';
-const { version, apiVersion } = ENV.APP;
+const { version } = ENV.APP;
 
 module('Acceptance | footer', function(hooks) {
   setupApplicationTest(hooks);
@@ -16,7 +16,9 @@ module('Acceptance | footer', function(hooks) {
     this.user = await setupAuthentication({ school });
   });
 
-  test('footer displays version', async function(assert) {
+  test('footer displays version', async function (assert) {
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    assert.ok(apiVersion);
     await visit('/');
     assert.ok(find('.ilios-footer .version').textContent.includes(version.match(versionRegExp)));
     assert.ok(find('.ilios-footer .version').textContent.includes(apiVersion));

--- a/tests/integration/components/api-version-check-test.js
+++ b/tests/integration/components/api-version-check-test.js
@@ -1,19 +1,16 @@
 import Service from '@ember/service';
-import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import ENV from 'ilios/config/environment';
-
-const { apiVersion } = ENV.APP;
 
 module('Integration | Component | api version check', function(hooks) {
   setupRenderingTest(hooks);
 
   test('shows no warning when versions match', async function(assert) {
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
     const iliosConfigMock = Service.extend({
-      apiVersion: resolve(apiVersion)
+      apiVersion
     });
     const warningOverlay = '.api-version-check-warning';
     this.owner.register('service:iliosConfig', iliosConfigMock);
@@ -25,7 +22,7 @@ module('Integration | Component | api version check', function(hooks) {
 
   test('shows warning on mismatch', async function(assert) {
     const iliosConfigMock = Service.extend({
-      apiVersion: resolve('bad')
+      apiVersion: 'bad'
     });
     const warningOverlay = '.api-version-check-warning';
     this.owner.register('service:iliosConfig', iliosConfigMock);

--- a/tests/integration/components/ilios-users-test.js
+++ b/tests/integration/components/ilios-users-test.js
@@ -5,9 +5,6 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, find, findAll, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import ENV from 'ilios/config/environment';
-
-const { apiVersion } = ENV.APP;
 
 module('Integration | Component | ilios users', function(hooks) {
   setupRenderingTest(hooks);
@@ -35,7 +32,9 @@ module('Integration | Component | ilios users', function(hooks) {
   });
 
   test('add user form renders when configured to', async function(assert) {
-    assert.expect(3);
+    assert.expect(4);
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    assert.ok(apiVersion);
     this.server.get('application/config', function() {
       return { config: {
         type: 'form',
@@ -73,7 +72,9 @@ module('Integration | Component | ilios users', function(hooks) {
   });
 
   test('directory search renders when configured to', async function(assert) {
-    assert.expect(3);
+    assert.expect(4);
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    assert.ok(apiVersion);
     this.server.get('application/config', function() {
       return { config: {
         type: 'form',


### PR DESCRIPTION
This is now handled by ilios-common and is provided through a service.
It's still pushed into our config environment by the addon.