### PR TITLE
Avoid console logging non errors

### DIFF
--- a/app/sentry.js
+++ b/app/sentry.js
@@ -13,16 +13,16 @@ function startSentry(config) {
     beforeSend(event, hint) {
       const error = hint.originalException;
 
+      // ignore aborted route transitions from the Ember.js router
+      if (error && error.name === 'TransitionAborted') {
+        return null;
+      }
+
       //print everything to the console when not in production
       if (isDevelopmentEnvironment && error) {
         console.error(error);
       }
       if (!captureErrors) {
-        return null;
-      }
-
-      // ignore aborted route transitions from the Ember.js router
-      if (error && error.name === 'TransitionAborted') {
         return null;
       }
 


### PR DESCRIPTION
The "TransitionAborted" error is thrown by ember all the time when the
page changes, our tests are being clogged up with these warnings and
they're annoying when developing. Let's stop logging them.