### PR TITLE
Fail tests builds when translations are missing

### DIFF
--- a/config/ember-intl.js
+++ b/config/ember-intl.js
@@ -1,0 +1,5 @@
+module.exports = function (env) {
+  return {
+    errorOnMissingTranslations: env === 'test',
+  };
+};


### PR DESCRIPTION
This is the best defense against this as recommended by the addon
author. Regular builds will show a warning, but test runs will not build
and die with an error message.