### PR TITLE
Remove runloop complication from scroll listener

### DIFF
--- a/app/components/dashboard-myreports.js
+++ b/app/components/dashboard-myreports.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { task, timeout } from 'ember-concurrency';
 import DomMixin from 'ember-lifeline/mixins/dom';
@@ -81,10 +80,8 @@ export default Component.extend(DomMixin, ReportTitleMixin, {
     }
 
     if (element) {
-      next(() => {
-        this.addEventListener('.dashboard-block-body', 'scroll', () => {
-          this.preserveScroll.set(this.scrollKey, element.scrollTop);
-        });
+      this.addEventListener(element, 'scroll', () => {
+        this.preserveScroll.set(this.scrollKey, element.scrollTop);
       });
     }
   },


### PR DESCRIPTION
Adding the call to `next()` here invalidates the if(element) condition
as the element may have been removed in between loops. Since this is
done in a didRender call already it can safely be removed.

Fixes #4951