### PR TITLE
[breaking] Remove loading indicator class

### DIFF
--- a/lib/ilios-loading/index.js
+++ b/lib/ilios-loading/index.js
@@ -76,7 +76,7 @@ module.exports = {
     }
 
     if (type === 'body') {
-      return `<div id='ilios-loading-indicator' data-deploy class="no-longer-required" aria-live="polite">
+      return `<div id='ilios-loading-indicator' data-deploy aria-live="polite">
         <h1 aria-label='Ilios is Loading'>
           <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 392.11 392.11" aria-hidden='true'>
             <title>Ilios is Loading</title>


### PR DESCRIPTION
This should only be merged once the latest API bump from common for CI reports is merged as it is a breaking change due to the way we interpret the loading frontend in PHP see https://github.com/ilios/ilios/issues/3890