### PR TITLE
Support Safari 12

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -4,6 +4,7 @@ import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mi
 import config from 'ilios/config/environment';
 import { all } from 'rsvp';
 import * as Sentry from '@sentry/browser';
+import { loadPolyfills } from 'ilios-common/utils/load-polyfills';
 
 export default Route.extend(ApplicationRouteMixin, {
   currentUser: service(),
@@ -22,7 +23,8 @@ export default Route.extend(ApplicationRouteMixin, {
     });
   },
 
-  beforeModel() {
+  async beforeModel() {
+    await loadPolyfills();
     const intl = this.intl;
     const moment = this.moment;
     const locale = intl.get('locale');

--- a/config/targets.js
+++ b/config/targets.js
@@ -12,7 +12,8 @@ const isProductionLikeBuild = ['production', 'preview'].includes(process.env.EMB
 if (isCI || isProductionLikeBuild) {
   browsers.push('last 1 edge versions');
   browsers.push('firefox esr'); //sometimes points to the last 2 ESR releases when they overlap
-  browsers.push('last 1 ios versions');
+  browsers.push('last 4 ios versions');
+  browsers.push('last 3 safari versions');
 }
 
 module.exports = {


### PR DESCRIPTION
This version of Safari is still active for many of our users. To support
it we needed to modify our browser targets to build Ilios to work in the
browser and also add some polyfills to Intl which are not available in
that version.

Refs ilios/common#1412
Requires: ilios/common#1413 and a new common release.