### PR TITLE
Delete learner group and descendants at the same time

### DIFF
--- a/app/components/learner-groups/list-item.js
+++ b/app/components/learner-groups/list-item.js
@@ -62,8 +62,7 @@ export default class LearnerGroupsListItemComponent extends Component {
   @dropTask
   *remove() {
     const descendants = yield this.args.learnerGroup.allDescendants;
-    yield all(descendants.invoke('destroyRecord'));
-    yield this.args.learnerGroup.destroyRecord();
+    yield all([...descendants.invoke('destroyRecord'), this.args.learnerGroup.destroyRecord()]);
   }
 
   @action


### PR DESCRIPTION
Improvements to ember data will soon cause destroy record to unload at
the same time, this is an issue here because removing the descendants
causes the list to re-render and then the learner group doesn't get
removed.