### PR TITLE
Fix service worker deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,10 +6,10 @@ on:
       - '*'
 
 env:
-  SW_DISABLED: true
   COVERAGE: false
   SENTRY_ORG: ilios
   SENTRY_PROJECT: frontend
+  CI: true
 
 jobs:
   test:
@@ -22,6 +22,8 @@ jobs:
           node-version: 12
       - run: npm ci
       - run: npm test
+        env:
+          SW_DISABLED: true
 
   deploy:
     name: Deploy and Create Sentry Release

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -6,8 +6,8 @@ on:
       - master
 
 env:
-  SW_DISABLED: true
   COVERAGE: false
+  CI: true
 
 jobs:
   test:
@@ -20,6 +20,8 @@ jobs:
           node-version: 12
       - run: npm ci
       - run: npm test
+        env:
+          SW_DISABLED: true
 
   deploy:
     name: Deploy


### PR DESCRIPTION
This shouldn't have been disabled for the deploy step as it means our
app doesn't get service workers.