### PR TITLE
Remove capitals from route names

### DIFF
--- a/app/components/curriculum-inventory/report-list-item.hbs
+++ b/app/components/curriculum-inventory/report-list-item.hbs
@@ -9,7 +9,7 @@
     role="button"
     data-test-name
   >
-    <LinkTo @route="curriculumInventoryReport" @model={{@report}}>
+    <LinkTo @route="curriculum-inventory-report" @model={{@report}}>
       {{@report.name}}
     </LinkTo>
   </td>

--- a/app/components/curriculum-inventory/report-overview.hbs
+++ b/app/components/curriculum-inventory/report-overview.hbs
@@ -12,7 +12,7 @@
         </div>
         <div class="report-overview-actions">
           <LinkTo
-            @route="verificationPreview"
+            @route="verification-preview"
             @model={{@report}}
             class="verification-preview"
             data-test-transition-to-verification-preview

--- a/app/components/curriculum-inventory/report-overview.js
+++ b/app/components/curriculum-inventory/report-overview.js
@@ -28,7 +28,7 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
   @tracked canRollover = false;
 
   get showRollover() {
-    if (this.router.currentRouteName === 'curriculumInventoryReport.rollover') {
+    if (this.router.currentRouteName === 'curriculum-inventory-report.rollover') {
       return false;
     }
 
@@ -131,7 +131,7 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
 
   @action
   transitionToRollover() {
-    this.router.transitionTo('curriculumInventoryReport.rollover', this.args.report);
+    this.router.transitionTo('curriculum-inventory-report.rollover', this.args.report);
     scrollTo('.rollover-form');
   }
 }

--- a/app/components/curriculum-inventory/report-rollover.hbs
+++ b/app/components/curriculum-inventory/report-rollover.hbs
@@ -95,7 +95,7 @@
             {{t "general.done"}}
           {{/if}}
         </button>
-        <LinkTo @route="curriculumInventoryReport" @model={{@report}}>
+        <LinkTo @route="curriculum-inventory-report" @model={{@report}}>
           <button
             type="button"
             class="cancel text"

--- a/app/components/curriculum-inventory/reports.hbs
+++ b/app/components/curriculum-inventory/reports.hbs
@@ -68,7 +68,7 @@
         {{/if}}
         {{#if this.newReport}}
           <div class="saved-result" data-test-saved-results>
-            <LinkTo @route="curriculumInventoryReport" @model={{this.newReport}}>
+            <LinkTo @route="curriculum-inventory-report" @model={{this.newReport}}>
               <FaIcon @icon="square-up-right" />
               {{this.newReport.name}}
             </LinkTo>

--- a/app/components/curriculum-inventory/sequence-block-details.hbs
+++ b/app/components/curriculum-inventory/sequence-block-details.hbs
@@ -6,7 +6,7 @@
   <div class="breadcrumbs" data-test-breadcrumbs>
     <span data-test-report-crumb>
       <LinkTo
-        @route="curriculumInventoryReport"
+        @route="curriculum-inventory-report"
         @model={{@sequenceBlock.report}}
       >
         {{t "general.curriculumInventoryReport"}}
@@ -14,7 +14,7 @@
     </span>
     {{#each (reverse this.allParents) as |parent|}}
       <span data-test-block-crumb>
-        <LinkTo @route="curriculumInventorySequenceBlock" @model={{parent}}>
+        <LinkTo @route="curriculum-inventory-sequence-block" @model={{parent}}>
           {{parent.title}}
         </LinkTo>
       </span>

--- a/app/components/curriculum-inventory/sequence-block-list-item.hbs
+++ b/app/components/curriculum-inventory/sequence-block-list-item.hbs
@@ -4,7 +4,7 @@
 >
   <td class="text-left" colspan="4" data-test-title>
     <LinkTo
-      @route="curriculumInventorySequenceBlock"
+      @route="curriculum-inventory-sequence-block"
       @model={{@sequenceBlock}}
     >
       {{@sequenceBlock.title}}

--- a/app/components/curriculum-inventory/sequence-block-list.hbs
+++ b/app/components/curriculum-inventory/sequence-block-list.hbs
@@ -24,7 +24,7 @@
     {{/if}}
     {{#if this.savedBlock}}
       <div class="saved-result">
-        <LinkTo @route="curriculumInventorySequenceBlock" @model={{this.savedBlock}}>
+        <LinkTo @route="curriculum-inventory-sequence-block" @model={{this.savedBlock}}>
           <FaIcon @icon="square-up-right" />
           {{this.savedBlock.title}}
         </LinkTo>

--- a/app/components/ilios-navigation.hbs
+++ b/app/components/ilios-navigation.hbs
@@ -74,9 +74,9 @@
         </li>
         <li>
           <LinkTo
-            @route="learnerGroups"
+            @route="learner-groups"
             title={{t "general.learnerGroups"}}
-            @current-when="learnerGroups learnerGroup"
+            @current-when="learner-groups learner-group"
           >
             <FaIcon @icon="graduation-cap" @fixedWidth={{true}} />
             <span class="text">
@@ -86,9 +86,9 @@
         </li>
         <li>
           <LinkTo
-            @route="instructorGroups"
+            @route="instructor-groups"
             title={{t "general.instructorGroups"}}
-            @current-when="instructorGroups instructorGroup"
+            @current-when="instructor-groups instructor-group"
           >
             <FaIcon @icon="user-doctor" @fixedWidth={{true}} />
             <span class="text">
@@ -138,15 +138,15 @@
       {{#if this.currentUser.performsNonLearnerFunction}}
         <li>
           <LinkTo
-            @route="curriculumInventoryReports"
+            @route="curriculum-inventory-reports"
             title={{t "general.curriculumInventory"}}
             @current-when={{
               join " "
               (array
-                "curriculumInventoryReport"
-                "curriculumInventoryReports"
-                "curriculumInventorySequenceBlock"
-                "verificationPreview"
+                "curriculum-inventory-report"
+                "curriculum-inventory-reports"
+                "curriculum-inventory-sequence-block"
+                "verification-preview"
               )
             }}
           >

--- a/app/components/instructor-groups/list-item.hbs
+++ b/app/components/instructor-groups/list-item.hbs
@@ -3,7 +3,7 @@
   data-test-instructor-groups-list-item
 >
   <td class="text-left" colspan="2" data-test-title>
-    <LinkTo @route="instructorGroup" @model={{@instructorGroup}}>
+    <LinkTo @route="instructor-group" @model={{@instructorGroup}}>
       {{@instructorGroup.title}}
     </LinkTo>
   </td>

--- a/app/components/instructor-groups/root.hbs
+++ b/app/components/instructor-groups/root.hbs
@@ -60,7 +60,7 @@
       {{/if}}
       {{#if this.newInstructorGroup}}
         <div class="saved-result">
-          <LinkTo @route="instructorGroup" @model={{this.newInstructorGroup}}>
+          <LinkTo @route="instructor-group" @model={{this.newInstructorGroup}}>
             <FaIcon @icon="square-up-right" />
             {{this.newInstructorGroup.title}}
           </LinkTo>

--- a/app/components/instructorgroup-header.hbs
+++ b/app/components/instructorgroup-header.hbs
@@ -40,13 +40,13 @@
   </div>
   <div class="breadcrumbs" data-test-breadcrumb>
     <span>
-      <LinkTo @route="instructorGroups">
+      <LinkTo @route="instructor-groups">
         {{t "general.instructorGroups"}}
       </LinkTo>
     </span>
     <span>
       <LinkTo
-        @route="instructorGroups"
+        @route="instructor-groups"
         @query={{hash
           schoolId=(get (await @instructorGroup.school) "id")
         }}

--- a/app/components/learner-groups/list-item.hbs
+++ b/app/components/learner-groups/list-item.hbs
@@ -3,7 +3,7 @@
   data-test-learner-groups-list-item
 >
   <td class="text-left" colspan="2" data-test-title>
-    <LinkTo @route="learnerGroup" @model={{@learnerGroup}}>
+    <LinkTo @route="learner-group" @model={{@learnerGroup}}>
       {{@learnerGroup.title}}
     </LinkTo>
   </td>

--- a/app/components/learner-groups/root.hbs
+++ b/app/components/learner-groups/root.hbs
@@ -103,7 +103,7 @@
       {{/if}}
       {{#if this.newLearnerGroup}}
         <div class="saved-result">
-          <LinkTo @route="learnerGroup" @model={{this.newLearnerGroup}}>
+          <LinkTo @route="learner-group" @model={{this.newLearnerGroup}}>
             <FaIcon @icon="square-up-right" />
             {{this.newLearnerGroup.title}}
           </LinkTo>

--- a/app/components/learnergroup-header.hbs
+++ b/app/components/learnergroup-header.hbs
@@ -48,7 +48,7 @@
     <div class="breadcrumbs">
       <span>
         <LinkTo
-          @route="learnerGroups"
+          @route="learner-groups"
           @query={{hash
             school=(await @learnerGroup.cohort.programYear.program.school.id)
             program=(await @learnerGroup.cohort.programYear.program.id)
@@ -61,7 +61,7 @@
       {{#each (reverse (await @learnerGroup.allParents)) as |parent|}}
         <span>
           <LinkTo
-            @route="learnerGroup"
+            @route="learner-group"
             @model={{parent}}
             @query={{hash sortUsersBy=@sortUsersBy}}
           >

--- a/app/components/learnergroup-list.hbs
+++ b/app/components/learnergroup-list.hbs
@@ -65,7 +65,7 @@
             data-test-active-row
           >
             <td class="text-left" colspan="2">
-              <LinkTo @route="learnerGroup" @model={{learnerGroup}}>
+              <LinkTo @route="learner-group" @model={{learnerGroup}}>
                 <span data-test-title>{{learnerGroup.title}}</span>
                 {{#if learnerGroup.needsAccommodation}}
                   <FaIcon @icon="universal-access" @title={{t "general.membersOfThisGroupRequireAccommodation"}} />

--- a/app/components/learnergroup-subgroup-list.hbs
+++ b/app/components/learnergroup-subgroup-list.hbs
@@ -37,7 +37,7 @@
     </section>
     {{#if this.savedGroup}}
       <div class="saved-result">
-        <LinkTo @route="learnerGroup" @model={{this.savedGroup}}>
+        <LinkTo @route="learner-group" @model={{this.savedGroup}}>
           <FaIcon @icon="square-up-right" />
           {{this.savedGroup.title}}
         </LinkTo>

--- a/app/components/learnergroup-user-manager.hbs
+++ b/app/components/learnergroup-user-manager.hbs
@@ -137,7 +137,7 @@
                   {{#if @isEditing}}
                     <td class="text-left" colspan="2">
                       <LinkTo
-                        @route="learnerGroup"
+                        @route="learner-group"
                         @model={{user.lowestGroupInTree}}
                         @query={{hash isEditing=@isEditing sortUsersBy=@sortBy}}
                       >
@@ -242,7 +242,7 @@
                     {{#if @isEditing}}
                       <td class="text-left" colspan="2">
                         <LinkTo
-                          @route="learnerGroup"
+                          @route="learner-group"
                           @model={{user.lowestGroupInTree}}
                           @query={{hash isEditing=@isEditing sortUsersBy=@sortBy}}
                         >

--- a/app/components/program-year/list-item.hbs
+++ b/app/components/program-year/list-item.hbs
@@ -5,7 +5,7 @@
   >
     <td class="text-left">
       <LinkTo
-        @route="programYear.index"
+        @route="program-year"
         @models={{array this.program @programYear}}
         data-test-link
       >

--- a/app/components/program-year/list.hbs
+++ b/app/components/program-year/list.hbs
@@ -29,7 +29,7 @@
       {{#if this.savedProgramYear}}
         <div class="saved-result">
           <LinkTo
-            @route="programYear.index"
+            @route="program-year"
             @models={{array @program this.savedProgramYear}}
           >
             <FaIcon @icon="square-up-right" />

--- a/app/router.js
+++ b/app/router.js
@@ -1,4 +1,3 @@
-/* eslint-disable ember/no-capital-letters-in-routes */
 import { inject as service } from '@ember/service';
 import EmberRouter from '@ember/routing/router';
 import config from 'ilios/config/environment';
@@ -60,13 +59,12 @@ Router.map(function () {
   this.route('print_course', { path: 'course/:course_id/print' });
   this.route('course-materials', { path: 'courses/:course_id/materials' });
 
-  this.route('instructorGroups', { path: 'instructorgroups' });
-  this.route('instructorGroup', { path: 'instructorgroups/:instructor_group_id' });
+  this.route('instructor-groups', { path: 'instructorgroups' });
+  this.route('instructor-group', { path: 'instructorgroups/:instructor_group_id' });
 
-  this.route('testModels');
   this.route('programs');
-  this.route('learnerGroup', { path: 'learnergroups/:learner_group_id' });
-  this.route('learnerGroups', { path: 'learnergroups' });
+  this.route('learner-group', { path: 'learnergroups/:learner_group_id' });
+  this.route('learner-groups', { path: 'learnergroups' });
   this.route(
     'program',
     {
@@ -74,15 +72,15 @@ Router.map(function () {
       resetNamespace: true,
     },
     function () {
-      this.route('publicationCheck', { path: '/publicationcheck' });
+      this.route('publication-check', { path: '/publicationcheck' });
       this.route(
-        'programYear',
+        'program-year',
         {
           path: '/programyears/:program_year_id',
           resetNamespace: true,
         },
         function () {
-          this.route('publicationCheck', { path: '/publicationcheck' });
+          this.route('publication-check', { path: '/publicationcheck' });
         }
       );
     }
@@ -92,7 +90,7 @@ Router.map(function () {
   this.route('events', { path: 'events/:slug' });
   this.route('users', {});
   this.route('user', { path: '/users/:user_id' });
-  this.route('fourOhFour', { path: '*path' });
+  this.route('four-oh-four', { path: '*path' });
   this.route('logout');
   this.route('pending-user-updates', { path: '/admin/userupdates' });
   this.route('schools');
@@ -101,14 +99,12 @@ Router.map(function () {
   this.route('myprofile');
   this.route('mymaterials');
   this.route('course-rollover');
-  this.route('verificationPreview', {
+  this.route('verification-preview', {
     path: 'curriculum-inventory-reports/:curriculum_inventory_report_id/verification-preview',
   });
-  this.route('curriculumInventoryReports', {
-    path: 'curriculum-inventory-reports',
-  });
+  this.route('curriculum-inventory-reports');
   this.route(
-    'curriculumInventoryReport',
+    'curriculum-inventory-report',
     {
       path: 'curriculum-inventory-reports/:curriculum_inventory_report_id',
     },
@@ -116,7 +112,7 @@ Router.map(function () {
       this.route('rollover');
     }
   );
-  this.route('curriculumInventorySequenceBlock', {
+  this.route('curriculum-inventory-sequence-block', {
     path: 'curriculum-inventory-sequence-block/:curriculum_inventory_sequence_block_id',
   });
   this.route('course-visualizations', {

--- a/app/templates/curriculum-inventory-report.hbs
+++ b/app/templates/curriculum-inventory-report.hbs
@@ -1,6 +1,6 @@
 {{page-title (t "general.curriculumInventoryReports")}}
 <div class="backtolink">
-  <LinkTo @route="curriculumInventoryReports">
+  <LinkTo @route="curriculum-inventory-reports">
     {{t "general.backToReports"}}
   </LinkTo>
 </div>

--- a/app/templates/program-year-visualizations.hbs
+++ b/app/templates/program-year-visualizations.hbs
@@ -1,7 +1,7 @@
 {{page-title (t "general.programs")}}
 <section class="program-year-visualizations">
   <div class="backtolink">
-    <LinkTo @route="programYear.index" @models={{array @model.program @model}}>
+    <LinkTo @route="program-year.index" @models={{array @model.program @model}}>
       {{t "general.backToProgramYear"}}
     </LinkTo>
   </div>
@@ -12,7 +12,7 @@
     <LinkTo @route="program" @model={{@model.program}}>
       {{get @model.program "title"}}
     </LinkTo>
-    <LinkTo @route="programYear" @models={{array @model.program @model}}>
+    <LinkTo @route="program-year" @models={{array @model.program @model}}>
       {{#if (get @model.cohort "title")}}
         {{get @model.cohort "title"}}
       {{else}}

--- a/app/templates/program-year-visualize-competencies.hbs
+++ b/app/templates/program-year-visualize-competencies.hbs
@@ -9,7 +9,7 @@
     <LinkTo @route="program" @model={{@model.program}}>
       {{get @model.program "title"}}
     </LinkTo>
-    <LinkTo @route="programYear" @models={{array @model.program @model}}>
+    <LinkTo @route="program-year" @models={{array @model.program @model}}>
       {{#if (get @model.cohort "title")}}
         {{get @model.cohort "title"}}
       {{else}}

--- a/app/templates/verification-preview.hbs
+++ b/app/templates/verification-preview.hbs
@@ -1,6 +1,6 @@
 {{page-title (t "general.curriculumInventoryReports")}}
 <div data-test-back-to-report class="backtolink">
-  <LinkTo @route="curriculumInventoryReport" @model={{@model}}>
+  <LinkTo @route="curriculum-inventory-report" @model={{@model}}>
     {{t "general.backToReport"}}
   </LinkTo>
 </div>

--- a/tests/acceptance/curriculum-inventory/report-test.js
+++ b/tests/acceptance/curriculum-inventory/report-test.js
@@ -23,7 +23,7 @@ module('Acceptance | curriculum inventory report', function (hooks) {
       .lookup('service:store')
       .find('curriculumInventoryReport', report.id);
     await page.visit({ reportId: reportModel.id });
-    assert.strictEqual(currentRouteName(), 'curriculumInventoryReport.index');
+    assert.strictEqual(currentRouteName(), 'curriculum-inventory-report.index');
     assert.notOk(page.blocks.newBlock.form.isVisible);
     await page.blocks.header.expandCollapse.toggle();
     assert.ok(page.blocks.newBlock.form.isVisible);
@@ -44,7 +44,7 @@ module('Acceptance | curriculum inventory report', function (hooks) {
       .lookup('service:store')
       .find('curriculumInventoryReport', report.id);
     await page.visit({ reportId: reportModel.id });
-    assert.strictEqual(currentRouteName(), 'curriculumInventoryReport.index');
+    assert.strictEqual(currentRouteName(), 'curriculum-inventory-report.index');
     assert.notOk(page.details.overview.rolloverLink.isVisible);
   });
 
@@ -64,7 +64,7 @@ module('Acceptance | curriculum inventory report', function (hooks) {
       .lookup('service:store')
       .find('curriculumInventoryReport', report.id);
     await page.visit({ reportId: reportModel.id });
-    assert.strictEqual(currentRouteName(), 'curriculumInventoryReport.index');
+    assert.strictEqual(currentRouteName(), 'curriculum-inventory-report.index');
     assert.ok(page.details.overview.rolloverLink.isVisible);
   });
 

--- a/tests/acceptance/curriculum-inventory/rollover-test.js
+++ b/tests/acceptance/curriculum-inventory/rollover-test.js
@@ -30,7 +30,7 @@ module('Acceptance | curriculum inventory report/rollover', function (hooks) {
       .lookup('service:store')
       .find('curriculumInventoryReport', report.id);
     await page.visit({ reportId: reportModel.id });
-    assert.strictEqual(currentRouteName(), 'curriculumInventoryReport.rollover');
+    assert.strictEqual(currentRouteName(), 'curriculum-inventory-report.rollover');
     assert.notOk(page.details.overview.rolloverLink.isVisible);
   });
 });

--- a/tests/acceptance/four-oh-four-test.js
+++ b/tests/acceptance/four-oh-four-test.js
@@ -15,7 +15,7 @@ module('Acceptance | FourOhFour', function (hooks) {
   test('visiting /four-oh-four', async function (assert) {
     await visit('/four-oh-four');
 
-    assert.strictEqual(currentRouteName(), 'fourOhFour');
+    assert.strictEqual(currentRouteName(), 'four-oh-four');
     assert
       .dom('.full-screen-error')
       .hasText(
@@ -25,6 +25,6 @@ module('Acceptance | FourOhFour', function (hooks) {
 
   test('visiting /nothing', async function (assert) {
     await visit('/nothing');
-    assert.strictEqual(currentRouteName(), 'fourOhFour');
+    assert.strictEqual(currentRouteName(), 'four-oh-four');
   });
 });

--- a/tests/acceptance/instructorgroup-test.js
+++ b/tests/acceptance/instructorgroup-test.js
@@ -53,7 +53,7 @@ module('Acceptance | Instructor Group Details', function (hooks) {
 
   test('check fields', async function (assert) {
     await visit(url);
-    assert.strictEqual(currentRouteName(), 'instructorGroup');
+    assert.strictEqual(currentRouteName(), 'instructor-group');
     assert.strictEqual(page.details.header.title.text, 'instructor group 0');
     assert.strictEqual(page.details.header.members, 'Members: 2');
     assert.strictEqual(page.details.header.breadcrumb.crumbs.length, 3);

--- a/tests/acceptance/instructorgroups-test.js
+++ b/tests/acceptance/instructorgroups-test.js
@@ -18,7 +18,7 @@ module('Acceptance | Instructor Groups', function (hooks) {
 
     test('visiting /instructorgroups', async function (assert) {
       await page.visit();
-      assert.strictEqual(currentRouteName(), 'instructorGroups');
+      assert.strictEqual(currentRouteName(), 'instructor-groups');
     });
 
     test('list groups', async function (assert) {

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -18,7 +18,7 @@ module('Acceptance | Learner Groups', function (hooks) {
 
   test('visiting /learnergroups', async function (assert) {
     await page.visit();
-    assert.strictEqual(currentRouteName(), 'learnerGroups');
+    assert.strictEqual(currentRouteName(), 'learner-groups');
   });
 
   test('single option filters', async function (assert) {
@@ -415,7 +415,7 @@ module('Acceptance | Learner Groups', function (hooks) {
     this.user.update({ administeredSchools: [this.school] });
 
     await page.visit();
-    assert.strictEqual(currentRouteName(), 'learnerGroups');
+    assert.strictEqual(currentRouteName(), 'learner-groups');
     assert.notOk(page.hasNewGroupToggle);
   });
 

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -121,7 +121,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
     this.server.create('cohort', { programYear });
     await page.visit({ programId: this.program.id });
     await page.programYears.items[0].link.click();
-    assert.strictEqual(currentRouteName(), 'programYear.index');
+    assert.strictEqual(currentRouteName(), 'program-year.index');
   });
 
   test('can delete a program-year', async function (assert) {

--- a/tests/acceptance/program/programyear/overview-test.js
+++ b/tests/acceptance/program/programyear/overview-test.js
@@ -29,7 +29,7 @@ module('Acceptance | Program Year - Overview', function (hooks) {
 
   test('list directors', async function (assert) {
     await page.visit({ programId: this.program.id, programYearId: this.programYear.id });
-    assert.strictEqual(currentRouteName(), 'programYear.index');
+    assert.strictEqual(currentRouteName(), 'program-year.index');
     assert.strictEqual(page.overview.directors.length, 3);
     assert.strictEqual(page.overview.directors[0].userNameInfo.fullName, '1 guy M. Mc1son');
     assert.notOk(page.overview.directors[0].userNameInfo.hasAdditionalInfo);
@@ -42,7 +42,7 @@ module('Acceptance | Program Year - Overview', function (hooks) {
   test('list directors with privileges', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: this.program.id, programYearId: this.programYear.id });
-    assert.strictEqual(currentRouteName(), 'programYear.index');
+    assert.strictEqual(currentRouteName(), 'program-year.index');
     assert.strictEqual(page.overview.directors.length, 3);
     assert.strictEqual(page.overview.directors[0].userNameInfo.fullName, '1 guy M. Mc1son');
     assert.strictEqual(page.overview.directors[1].userNameInfo.fullName, '3 guy M. Mc3son');
@@ -52,7 +52,7 @@ module('Acceptance | Program Year - Overview', function (hooks) {
   test('search directors', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: this.program.id, programYearId: this.programYear.id });
-    assert.strictEqual(currentRouteName(), 'programYear.index');
+    assert.strictEqual(currentRouteName(), 'program-year.index');
     await page.overview.search.searchBox.set('guy');
     assert.strictEqual(page.overview.search.results.items.length, 6);
     assert.strictEqual(
@@ -87,7 +87,7 @@ module('Acceptance | Program Year - Overview', function (hooks) {
   test('add director', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: this.program.id, programYearId: this.programYear.id });
-    assert.strictEqual(currentRouteName(), 'programYear.index');
+    assert.strictEqual(currentRouteName(), 'program-year.index');
     assert.strictEqual(page.overview.directors.length, 3);
     assert.strictEqual(page.overview.directors[0].userNameInfo.fullName, '1 guy M. Mc1son');
     assert.strictEqual(page.overview.directors[1].userNameInfo.fullName, '3 guy M. Mc3son');
@@ -104,7 +104,7 @@ module('Acceptance | Program Year - Overview', function (hooks) {
   test('remove director', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: this.program.id, programYearId: this.programYear.id });
-    assert.strictEqual(currentRouteName(), 'programYear.index');
+    assert.strictEqual(currentRouteName(), 'program-year.index');
     assert.strictEqual(page.overview.directors.length, 3);
     assert.strictEqual(page.overview.directors[0].userNameInfo.fullName, '1 guy M. Mc1son');
     assert.strictEqual(page.overview.directors[1].userNameInfo.fullName, '3 guy M. Mc3son');
@@ -125,7 +125,7 @@ module('Acceptance | Program Year - Overview', function (hooks) {
       programYear,
     });
     await page.visit({ programId: this.program.id, programYearId: programYear.id });
-    assert.strictEqual(currentRouteName(), 'programYear.index');
+    assert.strictEqual(currentRouteName(), 'program-year.index');
     assert.strictEqual(page.overview.directors.length, 0);
     await page.overview.search.searchBox.set('guy');
     assert.strictEqual(page.overview.search.results.items.length, 6);

--- a/tests/acceptance/program/publicationcheck-test.js
+++ b/tests/acceptance/program/publicationcheck-test.js
@@ -25,7 +25,7 @@ module('Acceptance | Program - Publication Check', function (hooks) {
 
   test('full program count', async function (assert) {
     await visit('/programs/' + this.fullProgram.id + '/publicationcheck');
-    assert.strictEqual(currentRouteName(), 'program.publicationCheck');
+    assert.strictEqual(currentRouteName(), 'program.publication-check');
     assert
       .dom('.program-publication-check .detail-content table tbody td:nth-of-type(1)')
       .hasText('program 0');
@@ -42,7 +42,7 @@ module('Acceptance | Program - Publication Check', function (hooks) {
 
   test('empty program count', async function (assert) {
     await visit('/programs/' + this.emptyProgram.id + '/publicationcheck');
-    assert.strictEqual(currentRouteName(), 'program.publicationCheck');
+    assert.strictEqual(currentRouteName(), 'program.publication-check');
     assert
       .dom('.program-publication-check .detail-content table tbody td:nth-of-type(1)')
       .hasText('program 1');

--- a/tests/unit/routes/program/publication-check-test.js
+++ b/tests/unit/routes/program/publication-check-test.js
@@ -5,7 +5,7 @@ module('Unit | Route | PublicationCheck ', function (hooks) {
   setupTest(hooks);
 
   test('it exists', function (assert) {
-    var route = this.owner.lookup('route:program/publicationCheck');
+    var route = this.owner.lookup('route:program/publication-check');
     assert.ok(route);
   });
 });


### PR DESCRIPTION
We've been ignoring this linting error for a while, but it causes big
problems with embroider so I've gone ahead and replaced all the capital
route names with dasherized.