### PR TITLE
fix did-update modifier usage on SchoolManager

### DIFF
--- a/app/components/school-session-types-collapsed.hbs
+++ b/app/components/school-session-types-collapsed.hbs
@@ -1,7 +1,7 @@
 <section
   class="school-session-types-collapsed"
   {{did-insert (perform this.load) @school}}
-  {{did-update (perform this.load) @school.sessionTypes}}
+  {{did-update (perform this.load) @school}}
   data-test-school-session-types-collapsed
   ...attributes
 >

--- a/tests/integration/components/school-manager-test.js
+++ b/tests/integration/components/school-manager-test.js
@@ -16,7 +16,8 @@ module('Integration | Component | school manager', function (hooks) {
     this.server.createList('vocabulary', 2, { school });
     this.server.createList('sessionType', 2, { school });
     this.server.createList('competency', 2, { school });
-    this.school = await this.owner.lookup('service:store').find('school', school.id);
+    this.store = this.owner.lookup('service:store');
+    this.school = await this.store.findRecord('school', school.id);
   });
 
   test('it renders expanded', async function (assert) {


### PR DESCRIPTION
activating the feature flags for custom-model-classes in EmberData results in us notifying unchanged relationships any time any relationship is change on a record. This is something we will address before release but while debugging the failures in ilios I noticed that one of them was because the update codepath was broken but not tested before (the extra notifications caused it to run).