### PR TITLE
Fix navigation on tablets

### DIFF
--- a/app/styles/layout/_layout.scss
+++ b/app/styles/layout/_layout.scss
@@ -35,7 +35,7 @@
     grid-template-rows: auto auto 1fr 20px;
 
     @include for-tablet-and-up {
-      grid-template-rows: 42px auto auto 20px;
+      grid-template-rows: 42px auto 1fr 20px;
     }
 
     @include for-laptop-and-up {


### PR DESCRIPTION
On a tablet sized screen in some cases for no particular reason that I
can tell the navigation will get huge when some items are selected.
Setting the body to 1fr seems to fix this so it may just be a browser
bug with double auto and our many hidden items in a collapsed navigation
view.

Bad:
<img width="870" alt="Screen Shot 2022-06-22 at 10 28 30 PM" src="https://user-images.githubusercontent.com/349624/175222300-b064c020-e4e7-4f1e-aee9-8e2ae083164d.png">

and now better:
<img width="844" alt="Screen Shot 2022-06-22 at 10 28 16 PM" src="https://user-images.githubusercontent.com/349624/175222335-39ae2523-434e-42fa-be72-6cad75b6855c.png">

