### PR TITLE
Use fetch service instead of commonAjax

### DIFF
--- a/app/components/curriculum-inventory-report-rollover.js
+++ b/app/components/curriculum-inventory-report-rollover.js
@@ -18,7 +18,7 @@ const Validations = buildValidations({
 });
 
 export default Component.extend(ValidationErrorDisplay, Validations, {
-  commonAjax: service(),
+  fetch: service(),
   flashMessages: service(),
   iliosConfig: service(),
   store: service(),
@@ -77,7 +77,6 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
       this.set('isSaving', false);
       return;
     }
-    const commonAjax = this.commonAjax;
     const reportId = this.get('report.id');
     const year = this.selectedYear.get('id');
     const description = this.description;
@@ -87,14 +86,9 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
       description,
       year,
     };
-    const host = this.host ? this.host : '';
-    const namespace = this.namespace;
 
-    let url = host + '/' + namespace + `/curriculuminventoryreports/${reportId}/rollover`;
-    const newReportObj = yield commonAjax.request(url, {
-      method: 'POST',
-      data
-    });
+    let url = `${this.namespace}/curriculuminventoryreports/${reportId}/rollover`;
+    const newReportObj = yield this.fetch.postToApiHost(url, data);
 
     const flashMessages = this.flashMessages;
     const store = this.store;

