### PR TITLE
Skip some bad errors

### DIFF
--- a/app/sentry.js
+++ b/app/sentry.js
@@ -26,6 +26,14 @@ function startSentry(config) {
         return null;
       }
 
+      // ignore aborted ajax calls, these happen when users navigate quickly between routes
+      if (error && (
+        error.message === 'The ajax operation was aborted' ||
+        error.message === 'The adapter operation was aborted'
+      )) {
+        return null;
+      }
+
       return event;
     },
   });


### PR DESCRIPTION
These apparently get thrown during many quick transitions when in flight
network requests get stopped. Unfortunately they aren't thrown with any
other identifying information that I could find so I've set them up to
skip on the message text.