### PR TITLE
use ember-exam to speed up test runs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14431,6 +14431,441 @@
         "ember-cli-babel": "^7.19.0"
       }
     },
+    "ember-exam": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ember-exam/-/ember-exam-6.1.0.tgz",
+      "integrity": "sha512-H9tg7eUgqkjAsr1/15UzxGyZobGLgsyTi56Ng0ySnkYGCRfvVpwtVc3xgcNOFnUaa9RExUFpxC0adjW3K87Uxw==",
+      "dev": true,
+      "requires": {
+        "@embroider/macros": "^0.36.0",
+        "chalk": "^4.1.0",
+        "cli-table3": "^0.6.0",
+        "debug": "^4.2.0",
+        "ember-auto-import": "^1.10.1",
+        "ember-cli-babel": "^7.21.0",
+        "ember-cli-version-checker": "^5.1.2",
+        "execa": "^4.0.3",
+        "fs-extra": "^9.0.1",
+        "js-yaml": "^3.14.0",
+        "npmlog": "^4.1.2",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.2",
+        "silent-error": "^1.1.1"
+      },
+      "dependencies": {
+        "@embroider/core": {
+          "version": "0.36.0",
+          "resolved": "https://registry.npmjs.org/@embroider/core/-/core-0.36.0.tgz",
+          "integrity": "sha512-J6esENP+aNt+/r070cF1RCJyCi/Rn1I6uFp37vxyLWwvGDuT0E7wGcaPU29VBkBFqxi4Z1n4F796BaGHv+kX6w==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.3",
+            "@babel/parser": "^7.12.3",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.12.1",
+            "@babel/runtime": "^7.12.5",
+            "@babel/traverse": "^7.12.1",
+            "@babel/types": "^7.12.1",
+            "@embroider/macros": "0.36.0",
+            "assert-never": "^1.1.0",
+            "babel-plugin-syntax-dynamic-import": "^6.18.0",
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-persistent-filter": "^3.1.2",
+            "broccoli-plugin": "^4.0.1",
+            "broccoli-source": "^3.0.0",
+            "debug": "^3.1.0",
+            "escape-string-regexp": "^4.0.0",
+            "fast-sourcemap-concat": "^1.4.0",
+            "filesize": "^4.1.2",
+            "fs-extra": "^7.0.1",
+            "fs-tree-diff": "^2.0.0",
+            "handlebars": "^4.4.2",
+            "js-string-escape": "^1.0.1",
+            "jsdom": "^16.4.0",
+            "json-stable-stringify": "^1.0.1",
+            "lodash": "^4.17.10",
+            "pkg-up": "^3.1.0",
+            "resolve": "^1.8.1",
+            "resolve-package-path": "^1.2.2",
+            "semver": "^7.3.2",
+            "strip-bom": "^3.0.0",
+            "typescript-memoize": "^1.0.0-alpha.3",
+            "walk-sync": "^1.1.3",
+            "wrap-legacy-hbs-plugin-if-needed": "^1.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.7",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "fs-extra": {
+              "version": "7.0.1",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+              "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            }
+          }
+        },
+        "@embroider/macros": {
+          "version": "0.36.0",
+          "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-0.36.0.tgz",
+          "integrity": "sha512-w37G4uXG+Wi3K3EHSFBSr/n6kGFXYG8nzZ9ptzDOC7LP3Oh5/MskBnVZW3+JkHXUPEqKsDGlxPxCVpPl1kQyjQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.3",
+            "@babel/traverse": "^7.12.1",
+            "@babel/types": "^7.12.1",
+            "@embroider/core": "0.36.0",
+            "assert-never": "^1.1.0",
+            "ember-cli-babel": "^7.23.0",
+            "lodash": "^4.17.10",
+            "resolve": "^1.8.1",
+            "semver": "^7.3.2"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "async-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.3",
+            "istextorbinary": "^2.5.1",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "rsvp": "^4.8.5",
+            "username-sync": "^1.0.2"
+          }
+        },
+        "broccoli-persistent-filter": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
+          "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
+          "dev": true,
+          "requires": {
+            "async-disk-cache": "^2.0.0",
+            "async-promise-queue": "^1.0.3",
+            "broccoli-plugin": "^4.0.3",
+            "fs-tree-diff": "^2.0.0",
+            "hash-for-dep": "^1.5.0",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "promise-map-series": "^0.2.1",
+            "rimraf": "^3.0.0",
+            "symlink-or-copy": "^1.0.1",
+            "sync-disk-cache": "^2.0.0"
+          }
+        },
+        "broccoli-plugin": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-output-wrapper": "^3.2.5",
+            "fs-merger": "^3.2.1",
+            "promise-map-series": "^0.3.0",
+            "quick-temp": "^0.1.8",
+            "rimraf": "^3.0.2",
+            "symlink-or-copy": "^1.3.1"
+          },
+          "dependencies": {
+            "promise-map-series": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+              "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+              "dev": true
+            }
+          }
+        },
+        "broccoli-source": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-3.0.1.tgz",
+          "integrity": "sha512-ZbGVQjivWi0k220fEeIUioN6Y68xjMy0xiLAc0LdieHI99gw+tafU8w0CggBDYVNsJMKUr006AZaM7gNEwCxEg==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.6.0"
+          }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "editions": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^2.0.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^3.1.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1"
+          },
+          "dependencies": {
+            "resolve-package-path": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+              "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+              "dev": true,
+              "requires": {
+                "path-root": "^0.1.1",
+                "resolve": "^1.17.0"
+              }
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          },
+          "dependencies": {
+            "jsonfile": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+              "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+              }
+            },
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+              "dev": true
+            }
+          }
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "istextorbinary": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+          "dev": true,
+          "requires": {
+            "binaryextensions": "^2.1.2",
+            "editions": "^2.2.0",
+            "textextensions": "^2.5.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "pkg-up": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+          "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "sync-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.6",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "username-sync": "^1.0.2"
+          }
+        },
+        "walk-sync": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+          "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^1.1.1"
+          }
+        }
+      }
+    },
     "ember-export-application-global": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
