### PR TITLE
removes Wait/Saving modal from ci report finalisation.

### DIFF
--- a/app/components/curriculum-inventory/report-details.hbs
+++ b/app/components/curriculum-inventory/report-details.hbs
@@ -2,7 +2,8 @@
   <CurriculumInventory::ReportHeader
     @report={{@report}}
     @finalize={{set this.showFinalizeConfirmation true}}
-    @canUpdate={{@canUpdate}}
+    @canUpdate={{this.canUpdate}}
+    @isFinalizing={{this.isFinalizing}}
   />
   {{#if this.showFinalizeConfirmation}}
     <div class="confirm-finalize">
@@ -10,10 +11,18 @@
         {{t "general.finalizeReportConfirmation"}}
         <br>
         <div class="confirm-buttons">
-          <button type="button" class="finalize text" {{on "click" (perform this.finalize)}}>
+          <button
+            type="button"
+            class="finalize text"
+            {{on "click" (perform this.finalize)}}
+          >
             {{t "general.yes"}}
           </button>
-          <button type="button" class="done text" {{on "click" (set this.showFinalizeConfirmation false)}}>
+          <button
+            type="button"
+            class="done text"
+            {{on "click" (set this.showFinalizeConfirmation false)}}
+          >
             {{t "general.cancel"}}
           </button>
         </div>
@@ -22,12 +31,12 @@
   {{/if}}
   <CurriculumInventory::ReportOverview
     @report={{@report}}
-    @canUpdate={{@canUpdate}}
+    @canUpdate={{this.canUpdate}}
   />
   {{#if @leadershipDetails}}
     <CurriculumInventory::LeadershipExpanded
       @report={{@report}}
-      @canUpdate={{@canUpdate}}
+      @canUpdate={{this.canUpdate}}
       @collapse={{fn @setLeadershipDetails false}}
       @expand={{fn @setLeadershipDetails true}}
       @isManaging={{@manageLeadership}}
@@ -41,8 +50,5 @@
       @administratorsCount={{has-many-length @report "administrators"}}
       @expand={{fn @setLeadershipDetails true}}
     />
-  {{/if}}
-  {{#if this.finalize.isRunning}}
-    <WaitSaving>{{t "general.finalizingReport"}}</WaitSaving>
   {{/if}}
 </div>

--- a/app/components/curriculum-inventory/report-details.js
+++ b/app/components/curriculum-inventory/report-details.js
@@ -7,13 +7,21 @@ export default class CurriculumInventoryReportDetailsComponent extends Component
   @service store;
   @tracked showFinalizeConfirmation = false;
 
+  get isFinalizing() {
+    return this.finalize.isRunning;
+  }
+
+  get canUpdate() {
+    return this.args.canUpdate && !this.isFinalizing;
+  }
+
   @dropTask
   *finalize() {
     const newExport = this.store.createRecord('curriculumInventoryExport', {
       report: this.args.report,
     });
+    this.showFinalizeConfirmation = false;
     const savedExport = yield newExport.save();
     this.args.report.set('export', savedExport);
-    this.showFinalizeConfirmation = false;
   }
 }

--- a/app/components/curriculum-inventory/report-header.hbs
+++ b/app/components/curriculum-inventory/report-header.hbs
@@ -45,8 +45,17 @@
     >
       {{t "general.download"}}
     </a>
-    <button type="button" class="finalize" disabled={{not @canUpdate}} {{on "click" @finalize}} data-test-finalize>
+    <button
+      type="button"
+      class="finalize"
+      disabled={{not @canUpdate}}
+      {{on "click" @finalize}}
+      data-test-finalize
+    >
       {{t "general.finalize"}}
+      {{#if @isFinalizing}}
+        <FaIcon @icon="spinner" @spin={{true}} />
+      {{/if}}
     </button>
   </div>
 </div>


### PR DESCRIPTION
instead, lock component and sub-components while report is being finalized.
slaps a spinner on the finalize button for some visual indication that things are moving.

refs #5900 