### PR TITLE
Make sorting criteria in top-level learner-groups and instructor-groups sticky

### DIFF
--- a/app/components/instructor-groups/list.hbs
+++ b/app/components/instructor-groups/list.hbs
@@ -10,8 +10,8 @@
         @sortedAscending={{this.sortedAscending}}
         @onClick={{fn this.setSortBy "title"}}
         @sortedBy={{or
-          (eq this.sortBy "title")
-          (eq this.sortBy "title:desc")
+          (eq @sortBy "title")
+          (eq @sortBy "title:desc")
         }}
       >
         {{t "general.instructorGroupTitle"}}
@@ -24,8 +24,8 @@
         @sortType="numeric"
         @onClick={{fn this.setSortBy "usersCount"}}
         @sortedBy={{or
-          (eq this.sortBy "usersCount")
-          (eq this.sortBy "usersCount:desc")
+          (eq @sortBy "usersCount")
+          (eq @sortBy "usersCount:desc")
         }}
       >
         {{t "general.members"}}
@@ -40,7 +40,7 @@
   </thead>
   <tbody>
     {{#each (
-      sort-by (if (or (eq this.sortBy "title") (eq this.sortBy "title:desc")) this.sortByTitle this.sortBy
+      sort-by (if (or (eq @sortBy "title") (eq @sortBy "title:desc")) this.sortByTitle @sortBy
     ) @instructorGroups) as |instructorGroup|
     }}
       <InstructorGroups::ListItem @instructorGroup={{instructorGroup}} />

