### PR TITLE
Load less data on learner group list

### DIFF
--- a/app/components/learnergroup-list.hbs
+++ b/app/components/learnergroup-list.hbs
@@ -5,7 +5,7 @@
         <SortableTh
           @colspan={{2}}
           @sortedAscending={{this.sortedAscending}}
-          @click={{action "sortBy" "title"}}
+          @click={{fn this.setSortBy "title"}}
         >
           {{t "general.learnerGroupTitle"}}
         </SortableTh>
@@ -15,7 +15,7 @@
           @hideFromSmallScreen={{true}}
           @sortedAscending={{this.sortedAscending}}
           @sortType="numeric"
-          @click={{action "sortBy" "usersCount"}}
+          @click={{fn this.setSortBy "usersCount"}}
         >
           {{t "general.members"}}
         </SortableTh>
@@ -25,7 +25,7 @@
           @hideFromSmallScreen={{true}}
           @sortedAscending={{this.sortedAscending}}
           @sortType="numeric"
-          @click={{action "sortBy" "childrenCount"}}
+          @click={{fn this.setSortBy "childrenCount"}}
         >
           {{t "general.subgroups"}}
         </SortableTh>
@@ -35,7 +35,7 @@
       </tr>
     </thead>
     <tbody>
-      {{#each this.sortedLearnerGroups as |learnerGroup|}}
+      {{#each (sort-by this.sortBy @learnerGroups) as |learnerGroup|}}
         <tr
           class={{if
             (contains learnerGroup this.learnerGroupsForRemovalConfirmation)
@@ -66,7 +66,7 @@
                   class="clickable remove"
                   role="button"
                   data-test-remove
-                  {{action "confirmRemove" learnerGroup}}
+                  {{on "click" (fn this.confirmRemove learnerGroup)}}
                 >
                   <FaIcon @icon="trash" class="enabled" />
                 </span>
@@ -81,7 +81,7 @@
                 @icon="copy"
                 class="clickable enabled"
                 @title={{t "general.copy"}}
-                @click={{action "startCopy" learnerGroup}}
+                @click={{fn this.startCopy learnerGroup}}
                 data-test-copy={{true}}
               />
             {{else}}
@@ -104,7 +104,7 @@
                     <button
                         type="button"
                         class="done text"
-                        onclick={{action "cancelRemove" learnerGroup}}
+                        onclick={{fn this.cancelRemove learnerGroup}}
                         data-test-cancel
                       >
                         {{t "general.ok"}}
@@ -119,7 +119,7 @@
                       <button
                         type="button"
                         class="remove text"
-                        onclick={{action @remove learnerGroup}}
+                        onclick={{fn @remove learnerGroup}}
                         data-test-confirm
                       >
                         {{t "general.yes"}}
@@ -127,7 +127,7 @@
                       <button
                         type="button"
                         class="done text"
-                        onclick={{action "cancelRemove" learnerGroup}}
+                        onclick={{fn this.cancelRemove learnerGroup}}
                         data-test-cancel
                       >
                         {{t "general.cancel"}}
@@ -149,7 +149,7 @@
                   <button
                     type="button"
                     class="done text"
-                    onclick={{action "copy" true learnerGroup}}
+                    onclick={{perform this.copy true learnerGroup}}
                     data-test-confirm-with-learners
                   >
                     {{t "general.copyWithLearners"}}
@@ -157,7 +157,7 @@
                   <button
                     type="button"
                     class="done text"
-                    onclick={{action "copy" false learnerGroup}}
+                    onclick={{perform this.copy false learnerGroup}}
                     data-test-confirm-without-learners
                   >
                     {{t "general.copyWithoutLearners"}}
@@ -166,7 +166,7 @@
                   <button
                     type="button"
                     class="done text"
-                    onclick={{action "copy" false learnerGroup}}
+                    onclick={{perform this.copy false learnerGroup}}
                     data-test-confirm-without-learners
                   >
                     {{t "general.copy"}}
@@ -175,7 +175,7 @@
                 <button
                   type="button"
                   class="cancel text"
-                  onclick={{action "cancelCopy" learnerGroup}}
+                  onclick={{fn this.cancelCopy learnerGroup}}
                 >
                   {{t "general.cancel"}}
                 </button>

--- a/app/components/learnergroup-list.hbs
+++ b/app/components/learnergroup-list.hbs
@@ -38,7 +38,7 @@
       {{#each (sort-by this.sortBy @learnerGroups) as |learnerGroup|}}
         <tr
           class={{if
-            (contains learnerGroup this.learnerGroupsForRemovalConfirmation)
+            (contains learnerGroup.id (map-by "id" this.toRemove))
             "confirm-removal"
           }}
           data-test-active-row
@@ -66,9 +66,13 @@
                   class="clickable remove"
                   role="button"
                   data-test-remove
-                  {{on "click" (fn this.confirmRemove learnerGroup)}}
+                  {{on "click" (perform this.confirmRemove learnerGroup)}}
                 >
-                  <FaIcon @icon="trash" class="enabled" />
+                  {{#if (contains learnerGroup this.preparingToRemove)}}
+                    <FaIcon @icon="spinner" @spin={{true}} />
+                  {{else}}
+                    <FaIcon @icon="trash" class="enabled" />
+                  {{/if}}
                 </span>
               {{else}}
                 <FaIcon @icon="trash" class="disabled" />
@@ -89,15 +93,15 @@
             {{/if}}
           </td>
         </tr>
-        {{#if (contains learnerGroup this.learnerGroupsForRemovalConfirmation)}}
-          <tr class="confirm-removal" data-test-confirm-removal>
-            <td colspan={{if (media "isLaptopAndUp") "5" "3"}}>
-              <div class="confirm-message" data-test-confirmation>
-                {{#if (is-fulfilled learnerGroup.courses)}}
-                  {{#if (gt (get (await learnerGroup.courses) "length") 0)}}
-                    {{t "general.canNotDeleteLearnerGroupWithAssociatedCourses" courseCount=(get (await learnerGroup.courses) "length")}}
+        {{#if (contains learnerGroup.id (map-by "id" this.toRemove))}}
+          {{#let (find-by "id" learnerGroup.id this.toRemove) as |removableGroup|}}
+            <tr class="confirm-removal" data-test-confirm-removal>
+              <td colspan={{if (media "isLaptopAndUp") "5" "3"}}>
+                <div class="confirm-message" data-test-confirmation>
+                  {{#if (gt removableGroup.courses.length 0)}}
+                    {{t "general.canNotDeleteLearnerGroupWithAssociatedCourses" courseCount=removableGroup.courses.length}}
                     <ul class="course-list">
-                      {{#each (sort-by "year" "title" (await learnerGroup.courses)) as |course|}}
+                      {{#each (sort-by "year" "title" removableGroup.courses) as |course|}}
                         <li>{{course.academicYear}} {{course.title}}</li>
                       {{/each}}
                     </ul>
@@ -134,14 +138,12 @@
                       </button>
                     </div>
                   {{/if}}
-                {{else}}
-                  <LoadingSpinner />
-                {{/if}}
-              </div>
-            </td>
-          </tr>
+                </div>
+              </td>
+            </tr>
+          {{/let}}
         {{/if}}
-        {{#if (contains learnerGroup this.learnerGroupsForCopy)}}
+        {{#if (contains learnerGroup this.toCopy)}}
           <tr class="confirm-copy" data-test-confirm-copy>
             <td colspan={{if (media "isLaptopAndUp") "6" "3"}}>
               <div class="confirm-buttons">

--- a/app/components/learnergroup-list.hbs
+++ b/app/components/learnergroup-list.hbs
@@ -107,7 +107,7 @@
                         onclick={{action "cancelRemove" learnerGroup}}
                         data-test-cancel
                       >
-                        {{t "general.cancel"}}
+                        {{t "general.ok"}}
                       </button>
                   {{else}}
                     {{t

--- a/app/components/learnergroup-list.hbs
+++ b/app/components/learnergroup-list.hbs
@@ -29,9 +29,6 @@
         >
           {{t "general.subgroups"}}
         </SortableTh>
-        <th class="text-center hide-from-small-screen">
-          {{t "general.courses"}}
-        </th>
         <th class="text-right">
           {{t "general.actions"}}
         </th>
@@ -57,16 +54,12 @@
           <td class="text-center hide-from-small-screen">
             {{learnerGroup.childrenCount}}
           </td>
-          <td class="text-center hide-from-small-screen">
-            {{get (await learnerGroup.courses) "length"}}
-          </td>
           <td class="text-right" data-test-actions>
             {{#if (is-fulfilled learnerGroup.hasLearnersInGroupOrSubgroups)}}
               {{#if
                 (and
                   @canDelete
                   (not (await learnerGroup.hasLearnersInGroupOrSubgroups))
-                  (eq (get (await learnerGroup.courses) "length") 0)
                 )
               }}
                 <span
@@ -98,31 +91,52 @@
         </tr>
         {{#if (contains learnerGroup this.learnerGroupsForRemovalConfirmation)}}
           <tr class="confirm-removal" data-test-confirm-removal>
-            <td colspan={{if (media "isLaptopAndUp") "6" "3"}}>
+            <td colspan={{if (media "isLaptopAndUp") "5" "3"}}>
               <div class="confirm-message" data-test-confirmation>
-                {{t
-                  "general.confirmRemoveLearnerGroup"
-                  subgroupCount=learnerGroup.children.length
-                }}
-                <br>
-                <div class="confirm-buttons">
-                  <button
-                    type="button"
-                    class="remove text"
-                    onclick={{action @remove learnerGroup}}
-                    data-test-confirm
-                  >
-                    {{t "general.yes"}}
-                  </button>
-                  <button
-                    type="button"
-                    class="done text"
-                    onclick={{action "cancelRemove" learnerGroup}}
-                    data-test-cancel
-                  >
-                    {{t "general.cancel"}}
-                  </button>
-                </div>
+                {{#if (is-fulfilled learnerGroup.courses)}}
+                  {{#if (gt (get (await learnerGroup.courses) "length") 0)}}
+                    {{t "general.canNotDeleteLearnerGroupWithAssociatedCourses" courseCount=(get (await learnerGroup.courses) "length")}}
+                    <ul class="course-list">
+                      {{#each (sort-by "year" "title" (await learnerGroup.courses)) as |course|}}
+                        <li>{{course.academicYear}} {{course.title}}</li>
+                      {{/each}}
+                    </ul>
+                    <button
+                        type="button"
+                        class="done text"
+                        onclick={{action "cancelRemove" learnerGroup}}
+                        data-test-cancel
+                      >
+                        {{t "general.cancel"}}
+                      </button>
+                  {{else}}
+                    {{t
+                      "general.confirmRemoveLearnerGroup"
+                      subgroupCount=learnerGroup.children.length
+                    }}
+                    <br>
+                    <div class="confirm-buttons">
+                      <button
+                        type="button"
+                        class="remove text"
+                        onclick={{action @remove learnerGroup}}
+                        data-test-confirm
+                      >
+                        {{t "general.yes"}}
+                      </button>
+                      <button
+                        type="button"
+                        class="done text"
+                        onclick={{action "cancelRemove" learnerGroup}}
+                        data-test-cancel
+                      >
+                        {{t "general.cancel"}}
+                      </button>
+                    </div>
+                  {{/if}}
+                {{else}}
+                  <LoadingSpinner />
+                {{/if}}
               </div>
             </td>
           </tr>

--- a/app/components/learnergroup-list.js
+++ b/app/components/learnergroup-list.js
@@ -25,12 +25,10 @@ export default class LearnerGroupListComponent extends Component {
 
   @task
   *confirmRemove(learnerGroup) {
-    if (this.args.canDelete) {
-      this.preparingToRemove = [...this.preparingToRemove, learnerGroup];
-      const deletableGroup = yield this.createDeletableGroup(learnerGroup);
-      this.toRemove = [...this.toRemove, deletableGroup];
-      this.preparingToRemove = this.preparingToRemove.filter(lg => lg !== learnerGroup);
-    }
+    this.preparingToRemove = [...this.preparingToRemove, learnerGroup];
+    const deletableGroup = yield this.createDeletableGroup(learnerGroup);
+    this.toRemove = [...this.toRemove, deletableGroup];
+    this.preparingToRemove = this.preparingToRemove.filter(lg => lg !== learnerGroup);
   }
 
   @action

--- a/app/components/learnergroup-list.js
+++ b/app/components/learnergroup-list.js
@@ -1,84 +1,57 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { task } from 'ember-concurrency-decorators';
 
-export default Component.extend({
-  tagName: "",
-  bubbleSort: true,
-  canCreate: false,
-  canDelete: false,
-  learnerGroups: null,
-  query: null,
-  sortBy: 'title',
-  copy() {},
-  remove() {},
-  setSortBy() {},
+export default class LearnerGroupListComponent extends Component {
+  @tracked learnerGroupsForCopy = [];
+  @tracked learnerGroupsForRemovalConfirmation = [];
+  @tracked localSortBy = 'title';
 
-  sortedAscending: computed('sortBy', function() {
+  get sortBy() {
+    return this.args.sortBy ?? this.localSortBy;
+  }
+
+  get sortedAscending(){
     return this.sortBy.search(/desc/) === -1;
-  }),
+  }
 
-  sortedLearnerGroups: computed('learnerGroups.[]', 'sortBy', 'sortedAscending', function () {
-    if (!this.learnerGroups) {
-      return [];
-    }
-    let sortBy = this.sortBy;
-    if (sortBy.indexOf(':') !== -1) {
-      sortBy = sortBy.split(':', 1)[0];
-    }
+  @action
+  cancelRemove(learnerGroup) {
+    this.learnerGroupsForRemovalConfirmation = this.learnerGroupsForRemovalConfirmation.filter(lg => lg !== learnerGroup);
+  }
 
-    let sortedLearnerGroups = this.learnerGroups.sortBy(sortBy);
-
-    if (!this.sortedAscending) {
-      sortedLearnerGroups = sortedLearnerGroups.slice().reverse();
-    }
-
-    return sortedLearnerGroups;
-  }),
-
-  init() {
-    this._super(...arguments);
-    this.set('learnerGroupsForCopy', []);
-    this.set('learnerGroupsForRemovalConfirmation', []);
-  },
-
-  actions: {
-    cancelRemove(learnerGroup) {
-      this.learnerGroupsForRemovalConfirmation.removeObject(learnerGroup);
-    },
-
-    confirmRemove(learnerGroup) {
-      const canDelete = this.canDelete;
-      if (canDelete) {
-        this.learnerGroupsForRemovalConfirmation.pushObject(learnerGroup);
-      }
-    },
-
-    cancelCopy(learnerGroup) {
-      this.learnerGroupsForCopy.removeObject(learnerGroup);
-    },
-
-    startCopy(learnerGroup) {
-      this.learnerGroupsForCopy.pushObject(learnerGroup);
-    },
-
-    async copy(withLearners, learnerGroup) {
-      const copy = this.copy;
-      await copy(withLearners, learnerGroup);
-      this.learnerGroupsForCopy.removeObject(learnerGroup);
-    },
-
-    sortBy(what) {
-      const sortBy = this.sortBy;
-
-      if (sortBy === what){
-        what += ':desc';
-      }
-
-      if (this.bubbleSort) {
-        this.setSortBy(what);
-      } else {
-        this.set('sortBy', what);
-      }
+  @action
+  confirmRemove(learnerGroup) {
+    if (this.args.canDelete) {
+      this.learnerGroupsForRemovalConfirmation = [...this.learnerGroupsForRemovalConfirmation, learnerGroup];
     }
   }
-});
+
+  @action
+  cancelCopy(learnerGroup) {
+    this.learnerGroupsForCopy = this.learnerGroupsForCopy.filter(lg => lg !== learnerGroup);
+  }
+
+  @action
+  startCopy(learnerGroup) {
+    this.learnerGroupsForCopy = [...this.learnerGroupsForCopy, learnerGroup];
+  }
+
+  @task
+  *copy(withLearners, learnerGroup) {
+    yield this.args.copy(withLearners, learnerGroup);
+    this.cancelCopy(learnerGroup);
+  }
+
+  @action
+  setSortBy(what) {
+    if(this.sortBy === what){
+      what += ':desc';
+    }
+    if (this.args.setSortBy) {
+      this.args.setSortBy(what);
+    }
+    this.localSortBy = what;
+  }
+}

--- a/app/components/learnergroup-summary.hbs
+++ b/app/components/learnergroup-summary.hbs
@@ -81,11 +81,16 @@
     </div>
     <div class="associatedcourses">
       <label>
-        {{t "general.associatedCourses"}} ({{get (await learnerGroup.courses) "length"}}):
+        {{t "general.associatedCourses"}} ({{get (await this.courses) "length"}}):
       </label>
       <ul>
-        {{#each (sort-by "title" (await learnerGroup.courses)) as |course|}}
-          <li>{{course.title}}</li>
+        {{#each (sort-by "courseTitle" (await this.courses)) as |obj|}}
+          <li>
+            {{obj.courseTitle}}
+            {{#if obj.groups}}
+              ({{obj.groups.length}} {{t "general.subgroups"}})
+            {{/if}}
+          </li>
         {{/each}}
       </ul>
     </div>

--- a/app/components/learnergroup-summary.hbs
+++ b/app/components/learnergroup-summary.hbs
@@ -5,52 +5,6 @@
     @canUpdate={{canUpdate}}
   />
   <section class="learnergroup-overview" data-test-overview>
-    <div class="learnergroup-overview-actions">
-      {{#if (or isEditing isBulkAssigning)}}
-        <button
-          type="button"
-          {{action
-            (pipe (action setIsEditing false) (action setIsBulkAssigning false))
-          }}
-        >
-          {{t "general.close"}}
-        </button>
-      {{else if canUpdate}}
-        <button type="button" data-test-activate-bulk-assign {{action setIsBulkAssigning true}}>
-          {{t "general.uploadGroupAssignments"}}
-        </button>
-        <button type="button" data-test-manage {{action setIsEditing true}}>
-          {{t "general.manage"}}
-        </button>
-      {{/if}}
-    </div>
-    {{#if isBulkAssigning}}
-      <LearnergroupBulkAssignment
-        @learnerGroup={{learnerGroup}}
-        @done={{action setIsBulkAssigning false}}
-      />
-    {{else if createUsersToPassToManager.lastSuccessful}}
-      <div class="learnergroup-overview-content">
-        <LearnergroupUserManager
-          @learnerGroupId={{learnerGroupId}}
-          @learnerGroupTitle={{learnerGroupTitle}}
-          @topLevelGroupTitle={{topLevelGroupTitle}}
-          @cohortTitle={{cohortTitle}}
-          @users={{createUsersToPassToManager.lastSuccessful.value}}
-          @sortBy={{sortUsersBy}}
-          @setSortBy={{setSortUsersBy}}
-          @isEditing={{isEditing}}
-          @addUserToGroup={{perform addUserToGroup}}
-          @removeUserFromGroup={{perform removeUserToCohort}}
-          @addUsersToGroup={{perform addUsersToGroup}}
-          @removeUsersFromGroup={{perform removeUsersToCohort}}
-        />
-      </div>
-    {{else}}
-      <h1 class="text-center">
-        <LoadingSpinner />
-      </h1>
-    {{/if}}
     <div class="block defaultlocation">
       <label>
         {{t "general.defaultLocation"}}:
@@ -125,22 +79,62 @@
         {{/if}}
       </div>
     </div>
-    <div class="block associatedcourses">
+    <div class="associatedcourses">
       <label>
-        {{t "general.associatedCourses"}}:
+        {{t "general.associatedCourses"}} ({{get (await learnerGroup.courses) "length"}}):
       </label>
-      <div>
-        {{#if (is-fulfilled learnerGroup.courses)}}
-          {{#if (get (await learnerGroup.courses) "length")}}
-            {{join "; " (map-by "title" (await learnerGroup.courses))}}
-          {{else}}
-            {{t "general.none"}}
-          {{/if}}
-        {{else}}
-          <LoadingSpinner />
-        {{/if}}
-      </div>
+      <ul>
+        {{#each (sort-by "title" (await learnerGroup.courses)) as |course|}}
+          <li>{{course.title}}</li>
+        {{/each}}
+      </ul>
     </div>
+    <div class="learnergroup-overview-actions">
+      {{#if (or isEditing isBulkAssigning)}}
+        <button
+          type="button"
+          {{action
+            (pipe (action setIsEditing false) (action setIsBulkAssigning false))
+          }}
+        >
+          {{t "general.close"}}
+        </button>
+      {{else if canUpdate}}
+        <button type="button" data-test-activate-bulk-assign {{action setIsBulkAssigning true}}>
+          {{t "general.uploadGroupAssignments"}}
+        </button>
+        <button type="button" data-test-manage {{action setIsEditing true}}>
+          {{t "general.manage"}}
+        </button>
+      {{/if}}
+    </div>
+    {{#if isBulkAssigning}}
+      <LearnergroupBulkAssignment
+        @learnerGroup={{learnerGroup}}
+        @done={{action setIsBulkAssigning false}}
+      />
+    {{else if createUsersToPassToManager.lastSuccessful}}
+      <div class="learnergroup-overview-content">
+        <LearnergroupUserManager
+          @learnerGroupId={{learnerGroupId}}
+          @learnerGroupTitle={{learnerGroupTitle}}
+          @topLevelGroupTitle={{topLevelGroupTitle}}
+          @cohortTitle={{cohortTitle}}
+          @users={{createUsersToPassToManager.lastSuccessful.value}}
+          @sortBy={{sortUsersBy}}
+          @setSortBy={{setSortUsersBy}}
+          @isEditing={{isEditing}}
+          @addUserToGroup={{perform addUserToGroup}}
+          @removeUserFromGroup={{perform removeUserToCohort}}
+          @addUsersToGroup={{perform addUsersToGroup}}
+          @removeUsersFromGroup={{perform removeUsersToCohort}}
+        />
+      </div>
+    {{else}}
+      <h1 class="text-center">
+        <LoadingSpinner />
+      </h1>
+    {{/if}}
     <p class="block" data-test-toggle-learnergroup-calendar>
       <ToggleButtons
         @firstOptionSelected={{not showLearnerGroupCalendar}}

--- a/app/styles/components/learnergroup-summary.scss
+++ b/app/styles/components/learnergroup-summary.scss
@@ -5,6 +5,9 @@
     display: block;
 
     .learnergroup-overview-actions {
+      border-top: 1px dotted $ilios-orange;
+      margin-top: .25rem;
+      padding-top: .5rem;
       text-align: right;
     }
 
@@ -19,6 +22,19 @@
       font-size: 2.25rem;
       margin: auto;
       text-align: center;
+    }
+  }
+
+  .associatedcourses {
+    margin-top: .3rem;
+    display: flex;
+
+    label {
+      white-space: nowrap;
+    }
+    ul {
+      @include ilios-tag-list;
+      margin: -8px 0 0 1rem;
     }
   }
 }

--- a/app/styles/components/learnergroups-list.scss
+++ b/app/styles/components/learnergroups-list.scss
@@ -42,6 +42,10 @@
 
   .list {
     @include main-list-box-table;
+
+    .confirm-removal .course-list {
+      list-style-type: none;
+    }
   }
 
   .fa-copy, .fa-trash {

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -328,7 +328,7 @@ module('Acceptance | Learner Groups', function(hooks) {
     assert.ok(page.learnerGroupList.groups[0].actions.canRemove);
 
     await page.learnerGroupList.groups[0].actions.remove();
-    assert.equal(page.learnerGroupList.confirmRemoval.confirmation, 'This group is attached to one course and cannot be deleted. 2013 - 2014 course 0 Cancel');
+    assert.equal(page.learnerGroupList.confirmRemoval.confirmation, 'This group is attached to one course and cannot be deleted. 2013 - 2014 course 0 OK');
     assert.notOk(page.learnerGroupList.confirmRemoval.canConfirm);
     assert.ok(page.learnerGroupList.confirmRemoval.canCancel);
     await page.learnerGroupList.confirmRemoval.cancel();

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -294,12 +294,9 @@ module('Acceptance | Learner Groups', function(hooks) {
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('programYear', { program });
     const cohort = this.server.create('cohort', { programYear });
-    const learnerGroup = this.server.create('learnerGroup', {
+    this.server.create('learnerGroup', {
       cohort,
       userIds: [2, 3, 4],
-    });
-    this.server.createList('offering', 2, {
-      learnerGroups: [learnerGroup]
     });
 
     assert.expect(3);
@@ -308,6 +305,34 @@ module('Acceptance | Learner Groups', function(hooks) {
     assert.equal(page.learnerGroupList.groups.length, 1);
     assert.equal(page.learnerGroupList.groups[0].title, 'learner group 0');
     assert.notOk(page.learnerGroupList.groups[0].actions.canRemove);
+  });
+
+  test('learner groups with courses cannot be deleted', async function (assert) {
+    assert.expect(7);
+    this.user.update({administeredSchools: [this.school]});
+
+    const program = this.server.create('program', { school: this.school });
+    const programYear = this.server.create('programYear', { program });
+    const cohort = this.server.create('cohort', { programYear });
+    const course = this.server.create('course');
+    const session = this.server.create('session', { course });
+    const offering = this.server.create('offering', { session });
+    this.server.create('learnerGroup', {
+      cohort,
+      offerings: [ offering ],
+    });
+
+    await page.visit();
+    assert.equal(page.learnerGroupList.groups.length, 1);
+    assert.equal(page.learnerGroupList.groups[0].title, 'learner group 0');
+    assert.ok(page.learnerGroupList.groups[0].actions.canRemove);
+
+    await page.learnerGroupList.groups[0].actions.remove();
+    assert.equal(page.learnerGroupList.confirmRemoval.confirmation, 'This group is attached to one course and cannot be deleted. 2013 - 2014 course 0 Cancel');
+    assert.notOk(page.learnerGroupList.confirmRemoval.canConfirm);
+    assert.ok(page.learnerGroupList.confirmRemoval.canCancel);
+    await page.learnerGroupList.confirmRemoval.cancel();
+    assert.equal(page.learnerGroupList.groups.length, 1);
   });
 
   test('click title takes you to learnergroup route', async function (assert) {

--- a/tests/integration/components/learnergroup-summary-test.js
+++ b/tests/integration/components/learnergroup-summary-test.js
@@ -60,13 +60,13 @@ module('Integration | Component | learnergroup summary', function(hooks) {
       @isBulkAssigning={{false}}
     />`);
 
-    const defaultLocation = '.learnergroup-overview .defaultlocation span:nth-of-type(1)';
-    const instructors = '.learnergroup-overview .defaultinstructors span';
-    const coursesList = '.learnergroup-overview .associatedcourses div';
+    const defaultLocation = '[data-test-overview] .defaultlocation span:nth-of-type(1)';
+    const instructors = '[data-test-overview] .defaultinstructors span';
+    const coursesList = '[data-test-overview] .associatedcourses ul';
 
     assert.dom(defaultLocation).hasText('test location');
     assert.dom(instructors).hasText('4 guy M. Mc4son; 5 guy M. Mc5son');
-    assert.dom(coursesList).hasText('course 0; course 1');
+    assert.dom(coursesList).hasText('course 0 course 1');
   });
 
   test('Update location', async function(assert) {
@@ -90,7 +90,7 @@ module('Integration | Component | learnergroup summary', function(hooks) {
       @isBulkAssigning={{false}}
     />`);
 
-    const defaultLocation = '.learnergroup-overview .defaultlocation span:nth-of-type(1)';
+    const defaultLocation = '[data-test-overview] .defaultlocation span:nth-of-type(1)';
     const editLocation = `${defaultLocation} .editable`;
     const input =  `${defaultLocation} input`;
     const save =  `${defaultLocation} .done`;

--- a/tests/pages/components/learnergroup-list.js
+++ b/tests/pages/components/learnergroup-list.js
@@ -32,6 +32,8 @@ const definition = {
     scope: '[data-test-confirm-removal]',
     confirm: clickable('[data-test-confirm]'),
     cancel: clickable('[data-test-cancel]'),
+    canConfirm: isPresent('[data-test-confirm]'),
+    canCancel: isPresent('[data-test-cancel]'),
     confirmation: text('[data-test-confirmation]'),
   },
   confirmCopy: {

--- a/tests/pages/components/learnergroup-subgroup-list.js
+++ b/tests/pages/components/learnergroup-subgroup-list.js
@@ -1,0 +1,66 @@
+import {
+  clickable,
+  create,
+  collection,
+  hasClass,
+  fillable,
+  isPresent,
+  isVisible,
+  text,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-learnergroup-subgroup-list]',
+  title: text('[data-test-title]'),
+  headings: collection('thead th', {
+    title: text(),
+  }),
+  groups: collection('tbody tr', {
+    title: text('td', { at: 0 }),
+    visit: clickable('td:nth-of-type(1) a'),
+    members: text('td', { at: 1 }),
+    subgroups: text('td', { at: 2 }),
+    hasRemoveStyle: hasClass('confirm-removal'),
+    actions: {
+      scope: '[data-test-actions]',
+      canRemove: isPresent('[data-test-remove]'),
+      remove: clickable('[data-test-remove]'),
+      canCopy: isPresent('[data-test-copy]'),
+      copy: clickable('[data-test-copy]'),
+    },
+  }),
+  confirmRemoval: {
+    scope: '[data-test-confirm-removal]',
+    confirm: clickable('[data-test-confirm]'),
+    cancel: clickable('[data-test-cancel]'),
+    canConfirm: isPresent('[data-test-confirm]'),
+    canCancel: isPresent('[data-test-cancel]'),
+    confirmation: text('[data-test-confirmation]'),
+  },
+  confirmCopy: {
+    scope: '[data-test-confirm-copy]',
+    confirmWithLearners: clickable('[data-test-confirm-with-learners]'),
+    confirmWithoutLearners: clickable('[data-test-confirm-without-learners]'),
+    canCopyWithLearners: isPresent('[data-test-confirm-with-learners]'),
+    canCopyWithoutLearners: isPresent('[data-test-confirm-without-learners]'),
+  },
+  newForm: {
+    scope: '[data-test-new-learner-group]',
+    title: fillable('[data-test-title]'),
+    save: clickable('.done'),
+    cancel: clickable('.cancel'),
+    isVisible: isVisible(),
+    singleGroupSelected: isPresent('[data-test-first-button][data-test-active]'),
+    multipleGroupSelected: isPresent('[data-test-second-button][data-test-active]'),
+    chooseSingleGroups: clickable('[data-test-first-button]'),
+    chooseMultipleGroups: clickable('[data-test-second-button]'),
+    setNumberOfGroups: fillable('[data-test-number-of-groups]'),
+  },
+  emptyListRowIsVisible: isVisible('[data-test-empty-list]'),
+  savedResult: text('.saved-result'),
+  toggleNewForm: clickable('[data-test-expand-collapse-button] button'),
+  hasNewGroupToggle: isPresent('[data-test-expand-collapse-button]'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/learner-group.js
+++ b/tests/pages/learner-group.js
@@ -4,12 +4,12 @@ import {
   collection,
   fillable,
   hasClass,
-  isPresent,
   isVisible,
   text,
   visitable
 } from 'ember-cli-page-object';
 import learnerGroupUserManager from './components/learnergroup-user-manager';
+import learnergroupSubgroupList from './components/learnergroup-subgroup-list';
 
 export default create({
   visit: visitable('/learnergroups/:learnerGroupId'),
@@ -87,57 +87,7 @@ export default create({
     canSubmitFinalData: isVisible('[data-test-finalize-users-submit]'),
     submitFinalData: clickable('[data-test-finalize-users-submit]'),
   },
-  subgroups: {
-    scope: '[data-test-learnergroup-subgroup-list]',
-    title: text('[data-test-title]'),
-    headings: collection('thead th', {
-      title: text(),
-    }),
-    groups: collection('tbody tr', {
-      title: text('td', { at: 0 }),
-      visit: clickable('td:nth-of-type(1) a'),
-      members: text('td', { at: 1 }),
-      subgroups: text('td', { at: 2 }),
-      courses: text('td', { at: 3 }),
-      hasRemoveStyle: hasClass('confirm-removal'),
-      actions: {
-        scope: '[data-test-actions]',
-        canRemove: isPresent('[data-test-remove]'),
-        remove: clickable('[data-test-remove]'),
-        canCopy: isPresent('[data-test-copy]'),
-        copy: clickable('[data-test-copy]'),
-      },
-    }),
-    confirmRemoval: {
-      scope: '[data-test-confirm-removal]',
-      confirm: clickable('[data-test-confirm]'),
-      cancel: clickable('[data-test-cancel]'),
-      confirmation: text('[data-test-confirmation]'),
-    },
-    confirmCopy: {
-      scope: '[data-test-confirm-copy]',
-      confirmWithLearners: clickable('[data-test-confirm-with-learners]'),
-      confirmWithoutLearners: clickable('[data-test-confirm-without-learners]'),
-      canCopyWithLearners: isPresent('[data-test-confirm-with-learners]'),
-      canCopyWithoutLearners: isPresent('[data-test-confirm-without-learners]'),
-    },
-    newForm: {
-      scope: '[data-test-new-learner-group]',
-      title: fillable('[data-test-title]'),
-      save: clickable('.done'),
-      cancel: clickable('.cancel'),
-      isVisible: isVisible(),
-      singleGroupSelected: isPresent('[data-test-first-button][data-test-active]'),
-      multipleGroupSelected: isPresent('[data-test-second-button][data-test-active]'),
-      chooseSingleGroups: clickable('[data-test-first-button]'),
-      chooseMultipleGroups: clickable('[data-test-second-button]'),
-      setNumberOfGroups: fillable('[data-test-number-of-groups]'),
-    },
-    emptyListRowIsVisible: isVisible('[data-test-empty-list]'),
-    savedResult: text('.saved-result'),
-    toggleNewForm: clickable('[data-test-expand-collapse-button] button'),
-    hasNewGroupToggle: isPresent('[data-test-expand-collapse-button]'),
-  },
+  subgroups: learnergroupSubgroupList,
   usersInCohort: {
     scope: '.cohortmembers',
     list: collection('tbody tr', {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -259,6 +259,7 @@ general:
   objectiveParentsTitle: "Select Parent Objectives"
   objectiveTitle: "Session Objective"
   off: Off
+  ok: OK
   on: On
   openSmallGroupGenerator: "Open Offering Small Group Generator"
   optional: Optional

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -45,6 +45,7 @@ general:
   calendarOn: "Calendar On"
   campusId: "Campus ID"
   canNotContinueWithInvalidRecords: "Cannot continue with these invalid records, please fix and re-upload the file."
+  canNotDeleteLearnerGroupWithAssociatedCourses: "This group is attached to {courseCount, plural, one {one course} other {# courses}} and cannot be deleted."
   childSequenceOrder: "Child Sequence Order"
   city: City
   clearDates: "Clear Dates"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -45,6 +45,7 @@ general:
   calendarOn: "Calendario en Uso"
   campusId: "Campus ID"
   canNotContinueWithInvalidRecords: "No se puede continuar con estos registros no válidos, por favor, corrija y vuelva a subir el archivo."
+  canNotDeleteLearnerGroupWithAssociatedCourses: "Este grupo está unido a {courseCount, plural, one {un curso} other {# cursos}} y no se puede eliminar."
   childSequenceOrder: "Orden de Secuencia de Los Hijos"
   city: Ciudad
   clearDates: "Borrar Fechas"
@@ -259,6 +260,7 @@ general:
   objectiveTitle: "Objetivos de la Sesión"
   off: Apagado
   on: Encendido
+  ok: OK
   openSmallGroupGenerator: "Abrir el Generador de Ofrecimientos para Grupos Pequeños"
   optional: Opcional
   optionalElective: "Opcional (electiva)"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -45,6 +45,7 @@ general:
   calendarOn: "Calendrier Allumé"
   campusId: "Campus ID"
   canNotContinueWithInvalidRecords: "Ne peut pas continuer avec ces rapports invalides, fixez s'il vous plaît et retéléchargez le fichier."
+  canNotDeleteLearnerGroupWithAssociatedCourses: "Ce groupe est rattaché à {courseCount}  cours et ne peut être supprimé."
   childSequenceOrder: "Ordre séquentiel des enfants"
   city: Ville
   clearDates: "Supprimer dates"
@@ -258,6 +259,7 @@ general:
   objectiveParentsTitle: "Affichez objectifs mères"
   objectiveTitle: "Objectif de Séance"
   off: "Éteindre"
+  ok: OK
   on: Allumer
   openSmallGroupGenerator: "Générateur des petites groupes"
   optional: Optionnel


### PR DESCRIPTION
I've removed the course count and moved the check for linked courses
into the delete dialog. This way we don't need to load the entire
curriculum when loading the learner groups list.

To make the course information easy to get to it has been highlighted
and re-styled in the single group view.

Fixes #5394

Todo:
- [x] Feedback on removal warning when courses are attached
- [x] Translations
- [x] Feedback on new single group summary