### PR TITLE
Remove our 'preview' environment in favor of an ENV var

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -128,18 +128,10 @@ module.exports = function (environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
-  }
-
-  if (environment === 'preview') {
-    // here you can enable a preview-specific feature
-    ENV.IliosFeatures.programYearVisualizations = true;
-    ENV['ember-a11y-testing'].componentOptions.turnAuditOff = true;
-    ENV.featureFlags['globalSearch'] = true;
-
-    //Remove mirage
-    ENV['ember-cli-mirage'] = {
-      enabled: false,
-    };
+    if (process.env.ENABLE_PREVIEW_FEATURES) {
+      ENV.IliosFeatures.programYearVisualizations = true;
+      ENV.featureFlags['globalSearch'] = true;
+    }
   }
 
   return ENV;

--- a/config/targets.js
+++ b/config/targets.js
@@ -3,9 +3,9 @@
 const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
 const isCI = Boolean(process.env.CI);
-const isProductionLikeBuild = ['production', 'preview'].includes(process.env.EMBER_ENV);
+const isProduction = process.env.EMBER_ENV === 'production';
 
-if (isCI || isProductionLikeBuild) {
+if (isCI || isProduction) {
   browsers.push('last 1 edge versions');
   browsers.push('firefox esr'); //sometimes points to the last 2 ESR releases when they overlap
   browsers.push('last 4 ios versions');

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,21 +6,16 @@ const broccoliAssetRevDefaults = require('broccoli-asset-rev/lib/default-options
 
 module.exports = function (defaults) {
   const env = EmberApp.env() || 'development';
-  const isProductionLikeBuild = ['production', 'staging', 'preview'].indexOf(env) > -1;
   const isTestBuild = env === 'test';
 
   const app = new EmberApp(defaults, {
     fingerprint: {
       extensions: broccoliAssetRevDefaults.extensions.concat(['webmanifest', 'svg']),
-      enabled: isProductionLikeBuild,
     },
     sourcemaps: {
       enabled: true,
     },
-    minifyCSS: { enabled: isProductionLikeBuild },
-    minifyJS: { enabled: isProductionLikeBuild },
 
-    tests: env.EMBER_CLI_TEST_COMMAND || !isProductionLikeBuild,
     hinting: isTestBuild,
     babel: {
       plugins: [require('ember-auto-import/babel-plugin')],


### PR DESCRIPTION
The preview environment was always a hack on our end and we end up
jumping through hoops to keep it working and use it in only one place
for our netlify builds. This actually causes our netlify builds to be
less like production as they end up including a bunch of code that Ember
normally strips out for production.