-    "test:ember": "ember test",
+    "test:ember": "ember exam --split=6 --parallel=6 --load-balance",
     "lint:style": "stylelint app/styles",
     "deploy:production": "ember deploy production --activate",
     "deploy:staging": "ember deploy staging --activate"
@@ -78,6 +78,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-cp-validations": "^4.0.0-beta.10",
+    "ember-exam": "^6.1.0",
     "ember-export-application-global": "^2.0.1",
     "ember-link-action": "^2.0.3",
     "ember-load": "0.0.17",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
-    "test:ember": "ember exam --parallel=6 --load-balance",
+    "test:ember": "ember exam --parallel=16 --load-balance",
     "lint:style": "stylelint app/styles",
     "deploy:production": "ember deploy production --activate",
     "deploy:staging": "ember deploy staging --activate"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
-    "test:ember": "ember exam --split=6 --parallel=6 --load-balance",
+    "test:ember": "ember exam --parallel=6 --load-balance",
     "lint:style": "stylelint app/styles",
     "deploy:production": "ember deploy production --activate",
     "deploy:staging": "ember deploy staging --activate"

--- a/testem.js
+++ b/testem.js
@@ -25,4 +25,5 @@ module.exports = {
       ci: ['--headless', '--window-size=1440,900'].filter(Boolean),
     },
   },
+  parallel: process.env.EMBER_EXAM_SPLIT_COUNT || -1,
 };

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,7 +3,7 @@ import config from 'ilios/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
-import { start } from 'ember-qunit';
+import start from 'ember-exam/test-support/start';
 
 import './helpers/flash-message';
 
@@ -11,4 +11,5 @@ setApplication(Application.create(config.APP));
 
 setup(QUnit.assert);
 
+// Options passed to `start` will be passed-through to ember-qunit or ember-mocha
 start();


### PR DESCRIPTION
`ember-exam` allows for load balancing and parallelizing test runs. I've configured this to balance across 16 partitions to maximize cores used.

Example with:

```
Out of requested 16 browser(s), 16 browser(s) has launched.

1..1139
# tests 1139
# pass  1137
# skip  2
# todo  0
# fail  0

# ok
✨  Done in 159.42s.

```

Example without:

```
1..1124
# tests 1124
# pass  1122
# skip  2
# todo  0
# fail  0

# ok
✨  Done in 311.09s.
```