### PR TITLE
Enforce minimum search length

### DIFF
--- a/app/components/course-search-result.js
+++ b/app/components/course-search-result.js
@@ -5,6 +5,7 @@ import { reads } from '@ember/object/computed';
 export default Component.extend({
   classNames: ['course-search-result'],
   tagName: 'li',
+  'data-test-course-search-result': true,
 
   course: null,
   showMore: false,

--- a/app/components/global-search-box.js
+++ b/app/components/global-search-box.js
@@ -12,6 +12,7 @@ const MIN_INPUT = 3;
 export default Component.extend({
   iliosConfig: service(),
   iliosSearch: service('search'),
+  intl: service(),
 
   autocompleteCache: null,
   autocompleteSelectedQuery: null,
@@ -46,7 +47,7 @@ export default Component.extend({
     },
 
     search() {
-      if (cleanQuery(this.computedQuery).length > 0) {
+      if (cleanQuery(this.computedQuery).length >= MIN_INPUT) {
         this.search(this.computedQuery);
         this.clear();
       }
@@ -84,8 +85,10 @@ export default Component.extend({
     }
 
     if (this.isEnterKey(keyCode)) {
-      this.search(this.computedQuery);
-      this.clear();
+      if (cleanQuery(this.computedQuery).length >= MIN_INPUT) {
+        this.search(this.computedQuery);
+        this.clear();
+      }
     }
 
     if (this.isEscapeKey(keyCode)) {
@@ -194,8 +197,14 @@ export default Component.extend({
   autocomplete: task(function* () {
     const q = cleanQuery(this.internalQuery);
 
-    if (isBlank(q) || q.length < MIN_INPUT) {
+    if (isBlank(q)) {
       return [];
+    }
+
+    if (q.length < MIN_INPUT) {
+      return [{
+        text: this.intl.t('general.moreInputRequiredPrompt')
+      }];
     }
 
     const cachedResults = this.findCachedAutocomplete(this.internalQuery);

--- a/app/components/global-search.js
+++ b/app/components/global-search.js
@@ -4,6 +4,8 @@ import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 
+const MIN_INPUT = 3;
+
 export default Component.extend({
   iliosConfig: service(),
   intl: service(),
@@ -56,7 +58,7 @@ export default Component.extend({
     this._super(...arguments);
     this.set('unselectedSchools', []);
 
-    if (this.query) {
+    if (this.query && this.query.length >= MIN_INPUT) {
       this.search.perform();
     }
   },

--- a/app/templates/components/global-search.hbs
+++ b/app/templates/components/global-search.hbs
@@ -35,7 +35,7 @@
     </fieldset>
   {{/if}}
 
-  <ul class="results {{unless (or this.isLoading this.hasResults) "hidden"}}">
+  <ul class="results {{unless (or this.isLoading this.hasResults) "hidden"}}" data-test-results>
     {{#if this.isLoading}}
       <li class="searching">
         {{fa-icon icon="spinner" class="orange" spin=true}}

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -133,4 +133,26 @@ module('Acceptance | search', function(hooks) {
     assert.equal(page.searchBox.inputValue, firstInput);
     assert.equal(page.searchBox.autocompleteResults.length, 0);
   });
+
+  test('search requires three chars #4769', async function(assert) {
+    assert.expect(3);
+    const input = 'br';
+
+    await page.visit();
+    await page.searchBox.input(input);
+    await page.searchBox.clickIcon();
+    assert.equal(page.results.length, 0);
+    assert.equal(page.searchBox.autocompleteResults.length, 1);
+    assert.equal(page.searchBox.autocompleteResults[0].text, 'keep typing...');
+  });
+
+  test('search requires three chars in URL #4769', async function(assert) {
+    assert.expect(2);
+    const input = 'br';
+
+    await page.visit({ q: input });
+    assert.equal(page.searchBox.inputValue, input);
+    await page.searchBox.clickIcon();
+    assert.equal(page.results.length, 0);
+  });
 });

--- a/tests/integration/components/global-search-box-test.js
+++ b/tests/integration/components/global-search-box-test.js
@@ -187,4 +187,19 @@ module('Integration | Component | global search box', function(hooks) {
     await component.input('');
     assert.equal(component.inputValue, '');
   });
+
+  test('require at least three chars to run autocomplete #4769', async function (assert) {
+    assert.expect(2);
+
+    const input = 'ty';
+
+    this.set('search', () => {
+      assert.ok(false, 'search should not be called');
+    });
+    await render(hbs`{{global-search-box search=(action this.search)}}`);
+    await component.input(input);
+    await component.triggerInput();
+    assert.equal(component.autocompleteResults.length, 1);
+    assert.equal(component.autocompleteResults[0].text, 'keep typing...');
+  });
 });

--- a/tests/pages/search.js
+++ b/tests/pages/search.js
@@ -1,5 +1,6 @@
 import {
   create,
+  collection,
   visitable
 } from 'ember-cli-page-object';
 
@@ -9,4 +10,5 @@ export default create({
   visit: visitable('/search'),
   scope: '[data-test-global-search]',
   searchBox,
+  results: collection('[data-test-results] [data-test-course-search-result]'),
 });


### PR DESCRIPTION
Added a keep typing prompt when more input is needed, don't do anything
if the search is too short.

Fixes #4769