### PR TITLE
Manually Register Listener for Connection Status

### DIFF
--- a/.lint-todo/d72a79b4793a0cb7fdab16e52f8415d49295f8c4/6cf70bf7.json
+++ b/.lint-todo/d72a79b4793a0cb7fdab16e52f8415d49295f8c4/6cf70bf7.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/connection-status.hbs","ruleId":"no-implicit-this","line":8,"column":10,"createdDate":1625900400000,"warnDate":1628492400000,"errorDate":1631084400000}

--- a/.lint-todo/d72a79b4793a0cb7fdab16e52f8415d49295f8c4/e1fc1961.json
+++ b/.lint-todo/d72a79b4793a0cb7fdab16e52f8415d49295f8c4/e1fc1961.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/connection-status.hbs","ruleId":"no-implicit-this","line":18,"column":52,"createdDate":1625900400000,"warnDate":1628492400000,"errorDate":1631084400000}

--- a/app/components/connection-status.hbs
+++ b/app/components/connection-status.hbs
@@ -3,9 +3,10 @@
   aria-hidden={{this.isOnline}}
   aria-role={{unless this.isOnline "alert"}}
   {{did-insert this.setup}}
+  {{will-destroy this.teardown}}
 >
   {{#unless this.isOnline}}
-    {{#if unableToReconnect}}
+    {{#if this.unableToReconnect}}
         <span>
           <FaIcon @icon="exclamation-triangle" />
           {{t "general.unableToReconnect"}}
@@ -15,7 +16,7 @@
           <FaIcon @icon="exclamation-circle" />
           {{t "general.connectionLost"}}
           {{#unless this.stopAttemptingToReconnect}}
-            {{t "general.reconnectionSeconds" count=timer}}
+            {{t "general.reconnectionSeconds" count=this.timer}}
           {{/unless}}
         </span>
         <div class="buttons">

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -19,6 +19,5 @@ window.deprecationWorkflow.config = {
     { handler: 'silence', matchId: 'implicit-injections' }, //https://github.com/simplabs/ember-simple-auth/issues/2302
     { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' }, //https://github.com/emberjs/ember-render-modifiers/issues/32
     { handler: 'silence', matchId: 'this-property-fallback' },
-    { handler: 'silence', matchId: 'ember-lifeline-deprecated-addeventlistener' },
   ],
 };


### PR DESCRIPTION
Ember Lifeline's implementation of addEventListener is deprecated in
favor of a modifer based approach.