--- a/app/components/curriculum-inventory-verification-preview.js
+++ b/app/components/curriculum-inventory-verification-preview.js
@@ -5,14 +5,13 @@ import { task } from 'ember-concurrency';
 
 
 export default Component.extend({
-  commonAjax: service(),
+  fetch: service(),
   iliosConfig: service(),
   'data-test-curriculum-inventory-verification-preview': true,
   classNames: ['curriculum-inventory-verification-preview'],
   report: null,
   tables: null,
   tocId: 'verification-preview-toc',
-  host: reads('iliosConfig.apiHost'),
   namespace: reads('iliosConfig.apiNameSpace'),
 
   didInsertElement() {
@@ -21,13 +20,10 @@ export default Component.extend({
   },
 
   loadTables: task(function* () {
-    const commonAjax = this.commonAjax;
     const reportId = this.report.id;
-    const host = this.host ? this.host : '';
-    const namespace = this.namespace;
 
-    const url = host + '/' + namespace + `/curriculuminventoryreports/${reportId}/verificationpreview`;
-    const data = yield commonAjax.request(url);
+    const url = `${this.namespace}/curriculuminventoryreports/${reportId}/verificationpreview`;
+    const data = yield this.fetch.getJsonFromApiHost(url);
     this.set('tables', data.preview);
   })
 });

--- a/app/components/my-profile.js
+++ b/app/components/my-profile.js
@@ -8,7 +8,7 @@ import { task, timeout } from 'ember-concurrency';
 import { padStart } from 'ember-pad/utils/pad';
 
 export default Component.extend({
-  commonAjax: service(),
+  fetch: service(),
   flashMessages: service(),
   iliosConfig: service(),
   session: service(),
@@ -78,17 +78,15 @@ export default Component.extend({
 
     let interval = `P${days}DT${hours}H${minutes}M${seconds}S`;
 
-    const commonAjax = this.commonAjax;
     let url = '/auth/token?ttl=' + interval;
-    let data = yield commonAjax.request(url);
+    let data = yield this.fetch.getJsonFromApiHost(url);
     this.set('generatedJwt', data.jwt);
   }),
 
   invalidateTokens: task(function* () {
     yield timeout(10); //small delay to allow rendering the spinner
-    const commonAjax = this.commonAjax;
     let url = '/auth/invalidatetokens';
-    let data = yield commonAjax.request(url);
+    let data = yield this.fetch.getJsonFromApiHost(url);
 
     if (isPresent(data.jwt)) {
       const flashMessages = this.flashMessages;

--- a/app/components/new-directory-user.js
+++ b/app/components/new-directory-user.js
@@ -40,7 +40,7 @@ const Validations = buildValidations({
 });
 
 export default Component.extend(NewUser, Validations, {
-  commonAjax: service(),
+  fetch: service(),
   iliosConfig: service(),
   intl: service(),
 
@@ -123,8 +123,7 @@ export default Component.extend(NewUser, Validations, {
     if (!isEmpty(searchTerms)) {
       this.set('isSearching', true);
       let url = '/application/directory/search?limit=51&searchTerms=' + searchTerms;
-      const commonAjax = this.commonAjax;
-      let data = yield commonAjax.request(url);
+      let data = yield this.fetch.getJsonFromApiHost(url);
       let mappedResults = data.results.map(result => {
         result.addable = isPresent(result.firstName) && isPresent(result.lastName) && isPresent(result.email) && isPresent(result.campusId);
         return result;

--- a/app/components/user-profile-bio.js
+++ b/app/components/user-profile-bio.js
@@ -89,9 +89,9 @@ const Validations = buildValidations({
 });
 
 export default Component.extend(ValidationErrorDisplay, Validations, {
-  commonAjax: service(),
   currentUser: service(),
   iliosConfig: service(),
+  fetch: service(),
   store: service(),
 
   classNameBindings: [':user-profile-bio', ':small-component', 'hasSavedRecently:has-saved:has-not-saved'],
@@ -270,9 +270,8 @@ export default Component.extend(ValidationErrorDisplay, Validations, {
     this.set('syncComplete', false);
     const userId = this.get('user.id');
     let url = `/application/directory/find/${userId}`;
-    const commonAjax = this.commonAjax;
     try {
-      let data = yield commonAjax.request(url);
+      let data = yield this.fetch.getJsonFromApiHost(url);
       let userData = data.result;
       const firstName = this.firstName;
       const lastName = this.lastName;

--- a/app/components/user-profile-calendar.js
+++ b/app/components/user-profile-calendar.js
@@ -6,7 +6,7 @@ import EventMixin from 'ilios-common/mixins/events';
 import moment from 'moment';
 
 export default Component.extend(EventMixin, {
-  commonAjax: service(),
+  fetch: service(),
   iliosConfig: service(),
 
   classNames: ['user-profile-calendar'],
@@ -17,7 +17,6 @@ export default Component.extend(EventMixin, {
   namespace: reads('iliosConfig.apiNameSpace'),
 
   calendarEvents: computed('user.id', 'date', async function() {
-    const commonAjax = this.commonAjax;
     const user = this.user;
     const date = this.date;
     const from = moment(date).day(0).hour(0).minute(0).second(0).format('X');
@@ -29,7 +28,7 @@ export default Component.extend(EventMixin, {
       url += '/' + namespace;
     }
     url += '/userevents/' + user.get('id') + '?from=' + from + '&to=' + to;
-    const data = await commonAjax.request(url);
+    const data = await this.fetch.getJsonFromApiHost(url);
     return data.userEvents.map(obj => this.createEventFromData(obj, true)).sortBy('startDate', 'name');
   }),
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -6,8 +6,8 @@ import { all } from 'rsvp';
 import * as Sentry from '@sentry/browser';
 
 export default Route.extend(ApplicationRouteMixin, {
-  commonAjax: service(),
   currentUser: service(),
+  fetch: service(),
   intl: service(),
   moment: service(),
   session: service(),
@@ -96,7 +96,7 @@ export default Route.extend(ApplicationRouteMixin, {
     Sentry.configureScope(scope => scope.clear());
     if (config.environment !== 'test') {
       let logoutUrl = '/auth/logout';
-      return this.commonAjax.request(logoutUrl).then(response => {
+      return this.fetch.getJsonFromApiHost(logoutUrl).then(response => {
         if(response.status === 'redirect'){
           window.location.replace(response.logoutUrl);
         } else {

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -6,8 +6,8 @@ import EmberConfig from 'ilios/config/environment';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
 export default Route.extend(UnauthenticatedRouteMixin, {
-  commonAjax: service(),
   currentUser: service(),
+  fetch: service(),
   iliosConfig: service(),
   session: service(),
 
@@ -41,7 +41,6 @@ export default Route.extend(UnauthenticatedRouteMixin, {
 
   async casLogin() {
     const iliosConfig = this.iliosConfig;
-    const commonAjax = this.commonAjax;
 
     let currentUrl = [window.location.protocol, '//', window.location.host, window.location.pathname].join('');
     let loginUrl = `/auth/login?service=${currentUrl}`;
@@ -57,7 +56,7 @@ export default Route.extend(UnauthenticatedRouteMixin, {
     if (isPresent(queryParams.ticket)) {
       loginUrl += `&ticket=${queryParams.ticket}`;
     }
-    const response = await commonAjax.request(loginUrl);
+    const response = await this.fetch.getJsonFromApiHost(loginUrl);
     if (response.status === 'redirect') {
       const casLoginUrl = await iliosConfig.itemFromConfig('casLoginUrl');
       await new Promise(() => {
@@ -78,9 +77,8 @@ export default Route.extend(UnauthenticatedRouteMixin, {
 
   async shibbolethAuth(){
     const iliosConfig = this.iliosConfig;
-    const commonAjax = this.commonAjax;
     const loginUrl = '/auth/login';
-    const response = await commonAjax.request(loginUrl);
+    const response = await this.fetch.getJsonFromApiHost(loginUrl);
     const status = response.status;
     if(status === 'redirect'){
       let shibbolethLoginUrl = await iliosConfig.itemFromConfig('loginUrl');

--- a/tests/integration/components/curriculum-inventory-report-rollover-test.js
+++ b/tests/integration/components/curriculum-inventory-report-rollover-test.js
@@ -1,4 +1,3 @@
-import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
@@ -9,8 +8,8 @@ import {
 } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
-import { resolve } from 'rsvp';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import queryString from 'query-string';
 
 module('Integration | Component | curriculum inventory report rollover', function(hooks) {
   setupRenderingTest(hooks);
@@ -51,24 +50,22 @@ module('Integration | Component | curriculum inventory report rollover', functio
     });
     const report = await this.owner.lookup('service:store').find('curriculum-inventory-report', 1);
 
-    let ajaxMock = Service.extend({
-      request(url, {method, data}){
-        assert.equal(url.trim(), `/api/curriculuminventoryreports/${report.get('id')}/rollover`);
-        assert.equal(method, 'POST');
-        assert.equal(data.year, thisYear + 1);
-        assert.equal(data.name, report.get('name'));
-        assert.equal(data.description, report.get('description'));
+    this.server.post(`/api/curriculuminventoryreports/:id/rollover`, (scheme, { params, requestBody}) => {
+      assert.ok('id' in params);
+      assert.equal(params.id, report.id);
+      const data = queryString.parse(requestBody);
+      assert.equal(data.year, thisYear + 1);
+      assert.equal(data.name, report.get('name'));
+      assert.equal(data.description, report.get('description'));
 
-        return resolve({
-          curriculumInventoryReports: [
-            {
-              id: 14
-            }
-          ]
-        });
-      }
+      return {
+        curriculumInventoryReports: [
+          {
+            id: 14
+          }
+        ]
+      };
     });
-    this.owner.register('service:commonAjax', ajaxMock);
     this.set('report', report);
     this.set('visit', (newReport) => {
       assert.equal(newReport.id, 14);
@@ -90,23 +87,22 @@ module('Integration | Component | curriculum inventory report rollover', functio
     const newDescription = 'new description';
     const newYear = thisYear + 4;
 
-    let ajaxMock = Service.extend({
-      request(url, {method, data}){
-        assert.equal(url.trim(), `/api/curriculuminventoryreports/${report.get('id')}/rollover`);
-        assert.equal(method, 'POST');
-        assert.equal(data.name, newName, 'The new name gets passed.');
-        assert.equal(data.description, newDescription, 'The new description gets passed.');
-        assert.equal(data.year, newYear, 'The new year gets passed.');
-        return resolve({
-          curriculumInventoryReports: [
-            {
-              id: 14
-            }
-          ]
-        });
-      }
+    this.server.post(`/api/curriculuminventoryreports/:id/rollover`, (scheme, { params, requestBody}) => {
+      assert.ok('id' in params);
+      assert.equal(params.id, report.id);
+      const data = queryString.parse(requestBody);
+      assert.equal(data.name, newName, 'The new name gets passed.');
+      assert.equal(data.description, newDescription, 'The new description gets passed.');
+      assert.equal(data.year, newYear, 'The new year gets passed.');
+
+      return {
+        curriculumInventoryReports: [
+          {
+            id: 14
+          }
+        ]
+      };
     });
-    this.owner.register('service:commonAjax', ajaxMock);
 
     this.set('report', report);
     this.set('visit', () => {});

--- a/tests/integration/components/curriculum-inventory-verification-preview-test.js
+++ b/tests/integration/components/curriculum-inventory-verification-preview-test.js
@@ -2,7 +2,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory-verification-preview';
@@ -12,29 +11,31 @@ module('Integration | Component | curriculum-inventory-verification-preview', fu
   setupMirage(hooks);
 
   test('it renders', async function(assert) {
-    assert.expect(28);
-    const ajaxMock = Service.extend({
-      async request() {
-        return {
-          preview: {
-            program_expectations_mapped_to_pcrs: [],
-            primary_instructional_methods_by_non_clerkship_sequence_blocks: {methods: [], rows: []},
-            non_clerkship_sequence_block_instructional_time: [],
-            clerkship_sequence_block_instructional_time: [],
-            instructional_method_counts: [],
-            non_clerkship_sequence_block_assessment_methods: {methods: [], rows: []},
-            clerkship_sequence_block_assessment_methods: {methods: [], rows: []},
-            all_events_with_assessments_tagged_as_formative_or_summative: [],
-            all_resource_types:[],
-          }
-        };
-      },
-    });
-    this.owner.register('service:commonAjax', ajaxMock);
+    assert.expect(30);
     this.server.create('curriculum-inventory-report', {
       name: 'Foo Bar 2019'
     });
     const report = await this.owner.lookup('service:store').find('curriculum-inventory-report', 1);
+
+    this.server.get(`/api/curriculuminventoryreports/:id/verificationpreview`, (scheme, { params }) => {
+      assert.ok('id' in params);
+      assert.equal(params.id, report.id);
+
+      return {
+        preview: {
+          program_expectations_mapped_to_pcrs: [],
+          primary_instructional_methods_by_non_clerkship_sequence_blocks: {methods: [], rows: []},
+          non_clerkship_sequence_block_instructional_time: [],
+          clerkship_sequence_block_instructional_time: [],
+          instructional_method_counts: [],
+          non_clerkship_sequence_block_assessment_methods: {methods: [], rows: []},
+          clerkship_sequence_block_assessment_methods: {methods: [], rows: []},
+          all_events_with_assessments_tagged_as_formative_or_summative: [],
+          all_resource_types:[],
+        }
+      };
+    });
+
     this.set('report', report);
     await render(hbs`<CurriculumInventoryVerificationPreview @report={{report}} />`);
     assert.equal(component.tableOfContents.items.length, 9);

--- a/tests/integration/components/new-directory-user-test.js
+++ b/tests/integration/components/new-directory-user-test.js
@@ -62,18 +62,19 @@ module('Integration | Component | new directory user', function(hooks) {
   });
 
   test('initial search input fires search and fills input', async function(assert) {
-    assert.expect(2);
+    assert.expect(5);
     const startingSearchTerms = 'start here';
 
-    let ajaxMock = Service.extend({
-      request(url){
-        assert.equal(url.trim(), `/application/directory/search?limit=51&searchTerms=${startingSearchTerms}`);
-        return resolve({
-          results: []
-        });
-      }
+    this.server.get(`/application/directory/search`, (scheme, { queryParams }) => {
+      assert.ok('limit' in queryParams);
+      assert.equal(queryParams.limit, 51);
+      assert.ok('searchTerms' in queryParams);
+      assert.equal(queryParams.searchTerms, startingSearchTerms);
+
+      return {
+        results: []
+      };
     });
-    this.owner.register('service:commonAjax', ajaxMock);
     this.set('nothing', parseInt);
     this.set('startingSearchTerms', startingSearchTerms);
     await render(hbs`<NewDirectoryUser


### PR DESCRIPTION
On the path to not needing jQuery this replaces the jQuery dependant
ember-ajax based service with one that uses the the fetch API instead.