### PR TITLE
Handle errors in an embroiderer compatible way

### DIFF
--- a/lib/ilios-error/index.js
+++ b/lib/ilios-error/index.js
@@ -6,24 +6,23 @@
 const browserslist = require('browserslist');
 const caniuse = require('caniuse-db/data.json').agents;
 
-const MergeTrees = require('broccoli-merge-trees');
-const WriteFile = require('broccoli-file-creator');
-
 module.exports = {
   name: 'ilios-error',
 
-  contentFor: function (type, config) {
+  contentFor: function (type) {
+    const script = this.getScript();
     if (type === 'body') {
       return `
-        <script defer src="${config.rootURL}ilios-error/script.js"></script>
+        <script>
+          ${script}
+        </script>
       `;
     }
   },
 
-  treeForPublic() {
-    const defaultTree = this._super.treeForPublic.apply(this, arguments);
+  getScript() {
     const supportedBrowsers = this.getSupportedBrowsers().join('');
-    const scriptContent = `
+    return `
       // if there is an uncaught runtime error show the error message
       window.addEventListener('error', function () {
         var loadingIndicator = document.getElementById('ilios-loading-indicator');
@@ -39,8 +38,7 @@ module.exports = {
           link.media = "screen";
 
           document.getElementsByTagName( "head" )[0].appendChild( link );
-          var errorContainer = document.createElement('dev');
-          errorContainer.classList.add('ember-load-indicator');
+          var errorContainer = document.createElement('div');
           errorContainer.id = 'ilios-loading-error';
           errorContainer.innerHTML = '' +
             '<h1>' +
@@ -48,44 +46,13 @@ module.exports = {
               'Please refresh this page or try a different browser.' +
             '</h1>' +
             '<div class="supported-browsers">' +
-              '<h2 id="ilios-loading-error-browsers">Supported Browsers</h2>' +
+              '<h2 id="ilios-loading-error-browsers">Minimum Supported Browsers</h2>' +
               '<ul aria-labelledby="ilios-loading-error-browsers">${supportedBrowsers}</ul>' +
             '</div>';
           document.body.appendChild(errorContainer);
         }
       });
     `;
-
-    const styleContent = `
-      #ilios-loading-error {
-        padding: 2em;
-      }
-      #ilios-loading-error h1,
-      #ilios-loading-error h2 {
-        text-align: center;
-      }
-      #ilios-loading-error .supported-browsers {
-        border: 1px solid blue;
-        margin-top: 1rem;
-        padding: 1rem 2rem;
-      }
-      #ilios-loading-error ul {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-around;
-        list-style-type: none;
-      }
-      #ilios-loading-error.hidden {
-        display: none;
-      }
-    `;
-    const scriptTree = WriteFile('ilios-error/script.js', scriptContent);
-    const styleTree = WriteFile('ilios-error/style.css', styleContent);
-    const trees = [scriptTree, styleTree];
-    if (defaultTree) {
-      trees.unshift(defaultTree);
-    }
-    return MergeTrees(trees);
   },
 
   getBrowserLogo(id) {

--- a/lib/ilios-error/public/style.css
+++ b/lib/ilios-error/public/style.css
@@ -1,0 +1,21 @@
+#ilios-loading-error {
+  padding: 2em;
+}
+#ilios-loading-error h1,
+#ilios-loading-error h2 {
+  text-align: center;
+}
+#ilios-loading-error .supported-browsers {
+  border: 1px solid blue;
+  margin-top: 1rem;
+  padding: 1rem 2rem;
+}
+#ilios-loading-error ul {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  list-style-type: none;
+}
+#ilios-loading-error.hidden {
+  display: none;
+}


### PR DESCRIPTION
Embroiderer hates treeFor* methods so I've placed the error script
inline into the html instead. I'd like to put it in a separate JS file,
but we need access to come build info to create the browser list.