### PR TITLE
Remove unneeded new-version config

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -53,10 +53,6 @@ module.exports = function (defaults) {
       version: '4',
       patterns: ['https://fonts.gstatic.com/(.+)'],
     },
-    newVersion: {
-      enabled: true,
-      useAppVersion: true,
-    },
     autoImport: {
       insertScriptsAt: 'auto-import-scripts',
     },


### PR DESCRIPTION
This is now the default behavior and we don't need to configure it
anymore.