### PR TITLE
Learner Group Management: display learner full-name instead of first/last name.

### DIFF
--- a/app/components/learnergroup-cohort-user-manager.hbs
+++ b/app/components/learnergroup-cohort-user-manager.hbs
@@ -28,20 +28,12 @@
               />
             </th>
             <SortableTh
-              @colspan={{2}}
-              @click={{fn this.setSortBy "firstName"}}
-              @sortedBy={{or (eq @sortBy "firstName") (eq @sortBy "firstName:desc")}}
+              @colspan={{4}}
+              @click={{fn this.setSortBy "fullName"}}
+              @sortedBy={{or (eq @sortBy "fullName") (eq @sortBy "fullName:desc")}}
               @sortedAscending={{this.sortedAscending}}
             >
-              {{t "general.firstName"}}
-            </SortableTh>
-            <SortableTh
-              @colspan={{2}}
-              @click={{fn this.setSortBy "lastName"}}
-              @sortedBy={{or (eq @sortBy "lastName") (eq @sortBy "lastName:desc")}}
-              @sortedAscending={{this.sortedAscending}}
-            >
-              {{t "general.lastName"}}
+              {{t "general.name"}}
             </SortableTh>
             <th class="text-left" colspan="2">
               {{t "general.campusId"}}
@@ -75,11 +67,8 @@
                   />
                 {{/unless}}
               </td>
-              <td class="text-left" colspan="2">
-                {{user.firstName}}
-              </td>
-              <td class="text-left" colspan="2">
-                {{user.lastName}}
+              <td class="text-left" colspan="4">
+                {{user.fullName}}
               </td>
               <td class="text-left" colspan="2">
                 {{user.campusId}}

--- a/app/components/learnergroup-cohort-user-manager.js
+++ b/app/components/learnergroup-cohort-user-manager.js
@@ -24,8 +24,7 @@ export default class LearnergroupCohortUserManagerComponent extends Component {
     }
 
     return this.args.users.filter((user) => {
-      return user.firstName.toLowerCase().includes(filter) ||
-        user.lastName.toLowerCase().includes(filter) ||
+      return user.fullName.toLowerCase().includes(filter) ||
         user.email.toLowerCase().includes(filter);
     });
   }

--- a/app/components/learnergroup-cohort-user-manager.js
+++ b/app/components/learnergroup-cohort-user-manager.js
@@ -24,7 +24,9 @@ export default class LearnergroupCohortUserManagerComponent extends Component {
     }
 
     return this.args.users.filter((user) => {
-      return user.fullName.toLowerCase().includes(filter) ||
+      return user.firstName.toLowerCase().includes(filter) ||
+        user.lastName.toLowerCase().includes(filter) ||
+        user.fullName.toLowerCase().includes(filter) ||
         user.email.toLowerCase().includes(filter);
     });
   }

--- a/app/components/learnergroup-user-manager.hbs
+++ b/app/components/learnergroup-user-manager.hbs
@@ -31,23 +31,15 @@
                 {{/if}}
               </th>
               <SortableTh
-                @colspan={{2}}
-                @click={{fn this.setSortBy "firstName"}}
+                @colspan={{4}}
+                @click={{fn this.setSortBy "fullName"}}
                 @sortedBy={{or
-                  (eq sortBy "firstName")
-                  (eq sortBy "firstName:desc")
+                  (eq sortBy "fullName")
+                  (eq sortBy "fullName:desc")
                 }}
                 @sortedAscending={{sortedAscending}}
               >
-                {{t "general.firstName"}}
-              </SortableTh>
-              <SortableTh
-                @colspan={{2}}
-                @click={{fn this.setSortBy "lastName"}}
-                @sortedBy={{or (eq sortBy "lastName") (eq sortBy "lastName:desc")}}
-                @sortedAscending={{sortedAscending}}
-              >
-                {{t "general.lastName"}}
+                {{t "general.name"}}
               </SortableTh>
               <th class="text-left" colspan="2">
                 {{t "general.campusId"}}
@@ -102,11 +94,8 @@
                     />
                   {{/unless}}
                 </td>
-                <td class="text-left" colspan="2">
-                  {{user.firstName}}
-                </td>
-                <td class="text-left" colspan="2">
-                  {{user.lastName}}
+                <td class="text-left" colspan="4">
+                  {{user.fullName}}
                 </td>
                 <td class="text-left" colspan="2">
                   {{user.campusId}}
@@ -174,11 +163,8 @@
                       />
                     {{/unless}}
                   </td>
-                  <td class="text-left" colspan="2">
-                    {{user.firstName}}
-                  </td>
-                  <td class="text-left" colspan="2">
-                    {{user.lastName}}
+                  <td class="text-left" colspan="4">
+                    {{user.fullName}}
                   </td>
                   <td class="text-left" colspan="2">
                     {{user.campusId}}

--- a/app/components/learnergroup-user-manager.hbs
+++ b/app/components/learnergroup-user-manager.hbs
@@ -33,11 +33,8 @@
               <SortableTh
                 @colspan={{4}}
                 @click={{fn this.setSortBy "fullName"}}
-                @sortedBy={{or
-                  (eq sortBy "fullName")
-                  (eq sortBy "fullName:desc")
-                }}
-                @sortedAscending={{sortedAscending}}
+                @sortedBy={{or (eq @sortBy "fullName") (eq @sortBy "fullName:desc")}}
+                @sortedAscending={{this.sortedAscending}}
               >
                 {{t "general.name"}}
               </SortableTh>
@@ -51,11 +48,8 @@
                 <SortableTh
                   @colspan={{2}}
                   @click={{fn this.setSortBy "lowestGroupInTreeTitle"}}
-                  @sortedBy={{or
-                    (eq sortBy "lowestGroupInTreeTitle")
-                    (eq sortBy "lowestGroupInTreeTitle:desc")
-                  }}
-                  @sortedAscending={{sortedAscending}}
+                  @sortedBy={{or (eq @sortBy "lowestGroupInTreeTitle") (eq @sortBy "lowestGroupInTreeTitle:desc")}}
+                  @sortedAscending={{this.sortedAscending}}
                 >
                   {{t "general.groupName"}}
                 </SortableTh>

--- a/app/components/learnergroup-user-manager.js
+++ b/app/components/learnergroup-user-manager.js
@@ -26,8 +26,10 @@ export default class LearnergroupCohortUserManagerComponent extends Component {
       return this.args.users;
     }
 
-    return this.args.users.filter((user) => {
-      return user.get('fullName').toLowerCase().includes(filter) ||
+    return this.args.users.filter(user => {
+      return user.get('firstName').toLowerCase().includes(filter) ||
+        user.get('lastName').toLowerCase().includes(filter) ||
+        user.get('fullName').toLowerCase().includes(filter) ||
         user.get('email').toLowerCase().includes(filter);
     });
   }

--- a/app/components/learnergroup-user-manager.js
+++ b/app/components/learnergroup-user-manager.js
@@ -27,8 +27,7 @@ export default class LearnergroupCohortUserManagerComponent extends Component {
     }
 
     return this.args.users.filter((user) => {
-      return user.get('firstName').toLowerCase().includes(filter) ||
-        user.get('lastName').toLowerCase().includes(filter) ||
+      return user.get('fullName').toLowerCase().includes(filter) ||
         user.get('email').toLowerCase().includes(filter);
     });
   }

