### PR TITLE
Silence common.async-computed deprecation

### DIFF
--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -14,5 +14,6 @@ window.deprecationWorkflow.config = {
     { handler: "silence", matchId: "ember-name-key-usage"}, //waiting for https://github.com/offirgolan/ember-cp-validations/issues/620
     { handler: "silence", matchId: "ember-views.curly-components.jquery-element"},
     { handler: "silence", matchId: "computed-property.volatile"},
+    { handler: "silence", matchId: "common.async-computed"},
   ]
 };


### PR DESCRIPTION
This is our own deprecation, but it's very noisy in tests so I've
silenced it until we can fix.