### PR TITLE
Replace ember-load addon

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -31,6 +31,8 @@ export default class AuthenticatedRoute extends Route {
   }
 
   activate() {
+    //remove our loading animation once the application is loaded
+    document.getElementById('ilios-loading-indicator')?.remove();
     if ('serviceWorker' in navigator) {
       const { controller: currentController } = navigator.serviceWorker;
       this.event = navigator.serviceWorker.addEventListener('controllerchange', async () => {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -29,4 +29,3 @@
   <LoadingBar @isLoading={{this.currentlyLoading}} />
 </div>
 <FlashMessages />
-<EmberLoadRemover />

--- a/lib/ilios-loading/index.js
+++ b/lib/ilios-loading/index.js
@@ -76,7 +76,7 @@ module.exports = {
     }
 
     if (type === 'body') {
-      return `<div id='ilios-loading-indicator' data-deploy class='ember-load-indicator' aria-live="polite">
+      return `<div id='ilios-loading-indicator' data-deploy aria-live="polite">
         <h1 aria-label='Ilios is Loading'>
           <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 392.11 392.11" aria-hidden='true'>
             <title>Ilios is Loading</title>

--- a/lib/ilios-loading/public/remove-loader-tests.js
+++ b/lib/ilios-loading/public/remove-loader-tests.js
@@ -1,3 +1,3 @@
 /* global document */
 // Remove the loader when testing
-document.getElementById('ilios-loading-indicator').remove();
+document.getElementById('ilios-loading-indicator')?.remove();

--- a/package-lock.json
+++ b/package-lock.json
@@ -16982,63 +16982,6 @@
         }
       }
     },
-    "ember-load": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/ember-load/-/ember-load-0.0.17.tgz",
-      "integrity": "sha512-gyJrGwUHOri9En8QG/v2NIwxHFC5DFifar+1TRLwsNSeyJaUSwoFExLCVN8xYoDrI5CX1lmRoOUcfcrEApKwfg==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^7.1.3",
-        "ember-cli-htmlbars": "^3.0.0",
-        "ember-cli-version-checker": "^3.0.0"
-      },
-      "dependencies": {
-        "ember-cli-htmlbars": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-3.1.0.tgz",
-          "integrity": "sha512-cgvRJM73IT0aePUG7oQ/afB7vSRBV3N0wu9BrWhHX2zkR7A7cUBI7KC9VPk6tbctCXoM7BRGsCC4aIjF7yrfXA==",
-          "dev": true,
-          "requires": {
-            "broccoli-persistent-filter": "^2.3.1",
-            "hash-for-dep": "^1.5.1",
-            "json-stable-stringify": "^1.0.1",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
-          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
-          "dev": true,
-          "requires": {
-            "resolve-package-path": "^1.2.6",
-            "semver": "^5.6.0"
-          }
-        },
-        "resolve-package-path": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-1.2.7.tgz",
-          "integrity": "sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==",
-          "dev": true,
-          "requires": {
-            "path-root": "^0.1.1",
-            "resolve": "^1.10.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
-      }
-    },
     "ember-load-initializers": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-export-application-global": "^2.0.1",
-    "ember-load": "0.0.17",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-metrics": "1.4.2",


### PR DESCRIPTION
This isn't maintained anymore and with the removal of IE11 there isn't
anything special about it. We can do this work in our application route
instead.