### PR TITLE
rm dependency on ember-test-selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "ember-service-worker-cache-first": "^0.6.2",
     "ember-source": "~3.14.1",
     "ember-template-lint": "^1.8.2",
-    "ember-test-selectors": "^2.1.0",
     "ember-truth-helpers": "^2.0.0",
     "ember-uploader": "2.0.0",
     "ember-web-app": "^3.0.0",


### PR DESCRIPTION
we're getting this one from common already,
no reason to double-down.