### PR TITLE
Improve Accessibility of the Header

### DIFF
--- a/app/templates/components/ilios-header.hbs
+++ b/app/templates/components/ilios-header.hbs
@@ -4,7 +4,9 @@
   </h1>
   <span class="image"></span>
 {{/link-to}}
-<h1>{{title}}</h1>
+{{#if @title}}
+  <h1 data-test-title>{{@title}}</h1>
+{{/if}}
 <div class="tools">
   {{#if (await showSearch)}}
     <GlobalSearchBox @search={{action "search"}} />

--- a/tests/integration/components/ilios-header-test.js
+++ b/tests/integration/components/ilios-header-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { component } from 'ilios/tests/pages/components/ilios-header';
+
+module('Integration | Component | ilios-header', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders and is accessible', async function (assert) {
+    this.set('title', 'Some Title');
+    await render(hbs`<IliosHeader @title={{this.title}} />`);
+    assert.ok(component.hasTitle);
+    assert.equal(component.title, 'Some Title');
+
+    await a11yAudit(this.element);
+  });
+
+  test('title is hidden when not set', async function (assert) {
+    await render(hbs`<IliosHeader />`);
+    assert.ok(!component.hasTitle);
+
+    await a11yAudit(this.element);
+  });
+});

--- a/tests/pages/components/ilios-header.js
+++ b/tests/pages/components/ilios-header.js
@@ -1,0 +1,14 @@
+import {
+  create,
+  isPresent,
+  text
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-ilios-header]',
+  hasTitle: isPresent('[data-test-title]'),
+  title: text('[data-test-title]'),
+};
+
+export default definition;
+export const component = create(definition);


### PR DESCRIPTION
When title is empty the H1 should not be displayed as having an empty
header is an a11y violation. Added automated a11y tests to this
component for the future.