### PR TITLE
Replace missing component

### DIFF
--- a/app/templates/pending-user-updates.hbs
+++ b/app/templates/pending-user-updates.hbs
@@ -117,7 +117,7 @@
         </table>
       </div>
     {{else}}
-      <WaveLoader />
+      <LoadingSpinner />
     {{/liquid-if}}
   </div>
 </section>


### PR DESCRIPTION
I'm not sure when this was removed, but it doesn't exist anymore.
Replace it with the loading spinner we use everywhere else.

Fixes #4889