### PR TITLE
Refactor last remaining async CPs from common

### DIFF
--- a/.lint-todo/531aed479b69af84bfa48439fcd1904da3978700/297840a4.json
+++ b/.lint-todo/531aed479b69af84bfa48439fcd1904da3978700/297840a4.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/user-profile-roles.hbs","ruleId":"no-implicit-this","line":70,"column":37,"createdDate":1625900400000,"warnDate":1628492400000,"errorDate":1631084400000}

--- a/.lint-todo/94299d214b7cd034c0207c4ab9a1e3ec3aa322eb/953f44e2.json
+++ b/.lint-todo/94299d214b7cd034c0207c4ab9a1e3ec3aa322eb/953f44e2.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/user-menu.hbs","ruleId":"no-implicit-this","line":20,"column":19,"createdDate":1625900400000,"warnDate":1628492400000,"errorDate":1631084400000}

--- a/.lint-todo/a1d301c52fa0e70e5b0c86cb0ab2898e390c1b93/bbd80021.json
+++ b/.lint-todo/a1d301c52fa0e70e5b0c86cb0ab2898e390c1b93/bbd80021.json
@@ -1,1 +1,0 @@
-{"engine":"ember-template-lint","filePath":"app/components/user-profile.hbs","ruleId":"no-implicit-this","line":42,"column":24,"createdDate":1625900400000,"warnDate":1628492400000,"errorDate":1631084400000}

