### PR TITLE
Remove course-loading route

### DIFF
--- a/app/templates/course-loading.hbs
+++ b/app/templates/course-loading.hbs
@@ -1,1 +1,0 @@
-<CourseLoading />


### PR DESCRIPTION
This is now provided by common as of https://github.com/ilios/common/pull/1481