### PR TITLE
Use browser native hash utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,9 +1006,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.16",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-          "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+          "version": "0.5.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
+          "integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -3324,34 +3324,34 @@
       "dev": true
     },
     "@glimmer/interfaces": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.50.2.tgz",
-      "integrity": "sha512-SbrEspWDHQ6j0DI0inYpg29SMlfEEUS895apZWxMzC2RyGHy5SKmZJ4xjishaq7A0E1AaTfDKYnE/wfWrQZSsw==",
+      "version": "0.50.4",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.50.4.tgz",
+      "integrity": "sha512-Unca/P41yhOTK9EVSoFdnKoAs5IY2NbXrBEhXhD5E+Sp76pux+4YknxD+sOuAynaxAcarUcj37u95ZO8TGGC1w==",
       "dev": true,
       "requires": {
         "@simple-dom/interface": "^1.4.0"
       }
     },
     "@glimmer/syntax": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.50.2.tgz",
-      "integrity": "sha512-kmMZK4bN674sUhphLuads1RQNm3pzEuNcW7SHQiDJJz3zDsMFQ69YPtgYBrpJZtPgF6Oj/QgwUcD0d+ql5/cpw==",
+      "version": "0.50.4",
+      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.50.4.tgz",
+      "integrity": "sha512-LcxISf0Qs2uiSnKCflmkJIDkNreo72fKcfq3JfkGsIU3w4wWjr1rHVA17xWKSljCyb9NeFXGlzxu7/rwh8EApA==",
       "dev": true,
       "requires": {
-        "@glimmer/interfaces": "^0.50.2",
-        "@glimmer/util": "^0.50.2",
-        "handlebars": "^4.5.1",
+        "@glimmer/interfaces": "^0.50.4",
+        "@glimmer/util": "^0.50.4",
+        "handlebars": "^4.7.4",
         "simple-html-tokenizer": "^0.5.9"
       },
       "dependencies": {
         "@glimmer/util": {
-          "version": "0.50.2",
-          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.50.2.tgz",
-          "integrity": "sha512-FG3gWONYZWUBwZojvuYdPALu6DWKzc2QGBzb6zBgY5vO2otAqLsi8WlfGP8ekkFsEHUtlPGeUAOqr+lSox+DQw==",
+          "version": "0.50.4",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.50.4.tgz",
+          "integrity": "sha512-lKKGe5rbuSHRPBp4JdSyOVW4AvU/LONEtxuGsSVh0KltSR8zuEYPBjLIwe54g4Gumj9om5yg6zC/WNozKOjdzA==",
           "dev": true,
           "requires": {
             "@glimmer/env": "0.1.7",
-            "@glimmer/interfaces": "^0.50.2",
+            "@glimmer/interfaces": "^0.50.4",
             "@simple-dom/interface": "^1.4.0"
           }
         }
@@ -3516,24 +3516,6 @@
         "@sentry/types": "5.15.5",
         "@sentry/utils": "5.15.5",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "@sentry/types": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
-          "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw==",
-          "dev": true
-        },
-        "@sentry/utils": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
-          "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
-          "dev": true,
-          "requires": {
-            "@sentry/types": "5.15.5",
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "@sentry/minimal": {
@@ -3674,9 +3656,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.4.tgz",
-      "integrity": "sha512-dPs6CaRWxsfHbYDVU51VjEJaUJEcli4UI0fFMT4oWmgCvHj+j7oIxz5MLHVL0Rv++N004c21ylJNdWQvPkkb5w==",
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.5.tgz",
+      "integrity": "sha512-578YH5Lt88AKoADy0b2jQGwJtrBxezXtVe/MBqWXKZpqx91SnC0pVkVCcxcytz3lWW+cHBYDi3Ysh0WXc+rAYw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -3722,9 +3704,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
+      "version": "13.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.2.tgz",
+      "integrity": "sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -4062,9 +4044,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -4478,9 +4460,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.656.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.656.0.tgz",
-      "integrity": "sha512-UzqDvvt6i7gpuzEdK0GT/JOfBJcsCPranzZWdQ9HR4+5E0m5kf5gybZ6OX+UseIAE2/WND6Dv0aHgiI21AKenw==",
+      "version": "2.662.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.662.0.tgz",
+      "integrity": "sha512-emZOIKHCV2EHByRNAm7d++1ugzRpLx4WhMm+T9ydy/OyKcOGVAAMPVW0Mib5GXuWpC6A6aE7ACi3pZTjK9LMQA==",
       "dev": true,
       "requires": {
         "buffer": "4.9.1",
@@ -4881,9 +4863,9 @@
       }
     },
     "babel-plugin-dynamic-import-node": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
       "dev": true,
       "requires": {
         "object.assign": "^4.1.0"
@@ -6283,9 +6265,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.16",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-          "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+          "version": "0.5.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
+          "integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -6727,9 +6709,9 @@
           }
         },
         "walk-sync": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.0.2.tgz",
