### PR TITLE
adds input options for start/end-date to ci rollover form.

### DIFF
--- a/app/components/curriculum-inventory-report-rollover.js
+++ b/app/components/curriculum-inventory-report-rollover.js
@@ -14,6 +14,18 @@ const Validations = buildValidations({
       min: 3,
       max: 200
     })
+  ],
+  startDate: [
+    validator('date', {
+      dependentKeys: ['model.endDate'],
+      onOrBefore: reads('model.endDate'),
+    }),
+  ],
+  endDate: [
+    validator('date', {
+      dependentKeys: ['model.startDate'],
+      onOrAfter: reads('model.startDate'),
+    })
   ]
 });
 
@@ -31,6 +43,8 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   report: null,
   selectedYear: null,
   years: null,
+  startDate: null,
+  endDate: null,
 
   host: reads('iliosConfig.apiHost'),
   namespace: reads('iliosConfig.apiNameSpace'),
@@ -40,6 +54,8 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     const report = this.report;
     const thisYear = parseInt(moment().format('YYYY'), 10);
     const reportYear = parseInt(report.get('year'), 10);
+    const reportStartDate = report.get('startDate');
+    const reportEndDate = report.get('endDate');
     const startYear = Math.min(thisYear, reportYear);
     const endYear = Math.max(thisYear, reportYear) + 5;
     let years = [];
@@ -55,7 +71,20 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     if (! selectedYear) {
       selectedYear = years.findBy('id', reportYear + 1);
     }
+
+    const newReportYear = selectedYear.id;
+    const yearDiff = moment(reportEndDate).get('year') - moment(reportStartDate).get('year');
+    const startDate = moment(reportStartDate).set('year', newReportYear).toDate();
+    const endDate = moment(reportEndDate).set('year', newReportYear + yearDiff).toDate();
+
+    console.log(reportStartDate);
+    console.log(reportEndDate);
+    console.log(startDate);
+    console.log(endDate);
+
     this.set('name', report.get('name'));
+    this.set('startDate', startDate);
+    this.set('endDate', endDate);
     this.set('description', report.get('description'));
     this.set('selectedYear', selectedYear);
     this.set('years', years);
@@ -64,7 +93,7 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
   actions: {
     changeName(newName){
       this.set('name', newName);
-    }
+    },
   },
 
   save: task(function* () {
@@ -82,10 +111,14 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     const year = this.selectedYear.get('id');
     const description = this.description;
     const name = this.name;
+    const startDate = this.startDate;
+    const endDate = this.endDate;
     let data = {
       name,
       description,
       year,
+      startDate,
+      endDate
     };
     const host = this.host ? this.host : '';
     const namespace = this.namespace;

--- a/app/styles/components/curriculum-inventory-report-rollover.scss
+++ b/app/styles/components/curriculum-inventory-report-rollover.scss
@@ -7,7 +7,6 @@
   .rollover-form {
     @include ilios-form;
     border: 1px solid $ilios-blue;
-    display: block;
     margin-top: 1rem;
     padding: 1rem;
 
@@ -21,22 +20,22 @@
 
     .description {
       grid-column: 1 / -1;
-      margin-bottom: 4rem;
+    }
+
+    .rollover-summary {
+      font-weight: 400;
+      grid-column: 1 / -1;
+      margin: 0 1rem 2rem;
+
+      @include for-laptop-and-up {
+        padding: .5rem 6rem 0 4rem;
+      }
     }
 
     .years {
       select {
         display: block;
       }
-    }
-  }
-
-  .rollover-summary {
-    font-weight: 400;
-    margin: 0 1rem 2rem;
-
-    @include for-laptop-and-up {
-      padding: .5rem 6rem 0 4rem;
     }
   }
 }

--- a/app/templates/components/curriculum-inventory-report-rollover.hbs
+++ b/app/templates/components/curriculum-inventory-report-rollover.hbs
@@ -22,16 +22,6 @@
     {{/if}}
   </div>
 
-  <div class="item description">
-    <label>{{t "general.description"}}:</label>
-    <textarea
-      value={{description}}
-      oninput={{action (mut description) value="target.value"}}
-      disabled={{isSaving}}
-      placeholder={{t "general.reportDescriptionPlaceholder"}}
-    ></textarea>
-  </div>
-
   <div class="item years">
     <label>{{t "general.academicYear"}}:</label>
     {{one-way-select
@@ -42,6 +32,48 @@
       disabled=isSaving
       update=(action (mut selectedYear))
     }}
+  </div>
+
+  <div class="item start-date">
+    <label>{{t "general.start"}}:</label>
+    <span>
+      {{pikaday-input
+        value=startDate
+        format="L"
+        onSelection=(action (mut startDate))
+        focusOut=(action "addErrorDisplayFor" "startDate")
+      }}
+      {{#if
+        (and (v-get this "startDate" "isInvalid") (is-in showErrorsFor "startDate"))
+      }}
+        <span class="validation-error-message">{{v-get this "startDate" "message"}}</span>
+      {{/if}}
+    </span>
+  </div>
+
+  <div class="item end-date">
+    <label>{{t "general.end"}}:</label>
+    <span>
+      {{pikaday-input
+        value=endDate
+        format="L"
+        onSelection=(action (mut endDate))
+        focusOut=(action "addErrorDisplayFor" "endDate")
+      }}
+      {{#if (and (v-get this "endDate" "isInvalid") (is-in showErrorsFor "endDate"))}}
+        <span class="validation-error-message">{{v-get this "endDate" "message"}}</span>
+      {{/if}}
+    </span>
+  </div>
+
+  <div class="item description">
+    <label>{{t "general.description"}}:</label>
+    <textarea
+      value={{description}}
+      oninput={{action (mut description) value="target.value"}}
+      disabled={{isSaving}}
+      placeholder={{t "general.reportDescriptionPlaceholder"}}
+    ></textarea>
   </div>
 
   <div class="buttons">


### PR DESCRIPTION
fixes #4042 

this tightens up the rollover form while at it.

![Selection_670](https://user-images.githubusercontent.com/1410427/62498566-853e3480-b794-11e9-821b-85b882590763.png)
