### PR TITLE
Persist search filters to the URL

### DIFF
--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -1,20 +1,41 @@
 import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 
 export default Controller.extend({
   queryParams: {
     page: 'page',
-    query: 'q'
+    query: 'q',
+    ignoredSchoolIds: 'ignoredSchools',
+    selectedYear: 'year',
   },
 
   page: 1,
   query: '',
+  ignoredSchoolIds: null,
+  selectedYear: null,
+
+  init() {
+    this._super(...arguments);
+  },
+
+  ignoredSchoolIdsArray: computed('ignoredSchoolIds.[]', function() {
+    return this.ignoredSchoolIds ? this.ignoredSchoolIds.split('-') : [];
+  }),
+
+  selectedYearInt: computed('selectedYear', function() {
+    return this.selectedYear ? parseInt(this.selectedYear, 10) : null;
+  }),
 
   actions: {
     setQuery(query) {
       // don't reset the page when returning back to the same query
       if (query !== this.query) {
-        this.setProperties({ page: 1, query });
+        this.setProperties({ page: 1, query, ignoredSchoolIds: null, selectedYear: null });
       }
+    },
+    setIgnoredSchools(schools) {
+      const str = schools.length ? schools.join('-') : null;
+      this.set('ignoredSchoolIds', str);
     }
   }
 });

--- a/app/templates/components/global-search.hbs
+++ b/app/templates/components/global-search.hbs
@@ -41,8 +41,8 @@
               <input
                 id="school={{index}}"
                 type="checkbox"
-                checked={{or (eq obj.results 0) (not (contains obj.title unselectedSchools))}}
-                onclick={{action "toggleSchoolSelection" obj.title}}
+                checked={{or (eq obj.results 0) (not (contains obj.id ignoredSchoolIds))}}
+                onclick={{action "toggleSchoolSelection" obj.id}}
                 disabled={{eq obj.results 0}}
               >
               <label for="school={{index}}">{{obj.title}} ({{obj.results}})</label>

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -3,4 +3,8 @@
   @query={{this.query}}
   @onQuery={{action "setQuery"}}
   @onSelectPage={{action (mut this.page)}}
+  @ignoredSchoolIds={{this.ignoredSchoolIdsArray}}
+  @setIgnoredSchoolIds={{action "setIgnoredSchools"}}
+  @selectedYear={{this.selectedYearInt}}
+  @setSelectedYear={{action (mut this.selectedYear)}}
 />

--- a/tests/integration/components/global-search-test.js
+++ b/tests/integration/components/global-search-test.js
@@ -84,7 +84,13 @@ module('Integration | Component | global-search', function(hooks) {
     });
 
     this.set('query', 'hello world');
-    await render(hbs`{{global-search page=1 query=this.query}}`);
+    this.set('selectedYear', null);
+    await render(hbs`<GlobalSearch
+      @page=1
+      @query={{this.query}}
+      @selectedYear={{this.selectedYear}}
+      @setSelectedYear={{action (mut this.selectedYear)}}
+    />`);
     assert.equal(component.academicYear, '');
     assert.equal(component.academicYearOptions, 'All Academic Years 2021 - 2022 2020 - 2021 2019 - 2020');
     assert.equal(component.courseTitleLinks.length, 4);
@@ -142,7 +148,13 @@ module('Integration | Component | global-search', function(hooks) {
     });
 
     this.set('query', 'hello world');
-    await render(hbs`<GlobalSearch @page=1 @query={{this.query}} />`);
+    this.set('ignoredSchoolIds', []);
+    await render(hbs`<GlobalSearch
+      @page=1
+      @query={{this.query}}
+      @ignoredSchoolIds={{this.ignoredSchoolIds}}
+      @setIgnoredSchoolIds={{action (mut this.ignoredSchoolIds)}}
+    />`);
     assert.equal(component.courseTitleLinks.length, 4);
     assert.equal(component.courseTitleLinks[0].text, 'Course 1');
     assert.equal(component.courseTitleLinks[1].text, 'Course 2');


### PR DESCRIPTION
By adding search filters to the URL they become part of the history and
going back will keep the same search items on the screen.  When choosing
a new filter reset the current page, otherwise it's possible to end up
with no results showing up.

Fixes #4779