### PR TITLE
Improve style and accessibility of noscript display

### DIFF
--- a/app/styles/layout/_noscript.scss
+++ b/app/styles/layout/_noscript.scss
@@ -2,9 +2,14 @@ noscript {
   p {
     background-color: $background-grey;
     border: 2px dashed $ilios-orange;
-    color: $ilios-orange;
+    color: $text-grey;
+    font-size: 2em;
     font-weight: bold;
     margin: 2rem;
     padding: 2rem;
+  }
+
+  a {
+    text-decoration: underline;
   }
 }

--- a/lib/ilios-loading/index.js
+++ b/lib/ilios-loading/index.js
@@ -13,6 +13,7 @@ module.exports = {
             height: 100vh;
             left: 0;
             position: fixed;
+            visibility: hidden;
             width: 100vw;
           }
 
@@ -85,7 +86,9 @@ module.exports = {
             <circle class='third-circle' cx="50%" cy="50%" r="25%"/>
           </svg>
         </h1>
-      </div>`;
+      </div>
+      <script defer src="${config.rootURL}ilios-loading/display-loader.js"></script>
+      `;
     }
   }
 };

--- a/lib/ilios-loading/public/display-loader.js
+++ b/lib/ilios-loading/public/display-loader.js
@@ -1,0 +1,10 @@
+/* global document */
+function displayIliosLoader() {
+  // Show the loader only if javascript is enabled
+  var iliosLoadingIndicator = document.getElementById('ilios-loading-indicator');
+  if (iliosLoadingIndicator) {
+    iliosLoadingIndicator.style.visibility = 'visible';
+  }
+}
+
+displayIliosLoader();


### PR DESCRIPTION
Fixes some a11y issues with the noscript tag's display and also removes
the loader so it isn't flashing over the top of the display making the
tag difficult to read and also making it appear like something might
happen.