### PR TITLE
Move noscript tag into the footer of the body tag

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -73,7 +73,7 @@ module.exports = function (environment) {
       environment,
     },
     noScript: {
-      'placeIn': 'head-footer'
+      'placeIn': 'body-footer'
     },
     EmberENV: {
       FEATURES: {


### PR DESCRIPTION
Putting this anywhere in the header messes with a11y automated scanning
when we replace the title tag.