### PR TITLE
Stop relying on the default model hook

### DIFF
--- a/app/routes/curriculum-inventory-report.js
+++ b/app/routes/curriculum-inventory-report.js
@@ -4,10 +4,18 @@ import { inject as service } from '@ember/service';
 export default class CurriculumInventoryReportReport extends Route {
   @service permissionChecker;
   @service session;
+  @service store;
   canUpdate = false;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+  }
+
+  model(params) {
+    return this.store.findRecord(
+      'curriculum-inventory-report',
+      params.curriculum_inventory_report_id
+    );
   }
 
   async afterModel(report) {

--- a/app/routes/curriculum-inventory-sequence-block.js
+++ b/app/routes/curriculum-inventory-sequence-block.js
@@ -4,11 +4,19 @@ import { inject as service } from '@ember/service';
 export default class CurriculumInventorySequenceBlockRoute extends Route {
   @service permissionChecker;
   @service session;
+  @service store;
 
   canUpdate = false;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+  }
+
+  model(params) {
+    return this.store.findRecord(
+      'curriculum-inventory-sequence-block',
+      params.curriculum_inventory_sequence_block_id
+    );
   }
 
   async afterModel(model) {

--- a/app/routes/instructor-group.js
+++ b/app/routes/instructor-group.js
@@ -4,11 +4,16 @@ import { inject as service } from '@ember/service';
 export default class InstructorGroupRoute extends Route {
   @service permissionChecker;
   @service session;
+  @service store;
 
   canUpdate = false;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+  }
+
+  model(params) {
+    return this.store.findRecord('instructor-group', params.instructor_group_id);
   }
 
   async afterModel(instructorGroup) {

--- a/app/routes/program-year.js
+++ b/app/routes/program-year.js
@@ -5,11 +5,16 @@ import { loadFroalaEditor } from 'ilios-common/utils/load-froala-editor';
 export default class ProgramYearRoute extends Route {
   @service permissionChecker;
   @service session;
+  @service store;
 
   canUpdate = false;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+  }
+
+  model(params) {
+    return this.store.findRecord('program-year', params.program_year_id);
   }
 
   /**

--- a/app/routes/program.js
+++ b/app/routes/program.js
@@ -4,11 +4,16 @@ import { inject as service } from '@ember/service';
 export default class ProgramRoute extends Route {
   @service permissionChecker;
   @service session;
+  @service store;
 
   canUpdate = false;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+  }
+
+  model(params) {
+    return this.store.findRecord('program', params.program_id);
   }
 
   async afterModel(program) {

--- a/app/routes/school.js
+++ b/app/routes/school.js
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 export default class SchoolRoute extends Route {
   @service permissionChecker;
   @service session;
+  @service store;
 
   canUpdateSchool = false;
   canUpdateCompetency = false;
@@ -23,6 +24,10 @@ export default class SchoolRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+  }
+
+  model(params) {
+    return this.store.findRecord('school', params.school_id);
   }
 
   async afterModel(school) {

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -12,6 +12,10 @@ export default class UserRoute extends Route {
     this.session.requireAuthentication(transition, 'login');
   }
 
+  model(params) {
+    return this.store.findRecord('user', params.user_id);
+  }
+
   /**
    * Prefetch user relationship data to smooth loading
    **/

--- a/app/routes/verification-preview.js
+++ b/app/routes/verification-preview.js
@@ -3,8 +3,16 @@ import Route from '@ember/routing/route';
 
 export default class VerificationPreviewRoute extends Route {
   @service session;
+  @service store;
 
   async beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+  }
+
+  model(params) {
+    return this.store.findRecord(
+      'curriculum-inventory-report',
+      params.curriculum_inventory_report_id
+    );
   }
 }


### PR DESCRIPTION
This is deprecated and won't work very well in Ember v4 do to the
absence of a default store. Let's get ahead and remove these and
replace with explicit model loading.