### PR TITLE
Avoid resetting the page when navigating back

### DIFF
--- a/app/components/pagination-links.js
+++ b/app/components/pagination-links.js
@@ -4,6 +4,7 @@ import { equal } from '@ember/object/computed';
 
 export default Component.extend({
   classNames: ['pagination-links'],
+  'data-test-pagination-links': true,
 
   page: null,
   results: null,

--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -11,7 +11,10 @@ export default Controller.extend({
 
   actions: {
     setQuery(query) {
-      this.setProperties({ page: 1, query });
+      // don't reset the page when returning back to the same query
+      if (query !== this.query) {
+        this.setProperties({ page: 1, query });
+      }
     }
   }
 });

--- a/tests/pages/components/global-search.js
+++ b/tests/pages/components/global-search.js
@@ -23,6 +23,10 @@ const definition = {
     school: text('label'),
     toggle: clickable('label'),
   }),
+  results: collection('[data-test-results] [data-test-course-search-result]', {
+    courseTitle: text('a:first-of-type'),
+    clickCourse: clickable('a:first-of-type'),
+  }),
 };
 
 export default definition;

--- a/tests/pages/search.js
+++ b/tests/pages/search.js
@@ -1,14 +1,15 @@
 import {
-  create,
   collection,
+  create,
   visitable
 } from 'ember-cli-page-object';
 
 import searchBox from 'ilios/tests/pages/components/global-search-box';
+import globalSearch from 'ilios/tests/pages/components/global-search';
 
 export default create({
   visit: visitable('/search'),
-  scope: '[data-test-global-search]',
+  paginationLinks: collection('[data-test-pagination-links] button'),
+  globalSearch,
   searchBox,
-  results: collection('[data-test-results] [data-test-course-search-result]'),
 });


### PR DESCRIPTION
When returning via the back button to a previously run search the page
shouldn't be reset. Doing that not only is confusing for users, but it
actually breaks when ember tries to set the same property twice in the
same render.

Fixes #4768