### PR TITLE
updates ember-cli-inject-live-reload dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11002,9 +11002,9 @@
       "dev": true
     },
     "ember-cli-inject-live-reload": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.10.2.tgz",
-      "integrity": "sha512-yFvZE4WFyWjzMJ6MTYIyjCXpcJNFMTaZP61JXITMkXhSkhuDkzMD/XfwR5+fr004TYcwrbNWpg1oGX5DbOgcaQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-2.0.1.tgz",
+      "integrity": "sha512-vrW/3KSrku+Prqmp7ZkpCxYkabnLrTHDEvV9B1yphTP++dhiV7n7Dv9NrmyubkoF3Inm0xrbbhB5mScvvuTQSg==",
       "dev": true,
       "requires": {
         "clean-base-url": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-image-transformer": "^3.0.1",
-    "ember-cli-inject-live-reload": "^1.8.2",
+    "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-new-version": "^2.0.1",
     "ember-cli-postcss": "^5.0.0",
     "ember-cli-progress": "^1.0.11",


### PR DESCRIPTION
dependabot didn't pick up that major version change, so rolling this by hand.

https://github.com/ember-cli/ember-cli-inject-live-reload/compare/v1.10.2...v2.0.1


