### PR TITLE
[breaking] Add brotli compressed assets to the deploy

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -6,7 +6,7 @@ module.exports = function (deployTarget) {
     build: {},
     pipeline: {
       runOrder: {
-        'archive': { after: 'gzip' },
+        'archive': { after: ['gzip', 'brotli'] },
       },
     },
     's3-index': {
@@ -31,7 +31,7 @@ module.exports = function (deployTarget) {
     },
     'json-config': {
       jsonBlueprint(context, pluginHelper) {
-        var jsonBlueprint = pluginHelper.readConfigDefault('jsonBlueprint');
+        const jsonBlueprint = pluginHelper.readConfigDefault('jsonBlueprint');
         jsonBlueprint.meta.selector = 'meta';
         jsonBlueprint.meta.attributes.push('charset');
         jsonBlueprint.meta.attributes.push('http-equiv');
@@ -61,7 +61,13 @@ module.exports = function (deployTarget) {
     gzip: {
       filePattern: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2,webmanifest}',
       ignorePattern: 'index.json',
-    }
+      keep: true,
+    },
+    brotli: {
+      filePattern: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2,webmanifest}',
+      ignorePattern: 'index.json',
+      keep: true,
+    },
   };
 
   if (deployTarget === 'staging') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10716,6 +10716,54 @@
         }
       }
     },
+    "ember-cli-deploy-brotli": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-deploy-brotli/-/ember-cli-deploy-brotli-0.2.1.tgz",
+      "integrity": "sha512-76ptcZZ8wYA2h3UvtNOSFvASaNhBhWONUYuL0sjWyntA7q/nGSbXU6bqF0Qg+vzWNKv4QmPgylnrSSNRFJgW/g==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "core-object": "3.1.5",
+        "ember-cli-deploy-plugin": "^0.2.6",
+        "iltorb": "^2.0.0",
+        "minimatch": "^3.0.4",
+        "rsvp": "4.7.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "rsvp": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.7.0.tgz",
+          "integrity": "sha1-3BsLGlNvfeydK+ReChKtQZfJ/ZY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
+      }
+    },
     "ember-cli-deploy-build": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-deploy-build/-/ember-cli-deploy-build-2.0.0.tgz",
@@ -18510,6 +18558,19 @@
         }
       }
     },
+    "iltorb": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-2.4.5.tgz",
+      "integrity": "sha512-EMCMl3LnnNSZJS5QrxyZmMTaAC4+TJkM5woD+xbpm9RB+mFYCr7C05GFE3TEGCsVQSVHmjX+3sf5AiwsylNInQ==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "nan": "^2.14.0",
+        "npmlog": "^4.1.2",
+        "prebuild-install": "^5.3.3",
+        "which-pm-runs": "^1.0.0"
+      }
+    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -20863,8 +20924,7 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ember-cli-dependency-lint": "1.1.3",
     "ember-cli-deploy": "1.0.2",
     "ember-cli-deploy-archive": "1.0.0-beta.2",
+    "ember-cli-deploy-brotli": "^0.2.1",
     "ember-cli-deploy-build": "2.0.0",
     "ember-cli-deploy-cloudfront": "^3.0.0",
     "ember-cli-deploy-display-revisions": "1.0.1",


### PR DESCRIPTION
This modifies our deploy to now compress everything with both gzip and
brotli. Brotli is significantly more efficient and supported in most
browsers so we wand to use it wherever possible. However it doesn't work
at all over gzip and neither will work well if the correct headers are
not sent. So instead of overwriting the original file with a compressed
version this provided a .gz and .br version of each and we'll modify the
API server to decide which to send.

WIP:
- [ ] should not be merged until the next API bump out of common.