### PR TITLE
pins ember-a11y-refocus dependency to version 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10841,9 +10841,9 @@
       }
     },
     "ember-a11y-refocus": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ember-a11y-refocus/-/ember-a11y-refocus-2.1.0.tgz",
-      "integrity": "sha512-jF9aOviA0T6d9P+4AmVtrMRcHVQcT4uBfq5OIGsx2rYrdP6LWj/7Tb+yNLLTDbPIdZDbluzofG7UU6HZYzkJIg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-a11y-refocus/-/ember-a11y-refocus-2.0.0.tgz",
+      "integrity": "sha512-o7TGB3/H4oT9I7i3sAs9YRQ6/chimaAeKUzdlJIMu3s45qauVtYv3OiV12UsI6zXMJw2kKXPzliWrGvEDWgdwQ==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "browserslist": "^4.19.1",
     "caniuse-db": "^1.0.30001296",
     "dotenv": "^10.0.0",
-    "ember-a11y-refocus": "^2.1.0",
+    "ember-a11y-refocus": "2.0.0",
     "ember-a11y-testing": "^5.0.0",
     "ember-ajax": "^5.1.1",
     "ember-auto-import": "^2.2.3",


### PR DESCRIPTION
the next version of this plugin, v2.1.0, introduces some
behavior that we don't want in ilios.
it is also not clear to us at this point whether those changes
consistute a bug or feature.
therefore reverting to a known, "good" state.

fixes https://github.com/ilios/frontend/issues/6417