-          "integrity": "sha512-dCZkrxfHjPn7tIvdYrX3uMD/R0beVrHpA8lROQ5wWrl8psJgR6xwCkwqTFes0dNujbS2o/ITpvSYgIFsLsf13A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
+          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
           "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
@@ -6845,9 +6827,9 @@
       }
     },
     "broccoli-slow-trees": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-3.0.1.tgz",
-      "integrity": "sha1-m/Kp4vjrPtOj8qvd6YjaQ3zNybQ=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-3.1.0.tgz",
+      "integrity": "sha512-FRI7mRTk2wjIDrdNJd6znS7Kmmne4VkAkl8Ix1R/VoePFMD0g0tEl671xswzFqaRjpT9Qu+CC4hdXDLDJBuzMw==",
       "dev": true,
       "requires": {
         "heimdalljs": "^0.2.1"
@@ -7222,20 +7204,6 @@
         "electron-to-chromium": "^1.3.413",
         "node-releases": "^1.1.53",
         "pkg-up": "^2.0.0"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001045",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001045.tgz",
-          "integrity": "sha512-Y8o2Iz1KPcD6FjySbk1sPpvJqchgxk/iow0DABpGyzA1UeQAuxh63Xh0Enj5/BrsYbXtCN32JmR4ZxQTCQ6E6A==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.414",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.414.tgz",
-          "integrity": "sha512-UfxhIvED++qLwWrAq9uYVcqF8FdeV9sU2S7qhiHYFODxzXRrd1GZRl/PjITHsTEejgibcWDraD8TQqoHb1aCBQ==",
-          "dev": true
-        }
       }
     },
     "bser": {
@@ -7480,15 +7448,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30001045",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001045.tgz",
-      "integrity": "sha512-bwCb2ssU32vcxjG1P2VBOi1YV9W7G3RCG9m2++cX6Kql1oR+5w7vUBFL2SO47svJRUw+ai/d7yNT5VqoA2g3Sw==",
+      "version": "1.0.30001046",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001046.tgz",
+      "integrity": "sha512-SNiAsLnpLkqPyWyCZW0N44gTXRUyGh45TX9dif9gzlvbTWzCOP5jrnygvyjsJJvCRhnC9XHq49jX/IO2p0mVZw==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001041",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001041.tgz",
-      "integrity": "sha512-fqDtRCApddNrQuBxBS7kEiSGdBsgO4wiVw4G/IClfqzfhW45MbTumfN4cuUJGTM0YGFNn97DCXPJ683PS6zwvA==",
+      "version": "1.0.30001046",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001046.tgz",
+      "integrity": "sha512-CsGjBRYWG6FvgbyGy+hBbaezpwiqIOLkxQPY4A4Ea49g1eNsnQuESB+n4QM0BKii1j80MyJ26Ir5ywTQkbRE4g==",
       "dev": true
     },
     "capture-exit": {
@@ -7956,9 +7924,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
     "clipboard": {
@@ -8216,9 +8184,9 @@
       },
       "dependencies": {
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
@@ -8648,12 +8616,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==",
-      "dev": true
-    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -8730,9 +8692,9 @@
       "dev": true
     },
     "d3-color": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.0.tgz",
-      "integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
       "dev": true
     },
     "d3-dispatch": {
@@ -9283,9 +9245,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.403",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.403.tgz",
-      "integrity": "sha512-JaoxV4RzdBAZOnsF4dAlZ2ijJW72MbqO5lNfOBHUWiBQl3Rwe+mk2RCUMrRI3rSClLJ8HSNQNqcry12H+0ZjFw==",
+      "version": "1.3.415",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.415.tgz",
+      "integrity": "sha512-GbtYqKffx3sU8G0HxwXuJFfs58Q7+iwLa5rBwaULwET6jWW8IAQSrVnu7vEfiUIcMVfbYyFg7cw3zdm+EbBJmw==",
       "dev": true
     },
     "element-resize-detector": {
@@ -10372,9 +10334,9 @@
           }
         },
         "walk-sync": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.0.2.tgz",
