### PR TITLE
Add a test build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,19 @@ jobs:
       run: npm run lint:js
     - name: test
       run: npm run test:ember
+  build:
+    name: Lint and Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: install dependencies
+      run: npm ci
+    - name: test build
+      run: npm run build


### PR DESCRIPTION
Ensures we can get a production build without relying on netlify or
another action to fail.