### PR TITLE
Load schools more carefully

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -13,6 +13,7 @@ export default class AuthenticatedRoute extends Route {
   @service store;
   @service router;
   @service announcer;
+  @service session;
 
   @tracked event;
 
@@ -25,8 +26,11 @@ export default class AuthenticatedRoute extends Route {
   }
 
   async afterModel() {
-    //preload all the schools, we need these everywhere
-    await this.store.findAll('school');
+    if (this.session.isAuthenticated) {
+      //preload all the schools, we need these everywhere
+      //this is also done when a user is first authetnicated in app/services/session.js
+      await this.store.findAll('school');
+    }
   }
 
   activate() {

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -6,6 +6,7 @@ import { inject as service } from '@ember/service';
 export default class SessionService extends ESASessionService {
   @service fetch;
   @service currentUser;
+  @service store;
 
   async handleAuthentication() {
     super.handleAuthentication(...arguments);
@@ -16,6 +17,9 @@ export default class SessionService extends ESASessionService {
       }
     }
     const user = await this.currentUser.getModel();
+    //preload all the schools, we need these everywhere
+    //this is also done for authenticated users in the Application Route
+    await this.store.findAll('school');
     Sentry.setUser({ id: user.id });
   }
 


### PR DESCRIPTION
We can only load schools when a user is authenticated. After this change
we'll load them for authenticated users when the application route is
encountered and load them on session creation for newly authenticated
users.

Fixes #6238