### PR TITLE
Stop compressing font files

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -59,12 +59,12 @@ module.exports = function (deployTarget) {
       }
     },
     gzip: {
-      filePattern: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2,webmanifest}',
+      filePattern: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,webmanifest}',
       ignorePattern: 'index.json',
       keep: true,
     },
     brotli: {
-      filePattern: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2,webmanifest}',
+      filePattern: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,webmanifest}',
       ignorePattern: 'index.json',
       keep: true,
     },


### PR DESCRIPTION
Woff and Woff2 are specialized formats that are highly
compressed and tend to get bigger when gzipped. They shouldn't be
included in the defaults.