### PR TITLE
Replace is-in with contains

### DIFF
--- a/app/components/assign-students.hbs
+++ b/app/components/assign-students.hbs
@@ -73,13 +73,13 @@
     </thead>
     <tbody>
       {{#each this.filteredStudents as |user|}}
-        <tr class={{if (is-in this.selectedUserIds user.id) "highlighted"}}>
+        <tr class={{if (contains user.id this.selectedUserIds) "highlighted"}}>
           <td
             class="text-left clickable"
             colspan="1"
             {{action "toggleUserSelection" user.id}}
           >
-            {{#if (is-in this.selectedUserIds user.id)}}
+            {{#if (contains user.id this.selectedUserIds)}}
               <input type="checkbox" checked="">
             {{else}}
               <input type="checkbox">

--- a/app/components/competency-title-editor.hbs
+++ b/app/components/competency-title-editor.hbs
@@ -14,7 +14,7 @@
       onkeyup={{action "addErrorDisplayFor" "title"}}
     >
   </EditableField>
-  {{#if (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))}}
+  {{#if (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))}}
     <span class="validation-error-message">
       {{v-get this "title" "message"}}
     </span>

--- a/app/components/curriculum-inventory-report-header.hbs
+++ b/app/components/curriculum-inventory-report-header.hbs
@@ -18,7 +18,7 @@
       {{#if
         (and
           (v-get this "reportName" "isInvalid")
-          (is-in showErrorsFor "reportName")
+          (contains "reportName" showErrorsFor)
         )
       }}
         <span class="validation-error-message">

--- a/app/components/curriculum-inventory-report-overview.hbs
+++ b/app/components/curriculum-inventory-report-overview.hbs
@@ -51,7 +51,7 @@
             {{#if
               (and
                 (v-get this "startDate" "isInvalid")
-                (is-in showErrorsFor "startDate")
+                (contains "startDate" showErrorsFor)
               )
             }}
               <span class="validation-error-message">
@@ -84,7 +84,7 @@
             {{#if
               (and
                 (v-get this "endDate" "isInvalid")
-                (is-in showErrorsFor "endDate")
+                (contains "endDate" showErrorsFor)
               )
             }}
               <span class="validation-error-message">
@@ -155,7 +155,7 @@
             {{#if
               (and
                 (v-get this "description" "isInvalid")
-                (is-in showErrorsFor "description")
+                (contains "description" showErrorsFor)
               )
             }}
               <span class="validation-error-message">

--- a/app/components/curriculum-inventory-report-rollover.hbs
+++ b/app/components/curriculum-inventory-report-rollover.hbs
@@ -20,7 +20,7 @@
       onkeyup={{action "addErrorDisplayFor" "name"}}
       placeholder={{t "general.reportNamePlaceholder"}}
     >
-    {{#if (and (v-get this "name" "isInvalid") (is-in showErrorsFor "name"))}}
+    {{#if (and (v-get this "name" "isInvalid") (contains "name" showErrorsFor))}}
       <span class="validation-error-message">
         {{v-get this "name" "message"}}
       </span>

--- a/app/components/curriculum-inventory-sequence-block-dates-duration-editor.hbs
+++ b/app/components/curriculum-inventory-sequence-block-dates-duration-editor.hbs
@@ -8,7 +8,7 @@
     @format="M/D/YYYY"
   />
   {{#if
-    (and (v-get this "startDate" "isInvalid") (is-in showErrorsFor "startDate"))
+    (and (v-get this "startDate" "isInvalid") (contains "startDate" showErrorsFor))
   }}
     <span class="validation-error-message">
       {{v-get this "startDate" "message"}}
@@ -24,7 +24,7 @@
     @onSelection={{action "changeEndDate"}}
     @format="M/D/YYYY"
   />
-  {{#if (and (v-get this "endDate" "isInvalid") (is-in showErrorsFor "endDate"))}}
+  {{#if (and (v-get this "endDate" "isInvalid") (contains "endDate" showErrorsFor))}}
     <span class="validation-error-message">
       {{v-get this "endDate" "message"}}
     </span>
@@ -42,7 +42,7 @@
     onkeyup={{action "addErrorDisplayFor" "duration"}}
   >
   {{#if
-    (and (v-get this "duration" "isInvalid") (is-in showErrorsFor "duration"))
+    (and (v-get this "duration" "isInvalid") (contains "duration" showErrorsFor))
   }}
     <span class="validation-error-message">
       {{v-get this "duration" "message"}}

--- a/app/components/curriculum-inventory-sequence-block-header.hbs
+++ b/app/components/curriculum-inventory-sequence-block-header.hbs
@@ -18,7 +18,7 @@
       {{#if
         (and
           (v-get this "blockTitle" "isInvalid")
-          (is-in showErrorsFor "blockTitle")
+          (contains "blockTitle" showErrorsFor)
         )
       }}
         <span class="validation-error-message">

--- a/app/components/curriculum-inventory-sequence-block-min-max-editor.hbs
+++ b/app/components/curriculum-inventory-sequence-block-min-max-editor.hbs
@@ -9,7 +9,7 @@
     disabled={{or isSaving isElective}}
     onkeyup={{action "addErrorDisplayFor" "minimum"}}
   >
-  {{#if (and (v-get this "minimum" "isInvalid") (is-in showErrorsFor "minimum"))
+  {{#if (and (v-get this "minimum" "isInvalid") (contains "minimum" showErrorsFor))
   }}
     <span class="validation-error-message">
       {{v-get this "minimum" "message"}}
@@ -27,7 +27,7 @@
     disabled={{isSaving}}
     onkeyup={{action "addErrorDisplayFor" "maximum"}}
   >
-  {{#if (and (v-get this "maximum" "isInvalid") (is-in showErrorsFor "maximum"))
+  {{#if (and (v-get this "maximum" "isInvalid") (contains "maximum" showErrorsFor))
   }}
     <span class="validation-error-message">
       {{v-get this "maximum" "message"}}

--- a/app/components/curriculum-inventory-sequence-block-session-list.hbs
+++ b/app/components/curriculum-inventory-sequence-block-session-list.hbs
@@ -50,14 +50,14 @@
           <tr>
             <td class="text-center" colspan="2">
               {{if
-                (is-in linkedSessions session)
+                (contains session linkedSessions)
                 (t "general.yes")
                 (t "general.no")
               }}
             </td>
             <td class="text-center" colspan="2">
               {{if
-                (is-in excludedSessions session)
+                (contains session excludedSessions)
                 (t "general.yes")
                 (t "general.no")
               }}
@@ -74,7 +74,7 @@
               {{get (await session.sessionType) "title"}}
             </td>
             <td class="text-center" colspan="1">
-              {{#if (is-in linkedSessions session)}}
+              {{#if (contains session linkedSessions)}}
                 {{#unless (is-fulfilled session.maxDuration)}}
                   <LoadingSpinner />
                 {{else}}

--- a/app/components/curriculum-inventory-sequence-block-session-manager.hbs
+++ b/app/components/curriculum-inventory-sequence-block-session-manager.hbs
@@ -74,14 +74,14 @@
             <td class="text-center" colspan="2">
               <Input
                 @type="checkbox"
-                @checked={{is-in linkedSessionsBuffer session}}
+                @checked={{contains session linkedSessionsBuffer}}
                 @change={{action "changeSession" session}}
               />
             </td>
             <td class="text-center" colspan="2">
               <Input
                 @type="checkbox"
-                @checked={{is-in excludedSessionsBuffer session}}
+                @checked={{contains session excludedSessionsBuffer}}
                 @change={{action "excludeSession" session}}
               />
             </td>
@@ -97,7 +97,7 @@
               {{get (await session.sessionType) "title"}}
             </td>
             <td class="text-center" colspan="1">
-              {{#if (is-in linkedSessionsBuffer session)}}
+              {{#if (contains session linkedSessionsBuffer)}}
                 {{#unless (is-fulfilled session.maxDuration)}}
                   <LoadingSpinner />
                 {{else}}

--- a/app/components/instructorgroup-header.hbs
+++ b/app/components/instructorgroup-header.hbs
@@ -20,7 +20,7 @@
         disabled={{isSaving}}
         onkeyup={{action "addErrorDisplayFor" "title"}}
       >
-      {{#if (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))
+      {{#if (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))
       }}
         <span class="validation-error-message">
           {{v-get this "title" "message"}}

--- a/app/components/learnergroup-header.hbs
+++ b/app/components/learnergroup-header.hbs
@@ -17,7 +17,7 @@
             onkeyup={{action "addErrorDisplayFor" "title"}}
           >
           {{#if
-            (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))
+            (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))
           }}
             <span class="validation-error-message">
               {{v-get this "title" "message"}}

--- a/app/components/learnergroup-summary.hbs
+++ b/app/components/learnergroup-summary.hbs
@@ -72,7 +72,7 @@
           {{#if
             (and
               (v-get this "location" "isInvalid")
-              (is-in showErrorsFor "location")
+              (contains "location" showErrorsFor)
             )
           }}
             <span class="validation-error-message">

--- a/app/components/new-competency.hbs
+++ b/app/components/new-competency.hbs
@@ -12,7 +12,7 @@
     {{t "general.add"}}
   {{/if}}
 </button>
-{{#if (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))}}
+{{#if (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))}}
   <span class="validation-error-message">
     {{v-get this "title" "message"}}
   </span>

--- a/app/components/new-course.hbs
+++ b/app/components/new-course.hbs
@@ -17,7 +17,7 @@
       onkeyup={{action "addErrorDisplayFor" "title"}}
     >
     {{#if
-      (and (v-get this "title" "isInvalid") (is-in this.showErrorsFor "title"))
+      (and (v-get this "title" "isInvalid") (contains "title" this.showErrorsFor))
     }}
       <span class="validation-error-message">
         {{v-get this "title" "message"}}

--- a/app/components/new-curriculum-inventory-report.hbs
+++ b/app/components/new-curriculum-inventory-report.hbs
@@ -16,7 +16,7 @@
         onkeyup={{action "addErrorDisplayFor" "name"}}
         placeholder={{t "general.reportNamePlaceholder"}}
       >
-      {{#if (and (v-get this "name" "isInvalid") (is-in showErrorsFor "name"))}}
+      {{#if (and (v-get this "name" "isInvalid") (contains "name" showErrorsFor))}}
         <span class="validation-error-message">
           {{v-get this "name" "message"}}
         </span>

--- a/app/components/new-curriculum-inventory-sequence-block.hbs
+++ b/app/components/new-curriculum-inventory-sequence-block.hbs
@@ -15,7 +15,7 @@
         onkeyup={{action "addErrorDisplayFor" "title"}}
         placeholder={{t "general.sequenceBlockTitlePlaceholder"}}
       >
-      {{#if (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))
+      {{#if (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))
       }}
         <span class="validation-error-message">
           {{v-get this "title" "message"}}
@@ -89,7 +89,7 @@
       />
       {{#if
         (and
-          (v-get this "startDate" "isInvalid") (is-in showErrorsFor "startDate")
+          (v-get this "startDate" "isInvalid") (contains "startDate" showErrorsFor)
         )
       }}
         <span class="validation-error-message">
@@ -107,7 +107,7 @@
         @format="M/D/YYYY"
       />
       {{#if
-        (and (v-get this "endDate" "isInvalid") (is-in showErrorsFor "endDate"))
+        (and (v-get this "endDate" "isInvalid") (contains "endDate" showErrorsFor))
       }}
         <span class="validation-error-message">
           {{v-get this "endDate" "message"}}
@@ -127,7 +127,7 @@
       >
       {{#if
         (and
-          (v-get this "duration" "isInvalid") (is-in showErrorsFor "duration")
+          (v-get this "duration" "isInvalid") (contains "duration" showErrorsFor)
         )
       }}
         <span class="validation-error-message">
@@ -158,7 +158,7 @@
         onkeyup={{action "addErrorDisplayFor" "minimum"}}
       >
       {{#if
-        (and (v-get this "minimum" "isInvalid") (is-in showErrorsFor "minimum"))
+        (and (v-get this "minimum" "isInvalid") (contains "minimum" showErrorsFor))
       }}
         <span class="validation-error-message">
           {{v-get this "minimum" "message"}}
@@ -177,7 +177,7 @@
         onkeyup={{action "addErrorDisplayFor" "maximum"}}
       >
       {{#if
-        (and (v-get this "maximum" "isInvalid") (is-in showErrorsFor "maximum"))
+        (and (v-get this "maximum" "isInvalid") (contains "maximum" showErrorsFor))
       }}
         <span class="validation-error-message">
           {{v-get this "maximum" "message"}}

--- a/app/components/new-directory-user.hbs
+++ b/app/components/new-directory-user.hbs
@@ -68,7 +68,7 @@
         onkeyup={{action "addErrorDisplayFor" "otherId"}}
       >
       {{#if
-        (and (v-get this "otherId" "isInvalid") (is-in showErrorsFor "otherId"))
+        (and (v-get this "otherId" "isInvalid") (contains "otherId" showErrorsFor))
       }}
         <span class="validation-error-message">
           {{v-get this "otherId" "message"}}
@@ -88,7 +88,7 @@
         >
         {{#if
           (and
-            (v-get this "username" "isInvalid") (is-in showErrorsFor "username")
+            (v-get this "username" "isInvalid") (contains "username" showErrorsFor)
           )
         }}
           <span class="validation-error-message">
@@ -114,7 +114,7 @@
         >
         {{#if
           (and
-            (v-get this "password" "isInvalid") (is-in showErrorsFor "password")
+            (v-get this "password" "isInvalid") (contains "password" showErrorsFor)
           )
         }}
           <span class="validation-error-message">

--- a/app/components/new-instructorgroup.hbs
+++ b/app/components/new-instructorgroup.hbs
@@ -15,7 +15,7 @@
       placeholder={{t "general.instructorGroupTitlePlaceholder"}}
       data-test-title
     >
-    {{#if (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))}}
+    {{#if (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))}}
       <span class="validation-error-message">
         {{v-get this "title" "message"}}
       </span>

--- a/app/components/new-learnergroup-multiple.hbs
+++ b/app/components/new-learnergroup-multiple.hbs
@@ -18,7 +18,7 @@
     {{#if
       (and
         (v-get this "numSubGroups" "isInvalid")
-        (is-in showErrorsFor "numSubGroups")
+        (contains "numSubGroups" showErrorsFor)
       )
     }}
       <span class="validation-error-message">

--- a/app/components/new-learnergroup-single.hbs
+++ b/app/components/new-learnergroup-single.hbs
@@ -10,7 +10,7 @@
     onkeyup={{action "addErrorDisplayFor" "title"}}
     placeholder={{t "general.learnerGroupTitlePlaceholder"}}
   >
-  {{#if (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))}}
+  {{#if (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))}}
     <span class="validation-error-message">
       {{v-get this "title" "message"}}
     </span>

--- a/app/components/new-myreport.hbs
+++ b/app/components/new-myreport.hbs
@@ -14,7 +14,7 @@
       onkeyup={{action "addErrorDisplayFor" "title"}}
       data-test-report-title
     >
-    {{#if (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))}}
+    {{#if (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))}}
       <span class="validation-error-message">
         {{v-get this "title" "message"}}
       </span>

--- a/app/components/new-program.hbs
+++ b/app/components/new-program.hbs
@@ -14,7 +14,7 @@
       onkeyup={{action "addErrorDisplayFor" "title"}}
       placeholder={{t "general.programTitlePlaceholder"}}
     >
-    {{#if (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))}}
+    {{#if (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))}}
       <span class="validation-error-message">
         {{v-get this "title" "message"}}
       </span>

--- a/app/components/new-user.hbs
+++ b/app/components/new-user.hbs
@@ -25,7 +25,7 @@
     >
     {{#if
       (and
-        (v-get this "firstName" "isInvalid") (is-in showErrorsFor "firstName")
+        (v-get this "firstName" "isInvalid") (contains "firstName" showErrorsFor)
       )
     }}
       <span class="message error">
@@ -45,7 +45,7 @@
     >
     {{#if
       (and
-        (v-get this "middleName" "isInvalid") (is-in showErrorsFor "middleName")
+        (v-get this "middleName" "isInvalid") (contains "middleName" showErrorsFor)
       )
     }}
       <span class="message error">
@@ -64,7 +64,7 @@
       onkeyup={{action "addErrorDisplayFor" "lastName"}}
     >
     {{#if
-      (and (v-get this "lastName" "isInvalid") (is-in showErrorsFor "lastName"))
+      (and (v-get this "lastName" "isInvalid") (contains "lastName" showErrorsFor))
     }}
       <span class="message error">
         {{v-get this "lastName" "message"}}
@@ -82,7 +82,7 @@
       onkeyup={{action "addErrorDisplayFor" "campusId"}}
     >
     {{#if
-      (and (v-get this "campusId" "isInvalid") (is-in showErrorsFor "campusId"))
+      (and (v-get this "campusId" "isInvalid") (contains "campusId" showErrorsFor))
     }}
       <span class="message error">
         {{v-get this "campusId" "message"}}
@@ -100,7 +100,7 @@
       onkeyup={{action "addErrorDisplayFor" "otherId"}}
     >
     {{#if
-      (and (v-get this "otherId" "isInvalid") (is-in showErrorsFor "otherId"))
+      (and (v-get this "otherId" "isInvalid") (contains "otherId" showErrorsFor))
     }}
       <span class="message error">
         {{v-get this "otherId" "message"}}
@@ -117,7 +117,7 @@
       oninput={{action (mut email) value="target.value"}}
       onkeyup={{action "addErrorDisplayFor" "email"}}
     >
-    {{#if (and (v-get this "email" "isInvalid") (is-in showErrorsFor "email"))}}
+    {{#if (and (v-get this "email" "isInvalid") (contains "email" showErrorsFor))}}
       <span class="message error">
         {{v-get this "email" "message"}}
       </span>
@@ -133,7 +133,7 @@
       oninput={{action (mut phone) value="target.value"}}
       onkeyup={{action "addErrorDisplayFor" "phone"}}
     >
-    {{#if (and (v-get this "phone" "isInvalid") (is-in showErrorsFor "phone"))}}
+    {{#if (and (v-get this "phone" "isInvalid") (contains "phone" showErrorsFor))}}
       <span class="message error">
         {{v-get this "phone" "message"}}
       </span>
@@ -150,7 +150,7 @@
       onkeyup={{action "addErrorDisplayFor" "username"}}
     >
     {{#if
-      (and (v-get this "username" "isInvalid") (is-in showErrorsFor "username"))
+      (and (v-get this "username" "isInvalid") (contains "username" showErrorsFor))
     }}
       <span class="message error">
         {{v-get this "username" "message"}}
@@ -168,7 +168,7 @@
       onkeyup={{action "addErrorDisplayFor" "password"}}
     >
     {{#if
-      (and (v-get this "password" "isInvalid") (is-in showErrorsFor "password"))
+      (and (v-get this "password" "isInvalid") (contains "password" showErrorsFor))
     }}
       <span class="message error">
         {{v-get this "password" "message"}}

--- a/app/components/program-header.hbs
+++ b/app/components/program-header.hbs
@@ -18,7 +18,7 @@
         {{#if
           (and
             (v-get this "programTitle" "isInvalid")
-            (is-in showErrorsFor "programTitle")
+            (contains "programTitle" showErrorsFor)
           )
         }}
           <span class="validation-error-message">

--- a/app/components/program-overview.hbs
+++ b/app/components/program-overview.hbs
@@ -26,7 +26,7 @@
           {{#if
             (and
               (v-get this "shortTitle" "isInvalid")
-              (is-in showErrorsFor "shortTitle")
+              (contains "shortTitle" showErrorsFor)
             )
           }}
             <span class="validation-error-message">

--- a/app/components/programyear-objective-list-item.hbs
+++ b/app/components/programyear-objective-list-item.hbs
@@ -12,13 +12,13 @@
       @renderHtml={{true}}
       @isSaveDisabled={{and
         (v-get this "title" "isInvalid")
-        (is-in showErrorsFor "title")
+        (contains "title" showErrorsFor)
       }}
       @save={{action "saveTitleChanges"}}
       @close={{action "revertTitleChanges"}}
     >
       <HtmlEditor @content={{title}} @update={{action "changeTitle"}} />
-      {{#if (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))}}
+      {{#if (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))}}
         <span class="validation-error-message">
           {{v-get this "title" "message"}}
         </span>

--- a/app/components/school-curriculum-inventory-institution-manager.hbs
+++ b/app/components/school-curriculum-inventory-institution-manager.hbs
@@ -34,7 +34,7 @@
         oninput={{action (mut this.name) value="target.value"}}
         onkeyup={{action "addErrorDisplayFor" "name"}}
       >
-      {{#if (and (v-get this "name" "isInvalid") (is-in showErrorsFor "name"))}}
+      {{#if (and (v-get this "name" "isInvalid") (contains "name" showErrorsFor))}}
         <span class="validation-error-message">
           {{v-get this "name" "message"}}
         </span>
@@ -53,7 +53,7 @@
       >
       {{#if
         (and
-          (v-get this "aamcCode" "isInvalid") (is-in showErrorsFor "aamcCode")
+          (v-get this "aamcCode" "isInvalid") (contains "aamcCode" showErrorsFor)
         )
       }}
         <span class="validation-error-message">
@@ -74,7 +74,7 @@
       {{#if
         (and
           (v-get this "addressStreet" "isInvalid")
-          (is-in showErrorsFor "addressStreet")
+          (contains "addressStreet" showErrorsFor)
         )
       }}
         <span class="validation-error-message">
@@ -95,7 +95,7 @@
       {{#if
         (and
           (v-get this "addressCity" "isInvalid")
-          (is-in showErrorsFor "addressCity")
+          (contains "addressCity" showErrorsFor)
         )
       }}
         <span class="validation-error-message">
@@ -117,7 +117,7 @@
       {{#if
         (and
           (v-get this "addressStateOrProvince" "isInvalid")
-          (is-in showErrorsFor "addressStateOrProvince")
+          (contains "addressStateOrProvince" showErrorsFor)
         )
       }}
         <span class="validation-error-message">
@@ -138,7 +138,7 @@
       {{#if
         (and
           (v-get this "addressZipCode" "isInvalid")
-          (is-in showErrorsFor "addressZipCode")
+          (contains "addressZipCode" showErrorsFor)
         )
       }}
         <span class="validation-error-message">
@@ -160,7 +160,7 @@
       {{#if
         (and
           (v-get this "addressCountryCode" "isInvalid")
-          (is-in showErrorsFor "addressCountryCode")
+          (contains "addressCountryCode" showErrorsFor)
         )
       }}
         <span class="validation-error-message">

--- a/app/components/school-list.hbs
+++ b/app/components/school-list.hbs
@@ -31,13 +31,13 @@
             onkeyup={{action "addErrorDisplayFor" "title"}}
             class={{if
               (and
-                (v-get this "title" "isInvalid") (is-in showErrorsFor "title")
+                (v-get this "title" "isInvalid") (contains "title" showErrorsFor)
               )
               "has-error"
             }}
           >
           {{#if
-            (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))
+            (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))
           }}
             <span class="validation-error-message">
               {{v-get this "title" "message"}}
@@ -57,7 +57,7 @@
             class={{if
               (and
                 (v-get this "iliosAdministratorEmail" "isInvalid")
-                (is-in showErrorsFor "iliosAdministratorEmail")
+                (contains "iliosAdministratorEmail" showErrorsFor)
               )
               "has-error"
             }}
@@ -65,7 +65,7 @@
           {{#if
             (and
               (v-get this "iliosAdministratorEmail" "isInvalid")
-              (is-in showErrorsFor "iliosAdministratorEmail")
+              (contains "iliosAdministratorEmail" showErrorsFor)
             )
           }}
             <span class="validation-error-message">

--- a/app/components/school-manager.hbs
+++ b/app/components/school-manager.hbs
@@ -21,7 +21,7 @@
           onkeyup={{action "addErrorDisplayFor" "title"}}
         >
         {{#if
-          (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))
+          (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))
         }}
           <span class="validation-error-message">
             {{v-get this "title" "message"}}

--- a/app/components/school-session-type-form.hbs
+++ b/app/components/school-session-type-form.hbs
@@ -11,7 +11,7 @@
         oninput={{action (mut title) value="target.value"}}
         onkeyup={{action "addErrorDisplayFor" "title"}}
       >
-      {{#if (and (v-get this "title" "isInvalid") (is-in showErrorsFor "title"))
+      {{#if (and (v-get this "title" "isInvalid") (contains "title" showErrorsFor))
       }}
         <span class="message error">
           {{v-get this "title" "message"}}
@@ -50,7 +50,7 @@
         {{#if
           (and
             (v-get this "selectedAamcMethodId" "isInvalid")
-            (is-in showErrorsFor "selectedAamcMethodId")
+            (contains "selectedAamcMethodId" showErrorsFor)
           )
         }}
           <span class="message error">
@@ -83,7 +83,7 @@
       {{#if
         (and
           (v-get this "calendarColor" "isInvalid")
-          (is-in showErrorsFor "calendarColor")
+          (contains "calendarColor" showErrorsFor)
         )
       }}
         <span class="message error">

--- a/app/components/school-vocabularies-list.hbs
+++ b/app/components/school-vocabularies-list.hbs
@@ -24,7 +24,7 @@
         {{#if
           (and
             (v-get this "newVocabularyTitle" "isInvalid")
-            (is-in showErrorsFor "newVocabularyTitle")
+            (contains "newVocabularyTitle" showErrorsFor)
           )
         }}
           <span class="validation-error-message">

--- a/app/components/school-vocabulary-manager.hbs
+++ b/app/components/school-vocabulary-manager.hbs
@@ -18,7 +18,7 @@
       @close={{action "revertVocabularyTitleChanges"}}
       @isSaveDisabled={{and
         (v-get this "vocabularyTitle" "isInvalid")
-        (is-in showErrorsFor "vocabularyTitle")
+        (contains "vocabularyTitle" showErrorsFor)
       }}
       @saveOnEnter={{true}}
       @closeOnEscape={{true}} as |isSaving|
@@ -33,7 +33,7 @@
     {{#if
       (and
         (v-get this "vocabularyTitle" "isInvalid")
-        (is-in showErrorsFor "vocabularyTitle")
+        (contains "vocabularyTitle" showErrorsFor)
       )
     }}
       <span class="validation-error-message" data-test-title-error-message>
@@ -75,7 +75,7 @@
       {{#if
         (and
           (v-get this "newTermTitle" "isInvalid")
-          (is-in showErrorsFor "newTermTitle")
+          (contains "newTermTitle" showErrorsFor)
         )
       }}
         <span class="validation-error-message" data-test-error-message>

--- a/app/components/school-vocabulary-term-manager.hbs
+++ b/app/components/school-vocabulary-term-manager.hbs
@@ -41,7 +41,7 @@
       {{/if}}
       {{#if
         (and
-          (v-get this "termTitle" "isInvalid") (is-in showErrorsFor "termTitle")
+          (v-get this "termTitle" "isInvalid") (contains "termTitle" showErrorsFor)
         )
       }}
         <span class="validation-error-message" data-test-title-error-message>
@@ -134,7 +134,7 @@
       {{#if
         (and
           (v-get this "newTermTitle" "isInvalid")
-          (is-in showErrorsFor "newTermTitle")
+          (contains "newTermTitle" showErrorsFor)
         )
       }}
         <span class="validation-error-message" data-test-error-message>

--- a/app/components/user-profile-bio.hbs
+++ b/app/components/user-profile-bio.hbs
@@ -53,7 +53,7 @@
       >
       {{#if
         (and
-          (v-get this "firstName" "isInvalid") (is-in showErrorsFor "firstName")
+          (v-get this "firstName" "isInvalid") (contains "firstName" showErrorsFor)
         )
       }}
         <span class="message error">
@@ -81,7 +81,7 @@
       {{#if
         (and
           (v-get this "middleName" "isInvalid")
-          (is-in showErrorsFor "middleName")
+          (contains "middleName" showErrorsFor)
         )
       }}
         <span class="message error">
@@ -112,7 +112,7 @@
       >
       {{#if
         (and
-          (v-get this "lastName" "isInvalid") (is-in showErrorsFor "lastName")
+          (v-get this "lastName" "isInvalid") (contains "lastName" showErrorsFor)
         )
       }}
         <span class="message error">
@@ -162,7 +162,7 @@
         </button>
         {{#if
           (and
-            (v-get this "campusId" "isInvalid") (is-in showErrorsFor "campusId")
+            (v-get this "campusId" "isInvalid") (contains "campusId" showErrorsFor)
           )
         }}
           <span class="message error">
@@ -194,7 +194,7 @@
         data-test-other-id-input
       >
       {{#if
-        (and (v-get this "otherId" "isInvalid") (is-in showErrorsFor "otherId"))
+        (and (v-get this "otherId" "isInvalid") (contains "otherId" showErrorsFor))
       }}
         <span class="message error">
           {{v-get this "otherId" "message"}}
@@ -221,7 +221,7 @@
         onkeyup={{action "addErrorDisplayFor" "email"}}
         data-test-email-input
       >
-      {{#if (and (v-get this "email" "isInvalid") (is-in showErrorsFor "email"))
+      {{#if (and (v-get this "email" "isInvalid") (contains "email" showErrorsFor))
       }}
         <span class="message error">
           {{v-get this "email" "message"}}
@@ -254,7 +254,7 @@
       {{#if
         (and
           (v-get this "displayName" "isInvalid")
-          (is-in showErrorsFor "displayName")
+          (contains "displayName" showErrorsFor)
         )
       }}
         <span class="message error">
@@ -288,7 +288,7 @@
       {{#if
         (and
           (v-get this "preferredEmail" "isInvalid")
-          (is-in showErrorsFor "preferredEmail")
+          (contains "preferredEmail" showErrorsFor)
         )
       }}
         <span class="message error">
@@ -316,7 +316,7 @@
         onkeyup={{action "addErrorDisplayFor" "phone"}}
         data-test-phone-input
       >
-      {{#if (and (v-get this "phone" "isInvalid") (is-in showErrorsFor "phone"))
+      {{#if (and (v-get this "phone" "isInvalid") (contains "phone" showErrorsFor))
       }}
         <span class="message error">
           {{v-get this "phone" "message"}}
@@ -347,7 +347,7 @@
       >
       {{#if
         (and
-          (v-get this "username" "isInvalid") (is-in showErrorsFor "username")
+          (v-get this "username" "isInvalid") (contains "username" showErrorsFor)
         )
       }}
         <span class="message error">
@@ -375,7 +375,7 @@
           onkeyup={{action "addErrorDisplayFor" "password"}}
           data-test-password-input
         >
-        {{#if (and (v-get this "password" "isInvalid") (is-in showErrorsFor "password"))}}
+        {{#if (and (v-get this "password" "isInvalid") (contains "password" showErrorsFor))}}
           <span class="message error">
             {{v-get this "password" "message"}}
           </span>

--- a/app/templates/pending-user-updates.hbs
+++ b/app/templates/pending-user-updates.hbs
@@ -69,7 +69,7 @@
                 </td>
                 <td></td>
                 <td class="text-left" colspan="2">
-                  {{#if (is-in updatesBeingSaved update)}}
+                  {{#if (contains update updatesBeingSaved)}}
                     <LoadingSpinner />
                   {{else}}
                     {{#if (eq update.type "emailMismatch")}}


### PR DESCRIPTION
Contains is provided by ember-composable-helpers and switching to it allows
us to remove the is-in helper in common.