-          "integrity": "sha512-dCZkrxfHjPn7tIvdYrX3uMD/R0beVrHpA8lROQ5wWrl8psJgR6xwCkwqTFes0dNujbS2o/ITpvSYgIFsLsf13A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
+          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
           "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
@@ -11515,9 +11477,9 @@
           }
         },
         "semver": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.2.tgz",
-          "integrity": "sha512-Zo84u6o2PebMSK3zjJ6Zp5wi8VnQZnEaCP13Ul/lt1ANsLACxnJxq4EEm1PY94/por1Hm9+7xpIswdS5AkieMA==",
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         },
         "shebang-command": {
@@ -11653,9 +11615,9 @@
           "dev": true
         },
         "walk-sync": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.0.2.tgz",
-          "integrity": "sha512-dCZkrxfHjPn7tIvdYrX3uMD/R0beVrHpA8lROQ5wWrl8psJgR6xwCkwqTFes0dNujbS2o/ITpvSYgIFsLsf13A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
+          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
           "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
@@ -12696,9 +12658,9 @@
           "dev": true
         },
         "walk-sync": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.0.2.tgz",
-          "integrity": "sha512-dCZkrxfHjPn7tIvdYrX3uMD/R0beVrHpA8lROQ5wWrl8psJgR6xwCkwqTFes0dNujbS2o/ITpvSYgIFsLsf13A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
+          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
           "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
@@ -13775,9 +13737,9 @@
           "dev": true
         },
         "walk-sync": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.0.2.tgz",
-          "integrity": "sha512-dCZkrxfHjPn7tIvdYrX3uMD/R0beVrHpA8lROQ5wWrl8psJgR6xwCkwqTFes0dNujbS2o/ITpvSYgIFsLsf13A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
+          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
           "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
@@ -13818,9 +13780,9 @@
       }
     },
     "ember-compatibility-helpers": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz",
-      "integrity": "sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.1.tgz",
+      "integrity": "sha512-6wzYvnhg1ihQUT5yGqnLtleq3Nv5KNv79WhrEuNU9SwR4uIxCO+KpyC7r3d5VI0EM7/Nmv9Nd0yTkzmTMdVG1A==",
       "dev": true,
       "requires": {
         "babel-plugin-debug-macros": "^0.2.0",
@@ -13850,9 +13812,9 @@
       }
     },
     "ember-composable-helpers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-3.1.1.tgz",
-      "integrity": "sha512-lPmPhk4wIg1JDnuOfzcDzrCZoaDoTvZrYVaBi4Eia2SdEEfcDNipQTXTk0yHFCvKfSjXjuNlTtNP9UANH58TzQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-3.2.0.tgz",
+      "integrity": "sha512-OBnwpDkeOnDBMGQ/96B7TUy3e3wR1dqmAJ8+zDQTEjWrrCztKFg2dNGzCJchN1AD1i4FS4B/9iloAnn1pPWw8w==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.0.0",
@@ -18477,12 +18439,12 @@
       }
     },
     "ember-template-recast": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/ember-template-recast/-/ember-template-recast-4.1.2.tgz",
-      "integrity": "sha512-ySBuPVKnGPvJ+y+5MEZ7qHE1p2LunM2CV9RUES0CP4O+fksPNwl79HPV+8rL0gJvN2nUOfkatNF6pcWNxxXaxg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ember-template-recast/-/ember-template-recast-4.1.3.tgz",
+      "integrity": "sha512-QxuAGZokAanPjaDrVLQb+IbtikSWdonheA2hPFEH0oTDCGwKNKOEQ85KoXEyhKDITFJ24EXLBfTwdRpxc+8q6Q==",
       "dev": true,
       "requires": {
-        "@glimmer/syntax": "^0.50.0",
+        "@glimmer/syntax": "^0.50.3",
         "async-promise-queue": "^1.0.5",
         "colors": "^1.4.0",
         "commander": "^5.0.0",
@@ -18608,9 +18570,9 @@
           }
         },
         "ora": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.3.tgz",
