### PR TITLE
Silence Noisy Ember Global Deprecation

### DIFF
--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -13,5 +13,6 @@ window.deprecationWorkflow.config = {
     { handler: 'silence', matchId: 'common.curriculum-inventory-report-is-finalized' },
     { handler: 'silence', matchId: 'common.async-computed' },
     { handler: 'silence', matchId: 'common.school-cohorts' },
+    { handler: 'silence', matchId: 'ember-global' },
   ],
 };


### PR DESCRIPTION
This thing is impossibly loud, but we can silence it now so our tests
are once again readable.