### PR TITLE
Update Ilios Common and replace scroll usage on reports

### DIFF
--- a/app/components/dashboard-myreports.hbs
+++ b/app/components/dashboard-myreports.hbs
@@ -6,7 +6,7 @@
       </h3>
       <div class="dashboard-block-actions">
         {{#if @selectedReport}}
-          <button type="button" onclick={{action @onReportSelect null}}>
+          <button type="button" {{on "click" (action this.clearReport)}}>
             {{t "general.allReports"}}
           </button>
           <button
@@ -34,7 +34,13 @@
       </div>
     </div>
     {{#if @selectedReport}}
-      <div class="dashboard-block-body" data-test-selected-report>
+      <div
+        class="dashboard-block-body"
+        data-test-selected-report
+        {{did-insert (set this.scrollTarget)}}
+        {{! template-lint-disable no-invalid-interactive }}
+        {{on "scroll" (action this.setScroll)}}
+      >
         <h3 data-test-report-title>
           {{await selectedReportTitle}}
         </h3>
@@ -64,7 +70,7 @@
         {{/if}}
         {{#if (is-fulfilled reportResultsList)}}
           {{#if (get (await reportResultsList) "length")}}
-            <ul data-test-results>
+            <ul data-test-results {{did-insert (action this.scrollDown)}}>
               {{#each (await reportResultsList) as |item|}}
                 {{#if item.model2}}
                   <li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2866,21 +2866,21 @@
       }
     },
     "@formatjs/intl-pluralrules": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-2.2.11.tgz",
-      "integrity": "sha512-vrr6vpIGCw/PNkB9LmswJRE4T1QfWBIINzIct7bUHwEgG407aUOrn6FTjSHIprK2k0+QyEXnrQkrFVa6cK/RgA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-3.0.2.tgz",
+      "integrity": "sha512-eNJZ1kS//0WAQhgQbu3LOsG4u7GnZHvQqPlYWf3mfgHzHDZk9j5DMvcR6csV9QVJfIrG+2hZg6SSSrZZnPO8Ag==",
       "dev": true,
       "requires": {
-        "@formatjs/intl-utils": "^3.5.0"
+        "@formatjs/intl-utils": "^3.6.0"
       }
     },
     "@formatjs/intl-relativetimeformat": {
-      "version": "5.2.11",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-5.2.11.tgz",
-      "integrity": "sha512-Lf7SEIICJ4cGX1vFAMeyRQG8L1Pf18qfXXX4OWIswUnCyCcoIidLMvVN2xjrtB/OToc6mgZhhCTF35hRA0hl7Q==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-6.0.2.tgz",
+      "integrity": "sha512-HjNQwA9mqVYLOWm/0Xg+S/VHdCxcqUB6nG1MVGd0yvLaIaHIQCnIx9KnX/ywsHsqGg32W85jU+ELt+dl5LrEMQ==",
       "dev": true,
       "requires": {
-        "@formatjs/intl-utils": "^3.5.0"
+        "@formatjs/intl-utils": "^3.6.0"
       }
     },
     "@formatjs/intl-utils": {
@@ -14681,15 +14681,6 @@
       "integrity": "sha512-LNVv8NYZsNEvzkm4jpnk56qZ1880ncipnKwdB1IpZ9jZJ+E/UD+9fM3mpDOkNWJfkc0Inf7zi/eTZLYwi/HEKw==",
       "dev": true
     },
-    "ember-on-helper": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ember-on-helper/-/ember-on-helper-0.1.0.tgz",
-      "integrity": "sha512-jjafBnWfoA4VSSje476ft5G+urlvvuSDddwAJjKDCjKY9mbe3hAEsJiMBAaPObJRMm1FOglCuKjQZfwDDls6MQ==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^7.7.3"
-      }
-    },
     "ember-pad": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/ember-pad/-/ember-pad-1.2.3.tgz",
@@ -18637,14 +18628,14 @@
       "dev": true
     },
     "ilios-common": {
-      "version": "45.0.0",
-      "resolved": "https://registry.npmjs.org/ilios-common/-/ilios-common-45.0.0.tgz",
-      "integrity": "sha512-DXgVDdiRRkimjZsSrcKV/1yeV9g9CDo5lTh2HOKJOnVhSx7o4E5UHa1VliXw50tLB8hpAZMyOkiXS8pbKqNADg==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/ilios-common/-/ilios-common-46.0.0.tgz",
+      "integrity": "sha512-x7uofpx4O7w/Zr8qhIlcmPELh0unSWBIHZ9IELlMSRCVRhhG3tZqh9HyZRIjRcBPVastUe41Hdw/JP6fm+Qw+A==",
       "dev": true,
       "requires": {
         "@ember/render-modifiers": "^1.0.2",
-        "@formatjs/intl-pluralrules": "^2.2.4",
-        "@formatjs/intl-relativetimeformat": "^5.2.4",
+        "@formatjs/intl-pluralrules": "^3.0.2",
+        "@formatjs/intl-relativetimeformat": "^6.0.2",
         "@fortawesome/ember-fontawesome": "^0.2.0",
         "@fortawesome/free-brands-svg-icons": "^5.6.1",
         "@fortawesome/free-regular-svg-icons": "^5.6.1",
@@ -18686,7 +18677,6 @@
         "ember-modal-dialog": "3.0.0-beta.4",
         "ember-modifier": "^1.0.2",
         "ember-moment": "^8.0.0",
-        "ember-on-helper": "^0.1.0",
         "ember-pad": "^1.2.3",
         "ember-page-title": "^5.0.1",
         "ember-pikaday": "^3.0.0",
@@ -27135,9 +27125,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.1.0.tgz",
-      "integrity": "sha512-pgmbsVWKpH9GxLXZmtdowDIqtb/rvPyjjQv3z9wLcmgWKFHilKnZD3ldgrOlwJoPGOUluQsRPWd52yVkPfmI1A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz",
+      "integrity": "sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==",
       "dev": true
     },
     "whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ember-web-app": "^4.0.0",
     "eslint": "^7.4.0",
     "file-saver": "^2.0.2",
-    "ilios-common": "^45.0.0",
+    "ilios-common": "46.0.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "papaparse": "^5.2.0",


### PR DESCRIPTION
Removing the DomMixin from reports is a step towards octanifcation. This is paired with the common update to use the correct API for scroll position tracking and remove the random setter on an object that was being used here before.