### PR TITLE
Don't redeploy PR builds automatically

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -2,7 +2,7 @@ name: Deploy Pull Request
 
 on:
   pull_request_target:
-    types: [labeled,opened,reopened,synchronize]
+    types: [labeled]
 
 env:
   COVERAGE: false


### PR DESCRIPTION
A little bit more secure, we'll have to remove and re-apply the label
anytime we want to re-deploy one of these PR builds.