### PR TITLE
Move heading into header

### DIFF
--- a/app/components/ilios-header.hbs
+++ b/app/components/ilios-header.hbs
@@ -4,6 +4,9 @@
     @skipText={{t "general.skipToMainContent"}}
     @routeChangeValidator={{this.checkRouteChange}}
   />
+  <h1 data-test-title>
+    {{this.pageTitle.title}}
+  </h1>
   <div class="header-content">
     <div class="tools">
       {{#if this.showSearch}}

--- a/app/components/ilios-header.js
+++ b/app/components/ilios-header.js
@@ -10,6 +10,7 @@ export default class IliosHeaderComponent extends Component {
   @service session;
   @service router;
   @service iliosConfig;
+  @service pageTitle;
 
   @use searchEnabled = new ResolveAsyncValue(() => [this.iliosConfig.getSearchEnabled()]);
 

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -11,7 +11,6 @@ export default class ApplicationController extends Controller {
   @service currentUser;
   @service intl;
   @service session;
-  @service pageTitle;
   @service iliosConfig;
 
   @tracked currentlyLoading = false;

--- a/app/styles/components/ilios-header.scss
+++ b/app/styles/components/ilios-header.scss
@@ -1,5 +1,10 @@
 .ilios-header {
   background-color: $orange;
+
+  h1 {
+    @include visually-hidden;
+  }
+
   .header-content {
     align-items: center;
     display: grid;

--- a/app/styles/components/ilios-logo.scss
+++ b/app/styles/components/ilios-logo.scss
@@ -5,14 +5,8 @@
       padding-bottom: calc($golden-ratio-small * 1rem);
     }
 
-    .image {
-        background-image: url('images/ilios-logo.svg');
-        background-repeat: no-repeat;
+    img {
         display: block;
         height: 95%;
-    }
-
-    .visually-hidden {
-      @include visually-hidden;
     }
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -10,10 +10,7 @@
 >
   <div class="ilios-logo">
     <LinkTo @route="dashboard" title={{t "general.dashboard"}}>
-      <h1 class="visually-hidden" data-test-title>
-        {{this.pageTitle.title}}
-      </h1>
-      <span class="image"></span>
+      <img role="presentation" src="/assets/images/ilios-logo.svg" alt="">
     </LinkTo>
   </div>
   <IliosHeader />

--- a/tests/integration/components/ilios-header-test.js
+++ b/tests/integration/components/ilios-header-test.js
@@ -13,8 +13,13 @@ module('Integration | Component | ilios-header', function (hooks) {
   setupMirage(hooks); //even though we're not using mirage directly we need to ensure that /config API is owned
 
   test('it renders and is accessible', async function (assert) {
-    await render(hbs`<IliosHeader />`);
+    this.set('title', 'test');
+    await render(hbs`
+      {{page-title this.title}}
+      <IliosHeader />
+    `);
     assert.ok(component.isPresent);
+    assert.strictEqual(component.title, 'test');
 
     await a11yAudit(this.element);
   });

--- a/tests/pages/components/ilios-header.js
+++ b/tests/pages/components/ilios-header.js
@@ -1,8 +1,9 @@
-import { create } from 'ember-cli-page-object';
+import { create, text } from 'ember-cli-page-object';
 import searchBox from 'ilios/tests/pages/components/global-search-box';
 
 const definition = {
   scope: '[data-test-ilios-header]',
+  title: text('[data-test-title]'),
   searchBox,
 };
 


### PR DESCRIPTION
A11y requires that the page header be inside a known landmark, for h1
that really needs to be the header.