### PR TITLE
Add the app version to the footer

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -2,6 +2,9 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { use } from 'ember-could-get-used-to-this';
+import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { appVersion } from 'ilios/helpers/app-version';
 
 export default class ApplicationController extends Controller {
   @service apiVersion;
@@ -9,10 +12,38 @@ export default class ApplicationController extends Controller {
   @service intl;
   @service session;
   @service pageTitle;
+  @service iliosConfig;
 
   @tracked currentlyLoading = false;
   @tracked errors = [];
   @tracked showErrorDisplay = false;
+
+  @use appVersion = new ResolveAsyncValue(() => [this.iliosConfig.getAppVersion()]);
+
+  get iliosVersionTag() {
+    if (this.appVersion) {
+      return `v${this.appVersion}`;
+    }
+
+    return '';
+  }
+
+  get apiVersionTag() {
+    if (this.apiVersion.version) {
+      return `API: ${this.apiVersion.version}`;
+    }
+
+    return '';
+  }
+
+  get frontendVersionTag() {
+    const version = appVersion(null, { versionOnly: true });
+    if (version) {
+      return `Frontend: v${version}`;
+    }
+
+    return '';
+  }
 
   @action
   clearErrors() {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -21,9 +21,9 @@
   </main>
   <footer class="ilios-footer">
     <div class="version">
-      {{this.apiVersion.version}}
-      {{! template-lint-disable no-curly-component-invocation }}
-      {{app-version versionOnly=true}}
+      {{this.iliosVersionTag}}
+      {{this.apiVersionTag}}
+      {{this.frontendVersionTag}}
     </div>
   </footer>
   <LoadingBar @isLoading={{this.currentlyLoading}} />

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -60,6 +60,7 @@ export default function (config) {
           config: {
             type: 'form',
             apiVersion,
+            appVersion: '1.2.3',
           },
         };
         // return { config: {

--- a/tests/acceptance/footer-test.js
+++ b/tests/acceptance/footer-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { find, visit } from '@ember/test-helpers';
+import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupAuthentication } from 'ilios-common';
@@ -20,7 +20,9 @@ module('Acceptance | footer', function (hooks) {
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
     assert.ok(apiVersion);
     await visit('/');
-    assert.ok(find('.ilios-footer .version').textContent.includes(version.match(versionRegExp)));
-    assert.ok(find('.ilios-footer .version').textContent.includes(apiVersion));
+    const frontendVersion = version.match(versionRegExp);
+    assert
+      .dom('.ilios-footer .version')
+      .hasText(`v1.2.3 API: ${apiVersion} Frontend: v${frontendVersion}`);
   });
 });


### PR DESCRIPTION
Now that we can get the version of the backend from the API we can
display it in the footer. Fixes ilios/ilios#2043

![Ilios footer post change](https://user-images.githubusercontent.com/349624/162324249-75fe54bf-63b5-43cf-bf36-edb25dd25524.png)
