### PR TITLE
Cleanup Application Route

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,111 +1,70 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
-import config from 'ilios/config/environment';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { all } from 'rsvp';
 import * as Sentry from '@sentry/browser';
 import { loadPolyfills } from 'ilios-common/utils/load-polyfills';
 
-export default Route.extend(ApplicationRouteMixin, {
-  currentUser: service(),
-  fetch: service(),
-  intl: service(),
-  moment: service(),
-  session: service(),
-  store: service(),
+export default class AuthenticatedRoute extends Route {
+  @service currentUser;
+  @service intl;
+  @service moment;
+  @service store;
+  @service router;
 
-  init() {
-    this._super(...arguments);
-    this.on('routeWillChange', () => {
+  @tracked event;
+
+  constructor() {
+    super(...arguments);
+    this.router.on('routeWillChange', () => {
       const controller = this.controllerFor('application');
       controller.set('errors', []);
       controller.set('showErrorDisplay', false);
     });
-  },
+  }
 
   async beforeModel() {
     await loadPolyfills();
-    const intl = this.intl;
-    const moment = this.moment;
-    const locale = intl.get('locale');
-    moment.setLocale(locale);
+    const locale = this.intl.get('locale');
+    this.moment.setLocale(locale);
     window.document.querySelector('html').setAttribute('lang', locale);
-  },
+  }
 
   /**
-   * Preload the user model and the users roles
+   * Preload the schools and user roles
    * This makes the initial page rendering (especially the navigation) much smoother
    */
   async afterModel() {
-    const currentUser = this.currentUser;
-    const user = await currentUser.get('model');
-    if (user) {
-      await all([
-        user.get('roles'),
-        this.store.findAll('school')
-      ]);
-    }
-  },
+    await all([
+      this.store.findAll('userRole'),
+      this.store.findAll('school')
+    ]);
+  }
 
   activate() {
     if ('serviceWorker' in navigator) {
       const { controller: currentController } = navigator.serviceWorker;
-      const event = navigator.serviceWorker.addEventListener('controllerchange', async () => {
+      this.event = navigator.serviceWorker.addEventListener('controllerchange', async () => {
         // only reload the page if there was a previously active controller
         if (currentController) {
           window.location.reload();
         }
       });
-      this.set('event', event);
     }
-
-    const session = this.session;
-    session.on('authenticationSucceeded', async () => {
-      if ('serviceWorker' in navigator) {
-        const reg = await navigator.serviceWorker.getRegistration();
-        if (reg && reg.waiting) {
-          reg.waiting.postMessage('skipWaiting');
-        }
-      }
-    });
-    const { currentUserId } = this.currentUser;
-    if (currentUserId) {
-      Sentry.setUser({id: currentUserId});
-    }
-  },
-
-  deactivate() {
-    const event = this.event;
-    if (event && 'serviceWorker' in navigator) {
-      navigator.serviceWorker.removeEventListener(event);
-    }
-  },
-
-  actions: {
-    loading(transition) {
-      const controller = this.controllerFor('application');
-      controller.set('currentlyLoading', true);
-      transition.promise.finally(() => {
-        controller.set('currentlyLoading', false);
-      });
-
-      return true;
-    }
-  },
-
-  //Override the default session invalidator so we can do auth stuff
-  sessionInvalidated() {
-    Sentry.configureScope(scope => scope.clear());
-    if (config.environment !== 'test') {
-      const logoutUrl = '/auth/logout';
-      return this.fetch.getJsonFromApiHost(logoutUrl).then(response => {
-        if(response.status === 'redirect'){
-          window.location.replace(response.logoutUrl);
-        } else {
-          this.flashMessages.success('general.confirmLogout');
-          window.location.replace(config.rootURL);
-        }
-      });
+    if (this.currentUser.currentUserId) {
+      Sentry.setUser({id: this.currentUser.currentUserId});
     }
   }
-});
+
+  @action
+  loading(transition) {
+    const controller = this.controllerFor('application');
+    controller.set('currentlyLoading', true);
+    transition.promise.finally(() => {
+      controller.set('currentlyLoading', false);
+    });
+
+    return true;
+  }
+}

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,0 +1,35 @@
+import ESASessionService from 'ember-simple-auth/services/session';
+import config from 'ilios/config/environment';
+import * as Sentry from '@sentry/browser';
+import { inject as service } from '@ember/service';
+
+export default class SessionService extends ESASessionService {
+  @service fetch;
+  @service currentUser;
+
+  async handleAuthentication() {
+    super.handleAuthentication(...arguments);
+    if ('serviceWorker' in navigator) {
+      const reg = await navigator.serviceWorker.getRegistration();
+      if (reg && reg.waiting) {
+        reg.waiting.postMessage('skipWaiting');
+      }
+    }
+    const user = await this.currentUser.get('model');
+    Sentry.setUser({id: user.id});
+  }
+
+  async handleInvalidation() {
+    Sentry.configureScope(scope => scope.clear());
+    if (config.environment !== 'test') {
+      const logoutUrl = '/auth/logout';
+      return this.fetch.getJsonFromApiHost(logoutUrl).then(response => {
+        if(response.status === 'redirect'){
+          window.location.replace(response.logoutUrl);
+        } else {
+          window.location.replace(config.rootURL);
+        }
+      });
+    }
+  }
+}

--- a/tests/unit/services/session-test.js
+++ b/tests/unit/services/session-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | session', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    const service = this.owner.lookup('service:session');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
Override ESA session service with out own which allows us to ditch events which are now deprecated by ESA and
instead handle our custom auth/setup/teardown logic directly here.

Modernize and cleanup the application route.

Fixes #5848 