### PR TITLE
rm direct dependency on ember-cli-flash.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "ember-cli-deploy-revision-data": "1.0.0",
     "ember-cli-deploy-s3-index": "1.2.0",
     "ember-cli-deprecation-workflow": "1.0.1",
-    "ember-cli-flash": "1.9.0",
     "ember-cli-htmlbars": "^5.2.0",
     "ember-cli-image-transformer": "^4.0.3",
     "ember-cli-inject-live-reload": "^2.0.2",


### PR DESCRIPTION
we're getting this from common already, remove it.

refs https://github.com/ilios/frontend/pull/5767