--- a/app/components/instructor-groups/list.js
+++ b/app/components/instructor-groups/list.js
@@ -8,22 +8,21 @@ export default class LearnerGroupListComponent extends Component {
   @tracked sortBy = 'title';
 
   get sortedAscending() {
-    return this.sortBy.search(/desc/) === -1;
+    return !this.args.sortBy.includes(':desc');
   }
 
   @action
   setSortBy(what) {
-    if (this.sortBy === what) {
+    if (this.args.sortBy === what) {
       what += ':desc';
     }
-
-    this.sortBy = what;
+    this.args.setSortBy(what);
   }
 
   @action
   sortByTitle(instructorGroupA, instructorGroupB) {
     const locale = this.intl.get('primaryLocale');
-    if ('title:desc' === this.sortBy) {
+    if ('title:desc' === this.args.sortBy) {
       return instructorGroupB.title.localeCompare(instructorGroupA.title, locale, {
         numeric: true,
       });

--- a/app/components/instructor-groups/root.hbs
+++ b/app/components/instructor-groups/root.hbs
@@ -70,7 +70,11 @@
     </div>
     <div class="list">
       {{#if this.isLoaded}}
-        <InstructorGroups::List @instructorGroups={{sort-by "title" this.filteredInstructorGroups}} />
+        <InstructorGroups::List
+          @instructorGroups={{this.filteredInstructorGroups}}
+          @sortBy={{@sortBy}}
+          @setSortBy={{@setSortBy}}
+        />
       {{else}}
         <InstructorGroups::Loading @count={{this.countForSelectedSchool}} />
       {{/if}}

--- a/app/components/learner-groups/list.hbs
+++ b/app/components/learner-groups/list.hbs
@@ -1,7 +1,7 @@
 <table
   class="learner-groups-list"
-  ...attributes
   data-test-learner-groups-list
+  ...attributes
 >
   <thead>
     <tr>
@@ -10,8 +10,8 @@
         @sortedAscending={{this.sortedAscending}}
         @onClick={{fn this.setSortBy "title"}}
         @sortedBy={{or
-          (eq this.sortBy "title")
-          (eq this.sortBy "title:desc")
+          (eq @sortBy "title")
+          (eq @sortBy "title:desc")
         }}
       >
         {{t "general.learnerGroupTitle"}}
@@ -24,8 +24,8 @@
         @sortType="numeric"
         @onClick={{fn this.setSortBy "usersCount"}}
         @sortedBy={{or
-          (eq this.sortBy "usersCount")
-          (eq this.sortBy "usersCount:desc")
+          (eq @sortBy "usersCount")
+          (eq @sortBy "usersCount:desc")
         }}
       >
         {{t "general.members"}}
@@ -38,8 +38,8 @@
         @sortType="numeric"
         @onClick={{fn this.setSortBy "childrenCount"}}
         @sortedBy={{or
-          (eq this.sortBy "childrenCount")
-          (eq this.sortBy "childrenCount:desc")
+          (eq @sortBy "childrenCount")
+          (eq @sortBy "childrenCount:desc")
         }}
       >
         {{t "general.subgroups"}}
@@ -51,7 +51,7 @@
   </thead>
   <tbody>
     {{#each (
-      sort-by (if (or (eq this.sortBy "title") (eq this.sortBy "title:desc")) this.sortByTitle this.sortBy
+      sort-by (if (or (eq @sortBy "title") (eq @sortBy "title:desc")) this.sortByTitle @sortBy
       ) @learnerGroups) as |learnerGroup|
     }}
       <LearnerGroups::ListItem

--- a/app/components/learner-groups/list.js
+++ b/app/components/learner-groups/list.js
@@ -1,28 +1,26 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class LearnerGroupsListComponent extends Component {
   @service intl;
-  @tracked sortBy = 'title';
 
   get sortedAscending() {
-    return this.sortBy.search(/desc/) === -1;
+    return !this.args.sortBy.includes(':desc');
   }
 
   @action
   setSortBy(what) {
-    if (this.sortBy === what) {
+    if (this.args.sortBy === what) {
       what += ':desc';
     }
-    this.sortBy = what;
+    this.args.setSortBy(what);
   }
 
   @action
   sortByTitle(learnerGroupA, learnerGroupB) {
     const locale = this.intl.get('primaryLocale');
-    if ('title:desc' === this.sortBy) {
+    if ('title:desc' === this.args.sortBy) {
       return learnerGroupB.title.localeCompare(learnerGroupA.title, locale, { numeric: true });
     }
     return learnerGroupA.title.localeCompare(learnerGroupB.title, locale, { numeric: true });

--- a/app/components/learner-groups/root.hbs
+++ b/app/components/learner-groups/root.hbs
@@ -117,6 +117,8 @@
           @learnerGroups={{this.filteredLearnerGroups}}
           @canCopyWithLearners={{true}}
           @copyGroup={{perform this.copyGroup}}
+          @sortBy={{@sortBy}}
+          @setSortBy={{@setSortBy}}
         />
       {{else}}
         <PulseLoader />

--- a/app/controllers/instructor-groups.js
+++ b/app/controllers/instructor-groups.js
@@ -3,9 +3,10 @@ import { restartableTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 
 export default class InstructorGroupsController extends Controller {
-  queryParams = [{ schoolId: 'school' }, { titleFilter: 'filter' }];
+  queryParams = [{ schoolId: 'school' }, { titleFilter: 'filter' }, 'sortBy'];
   @tracked schoolId;
   @tracked titleFilter;
+  @tracked sortBy = 'title';
 
   @restartableTask
   *changeTitleFilter(value) {

--- a/app/controllers/learner-groups.js
+++ b/app/controllers/learner-groups.js
@@ -3,12 +3,13 @@ import { restartableTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 
 export default class LearnerGroupsController extends Controller {
-  queryParams = ['program', 'programYear', 'school', 'filter'];
+  queryParams = ['program', 'programYear', 'school', 'filter', 'sortBy'];
 
   @tracked programId;
   @tracked programYearId;
   @tracked schoolId;
   @tracked filter;
+  @tracked sortBy = 'title';
 
   @restartableTask
   *setTitleFilter(value) {

--- a/app/templates/instructor-groups.hbs
+++ b/app/templates/instructor-groups.hbs
@@ -5,4 +5,6 @@
   @setSchoolId={{set this.schoolId}}
   @schoolId={{this.schoolId}}
   @schools={{this.model}}
+  @sortBy={{this.sortBy}}
+  @setSortBy={{set this.sortBy}}
 />

--- a/app/templates/learner-groups.hbs
+++ b/app/templates/learner-groups.hbs
@@ -9,4 +9,6 @@
   @schools={{this.model}}
   @titleFilter={{this.filter}}
   @setTitleFilter={{perform this.setTitleFilter}}
+  @sortBy={{this.sortBy}}
+  @setSortBy={{set this.sortBy}}
 />

--- a/tests/integration/components/instructor-groups/list-test.js
+++ b/tests/integration/components/instructor-groups/list-test.js
@@ -29,8 +29,11 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
       .lookup('service:store')
       .findAll('instructor-group');
     this.set('instructorGroups', instructorGroupModels);
-    await render(hbs`<InstructorGroups::List @instructorGroups={{this.instructorGroups}} />`);
-
+    await render(hbs`<InstructorGroups::List
+      @instructorGroups={{this.instructorGroups}}
+      @sortBy="title"
+      @setSortBy={{(noop)}}
+    />`);
     assert.strictEqual(component.header.title.text, 'Instructor Group Title');
     assert.strictEqual(component.header.members.text, 'Members');
     assert.strictEqual(component.items.length, 3);
@@ -44,7 +47,11 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
   });
 
   test('it renders empty', async function (assert) {
-    await render(hbs`<InstructorGroups::List @programs={{(array)}} />`);
+    await render(hbs`<InstructorGroups::List
+      @programs={{(array)}}
+      @sortBy="title"
+      @setSortBy={{this.sortBy}}
+    />`);
 
     assert.strictEqual(component.items.length, 0);
     assert.ok(component.isEmpty);
@@ -57,7 +64,11 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
       .lookup('service:store')
       .findAll('instructor-group');
     this.set('instructorGroups', instructorGroupModels);
-    await render(hbs`<InstructorGroups::List @instructorGroups={{this.instructorGroups}} />`);
+    await render(hbs`<InstructorGroups::List
+      @instructorGroups={{this.instructorGroups}}
+      @sortBy="title"
+      @setSortBy={{(noop)}}
+    />`);
     assert.strictEqual(this.server.db.instructorGroups.length, 3);
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].title, 'instructor group 0');
@@ -75,7 +86,11 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
       .lookup('service:store')
       .findAll('instructor-group');
     this.set('instructorGroups', instructorGroupModels);
-    await render(hbs`<InstructorGroups::List @instructorGroups={{this.instructorGroups}} />`);
+    await render(hbs`<InstructorGroups::List
+      @instructorGroups={{this.instructorGroups}}
+      @sortBy="title"
+      @setSortBy={{(noop)}}
+    />`);
     assert.strictEqual(this.server.db.instructorGroups.length, 3);
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].title, 'instructor group 0');
@@ -96,9 +111,13 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
     const instructorGroupModels = await this.owner
       .lookup('service:store')
       .findAll('instructor-group');
+    this.set('sortBy', 'title');
     this.set('instructorGroups', instructorGroupModels);
-    await render(hbs`<InstructorGroups::List @instructorGroups={{this.instructorGroups}} />`);
-
+    await render(hbs`<InstructorGroups::List
+      @instructorGroups={{this.instructorGroups}}
+      @sortBy={{this.sortBy}}
+      @setSortBy={{set this.sortBy}}
+    />`);
     assert.strictEqual(component.items.length, 3);
     assert.ok(component.header.title.isSortedAscending);
     assert.ok(component.header.members.isNotSorted);

--- a/tests/integration/components/instructor-groups/list-test.js
+++ b/tests/integration/components/instructor-groups/list-test.js
@@ -50,7 +50,7 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
     await render(hbs`<InstructorGroups::List
       @programs={{(array)}}
       @sortBy="title"
-      @setSortBy={{this.sortBy}}
+      @setSortBy={{(noop)}}
     />`);
 
     assert.strictEqual(component.items.length, 0);

--- a/tests/integration/components/instructor-groups/root-test.js
+++ b/tests/integration/components/instructor-groups/root-test.js
@@ -45,7 +45,11 @@ module('Integration | Component | instructor-groups/root', function (hooks) {
   test('it renders', async function (assert) {
     setupPermissionChecker(this, true);
     this.set('schools', this.schools);
-    await render(hbs`<InstructorGroups::Root @schools={{this.schools}} />`);
+    await render(hbs`<InstructorGroups::Root
+      @schools={{this.schools}}
+      @sortBy="title"
+      @setSortBy={{(noop)}}
+    />`);
     assert.strictEqual(component.list.items.length, 3);
     assert.strictEqual(component.list.items[0].title, 'instructor group 3');
     assert.strictEqual(component.list.items[1].title, 'instructor group 4');
@@ -71,6 +75,8 @@ module('Integration | Component | instructor-groups/root', function (hooks) {
       @schools={{this.schools}}
       @setSchoolId={{this.setSchoolId}}
       @schoolId={{this.schoolId}}
+      @sortBy="title"
+      @setSortBy={{(noop)}}
     />`);
     assert.strictEqual(component.schoolFilter.selectedSchool, '2');
     assert.strictEqual(component.list.items.length, 3);
@@ -98,6 +104,8 @@ module('Integration | Component | instructor-groups/root', function (hooks) {
       @schools={{this.schools}}
       @setTitleFilter={{this.setTitleFilter}}
       @titleFilter={{this.titleFilter}}
+      @sortBy="title"
+      @setSortBy={{(noop)}}
     />`);
     assert.strictEqual(component.list.items.length, 3);
     assert.strictEqual(component.list.items[0].title, 'instructor group 3');
@@ -107,5 +115,32 @@ module('Integration | Component | instructor-groups/root', function (hooks) {
     await component.setTitleFilter('4');
     assert.strictEqual(component.list.items.length, 1);
     assert.strictEqual(component.list.items[0].title, 'instructor group 4');
+  });
+
+  test('sort', async function (assert) {
+    assert.expect(7);
+    setupPermissionChecker(this, true);
+    this.set('schools', this.schools);
+    this.set('sortBy', 'title');
+    this.set('setSortBy', (sortBy) => {
+      this.set(sortBy, 'title:desc');
+      this.set('sortBy', sortBy);
+    });
+
+    await render(hbs`<InstructorGroups::Root
+      @schools={{this.schools}}
+      @sortBy={{this.sortBy}}
+      @setSortBy={{this.setSortBy}}
+    />`);
+
+    assert.strictEqual(component.list.items.length, 3);
+    assert.strictEqual(component.list.items[0].title, 'instructor group 3');
+    assert.strictEqual(component.list.items[1].title, 'instructor group 4');
+    assert.strictEqual(component.list.items[2].title, 'instructor group 5');
+
+    await component.list.header.title.click();
+    assert.strictEqual(component.list.items[0].title, 'instructor group 5');
+    assert.strictEqual(component.list.items[1].title, 'instructor group 4');
+    assert.strictEqual(component.list.items[2].title, 'instructor group 3');
   });
 });

--- a/tests/integration/components/learner-groups/root-test.js
+++ b/tests/integration/components/learner-groups/root-test.js
@@ -61,7 +61,11 @@ module('Integration | Component | learner-groups/root', function (hooks) {
   test('it renders', async function (assert) {
     setupPermissionChecker(this, true);
     this.set('schools', this.schools);
-    await render(hbs`<LearnerGroups::Root @schools={{this.schools}} />`);
+    await render(hbs`<LearnerGroups::Root
+      @schools={{this.schools}}
+      @sortBy="title"
+      @setSortBy={{(noop)}}
+    />`);
     assert.strictEqual(component.list.items.length, 2);
     assert.strictEqual(component.list.items[0].title, 'learner group 2');
     assert.strictEqual(component.list.items[1].title, 'learner group 3');
@@ -111,6 +115,8 @@ module('Integration | Component | learner-groups/root', function (hooks) {
       @programId={{this.programId}}
       @setProgramYearId={{this.setProgramYearId}}
       @programYearId={{this.programYearId}}
+      @sortBy="title"
+      @setSortBy={{(noop)}}
     />`);
     assert.strictEqual(component.schoolFilter.selectedSchool, '2');
     assert.strictEqual(component.programFilter.selectedProgram, '4');
@@ -150,6 +156,8 @@ module('Integration | Component | learner-groups/root', function (hooks) {
       @programId={{this.programId}}
       @setProgramYearId={{this.setProgramYearId}}
       @programYearId={{this.programYearId}}
+      @sortBy="title"
+      @setSortBy={{(noop)}}
     />`);
     assert.strictEqual(component.schoolFilter.selectedSchool, '2');
     assert.strictEqual(component.programFilter.selectedProgram, '4');
@@ -187,6 +195,8 @@ module('Integration | Component | learner-groups/root', function (hooks) {
       @programId={{this.programId}}
       @setProgramYearId={{this.setProgramYearId}}
       @programYearId={{this.programYearId}}
+      @sortBy="title"
+      @setSortBy={{(noop)}}
     />`);
     assert.strictEqual(component.schoolFilter.selectedSchool, '2');
     assert.strictEqual(component.programFilter.selectedProgram, '4');
@@ -212,6 +222,8 @@ module('Integration | Component | learner-groups/root', function (hooks) {
       @schools={{this.schools}}
       @setTitleFilter={{this.setTitleFilter}}
       @titleFilter={{this.titleFilter}}
+      @sortBy="title"
+      @setSortBy={{(noop)}}
     />`);
     assert.strictEqual(component.list.items.length, 2);
     assert.strictEqual(component.list.items[0].title, 'learner group 2');
@@ -220,5 +232,29 @@ module('Integration | Component | learner-groups/root', function (hooks) {
     await component.setTitleFilter('3');
     assert.strictEqual(component.list.items.length, 1);
     assert.strictEqual(component.list.items[0].title, 'learner group 3');
+  });
+
+  test('sort', async function (assert) {
+    assert.expect(6);
+    setupPermissionChecker(this, true);
+    this.set('schools', this.schools);
+    this.set('sortBy', 'title');
+    this.set('setSortBy', (sortBy) => {
+      assert.strictEqual(sortBy, 'title:desc');
+      this.set('sortBy', sortBy);
+    });
+
+    await render(hbs`<LearnerGroups::Root
+      @schools={{this.schools}}
+      @sortBy={{this.sortBy}}
+      @setSortBy={{this.setSortBy}}
+    />`);
+
+    assert.strictEqual(component.list.items.length, 2);
+    assert.strictEqual(component.list.items[0].title, 'learner group 2');
+    assert.strictEqual(component.list.items[1].title, 'learner group 3');
+    await component.list.header.title.click();
+    assert.strictEqual(component.list.items[0].title, 'learner group 3');
+    assert.strictEqual(component.list.items[1].title, 'learner group 2');
   });
 });

--- a/tests/pages/components/learner-groups/list.js
+++ b/tests/pages/components/learner-groups/list.js
@@ -1,8 +1,32 @@
-import { clickable, create, collection, isPresent, text } from 'ember-cli-page-object';
+import { clickable, create, collection, hasClass, isPresent, text } from 'ember-cli-page-object';
 import listItem from './list-item';
 
 const definition = {
   scope: '[data-test-learner-groups-list]',
+  header: {
+    scope: 'thead',
+    title: {
+      scope: 'th:nth-of-type(1)',
+      isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
+      isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
+      isNotSorted: hasClass('fa-sort', 'svg'),
+      click: clickable('button'),
+    },
+    users: {
+      scope: 'th:nth-of-type(2)',
+      isSortedAscending: hasClass('fa-arrow-down-1-9', 'svg'),
+      isSortedDescending: hasClass('fa-arrow-down-9-1', 'svg'),
+      isNotSorted: hasClass('fa-sort', 'svg'),
+      click: clickable('button'),
+    },
+    children: {
+      isSortedAscending: hasClass('fa-arrow-down-1-9', 'svg'),
+      isSortedDescending: hasClass('fa-arrow-down-9-1', 'svg'),
+      isNotSorted: hasClass('fa-sort', 'svg'),
+      scope: 'th:nth-of-type(3)',
+      click: clickable('button'),
+    },
+  },
   items: collection('[data-test-learner-groups-list-item]', listItem),
   isEmpty: isPresent('[data-test-empty-list]'),
   confirmRemoval: {


### PR DESCRIPTION
fixes https://github.com/ilios/frontend/issues/6641

i threw in that feature for instructor group lists for good measure.