### PR TITLE
removes padding from "back to school" link.

### DIFF
--- a/app/styles/components/school-manager.scss
+++ b/app/styles/components/school-manager.scss
@@ -3,6 +3,7 @@
 
   .backtolink {
     margin: .5rem 0;
+    padding: 0;
   }
 
   .school-overview {


### PR DESCRIPTION
this aligns it with the heading underneath is.

fixes https://github.com/ilios/frontend/issues/6212