### PR TITLE
Fix column span for learner group list

### DIFF
--- a/app/components/learnergroup-list.hbs
+++ b/app/components/learnergroup-list.hbs
@@ -179,7 +179,7 @@
           {{/if}}
           {{#if (includes learnerGroup this.toCopy)}}
             <tr class="confirm-copy" data-test-confirm-copy>
-              <td colspan={{if (media "isLaptopAndUp") "6" "3"}}>
+              <td colspan={{if (media "isLaptopAndUp") "5" "3"}}>
                 <div class="confirm-buttons">
                   {{#if @canCopyWithLearners}}
                     <button
@@ -221,7 +221,7 @@
           {{/if}}
         {{else}}
           <tr data-test-empty-list>
-            <td class="text-center" colspan={{if (media "isLaptopAndUp") "6" "3"}}>
+            <td class="text-center" colspan={{if (media "isLaptopAndUp") "5" "3"}}>
               <span data-test-title>{{if @query (t "general.noResultsFound") (t "general.none")}}</span>
             </td>
           </tr>


### PR DESCRIPTION
Copying and empty lists were both off by a bit making it all ugly and
stuff.