### PR TITLE
re-layouts instructorgroup header bar

### DIFF
--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/265b0c9d.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/265b0c9d.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":25,"column":32,"createdDate":1615017600000,"warnDate":1617606000000,"errorDate":1620198000000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/2a6a740c.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/2a6a740c.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":9,"column":17,"createdDate":1615017600000,"warnDate":1617606000000,"errorDate":1620198000000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/44a70140.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/44a70140.json
@@ -1,0 +1,1 @@
+{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":39,"column":10,"createdDate":1618988400000,"warnDate":1621580400000,"errorDate":1624172400000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/4a9c994f.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/4a9c994f.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":47,"column":38,"createdDate":1615017600000,"warnDate":1617606000000,"errorDate":1620198000000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/4d5ae12b.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/4d5ae12b.json
@@ -1,0 +1,1 @@
+{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":49,"column":26,"createdDate":1618988400000,"warnDate":1621580400000,"errorDate":1624172400000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/541e0ad8.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/541e0ad8.json
@@ -1,0 +1,1 @@
+{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":20,"column":32,"createdDate":1618988400000,"warnDate":1621580400000,"errorDate":1624172400000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/58bd8b2d.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/58bd8b2d.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":28,"column":18,"createdDate":1615017600000,"warnDate":1617606000000,"errorDate":1620198000000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/62eb7359.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/62eb7359.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-action","line":46,"column":17,"createdDate":1615017600000,"warnDate":1617606000000,"errorDate":1620198000000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/6ba9e73e.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/6ba9e73e.json
@@ -1,0 +1,1 @@
+{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-action","line":41,"column":17,"createdDate":1618988400000,"warnDate":1621580400000,"errorDate":1624172400000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/7c46c9fd.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/7c46c9fd.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-action","line":29,"column":50,"createdDate":1615017600000,"warnDate":1617606000000,"errorDate":1620198000000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/7db120e8.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/7db120e8.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":44,"column":10,"createdDate":1615017600000,"warnDate":1617606000000,"errorDate":1620198000000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/836f93d7.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/836f93d7.json
@@ -1,0 +1,1 @@
+{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":4,"column":17,"createdDate":1618988400000,"warnDate":1621580400000,"errorDate":1624172400000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/8810896a.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/8810896a.json
@@ -1,0 +1,1 @@
+{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":3,"column":23,"createdDate":1618988400000,"warnDate":1621580400000,"errorDate":1624172400000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/88d1e069.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/88d1e069.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":17,"column":24,"createdDate":1615017600000,"warnDate":1617606000000,"errorDate":1620198000000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/9e4c34b2.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/9e4c34b2.json
@@ -1,0 +1,1 @@
+{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":12,"column":24,"createdDate":1618988400000,"warnDate":1621580400000,"errorDate":1624172400000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/9eced22b.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/9eced22b.json
@@ -1,0 +1,1 @@
+{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":51,"column":42,"createdDate":1618988400000,"warnDate":1621580400000,"errorDate":1624172400000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/c0ddda67.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/c0ddda67.json
@@ -1,0 +1,1 @@
+{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-action","line":24,"column":50,"createdDate":1618988400000,"warnDate":1621580400000,"errorDate":1624172400000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/c2c1e379.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/c2c1e379.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":54,"column":26,"createdDate":1615017600000,"warnDate":1617606000000,"errorDate":1620198000000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/c9ca894b.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/c9ca894b.json
@@ -1,0 +1,1 @@
+{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":42,"column":38,"createdDate":1618988400000,"warnDate":1621580400000,"errorDate":1624172400000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/de598e26.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/de598e26.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":56,"column":42,"createdDate":1615017600000,"warnDate":1617606000000,"errorDate":1620198000000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/eca1b189.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/eca1b189.json
@@ -1,0 +1,1 @@
+{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":23,"column":18,"createdDate":1618988400000,"warnDate":1621580400000,"errorDate":1624172400000}

--- a/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/ffffd0d5.json
+++ b/.lint-todo/a27e6658b20f4deb1f2438afb329d41a93e6e9c5/ffffd0d5.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/instructorgroup-details.hbs","ruleId":"no-implicit-this","line":8,"column":23,"createdDate":1615017600000,"warnDate":1617606000000,"errorDate":1620198000000}

--- a/app/components/instructorgroup-details.hbs
+++ b/app/components/instructorgroup-details.hbs
@@ -1,9 +1,4 @@
 <div class="instructorgroup-details" ...attributes>
-  <div class="backtolink">
-    <LinkTo @route="instructorGroups">
-      {{t "general.backToInstructorGroups"}}
-    </LinkTo>
-  </div>
   <InstructorgroupHeader
     @instructorGroup={{instructorGroup}}
     @canUpdate={{canUpdate}}

--- a/app/components/instructorgroup-header.hbs
+++ b/app/components/instructorgroup-header.hbs
@@ -7,9 +7,10 @@
 >
   {{! template-lint-disable no-bare-strings }}
   <div class="header-bar">
-    <span class="title" data-test-title>
+    <span class="title">
       {{#if @canUpdate}}
         <EditableField
+          data-test-title
           @value={{this.title}}
           @save={{perform this.changeTitle}}
           @close={{this.revertTitleChanges}}
@@ -41,7 +42,7 @@
       {{@instructorGroup.users.length}}
     </span>
   </div>
-  <div class="breadcrumbs">
+  <div class="breadcrumbs" data-test-breadcrumb>
     <span>
       <LinkTo @route="instructorGroups">
         {{t "general.instructorGroups"}}

--- a/app/components/instructorgroup-header.hbs
+++ b/app/components/instructorgroup-header.hbs
@@ -6,45 +6,59 @@
   ...attributes
 >
   {{! template-lint-disable no-bare-strings }}
-  <div class="title" data-test-title>
-    <h4
-      class="school-title"
-      data-test-school-title
-    >
-      {{@instructorGroup.school.title}}
-      &gt;
-    </h4>
-    {{#if @canUpdate}}
-      <EditableField
-        data-test-group-title
-        @value={{this.title}}
-        @save={{perform this.changeTitle}}
-        @close={{this.revertTitleChanges}}
-        @saveOnEnter={{true}}
-        @closeOnEscape={{true}} as |isSaving|
-      >
-        <input
-          aria-label={{t "general.instructorGroupTitle"}}
-          type="text"
-          value={{this.title}}
-          disabled={{isSaving}}
-          {{on "input" (pick "target.value" (set this.title))}}
-          {{on "keyup" (fn this.addErrorDisplayFor "title")}}
+  <div class="header-bar">
+    <span class="title" data-test-title>
+      {{#if @canUpdate}}
+        <EditableField
+          @value={{this.title}}
+          @save={{perform this.changeTitle}}
+          @close={{this.revertTitleChanges}}
+          @saveOnEnter={{true}}
+          @closeOnEscape={{true}} as |isSaving|
         >
-        {{#each (await (compute this.getErrorsFor "title")) as |message|}}
-          <span class="validation-error-message">
-            {{message}}
-          </span>
-        {{/each}}
-      </EditableField>
-    {{else}}
-      <h4 data-test-group-title>
-        {{this.title}}
-      </h4>
-    {{/if}}
+          <input
+            aria-label={{t "general.instructorGroupTitle"}}
+            type="text"
+            value={{this.title}}
+            disabled={{isSaving}}
+            {{on "input" (pick "target.value" (set this.title))}}
+            {{on "keyup" (fn this.addErrorDisplayFor "title")}}
+          >
+          {{#each (await (compute this.getErrorsFor "title")) as |message|}}
+            <span class="validation-error-message">
+              {{message}}
+            </span>
+          {{/each}}
+        </EditableField>
+      {{else}}
+        <h2 data-test-title>
+          {{this.title}}
+        </h2>
+      {{/if}}
+    </span>
+    <span class="info" data-test-members>
+      {{t "general.members"}}:
+      {{@instructorGroup.users.length}}
+    </span>
   </div>
-  <span class="info" data-test-members>
-    {{t "general.members"}}:
-    {{@instructorGroup.users.length}}
-  </span>
+  <div class="breadcrumbs">
+    <span>
+      <LinkTo @route="instructorGroups">
+        {{t "general.instructorGroups"}}
+      </LinkTo>
+    </span>
+    <span>
+      <LinkTo
+        @route="instructorGroups"
+        @query={{hash
+          schoolId=(get (await @instructorGroup.school) "id")
+        }}
+      >
+        {{@instructorGroup.school.title}}
+      </LinkTo>
+    </span>
+    <span>
+      {{@instructorGroup.title}}
+    </span>
+  </div>
 </div>

--- a/app/styles/components/instructorgroup-header.scss
+++ b/app/styles/components/instructorgroup-header.scss
@@ -1,35 +1,29 @@
 .instructorgroup-header {
-  background-color: $header-grey;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: .8rem;
-
-  @include for-tablet-and-up {
-    flex-direction: row;
-  }
-
-  .title {
+  .header-bar {
+    background-color: $header-grey;
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
+    padding: .8rem;
 
     @include for-tablet-and-up {
       flex-direction: row;
     }
 
-    .editable,
-    h4 {
-      display: block;
-      font-size: 1.5rem;
+    h2 {
+      @include ilios-heading-h4;
 
       @include for-laptop-and-up {
         display: inline;
       }
     }
 
-    @include for-tablet-and-up {
-      h4 {
-        margin-left: 1rem;
+    .title {
+      @include ilios-heading-h4;
+      flex-grow: 2;
+
+      input {
+        width: 90%;
       }
     }
   }

--- a/tests/acceptance/instructorgroup-test.js
+++ b/tests/acceptance/instructorgroup-test.js
@@ -54,10 +54,12 @@ module('Acceptance | Instructor Group Details', function (hooks) {
   test('check fields', async function (assert) {
     await visit(url);
     assert.equal(currentRouteName(), 'instructorGroup');
-    assert.equal(page.header.schoolTitle, 'school 0 >');
-    assert.equal(page.header.groupTitle.text, 'instructor group 0');
-    assert.equal(page.header.membersInfo, 'Members: 2');
-    assert.equal(page.details.title, 'instructor group 0 Members (2)');
+    assert.equal(page.details.header.title.text, 'instructor group 0');
+    assert.equal(page.details.header.members, 'Members: 2');
+    assert.equal(page.details.header.breadcrumb.crumbs.length, 3);
+    assert.equal(page.details.header.breadcrumb.crumbs[0].text, 'Instructor Groups');
+    assert.equal(page.details.header.breadcrumb.crumbs[1].text, 'school 0');
+    assert.equal(page.details.header.breadcrumb.crumbs[2].text, 'instructor group 0');
 
     assert.equal(page.details.list.length, 2);
     assert.equal(page.details.list[0].name, '1 guy M. Mc1son');
@@ -71,12 +73,12 @@ module('Acceptance | Instructor Group Details', function (hooks) {
   test('change title', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     await visit(url);
-    assert.equal(page.header.groupTitle.text, 'instructor group 0');
-    await page.header.groupTitle.edit();
-    assert.equal(page.header.groupTitle.inputValue, 'instructor group 0');
-    page.header.groupTitle.fillInput('test new title');
-    await page.header.groupTitle.save();
-    assert.equal(page.header.groupTitle.text, 'test new title');
+    assert.equal(page.details.header.title.text, 'instructor group 0');
+    await page.details.header.title.edit();
+    assert.equal(page.details.header.title.value, 'instructor group 0');
+    await page.details.header.title.set('test new title');
+    await page.details.header.title.save();
+    assert.equal(page.details.header.title.text, 'test new title');
   });
 
   test('search instructors', async function (assert) {
@@ -127,8 +129,10 @@ module('Acceptance | Instructor Group Details', function (hooks) {
 
   test('no associated courses', async function (assert) {
     await visit('/instructorgroups/3');
-    assert.equal(page.header.schoolTitle, 'school 0 >');
-    assert.equal(page.header.groupTitle.text, 'instructor group 2');
+    assert.equal(page.details.header.breadcrumb.crumbs.length, 3);
+    assert.equal(page.details.header.breadcrumb.crumbs[0].text, 'Instructor Groups');
+    assert.equal(page.details.header.breadcrumb.crumbs[1].text, 'school 0');
+    assert.equal(page.details.header.breadcrumb.crumbs[2].text, 'instructor group 2');
     assert.equal(page.associatedCourses.text, 'Associated Courses: None');
   });
 });

--- a/tests/integration/components/instructorgroup-header-test.js
+++ b/tests/integration/components/instructorgroup-header-test.js
@@ -31,10 +31,13 @@ module('Integration | Component | instructorgroup header', function (hooks) {
       hbs`<InstructorgroupHeader @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
-    assert.equal(component.schoolTitle, 'Medicine >');
     assert.equal(component.title.text, 'lorem ipsum');
     assert.ok(component.title.isEditable);
     assert.ok(component.members, 'Members: 3');
+    assert.equal(component.breadcrumb.crumbs.length, 3);
+    assert.equal(component.breadcrumb.crumbs[0].text, 'Instructor Groups');
+    assert.equal(component.breadcrumb.crumbs[1].text, 'Medicine');
+    assert.equal(component.breadcrumb.crumbs[2].text, 'lorem ipsum');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -47,7 +50,6 @@ module('Integration | Component | instructorgroup header', function (hooks) {
       hbs`<InstructorgroupHeader @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
-    assert.equal(component.schoolTitle, 'Medicine >');
     assert.equal(component.title.text, 'lorem ipsum');
     assert.notOk(component.title.isEditable);
     assert.ok(component.members, 'Members: 3');

--- a/tests/pages/components/instructorgroup-header.js
+++ b/tests/pages/components/instructorgroup-header.js
@@ -10,9 +10,8 @@ import {
 
 const definition = {
   scope: '[data-test-instructorgroup-header]',
-  schoolTitle: text('[data-test-school-title]'),
   title: {
-    scope: '[data-test-group-title]',
+    scope: '[data-test-title]',
     edit: clickable('[data-test-edit]'),
     set: fillable('input'),
     value: value('input'),
@@ -22,6 +21,10 @@ const definition = {
     isEditable: hasClass('editinplace'),
   },
   members: text('[data-test-members]'),
+  breadcrumb: {
+    scope: '[data-test-breadcrumb]',
+    crumbs: collection('span'),
+  },
 };
 
 export default definition;

--- a/tests/pages/instructor-group.js
+++ b/tests/pages/instructor-group.js
@@ -6,31 +6,16 @@ import {
   fillable,
   hasClass,
   text,
-  value,
   visitable,
 } from 'ember-cli-page-object';
 
+import header from './components/instructorgroup-header';
+
 export default create({
   visit: visitable('/instructorgroups/:instructorGroupId'),
-
-  header: {
-    scope: '.instructorgroup-header',
-    title: text('.title'),
-    schoolTitle: text('.school-title'),
-    groupTitle: {
-      scope: '[data-test-group-title]',
-      text: text(),
-      edit: clickable('.clickable'),
-      fillInput: fillable('input'),
-      inputValue: value('input'),
-      save: clickable('.actions .done'),
-    },
-    membersInfo: text('.info'),
-  },
-
   details: {
     scope: '.instructorgroup-details',
-    title: text('h2'),
+    header,
     list: collection('.instructorgroup-users li', {
       removable: hasClass('clickable'),
       remove: clickable(),


### PR DESCRIPTION
removes the school-prefix from the header bar, and adds a clickable breadcrumb underneath instead.

fixes #5990 

![image](https://user-images.githubusercontent.com/1410427/115607133-7154a200-a299-11eb-8e99-6aca1c144400.png) 
