### PR TITLE
Fix bulk user validation class

### DIFF
--- a/app/components/bulk-new-users.js
+++ b/app/components/bulk-new-users.js
@@ -298,8 +298,8 @@ class ProposedUser extends CoreObject {
   addedViaIlios = true;
   enabled = true;
 
-  init(data) {
-    super.init(...arguments);
+  constructor(data) {
+    super(...arguments);
     this.firstName = data.firstName;
     this.lastName = data.lastName;
     this.middleName = data.middleName;


### PR DESCRIPTION
This worked because of a quirk of ember, but a constructor is called for
here not init.