--- a/app/controllers/learner-group.js
+++ b/app/controllers/learner-group.js
@@ -8,7 +8,7 @@ export default Controller.extend({
   },
   isEditing: false,
   isBulkAssigning: false,
-  sortUsersBy: 'firstName',
+  sortUsersBy: 'fullName',
   canCreate: false,
   canUpdate: false,
   canDelete: false,

--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -2,7 +2,6 @@ import { currentURL } from '@ember/test-helpers';
 import { test, module } from 'qunit';
 import setupAuthentication from 'ilios/tests/helpers/setup-authentication';
 import moment from 'moment';
-
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from '../pages/learner-group';
@@ -31,15 +30,15 @@ module('Acceptance | Learnergroup', function(hooks) {
     await page.overview.manage();
     assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 0);
     assert.equal(page.usersInCohort.list.length, 2);
-    assert.equal(page.usersInCohort.list[0].firstName, '1 guy');
-    assert.equal(page.usersInCohort.list[1].firstName, '2 guy');
+    assert.equal(page.usersInCohort.list[0].fullName, '1 guy M. Mc1son');
+    assert.equal(page.usersInCohort.list[1].fullName, '2 guy M. Mc2son');
 
     await page.usersInCohort.list[0].add();
 
     assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 1);
-    assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup[0].firstName, '1 guy');
+    assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup[0].fullName, '1 guy M. Mc1son');
     assert.equal(page.usersInCohort.list.length, 1);
-    assert.equal(page.usersInCohort.list[0].firstName, '2 guy');
+    assert.equal(page.usersInCohort.list[0].fullName, '2 guy M. Mc2son');
   });
 
   test('remove learners individually from group', async function(assert) {
@@ -54,16 +53,16 @@ module('Acceptance | Learnergroup', function(hooks) {
     await page.visit({ learnerGroupId: 1 });
     await page.overview.manage();
     assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 2);
-    assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup[0].firstName, '1 guy');
-    assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup[1].firstName, '2 guy');
+    assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup[0].fullName, '1 guy M. Mc1son');
+    assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup[1].fullName, '2 guy M. Mc2son');
     assert.equal(page.usersInCohort.list.length, 0);
 
     await page.overview.learnerGroupUserManager.usersInCurrentGroup[0].remove();
 
     assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 1);
-    assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup[0].firstName, '2 guy');
+    assert.equal(page.overview.learnerGroupUserManager.usersInCurrentGroup[0].fullName, '2 guy M. Mc2son');
     assert.equal(page.usersInCohort.list.length, 1);
