### PR TITLE
replace task with async action.

### DIFF
--- a/app/components/curriculum-inventory/sequence-block-overview.hbs
+++ b/app/components/curriculum-inventory/sequence-block-overview.hbs
@@ -18,13 +18,12 @@
               {{#if @canUpdate}}
                 <EditableField
                   @value={{this.course.title}}
-                  @save={{perform this.saveCourse}}
+                  @save={{this.saveCourse}}
                   @close={{this.revertCourseChanges}}
                   @clickPrompt={{t "general.selectCourse"}}
                 >
                   <select
                     id="course-{{templateId}}"
-                    disabled={{this.saveCourse.isRunning}}
                     {{on "change" this.updateCourse}}
                   >
                     <option value="" selected={{is-empty this.course}}>{{t "general.selectCourse"}}</option>

--- a/app/components/curriculum-inventory/sequence-block-overview.js
+++ b/app/components/curriculum-inventory/sequence-block-overview.js
@@ -222,13 +222,15 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
 
   @action
   async saveCourse() {
-    const oldCourse = await this.args.sequenceBlock.course;
-    if (oldCourse !== this.course) {
-      this.args.sequenceBlock.set('sessions', []);
-      this.args.sequenceBlock.set('excludedSessions', []);
+    if (!this.isDestroying) {
+      const oldCourse = await this.args.sequenceBlock.course;
+      if (oldCourse !== this.course) {
+        this.args.sequenceBlock.set('sessions', []);
+        this.args.sequenceBlock.set('excludedSessions', []);
+      }
+      this.args.sequenceBlock.set('course', this.course);
+      await this.args.sequenceBlock.save();
     }
-    this.args.sequenceBlock.set('course', this.course);
-    await this.args.sequenceBlock.save();
   }
 
   @action

--- a/app/components/curriculum-inventory/sequence-block-overview.js
+++ b/app/components/curriculum-inventory/sequence-block-overview.js
@@ -220,15 +220,15 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     this.minimum = this.args.sequenceBlock.minimum;
   }
 
-  @dropTask
-  *saveCourse() {
-    const oldCourse = yield this.args.sequenceBlock.course;
+  @action
+  async saveCourse() {
+    const oldCourse = await this.args.sequenceBlock.course;
     if (oldCourse !== this.course) {
       this.args.sequenceBlock.set('sessions', []);
       this.args.sequenceBlock.set('excludedSessions', []);
     }
     this.args.sequenceBlock.set('course', this.course);
-    yield this.args.sequenceBlock.save();
+    await this.args.sequenceBlock.save();
   }
 
   @action

--- a/app/components/curriculum-inventory/sequence-block-overview.js
+++ b/app/components/curriculum-inventory/sequence-block-overview.js
@@ -222,8 +222,8 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
 
   @action
   async saveCourse() {
+    const oldCourse = await this.args.sequenceBlock.course;
     if (!this.isDestroying) {
-      const oldCourse = await this.args.sequenceBlock.course;
       if (oldCourse !== this.course) {
         this.args.sequenceBlock.set('sessions', []);
         this.args.sequenceBlock.set('excludedSessions', []);


### PR DESCRIPTION
currently, this is the only way to shake the self-cancel warning that's being emitted by ember-concurrency.
editable-field is not aware what kind of save callback is being passed - it could be a task or an action - so it just "yields".
using an action instead of a task appears to be an adequate solution for this problem to me.

fixes #6609 