### PR TITLE
Improve network loading for user profile data

### DIFF
--- a/app/routes/myprofile.js
+++ b/app/routes/myprofile.js
@@ -4,12 +4,13 @@ import Route from '@ember/routing/route';
 export default class MyprofileRoute extends Route {
   @service currentUser;
   @service session;
+  @service dataLoader;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
   }
 
   model() {
-    return this.currentUser.getModel();
+    return this.dataLoader.loadUserProfile(this.currentUser.currentUserId);
   }
 }

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -1,5 +1,4 @@
 import Route from '@ember/routing/route';
-import { hash, all } from 'rsvp';
 import { inject as service } from '@ember/service';
 
 export default class UserRoute extends Route {
@@ -7,26 +6,21 @@ export default class UserRoute extends Route {
   @service currentUser;
   @service iliosConfig;
   @service session;
+  @service dataLoader;
 
   async beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
   }
 
   model(params) {
-    return this.store.findRecord('user', params.user_id);
+    return this.dataLoader.loadUserProfile(params.user_id);
   }
 
   /**
    * Prefetch user relationship data to smooth loading
    **/
   async afterModel(user) {
-    const obj = await hash({
-      cohorts: user.get('cohorts'),
-      learnerGroups: user.get('learnerGroups'),
-      roles: user.get('roles'),
-      schools: user.get('schools'),
-    });
-    await all([all(obj.cohorts.mapBy('school')), all(obj.learnerGroups.mapBy('school'))]);
+    await this.dataLoader.loadUserProfile(user.id);
 
     const userSearchType = await this.iliosConfig.getUserSearchType();
     if (userSearchType !== 'ldap') {

--- a/app/services/data-loader.js
+++ b/app/services/data-loader.js
@@ -5,6 +5,7 @@ export default class DataLoaderService extends CommonDataLoaderService {
   #loadedLearnerGroup = new Map();
   #loadedSchoolInstructorGroups = new Map();
   #loadedCohortLearnerGroups = new Map();
+  #loadedUserProfiles = new Map();
   async loadCoursesForLearnerGroup(learnerGroupId) {
     if (!this.#loadedLearnerGroupWithCourses.has(learnerGroupId)) {
       const sessionIncludes = 'offerings.session.course';
@@ -81,5 +82,43 @@ export default class DataLoaderService extends CommonDataLoaderService {
     }
 
     return this.#loadedSchoolInstructorGroups.get(schoolId);
+  }
+  async loadUserProfile(id) {
+    if (!this.#loadedUserProfiles.has(id)) {
+      const includes = [
+        'directedCourses.sessions',
+        'administeredCourses.sessions',
+        'studentAdvisedCourses.sessions',
+        'studentAdvisedSessions.course',
+        'learnerGroups.offerings.session.course',
+        'learnerGroups.ilmSessions.session.course',
+        'instructedLearnerGroups.offerings.session.course',
+        'instructedLearnerGroups.ilmSessions.session.course',
+        'instructorGroups.offerings.session.course',
+        'instructorGroups.ilmSessions.session.course',
+        'instructorIlmSessions.session.course',
+        'learnerIlmSessions.session.course',
+        'offerings.session.course',
+        'instructedOfferings.session.course',
+        'programYears',
+        'directedSchools',
+        'administeredSchools',
+        'administeredSessions',
+        'directedPrograms',
+        'cohorts.programYear.program',
+        'primaryCohort',
+        'administeredCurriculumInventoryReports',
+        'roles',
+      ];
+      this.#loadedUserProfiles.set(
+        id,
+        this.store.findRecord('user', id, {
+          reload: true,
+          include: includes.join(','),
+        })
+      );
+    }
+
+    return this.#loadedUserProfiles.get(id);
   }
 }


### PR DESCRIPTION
Previously this required a *lot* of requests to load all the ways a user
is connected to courses and sessions. Putting this all in a service
reduces the requests and ensures everything we need it already loaded.