### PR TITLE
Send deployed release info to sentry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,12 +50,9 @@ jobs:
       env: COVERAGE=false
       script:
        - node_modules/.bin/ember deploy production --activate
-    - stage: send release to sentry
-      if: tag IS present
-      env: COVERAGE=false
-      before_script: npm install -g @sentry/cli
-      script:
+      after_success:
+       - npm install -g @sentry/cli
        - sentry-cli releases new $TRAVIS_TAG
        - sentry-cli releases set-commits --auto $TRAVIS_TAG
-       - sentry-cli releases files $TRAVIS_TAG upload-sourcemaps dist/
+       - sentry-cli releases files $TRAVIS_TAG upload-sourcemaps tmp/deploy-dist/
        - sentry-cli releases finalize $TRAVIS_TAG


### PR DESCRIPTION
In order to line up the build and release files we should just send what
the final deployed build is to sentry.