### PR TITLE
Stop modifying user queries

### DIFF
--- a/app/components/global-search-box.js
+++ b/app/components/global-search-box.js
@@ -43,7 +43,7 @@ export default Component.extend({
 
       if (q.length > 0) {
         this.autocompleteCache = [];
-        this.search(q);
+        this.search(this.query);
         this.set('showResults', false);
       }
     },
@@ -190,7 +190,7 @@ export default Component.extend({
       return [];
     }
 
-    const cachedResults = this.findCachedAutocomplete(q);
+    const cachedResults = this.findCachedAutocomplete(this.query);
     if (cachedResults.length) {
       return cachedResults.map(text => {
         return { text };
@@ -199,8 +199,8 @@ export default Component.extend({
 
     yield timeout(DEBOUNCE_MS);
 
-    const { autocomplete } = yield this.iliosSearch.forCurriculum(q, true);
-    this.autocompleteCache.pushObject({ q, autocomplete });
+    const { autocomplete } = yield this.iliosSearch.forCurriculum(this.query, true);
+    this.autocompleteCache.pushObject({ q: this.query, autocomplete });
 
     return autocomplete.map(text => {
       return { text };

--- a/app/components/global-search.js
+++ b/app/components/global-search.js
@@ -1,5 +1,4 @@
 import Component from '@ember/component';
-import { cleanQuery } from 'ilios-common/utils/query-utils';
 import { computed } from '@ember/object';
 import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
@@ -41,9 +40,8 @@ export default Component.extend({
   }),
 
   search: task(function* () {
-    const q = cleanQuery(this.query);
-    this.onQuery(q);
-    const { courses } = yield this.iliosSearch.forCurriculum(q);
+    this.onQuery(this.query);
+    const { courses } = yield this.iliosSearch.forCurriculum(this.query);
     this.setUpYearFilter(courses.mapBy('year'));
 
     return courses;

--- a/app/components/ilios-header.js
+++ b/app/components/ilios-header.js
@@ -16,6 +16,8 @@ export default Component.extend({
   ariaRole: 'banner',
   title: null,
 
+  'data-test-ilios-header': true,
+
   showSearch: computed('session.isAuthenticated', 'router.currentRouteName', function () {
     return this.session.isAuthenticated && this.router.currentRouteName !== 'search';
   }),

--- a/app/templates/components/global-search-box.hbs
+++ b/app/templates/components/global-search-box.hbs
@@ -6,7 +6,8 @@
     value={{this.query}}
     oninput={{action (queue
       (action (mut this.query) value="target.value")
-      (perform this.autocomplete))}}>
+      (perform this.autocomplete))}}
+  >
 
   <span
     class="search-icon"

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -2,4 +2,5 @@
   @page={{this.page}}
   @query={{this.query}}
   @onQuery={{action "setQuery"}}
-  @onSelectPage={{action (mut this.page)}} />
+  @onSelectPage={{action (mut this.page)}}
+/>

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
+import { click, currentURL, fillIn, find, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
@@ -36,5 +36,52 @@ module('Acceptance | search', function(hooks) {
     assert.equal(currentURL(), '/search', 'entering input value does not update query param');
     await click('[data-test-search-icon]');
     assert.equal(currentURL(), `/search?q=${input}`, 'triggering search updates query param');
+  });
+
+  test('search with special chars #4752', async function(assert) {
+    assert.expect(4);
+
+    const input = 'H&L+foo=bar';
+
+    this.server.get('search/v1/curriculum', () => {
+      return {
+        results: {
+          autocomplete: [],
+          courses: []
+        }
+      };
+    });
+
+    await visit('/search');
+    assert.equal(currentURL(), '/search');
+    await fillIn('input.global-search-input', input);
+    assert.equal(currentURL(), '/search', 'entering input value does not update query param');
+    await click('[data-test-search-icon]');
+    assert.equal(currentURL(), `/search?q=${encodeURIComponent(input)}`);
+    assert.equal(find('input.global-search-input').value, input);
+  });
+
+  test('search with special chars from dashboard #4752', async function(assert) {
+    assert.expect(3);
+
+    const input = 'H&L+foo=bar';
+
+    this.server.get('search/v1/curriculum', () => {
+      return {
+        results: {
+          autocomplete: [],
+          courses: []
+        }
+      };
+    });
+    const headerSearchBox = '[data-test-ilios-header] [data-test-global-search-box] input';
+    const searchBox = '[data-test-global-search] [data-test-global-search-box] input';
+
+    await visit('/dashboard');
+    assert.equal(currentURL(), '/dashboard');
+    await fillIn(headerSearchBox, input);
+    await click('[data-test-search-icon]');
+    assert.equal(currentURL(), `/search?page=1&q=${encodeURIComponent(input)}`);
+    assert.equal(find(searchBox).value, input);
   });
 });


### PR DESCRIPTION
Elasticsearch can handle special chars and we have many valid search
terms with them included. This change removes the query stripping we
usually use on regex type queries and just uses the real value instead.

Fixes #4752