### PR TITLE
rm deprecated use of array helper.

### DIFF
--- a/app/components/new-myreport.hbs
+++ b/app/components/new-myreport.hbs
@@ -141,7 +141,7 @@
                 </li>
               </ul>
             {{else}}
-              <MeshManager @add={{this.chooseMeshTerm}} @editable={{true}} @terms={{array}} />
+              <MeshManager @add={{this.chooseMeshTerm}} @editable={{true}} />
             {{/if}}
           {{else if this.isPrepositionalObjectIdListLoaded}}
             <select


### PR DESCRIPTION
MeshManager component has been updated to make the terms input argument optional.

refs https://github.com/ilios/common/pull/2409

refs https://github.com/ilios/frontend/issues/6365