### PR TITLE
Build tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ before_install:
 branches:
   only:
     - master
+    # npm version tags
+    - /^v\d+\.\d+\.\d+/
 
 script:
   - npm run lint:style


### PR DESCRIPTION
This got removed by an ember-cli blueprint change, but we rely on travis
to build tags for release so we need it back.