-          "integrity": "sha512-fnDebVFyz309A73cqCipVL1fBZewq4vwgSHfxh43vVy31mbyoQ8sCH3Oeaog/owYOs/lLlGVPCISQonTneg6Pg==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.4.tgz",
+          "integrity": "sha512-77iGeVU1cIdRhgFzCK8aw1fbtT1B/iZAvWjS+l/o1x0RShMgxHUZaD2yDpWsNCPwXg9z1ZA78Kbdvr8kBmG/Ww==",
           "dev": true,
           "requires": {
             "chalk": "^3.0.0",
@@ -19173,9 +19135,9 @@
           }
         },
         "webidl-conversions": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.0.0.tgz",
-          "integrity": "sha512-jTZAeJnc6D+yAOjygbJOs33kVQIk5H6fj9SFDOhIKjsf9HiAzL/c+tAJsc8ASWafvhNkH+wJZms47pmajkhatA==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
           "dev": true
         },
         "whatwg-url": {
@@ -19398,9 +19360,9 @@
       }
     },
     "engine.io": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.0.tgz",
-      "integrity": "sha512-XCyYVWzcHnK5cMz7G4VTu2W7zJS7SM1QkcelghyIk/FmobWBtXE7fwhBusEKvCSqc3bMh8fNFMlUkCKTFRxH2w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.1.tgz",
+      "integrity": "sha512-8MfIfF1/IIfxuc2gv5K+XlFZczw/BpTvqBdl0E2fBLkYQp4miv4LuDTVtYt4yMyaIFLEr4vtaSgV4mjvll8Crw==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -19441,9 +19403,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.0.tgz",
-      "integrity": "sha512-a4J5QO2k99CM2a0b12IznnyQndoEvtA4UAldhGzKqnHf42I3Qs2W5SPnDvatZRcMaNZs4IevVicBPayxYt6FwA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.1.tgz",
+      "integrity": "sha512-RJNmA+A9Js+8Aoq815xpGAsgWH1VoSYM//2VgIiu9lNOaHFfLpTjH4tOzktBpjIs5lvOfiNY1dwf+NuU6D38Mw==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -19895,18 +19857,18 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.2.0.tgz",
-      "integrity": "sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^5.0.0"
+        "estraverse": "^5.1.0"
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.0.0.tgz",
-          "integrity": "sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
           "dev": true
         }
       }
@@ -20934,9 +20896,9 @@
       }
     },
     "fs-merger": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fs-merger/-/fs-merger-3.0.2.tgz",
-      "integrity": "sha512-63wmgjPDClP5XcTSKdIXz66X5paYy/m2Ymq5c5YpGxRQEk1HFZ8rtti3LMNSOSw1ketbBMGbSFFcQeEnpnzDpQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-merger/-/fs-merger-3.0.3.tgz",
+      "integrity": "sha512-d9Qx+XlPRU4mkp+JYhUvp5NyS31uhqffIgs6EBnZcjrlO9RwSv0lkWi6PIDxgdNF+vjn9QCZevunGDpfoy4BGg==",
       "dev": true,
       "requires": {
         "broccoli-node-api": "^1.7.0",
@@ -20982,9 +20944,9 @@
           }
         },
         "walk-sync": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.0.2.tgz",
-          "integrity": "sha512-dCZkrxfHjPn7tIvdYrX3uMD/R0beVrHpA8lROQ5wWrl8psJgR6xwCkwqTFes0dNujbS2o/ITpvSYgIFsLsf13A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
+          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
           "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
@@ -21047,9 +21009,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
     },
@@ -24344,9 +24306,9 @@
       }
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "dev": true,
       "optional": true
     },
@@ -24410,9 +24372,9 @@
       }
     },
     "node-abi": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
