### PR TITLE
Task: remove deprecation for runDisposables

### DIFF
--- a/app/components/connection-status.js
+++ b/app/components/connection-status.js
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency-decorators';
 import { timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
-import { addEventListener, runDisposables } from 'ember-lifeline';
+import { addEventListener } from 'ember-lifeline';
 
 export default class ConnectionStatusComponent extends Component {
   @tracked isOnline = true;
@@ -23,10 +23,6 @@ export default class ConnectionStatusComponent extends Component {
     addEventListener(this, window, 'offline', () => {
       this.changeConnectionState.perform(false);
     });
-  }
-
-  willDestroy() {
-    runDisposables(this);
   }
 
   @restartableTask


### PR DESCRIPTION
Working through an external partner issue with Ember Data and came across this and decided to put up a simple PR!

Ref PR https://github.com/ember-lifeline/ember-lifeline/pull/852 

https://github.com/ember-lifeline/ember-lifeline/blob/master/CHANGELOG.md#v600-2020-08-03

<img width="979" alt="Screen Shot 2020-08-22 at 11 26 10 AM" src="https://user-images.githubusercontent.com/7374640/90963315-77288800-e46b-11ea-9d57-a1eff3033f89.png">
