### PR TITLE
rm redundant dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
     "ember-click-outside": "^1.3.0",
-    "ember-composable-helpers": "^3.1.1",
     "ember-export-application-global": "^2.0.1",
     "ember-inflector": "^3.0.0",
     "ember-link-action": "^1.0.0",


### PR DESCRIPTION
we're getting `ember-composable-helpers` from `common` already, let's remove the explicit dependency here since it's redundant.