### PR TITLE
rm explicit dependency on ember-inflector.

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "ember-cli-uglify": "^3.0.0",
     "ember-cp-validations": "^4.0.0-beta.10",
     "ember-export-application-global": "^2.0.1",
-    "ember-inflector": "^3.0.0",
     "ember-link-action": "^2.0.0",
     "ember-load": "0.0.17",
     "ember-load-initializers": "^2.1.1",


### PR DESCRIPTION
we're getting inflector out of common now.