### PR TITLE
Fix annoying horizontal scroll

### DIFF
--- a/app/styles/layout/_layout.scss
+++ b/app/styles/layout/_layout.scss
@@ -7,7 +7,7 @@
   'footer';
   grid-template-rows: auto 10px 1fr 20px;
   height: 100vh;
-  width: 100vw;
+  width: 100%;
 
   & > header {
     grid-area: header;


### PR DESCRIPTION
This appears to be a known browser bug, I'm not sure why it is popping
up for us now, but using vw units doesn't account for any scroll bars so
anytime there is a need for vertical scroll we were getting horizontal
bars as well. By using a 100% of the body we get the same effect without
the bug.

Fixes ilios/ilios#3999