### PR TITLE
Fix pull request preview action

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -2,7 +2,7 @@ name: Deploy Pull Request
 
 on:
   pull_request_target:
-    types: [labeled]
+    types: [labeled,opened,reopened,synchronize]
 
 env:
   COVERAGE: false
@@ -14,6 +14,8 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'safe to deploy')
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Use Node.js 16
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
The `pull_request_target` event loads to a checkout of `master` and not
the PR commit. Since we're only running this action when a label has
been added we can go ahead and checkout the PR ref and run there. I also
added some more events so deployed PRs will get re-deployed when they
are changed.