### PR TITLE
Refactor and octaneify program year objectives

### DIFF
--- a/app/components/program-year/manage-objective-competency-item.hbs
+++ b/app/components/program-year/manage-objective-competency-item.hbs
@@ -1,0 +1,16 @@
+{{#if @isSelected}}
+  <label {{on "click" @remove}} class="selected">
+    <input
+      type="radio"
+      checked="checked"
+    >
+    {{@title}}
+  </label>
+{{else}}
+  <label {{on "click" @add}}>
+    <input
+      type="radio"
+    >
+    {{@title}}
+  </label>
+{{/if}}

--- a/app/components/program-year/manage-objective-competency.hbs
+++ b/app/components/program-year/manage-objective-competency.hbs
@@ -1,0 +1,41 @@
+<section
+  class="program-year-manage-objective-competency"
+  data-test-program-year-manage-objective-competency
+>
+  <h3 class="objective-title" data-test-objective-title>
+    {{! template-lint-disable no-triple-curlies }}
+    {{{@objectiveTitle}}}
+  </h3>
+  {{#if @domains.length}}
+    <ul class="parent-picker" data-test-parent-picker>
+      {{#each @domains as |domain|}}
+        <li class="domain {{if
+              (contains @selected.id (map-by "id" domain.competencies))
+              "selected"
+            }}"
+            data-test-domain
+        >
+          <h4
+            class="domain-title"
+          >
+            {{domain.title}}
+          </h4>
+          <ul>
+            {{#each (sort-by "title" domain.competencies) as |competency|}}
+              <li>
+                <ProgramYear::ManageObjectiveCompetencyItem
+                  @title={{competency.title}}
+                  @isSelected={{eq competency.id @selected.id}}
+                  @add={{fn @add competency.id}}
+                  @remove={{@remove}}
+                />
+              </li>
+            {{/each}}
+          </ul>
+        </li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <p class="no-group" data-test-no-competencies-message>{{t "general.missingCompetenciesMessage"}}</p>
+  {{/if}}
+</section>

--- a/app/components/program-year/manage-objective-descriptors.hbs
+++ b/app/components/program-year/manage-objective-descriptors.hbs
@@ -1,0 +1,12 @@
+<div data-test-program-year-manage-objective-descriptors>
+  <span data-test-objective-title>
+    {{! template-lint-disable no-triple-curlies}}
+    {{{@objectiveTitle}}}
+  </span>
+  <MeshManager
+    @add={{@add}}
+    @remove={{@remove}}
+    @terms={{@selected}}
+    @editable={{@editable}}
+  />
+</div>

--- a/app/components/program-year/objectives.hbs
+++ b/app/components/program-year/objectives.hbs
@@ -1,0 +1,95 @@
+<section
+  class="detail-objectives {{if this.showCollapsible "collapsible"}}"
+  data-test-program-year-objectives
+  {{did-insert (perform this.load) @programYear @programYear.objectives @programYear.program.school.competencies}}
+  {{did-update (perform this.load) @programYear @programYear.objectives @programYear.program.school.competencies}}
+>
+  <div class="detail-objectives-header">
+    {{#if this.isManaging}}
+      <div class="title">
+        {{#if this.isManagingCompetency}}
+          <span class="specific-title">
+            {{t "general.objectiveCompetencyManagerTitle"}}
+          </span>
+        {{/if}}
+        {{#if this.isManagingDescriptors}}
+          <span class="specific-title">
+            {{t "general.objectiveDescriptorTitle"}}
+          </span>
+        {{/if}}
+      </div>
+    {{else}}
+      <div
+        class="title {{if this.showCollapsible "clickable collapsible"}}"
+        role="button"
+        {{on "click" this.collapse}}
+      >
+        {{t "general.objectives"}} ({{@programYear.objectives.length}})
+      </div>
+    {{/if}}
+    <div class="detail-objectives-actions" data-test-actions>
+      {{#if this.isManaging}}
+        <button
+          type="button"
+          class="bigadd"
+          {{on "click" (perform this.save)}}
+          aria-label={{t "general.save"}}
+          data-test-save
+        >
+          <FaIcon @icon="check" />
+        </button>
+        <button
+          type="button"
+          class="bigcancel"
+          {{on "click" this.cancel}}
+          aria-label={{t "general.cancel"}}
+          data-test-cancel
+        >
+          <FaIcon @icon="undo" />
+        </button>
+      {{else if @editable}}
+        <ExpandCollapseButton
+          @value={{this.newObjectiveEditorOn}}
+          @action={{this.toggleNewObjectiveEditor}}
+          @expandButtonLabel={{t "general.addNew"}}
+        />
+      {{/if}}
+    </div>
+  </div>
+  <div class="detail-objectives-content">
+    {{#if this.newObjectiveEditorOn class="vertical"}}
+      <NewObjective
+        @save={{perform this.saveNewObjective}}
+        @cancel={{this.toggleNewObjectiveEditor}}
+      />
+    {{/if}}
+    {{#if (not this.isManaging)}}
+      <ProgramyearObjectiveList
+        @subject={{@programYear}}
+        @editable={{@editable}}
+        @manageDescriptors={{perform this.manageDescriptors}}
+        @manageCompetency={{perform this.manageCompetency}}
+      />
+    {{else}}
+      {{#if this.isManagingDescriptors}}
+        <ProgramYear::ManageObjectiveDescriptors
+          @objectiveTitle={{this.manageDescriptorsObjective.title}}
+          @selected={{this.descriptorsBuffer}}
+          @add={{this.addDescriptorToBuffer}}
+          @remove={{this.removeDescriptorFromBuffer}}
+          @editable={{@editable}}
+        />
+      {{/if}}
+      {{#if this.isManagingCompetency}}
+        <ProgramYear::ManageObjectiveCompetency
+          @objectiveTitle={{this.manageCompetencyObjective.title}}
+          @selected={{this.competencyBuffer}}
+          @domains={{this.schoolDomains}}
+          @add={{this.setCompetencyBuffer}}
+          @remove={{set this.competencyBuffer null}}
+          @editable={{@editable}}
+        />
+      {{/if}}
+    {{/if}}
+  </div>
+</section>

--- a/app/components/program-year/objectives.js
+++ b/app/components/program-year/objectives.js
@@ -1,0 +1,163 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { dropTask, restartableTask } from 'ember-concurrency-decorators';
+import { waitForProperty } from 'ember-concurrency';
+import { action } from '@ember/object';
+import scrollTo from 'ilios-common/utils/scroll-to';
+import { map } from 'rsvp';
+
+export default class ProgramYearObjectivesComponent extends Component {
+  @service store;
+  @service intl;
+  @service flashMessages;
+
+  @tracked manageCompetencyObjective;
+  @tracked competencyBuffer;
+  @tracked manageDescriptorsObjective;
+  @tracked descriptorsBuffer = [];
+
+  @tracked newObjectiveEditorOn = false;
+  @tracked newObjectiveTitle;
+
+  @tracked objectives;
+  @tracked schoolDomains;
+
+  @restartableTask
+  *load(event, [programYear]) {
+    if (!programYear) {
+      return;
+    }
+    this.objectives = yield (programYear.objectives).toArray();
+    const program = yield programYear.program;
+    const school = yield program.school;
+    this.schoolCompetencies = (yield school.competencies).toArray();
+    this.schoolDomains = yield this.getSchoolDomains(this.schoolCompetencies);
+  }
+
+  async getSchoolDomains(schoolCompetencies) {
+    const domains = schoolCompetencies.filterBy('isDomain').toArray();
+    return await map(domains, async domain => {
+      const competencies = (await domain.children).map(competency => {
+        return {
+          id: competency.id,
+          title: competency.title
+        };
+      });
+      return {
+        id: domain.id,
+        title: domain.title,
+        competencies
+      };
+    });
+  }
+
+  get isManaging() {
+    return this.isManagingCompetency || this.isManagingDescriptors;
+  }
+
+  get isManagingCompetency() {
+    return !!this.manageCompetencyObjective;
+  }
+  get isManagingDescriptors() {
+    return !!this.manageDescriptorsObjective;
+  }
+
+  get showCollapsible(){
+    return this.objectives?.length && !this.isManaging;
+  }
+
+  @dropTask
+  *manageCompetency(objective) {
+    yield waitForProperty(this, 'schoolDomains', Array.isArray);
+    this.competencyBuffer = yield objective.competency;
+    this.manageCompetencyObjective = objective;
+  }
+  @dropTask
+  *manageDescriptors(objective) {
+    const meshDescriptors = yield objective.meshDescriptors;
+    scrollTo('.detail-objectives', 1000);
+    this.descriptorsBuffer = meshDescriptors.toArray();
+    this.manageDescriptorsObjective = objective;
+  }
+
+  @dropTask
+  *save() {
+    if(this.isManagingCompetency){
+      yield this.saveCompetency.perform();
+    }
+    if(this.isManagingDescriptors){
+      yield this.saveMesh.perform();
+    }
+  }
+
+  @dropTask
+  *saveCompetency() {
+    const objective = this.manageCompetencyObjective;
+    objective.set('competency', this.competencyBuffer);
+    yield objective.save();
+    this.competencyBuffer = null;
+    this.manageCompetencyObjective = null;
+    scrollTo("#objective-" + objective.get('id'));
+  }
+
+  @dropTask
+  *saveMesh() {
+    const objective = this.manageDescriptorsObjective;
+    objective.set('meshDescriptors', this.descriptorsBuffer);
+    yield objective.save();
+    this.manageDescriptorsObjective = null;
+    scrollTo("#objective-" + objective.get('id'));
+  }
+
+  @dropTask
+  *saveNewObjective(title) {
+    const newObjective = this.store.createRecord('objective');
+    newObjective.set('title', title);
+    let position = 0;
+
+    if (this.objectives?.length) {
+      position = this.objectives.sortBy('position').lastObject.position + 1;
+    }
+
+    newObjective.set('position', position);
+    newObjective.set('programYears', [this.args.programYear]);
+
+    yield newObjective.save();
+    this.newObjectiveEditorOn = false;
+    this.flashMessages.success('general.newObjectiveSaved');
+  }
+
+  @action
+  setCompetencyBuffer(competencyId) {
+    this.competencyBuffer = this.schoolCompetencies.findBy('id', competencyId);
+  }
+
+  @action
+  cancel() {
+    this.manageCompetencyObjective = null;
+    this.manageDescriptorsObjective = null;
+  }
+
+  @action
+  toggleNewObjectiveEditor() {
+    //force expand the objective component
+    //otherwise adding the first new objective will cause it to close
+    this.args.expand();
+    this.newObjectiveEditorOn = !this.newObjectiveEditorOn;
+  }
+  @action
+  collapse() {
+    if (this.objectives.length) {
+      this.args.collapse();
+    }
+  }
+  @action
+  addDescriptorToBuffer(descriptor) {
+    this.descriptorsBuffer = [...this.descriptorsBuffer, descriptor];
+  }
+  @action
+  removeDescriptorFromBuffer(descriptor) {
+    this.descriptorsBuffer = this.descriptorsBuffer.filter(obj => obj.id !== descriptor.id);
+  }
+}

--- a/app/components/programyear-details.hbs
+++ b/app/components/programyear-details.hbs
@@ -1,4 +1,4 @@
-<div class="programyear-details" ...attributes>
+<div class="programyear-details" data-test-program-year-details ...attributes>
   {{#liquid-if (or (eq programYear.competencies.length 0) pyCompetencyDetails)}}
     <ProgramyearCompetencies
       @programYear={{programYear}}
@@ -15,12 +15,11 @@
     />
   {{/liquid-if}}
   {{#liquid-if (or (eq programYear.objectives.length 0) pyObjectiveDetails)}}
-    <DetailObjectives
-      @subject={{programYear}}
-      @isProgramYear={{true}}
-      @editable={{canUpdate}}
-      @collapse={{action setPyObjectiveDetails false}}
-      @expand={{action setPyObjectiveDetails true}}
+    <ProgramYear::Objectives
+      @programYear={{@programYear}}
+      @editable={{@canUpdate}}
+      @collapse={{fn @setPyObjectiveDetails false}}
+      @expand={{fn @setPyObjectiveDetails true}}
     />
   {{else}}
     <CollapsedObjectivesProgramYears

--- a/app/components/programyear-objective-list-item-expanded.hbs
+++ b/app/components/programyear-objective-list-item-expanded.hbs
@@ -14,15 +14,15 @@
 </tr>
 {{#if (is-fulfilled courseObjects)}}
   {{#each (sort-by "title" (await courseObjects)) as |obj|}}
-    <tr class="programyear-objective-list-item-expanded">
+    <tr class="programyear-objective-list-item-expanded" data-test-programyear-objective-list-item-expanded>
       <td colspan="2"></td>
-      <td colspan="13" class="text-top">
+      <td colspan="13" class="text-top" data-test-course>
         {{obj.title}}
       </td>
       <td colspan="13" class="text-top">
-        <ul>
+        <ul data-test-course-objectives>
           {{#each (sort-by "title" obj.objectives) as |obj|}}
-            <li>
+            <li data-test-course-objective>
               {{obj.title}}
             </li>
           {{/each}}

--- a/app/components/programyear-objective-list-item.hbs
+++ b/app/components/programyear-objective-list-item.hbs
@@ -1,4 +1,4 @@
-<td colspan="1" class="link" {{action toggleExpand objective.id}}>
+<td colspan="1" class="link" {{action toggleExpand objective.id}} data-test-toggle-expand>
   {{#if expanded}}
     <FaIcon @icon="caret-down" />
   {{else}}
@@ -31,11 +31,11 @@
 <td class="text-left text-top" colspan="8">
   {{#if (await objective.competency)}}
     {{#if editable}}
-      <span class="clickable link" {{action manageCompetency objective}}>
+      <span class="clickable link" {{action manageCompetency objective}} data-test-competency data-test-manage-competency>
         {{get (await objective.competency) "title"}}
       </span>
     {{else}}
-      {{get (await objective.competency) "title"}}
+      <span data-test-competency>{{get (await objective.competency) "title"}}</span>
     {{/if}}
     {{#if
       (not-eq
@@ -43,10 +43,10 @@
         (get (await objective.competency.domain) "id")
       )
     }}
-      ({{get (await objective.competency.domain) "title"}})
+      <span data-test-domain>({{get (await objective.competency.domain) "title"}})</span>
     {{/if}}
   {{else if editable}}
-    <button type="button" {{action manageCompetency objective}}>
+    <button type="button" {{action manageCompetency objective}}  data-test-manage-competency>
       {{t "general.addNew"}}
     </button>
   {{else}}
@@ -58,11 +58,11 @@
     <ul>
       {{#each (await objective.meshDescriptors) as |descriptor|}}
         {{#if editable}}
-          <li class="clickable link" {{action manageDescriptors objective}}>
+          <li class="clickable link" {{action manageDescriptors objective}} data-test-term>
             {{descriptor.name}}
           </li>
         {{else}}
-          <li>
+          <li data-test-term>
             {{descriptor.name}}
           </li>
         {{/if}}

--- a/app/components/programyear-objective-list-item.js
+++ b/app/components/programyear-objective-list-item.js
@@ -5,4 +5,5 @@ export default Component.extend(ObjectiveListItem, {
   classNames: ['objective-list-item'],
   programYear: null,
   expanded: true,
+  'data-test-programyear-objective-list-item': true,
 });

--- a/app/components/programyear-objective-list.hbs
+++ b/app/components/programyear-objective-list.hbs
@@ -2,7 +2,7 @@
   {{#if (is-fulfilled objectives)}}
     {{#if isSorting}}
       <ObjectiveSortManager
-        @subject={{programYear}}
+        @subject={{@subject}}
         @save={{action "saveSortOrder"}}
         @cancel={{action "cancelSorting"}}
       />
@@ -12,7 +12,7 @@
           {{t "general.sortObjectives"}}
         </button>
       {{/if}}
-      <button type="button" class="download" {{action (perform downloadReport subject)}}>
+      <button type="button" class="download" {{action (perform downloadReport @subject)}}>
         <FaIcon
           @icon={{if downloadReport.isRunning "spinner" "download"}}
           @spin={{if downloadReport.isRunning true false}}

--- a/app/components/programyear-objective-list.js
+++ b/app/components/programyear-objective-list.js
@@ -5,8 +5,6 @@ import SortableObjectiveList from 'ilios-common/mixins/sortable-objective-list';
 import { task } from 'ember-concurrency';
 import fetch from 'fetch';
 
-const { alias } = computed;
-
 export default Component.extend(SortableObjectiveList, {
   ajax: service(),
   iliosConfig: service(),
@@ -14,9 +12,7 @@ export default Component.extend(SortableObjectiveList, {
   tagName: "",
   editable: false,
   isDownloading: false,
-  subject: null,
   expandedObjectiveIds: null,
-  programYear: alias('subject'),
 
   authHeaders: computed('session.isAuthenticated', function(){
     const session = this.session;
@@ -46,9 +42,9 @@ export default Component.extend(SortableObjectiveList, {
     }
   },
 
-  downloadReport: task(function * (subject) {
+  downloadReport: task(function * (programYear) {
     const apiPath = '/' + this.iliosConfig.apiNameSpace;
-    const resourcePath = '/programyears/' + subject.get('id') + '/downloadobjectivesmapping';
+    const resourcePath = '/programyears/' + programYear.get('id') + '/downloadobjectivesmapping';
     const host = this.iliosConfig.get('apiHost')?this.iliosConfig.get('apiHost'):window.location.protocol + '//' + window.location.host;
     const url = host + apiPath + resourcePath;
     const { saveAs } = yield import('file-saver');

--- a/app/styles/components.scss
+++ b/app/styles/components.scss
@@ -126,3 +126,5 @@
 @import 'components/visualizer-program-year-competencies';
 @import 'components/visualizer-session-type-terms';
 @import 'components/visualizer-session-type-vocabularies';
+
+@import 'components/program-year/manage-objective-competency';

--- a/app/styles/components/program-year/manage-objective-competency.scss
+++ b/app/styles/components/program-year/manage-objective-competency.scss
@@ -1,0 +1,49 @@
+.program-year-manage-objective-competency {
+  .objective-title {
+    @include ilios-browser-defaults;
+    background-color: $background-grey;
+    margin-bottom: 1rem;
+    padding: .5rem;
+  }
+
+  .parent-picker {
+    @include ilios-list-reset;
+    height: auto;
+    line-height: 1.3rem;
+
+    .domain {
+      border-left: 10px solid $white;
+
+      .domain-title {
+        margin: .5rem 0 0 .5rem;
+        padding: 0;
+      }
+      &.selected {
+        border-left: 10px solid $ilios-orange;
+
+        .domain-title {
+          color: $ilios-green;
+          font-weight: bold;
+        }
+      }
+    }
+
+    li {
+      margin: 0;
+      padding: 0;
+
+      ul {
+        padding-left: .5rem;
+
+        .selected {
+          font-weight: bold;
+        }
+      }
+    }
+  }
+
+  .no-group {
+    color: $warning-color;
+    font-weight: bold;
+  }
+}

--- a/tests/acceptance/program/programyear/objectives-test.js
+++ b/tests/acceptance/program/programyear/objectives-test.js
@@ -1,20 +1,11 @@
 import {
   module,
-  skip,
   test
 } from 'qunit';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
-import {
-  click,
-  find,
-  findAll,
-  visit
-} from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { getElementText, getText } from 'ilios-common';
-import { fillInFroalaEditor } from 'ilios-common';
-const url = '/programs/1/programyears/1?pyObjectiveDetails=true';
+import page from 'ilios/tests/pages/program-year';
 
 module('Acceptance | Program Year - Objectives', function(hooks) {
   setupApplicationTest(hooks);
@@ -75,167 +66,292 @@ module('Acceptance | Program Year - Objectives', function(hooks) {
 
   test('list editable', async function(assert) {
     this.user.update({ administeredSchools: [this.school] });
-    await visit(url);
-    assert.dom('.programyear-objective-list tbody tr').exists({ count: 3 });
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    assert.equal(page.objectives.current.length, 3);
+    assert.equal(page.objectives.current[0].description.text, 'objective 0');
+    assert.ok(page.objectives.current[0].hasCompetency);
+    assert.equal(page.objectives.current[0].competencyTitle, 'competency 1');
+    assert.ok(page.objectives.current[0].hasDomain);
+    assert.equal(page.objectives.current[0].domainTitle, '(competency 0)');
+    assert.equal(page.objectives.current[0].meshTerms.length, 2);
+    assert.equal(page.objectives.current[0].meshTerms[0].text, 'descriptor 0');
+    assert.equal(page.objectives.current[0].meshTerms[1].text, 'descriptor 1');
 
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(1) td:nth-of-type(2)'), getText('objective 0'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(1) td:nth-of-type(3)'), getText('competency 1 (competency 0)'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(1) td:nth-of-type(4)'), getText('descriptor 0 descriptor 1'));
+    assert.equal(page.objectives.current[1].description.text, 'objective 1');
+    assert.ok(page.objectives.current[1].hasCompetency);
+    assert.equal(page.objectives.current[1].competencyTitle, 'competency 3');
+    assert.notOk(page.objectives.current[1].hasDomain);
+    assert.equal(page.objectives.current[1].meshTerms.length, 0);
 
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(2) td:nth-of-type(2)'), getText('objective 1'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(2) td:nth-of-type(3)'), getText('competency 3'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(2) td:nth-of-type(4)'), getText('Add New'));
-
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(3) td:nth-of-type(2)'), getText('objective 2'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(3) td:nth-of-type(3)'), getText('Add New'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(3) td:nth-of-type(4)'), getText('Add New'));
+    assert.equal(page.objectives.current[2].description.text, 'objective 2');
+    assert.notOk(page.objectives.current[2].hasCompetency);
+    assert.notOk(page.objectives.current[2].hasDomain);
+    assert.equal(page.objectives.current[2].meshTerms.length, 0);
   });
 
-  test('list not editable', async function(assert) {
-    await visit(url);
-    assert.dom('.programyear-objective-list tbody tr').exists({ count: 3 });
+  test('list not editable', async function (assert) {
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    assert.equal(page.objectives.current.length, 3);
+    assert.equal(page.objectives.current[0].description.text, 'objective 0');
+    assert.ok(page.objectives.current[0].hasCompetency);
+    assert.equal(page.objectives.current[0].competencyTitle, 'competency 1');
+    assert.ok(page.objectives.current[0].hasDomain);
+    assert.equal(page.objectives.current[0].domainTitle, '(competency 0)');
+    assert.equal(page.objectives.current[0].meshTerms.length, 2);
+    assert.equal(page.objectives.current[0].meshTerms[0].text, 'descriptor 0');
+    assert.equal(page.objectives.current[0].meshTerms[1].text, 'descriptor 1');
 
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(1) td:nth-of-type(2)'), getText('objective 0'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(1) td:nth-of-type(3)'), getText('competency 1 (competency 0)'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(1) td:nth-of-type(4)'), getText('descriptor 0 descriptor 1'));
+    assert.equal(page.objectives.current[1].description.text, 'objective 1');
+    assert.ok(page.objectives.current[1].hasCompetency);
+    assert.equal(page.objectives.current[1].competencyTitle, 'competency 3');
+    assert.notOk(page.objectives.current[1].hasDomain);
+    assert.equal(page.objectives.current[1].meshTerms.length, 0);
 
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(2) td:nth-of-type(2)'), getText('objective 1'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(2) td:nth-of-type(3)'), getText('competency 3'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(2) td:nth-of-type(4)'), getText('None'));
-
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(3) td:nth-of-type(2)'), getText('objective 2'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(3) td:nth-of-type(3)'), getText('None'));
-    assert.equal(await getElementText('.programyear-objective-list tbody tr:nth-of-type(3) td:nth-of-type(4)'), getText('None'));
+    assert.equal(page.objectives.current[2].description.text, 'objective 2');
+    assert.notOk(page.objectives.current[2].hasCompetency);
+    assert.notOk(page.objectives.current[2].hasDomain);
+    assert.equal(page.objectives.current[2].meshTerms.length, 0);
   });
 
-  skip('manage terms', async function() {
-    //skip until we convert this test to the page object system
-  });
-
-  skip('save terms', async function() {
-    //skip until we convert this test to the page object system
-  });
-
-  skip('cancel term changes', async function() {
-    //skip until we convert this test to the page object system
-  });
-
-  test('manage competencies', async function(assert) {
+  test('manage terms', async function(assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(14);
-    await visit(url);
-    const tds = findAll('.programyear-objective-list tbody tr:nth-of-type(1) td');
-    assert.equal(tds.length, 4);
-    await click(find('.programyear-objective-list tbody tr:nth-of-type(1) td:nth-of-type(3) .link'));
-    assert.equal(await getElementText(find('.specific-title')), 'SelectParentCompetencyforObjective');
-    assert.equal(await getElementText(find('.objective-manage-competency .objectivetitle')), getText('objective 0'));
-    assert.equal(await getElementText(find('.objective-manage-competency .parent-picker')), getText('competency0 competency1 competency2 competency3 competency4'));
-    let items = findAll('.parent-picker li.competency-title');
-    assert.equal(items.length, 4);
-    assert.dom('.parent-picker h5').hasClass('selected');
-    assert.dom(items[0]).hasClass('selected');
-    assert.ok(!find(items[1]).classList.contains('selected'));
-    assert.ok(!findAll('.parent-picker h5')[1].classList.contains('selected'));
-    assert.ok(!findAll('.parent-picker h5')[2].classList.contains('selected'));
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    assert.equal(page.objectives.current.length, 3);
 
-    await click(findAll('.objective-manage-competency .parent-picker .clickable')[2]);
-    items = findAll('.parent-picker li.competency-title');
-    assert.ok(!find(items[0]).classList.contains('selected'));
-    assert.ok(!find(items[1]).classList.contains('selected'));
-    assert.dom(items[2]).hasClass('selected');
-    assert.ok(!find(items[3]).classList.contains('selected'));
+    assert.equal(page.objectives.current[0].description.text, 'objective 0');
+    assert.equal(page.objectives.current[0].meshTerms.length, 2);
+    assert.equal(page.objectives.current[0].meshTerms[0].title, 'descriptor 0');
+    assert.equal(page.objectives.current[0].meshTerms[1].title, 'descriptor 1');
+
+    await page.objectives.current[0].manageMesh();
+    const m = page.objectives.manageObjectiveDescriptors.meshManager;
+    assert.equal(m.selectedTerms.length, 2);
+    assert.equal(m.selectedTerms[0].title, 'descriptor 0');
+    assert.equal(m.selectedTerms[1].title, 'descriptor 1');
+    await m.search('descriptor');
+    await m.runSearch();
+
+    assert.equal(m.searchResults.length, 4);
+    for (let i = 0; i < 4; i++) {
+      assert.equal(m.searchResults[i].title, `descriptor ${i}`);
+    }
+    assert.ok(m.searchResults[0].isDisabled);
+    assert.ok(m.searchResults[1].isDisabled);
+    assert.ok(m.searchResults[2].isEnabled);
+    assert.ok(m.searchResults[3].isEnabled);
+
+    await m.selectedTerms[0].remove();
+    await m.searchResults[2].add();
+    assert.ok(m.searchResults[0].isEnabled);
+    assert.ok(m.searchResults[1].isDisabled);
+    assert.ok(m.searchResults[2].isDisabled);
+    assert.equal(m.selectedTerms.length, 2);
+
+    assert.equal(m.selectedTerms[0].title, 'descriptor 1');
+    assert.equal(m.selectedTerms[1].title, 'descriptor 2');
   });
 
-  test('save competency', async function(assert) {
+  test('save terms', async function(assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(1);
-    await visit(url);
-    await click('.programyear-objective-list tbody tr:nth-of-type(1) td:nth-of-type(3) .link');
-    const objectiveManager = find('.objective-manage-competency')[0];
-    await click(findAll('.parent-picker .clickable')[1], objectiveManager);
-    await click('.detail-objectives button.bigadd');
-    assert.equal(await getElementText(find(findAll('.programyear-objective-list tbody tr td')[2])), getText('competency 2 (competency 0)'));
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    assert.equal(page.objectives.current.length, 3);
+
+    assert.equal(page.objectives.current[0].description.text, 'objective 0');
+    assert.equal(page.objectives.current[0].meshTerms.length, 2);
+    await page.objectives.current[0].manageMesh();
+
+    const m = page.objectives.manageObjectiveDescriptors.meshManager;
+    assert.equal(m.selectedTerms.length, 2);
+    await m.search('descriptor');
+    await m.runSearch();
+
+    await m.selectedTerms[0].remove();
+    await m.searchResults[2].add();
+
+    assert.equal(m.selectedTerms.length, 2);
+    assert.equal(m.selectedTerms[0].title, 'descriptor 1');
+    assert.equal(m.selectedTerms[1].title, 'descriptor 2');
+
+    await page.objectives.save();
+    assert.equal(page.objectives.current[0].meshTerms.length, 2);
+    assert.equal(page.objectives.current[0].meshTerms[0].title, 'descriptor 1');
+    assert.equal(page.objectives.current[0].meshTerms[1].title, 'descriptor 2');
   });
 
-  test('save no competency', async function(assert) {
+  test('cancel changes', async function(assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(1);
-    await visit(url);
-    await click('.programyear-objective-list tbody tr:nth-of-type(1) td:nth-of-type(3) .link');
-    const objectiveManager = find('.objective-manage-competency')[0];
-    await click(find('.parent-picker .clickable'), objectiveManager);
-    await click('.detail-objectives button.bigadd');
-    assert.equal(await getElementText(find(findAll('.programyear-objective-list tbody tr td')[2])), getText('Add New'));
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    assert.equal(page.objectives.current.length, 3);
+
+    assert.equal(page.objectives.current[0].description.text, 'objective 0');
+    assert.equal(page.objectives.current[0].meshTerms.length, 2);
+    await page.objectives.current[0].manageMesh();
+
+    const m = page.objectives.manageObjectiveDescriptors.meshManager;
+    assert.equal(m.selectedTerms.length, 2);
+    await m.search('descriptor');
+    await m.runSearch();
+
+    await m.selectedTerms[0].remove();
+    await m.searchResults[2].add();
+
+    assert.equal(m.selectedTerms.length, 2);
+    assert.equal(m.selectedTerms[0].title, 'descriptor 1');
+    assert.equal(m.selectedTerms[1].title, 'descriptor 2');
+
+    await page.objectives.cancel();
+    assert.equal(page.objectives.current[0].meshTerms.length, 2);
+    assert.equal(page.objectives.current[0].meshTerms[0].title, 'descriptor 0');
+    assert.equal(page.objectives.current[0].meshTerms[1].title, 'descriptor 1');
   });
 
-  test('cancel competency change', async function(assert) {
+  test('manage competency', async function(assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(1);
-    await visit(url);
-    await click('.programyear-objective-list tbody tr:nth-of-type(1) td:nth-of-type(3) .link');
-    const objectiveManager = find('.objective-manage-competency')[0];
-    await click(findAll('.parent-picker li')[1], objectiveManager);
-    await click('.detail-objectives button.bigcancel');
-    assert.equal(await getElementText(find(findAll('.programyear-objective-list tbody tr td')[2])), getText('competency 1 (competency 0)'));
+    assert.expect(13);
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    await page.objectives.current[0].manageCompetency();
+    const m = page.objectives.manageObjectiveCompetency;
+    assert.equal(m.objectiveTitle, 'objective 0');
+
+    assert.equal(m.domains.length, 3);
+    assert.equal(m.domains[0].title, 'competency 0');
+    assert.ok(m.domains[0].selected);
+
+    assert.equal(m.domains[0].competencies.length, 2);
+    assert.equal(m.domains[0].competencies[0].title, 'competency 1');
+    assert.ok(m.domains[0].competencies[0].selected);
+    assert.equal(m.domains[0].competencies[1].title, 'competency 2');
+    assert.ok(m.domains[0].competencies[1].notSelected);
+
+    assert.equal(m.domains[1].title, 'competency 3');
+    assert.ok(m.domains[1].notSelected);
+    assert.equal(m.domains[2].title, 'competency 4');
+    assert.ok(m.domains[2].notSelected);
   });
 
-  test('cancel remove competency change', async function(assert) {
+  test('save competency', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(1);
-    await visit(url);
-    await click('.programyear-objective-list tbody tr:nth-of-type(1) td:nth-of-type(3) .link');
-    const objectiveManager = find('.objective-manage-competency')[0];
-    await click(find('.parent-picker li'), objectiveManager);
-    await click('.detail-objectives button.bigcancel');
-    assert.equal(await getElementText(find(findAll('.programyear-objective-list tbody tr td')[2])), getText('competency 1 (competency 0)'));
+    assert.expect(9);
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    await page.objectives.current[0].manageCompetency();
+    const m = page.objectives.manageObjectiveCompetency;
+    assert.equal(m.objectiveTitle, 'objective 0');
+    await m.domains[0].competencies[1].add();
+    assert.ok(m.domains[0].selected);
+    assert.ok(m.domains[0].competencies[0].notSelected);
+    assert.ok(m.domains[0].competencies[1].selected);
+    await page.objectives.save();
+
+
+    assert.equal(page.objectives.current[0].description.text, 'objective 0');
+    assert.ok(page.objectives.current[0].hasCompetency);
+    assert.equal(page.objectives.current[0].competencyTitle, 'competency 2');
+    assert.ok(page.objectives.current[0].hasDomain);
+    assert.equal(page.objectives.current[0].domainTitle, '(competency 0)');
   });
 
-  test('add competency', async function(assert) {
+  test('save no competency', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(1);
-    await visit(url);
-    await click('.programyear-objective-list tbody tr:nth-of-type(3) td:nth-of-type(3) button');
-    const objectiveManager = find('.objective-manage-competency')[0];
-    await click(findAll('.parent-picker .clickable')[1], objectiveManager);
-    await click('.detail-objectives button.bigadd');
-    assert.equal(await getElementText(find(findAll('.programyear-objective-list tbody tr:nth-of-type(3) td')[2])), getText('competency 2 (competency 0)'));
+    assert.expect(5);
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    await page.objectives.current[0].manageCompetency();
+    const m = page.objectives.manageObjectiveCompetency;
+    assert.equal(m.objectiveTitle, 'objective 0');
+    await m.domains[0].competencies[0].add();
+    assert.ok(m.domains[0].notSelected);
+    assert.ok(m.domains[0].competencies[0].notSelected);
+    await page.objectives.save();
+
+    assert.equal(page.objectives.current[0].description.text, 'objective 0');
+    assert.notOk(page.objectives.current[0].hasCompetency);
   });
 
-  test('empty objective title can not be saved', async function(assert) {
+  test('cancel competency change', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(3);
-    await visit(url);
-    const container = '.programyear-objective-list';
-    const title = `${container} tbody tr:nth-of-type(1) td:nth-of-type(2)`;
-    const edit = `${title} .editable`;
-    const editor = `${title} [data-test-html-editor]`;
-    const initialObjectiveTitle = 'objective 0';
-    const save = `${title} .done`;
-    const errorMessage = `${title} .validation-error-message`;
+    assert.expect(9);
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    await page.objectives.current[0].manageCompetency();
+    const m = page.objectives.manageObjectiveCompetency;
+    assert.equal(m.objectiveTitle, 'objective 0');
+    await m.domains[0].competencies[1].add();
+    assert.ok(m.domains[0].selected);
+    assert.ok(m.domains[0].competencies[0].notSelected);
+    assert.ok(m.domains[0].competencies[1].selected);
+    await page.objectives.cancel();
 
-    assert.equal(await getElementText(title), getText(initialObjectiveTitle));
-    await click(edit);
+    assert.equal(page.objectives.current[0].description.text, 'objective 0');
+    assert.ok(page.objectives.current[0].hasCompetency);
+    assert.equal(page.objectives.current[0].competencyTitle, 'competency 1');
+    assert.ok(page.objectives.current[0].hasDomain);
+    assert.equal(page.objectives.current[0].domainTitle, '(competency 0)');
+  });
 
-    await fillInFroalaEditor(find(editor), '<p>&nbsp;</p><div></div><span>  </span>');
+  test('cancel remove competency change', async function (assert) {
+    this.user.update({ administeredSchools: [this.school] });
+    assert.expect(9);
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    await page.objectives.current[0].manageCompetency();
+    const m = page.objectives.manageObjectiveCompetency;
+    assert.equal(m.objectiveTitle, 'objective 0');
+    await m.domains[0].competencies[0].add();
+    assert.ok(m.domains[0].notSelected);
+    assert.ok(m.domains[0].competencies[0].notSelected);
+    assert.ok(m.domains[0].competencies[1].notSelected);
+    await page.objectives.cancel();
 
-    assert.equal(await getElementText(errorMessage), getText('This field cannot be blank'));
-    assert.dom(save).isDisabled();
+    assert.equal(page.objectives.current[0].description.text, 'objective 0');
+    assert.ok(page.objectives.current[0].hasCompetency);
+    assert.equal(page.objectives.current[0].competencyTitle, 'competency 1');
+    assert.ok(page.objectives.current[0].hasDomain);
+    assert.equal(page.objectives.current[0].domainTitle, '(competency 0)');
+  });
+
+  test('add competency', async function (assert) {
+    this.user.update({ administeredSchools: [this.school] });
+    assert.expect(11);
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    assert.equal(page.objectives.current[2].description.text, 'objective 2');
+    assert.notOk(page.objectives.current[2].hasCompetency);
+
+    await page.objectives.current[2].manageCompetency();
+    const m = page.objectives.manageObjectiveCompetency;
+    assert.equal(m.objectiveTitle, 'objective 2');
+    await m.domains[0].competencies[1].add();
+    assert.ok(m.domains[0].selected);
+    assert.ok(m.domains[0].competencies[0].notSelected);
+    assert.ok(m.domains[0].competencies[1].selected);
+    await page.objectives.save();
+
+    assert.equal(page.objectives.current[2].description.text, 'objective 2');
+    assert.ok(page.objectives.current[2].hasCompetency);
+    assert.equal(page.objectives.current[2].competencyTitle, 'competency 2');
+    assert.ok(page.objectives.current[2].hasDomain);
+    assert.equal(page.objectives.current[2].domainTitle, '(competency 0)');
+  });
+
+  test('empty objective title can not be saved', async function (assert) {
+    this.user.update({ administeredSchools: [this.school] });
+    assert.expect(5);
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    assert.equal(page.objectives.current.length, 3);
+    assert.equal(page.objectives.current[0].description.text, 'objective 0');
+    await page.objectives.createNew();
+    assert.notOk(page.objectives.newObjective.hasValidationError);
+    await page.objectives.newObjective.description('<p>&nbsp</p><div></div><span>  </span>');
+    await page.objectives.newObjective.save();
+    assert.ok(page.objectives.newObjective.hasValidationError);
+    assert.equal(page.objectives.newObjective.validationError, 'This field can not be blank');
   });
 
   test('expand objective and view links', async function(assert) {
-    assert.expect(2);
-    await visit(url);
-    const rows = '.programyear-objective-list tbody tr';
-    const objective = `${rows}:nth-of-type(1)`;
-    const expand = `${objective} td:nth-of-type(1)`;
-    const firstCourse = `${rows}:nth-of-type(3)`;
-    const firstCourseTitle = `${firstCourse} td:nth-of-type(2)`;
-    const firstCourseObjectives = `${firstCourse} td:nth-of-type(3) li`;
-    const firstCourseFirstObjective = `${firstCourseObjectives}:nth-of-type(1)`;
-
-    await click(expand);
-    assert.equal(await getElementText(firstCourseTitle), getText('course 0'));
-    assert.equal(await getElementText(firstCourseFirstObjective), getText('objective 3'));
-
+    assert.expect(6);
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    assert.equal(page.objectives.current[0].description.text, 'objective 0');
+    assert.equal(page.objectives.expanded.length, 0);
+    await page.objectives.current[0].toggleExpandCollapse();
+    assert.equal(page.objectives.expanded.length, 1);
+    assert.equal(page.objectives.expanded[0].courseTitle, 'course 0');
+    assert.equal(page.objectives.expanded[0].objectives.length, 1);
+    assert.equal(page.objectives.expanded[0].objectives[0].text, 'objective 3');
   });
 });

--- a/tests/integration/components/program-year/manage-objective-competency-item-test.js
+++ b/tests/integration/components/program-year/manage-objective-competency-item-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | program-year/manage-objective-competency-item', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    this.set('isSelected', true);
+    await render(hbs`<ProgramYear::ManageObjectiveCompetencyItem
+      @title="objective"
+      @isSelected={{this.isSelected}}
+      @add={{noop}}
+      @remove={{noop}}
+    />`);
+
+    assert.dom('input[type="radio"]').exists();
+    assert.dom('input').isChecked();
+    assert.dom('label').hasClass('selected');
+    assert.dom('label').hasText('objective');
+
+    this.set('isSelected', false);
+    assert.dom('input[type="radio"]').exists();
+    assert.dom('input').isNotChecked();
+    assert.dom('label').doesNotHaveClass('selected');
+    assert.dom('label').hasText('objective');
+  });
+});

--- a/tests/integration/components/program-year/manage-objective-competency-test.js
+++ b/tests/integration/components/program-year/manage-objective-competency-test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { component } from 'ilios/tests/pages/components/program-year/manage-objective-competency';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Integration | Component | program-year/manage-objective-competency', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it renders and is accessible', async function (assert) {
+    const course = this.server.create('course');
+    const objective = this.server.create('objective', {
+      courses: [course],
+    });
+    const objectiveModel = await this.owner.lookup('service:store').find('objective', objective.id);
+
+    const domains = [
+      {
+        title: 'domain 0',
+        id: 1,
+        competencies: [
+          {
+            id: 2,
+            title: 'competency 0',
+          }
+        ]
+      }
+    ];
+    this.set('objectiveTitle', objectiveModel.title);
+    this.set('domains', domains);
+    await render(hbs`<ProgramYear::ManageObjectiveCompetency
+      @objectiveTitle={{this.objectiveTitle}}
+      @domains={{this.domains}}
+      @selected={{null}}
+      @add={{noop}}
+      @remove={{noop}}
+    />`);
+
+    assert.equal(component.objectiveTitle, objectiveModel.title);
+
+    assert.equal(component.domains.length, 1);
+    assert.equal(component.domains[0].title, 'domain 0');
+    assert.ok(component.domains[0].notSelected);
+
+    assert.equal(component.domains[0].competencies.length, 1);
+    assert.equal(component.domains[0].competencies[0].title, 'competency 0');
+    assert.ok(component.domains[0].competencies[0].notSelected);
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+});

--- a/tests/integration/components/program-year/manage-objective-descriptors-test.js
+++ b/tests/integration/components/program-year/manage-objective-descriptors-test.js
@@ -1,0 +1,119 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { component } from 'ilios/tests/pages/components/program-year/manage-objective-descriptors';
+
+module('Integration | Component | program-year/manage-objective-descriptors', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it renders', async function(assert) {
+    const descriptors = this.server.createList('meshDescriptor', 4);
+    const descriptorModel = await this.owner.lookup('service:store').find('meshDescriptor', descriptors[0].id);
+    this.set('selected', [descriptorModel]);
+    await render(hbs`<ProgramYear::ManageObjectiveDescriptors
+      @objectiveTitle="Jayden Rules!"
+      @selected={{this.selected}}
+      @add={{noop}}
+      @remove={{noop}}
+      @editable={{true}}
+    />`);
+    assert.equal(component.objectiveTitle, 'Jayden Rules!');
+    const m = component.meshManager;
+
+    assert.equal(m.selectedTerms.length, 1);
+    assert.equal(m.selectedTerms[0].title, 'descriptor 0');
+    await m.search('descriptor');
+    await m.runSearch();
+    assert.equal(m.searchResults.length, 4);
+    assert.equal(m.searchResults[0].title, `descriptor 0`);
+    assert.ok(m.searchResults[0].isDisabled);
+    assert.equal(m.searchResults[1].title, `descriptor 1`);
+    assert.ok(m.searchResults[1].isEnabled);
+    assert.equal(m.searchResults[2].title, `descriptor 2`);
+    assert.ok(m.searchResults[2].isEnabled);
+    assert.equal(m.searchResults[3].title, `descriptor 3`);
+    assert.ok(m.searchResults[3].isEnabled);
+  });
+
+  test('add works', async function (assert) {
+    assert.expect(17);
+    const descriptors = this.server.createList('meshDescriptor', 2);
+    const descriptorModel = await this.owner.lookup('service:store').find('meshDescriptor', descriptors[0].id);
+    this.set('selected', [descriptorModel]);
+    this.set('add', (descriptor) => {
+      this.set('selected', [descriptorModel, descriptor]);
+      assert.ok(true);
+    });
+    await render(hbs`<ProgramYear::ManageObjectiveDescriptors
+      @objectiveTitle="Jayden Rules!"
+      @selected={{this.selected}}
+      @add={{this.add}}
+      @remove={{noop}}
+      @editable={{true}}
+    />`);
+    assert.equal(component.objectiveTitle, 'Jayden Rules!');
+    const m = component.meshManager;
+
+    assert.equal(m.selectedTerms.length, 1);
+    assert.equal(m.selectedTerms[0].title, 'descriptor 0');
+    await m.search('descriptor');
+    await m.runSearch();
+    assert.equal(m.searchResults.length, 2);
+    assert.equal(m.searchResults[0].title, `descriptor 0`);
+    assert.ok(m.searchResults[0].isDisabled);
+    assert.equal(m.searchResults[1].title, `descriptor 1`);
+    assert.ok(m.searchResults[1].isEnabled);
+    await m.searchResults[1].add();
+
+    assert.equal(m.selectedTerms.length, 2);
+    assert.equal(m.selectedTerms[0].title, 'descriptor 0');
+    assert.equal(m.selectedTerms[1].title, 'descriptor 1');
+    assert.equal(m.searchResults.length, 2);
+    assert.equal(m.searchResults[0].title, `descriptor 0`);
+    assert.ok(m.searchResults[0].isDisabled);
+    assert.equal(m.searchResults[1].title, `descriptor 1`);
+    assert.ok(m.searchResults[1].isDisabled);
+  });
+
+  test('remove works', async function(assert) {
+    assert.expect(16);
+    const descriptors = this.server.createList('meshDescriptor', 2);
+    const descriptorModel = await this.owner.lookup('service:store').find('meshDescriptor', descriptors[0].id);
+    this.set('selected', [descriptorModel]);
+    this.set('remove', (descriptor) => {
+      assert.equal(descriptor.id, descriptorModel.id);
+      this.set('selected', []);
+      assert.ok(true);
+    });
+    await render(hbs`<ProgramYear::ManageObjectiveDescriptors
+      @objectiveTitle="Jayden Rules!"
+      @selected={{this.selected}}
+      @add={{noop}}
+      @remove={{this.remove}}
+      @editable={{true}}
+    />`);
+    assert.equal(component.objectiveTitle, 'Jayden Rules!');
+    const m = component.meshManager;
+
+    assert.equal(m.selectedTerms.length, 1);
+    assert.equal(m.selectedTerms[0].title, 'descriptor 0');
+    await m.search('descriptor');
+    await m.runSearch();
+    assert.equal(m.searchResults.length, 2);
+    assert.equal(m.searchResults[0].title, `descriptor 0`);
+    assert.ok(m.searchResults[0].isDisabled);
+    assert.equal(m.searchResults[1].title, `descriptor 1`);
+    assert.ok(m.searchResults[1].isEnabled);
+    await m.selectedTerms[0].remove();
+
+    assert.equal(m.selectedTerms.length, 0);
+    assert.equal(m.searchResults.length, 2);
+    assert.equal(m.searchResults[0].title, `descriptor 0`);
+    assert.ok(m.searchResults[0].isEnabled);
+    assert.equal(m.searchResults[1].title, `descriptor 1`);
+    assert.ok(m.searchResults[1].isEnabled);
+  });
+});

--- a/tests/integration/components/program-year/objectives-test.js
+++ b/tests/integration/components/program-year/objectives-test.js
@@ -1,0 +1,107 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { component } from 'ilios/tests/pages/components/program-year/objectives';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+module('Integration | Component | program-year/objectives', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it renders and is accessible with a single cohort', async function (assert) {
+    const school = this.server.create('school');
+    const program = this.server.create('program', { school });
+    const programYear = this.server.create('program-year', { program });
+    const domains = this.server.createList('competency', 2, { school });
+
+    const competencies = this.server.createList('competency', 2, { school, parent: domains[0] });
+    this.server.createList('competency', 2, { school, parent: domains[1] });
+
+    this.server.create('objective', {
+      competency: competencies[0],
+      programYears: [programYear]
+    });
+    this.server.create('objective', {
+      programYears: [programYear]
+    });
+    const programYearModel = await this.owner.lookup('service:store').find('program-year', programYear.id);
+
+    this.set('programYear', programYearModel);
+    await render(hbs`<ProgramYear::Objectives
+      @programYear={{this.programYear}}
+      @editable={{true}}
+      @collapse={{noop}}
+      @expand={{noop}}
+    />`);
+
+    assert.equal(component.current.length, 2);
+    assert.equal(component.current[0].description.text, 'objective 0');
+    assert.ok(component.current[0].hasCompetency);
+    assert.equal(component.current[0].competencyTitle, 'competency 2');
+    assert.equal(component.current[0].domainTitle, '(competency 0)');
+    assert.equal(component.current[0].meshTerms.length, 0);
+
+    assert.equal(component.current[1].description.text, 'objective 1');
+    assert.notOk(component.current[1].hasCompetency);
+    assert.equal(component.current[1].meshTerms.length, 0);
+
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it loads data for a school domains', async function (assert) {
+    const school = this.server.create('school');
+    const program = this.server.create('program', { school });
+    const programYear = this.server.create('program-year', { program });
+    const domains = this.server.createList('competency', 2, { school });
+
+    const competencies = this.server.createList('competency', 3, { school, parent: domains[0] });
+    this.server.createList('competency', 2, { school, parent: domains[1] });
+
+    this.server.create('objective', {
+      competency: competencies[0],
+      programYears: [programYear]
+    });
+    const programYearModel = await this.owner.lookup('service:store').find('program-year', programYear.id);
+
+    this.set('programYear', programYearModel);
+    await render(hbs`<ProgramYear::Objectives
+      @programYear={{this.programYear}}
+      @editable={{true}}
+      @collapse={{noop}}
+      @expand={{noop}}
+    />`);
+
+    assert.equal(component.current.length, 1);
+    assert.equal(component.current[0].description.text, 'objective 0');
+    assert.ok(component.current[0].hasCompetency);
+    await component.current[0].manageCompetency();
+    const m = component.manageObjectiveCompetency;
+    assert.equal(m.objectiveTitle, 'objective 0');
+
+    assert.equal(m.domains.length, 2);
+
+    assert.equal(m.domains[0].title, 'competency 0');
+    assert.ok(m.domains[0].selected);
+    assert.equal(m.domains[0].competencies.length, 3);
+    assert.equal(m.domains[0].competencies[0].title, 'competency 2');
+    assert.ok(m.domains[0].competencies[0].selected);
+    assert.equal(m.domains[0].competencies[1].title, 'competency 3');
+    assert.ok(m.domains[0].competencies[1].notSelected);
+    assert.equal(m.domains[0].competencies[2].title, 'competency 4');
+    assert.ok(m.domains[0].competencies[2].notSelected);
+
+    assert.equal(m.domains[1].title, 'competency 1');
+    assert.ok(m.domains[1].notSelected);
+    assert.equal(m.domains[1].competencies.length, 2);
+    assert.equal(m.domains[1].competencies[0].title, 'competency 5');
+    assert.ok(m.domains[1].competencies[0].notSelected);
+    assert.equal(m.domains[1].competencies[1].title, 'competency 6');
+    assert.ok(m.domains[1].competencies[1].notSelected);
+
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+});

--- a/tests/pages/components/program-year/manage-objective-competency.js
+++ b/tests/pages/components/program-year/manage-objective-competency.js
@@ -1,0 +1,29 @@
+import {
+  create,
+  clickable,
+  collection,
+  hasClass,
+  isPresent,
+  notHasClass,
+  text,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-program-year-manage-objective-competency]',
+  objectiveTitle: text('[data-test-objective-title]'),
+  domains: collection('.parent-picker [data-test-domain]', {
+    title: text('.domain-title'),
+    selected: hasClass('selected'),
+    notSelected: notHasClass('selected'),
+    competencies: collection('ul li', {
+      title: text(),
+      selected: hasClass('selected', 'label'),
+      notSelected: notHasClass('selected', 'label'),
+      add: clickable('input')
+    }),
+  }),
+  hasNoCompetenciesMessage: isPresent('[data-test-no-competencies-message]'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/program-year/manage-objective-descriptors.js
+++ b/tests/pages/components/program-year/manage-objective-descriptors.js
@@ -1,0 +1,14 @@
+import {
+  create,
+  text,
+} from 'ember-cli-page-object';
+import meshManager from 'ilios-common/page-objects/components/mesh-manager';
+
+const definition = {
+  scope: '[data-test-program-year-manage-objective-descriptors]',
+  objectiveTitle: text('[data-test-objective-title]'),
+  meshManager,
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/program-year/objectives.js
+++ b/tests/pages/components/program-year/objectives.js
@@ -1,0 +1,59 @@
+import {
+  clickable,
+  create,
+  collection,
+  isVisible,
+  property,
+  text,
+} from 'ember-cli-page-object';
+import {
+  pageObjectFillInFroalaEditor,
+  pageObjectFroalaEditorValue
+} from 'ilios-common';
+import manageObjectiveDescriptors from './manage-objective-descriptors';
+import manageObjectiveCompetency from './manage-objective-competency';
+
+const definition = {
+  scope: '[data-test-program-year-objectives]',
+  createNew: clickable('[data-test-actions] [data-test-expand-collapse-button] button'),
+  save: clickable('[data-test-actions] [data-test-save]'),
+  cancel: clickable('[data-test-actions] [data-test-cancel]'),
+  newObjective: {
+    description: pageObjectFillInFroalaEditor('[data-test-html-editor]'),
+    save: clickable('.done'),
+    cancel: clickable('.cancel'),
+    canSave: property('disabled', '.done'),
+    validationError: text('.validation-error-message'),
+    hasValidationError: isVisible('.validation-error-message'),
+  },
+  current: collection('table tbody [data-test-programyear-objective-list-item]', {
+    toggleExpandCollapse: clickable('[data-test-toggle-expand]'),
+    description: {
+      scope: 'td:eq(1)',
+      openEditor: clickable('[data-test-edit]'),
+      editorContents: pageObjectFroalaEditorValue('[data-test-html-editor]'),
+      edit: pageObjectFillInFroalaEditor('[data-test-html-editor]'),
+      save: clickable('.done'),
+      validationError: text('.validation-error-message'),
+      hasValidationError: isVisible('.validation-error-message'),
+    },
+    hasCompetency: isVisible('[data-test-competency]'),
+    competencyTitle: text('[data-test-competency]'),
+    hasDomain: isVisible('[data-test-domain]'),
+    domainTitle: text('[data-test-domain]'),
+    manageCompetency: clickable('[data-test-manage-competency]', { scope: 'td:eq(2)' }),
+    meshTerms: collection('td:eq(3) [data-test-term]', {
+      title: text(),
+    }, { at: 1 }),
+    manageMesh: clickable('[data-test-term]'),
+  }),
+  expanded: collection('table tbody [data-test-programyear-objective-list-item-expanded]', {
+    courseTitle: text('[data-test-course]'),
+    objectives: collection('[data-test-course-objectives] [data-test-course-objective]'),
+  }),
+  manageObjectiveCompetency,
+  manageObjectiveDescriptors,
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/program-year/publication-menu.js
+++ b/tests/pages/components/program-year/publication-menu.js
@@ -1,0 +1,26 @@
+import {
+  create,
+  triggerable,
+  isVisible,
+  isHidden
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-course-publication-menu]',
+  toggle: {
+    scope: '[data-test-toggle]',
+    enter: triggerable('keydown', '', { eventProperties: { key: 'Enter' } }),
+    down: triggerable('keydown', '', { eventProperties: { key: 'ArrowDown' } }),
+    esc: triggerable('keydown', '', { eventProperties: { key: 'Escape' } }),
+  },
+  menuClosed: isHidden('[data-test-menu]'),
+  menuOpen: isVisible('[data-test-menu]'),
+  hasPublishAsIs: isVisible('[data-test-publish-as-is]'),
+  hasPublish: isVisible('[data-test-publish]'),
+  hasReview: isVisible('[data-test-review]'),
+  hasTbd: isVisible('[data-test-tbd]'),
+  hasUnPublish: isVisible('[data-test-un-publish]'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/program-year.js
+++ b/tests/pages/program-year.js
@@ -1,0 +1,13 @@
+import {
+  create,
+  visitable
+} from 'ember-cli-page-object';
+
+import objectives from './components/program-year/objectives';
+
+
+export default create({
+  scope: '[data-test-program-year-details]',
+  visit: visitable('/programs/:programId/programyears/:programYearId'),
+  objectives
+});


### PR DESCRIPTION
Remove this from the <DetailObjectives> component and make a set of
components specifically for program year objectives.

Next step in https://github.com/ilios/common/pull/1241 and the last thing required to remove `<DetailObjectives>`.
