### PR TITLE
Deploy more link attributes

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -37,6 +37,8 @@ module.exports = function (deployTarget) {
         jsonBlueprint.meta.attributes.push('http-equiv');
         jsonBlueprint.link.attributes.push('sizes');
         jsonBlueprint.link.attributes.push('type');
+        jsonBlueprint.link.attributes.push('as');
+        jsonBlueprint.link.attributes.push('crossorigin');
         jsonBlueprint.style = {
           selector: 'style',
           attributes: ['type'],


### PR DESCRIPTION
Both of these are needed for preloading fonts. "as" tells the browser what
to do and "crossorgin" is a special case for fonts which must be fetched
this way for historical reasons.