### PR TITLE
give the my-courses table some room inside its container.

### DIFF
--- a/app/components/dashboard-mycourses.hbs
+++ b/app/components/dashboard-mycourses.hbs
@@ -7,39 +7,27 @@
   <div class="dashboard-block-body">
     {{#if (is-array this.listOfCourses)}}
       {{#if this.listOfCourses.length}}
-        <table>
-          <tbody>
-            {{#each (sort-by "year" "title" this.listOfCourses) as |course|}}
-              {{#if this.canEditCourses}}
-                <tr class="clickable">
-                  <td>
-                    <LinkTo @route="course" @model={{course}}>
-                      <FaIcon @icon="external-link-square-alt" />
-                      {{course.academicYear}}
-                    </LinkTo>
-                  </td>
-                  <td>
-                    <LinkTo @route="course" @model={{course}}>
-                      {{course.title}}
-                      {{#if course.externalId}}
-                        ({{course.externalId}})
-                      {{/if}}
-                    </LinkTo>
-                  </td>
-                </tr>
-              {{else}}
-                <tr>
-                  <td>
-                    {{course.academicYear}}
-                  </td>
-                  <td>
-                    {{course.title}}
-                  </td>
-                </tr>
-              {{/if}}
-            {{/each}}
-          </tbody>
-        </table>
+        <ul>
+          {{#each (sort-by "year" "title" this.listOfCourses) as |course|}}
+            {{#if this.canEditCourses}}
+              <li>
+                <LinkTo @route="course" @model={{course}}>
+                  <FaIcon @icon="external-link-square-alt" />
+                  {{course.academicYear}}
+                  {{course.title}}
+                  {{#if course.externalId}}
+                    ({{course.externalId}})
+                  {{/if}}
+                </LinkTo>
+              </li>
+            {{else}}
+              <li>
+                {{course.academicYear}}
+                {{course.title}}
+              </li>
+            {{/if}}
+          {{/each}}
+        </ul>
       {{else}}
         {{t "general.none"}}
       {{/if}}

--- a/app/components/dashboard-mycourses.hbs
+++ b/app/components/dashboard-mycourses.hbs
@@ -1,16 +1,16 @@
-<div class="dashboard-mycourses" ...attributes>
+<div class="dashboard-mycourses" data-test-dashboard-mycourses ...attributes>
   <div class="dashboard-block-header">
-    <h3>
+    <h3 data-test-title>
       {{t "general.myCourses"}}
     </h3>
   </div>
   <div class="dashboard-block-body">
     {{#if (is-array this.listOfCourses)}}
-      {{#if this.listOfCourses.length}}
-        <ul>
+      <ul>
+        {{#if this.listOfCourses.length}}
           {{#each (sort-by "year" "title" this.listOfCourses) as |course|}}
             {{#if this.canEditCourses}}
-              <li>
+              <li data-test-course>
                 <LinkTo @route="course" @model={{course}}>
                   <FaIcon @icon="external-link-square-alt" />
                   {{course.academicYear}}
@@ -21,16 +21,16 @@
                 </LinkTo>
               </li>
             {{else}}
-              <li>
+              <li data-test-course>
                 {{course.academicYear}}
                 {{course.title}}
               </li>
             {{/if}}
           {{/each}}
-        </ul>
-      {{else}}
-        {{t "general.none"}}
-      {{/if}}
+        {{else}}
+          <li data-test-course>{{t "general.none"}}</li>
+        {{/if}}
+      </ul>
     {{else}}
       <LoadingSpinner />
     {{/if}}

--- a/app/styles/components/dashboard-mycourses.scss
+++ b/app/styles/components/dashboard-mycourses.scss
@@ -2,9 +2,9 @@
   @include dashboard-block;
 
   .dashboard-block-body {
-    table {
+    ul {
+      @include ilios-list-reset;
       margin: .5rem;
-      width: auto;
     }
   }
 }

--- a/app/styles/components/dashboard-mycourses.scss
+++ b/app/styles/components/dashboard-mycourses.scss
@@ -3,6 +3,7 @@
 
   .dashboard-block-body {
     table {
+      margin: .5rem;
       width: auto;
     }
   }

--- a/tests/integration/components/dashboard-mycourses-test.js
+++ b/tests/integration/components/dashboard-mycourses-test.js
@@ -4,13 +4,13 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
+import { component } from 'ilios/tests/pages/components/dashboard-mycourses';
 
 module('Integration | Component | dashboard mycourses', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
   test('list courses for privileged users', async function(assert) {
-    assert.expect(10);
     const user = this.server.create('user');
     const jwtObject = {
       'user_id': user.id,
@@ -32,37 +32,20 @@ module('Integration | Component | dashboard mycourses', function(hooks) {
       assert.ok('my' in queryParams);
       return schema.courses.all();
     });
+
     await render(hbs`<DashboardMycourses />`);
 
-    const header = '.dashboard-block-header';
-    const allLinks = `table a`;
-    const courses = `table tr`;
-    const firstCourse = `${courses}:nth-of-type(1)`;
-    const firstCourseYear = `${firstCourse} td:nth-of-type(1)`;
-    const firstCourseTitle = `${firstCourse} td:nth-of-type(2)`;
-    const secondCourse = `${courses}:nth-of-type(2)`;
-    const secondCourseYear = `${secondCourse} td:nth-of-type(1)`;
-    const secondCourseTitle = `${secondCourse} td:nth-of-type(2)`;
-    const thirdCourse = `${courses}:nth-of-type(3)`;
-    const thirdCourseYear = `${thirdCourse} td:nth-of-type(1)`;
-    const thirdCourseTitle = `${thirdCourse} td:nth-of-type(2)`;
-
-    assert.dom(header).hasText('My Courses');
-    assert.dom(allLinks).exists({ count: 6 });
-    assert.dom(courses).exists({ count: 3 });
-
-    assert.dom(firstCourseYear).hasText('2013 - 2014');
-    assert.dom(firstCourseTitle).hasText('course 0 (ABC123)');
-
-    assert.dom(secondCourseYear).hasText('2013 - 2014');
-    assert.dom(secondCourseTitle).hasText('course 1');
-
-    assert.dom(thirdCourseYear).hasText('2013 - 2014');
-    assert.dom(thirdCourseTitle).hasText('course 2');
+    assert.equal(component.title, 'My Courses');
+    assert.equal(component.courses.length, 3);
+    assert.equal(component.courses[0].text, '2013 - 2014 course 0 (ABC123)');
+    assert.equal(component.courses[1].text, '2013 - 2014 course 1');
+    assert.equal(component.courses[2].text, '2013 - 2014 course 2');
+    assert.ok(component.courses[0].isLinked);
+    assert.ok(component.courses[1].isLinked);
+    assert.ok(component.courses[2].isLinked);
   });
 
   test('list courses for un-privileged users', async function(assert) {
-    assert.expect(10);
     const user = this.server.create('user');
     const jwtObject = {
       'user_id': user.id,
@@ -87,35 +70,16 @@ module('Integration | Component | dashboard mycourses', function(hooks) {
 
     await render(hbs`<DashboardMycourses />`);
 
-    const header = '.dashboard-block-header';
-    const allLinks = `table a`;
-    const courses = `table tr`;
-    const firstCourse = `${courses}:nth-of-type(1)`;
-    const firstCourseYear = `${firstCourse} td:nth-of-type(1)`;
-    const firstCourseTitle = `${firstCourse} td:nth-of-type(2)`;
-    const secondCourse = `${courses}:nth-of-type(2)`;
-    const secondCourseYear = `${secondCourse} td:nth-of-type(1)`;
-    const secondCourseTitle = `${secondCourse} td:nth-of-type(2)`;
-    const thirdCourse = `${courses}:nth-of-type(3)`;
-    const thirdCourseYear = `${thirdCourse} td:nth-of-type(1)`;
-    const thirdCourseTitle = `${thirdCourse} td:nth-of-type(2)`;
-
-    assert.dom(header).hasText('My Courses');
-    assert.dom(allLinks).doesNotExist();
-    assert.dom(courses).exists({ count: 3 });
-
-    assert.dom(firstCourseYear).hasText('2013 - 2014');
-    assert.dom(firstCourseTitle).hasText('course 0');
-
-    assert.dom(secondCourseYear).hasText('2013 - 2014');
-    assert.dom(secondCourseTitle).hasText('course 1');
-
-    assert.dom(thirdCourseYear).hasText('2013 - 2014');
-    assert.dom(thirdCourseTitle).hasText('course 2');
+    assert.equal(component.courses.length, 3);
+    assert.equal(component.courses[0].text, '2013 - 2014 course 0');
+    assert.equal(component.courses[1].text, '2013 - 2014 course 1');
+    assert.equal(component.courses[2].text, '2013 - 2014 course 2');
+    assert.notOk(component.courses[0].isLinked);
+    assert.notOk(component.courses[1].isLinked);
+    assert.notOk(component.courses[2].isLinked);
   });
 
   test('display none when no courses', async function(assert) {
-    assert.expect(2);
     await authenticateSession();
     this.server.get('/api/courses', (schema, { queryParams }) => {
       assert.ok('my' in queryParams);
@@ -123,9 +87,8 @@ module('Integration | Component | dashboard mycourses', function(hooks) {
     });
 
     await render(hbs`<DashboardMycourses />`);
-    assert.dom('.dashboard-block-header').hasText('My Courses');
 
-    assert.dom('.dashboard-block-body').hasText('None');
-
+    assert.equal(component.courses.length, 1);
+    assert.equal(component.courses[0].text, 'None');
   });
 });

--- a/tests/pages/components/dashboard-mycourses.js
+++ b/tests/pages/components/dashboard-mycourses.js
@@ -1,0 +1,12 @@
+import { create, collection, isPresent, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-dashboard-mycourses]',
+  title: text('[data-test-title]'),
+  courses: collection('[data-test-course]', {
+    isLinked: isPresent('a'),
+  }),
+};
+
+export default definition;
+export const component = create(definition);


### PR DESCRIPTION

![Selection_154](https://user-images.githubusercontent.com/1410427/103937921-57be8e80-50de-11eb-8793-48acdd737564.png)


~~that should be close enough (not exactly tho). my-reports uses a list to lay out its items, whereas the my-courses uses a table to do so for its items. so there are subtle spacing/padding differences that i don't want to get into.~~
this required changing the my-courses layout from using a table to using a list.


fixes #5783
 