### PR TITLE
replaces broken async-process resource with dedicated perms checker resource

### DIFF
--- a/app/classes/permission-checker.js
+++ b/app/classes/permission-checker.js
@@ -1,0 +1,18 @@
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { Resource } from 'ember-could-get-used-to-this';
+export default class PermissionCheckerResources extends Resource {
+  @service permissionChecker;
+  @tracked data;
+
+
+  get value() {
+    return this.data;
+  }
+
+  async setup() {
+    const fnName = this.args.positional[0];
+    //pass any remaining arguments directly to the processor function
+    this.data = await this.permissionChecker[fnName](...this.args.positional.slice(1));
+  }
+}

--- a/app/classes/permission-checker.js
+++ b/app/classes/permission-checker.js
@@ -1,7 +1,8 @@
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { Resource } from 'ember-could-get-used-to-this';
-export default class PermissionCheckerResources extends Resource {
+
+export default class PermissionCheckerResource extends Resource {
   @service permissionChecker;
   @tracked data;
 

--- a/app/components/program-year/list-item.hbs
+++ b/app/components/program-year/list-item.hbs
@@ -78,6 +78,7 @@
             @icon="trash"
             class="clickable remove enabled"
             @click={{set this.showRemoveConfirmation true}}
+            data-test-remove
           />
         {{else}}
           <FaIcon @icon="trash" class="disabled" />

--- a/app/components/program-year/list-item.js
+++ b/app/components/program-year/list-item.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import AsyncProcess from 'ilios-common/classes/resolve-async-value';
+import AsyncProcess from 'ilios-common/classes/async-process';
 import { use } from 'ember-could-get-used-to-this';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';

--- a/app/components/program-year/list-item.js
+++ b/app/components/program-year/list-item.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import AsyncProcess from 'ilios-common/classes/async-process';
+import PermissionChecker from 'ilios/classes/permission-checker';
 import { use } from 'ember-could-get-used-to-this';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
@@ -14,18 +14,9 @@ export default class ProgramYearListItemComponent extends Component {
 
   @use program = new ResolveAsyncValue(() => [this.args.programYear.program]);
   @use cohort = new ResolveAsyncValue(() => [this.args.programYear.cohort]);
-  @use canDeletePermission = new AsyncProcess(() => [
-    this.permissionChecker.canDeleteProgramYear,
-    this.args.programYear,
-  ]);
-  @use canLock = new AsyncProcess(() => [
-    this.permissionChecker.canLockProgramYear,
-    this.args.programYear,
-  ]);
-  @use canUnlock = new AsyncProcess(() => [
-    this.permissionChecker.canUnlockProgramYear,
-    this.args.programYear,
-  ]);
+  @use canDeletePermission = new PermissionChecker(() => ["canDeleteProgramYear", this.args.programYear]);
+  @use canLock = new PermissionChecker(() => ["canLockProgramYear", this.args.programYear]);
+  @use canUnlock = new PermissionChecker(() => ["canUnlockProgramYear", this.args.programYear]);
 
   get canDelete() {
     if (!this.cohort) {

--- a/tests/integration/components/program-year/list-item-test.js
+++ b/tests/integration/components/program-year/list-item-test.js
@@ -84,4 +84,40 @@ module('Integration | Component | program-year/list-item', function(hooks) {
     />`);
     assert.equal(component.link.text, '2012 - 2013');
   });
+
+
+  test('can be deleted', async function(assert) {
+    const school = this.server.create('school');
+    const program = this.server.create('program', { school });
+    const cohort = this.server.create('cohort');
+    const programYear = this.server.create('program-year', { program, cohort });
+    const programYearModel = await this.owner.lookup('service:store').find('program-year', programYear.id);
+
+    this.set('programYear', programYearModel);
+    await render(hbs`<ProgramYear::ListItem
+      @programYear={{this.programYear}}
+      @academicYearCrossesCalendarYearBoundaries={{false}}
+    />`);
+    assert.ok(component.canBeDeleted);
+  });
+
+  test('cannot be deleted', async function(assert) {
+    this.permissionCheckerMock.reopen({
+      canDeleteProgramYear() {
+        return false;
+      },
+    });
+    const school = this.server.create('school');
+    const program = this.server.create('program', { school });
+    const cohort = this.server.create('cohort');
+    const programYear = this.server.create('program-year', { program, cohort });
+    const programYearModel = await this.owner.lookup('service:store').find('program-year', programYear.id);
+
+    this.set('programYear', programYearModel);
+    await render(hbs`<ProgramYear::ListItem
+      @programYear={{this.programYear}}
+      @academicYearCrossesCalendarYearBoundaries={{false}}
+    />`);
+    assert.notOk(component.canBeDeleted);
+  });
 });

--- a/tests/integration/components/program-year/list-item-test.js
+++ b/tests/integration/components/program-year/list-item-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,6 +9,21 @@ import { component } from 'ilios/tests/pages/components/program-year/list-item';
 module('Integration | Component | program-year/list-item', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    this.permissionCheckerMock = Service.extend({
+      canDeleteProgramYear() {
+        return true;
+      },
+      canLockProgramYear() {
+        return true;
+      },
+      canUnlockProgramYear() {
+        return true;
+      }
+    });
+    this.owner.register('service:permissionChecker', this.permissionCheckerMock);
+  });
 
   test('it renders with cohort title', async function(assert) {
     const school = this.server.create('school');

--- a/tests/integration/components/program-year/list-test.js
+++ b/tests/integration/components/program-year/list-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,6 +9,21 @@ import { component } from 'ilios/tests/pages/components/program-year/list';
 module('Integration | Component | program-year/list', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    this.permissionCheckerMock = Service.extend({
+      canDeleteProgramYear() {
+        return true;
+      },
+      canLockProgramYear() {
+        return true;
+      },
+      canUnlockProgramYear() {
+        return true;
+      }
+    });
+    this.owner.register('service:permissionChecker', this.permissionCheckerMock);
+  });
 
   test('it renders short year', async function(assert) {
     this.server.get('application/config', function() {

--- a/tests/pages/components/program-year/list-item.js
+++ b/tests/pages/components/program-year/list-item.js
@@ -1,7 +1,4 @@
-import {
-  create,
-  text,
-} from 'ember-cli-page-object';
+import { create, isVisible, text } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-program-year-list-item]',
@@ -9,6 +6,7 @@ const definition = {
     scope: '[data-test-link]',
   },
   title: text('[data-test-title]'),
+  canBeDeleted: isVisible('[data-test-remove]'),
 };
 
 export default definition;


### PR DESCRIPTION
added here a stop-gap solution, the perms checker resource should be moved into `common` as a follow-up step.