-      "integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
+      "integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"
@@ -24678,9 +24640,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.2.tgz",
-          "integrity": "sha512-Zo84u6o2PebMSK3zjJ6Zp5wi8VnQZnEaCP13Ul/lt1ANsLACxnJxq4EEm1PY94/por1Hm9+7xpIswdS5AkieMA==",
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
       }
@@ -26157,9 +26119,9 @@
           }
         },
         "walk-sync": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.0.2.tgz",
-          "integrity": "sha512-dCZkrxfHjPn7tIvdYrX3uMD/R0beVrHpA8lROQ5wWrl8psJgR6xwCkwqTFes0dNujbS2o/ITpvSYgIFsLsf13A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
+          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
           "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
@@ -26510,9 +26472,9 @@
       }
     },
     "remark-parse": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.1.tgz",
-      "integrity": "sha512-Ye/5W57tdQZWsfkuVyRq9SUWRgECHnDsMuyUMzdSKpTbNPkZeGtoYfsrkeSi4+Xyl0mhcPPddHITXPcCPHrl3w==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.2.tgz",
+      "integrity": "sha512-eMI6kMRjsAGpMXXBAywJwiwAse+KNpmt+BK55Oofy4KvBZEqUDj6mWbGLJZrujoPIPPxDXzn3T9baRlpsm2jnQ==",
       "dev": true,
       "requires": {
         "ccount": "^1.0.0",
@@ -26675,9 +26637,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -27048,9 +27010,9 @@
       }
     },
     "schema-utils": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-      "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
+      "integrity": "sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.0",
@@ -27716,9 +27678,9 @@
       "dev": true
     },
     "sort-package-json": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.41.0.tgz",
-      "integrity": "sha512-wiiqFbWReTOUBcNwRxUKJgYhoh3KN09RutpkcIZCE75cpZlf8CbyOTTMqWTZ3UXc4k6gyHjt/bonQeOfdPTOOQ==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.42.1.tgz",
+      "integrity": "sha512-+JgZVjEQhJuJ57RCUcF3rzESYCW/n3vCLWdhqBdPkerEgRTj5teGdJrCcj772zT1VzewqWk616/4xuRyIffyqQ==",
       "dev": true,
       "requires": {
         "detect-indent": "^6.0.0",
@@ -27861,9 +27823,9 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true
     },
     "spdx-expression-parse": {
@@ -28807,9 +28769,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.16",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-          "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+          "version": "0.5.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
+          "integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -28867,9 +28829,9 @@
       }
     },
     "testem": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/testem/-/testem-3.0.3.tgz",
-      "integrity": "sha512-mdBCCn8LlTmgFDpexemyGP4cjO1V0VASs/qbPGZk8Qo05EBnmch29LIqxvWUDih/nA6eau3reXp0rNEef7qpCw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/testem/-/testem-3.1.0.tgz",
+      "integrity": "sha512-wmPMqwocl9sU7kk32+fRpYFQVwL2XO6PszYF3IPIi6exw3zXb879Ulw4NQrkybdNtTS8yj9yv2lEuvYgpulbaw==",
       "dev": true,
       "requires": {
         "backbone": "^1.1.2",
@@ -29385,9 +29347,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.0.tgz",
-      "integrity": "sha512-j5wNQBWaql8gr06dOUrfaohHlscboQZ9B8sNsoK5o4sBjm7Ht9dxSbrMXyktQpA16Acaij8AcoozteaPYZON0g==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.1.tgz",
+      "integrity": "sha512-JUPoL1jHsc9fOjVFHdQIhqEEJsQvfKDjlubcCilu8U26uZ73qOg8VsN8O1jbuei44ZPlwL7kmbAdM4tzaUvqnA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -31205,9 +31167,9 @@
       }
     },
     "yargs-parser": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-      "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "broccoli-merge-trees": "^4.2.0",
     "browserslist": "^4.12.0",
     "caniuse-db": "^1.0.30001045",
-    "crypto-js": "^4.0.0",
     "dotenv": "^8.2.0",
     "ember-a11y-testing": "^2.0.0",
     "ember-ajax": "^5.0.0",


### PR DESCRIPTION
Crypto.js is no longer needed to sha256 hash a string. We can hash with
browser native functions in all of our supported environments. This will
save our users some download size and remove a dependency that was
causing built warnings.