-    assert.equal(page.usersInCohort.list[0].firstName, '1 guy');
+    assert.equal(page.usersInCohort.list[0].fullName, '1 guy M. Mc1son');
   });
 
   test('generate new subgroups', async function(assert) {

--- a/tests/integration/components/learnergroup-cohort-user-manager-test.js
+++ b/tests/integration/components/learnergroup-cohort-user-manager-test.js
@@ -1,106 +1,95 @@
-import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import {
-  render,
-  settled,
-  click,
-  findAll,
-  find
-} from '@ember/test-helpers';
+import { render, settled, click, findAll, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | learnergroup cohort user manager', function(hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   test('it renders', async function(assert) {
     const userList = 'tbody tr';
     const user1CheckBox = 'tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
-    const user1FirstName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
-    const user1LastName = 'tbody tr:nth-of-type(1) td:nth-of-type(3)';
-    const user1CampusId = 'tbody tr:nth-of-type(1) td:nth-of-type(4)';
-    const user1Email = 'tbody tr:nth-of-type(1) td:nth-of-type(5)';
+    const user1FullName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
+    const user1CampusId = 'tbody tr:nth-of-type(1) td:nth-of-type(3)';
+    const user1Email = 'tbody tr:nth-of-type(1) td:nth-of-type(4)';
     const user2Disabled = 'tbody tr:nth-of-type(2) td:nth-of-type(1) svg';
-    const user2FirstName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
-    const user2LastName = 'tbody tr:nth-of-type(2) td:nth-of-type(3)';
-    const user2CampusId = 'tbody tr:nth-of-type(2) td:nth-of-type(4)';
-    const user2Email = 'tbody tr:nth-of-type(2) td:nth-of-type(5)';
+    const user2FullName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
+    const user2CampusId = 'tbody tr:nth-of-type(2) td:nth-of-type(3)';
+    const user2Email = 'tbody tr:nth-of-type(2) td:nth-of-type(4)';
 
-    const user1 = EmberObject.create({
+    const user1 = this.server.create('user', {
       firstName: 'Jasper',
       lastName: 'Dog',
       campusId: '1234',
       email: 'testemail',
       enabled: true,
     });
-    const user2 = EmberObject.create({
+    const user2 = this.server.create('user', {
       firstName: 'Jackson',
       lastName: 'Doggy',
       campusId: '123',
       email: 'testemail2',
       enabled: false,
     });
+    const userModel1 = await this.owner.lookup('service:store').find('user', user1.id);
+    const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
 
-    this.set('users', [user1, user2]);
-    this.set('nothing', () => {});
+    this.set('users', [ userModel1, userModel2] );
 
     await render(hbs`<LearnergroupCohortUserManager
-      @users={{users}}
+      @users={{this.users}}
       @canUpdate={{true}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top level group"
       @sortBy="lastName"
-      @setSortBy={{action nothing}}
-      @addUserToGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
+      @setSortBy={{noop}}
+      @addUserToGroup={{noop}}
+      @addUsersToGroup={{noop}}
     />`);
 
     assert.dom('.title').hasText('Cohort Members NOT assigned to top level group (2)');
     assert.dom(userList).exists({ count: 2 });
     assert.dom(user1CheckBox).exists({ count: 1 });
     assert.dom(user1CheckBox).isNotChecked();
-    assert.dom(user1FirstName).hasText('Jasper');
-    assert.dom(user1LastName).hasText('Dog');
+    assert.dom(user1FullName).hasText('Jasper M. Dog');
     assert.dom(user1CampusId).hasText('1234');
     assert.dom(user1Email).hasText('testemail');
 
     assert.dom(user2Disabled).exists({ count: 1 });
-    assert.dom(user2FirstName).hasText('Jackson');
-    assert.dom(user2LastName).hasText('Doggy');
+    assert.dom(user2FullName).hasText('Jackson M. Doggy');
     assert.dom(user2CampusId).hasText('123');
     assert.dom(user2Email).hasText('testemail2');
   });
 
-  test('sort by firstName', async function(assert) {
+  test('sort by full name', async function(assert) {
     const userList = 'tbody tr';
-    const user1FirstName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
-    const user2FirstName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
+    const user1FullName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
+    const user2FullName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
 
-    const user1 = EmberObject.create({
-      firstName: 'Jasper',
-    });
-    const user2 = EmberObject.create({
-      firstName: 'Jackson',
-    });
+    const user1 = this.server.create('user', { firstName: 'Jasper' });
+    const user2 = this.server.create('user', { firstName: 'Jackson' });
+    const userModel1 = await this.owner.lookup('service:store').find('user', user1.id);
+    const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
 
-    this.set('users', [user1, user2]);
-    this.set('nothing', () => {});
+    this.set('users', [ userModel1, userModel2 ]);
 
     await render(hbs`<LearnergroupCohortUserManager
-      @users={{users}}
+      @users={{this.users}}
       @canUpdate={{true}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top level group"
-      @sortBy="firstName"
-      @setSortBy={{action nothing}}
-      @addUserToGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
+      @sortBy="fullName"
+      @setSortBy={{noop}}
+      @addUserToGroup={{noop}}
+      @addUsersToGroup={{noop}}
     />`);
 
     assert.dom(userList).exists({ count: 2 });
-    assert.dom(user1FirstName).hasText('Jackson');
-    assert.dom(user2FirstName).hasText('Jasper');
+    assert.dom(user1FullName).hasText('Jackson M. Mc1son');
+    assert.dom(user2FullName).hasText('Jasper M. Mc0son');
   });
 
   test('add multiple users', async function(assert) {
@@ -108,25 +97,23 @@ module('Integration | Component | learnergroup cohort user manager', function(ho
     const user1CheckBox = 'tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
     const button = 'button.done';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-    });
+    const user = this.server.create('user', { enabled: true });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
 
-    this.set('users', [user1]);
-    this.set('nothing', () => {});
-    this.set('addMany', ([user]) => {
-      assert.equal(user1, user);
+    this.set('users', [ userModel ]);
+    this.set('addMany', ([ user ]) => {
+      assert.equal(userModel, user);
     });
 
     await render(hbs`<LearnergroupCohortUserManager
-      @users={{users}}
+      @users={{this.users}}
       @canUpdate={{true}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top level group"
       @sortBy="firstName"
-      @setSortBy={{action nothing}}
-      @addUserToGroup={{action nothing}}
-      @addUsersToGroup={{action addMany}}
+      @setSortBy={{noop}}
+      @addUserToGroup={{noop}}
+      @addUsersToGroup={{this.addMany}}
     />`);
 
     assert.dom(button).doesNotExist();
@@ -139,27 +126,25 @@ module('Integration | Component | learnergroup cohort user manager', function(ho
 
   test('add single user', async function(assert) {
     assert.expect(1);
-    const action = 'tbody tr:nth-of-type(1) td:nth-of-type(6) .clickable';
+    const action = 'tbody tr:nth-of-type(1) td:nth-of-type(5) .clickable';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-    });
+    const user = this.server.create('user', { enabled: true });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
 
-    this.set('users', [user1]);
-    this.set('nothing', () => {});
+    this.set('users', [ userModel ]);
     this.set('addOne', user => {
-      assert.equal(user1, user);
+      assert.equal(userModel, user);
     });
 
     await render(hbs`<LearnergroupCohortUserManager
-      @users={{users}}
+      @users={{this.users}}
       @canUpdate={{true}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top level group"
       @sortBy="firstName"
-      @setSortBy={{action nothing}}
-      @addUserToGroup={{action addOne}}
-      @addUsersToGroup={{action nothing}}
+      @setSortBy={{noop}}
+      @addUserToGroup={{this.addOne}}
+      @addUsersToGroup={{noop}}
     />`);
 
     await click(action);
@@ -168,24 +153,22 @@ module('Integration | Component | learnergroup cohort user manager', function(ho
   test('when users are selected single action is disabled', async function(assert) {
     assert.expect(1);
     const user1CheckBox = 'tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
-    const action = 'tbody tr:nth-of-type(1) td:nth-of-type(6) .clickable';
+    const action = 'tbody tr:nth-of-type(1) td:nth-of-type(5) .clickable';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-    });
+    const user = this.server.create('user', { enabled: true });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
 
-    this.set('users', [user1]);
-    this.set('nothing', () => {});
+    this.set('users', [ userModel ]);
 
     await render(hbs`<LearnergroupCohortUserManager
-      @users={{users}}
+      @users={{this.users}}
       @canUpdate={{true}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top level group"
       @sortBy="firstName"
-      @setSortBy={{action nothing}}
-      @addUserToGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
+      @setSortBy={{noop}}
+      @addUserToGroup={{noop}}
+      @addUsersToGroup={{noop}}
     />`);
 
     await click(user1CheckBox);
@@ -200,29 +183,26 @@ module('Integration | Component | learnergroup cohort user manager', function(ho
     const user2CheckBox = 'tbody tr:nth-of-type(2) td:nth-of-type(1) input[type=checkbox]';
     const button = 'button.done';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-    });
-    const user2 = EmberObject.create({
-      enabled: true,
-    });
+    const user1 = this.server.create('user', { firstName: 'Jasper' });
+    const user2 = this.server.create('user', { firstName: 'Jackson' });
+    const userModel1 = await this.owner.lookup('service:store').find('user', user1.id);
+    const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
 
-    this.set('users', [user1, user2]);
-    this.set('nothing', () => {});
+    this.set('users', [ userModel1, userModel2 ]);
     this.set('addMany', ([userA, userB]) => {
-      assert.equal(user1, userA);
-      assert.equal(user2, userB);
+      assert.equal(userModel1, userA);
+      assert.equal(userModel2, userB);
     });
 
     await render(hbs`<LearnergroupCohortUserManager
-      @users={{users}}
+      @users={{this.users}}
       @canUpdate={{true}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top level group"
       @sortBy="firstName"
-      @setSortBy={{action nothing}}
-      @addUserToGroup={{action nothing}}
-      @addUsersToGroup={{action addMany}}
+      @setSortBy={{noop}}
+      @addUserToGroup={{noop}}
+      @addUsersToGroup={{this.addMany}}
     />`);
 
     await click(checkAllBox);
@@ -239,25 +219,22 @@ module('Integration | Component | learnergroup cohort user manager', function(ho
     const user1CheckBox = 'tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
     const user2CheckBox = 'tbody tr:nth-of-type(2) td:nth-of-type(1) input[type=checkbox]';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-    });
-    const user2 = EmberObject.create({
-      enabled: true,
-    });
+    const user1 = this.server.create('user', { enabled: true });
+    const user2 = this.server.create('user', { enabled: true });
+    const userModel1 = await this.owner.lookup('service:store').find('user', user1.id);
+    const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
 
-    this.set('users', [user1, user2]);
-    this.set('nothing', () => {});
+    this.set('users', [ userModel1, userModel2 ]);
 
     await render(hbs`<LearnergroupCohortUserManager
-      @users={{users}}
+      @users={{this.users}}
       @canUpdate={{true}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top level group"
       @sortBy="firstName"
-      @setSortBy={{action nothing}}
-      @addUserToGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
+      @setSortBy={{noop}}
+      @addUserToGroup={{noop}}
+      @addUsersToGroup={{noop}}
     />`);
 
     await click(user1CheckBox);
@@ -279,23 +256,19 @@ module('Integration | Component | learnergroup cohort user manager', function(ho
     const userCheckbox = 'tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
     const userDisabledIcon = 'tbody tr:nth-of-type(1) td:nth-of-type(1) .fa-user-times';
 
+    const user = this.server.create('user', { enabled: false });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
 
-    const user1 = EmberObject.create({
-      enabled: false,
-    });
-
-    this.set('users', [user1]);
-    this.set('nothing', () => {});
-
+    this.set('users', [ userModel ]);
     await render(hbs`<LearnergroupCohortUserManager
-      @users={{users}}
+      @users={{this.users}}
       @canUpdate={{true}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top level group"
       @sortBy="firstName"
-      @setSortBy={{action nothing}}
-      @addUserToGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
+      @setSortBy={{noop}}
+      @addUserToGroup={{noop}}
+      @addUsersToGroup={{noop}}
     />`);
 
     assert.equal(1, findAll(userCheckbox).length, 'Checkbox visible');
@@ -313,22 +286,20 @@ module('Integration | Component | learnergroup cohort user manager', function(ho
     const userDisabledIcon = 'tbody tr:nth-of-type(1) td:nth-of-type(1) .fa-user-times';
 
 
-    const user1 = EmberObject.create({
-      enabled: false,
-    });
+    const user = this.server.create('user', { enabled: false });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
 
-    this.set('users', [user1]);
-    this.set('nothing', () => {});
+    this.set('users', [ userModel ]);
 
     await render(hbs`<LearnergroupCohortUserManager
-      @users={{users}}
+      @users={{this.users}}
       @canUpdate={{true}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top level group"
       @sortBy="firstName"
-      @setSortBy={{action nothing}}
-      @addUserToGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
+      @setSortBy={{noop}}
+      @addUserToGroup={{noop}}
+      @addUsersToGroup={{noop}}
     />`);
 
     assert.equal(0, findAll(userCheckbox).length, 'Checkbox not visible');

--- a/tests/integration/components/learnergroup-cohort-user-manager-test.js
+++ b/tests/integration/components/learnergroup-cohort-user-manager-test.js
@@ -68,13 +68,16 @@ module('Integration | Component | learnergroup cohort user manager', function(ho
     const userList = 'tbody tr';
     const user1FullName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
     const user2FullName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
+    const user3FullName = 'tbody tr:nth-of-type(3) td:nth-of-type(2)';
 
     const user1 = this.server.create('user', { firstName: 'Jasper' });
     const user2 = this.server.create('user', { firstName: 'Jackson' });
+    const user3 = this.server.create('user', { firstName: 'Jayden', displayName: 'Captain J' });
     const userModel1 = await this.owner.lookup('service:store').find('user', user1.id);
     const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
+    const userModel3 = await this.owner.lookup('service:store').find('user', user3.id);
 
-    this.set('users', [ userModel1, userModel2 ]);
+    this.set('users', [ userModel1, userModel2, userModel3 ]);
 
     await render(hbs`<LearnergroupCohortUserManager
       @users={{this.users}}
@@ -87,9 +90,10 @@ module('Integration | Component | learnergroup cohort user manager', function(ho
       @addUsersToGroup={{noop}}
     />`);
 
-    assert.dom(userList).exists({ count: 2 });
-    assert.dom(user1FullName).hasText('Jackson M. Mc1son');
-    assert.dom(user2FullName).hasText('Jasper M. Mc0son');
+    assert.dom(userList).exists({ count: 3 });
+    assert.dom(user1FullName).hasText('Captain J');
+    assert.dom(user2FullName).hasText('Jackson M. Mc1son');
+    assert.dom(user3FullName).hasText('Jasper M. Mc0son');
   });
 
   test('add multiple users', async function(assert) {

--- a/tests/integration/components/learnergroup-user-manager-test.js
+++ b/tests/integration/components/learnergroup-user-manager-test.js
@@ -1,75 +1,81 @@
-import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import ObjectProxy from '@ember/object/proxy';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import {
-  render,
-  settled,
-  click,
-  findAll,
-  find
-} from '@ember/test-helpers';
+import { render, settled, click, findAll, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | learnergroup user manager', function(hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   test('it renders', async function(assert) {
     const userList = 'tbody tr';
-    const user1FirstName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
-    const user1LastName = 'tbody tr:nth-of-type(1) td:nth-of-type(3)';
-    const user1CampusId = 'tbody tr:nth-of-type(1) td:nth-of-type(4)';
-    const user1Email = 'tbody tr:nth-of-type(1) td:nth-of-type(5)';
+    const user1FullName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
+    const user1CampusId = 'tbody tr:nth-of-type(1) td:nth-of-type(3)';
+    const user1Email = 'tbody tr:nth-of-type(1) td:nth-of-type(4)';
     const user2Disabled = 'tbody tr:nth-of-type(2) td:nth-of-type(1) svg';
-    const user2FirstName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
-    const user2LastName = 'tbody tr:nth-of-type(2) td:nth-of-type(3)';
-    const user2CampusId = 'tbody tr:nth-of-type(2) td:nth-of-type(4)';
-    const user2Email = 'tbody tr:nth-of-type(2) td:nth-of-type(5)';
+    const user2FullName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
+    const user2CampusId = 'tbody tr:nth-of-type(2) td:nth-of-type(3)';
+    const user2Email = 'tbody tr:nth-of-type(2) td:nth-of-type(4)';
 
-    const user1 = EmberObject.create({
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const user1 = this.server.create('user', {
       firstName: 'Jasper',
       lastName: 'Dog',
       campusId: '1234',
       email: 'testemail',
       enabled: true,
+      learnerGroups: [ learnerGroup ],
+
     });
-    const user2 = EmberObject.create({
+    const user2 = this.server.create('user', {
       firstName: 'Jackson',
       lastName: 'Doggy',
       campusId: '123',
       email: 'testemail2',
       enabled: false,
+      learnerGroups: [ learnerGroup ],
     });
-
-    this.set('users', [user1, user2]);
-    this.set('nothing', parseInt);
-
+    const userModel1 = await this.owner.lookup('service:store').find('user', user1.id);
+    const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    // @todo gross! see if proxy can be eliminated in upstream component <LearnergroupSummary> [ ST 2020/08/07 ]
+    const userModelProxy1 = ObjectProxy.create({
+      content: userModel1,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
+    });
+    const userModelProxy2 = ObjectProxy.create({
+      content: userModel2,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
+    });
+    this.set('users', [ userModelProxy1, userModelProxy2 ]);
+    this.set('learnerGroup', learnerGroupModel );
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroup.id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="lastName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{noop}}
       @isEditing={{false}}
-      @addUserToGroup={{action nothing}}
-      @removeUserFromGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
-      @removeUsersFromGroup={{action nothing}}
+      @addUserToGroup={{noop}}
+      @removeUserFromGroup={{noop}}
+      @addUsersToGroup={{noop}}
+      @removeUsersFromGroup={{noop}}
     />`);
 
     assert.dom('.title').hasText('Members (2)');
     assert.dom(userList).exists({ count: 2 });
-    assert.dom(user1FirstName).hasText('Jasper');
-    assert.dom(user1LastName).hasText('Dog');
+    assert.dom(user1FullName).hasText('Jasper M. Dog');
     assert.dom(user1CampusId).hasText('1234');
     assert.dom(user1Email).hasText('testemail');
-
     assert.dom(user2Disabled).exists({ count: 1 });
-    assert.dom(user2FirstName).hasText('Jackson');
-    assert.dom(user2LastName).hasText('Doggy');
+    assert.dom(user2FullName).hasText('Jackson M. Doggy');
     assert.dom(user2CampusId).hasText('123');
     assert.dom(user2Email).hasText('testemail2');
   });
@@ -77,53 +83,60 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
   test('it renders when editing', async function(assert) {
     const userList = 'tbody tr';
     const user1CheckBox = 'tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
-    const user1FirstName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
-    const user1LastName = 'tbody tr:nth-of-type(1) td:nth-of-type(3)';
-    const user1CampusId = 'tbody tr:nth-of-type(1) td:nth-of-type(4)';
-    const user1Email = 'tbody tr:nth-of-type(1) td:nth-of-type(5)';
+    const user1FullName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
+    const user1CampusId = 'tbody tr:nth-of-type(1) td:nth-of-type(3)';
+    const user1Email = 'tbody tr:nth-of-type(1) td:nth-of-type(4)';
     const user2Disabled = 'tbody tr:nth-of-type(2) td:nth-of-type(1) svg';
-    const user2FirstName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
-    const user2LastName = 'tbody tr:nth-of-type(2) td:nth-of-type(3)';
-    const user2CampusId = 'tbody tr:nth-of-type(2) td:nth-of-type(4)';
-    const user2Email = 'tbody tr:nth-of-type(2) td:nth-of-type(5)';
+    const user2FullName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
+    const user2CampusId = 'tbody tr:nth-of-type(2) td:nth-of-type(3)';
+    const user2Email = 'tbody tr:nth-of-type(2) td:nth-of-type(4)';
 
-    const user1 = EmberObject.create({
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const user1 = this.server.create('user', {
       firstName: 'Jasper',
       lastName: 'Dog',
       campusId: '1234',
       email: 'testemail',
       enabled: true,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+      learnerGroups: [ learnerGroup ],
     });
-    const user2 = EmberObject.create({
+    const user2 = this.server.create('user', {
       firstName: 'Jackson',
       lastName: 'Doggy',
       campusId: '123',
       email: 'testemail2',
       enabled: false,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+      learnerGroups: [ learnerGroup ],
+    });
+    const userModel1 = await this.owner.lookup('service:store').find('user', user1.id);
+    const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    const userModelProxy1 = ObjectProxy.create({
+      content: userModel1,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
+    });
+    const userModelProxy2 = ObjectProxy.create({
+      content: userModel2,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
     });
 
-    this.set('users', [user1, user2]);
-    this.set('nothing', parseInt);
-
+    this.set('users', [ userModelProxy1, userModelProxy2 ]);
+    this.set('learnerGroup', learnerGroupModel);
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroup.id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="lastName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{noop}}
       @isEditing={{true}}
-      @addUserToGroup={{action nothing}}
-      @removeUserFromGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
-      @removeUsersFromGroup={{action nothing}}
+      @addUserToGroup={{noop}}
+      @removeUserFromGroup={{noop}}
+      @addUsersToGroup={{noop}}
+      @removeUsersFromGroup={{noop}}
     />`);
 
     assert.dom('[data-test-group-members]').hasText('Members of current group (2)');
@@ -131,57 +144,64 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
     assert.dom(userList).exists({ count: 2 });
     assert.dom(user1CheckBox).exists({ count: 1 });
     assert.dom(user1CheckBox).isNotChecked();
-    assert.dom(user1FirstName).hasText('Jasper');
-    assert.dom(user1LastName).hasText('Dog');
+    assert.dom(user1FullName).hasText('Jasper M. Dog');
     assert.dom(user1CampusId).hasText('1234');
     assert.dom(user1Email).hasText('testemail');
 
     assert.dom(user2Disabled).exists({ count: 1 });
-    assert.dom(user2FirstName).hasText('Jackson');
-    assert.dom(user2LastName).hasText('Doggy');
+    assert.dom(user2FullName).hasText('Jackson M. Doggy');
     assert.dom(user2CampusId).hasText('123');
     assert.dom(user2Email).hasText('testemail2');
   });
 
-  test('sort by firstName', async function(assert) {
+  test('sort by fullName', async function(assert) {
     const userList = 'tbody tr';
-    const user1FirstName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
-    const user2FirstName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
+    const user1FullName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
+    const user2FullName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
 
-    const user1 = EmberObject.create({
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const user1 = this.server.create('user', {
       firstName: 'Jasper',
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+      learnerGroups: [ learnerGroup ],
     });
-    const user2 = EmberObject.create({
+    const user2 = this.server.create('user', {
       firstName: 'Jackson',
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+      learnerGroups: [ learnerGroup ],
+    });
+    const userModel1 = await this.owner.lookup('service:store').find('user', user1.id);
+    const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    const userModelProxy1 = ObjectProxy.create({
+      content: userModel1,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
+    });
+    const userModelProxy2 = ObjectProxy.create({
+      content: userModel2,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
     });
 
-    this.set('users', [user1, user2]);
-    this.set('nothing', parseInt);
-
+    this.set('users', [ userModelProxy1, userModelProxy2 ]);
+    this.set('learnerGroup', learnerGroupModel );
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroup.Id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="firstName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="fullName"
+      @setSortBy={{noop}}
       @isEditing={{true}}
-      @addUserToGroup={{action nothing}}
-      @removeUserFromGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
-      @removeUsersFromGroup={{action nothing}}
+      @addUserToGroup={{noop}}
+      @removeUserFromGroup={{noop}}
+      @addUsersToGroup={{noop}}
+      @removeUsersFromGroup={{noop}}
     />`);
 
     assert.dom(userList).exists({ count: 2 });
-    assert.dom(user1FirstName).hasText('Jackson');
-    assert.dom(user2FirstName).hasText('Jasper');
+    assert.dom(user1FullName).hasText('Jackson M. Mc1son');
+    assert.dom(user2FullName).hasText('Jasper M. Mc0son');
   });
 
   test('add multiple users', async function(assert) {
@@ -189,32 +209,34 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
     const user1CheckBox = 'table:nth-of-type(2) tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
     const button = 'button.done';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const user = this.server.create('user', { enabled: true, learnerGroups: [ learnerGroup ] });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    const userModelProxy = ObjectProxy.create({
+      content: userModel,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
     });
 
-    this.set('users', [ObjectProxy.create({content: user1})]);
-    this.set('nothing', parseInt);
-    this.set('addMany', ([user]) => {
-      assert.equal(user, user1);
+    this.set('users', [ userModelProxy ]);
+    this.set('learnerGroup', learnerGroupModel);
+    this.set('addMany', ([ user ]) => {
+      assert.equal(userModel, user);
     });
-
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroup.id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="lastName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{noop}}
       @isEditing={{true}}
-      @addUserToGroup={{action nothing}}
-      @removeUserFromGroup={{action nothing}}
-      @addUsersToGroup={{action addMany}}
-      @removeUsersFromGroup={{action nothing}}
+      @addUserToGroup={{noop}}
+      @removeUserFromGroup={{noop}}
+      @addUsersToGroup={{this.addMany}}
+      @removeUsersFromGroup={{noop}}
     />`);
 
     assert.dom(button).doesNotExist();
@@ -232,32 +254,34 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
     const user1CheckBox = 'table:nth-of-type(2) tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
     const button = 'button.cancel';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const user = this.server.create('user', { enabled: true, learnerGroups: [ learnerGroup ] });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    const userModelProxy = ObjectProxy.create({
+      content: userModel,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
     });
 
-    this.set('users', [ObjectProxy.create({content: user1})]);
-    this.set('nothing', parseInt);
-    this.set('removeMany', ([user]) => {
-      assert.equal(user, user1);
+    this.set('users', [ userModelProxy ]);
+    this.set('learnerGroup', learnerGroupModel);
+    this.set('removeMany', ([ user ]) => {
+      assert.equal(userModel, user);
     });
-
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroup.id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="lastName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{noop}}
       @isEditing={{true}}
-      @addUserToGroup={{action nothing}}
-      @removeUserFromGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
-      @removeUsersFromGroup={{action removeMany}}
+      @addUserToGroup={{noop}}
+      @removeUserFromGroup={{noop}}
+      @addUsersToGroup={{noop}}
+      @removeUsersFromGroup={{this.removeMany}}
     />`);
 
     assert.dom(button).doesNotExist();
@@ -271,34 +295,37 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
 
   test('remove single user', async function(assert) {
     assert.expect(1);
-    const action = 'table:nth-of-type(2) tbody tr:nth-of-type(1) td:nth-of-type(7) .clickable';
+    const action = 'table:nth-of-type(2) tbody tr:nth-of-type(1) td:nth-of-type(6) .clickable';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const user = this.server.create('user', { enabled: true, learnerGroups: [ learnerGroup ] });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    const userModelProxy = ObjectProxy.create({
+      content: userModel,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
     });
 
-    this.set('users', [ObjectProxy.create({content: user1})]);
-    this.set('nothing', parseInt);
-    this.set('removeOne', (user) => {
-      assert.equal(user1, user);
+    this.set('users', [ userModelProxy ]);
+    this.set('learnerGroup', learnerGroupModel);
+    this.set('removeOne', user => {
+      assert.equal(userModel, user);
     });
 
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroup.id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="lastName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{noop}}
       @isEditing={{true}}
-      @addUserToGroup={{action nothing}}
-      @removeUserFromGroup={{action removeOne}}
-      @addUsersToGroup={{action nothing}}
-      @removeUsersFromGroup={{action nothing}}
+      @addUserToGroup={{noop}}
+      @removeUserFromGroup={{this.removeOne}}
+      @addUsersToGroup={{noop}}
+      @removeUsersFromGroup={{noop}}
     />`);
 
     await click(action);
@@ -307,76 +334,83 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
 
   test('add single user', async function(assert) {
     assert.expect(1);
-    const action = 'table:nth-of-type(3) tbody tr:nth-of-type(1) td:nth-of-type(7) .clickable';
+    const action = 'table:nth-of-type(3) tbody tr:nth-of-type(1) td:nth-of-type(6) .clickable';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-      lowestGroupInTree: EmberObject.create({
-        id: 2
-      }),
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup2 = this.server.create('learnerGroup', { id: 2 });
+    const user = this.server.create('user', { enabled: true, learnerGroups: [ learnerGroup2 ] });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    const learnerGroupModel2 = await this.owner.lookup('service:store').find('learner-group', learnerGroup2.id);
+    const userModelProxy = ObjectProxy.create({
+      content: userModel,
+      lowestGroupInTree: learnerGroupModel2,
+      lowestGroupInTreeTitle: learnerGroupModel2.title
     });
 
-    this.set('users', [ObjectProxy.create({content: user1})]);
-    this.set('nothing', parseInt);
-    this.set('addOne', (user) => {
-      assert.equal(user1, user);
+    this.set('users', [ userModelProxy ]);
+    this.set('learnerGroup', learnerGroupModel);
+    this.set('addOne', user => {
+      assert.equal(userModel, user);
     });
 
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroupModel.id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="lastName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{noop}}
       @isEditing={{true}}
-      @addUserToGroup={{action addOne}}
-      @removeUserFromGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
-      @removeUsersFromGroup={{action nothing}}
+      @addUserToGroup={{this.addOne}}
+      @removeUserFromGroup={{noop}}
+      @addUsersToGroup={{noop}}
+      @removeUsersFromGroup={{noop}}
     />`);
-
     await click(action);
-
   });
 
   test('when users are selected single action is disabled', async function(assert) {
     assert.expect(2);
     const user1CheckBox = 'table:nth-of-type(2) tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
-    const action1 = 'table:nth-of-type(2) tbody tr:nth-of-type(1) td:nth-of-type(7) .clickable';
-    const action2 = 'table:nth-of-type(3) tbody tr:nth-of-type(1) td:nth-of-type(7) .clickable';
+    const action1 = 'table:nth-of-type(2) tbody tr:nth-of-type(1) td:nth-of-type(6) .clickable';
+    const action2 = 'table:nth-of-type(3) tbody tr:nth-of-type(1) td:nth-of-type(6) .clickable';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup2 = this.server.create('learnerGroup', { id: 2 });
+    const user = this.server.create('user', { enabled: true, learnerGroups: [ learnerGroup ] });
+    const user2 = this.server.create('user', { enabled: true, learnerGroups: [ learnerGroup2 ] });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    const learnerGroupModel2 = await this.owner.lookup('service:store').find('learner-group', learnerGroup2.id);
+    const userModelProxy = ObjectProxy.create({
+      content: userModel,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
+    });
+    const userModelProxy2 = ObjectProxy.create({
+      content: userModel2,
+      lowestGroupInTree: learnerGroupModel2,
+      lowestGroupInTreeTitle: learnerGroupModel2.title
     });
 
-    const user2 = EmberObject.create({
-      enabled: true,
-      lowestGroupInTree: EmberObject.create({
-        id: 2
-      }),
-    });
-
-    this.set('users', [ObjectProxy.create({content: user1}), ObjectProxy.create({content: user2})]);
-    this.set('nothing', parseInt);
-
+    this.set('users', [ userModelProxy, userModelProxy2 ]);
+    this.set('learnerGroup', learnerGroupModel);
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroup.id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="lastName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{noop}}
       @isEditing={{true}}
-      @addUserToGroup={{action nothing}}
-      @removeUserFromGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
-      @removeUsersFromGroup={{action nothing}}
+      @addUserToGroup={{noop}}
+      @removeUserFromGroup={{noop}}
+      @addUsersToGroup={{noop}}
+      @removeUsersFromGroup={{noop}}
     />`);
 
     await click(user1CheckBox);
@@ -392,39 +426,43 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
     const user2CheckBox = 'tbody tr:nth-of-type(2) td:nth-of-type(1) input[type=checkbox]';
     const button = 'button.done';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const user = this.server.create('user', { enabled: true, learnerGroups: [ learnerGroup ] });
+    const user2 = this.server.create('user', { enabled: true, learnerGroups: [ learnerGroup ] });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    const userModelProxy = ObjectProxy.create({
+      content: userModel,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
     });
-    const user2 = EmberObject.create({
-      enabled: true,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+    const userModelProxy2 = ObjectProxy.create({
+      content: userModel2,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
     });
 
-    this.set('users', [ObjectProxy.create({content: user1}), ObjectProxy.create({content: user2})]);
-    this.set('nothing', parseInt);
+    this.set('users', [ userModelProxy, userModelProxy2 ]);
     this.set('addMany', ([userA, userB]) => {
-      assert.equal(user1, userA);
-      assert.equal(user2, userB);
+      assert.equal(userModel, userA);
+      assert.equal(userModel2, userB);
     });
+    this.set('learnerGroup', learnerGroupModel);
 
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroup.id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="lastName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{noop}}
       @isEditing={{true}}
-      @addUserToGroup={{action nothing}}
-      @removeUserFromGroup={{action nothing}}
-      @addUsersToGroup={{action addMany}}
-      @removeUsersFromGroup={{action nothing}}
+      @addUserToGroup={{noop}}
+      @removeUserFromGroup={{noop}}
+      @addUsersToGroup={{this.addMany}}
+      @removeUsersFromGroup={{noop}}
     />`);
 
     await click(checkAllBox);
@@ -441,35 +479,39 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
     const user1CheckBox = 'tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
     const user2CheckBox = 'tbody tr:nth-of-type(2) td:nth-of-type(1) input[type=checkbox]';
 
-    const user1 = EmberObject.create({
-      enabled: true,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const user = this.server.create('user', { enabled: true, learnerGroups: [ learnerGroup ] });
+    const user2 = this.server.create('user', { enabled: true, learnerGroups: [ learnerGroup ] });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    const userModelProxy = ObjectProxy.create({
+      content: userModel,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
     });
-    const user2 = EmberObject.create({
-      enabled: true,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+    const userModelProxy2 = ObjectProxy.create({
+      content: userModel2,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
     });
 
-    this.set('users', [ObjectProxy.create({content: user1}), ObjectProxy.create({content: user2})]);
-    this.set('nothing', parseInt);
+    this.set('users', [ userModelProxy, userModelProxy2 ]);
+    this.set('learnerGroup', learnerGroupModel);
 
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroup.id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="lastName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{noop}}
       @isEditing={{true}}
-      @addUserToGroup={{action nothing}}
-      @removeUserFromGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
-      @removeUsersFromGroup={{action nothing}}
+      @addUserToGroup={{noop}}
+      @removeUserFromGroup={{noop}}
+      @addUsersToGroup={{noop}}
+      @removeUsersFromGroup={{noop}}
     />`);
 
     await click(user1CheckBox);
@@ -491,29 +533,31 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
     const userCheckbox = 'tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
     const userDisabledIcon = 'tbody tr:nth-of-type(1) td:nth-of-type(1) .fa-user-times';
 
-    const user1 = EmberObject.create({
-      enabled: false,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const user = this.server.create('user', { enabled: false, learnerGroups: [ learnerGroup ] });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    const userModelProxy = ObjectProxy.create({
+      content: userModel,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
     });
 
-    this.set('users', [ObjectProxy.create({content: user1})]);
-    this.set('nothing', parseInt);
-
+    this.set('users', [ userModelProxy ]);
+    this.set('learnerGroup', learnerGroupModel);
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroup.id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="lastName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{noop}}
       @isEditing={{true}}
-      @addUserToGroup={{action nothing}}
-      @removeUserFromGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
-      @removeUsersFromGroup={{action nothing}}
+      @addUserToGroup={{noop}}
+      @removeUserFromGroup={{noop}}
+      @addUsersToGroup={{noop}}
+      @removeUsersFromGroup={{noop}}
     />`);
 
     assert.equal(1, findAll(userCheckbox).length, 'Checkbox visible');
@@ -530,29 +574,31 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
     const userCheckbox = 'tbody tr:nth-of-type(1) td:nth-of-type(1) input[type=checkbox]';
     const userDisabledIcon = 'tbody tr:nth-of-type(1) td:nth-of-type(1) .fa-user-times';
 
-    const user1 = EmberObject.create({
-      enabled: false,
-      lowestGroupInTree: EmberObject.create({
-        id: 1
-      }),
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const user = this.server.create('user', { enabled: false, learnerGroups: [ learnerGroup ] });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
+    const userModelProxy = ObjectProxy.create({
+      content: userModel,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
     });
 
-    this.set('users', [ObjectProxy.create({content: user1})]);
-    this.set('nothing', parseInt);
-
+    this.set('users', [ userModelProxy ]);
+    this.set('learnerGroup', learnerGroupModel);
     await render(hbs`<LearnergroupUserManager
-      @learnerGroupId={{1}}
+      @learnerGroupId={{this.learnerGroup.id}}
       @learnerGroupTitle="this group"
       @topLevelGroupTitle="top group"
       @cohortTitle="this cohort"
-      @users={{users}}
-      @sortBy="lastName"
-      @setSortBy={{action nothing}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{noop}}
       @isEditing={{true}}
-      @addUserToGroup={{action nothing}}
-      @removeUserFromGroup={{action nothing}}
-      @addUsersToGroup={{action nothing}}
-      @removeUsersFromGroup={{action nothing}}
+      @addUserToGroup={{noop}}
+      @removeUserFromGroup={{noop}}
+      @addUsersToGroup={{noop}}
+      @removeUsersFromGroup={{noop}}
     />`);
 
     assert.equal(0, findAll(userCheckbox).length, 'Checkbox is not visible');

--- a/tests/integration/components/learnergroup-user-manager-test.js
+++ b/tests/integration/components/learnergroup-user-manager-test.js
@@ -154,10 +154,11 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
     assert.dom(user2Email).hasText('testemail2');
   });
 
-  test('sort by fullName', async function(assert) {
+  test('sort by full name', async function(assert) {
     const userList = 'tbody tr';
     const user1FullName = 'tbody tr:nth-of-type(1) td:nth-of-type(2)';
     const user2FullName = 'tbody tr:nth-of-type(2) td:nth-of-type(2)';
+    const user3FullName = 'tbody tr:nth-of-type(3) td:nth-of-type(2)';
 
     const learnerGroup = this.server.create('learnerGroup', { id: 1 });
     const user1 = this.server.create('user', {
@@ -168,8 +169,14 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
       firstName: 'Jackson',
       learnerGroups: [ learnerGroup ],
     });
+    const user3 = this.server.create('user', {
+      firstName: 'Jayden',
+      displayName: 'Captain J',
+      learnerGroups: [ learnerGroup ],
+    });
     const userModel1 = await this.owner.lookup('service:store').find('user', user1.id);
     const userModel2 = await this.owner.lookup('service:store').find('user', user2.id);
+    const userModel3 = await this.owner.lookup('service:store').find('user', user3.id);
     const learnerGroupModel = await this.owner.lookup('service:store').find('learner-group', learnerGroup.id);
     const userModelProxy1 = ObjectProxy.create({
       content: userModel1,
@@ -181,8 +188,13 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
       lowestGroupInTree: learnerGroupModel,
       lowestGroupInTreeTitle: learnerGroupModel.title
     });
+    const userModelProxy3 = ObjectProxy.create({
+      content: userModel3,
+      lowestGroupInTree: learnerGroupModel,
+      lowestGroupInTreeTitle: learnerGroupModel.title
+    });
 
-    this.set('users', [ userModelProxy1, userModelProxy2 ]);
+    this.set('users', [ userModelProxy1, userModelProxy2, userModelProxy3 ]);
     this.set('learnerGroup', learnerGroupModel );
     await render(hbs`<LearnergroupUserManager
       @learnerGroupId={{this.learnerGroup.Id}}
@@ -199,9 +211,10 @@ module('Integration | Component | learnergroup user manager', function(hooks) {
       @removeUsersFromGroup={{noop}}
     />`);
 
-    assert.dom(userList).exists({ count: 2 });
-    assert.dom(user1FullName).hasText('Jackson M. Mc1son');
-    assert.dom(user2FullName).hasText('Jasper M. Mc0son');
+    assert.dom(userList).exists({ count: 3 });
+    assert.dom(user1FullName).hasText('Captain J');
+    assert.dom(user2FullName).hasText('Jackson M. Mc1son');
+    assert.dom(user3FullName).hasText('Jasper M. Mc0son');
   });
 
   test('add multiple users', async function(assert) {

--- a/tests/pages/components/learnergroup-user-manager.js
+++ b/tests/pages/components/learnergroup-user-manager.js
@@ -8,17 +8,15 @@ import {
 const definition = {
   scope: '[data-test-learnergroup-user-manager]',
   usersInCurrentGroup: collection('[data-test-users-in-current-group] tr', {
-    firstName: text('td', {at: 1}),
-    lastName: text('td', {at: 2}),
-    campusId: text('td', {at: 3}),
-    email: text('td', {at: 4}),
+    fullName: text('td', {at: 1}),
+    campusId: text('td', {at: 2}),
+    email: text('td', {at: 3}),
     remove: clickable('.no.clickable'),
   }),
   usersNotInCurrentGroup: collection('[data-test-users-not-in-current-group] tr', {
-    firstName: text('td', {at: 1}),
-    lastName: text('td', {at: 2}),
-    campusId: text('td', {at: 3}),
-    email: text('td', {at: 4}),
+    fullName: text('td', {at: 1}),
+    campusId: text('td', {at: 2}),
+    email: text('td', {at: 3}),
     remove: clickable('.no.clickable'),
 
   }),

--- a/tests/pages/learner-group.js
+++ b/tests/pages/learner-group.js
@@ -38,18 +38,20 @@ export default create({
       item: {
         isValid: hasClass('fa-check', 'svg', { scope: 'td:nth-of-type(1)'}),
         hasWarning: hasClass('fa-exclamation-triangle', 'svg', { scope: 'td:nth-of-type(1)'}),
-        fullName: text('td', { at: 1 }),
-        campusId: text('td', { at: 2 }),
-        smallGroupName: text('td', { at: 3 }),
+        firstName: text('td', { at: 1 }),
+        lastName: text('td', { at: 2 }),
+        campusId: text('td', { at: 3 }),
+        smallGroupName: text('td', { at: 4 }),
       }
     }),
     invalidUploadedUsers: collection({
       itemScope: '[data-test-upload-data-invalid-users] tbody tr',
       item: {
-        fullName: text('td', { at: 0 }),
-        campusId: text('td', { at: 1 }),
-        smallGroupName: text('td', { at: 2 }),
-        errors: text('td', { at: 3 }),
+        firstName: text('td', { at: 0 }),
+        lastName: text('td', { at: 1 }),
+        campusId: text('td', { at: 2 }),
+        smallGroupName: text('td', { at: 3 }),
+        errors: text('td', { at: 4 }),
       }
     }),
     showConfirmUploadButton: isVisible('[data-test-upload-data-confirm]'),

--- a/tests/pages/learner-group.js
+++ b/tests/pages/learner-group.js
@@ -38,20 +38,18 @@ export default create({
       item: {
         isValid: hasClass('fa-check', 'svg', { scope: 'td:nth-of-type(1)'}),
         hasWarning: hasClass('fa-exclamation-triangle', 'svg', { scope: 'td:nth-of-type(1)'}),
-        firstName: text('td', { at: 1 }),
-        lastName: text('td', { at: 2 }),
-        campusId: text('td', { at: 3 }),
-        smallGroupName: text('td', { at: 4 }),
+        fullName: text('td', { at: 1 }),
+        campusId: text('td', { at: 2 }),
+        smallGroupName: text('td', { at: 3 }),
       }
     }),
     invalidUploadedUsers: collection({
       itemScope: '[data-test-upload-data-invalid-users] tbody tr',
       item: {
-        firstName: text('td', { at: 0 }),
-        lastName: text('td', { at: 1 }),
-        campusId: text('td', { at: 2 }),
-        smallGroupName: text('td', { at: 3 }),
-        errors: text('td', { at: 4 }),
+        fullName: text('td', { at: 0 }),
+        campusId: text('td', { at: 1 }),
+        smallGroupName: text('td', { at: 2 }),
+        errors: text('td', { at: 3 }),
       }
     }),
     showConfirmUploadButton: isVisible('[data-test-upload-data-confirm]'),
@@ -92,10 +90,9 @@ export default create({
     scope: '.cohortmembers',
     list: collection('tbody tr', {
       scope: '.list',
-      firstName: text('td', {at: 1}),
-      lastName: text('td', {at: 2}),
-      campusId: text('td', { at: 3 }),
-      email: text('td', { at: 4 }),
+      fullName: text('td', {at: 1 }),
+      campusId: text('td', { at: 2 }),
+      email: text('td', { at: 3 }),
       add: clickable('.yes.clickable'),
     }),
   }


### PR DESCRIPTION
Replace the first and last-name columns with one "name" column that considers user preferred names, if given.

Full name will use display-name ("preferred name") if given, otherwise it will fall back to firstname + middlename + lastname.