### PR TITLE
Add directory to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,5 +43,6 @@ updates:
   - dependency-name: qunit
   - dependency-name: qunit-dom
 - package-ecosystem: github-actions
+  directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
This is required to be present of the config won't be parsed.