### PR TITLE
Re-add loading indicator class

### DIFF
--- a/lib/ilios-loading/index.js
+++ b/lib/ilios-loading/index.js
@@ -76,7 +76,7 @@ module.exports = {
     }
 
     if (type === 'body') {
-      return `<div id='ilios-loading-indicator' data-deploy aria-live="polite">
+      return `<div id='ilios-loading-indicator' data-deploy class="no-longer-required" aria-live="polite">
         <h1 aria-label='Ilios is Loading'>
           <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 392.11 392.11" aria-hidden='true'>
             <title>Ilios is Loading</title>


### PR DESCRIPTION
Removing this will be a major version and API bump because it's expected
on the API when loading the frontend.