### PR TITLE
Don't display search when it is disabled

### DIFF
--- a/app/components/ilios-header.js
+++ b/app/components/ilios-header.js
@@ -10,6 +10,7 @@ export default Component.extend({
   session: service(),
   pageTitleList: service(),
   router: service(),
+  iliosConfig: service(),
 
   classNames: ['ilios-header'],
   tagName: 'header',
@@ -18,11 +19,19 @@ export default Component.extend({
 
   'data-test-ilios-header': true,
 
-  showSearch: computed('currentUser.performsNonLearnerFunction', 'session.isAuthenticated', 'router.currentRouteName', function () {
-    return this.session.isAuthenticated &&
-      this.router.currentRouteName !== 'search' &&
-      this.currentUser.performsNonLearnerFunction;
-  }),
+  showSearch: computed(
+    'currentUser.performsNonLearnerFunction',
+    'session.isAuthenticated',
+    'router.currentRouteName',
+    'iliosConfig.searchEnabled',
+    async function () {
+      const searchEnabled = await this.iliosConfig.searchEnabled;
+      return searchEnabled &&
+        this.session.isAuthenticated &&
+        this.router.currentRouteName !== 'search' &&
+        this.currentUser.performsNonLearnerFunction;
+    }
+  ),
 
   /**
    * We have to use an observer here

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -4,9 +4,11 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   currentUser: service(),
+  iliosConfig: service(),
 
-  beforeModel() {
-    if (!this.currentUser.performsNonLearnerFunction) {
+  async beforeModel() {
+    const searchEnabled = await this.iliosConfig.searchEnabled;
+    if (!searchEnabled || !this.currentUser.performsNonLearnerFunction) {
       this.transitionTo('dashboard');
     }
   }

--- a/app/templates/components/ilios-header.hbs
+++ b/app/templates/components/ilios-header.hbs
@@ -6,7 +6,7 @@
 {{/link-to}}
 <h1>{{title}}</h1>
 <div class="tools">
-  {{#if showSearch}}
+  {{#if (await showSearch)}}
     <GlobalSearchBox @search={{action "search"}} />
   {{/if}}
   {{locale-chooser}}

--- a/tests/acceptance/header-test.js
+++ b/tests/acceptance/header-test.js
@@ -3,18 +3,41 @@ import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
+import { resolve } from 'rsvp';
+import Service from '@ember/service';
 
 module('Acceptance | header', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   test('privileged users can view search', async function (assert) {
+    const iliosConfigMock = Service.extend({
+      apiNameSpace: '/api',
+      searchEnabled: resolve(true),
+    });
+    this.owner.register('service:iliosConfig', iliosConfigMock);
     await setupAuthentication({}, true);
     await visit('/');
     assert.dom('.global-search-box').exists();
   });
 
+  test('when search is disabled on the server it does not display', async function (assert) {
+    const iliosConfigMock = Service.extend({
+      apiNameSpace: '/api',
+      searchEnabled: resolve(false),
+    });
+    this.owner.register('service:iliosConfig', iliosConfigMock);
+    await setupAuthentication({}, true);
+    await visit('/');
+    assert.dom('.global-search-box').doesNotExist();
+  });
+
   test('students can not view search', async function (assert) {
+    const iliosConfigMock = Service.extend({
+      apiNameSpace: '/api',
+      searchEnabled: resolve(true),
+    });
+    this.owner.register('service:iliosConfig', iliosConfigMock);
     await setupAuthentication();
     await visit('/');
     assert.dom('.global-search-box').doesNotExist();

--- a/tests/acceptance/header-test.js
+++ b/tests/acceptance/header-test.js
@@ -3,41 +3,39 @@ import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
-import { resolve } from 'rsvp';
-import Service from '@ember/service';
 
 module('Acceptance | header', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   test('privileged users can view search', async function (assert) {
-    const iliosConfigMock = Service.extend({
-      apiNameSpace: '/api',
-      searchEnabled: resolve(true),
+    this.server.get('application/config', function() {
+      return { config: {
+        searchEnabled: true,
+      }};
     });
-    this.owner.register('service:iliosConfig', iliosConfigMock);
     await setupAuthentication({}, true);
     await visit('/');
     assert.dom('.global-search-box').exists();
   });
 
   test('when search is disabled on the server it does not display', async function (assert) {
-    const iliosConfigMock = Service.extend({
-      apiNameSpace: '/api',
-      searchEnabled: resolve(false),
+    this.server.get('application/config', function() {
+      return { config: {
+        searchEnabled: false,
+      }};
     });
-    this.owner.register('service:iliosConfig', iliosConfigMock);
     await setupAuthentication({}, true);
     await visit('/');
     assert.dom('.global-search-box').doesNotExist();
   });
 
   test('students can not view search', async function (assert) {
-    const iliosConfigMock = Service.extend({
-      apiNameSpace: '/api',
-      searchEnabled: resolve(true),
+    this.server.get('application/config', function() {
+      return { config: {
+        searchEnabled: true,
+      }};
     });
-    this.owner.register('service:iliosConfig', iliosConfigMock);
     await setupAuthentication();
     await visit('/');
     assert.dom('.global-search-box').doesNotExist();

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -11,6 +11,11 @@ module('Acceptance | search', function(hooks) {
 
   hooks.beforeEach(async function() {
     await setupAuthentication({}, true);
+    this.server.get('application/config', function() {
+      return { config: {
+        searchEnabled: true,
+      }};
+    });
   });
 
   test('visiting /search', async function(assert) {


### PR DESCRIPTION
It isn't just permissions that determine if search can be displayed,
configuration is the most important first check.