### PR TITLE
Revert to using this.model over @model

### DIFF
--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -1,8 +1,8 @@
 {{title (t "general.dashboard")}}
 <div class="ilios-dashboard" data-test-dashboard>
   <CommonDashboard
-    @allSchools={{@model.schools}}
-    @allAcademicYears={{@model.academicYears}}
+    @allSchools={{this.model.schools}}
+    @allAcademicYears={{this.model.academicYears}}
     @show={{this.show}}
     @setShow={{action (mut this.show)}}
     @selectedDate={{this.selectedDate}}


### PR DESCRIPTION
This model is used later to drive a getter in a did-update action. This
combination is throwing an error making it impossible to click on
calendar events. This is a quick fix while we wait for a fix upstream.

Working around https://github.com/emberjs/ember-render-modifiers/issues/21