### PR TITLE
Silence noisy deprecations

### DIFF
--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -19,5 +19,6 @@ window.deprecationWorkflow.config = {
     { handler: 'silence', matchId: 'ember-string.htmlsafe-ishtmlsafe' },
     { handler: 'silence', matchId: 'implicit-injections' }, //https://github.com/simplabs/ember-simple-auth/issues/2302
     { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' }, //https://github.com/emberjs/ember-render-modifiers/issues/32
+    { handler: 'silence', matchId: 'this-property-fallback' },
   ],
 };

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -20,5 +20,6 @@ window.deprecationWorkflow.config = {
     { handler: 'silence', matchId: 'implicit-injections' }, //https://github.com/simplabs/ember-simple-auth/issues/2302
     { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' }, //https://github.com/emberjs/ember-render-modifiers/issues/32
     { handler: 'silence', matchId: 'this-property-fallback' },
+    { handler: 'silence', matchId: 'ember-lifeline-deprecated-addeventlistener' },
   ],
 };

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -17,5 +17,7 @@ window.deprecationWorkflow.config = {
     { handler: 'silence', matchId: 'ember-metal.get-with-default' },
     { handler: 'silence', matchId: 'ember-test-helpers.trigger-event.options-blob-array' },
     { handler: 'silence', matchId: 'ember-string.htmlsafe-ishtmlsafe' },
+    { handler: 'silence', matchId: 'implicit-injections' }, //https://github.com/simplabs/ember-simple-auth/issues/2302
+    { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' }, //https://github.com/emberjs/ember-render-modifiers/issues/32
   ],
 };


### PR DESCRIPTION
Most of these will be fixed with time, the Ember Lifeline is the only one that will need special attention and we'll need to explore some options for adding an event listener to `window` in order to replace that code.