### PR TITLE
Add missing background to icon

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -30,6 +30,7 @@ module.exports = function(defaults) {
         {
           inputFilename: 'lib/images/sunburst.svg',
           outputFileName: 'sunburst-white-background',
+          background: {r: 255, g: 255, b: 255, alpha: 1},
           convertTo: 'png',
           sizes: [48, 96, 180, 192],
         },


### PR DESCRIPTION
This icon was named white-background, but it was transparent since that
is what the original SVG is. Add a background option to fix this so it
looks good on iOS and doesn't get the ugly black default background.