--- a/app/components/bulk-new-users.js
+++ b/app/components/bulk-new-users.js
@@ -74,7 +74,7 @@ export default class BulkNewUsersComponent extends Component {
 
   @restartableTask
   *load() {
-    const user = yield this.currentUser.model;
+    const user = yield this.currentUser.getModel();
     this.primarySchool = yield user.school;
     this.schools = yield this.loadSchools.perform();
     this.cohorts = yield this.loadCohorts.perform(this.bestSelectedSchool);

--- a/app/components/curriculum-inventory/reports.js
+++ b/app/components/curriculum-inventory/reports.js
@@ -62,7 +62,7 @@ export default class CurriculumInventoryReportsComponent extends Component {
     this.hasMoreThanOneSchool = this.sortedSchools.length > 1;
 
     if (!this.args.schoolId) {
-      const user = yield this.currentUser.model;
+      const user = yield this.currentUser.getModel();
       this.selectedSchool = yield user.school;
     } else {
       this.selectedSchool = this.args.schools.findBy('id', this.args.schoolId);

--- a/app/components/ilios-users.hbs
+++ b/app/components/ilios-users.hbs
@@ -33,7 +33,7 @@
           <button type="button" {{on "click" (fn @setShowNewUserForm true)}} data-test-show-new-user-form>
             {{t "general.create"}}
           </button>
-          {{#if (not-eq (await this.iliosConfig.userSearchType) "ldap")}}
+          {{#if (not-eq this.userSearchType "ldap")}}
             <button type="button" {{on "click" (fn @setShowBulkNewUserForm true)}} data-test-show-bulk-new-user-form>
               {{t "general.createBulk"}}
             </button>

--- a/app/components/ilios-users.js
+++ b/app/components/ilios-users.js
@@ -10,11 +10,12 @@ export default class IliosUsersComponent extends Component {
   @service iliosConfig;
   @service store;
   @tracked newUserComponent = null;
+  @tracked userSearchType = null;
 
   @restartableTask
   *load() {
-    const userSearchType = yield this.iliosConfig.getUserSearchType();
-    this.newUserComponent = userSearchType === 'ldap' ? 'new-directory-user' : 'new-user';
+    this.userSearchType = yield this.iliosConfig.getUserSearchType();
+    this.newUserComponent = this.userSearchType === 'ldap' ? 'new-directory-user' : 'new-user';
     yield this.searchForUsers.perform();
   }
 

--- a/app/components/new-directory-user.js
+++ b/app/components/new-directory-user.js
@@ -119,9 +119,9 @@ export default class NewDirectoryUserComponent extends Component {
 
   @restartableTask
   *load() {
-    const authType = yield this.iliosConfig.authenticationType;
+    const authType = yield this.iliosConfig.getAuthenticationType();
     this.allowCustomUserName = 'form' === authType;
-    const user = yield this.currentUser.model;
+    const user = yield this.currentUser.getModel();
     this.primarySchool = yield user.school;
     this.schools = yield this.loadSchools();
     this.cohorts = yield this.loadCohorts(this.primarySchool);

--- a/app/components/new-myreport.js
+++ b/app/components/new-myreport.js
@@ -340,14 +340,12 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
    * @public
    */
   schoolList: computed(async function () {
-    const store = this.store;
-
-    const schools = await store.findAll('school');
+    const schools = await this.store.findAll('school');
     return schools.sortBy('title');
   }),
 
   currentSchool: computed(
-    'currentUser.model.school',
+    'currentUser.currentUserId',
     'schoolChanged',
     'selectedSchool',
     async function () {
@@ -362,9 +360,8 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
         return null;
       }
 
-      const currentUser = this.currentUser;
-      const user = await currentUser.get('model');
-      const school = await user.get('school');
+      const user = await this.currentUser.getModel();
+      const school = await user.school;
 
       return school;
     }
@@ -437,7 +434,7 @@ export default Component.extend(Validations, ValidationErrorDisplay, {
     const store = this.store;
     const subject = this.currentSubject;
     const currentUser = this.currentUser;
-    const user = yield currentUser.get('model');
+    const user = yield currentUser.getModel();
     const title = this.title;
     const prepositionalObject = this.currentPrepositionalObject;
     const school = yield this.currentSchool;

--- a/app/components/new-user.js
+++ b/app/components/new-user.js
@@ -64,7 +64,7 @@ export default class NewUserComponent extends Component {
 
   @restartableTask
   *load() {
-    const user = yield this.currentUser.model;
+    const user = yield this.currentUser.getModel();
     this.primarySchool = yield user.school;
     this.schools = yield this.loadSchools();
     this.currentSchoolCohorts = yield this.bestSelectedSchool?.cohorts;

--- a/app/components/user-menu.hbs
+++ b/app/components/user-menu.hbs
@@ -17,7 +17,7 @@
   >
     <FaIcon @icon="user" />
     <span id="user-menu-title">
-      {{get (await currentUser.model) "fullName"}}
+      {{get this.model "fullName"}}
     </span>
   </button>
   {{#if isOpen}}

--- a/app/components/user-menu.js
+++ b/app/components/user-menu.js
@@ -3,12 +3,15 @@ import { schedule } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { use } from 'ember-could-get-used-to-this';
 
 export default class UserMenuComponent extends Component {
   @service intl;
   @service currentUser;
   @tracked isOpen = false;
   @tracked element;
+  @use model = new ResolveAsyncValue(() => [this.currentUser.getModel()]);
 
   @action
   toggleMenu() {

--- a/app/components/user-profile-roles.hbs
+++ b/app/components/user-profile-roles.hbs
@@ -67,7 +67,7 @@
           type="checkbox"
           checked={{this.isEnabled}}
           {{on "click" (set this.isEnabledFlipped (not this.isEnabledFlipped))}}
-          disabled={{if (eq @user.id currentUser.model.id) true}}
+          disabled={{if (eq @user.id this.currentUser.currentUserId) true}}
         >
       {{else}}
         <span class="value {{if this.isEnabled "yes" "no"}}">

--- a/app/components/user-profile.hbs
+++ b/app/components/user-profile.hbs
@@ -39,7 +39,7 @@
       @user={{@user}}
       @isManageable={{and
         @canUpdate
-        (eq (get (await currentUser.model) "id") @user.id)
+        (eq this.currentUser.currentUserId @user.id)
       }}
       @isManaging={{@isManagingIcs}}
       @setIsManaging={{@setIsManagingIcs}}

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -55,9 +55,12 @@ export default Controller.extend({
     }
   ),
 
-  allRelatedCourses: computed('currentUser.model.allRelatedCourses.[]', async function () {
-    const currentUser = this.currentUser;
-    const user = await currentUser.model;
+  userModel: computed('currentUser.currentUserId', async function () {
+    return this.currentUser.getModel();
+  }),
+
+  allRelatedCourses: computed('userModel.allRelatedCourses.[]', async function () {
+    const user = await this.userModel;
     return await user.allRelatedCourses;
   }),
 

--- a/app/routes/assign-students.js
+++ b/app/routes/assign-students.js
@@ -22,7 +22,7 @@ export default class AssignStudentsRoute extends Route {
     const currentUser = this.currentUser;
     const store = this.store;
     const permissionChecker = this.permissionChecker;
-    const user = await currentUser.get('model');
+    const user = await currentUser.getModel();
     const schools = await store.findAll('school');
     const primarySchool = await user.get('school');
     const schoolsWithUpdateUserPermission = await filter(schools.toArray(), async (school) => {

--- a/app/routes/myprofile.js
+++ b/app/routes/myprofile.js
@@ -10,6 +10,6 @@ export default class MyprofileRoute extends Route {
   }
 
   model() {
-    return this.currentUser.get('model');
+    return this.currentUser.getModel();
   }
 }

--- a/app/routes/pending-user-updates.js
+++ b/app/routes/pending-user-updates.js
@@ -26,7 +26,7 @@ export default class PendingUserUpdatesRoute extends Route {
     const schools = await filter(allSchools.toArray(), async (school) => {
       return permissionChecker.canUpdateUserInSchool(school);
     });
-    const user = await currentUser.get('model');
+    const user = await currentUser.getModel();
     const primarySchool = await user.get('school');
     return { primarySchool, schools };
   }

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -8,7 +8,7 @@ export default class SearchRoute extends Route {
 
   async beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    const searchEnabled = await this.iliosConfig.searchEnabled;
+    const searchEnabled = await this.iliosConfig.getSearchEnabled();
     if (!searchEnabled || !this.currentUser.performsNonLearnerFunction) {
       this.transitionTo('dashboard');
     }

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -32,7 +32,7 @@ export default class UserRoute extends Route {
 
     this.set('canUpdate', canUpdate);
 
-    const userSearchType = await this.iliosConfig.userSearchType;
+    const userSearchType = await this.iliosConfig.getUserSearchType();
     if (userSearchType !== 'ldap') {
       await import('zxcvbn');
     }

--- a/app/services/ilios-metrics.js
+++ b/app/services/ilios-metrics.js
@@ -10,8 +10,8 @@ export default Service.extend({
   async setup() {
     const iliosConfig = this.iliosConfig;
     const metrics = this.metrics;
-    const trackingEnabled = await iliosConfig.trackingEnabled;
-    const trackingCode = await iliosConfig.trackingCode;
+    const trackingEnabled = await iliosConfig.getTrackingEnabled();
+    const trackingCode = await iliosConfig.getTrackingCode();
 
     if (!trackingEnabled || isEmpty(trackingCode)) {
       return false;
@@ -33,7 +33,7 @@ export default Service.extend({
 
       if (setupSuccessful) {
         const metrics = this.metrics;
-        const user = await this.currentUser.model;
+        const user = await this.currentUser.getModel();
 
         if (user) {
           metrics.set('context.userId', user.id);

--- a/app/services/reporting.js
+++ b/app/services/reporting.js
@@ -13,8 +13,12 @@ export default Service.extend({
   intl: service(),
   iliosConfig: service(),
 
-  reportsList: computed('currentUser.model.reports.[]', async function () {
-    const user = await this.currentUser.model;
+  model: computed('currentUser.currentUserId', async function () {
+    return this.currentUser.getModel();
+  }),
+
+  reportsList: computed('model.reports.[]', async function () {
+    const user = await this.model;
     return isEmpty(user) ? [] : await user.reports;
   }),
 

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -15,7 +15,7 @@ export default class SessionService extends ESASessionService {
         reg.waiting.postMessage('skipWaiting');
       }
     }
-    const user = await this.currentUser.get('model');
+    const user = await this.currentUser.getModel();
     Sentry.setUser({ id: user.id });
   }
 

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -3,7 +3,6 @@
 window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
   workflow: [
-    { handler: 'silence', matchId: 'common.async-computed' },
     { handler: 'silence', matchId: 'ember-metal.get-with-default' },
     { handler: 'silence', matchId: 'implicit-injections' }, //https://github.com/simplabs/ember-simple-auth/issues/2302
     { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' }, //https://github.com/emberjs/ember-render-modifiers/issues/32

--- a/tests/integration/components/bulk-new-users-test.js
+++ b/tests/integration/components/bulk-new-users-test.js
@@ -1,6 +1,4 @@
-import { resolve } from 'rsvp';
 import Service from '@ember/service';
-import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import {
@@ -35,25 +33,23 @@ module('Integration | Component | bulk new users', function (hooks) {
     this.server.create('cohort', { id: 2, title: 'second', programYear: py1 });
     this.server.create('cohort', { id: 1, title: 'first', programYear: py2 });
 
-    const schoolModel = await this.owner.lookup('service:store').find('school', school.id);
-
-    const mockUser = EmberObject.create({
-      school: resolve(schoolModel),
-    });
-
-    const currentUserMock = Service.extend({
-      model: resolve(mockUser),
-    });
-
-    const permissionCheckerMock = Service.extend({
+    const user = this.server.create('user', { school });
+    this.server.create('authentication', { user });
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    class PermissionCheckerMock extends Service {
       async canCreateUser() {
-        return resolve(true);
-      },
-    });
+        return true;
+      }
+    }
+    class CurrentUserMock extends Service {
+      async getModel() {
+        return userModel;
+      }
+    }
 
-    this.owner.register('service:current-user', currentUserMock);
+    this.owner.register('service:current-user', CurrentUserMock);
     this.owner.lookup('service:flash-messages').registerTypes(['success', 'warning']);
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
   });
 
   const createFile = function (users) {
@@ -209,39 +205,39 @@ module('Integration | Component | bulk new users', function (hooks) {
     ];
     await triggerUpload(users, find('input[type=file]'));
     await click('.done');
-    assert.equal(this.server.db.users[0].firstName, 'jasper');
-    assert.equal(this.server.db.users[0].lastName, 'johnson');
-    assert.equal(this.server.db.users[0].middleName, null);
-    assert.equal(this.server.db.users[0].phone, '1234567890');
-    assert.equal(this.server.db.users[0].email, 'jasper.johnson@example.com');
-    assert.equal(this.server.db.users[0].campusId, '123Campus');
-    assert.equal(this.server.db.users[0].otherId, '123Other');
-    assert.equal(this.server.db.users[0].addedViaIlios, true);
-    assert.equal(this.server.db.users[0].enabled, true);
-    assert.equal(this.server.db.users[0].roleIds, null);
-    assert.equal(this.server.db.users[0].cohortIds, null);
-    assert.equal(this.server.db.users[0].authenticationId, '1');
-
-    assert.equal(this.server.db.authentications[0].username, 'jasper');
-    assert.equal(this.server.db.authentications[0].password, '123Test');
-    assert.equal(this.server.db.authentications[0].userId, '1');
-
-    assert.equal(this.server.db.users[1].firstName, 'jackson');
+    assert.equal(this.server.db.users[1].firstName, 'jasper');
     assert.equal(this.server.db.users[1].lastName, 'johnson');
-    assert.equal(this.server.db.users[1].middleName, 'middle');
-    assert.equal(this.server.db.users[1].phone, '12345');
-    assert.equal(this.server.db.users[1].email, 'jj@example.com');
-    assert.equal(this.server.db.users[1].campusId, '1234Campus');
-    assert.equal(this.server.db.users[1].otherId, '1234Other');
+    assert.equal(this.server.db.users[1].middleName, null);
+    assert.equal(this.server.db.users[1].phone, '1234567890');
+    assert.equal(this.server.db.users[1].email, 'jasper.johnson@example.com');
+    assert.equal(this.server.db.users[1].campusId, '123Campus');
+    assert.equal(this.server.db.users[1].otherId, '123Other');
     assert.equal(this.server.db.users[1].addedViaIlios, true);
     assert.equal(this.server.db.users[1].enabled, true);
     assert.equal(this.server.db.users[1].roleIds, null);
     assert.equal(this.server.db.users[1].cohortIds, null);
     assert.equal(this.server.db.users[1].authenticationId, '2');
 
-    assert.equal(this.server.db.authentications[1].username, 'jck');
-    assert.equal(this.server.db.authentications[1].password, '1234Test');
-    assert.equal(this.server.db.authentications[1].userId, 2);
+    assert.equal(this.server.db.authentications[1].username, 'jasper');
+    assert.equal(this.server.db.authentications[1].password, '123Test');
+    assert.equal(this.server.db.authentications[1].userId, '2');
+
+    assert.equal(this.server.db.users[2].firstName, 'jackson');
+    assert.equal(this.server.db.users[2].lastName, 'johnson');
+    assert.equal(this.server.db.users[2].middleName, 'middle');
+    assert.equal(this.server.db.users[2].phone, '12345');
+    assert.equal(this.server.db.users[2].email, 'jj@example.com');
+    assert.equal(this.server.db.users[2].campusId, '1234Campus');
+    assert.equal(this.server.db.users[2].otherId, '1234Other');
+    assert.equal(this.server.db.users[2].addedViaIlios, true);
+    assert.equal(this.server.db.users[2].enabled, true);
+    assert.equal(this.server.db.users[2].roleIds, null);
+    assert.equal(this.server.db.users[2].cohortIds, null);
+    assert.equal(this.server.db.users[2].authenticationId, '3');
+
+    assert.equal(this.server.db.authentications[2].username, 'jck');
+    assert.equal(this.server.db.authentications[2].password, '1234Test');
+    assert.equal(this.server.db.authentications[2].userId, 3);
   });
 
   test('saves valid student users', async function (assert) {
@@ -279,37 +275,37 @@ module('Integration | Component | bulk new users', function (hooks) {
     await triggerUpload(users, find('input[type=file]'));
     await click('.done');
 
-    assert.equal(this.server.db.users[0].firstName, 'jasper');
-    assert.equal(this.server.db.users[0].lastName, 'johnson');
-    assert.equal(this.server.db.users[0].middleName, null);
-    assert.equal(this.server.db.users[0].phone, '1234567890');
-    assert.equal(this.server.db.users[0].email, 'jasper.johnson@example.com');
-    assert.equal(this.server.db.users[0].campusId, '123Campus');
-    assert.equal(this.server.db.users[0].otherId, '123Other');
-    assert.equal(this.server.db.users[0].addedViaIlios, true);
-    assert.equal(this.server.db.users[0].enabled, true);
-    assert.deepEqual(this.server.db.users[0].roleIds, ['4']);
-    assert.equal(this.server.db.users[0].authenticationId, '1');
-
-    assert.equal(this.server.db.authentications[0].username, 'jasper');
-    assert.equal(this.server.db.authentications[0].password, '123Test');
-    assert.equal(this.server.db.authentications[0].userId, '1');
-
-    assert.equal(this.server.db.users[1].firstName, 'jackson');
+    assert.equal(this.server.db.users[1].firstName, 'jasper');
     assert.equal(this.server.db.users[1].lastName, 'johnson');
-    assert.equal(this.server.db.users[1].middleName, 'middle');
-    assert.equal(this.server.db.users[1].phone, '12345');
-    assert.equal(this.server.db.users[1].email, 'jj@example.com');
-    assert.equal(this.server.db.users[1].campusId, '1234Campus');
-    assert.equal(this.server.db.users[1].otherId, '1234Other');
+    assert.equal(this.server.db.users[1].middleName, null);
+    assert.equal(this.server.db.users[1].phone, '1234567890');
+    assert.equal(this.server.db.users[1].email, 'jasper.johnson@example.com');
+    assert.equal(this.server.db.users[1].campusId, '123Campus');
+    assert.equal(this.server.db.users[1].otherId, '123Other');
     assert.equal(this.server.db.users[1].addedViaIlios, true);
     assert.equal(this.server.db.users[1].enabled, true);
     assert.deepEqual(this.server.db.users[1].roleIds, ['4']);
     assert.equal(this.server.db.users[1].authenticationId, '2');
 
-    assert.equal(this.server.db.authentications[1].username, 'jck');
-    assert.equal(this.server.db.authentications[1].password, '1234Test');
-    assert.equal(this.server.db.authentications[1].userId, 2);
+    assert.equal(this.server.db.authentications[1].username, 'jasper');
+    assert.equal(this.server.db.authentications[1].password, '123Test');
+    assert.equal(this.server.db.authentications[1].userId, '2');
+
+    assert.equal(this.server.db.users[2].firstName, 'jackson');
+    assert.equal(this.server.db.users[2].lastName, 'johnson');
+    assert.equal(this.server.db.users[2].middleName, 'middle');
+    assert.equal(this.server.db.users[2].phone, '12345');
+    assert.equal(this.server.db.users[2].email, 'jj@example.com');
+    assert.equal(this.server.db.users[2].campusId, '1234Campus');
+    assert.equal(this.server.db.users[2].otherId, '1234Other');
+    assert.equal(this.server.db.users[2].addedViaIlios, true);
+    assert.equal(this.server.db.users[2].enabled, true);
+    assert.deepEqual(this.server.db.users[2].roleIds, ['4']);
+    assert.equal(this.server.db.users[2].authenticationId, '3');
+
+    assert.equal(this.server.db.authentications[2].username, 'jck');
+    assert.equal(this.server.db.authentications[2].password, '1234Test');
+    assert.equal(this.server.db.authentications[2].userId, 3);
   });
 
   test('cancel fires close', async function (assert) {
@@ -764,8 +760,8 @@ module('Integration | Component | bulk new users', function (hooks) {
       return findAll(proposedNewUsers).length === 0 && findAll(waitSaving).length === 0;
     });
     await settled();
-    assert.equal(this.server.db.users[0].firstName, 'jasper');
-    assert.equal(this.server.db.users[0].authenticationId, null);
+    assert.equal(this.server.db.users[1].firstName, 'jasper');
+    assert.equal(this.server.db.users[1].authenticationId, null);
   });
 
   test('ignore header row', async function (assert) {

--- a/tests/integration/components/curriculum-inventory/reports-test.js
+++ b/tests/integration/components/curriculum-inventory/reports-test.js
@@ -32,11 +32,13 @@ module('Integration | Component | curriculum-inventory/reports', function (hooks
     this.program1 = await this.owner.lookup('service:store').find('program', program1.id);
     this.program2 = await this.owner.lookup('service:store').find('program', program2.id);
     this.program3 = await this.owner.lookup('service:store').find('program', program3.id);
-    this.user = await this.owner.lookup('service:store').find('user', user.id);
-    const currentUserMock = Service.extend({
-      model: this.user,
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+    const userModel = await this.owner.lookup('service:store').find('user', user.id);
+    class CurrentUserMock extends Service {
+      async getModel() {
+        return userModel;
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
     const permissionCheckerMock = Service.extend({
       async canCreateCurriculumInventoryReport() {
         return true;

--- a/tests/integration/components/ilios-users-test.js
+++ b/tests/integration/components/ilios-users-test.js
@@ -1,4 +1,3 @@
-import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
@@ -73,13 +72,17 @@ module('Integration | Component | ilios users', function (hooks) {
     });
     const userModel = await this.owner.lookup('service:store').find('user', user.id);
 
-    const currentUserMock = Service.extend({
-      model: resolve(userModel),
+    class CurrentUserMock extends Service {
+      async getModel() {
+        return userModel;
+      }
       getRolesInSchool() {
         return [];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+
+    this.owner.register('service:current-user', CurrentUserMock);
+
     await render(hbs`<IliosUsers
       @showNewUserForm={{true}}
       @searchTerms={{array}}
@@ -117,13 +120,16 @@ module('Integration | Component | ilios users', function (hooks) {
     });
     const userModel = await this.owner.lookup('service:store').find('user', user.id);
 
-    const currentUserMock = Service.extend({
-      model: resolve(userModel),
+    class CurrentUserMock extends Service {
+      async getModel() {
+        return userModel;
+      }
       getRolesInSchool() {
         return [];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+
+    this.owner.register('service:current-user', CurrentUserMock);
 
     await render(hbs`<IliosUsers
       @showNewUserForm={{true}}
@@ -158,13 +164,16 @@ module('Integration | Component | ilios users', function (hooks) {
     });
     const userModel = await this.owner.lookup('service:store').find('user', user.id);
 
-    const currentUserMock = Service.extend({
-      model: resolve(userModel),
+    class CurrentUserMock extends Service {
+      async getModel() {
+        return userModel;
+      }
       getRolesInSchool() {
         return [];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+
+    this.owner.register('service:current-user', CurrentUserMock);
 
     this.set('setShowBulkNewUserForm', (value) => {
       assert.notOk(value);
@@ -201,13 +210,16 @@ module('Integration | Component | ilios users', function (hooks) {
     });
     const userModel = await this.owner.lookup('service:store').find('user', user.id);
 
-    const currentUserMock = Service.extend({
-      model: resolve(userModel),
+    class CurrentUserMock extends Service {
+      async getModel() {
+        return userModel;
+      }
       getRolesInSchool() {
         return [];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+
+    this.owner.register('service:current-user', CurrentUserMock);
     this.set('setShowNewUserForm', (value) => {
       assert.notOk(value);
     });
@@ -244,13 +256,16 @@ module('Integration | Component | ilios users', function (hooks) {
     });
     const userModel = await this.owner.lookup('service:store').find('user', user.id);
 
-    const currentUserMock = Service.extend({
-      model: resolve(userModel),
+    class CurrentUserMock extends Service {
+      async getModel() {
+        return userModel;
+      }
       getRolesInSchool() {
         return [];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+
+    this.owner.register('service:current-user', CurrentUserMock);
 
     this.set('setShowBulkNewUserForm', (value) => {
       assert.notOk(value);

--- a/tests/integration/components/instructor-groups/root-test.js
+++ b/tests/integration/components/instructor-groups/root-test.js
@@ -20,12 +20,12 @@ module('Integration | Component | instructor-groups/root', function (hooks) {
 
     const user = this.server.create('user', { schoolId: 2 });
     const userModel = await this.owner.lookup('service:store').find('user', user.id);
-    const currentUserMock = Service.extend({
+    class CurrentUserMock extends Service {
       async getModel() {
         return userModel;
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
   });
 
   const setupPermissionChecker = function (scope, can) {

--- a/tests/integration/components/learner-groups/root-test.js
+++ b/tests/integration/components/learner-groups/root-test.js
@@ -36,12 +36,12 @@ module('Integration | Component | learner-groups/root', function (hooks) {
 
     const user = this.server.create('user', { schoolId: 2 });
     const userModel = await this.owner.lookup('service:store').find('user', user.id);
-    const currentUserMock = Service.extend({
+    class CurrentUserMock extends Service {
       async getModel() {
         return userModel;
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
   });
 
   const setupPermissionChecker = function (scope, can) {

--- a/tests/integration/components/new-directory-user-test.js
+++ b/tests/integration/components/new-directory-user-test.js
@@ -23,7 +23,7 @@ module('Integration | Component | new directory user', function (hooks) {
       }
     }
     class CurrentUserMock extends Service {
-      async model() {
+      async getModel() {
         return userModel;
       }
     }

--- a/tests/integration/components/new-user-test.js
+++ b/tests/integration/components/new-user-test.js
@@ -22,19 +22,21 @@ module('Integration | Component | new user', function (hooks) {
     });
     const user = await this.owner.lookup('service:store').find('user', 1);
 
-    this.currentUserMock = Service.extend({
-      model: resolve(user),
+    class CurrentUserMock extends Service {
+      async getModel() {
+        return user;
+      }
       async canCreateUser() {
         return resolve(true);
-      },
-    });
+      }
+    }
 
     this.permissionCheckerMock = Service.extend({
       async canCreateUser() {
         return resolve(true);
       },
     });
-    this.owner.register('service:current-user', this.currentUserMock);
+    this.owner.register('service:current-user', CurrentUserMock);
     this.owner.register('service:permissionChecker', this.permissionCheckerMock);
   });
 

--- a/tests/integration/components/pending-updates-summary-test.js
+++ b/tests/integration/components/pending-updates-summary-test.js
@@ -21,12 +21,12 @@ module('Integration | Component | pending updates summary', function (hooks) {
       this.server.create('pending-user-update', { user });
     }
 
-    const currentUserMock = class extends Service {
+    class CurrentUserMock extends Service {
       async getModel() {
         return userModel;
       }
-    };
-    this.owner.register('service:currentUser', currentUserMock);
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     const schools = await this.owner.lookup('service:store').findAll('school');
     this.set('schools', schools);
@@ -51,12 +51,12 @@ module('Integration | Component | pending updates summary', function (hooks) {
       this.server.create('pending-user-update', { user });
     }
 
-    const currentUserMock = class extends Service {
+    class CurrentUserMock extends Service {
       async getModel() {
         return userModel;
       }
-    };
-    this.owner.register('service:currentUser', currentUserMock);
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     const schools = await this.owner.lookup('service:store').findAll('school');
     this.set('schools', schools);
@@ -77,12 +77,12 @@ module('Integration | Component | pending updates summary', function (hooks) {
     const user = this.server.create('user', { school });
     const userModel = await this.owner.lookup('service:store').find('user', user.id);
 
-    const currentUserMock = class extends Service {
+    class CurrentUserMock extends Service {
       async getModel() {
         return userModel;
       }
-    };
-    this.owner.register('service:currentUser', currentUserMock);
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     const schools = await this.owner.lookup('service:store').findAll('school');
     this.set('schools', schools);
@@ -111,12 +111,12 @@ module('Integration | Component | pending updates summary', function (hooks) {
       user: this.server.create('user', { school: schools[1] }),
     });
 
-    const currentUserMock = class extends Service {
+    class CurrentUserMock extends Service {
       async getModel() {
         return userModel;
       }
-    };
-    this.owner.register('service:currentUser', currentUserMock);
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     const schoolModels = await this.owner.lookup('service:store').findAll('school');
     this.set('schools', schoolModels);

--- a/tests/integration/components/programs/root-test.js
+++ b/tests/integration/components/programs/root-test.js
@@ -19,12 +19,12 @@ module('Integration | Component | programs/root', function (hooks) {
 
     const user = this.server.create('user', { schoolId: 2 });
     const userModel = await this.owner.lookup('service:store').find('user', user.id);
-    const currentUserMock = Service.extend({
+    class CurrentUserMock extends Service {
       async getModel() {
         return userModel;
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
   });
 
   const setupPermissionChecker = function (scope, can) {


### PR DESCRIPTION
Accessing these as computed properties has been deprecated for a while,
instead they should be accessed using the async methods on currentUser
and iliosConfig.