### PR TITLE
Restructure header for a11y

### DIFF
--- a/app/components/ilios-header.hbs
+++ b/app/components/ilios-header.hbs
@@ -4,19 +4,21 @@
     @skipText={{t "general.skipToMainContent"}}
     @routeChangeValidator={{this.checkRouteChange}}
   />
-  <LinkTo @route="dashboard" class="logo" title={{t "general.dashboard"}}>
-    <h1 class="visually-hidden" data-test-title>
-      {{@title}}
-    </h1>
-    <span class="image"></span>
-  </LinkTo>
-  <div class="tools">
-    {{#if this.showSearch}}
-      <GlobalSearchBox @search={{this.search}} />
-    {{/if}}
-    <LocaleChooser />
-    {{#if this.session.isAuthenticated}}
-      <UserMenu />
-    {{/if}}
+  <div class="header-content">
+    <LinkTo @route="dashboard" class="logo" title={{t "general.dashboard"}}>
+      <h1 class="visually-hidden" data-test-title>
+        {{@title}}
+      </h1>
+      <span class="image"></span>
+    </LinkTo>
+    <div class="tools">
+      {{#if this.showSearch}}
+        <GlobalSearchBox @search={{this.search}} />
+      {{/if}}
+      <LocaleChooser />
+      {{#if this.session.isAuthenticated}}
+        <UserMenu />
+      {{/if}}
+    </div>
   </div>
 </header>

--- a/app/styles/components/ilios-header.scss
+++ b/app/styles/components/ilios-header.scss
@@ -1,77 +1,79 @@
 .ilios-header {
-  align-items: center;
-  background-color: $ilios-orange;
-  display: grid;
-  grid-template-areas: 'logo tools';
-  height: auto;
-  grid-template-columns: 100px auto;
-
-  @media print {
-    display: none;
-  }
-
-  .logo {
-    grid-area: logo;
-
-    .image {
-      background-image: url('images/ilios-logo.svg');
-      background-repeat: no-repeat;
-      display: block;
-      height: 42px;
-    }
-  }
-
-  // Elements on the far right
-  .tools {
-    background: transparent;
-    grid-area: tools;
-    margin-right: .25rem;
-    padding: .25rem 0;
+  .header-content {
+    align-items: center;
+    background-color: $ilios-orange;
     display: grid;
-    justify-content: end;
-    grid-template-areas: 
-    ". locale user"
-    "search search search";
-    row-gap: .25rem;
+    grid-template-areas: 'logo tools';
+    height: auto;
+    grid-template-columns: 100px auto;
 
-
-    @include for-tablet-and-up {
-      grid-template-areas: "search locale user";
-      padding-bottom: 0;
+    @media print {
+      display: none;
     }
 
-    .locale-chooser {
-      grid-area: locale;
-    }
-    .user-menu {
-      grid-area: user;
-    }
+    .logo {
+      grid-area: logo;
 
-    .global-search-box {
-      margin-right: .5rem;
-      width: 13rem;
-      grid-area: search;
-
-      @include for-phone-only {
-        width: 10rem;
-      }
-
-      .autocomplete {
-        width: 25rem;
-
-        @include for-smaller-than-laptop {
-          right: 0rem;
-        }
-
-        @media screen and (max-width: 550px) {
-          left: -7rem;
-          right: auto;
-        }
+      .image {
+        background-image: url('images/ilios-logo.svg');
+        background-repeat: no-repeat;
+        display: block;
+        height: 42px;
       }
     }
-  }
 
-  .visually-hidden {
-    @include visually-hidden;
+    // Elements on the far right
+    .tools {
+      background: transparent;
+      grid-area: tools;
+      margin-right: .25rem;
+      padding: .25rem 0;
+      display: grid;
+      justify-content: end;
+      grid-template-areas: 
+      ". locale user"
+      "search search search";
+      row-gap: .25rem;
+
+
+      @include for-tablet-and-up {
+        grid-template-areas: "search locale user";
+        padding-bottom: 0;
+      }
+
+      .locale-chooser {
+        grid-area: locale;
+      }
+      .user-menu {
+        grid-area: user;
+      }
+
+      .global-search-box {
+        margin-right: .5rem;
+        width: 13rem;
+        grid-area: search;
+
+        @include for-phone-only {
+          width: 10rem;
+        }
+
+        .autocomplete {
+          width: 25rem;
+
+          @include for-smaller-than-laptop {
+            right: 0rem;
+          }
+
+          @media screen and (max-width: 550px) {
+            left: -7rem;
+            right: auto;
+          }
+        }
+      }
+    }
+
+    .visually-hidden {
+      @include visually-hidden;
+    }
   }
 }


### PR DESCRIPTION
This may only be an issue for our automated scanner, but it's having
trouble parsing out the route announcer because it is technically inside
the orange header. This restructuring moves the visual content into a
div with the background without changing the actual look of the page.