### PR TITLE
revamps learnergroup user management toolbar.

### DIFF
--- a/app/components/learnergroup-bulk-assignment.hbs
+++ b/app/components/learnergroup-bulk-assignment.hbs
@@ -3,9 +3,6 @@
   data-test-learnergroup-bulk-assignment
   ...attributes
 >
-  <h3>
-    {{t "general.uploadGroupAssignments"}}
-  </h3>
   {{#if this.validUsers}}
     <p>
       {{t "general.usersSelected" count=this.validUsers.length}}

--- a/app/components/learnergroup-calendar.hbs
+++ b/app/components/learnergroup-calendar.hbs
@@ -16,7 +16,7 @@
     </span>
   </p>
   <ul class="inline learnergroup-calendar-time-picker">
-    <li >
+    <li>
       <button
         class="link-button"
         type="button"
@@ -62,5 +62,4 @@
     {{t "general.loadingEvents"}}
     ...
   </span>
-
 </div>

--- a/app/components/learnergroup-header.hbs
+++ b/app/components/learnergroup-header.hbs
@@ -9,6 +9,7 @@
     <span class="title">
         {{#if @canUpdate}}
           <EditableField
+            data-test-title
             @value={{if this.title this.title (t "general.clickToEdit")}}
             @save={{perform this.changeTitle}}
             @close={{this.revertTitleChanges}}
@@ -26,7 +27,7 @@
             <ValidationError @errors={{get-errors-for this.title}} />
           </EditableField>
         {{else}}
-          <h2>{{this.title}}</h2>
+          <h2 data-test-title>{{this.title}}</h2>
         {{/if}}
     </span>
     <span class="info" data-test-members>
@@ -45,7 +46,7 @@
     </span>
   </div>
   {{#if (is-fulfilled @learnerGroup.allParents)}}
-    <div class="breadcrumbs">
+    <div class="breadcrumbs" data-test-breadcrumb>
       <span>
         <LinkTo
           @route="learner-groups"

--- a/app/components/learnergroup-summary.hbs
+++ b/app/components/learnergroup-summary.hbs
@@ -3,6 +3,7 @@
     class="learnergroup-summary"
     {{did-insert (perform this.load) @learnerGroup @isEditing @isBulkAssigning}}
     {{did-update (perform this.load) @learnerGroup @isEditing @isBulkAssigning}}
+    data-test-learnergroup-summary
     ...attributes
   >
     {{#unless this.load.isRunning}}
@@ -26,7 +27,7 @@
             {{/if}}
           </span>
         </div>
-        <div class="block defaultlocation">
+        <div class="block defaultlocation" data-test-location>
           <label for="location-{{templateId}}">
             {{t "general.defaultLocation"}}:
           </label>
@@ -55,7 +56,7 @@
             {{/if}}
           </span>
         </div>
-        <div class="block defaulturl">
+        <div class="block defaulturl" data-test-url>
           <label for="link-{{templateId}}">
             {{t "general.defaultVirtualLearningLink"}}:
           </label>
@@ -89,7 +90,7 @@
             {{/if}}
           </span>
         </div>
-        <div class="block associatedcourses">
+        <div class="block associatedcourses" data-test-courses>
           <label>
             {{t "general.associatedCourses"}} ({{this.courses.length}}):
           </label>
@@ -109,21 +110,53 @@
           @canUpdate={{@canUpdate}}
         />
         <div class="learnergroup-overview-actions" data-test-overview-actions>
-          {{#if (or @isEditing @isBulkAssigning)}}
-            <button
-              type="button"
-              {{on "click" (pipe (fn @setIsEditing false) (fn @setIsBulkAssigning false))}}
-            >
-              {{t "general.close"}}
-            </button>
-          {{else if @canUpdate}}
-            <button type="button" data-test-activate-bulk-assign {{on "click" (fn @setIsBulkAssigning true)}}>
+          <div class="title" data-test-title>
+            {{#if @isEditing}}
+              {{t "general.manageGroupMembership"}}
+            {{else if @isBulkAssigning}}
               {{t "general.uploadGroupAssignments"}}
-            </button>
-            <button type="button" data-test-manage {{on "click" (fn @setIsEditing true)}}>
-              {{t "general.manage"}}
-            </button>
-          {{/if}}
+            {{else}}
+              {{t "general.members"}}
+              ({{this.usersToPassToManager.length}})
+            {{/if}}
+          </div>
+          <span class="actions" data-test-buttons>
+            {{#if (or @isEditing @isBulkAssigning)}}
+              <button
+                class="close"
+                type="button"
+                {{on "click" (pipe (fn @setIsEditing false) (fn @setIsBulkAssigning false))}}
+                data-test-close
+              >
+                {{t "general.close"}}
+              </button>
+            {{else}}
+              <ToggleButtons
+                @firstOptionSelected={{not this.showLearnerGroupCalendar}}
+                @firstLabel={{t "general.hideCalendar"}}
+                @secondLabel={{t "general.showCalendar"}}
+                @toggle={{toggle "showLearnerGroupCalendar" this}}
+              />
+              {{#if @canUpdate}}
+                <button
+                  class="bulk-assign"
+                  type="button"
+                  data-test-activate-bulk-assign
+                  {{on "click" (fn @setIsBulkAssigning true)}}
+                >
+                  {{t "general.uploadGroupAssignments"}}
+                </button>
+                <button
+                  class="manage"
+                  type="button"
+                  data-test-manage
+                  {{on "click" (fn @setIsEditing true)}}
+                >
+                  {{t "general.manage"}}
+                </button>
+              {{/if}}
+            {{/if}}
+          </span>
         </div>
         {{#if @isBulkAssigning}}
           <LearnergroupBulkAssignment
@@ -148,14 +181,6 @@
             />
           </div>
         {{/if}}
-        <p class="block" data-test-toggle-learnergroup-calendar>
-          <ToggleButtons
-            @firstOptionSelected={{not this.showLearnerGroupCalendar}}
-            @firstLabel={{t "general.hideCalendar"}}
-            @secondLabel={{t "general.showCalendar"}}
-            @toggle={{toggle "showLearnerGroupCalendar" this}}
-          />
-        </p>
         {{#if this.showLearnerGroupCalendar}}
           <LearnergroupCalendar @learnerGroup={{@learnerGroup}} />
         {{/if}}

--- a/app/components/learnergroup-user-manager.hbs
+++ b/app/components/learnergroup-user-manager.hbs
@@ -1,11 +1,5 @@
 {{#let (unique-id) as |templateId|}}
   <div class="learnergroup-user-manager" ...attributes data-test-learnergroup-user-manager>
-    <div class="title" data-test-title>
-      {{#unless @isEditing}}
-        {{t "general.members"}}
-        ({{@users.length}})
-      {{/unless}}
-    </div>
     {{#if @users.length}}
       <div class="actions">
         <Input

--- a/app/styles/components/learnergroup-cohort-user-manager.scss
+++ b/app/styles/components/learnergroup-cohort-user-manager.scss
@@ -15,10 +15,6 @@
       justify-content: space-around;
     }
 
-    .title {
-      @include detail-container-title-style;
-    }
-
     .actions {
       text-align: right;
 

--- a/app/styles/components/learnergroup-summary.scss
+++ b/app/styles/components/learnergroup-summary.scss
@@ -1,6 +1,6 @@
 .learnergroup-summary {
   @include main-section;
-  
+
   .learnergroup-overview {
     @include ilios-overview($orange);
 
@@ -34,9 +34,21 @@
     }
 
     .learnergroup-overview-actions {
+      @include detail-container-header;
       margin-top: .25rem;
       padding-top: .5rem;
-      text-align: right;
+
+      .title {
+        @include detail-container-title;
+      }
+
+      .actions {
+        @include for-phone-and-up {
+          .toggle-buttons {
+            display: inline;
+          }
+        }
+      }
     }
   }
 

--- a/tests/acceptance/learnergroup-bulk-assign-test.js
+++ b/tests/acceptance/learnergroup-bulk-assign-test.js
@@ -60,7 +60,7 @@ module('Acceptance | learner group bulk assign', function (hooks) {
 
   test('upload users', async function (assert) {
     await page.visit({ learnerGroupId: 1 });
-    await page.activateBulkAssign();
+    await page.details.actions.buttons.bulkAssignment.click();
     this.server.create('user', {
       firstName: 'jasper',
       lastName: 'johnson',
@@ -80,24 +80,24 @@ module('Acceptance | learner group bulk assign', function (hooks) {
     await triggerUpload(users);
     await waitFor('[data-test-upload-data-valid-users]');
 
-    assert.strictEqual(page.bulkAssign.validUploadedUsers.length, 2);
-    assert.ok(page.bulkAssign.validUploadedUsers[0].isValid);
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[0].firstName, 'jasper');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[0].lastName, 'johnson');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[0].campusId, '1234567890');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[0].smallGroupName, '123Test');
-    assert.ok(page.bulkAssign.validUploadedUsers[1].isValid);
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[1].firstName, 'jackson');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[1].lastName, 'johnson');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[1].campusId, '12345');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[1].smallGroupName, '');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers.length, 2);
+    assert.ok(page.details.bulkAssignment.validUploadedUsers[0].isValid);
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[0].firstName, 'jasper');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[0].lastName, 'johnson');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[0].campusId, '1234567890');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[0].smallGroupName, '123Test');
+    assert.ok(page.details.bulkAssignment.validUploadedUsers[1].isValid);
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[1].firstName, 'jackson');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[1].lastName, 'johnson');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[1].campusId, '12345');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[1].smallGroupName, '');
 
-    assert.ok(page.bulkAssign.showConfirmUploadButton);
+    assert.ok(page.details.bulkAssignment.showConfirmUploadButton);
   });
 
   test('upload user warnings', async function (assert) {
     await page.visit({ learnerGroupId: 1 });
-    await page.activateBulkAssign();
+    await page.details.actions.buttons.bulkAssignment.click();
     this.server.create('user', {
       firstName: 'jasper',
       lastName: 'johnson',
@@ -117,27 +117,30 @@ module('Acceptance | learner group bulk assign', function (hooks) {
     await triggerUpload(users);
     await waitFor('[data-test-upload-data-valid-users]');
 
-    assert.strictEqual(page.bulkAssign.validUploadedUsers.length, 2);
-    assert.ok(page.bulkAssign.validUploadedUsers[0].hasWarning);
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[0].firstName, 'jasper (jasper J)');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[0].lastName, 'johnson');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[0].campusId, '1234567890');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[0].smallGroupName, '123Test');
-    assert.ok(page.bulkAssign.validUploadedUsers[1].hasWarning);
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[1].firstName, 'jackson');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers.length, 2);
+    assert.ok(page.details.bulkAssignment.validUploadedUsers[0].hasWarning);
     assert.strictEqual(
-      page.bulkAssign.validUploadedUsers[1].lastName,
+      page.details.bulkAssignment.validUploadedUsers[0].firstName,
+      'jasper (jasper J)'
+    );
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[0].lastName, 'johnson');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[0].campusId, '1234567890');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[0].smallGroupName, '123Test');
+    assert.ok(page.details.bulkAssignment.validUploadedUsers[1].hasWarning);
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[1].firstName, 'jackson');
+    assert.strictEqual(
+      page.details.bulkAssignment.validUploadedUsers[1].lastName,
       'johnson (johnson the seconds)'
     );
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[1].campusId, '12345');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers[1].smallGroupName, '');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[1].campusId, '12345');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers[1].smallGroupName, '');
 
-    assert.ok(page.bulkAssign.showConfirmUploadButton);
+    assert.ok(page.details.bulkAssignment.showConfirmUploadButton);
   });
 
   test('upload user errors', async function (assert) {
     await page.visit({ learnerGroupId: 1 });
-    await page.activateBulkAssign();
+    await page.details.actions.buttons.bulkAssignment.click();
     this.server.create('user', {
       firstName: 'jasper',
       lastName: 'johnson',
@@ -187,31 +190,37 @@ module('Acceptance | learner group bulk assign', function (hooks) {
     await triggerUpload(users);
     await waitFor('[data-test-upload-data-invalid-users]');
 
-    assert.strictEqual(page.bulkAssign.invalidUploadedUsers.length, 6);
-    assert.strictEqual(page.bulkAssign.invalidUploadedUsers[0].errors, 'First Name is required');
-    assert.strictEqual(page.bulkAssign.invalidUploadedUsers[1].errors, 'Last Name is required');
+    assert.strictEqual(page.details.bulkAssignment.invalidUploadedUsers.length, 6);
     assert.strictEqual(
-      page.bulkAssign.invalidUploadedUsers[2].errors,
+      page.details.bulkAssignment.invalidUploadedUsers[0].errors,
+      'First Name is required'
+    );
+    assert.strictEqual(
+      page.details.bulkAssignment.invalidUploadedUsers[1].errors,
+      'Last Name is required'
+    );
+    assert.strictEqual(
+      page.details.bulkAssignment.invalidUploadedUsers[2].errors,
       'Could not find a user with the campusId abcd'
     );
     assert.strictEqual(
-      page.bulkAssign.invalidUploadedUsers[3].errors,
+      page.details.bulkAssignment.invalidUploadedUsers[3].errors,
       "User is not in this group's cohort: class of this year"
     );
     assert.strictEqual(
-      page.bulkAssign.invalidUploadedUsers[4].errors,
+      page.details.bulkAssignment.invalidUploadedUsers[4].errors,
       'This user already exists in the upload.'
     );
     assert.strictEqual(
-      page.bulkAssign.invalidUploadedUsers[5].errors,
+      page.details.bulkAssignment.invalidUploadedUsers[5].errors,
       'User already exists in top-level group group 1 or one of its subgroups.'
     );
-    assert.notOk(page.bulkAssign.showConfirmUploadButton);
+    assert.notOk(page.details.bulkAssignment.showConfirmUploadButton);
   });
 
   test('choose small group match', async function (assert) {
     await page.visit({ learnerGroupId: 1 });
-    await page.activateBulkAssign();
+    await page.details.actions.buttons.bulkAssignment.click();
     this.server.create('user', {
       firstName: 'jasper',
       lastName: 'johnson',
@@ -230,13 +239,13 @@ module('Acceptance | learner group bulk assign', function (hooks) {
     ];
     await triggerUpload(users);
     await waitFor('[data-test-upload-data-valid-users]');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers.length, 2);
-    await page.bulkAssign.confirmUploadedUsers();
-    assert.strictEqual(page.bulkAssign.groupsToMatch.length, 1);
-    await page.bulkAssign.groupsToMatch[0].chooseGroup('3');
-    assert.strictEqual(page.bulkAssign.groupsToMatch[0].selected, 'group 1 child 1');
-    await page.bulkAssign.groupsToMatch[0].chooseGroup('2');
-    assert.strictEqual(page.bulkAssign.groupsToMatch[0].selected, 'group 1 child 0');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers.length, 2);
+    await page.details.bulkAssignment.confirmUploadedUsers();
+    assert.strictEqual(page.details.bulkAssignment.groupsToMatch.length, 1);
+    await page.details.bulkAssignment.groupsToMatch[0].chooseGroup('3');
+    assert.strictEqual(page.details.bulkAssignment.groupsToMatch[0].selected, 'group 1 child 1');
+    await page.details.bulkAssignment.groupsToMatch[0].chooseGroup('2');
+    assert.strictEqual(page.details.bulkAssignment.groupsToMatch[0].selected, 'group 1 child 0');
   });
 
   test('finalize and save', async function (assert) {
@@ -258,33 +267,36 @@ module('Acceptance | learner group bulk assign', function (hooks) {
       ['jackson', 'johnson', '12345', '123Test'],
     ];
     await page.visit({ learnerGroupId: 1 });
-    await page.activateBulkAssign();
+    await page.details.actions.buttons.bulkAssignment.click();
 
     await triggerUpload(users);
     await waitFor('[data-test-upload-data-valid-users]');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers.length, 2);
-    await page.bulkAssign.confirmUploadedUsers();
-    assert.strictEqual(page.bulkAssign.groupsToMatch.length, 1);
-    await page.bulkAssign.groupsToMatch[0].chooseGroup('3');
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers.length, 2);
+    await page.details.bulkAssignment.confirmUploadedUsers();
+    assert.strictEqual(page.details.bulkAssignment.groupsToMatch.length, 1);
+    await page.details.bulkAssignment.groupsToMatch[0].chooseGroup('3');
 
-    assert.strictEqual(page.bulkAssign.finalData.length, 2);
+    assert.strictEqual(page.details.bulkAssignment.finalData.length, 2);
     assert.strictEqual(
-      page.bulkAssign.finalData[0].user.userNameInfo.fullName,
+      page.details.bulkAssignment.finalData[0].user.userNameInfo.fullName,
       'jasper M. johnson'
     );
-    assert.notOk(page.bulkAssign.finalData[0].user.userNameInfo.hasAdditionalInfo);
-    assert.strictEqual(page.bulkAssign.finalData[0].campusId, '1234567890');
-    assert.strictEqual(page.bulkAssign.finalData[0].groupName, 'group 1');
-    assert.strictEqual(page.bulkAssign.finalData[1].user.userNameInfo.fullName, 'Jackson McFly');
-    assert.ok(page.bulkAssign.finalData[1].user.userNameInfo.hasAdditionalInfo);
-    assert.strictEqual(page.bulkAssign.finalData[1].campusId, '12345');
-    assert.strictEqual(page.bulkAssign.finalData[1].groupName, 'group 1 child 1');
-    assert.ok(page.bulkAssign.canSubmitFinalData);
+    assert.notOk(page.details.bulkAssignment.finalData[0].user.userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.bulkAssignment.finalData[0].campusId, '1234567890');
+    assert.strictEqual(page.details.bulkAssignment.finalData[0].groupName, 'group 1');
+    assert.strictEqual(
+      page.details.bulkAssignment.finalData[1].user.userNameInfo.fullName,
+      'Jackson McFly'
+    );
+    assert.ok(page.details.bulkAssignment.finalData[1].user.userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.bulkAssignment.finalData[1].campusId, '12345');
+    assert.strictEqual(page.details.bulkAssignment.finalData[1].groupName, 'group 1 child 1');
+    assert.ok(page.details.bulkAssignment.canSubmitFinalData);
     assert.strictEqual(this.server.db.learnerGroups[0].userIds, null);
     assert.strictEqual(this.server.db.learnerGroups[1].userIds, null);
     assert.strictEqual(this.server.db.learnerGroups[2].userIds, null);
 
-    await page.bulkAssign.submitFinalData();
+    await page.details.bulkAssignment.submitFinalData();
     assert.deepEqual(this.server.db.learnerGroups[0].userIds, ['2', '3']);
     assert.deepEqual(this.server.db.learnerGroups[1].userIds, null);
     assert.deepEqual(this.server.db.learnerGroups[2].userIds, ['3']);
@@ -300,24 +312,24 @@ module('Acceptance | learner group bulk assign', function (hooks) {
     });
     const users = [['jackson', 'johnson', '12345', '123Test']];
     await page.visit({ learnerGroupId: 1 });
-    await page.activateBulkAssign();
+    await page.details.actions.buttons.bulkAssignment.click();
 
     await triggerUpload(users);
     await waitFor('[data-test-upload-data-valid-users]');
-    assert.strictEqual(page.bulkAssign.validUploadedUsers.length, 1);
-    await page.bulkAssign.confirmUploadedUsers();
-    assert.strictEqual(page.bulkAssign.groupsToMatch.length, 1);
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers.length, 1);
+    await page.details.bulkAssignment.confirmUploadedUsers();
+    assert.strictEqual(page.details.bulkAssignment.groupsToMatch.length, 1);
     assert.strictEqual(this.server.db.learnerGroups.length, 3);
     assert.strictEqual(this.server.db.learnerGroups[0].userIds, null);
-    await page.bulkAssign.groupsToMatch[0].createNewGroup();
+    await page.details.bulkAssignment.groupsToMatch[0].createNewGroup();
     assert.strictEqual(this.server.db.learnerGroups.length, 4);
     assert.strictEqual(this.server.db.learnerGroups[3].userIds, null);
 
-    assert.strictEqual(page.bulkAssign.finalData.length, 1);
-    assert.strictEqual(page.bulkAssign.finalData[0].groupName, '123Test');
-    assert.ok(page.bulkAssign.canSubmitFinalData);
+    assert.strictEqual(page.details.bulkAssignment.finalData.length, 1);
+    assert.strictEqual(page.details.bulkAssignment.finalData[0].groupName, '123Test');
+    assert.ok(page.details.bulkAssignment.canSubmitFinalData);
 
-    await page.bulkAssign.submitFinalData();
+    await page.details.bulkAssignment.submitFinalData();
     assert.deepEqual(this.server.db.learnerGroups[0].userIds, ['2']);
     assert.strictEqual(this.server.db.learnerGroups[1].userIds, null);
     assert.strictEqual(this.server.db.learnerGroups[2].userIds, null);
@@ -327,7 +339,7 @@ module('Acceptance | learner group bulk assign', function (hooks) {
 
   test('small group matches are trimmed', async function (assert) {
     await page.visit({ learnerGroupId: 1 });
-    await page.activateBulkAssign();
+    await page.details.actions.buttons.bulkAssignment.click();
     const users = this.server.createList('user', 4, {
       cohortIds: [1],
     });
@@ -340,13 +352,13 @@ module('Acceptance | learner group bulk assign', function (hooks) {
     data[3].pushObject(' group 1 child 1');
     await triggerUpload(data);
     await waitFor('[data-test-upload-data-valid-users]');
-    await page.bulkAssign.confirmUploadedUsers();
-    assert.strictEqual(page.bulkAssign.groupsToMatch.length, 2);
+    await page.details.bulkAssignment.confirmUploadedUsers();
+    assert.strictEqual(page.details.bulkAssignment.groupsToMatch.length, 2);
   });
 
   test('ignore blank lines #3684', async function (assert) {
     await page.visit({ learnerGroupId: 1 });
-    await page.activateBulkAssign();
+    await page.details.actions.buttons.bulkAssignment.click();
     this.server.create('user', {
       firstName: 'jasper',
       lastName: 'johnson',
@@ -363,9 +375,9 @@ module('Acceptance | learner group bulk assign', function (hooks) {
     await triggerUpload(users);
     await waitFor('[data-test-upload-data-valid-users]');
 
-    assert.strictEqual(page.bulkAssign.validUploadedUsers.length, 1);
-    assert.ok(page.bulkAssign.validUploadedUsers[0].isValid);
-    assert.strictEqual(page.bulkAssign.invalidUploadedUsers.length, 0);
-    assert.ok(page.bulkAssign.showConfirmUploadButton);
+    assert.strictEqual(page.details.bulkAssignment.validUploadedUsers.length, 1);
+    assert.ok(page.details.bulkAssignment.validUploadedUsers[0].isValid);
+    assert.strictEqual(page.details.bulkAssignment.invalidUploadedUsers.length, 0);
+    assert.ok(page.details.bulkAssignment.showConfirmUploadButton);
   });
 });

--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -24,24 +24,29 @@ module('Acceptance | Learnergroup', function (hooks) {
     this.server.create('learnerGroup', { cohort });
     this.server.createList('user', 2, { cohorts: [cohort] });
 
-    assert.expect(8);
-
     await page.visit({ learnerGroupId: 1 });
-    await page.overview.manage();
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 0);
-    assert.strictEqual(page.usersInCohort.list.length, 2);
-    assert.strictEqual(page.usersInCohort.list[0].name.userNameInfo.fullName, '1 guy M. Mc1son');
-    assert.strictEqual(page.usersInCohort.list[1].name.userNameInfo.fullName, '2 guy M. Mc2son');
-
-    await page.usersInCohort.list[0].add();
-
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 1);
+    await page.details.actions.buttons.manageUsers.click();
+    assert.strictEqual(page.details.userManager.usersInCurrentGroup.length, 0);
+    assert.strictEqual(page.details.cohortUserManager.users.length, 2);
     assert.strictEqual(
-      page.overview.learnerGroupUserManager.usersInCurrentGroup[0].name.userNameInfo.fullName,
+      page.details.cohortUserManager.users[0].name.userNameInfo.fullName,
       '1 guy M. Mc1son'
     );
-    assert.strictEqual(page.usersInCohort.list.length, 1);
-    assert.strictEqual(page.usersInCohort.list[0].name.userNameInfo.fullName, '2 guy M. Mc2son');
+    assert.strictEqual(
+      page.details.cohortUserManager.users[1].name.userNameInfo.fullName,
+      '2 guy M. Mc2son'
+    );
+    await page.details.cohortUserManager.users[0].add();
+    assert.strictEqual(page.details.userManager.usersInCurrentGroup.length, 1);
+    assert.strictEqual(
+      page.details.userManager.usersInCurrentGroup[0].name.userNameInfo.fullName,
+      '1 guy M. Mc1son'
+    );
+    assert.strictEqual(page.details.cohortUserManager.users.length, 1);
+    assert.strictEqual(
+      page.details.cohortUserManager.users[0].name.userNameInfo.fullName,
+      '2 guy M. Mc2son'
+    );
   });
 
   test('remove learners individually from group', async function (assert) {
@@ -51,34 +56,32 @@ module('Acceptance | Learnergroup', function (hooks) {
     const learnerGroup = this.server.create('learnerGroup', { cohort });
     this.server.createList('user', 2, { cohorts: [cohort], learnerGroups: [learnerGroup] });
 
-    assert.expect(8);
-
     await page.visit({ learnerGroupId: 1 });
-    await page.overview.manage();
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 2);
+    await page.details.actions.buttons.manageUsers.click();
+    assert.strictEqual(page.details.userManager.usersInCurrentGroup.length, 2);
+    assert.strictEqual(page.details.cohortUserManager.users.length, 0);
     assert.strictEqual(
-      page.overview.learnerGroupUserManager.usersInCurrentGroup[0].name.userNameInfo.fullName,
+      page.details.userManager.usersInCurrentGroup[0].name.userNameInfo.fullName,
       '1 guy M. Mc1son'
     );
     assert.strictEqual(
-      page.overview.learnerGroupUserManager.usersInCurrentGroup[1].name.userNameInfo.fullName,
+      page.details.userManager.usersInCurrentGroup[1].name.userNameInfo.fullName,
       '2 guy M. Mc2son'
     );
-    assert.strictEqual(page.usersInCohort.list.length, 0);
-
-    await page.overview.learnerGroupUserManager.usersInCurrentGroup[0].remove();
-
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 1);
+    await page.details.userManager.usersInCurrentGroup[0].remove();
+    assert.strictEqual(page.details.userManager.usersInCurrentGroup.length, 1);
     assert.strictEqual(
-      page.overview.learnerGroupUserManager.usersInCurrentGroup[0].name.userNameInfo.fullName,
+      page.details.userManager.usersInCurrentGroup[0].name.userNameInfo.fullName,
       '2 guy M. Mc2son'
     );
-    assert.strictEqual(page.usersInCohort.list.length, 1);
-    assert.strictEqual(page.usersInCohort.list[0].name.userNameInfo.fullName, '1 guy M. Mc1son');
+    assert.strictEqual(page.details.cohortUserManager.users.length, 1);
+    assert.strictEqual(
+      page.details.cohortUserManager.users[0].name.userNameInfo.fullName,
+      '1 guy M. Mc1son'
+    );
   });
 
   test('generate new subgroups', async function (assert) {
-    assert.expect(23);
     this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('programYear', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
@@ -101,48 +104,47 @@ module('Acceptance | Learnergroup', function (hooks) {
     });
 
     await page.visit({ learnerGroupId: 1 });
-    assert.strictEqual(page.subgroups.groups.length, 2);
-    assert.strictEqual(page.subgroups.groups[0].title, 'learner group 1');
-    assert.strictEqual(page.subgroups.groups[1].title, 'learner group 2');
+    assert.strictEqual(page.details.subgroupList.groups.length, 2);
+    assert.strictEqual(page.details.subgroupList.groups[0].title, 'learner group 1');
+    assert.strictEqual(page.details.subgroupList.groups[1].title, 'learner group 2');
 
-    await page.subgroups.toggleNewForm();
-    assert.ok(page.subgroups.newForm.singleGroupSelected);
-    assert.notOk(page.subgroups.newForm.multipleGroupSelected);
-    await page.subgroups.newForm.chooseMultipleGroups();
-    await page.subgroups.newForm.multiple.setNumberOfGroups(5);
-    await page.subgroups.newForm.multiple.save();
+    await page.details.subgroupList.toggleNewForm();
 
-    assert.strictEqual(page.subgroups.groups.length, 7);
-    assert.strictEqual(page.subgroups.groups[0].title, 'learner group 0 1');
-    assert.strictEqual(page.subgroups.groups[1].title, 'learner group 0 2');
-    assert.strictEqual(page.subgroups.groups[2].title, 'learner group 0 3');
-    assert.strictEqual(page.subgroups.groups[3].title, 'learner group 0 4');
-    assert.strictEqual(page.subgroups.groups[4].title, 'learner group 0 5');
-    assert.strictEqual(page.subgroups.groups[5].title, 'learner group 1');
-    assert.strictEqual(page.subgroups.groups[6].title, 'learner group 2');
+    assert.ok(page.details.subgroupList.newForm.singleGroupSelected);
+    assert.notOk(page.details.subgroupList.newForm.multipleGroupSelected);
+    await page.details.subgroupList.newForm.chooseMultipleGroups();
+    await page.details.subgroupList.newForm.multiple.setNumberOfGroups(5);
+    await page.details.subgroupList.newForm.multiple.save();
+
+    assert.strictEqual(page.details.subgroupList.groups.length, 7);
+    assert.strictEqual(page.details.subgroupList.groups[0].title, 'learner group 0 1');
+    assert.strictEqual(page.details.subgroupList.groups[1].title, 'learner group 0 2');
+    assert.strictEqual(page.details.subgroupList.groups[2].title, 'learner group 0 3');
+    assert.strictEqual(page.details.subgroupList.groups[3].title, 'learner group 0 4');
+    assert.strictEqual(page.details.subgroupList.groups[4].title, 'learner group 0 5');
+    assert.strictEqual(page.details.subgroupList.groups[5].title, 'learner group 1');
+    assert.strictEqual(page.details.subgroupList.groups[6].title, 'learner group 2');
 
     // add two more subgroups
-    await page.subgroups.toggleNewForm();
-    await page.subgroups.newForm.chooseMultipleGroups();
-    await page.subgroups.newForm.multiple.setNumberOfGroups(2);
-    await page.subgroups.newForm.multiple.save();
+    await page.details.subgroupList.toggleNewForm();
+    await page.details.subgroupList.newForm.chooseMultipleGroups();
+    await page.details.subgroupList.newForm.multiple.setNumberOfGroups(2);
+    await page.details.subgroupList.newForm.multiple.save();
 
-    assert.strictEqual(page.subgroups.groups.length, 9);
-    assert.strictEqual(page.subgroups.groups[0].title, 'learner group 0 1');
-    assert.strictEqual(page.subgroups.groups[1].title, 'learner group 0 2');
-    assert.strictEqual(page.subgroups.groups[2].title, 'learner group 0 3');
-    assert.strictEqual(page.subgroups.groups[3].title, 'learner group 0 4');
-    assert.strictEqual(page.subgroups.groups[4].title, 'learner group 0 5');
-    assert.strictEqual(page.subgroups.groups[5].title, 'learner group 0 6');
-    assert.strictEqual(page.subgroups.groups[6].title, 'learner group 0 7');
-
-    assert.strictEqual(page.subgroups.groups[7].title, 'learner group 1');
-    assert.strictEqual(page.subgroups.groups[8].title, 'learner group 2');
+    assert.strictEqual(page.details.subgroupList.groups.length, 9);
+    assert.strictEqual(page.details.subgroupList.groups[0].title, 'learner group 0 1');
+    assert.strictEqual(page.details.subgroupList.groups[1].title, 'learner group 0 2');
+    assert.strictEqual(page.details.subgroupList.groups[2].title, 'learner group 0 3');
+    assert.strictEqual(page.details.subgroupList.groups[3].title, 'learner group 0 4');
+    assert.strictEqual(page.details.subgroupList.groups[4].title, 'learner group 0 5');
+    assert.strictEqual(page.details.subgroupList.groups[5].title, 'learner group 0 6');
+    assert.strictEqual(page.details.subgroupList.groups[6].title, 'learner group 0 7');
+    assert.strictEqual(page.details.subgroupList.groups[7].title, 'learner group 1');
+    assert.strictEqual(page.details.subgroupList.groups[8].title, 'learner group 2');
   });
 
   test('copy learnergroup without learners', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(26);
     const programYear = this.server.create('programYear', { program: this.program });
     const cohort = this.server.create('cohort', {
       programYear,
@@ -161,44 +163,43 @@ module('Acceptance | Learnergroup', function (hooks) {
 
     await page.visit({ learnerGroupId: 1 });
 
-    assert.strictEqual(page.subgroups.groups.length, 1);
-    assert.strictEqual(page.subgroups.groups[0].title, 'learner group 1');
-    assert.strictEqual(page.subgroups.groups[0].members, '0');
-    assert.strictEqual(page.subgroups.groups[0].subgroups, '2');
-    await page.subgroups.groups[0].actions.copy();
-    await page.subgroups.confirmCopy.confirmWithoutLearners();
+    assert.strictEqual(page.details.subgroupList.groups.length, 1);
+    assert.strictEqual(page.details.subgroupList.groups[0].title, 'learner group 1');
+    assert.strictEqual(page.details.subgroupList.groups[0].members, '0');
+    assert.strictEqual(page.details.subgroupList.groups[0].subgroups, '2');
+    await page.details.subgroupList.groups[0].actions.copy();
+    await page.details.subgroupList.confirmCopy.confirmWithoutLearners();
 
-    assert.strictEqual(page.subgroups.groups.length, 2);
-    assert.strictEqual(page.subgroups.groups[0].title, 'learner group 1');
-    assert.strictEqual(page.subgroups.groups[0].members, '0');
-    assert.strictEqual(page.subgroups.groups[0].subgroups, '2');
-    assert.strictEqual(page.subgroups.groups[1].title, 'learner group 1 (Copy)');
-    assert.strictEqual(page.subgroups.groups[1].members, '0');
-    assert.strictEqual(page.subgroups.groups[1].subgroups, '2');
+    assert.strictEqual(page.details.subgroupList.groups.length, 2);
+    assert.strictEqual(page.details.subgroupList.groups[0].title, 'learner group 1');
+    assert.strictEqual(page.details.subgroupList.groups[0].members, '0');
+    assert.strictEqual(page.details.subgroupList.groups[0].subgroups, '2');
+    assert.strictEqual(page.details.subgroupList.groups[1].title, 'learner group 1 (Copy)');
+    assert.strictEqual(page.details.subgroupList.groups[1].members, '0');
+    assert.strictEqual(page.details.subgroupList.groups[1].subgroups, '2');
 
     await page.visit({ learnerGroupId: 1 });
-    assert.strictEqual(page.subgroups.groups.length, 2);
-    assert.strictEqual(page.subgroups.groups[0].title, 'learner group 1');
-    assert.strictEqual(page.subgroups.groups[0].members, '0');
-    assert.strictEqual(page.subgroups.groups[0].subgroups, '2');
-    assert.strictEqual(page.subgroups.groups[1].title, 'learner group 1 (Copy)');
-    assert.strictEqual(page.subgroups.groups[1].members, '0');
-    assert.strictEqual(page.subgroups.groups[1].subgroups, '2');
+    assert.strictEqual(page.details.subgroupList.groups.length, 2);
+    assert.strictEqual(page.details.subgroupList.groups[0].title, 'learner group 1');
+    assert.strictEqual(page.details.subgroupList.groups[0].members, '0');
+    assert.strictEqual(page.details.subgroupList.groups[0].subgroups, '2');
+    assert.strictEqual(page.details.subgroupList.groups[1].title, 'learner group 1 (Copy)');
+    assert.strictEqual(page.details.subgroupList.groups[1].members, '0');
+    assert.strictEqual(page.details.subgroupList.groups[1].subgroups, '2');
 
-    await page.subgroups.groups[1].visit();
+    await page.details.subgroupList.groups[1].visit();
     assert.strictEqual(currentURL(), '/learnergroups/5');
-    assert.strictEqual(page.subgroups.groups.length, 2);
-    assert.strictEqual(page.subgroups.groups[0].title, 'learner group 2');
-    assert.strictEqual(page.subgroups.groups[0].members, '0');
-    assert.strictEqual(page.subgroups.groups[0].subgroups, '0');
-    assert.strictEqual(page.subgroups.groups[1].title, 'learner group 3');
-    assert.strictEqual(page.subgroups.groups[1].members, '0');
-    assert.strictEqual(page.subgroups.groups[1].subgroups, '0');
+    assert.strictEqual(page.details.subgroupList.groups.length, 2);
+    assert.strictEqual(page.details.subgroupList.groups[0].title, 'learner group 2');
+    assert.strictEqual(page.details.subgroupList.groups[0].members, '0');
+    assert.strictEqual(page.details.subgroupList.groups[0].subgroups, '0');
+    assert.strictEqual(page.details.subgroupList.groups[1].title, 'learner group 3');
+    assert.strictEqual(page.details.subgroupList.groups[1].members, '0');
+    assert.strictEqual(page.details.subgroupList.groups[1].subgroups, '0');
   });
 
   test('cannot copy learnergroup with learners', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(6);
     const users = this.server.createList('user', 3);
     const programYear = this.server.create('programYear', { program: this.program });
     const cohort = this.server.create('cohort', {
@@ -218,18 +219,17 @@ module('Acceptance | Learnergroup', function (hooks) {
     });
 
     await page.visit({ learnerGroupId: 1 });
-    assert.strictEqual(page.subgroups.groups.length, 1);
-    assert.strictEqual(page.subgroups.groups[0].title, 'learner group 1');
-    assert.strictEqual(page.subgroups.groups[0].members, '3');
-    assert.strictEqual(page.subgroups.groups[0].subgroups, '2');
-    await page.subgroups.groups[0].actions.copy();
-    assert.notOk(page.subgroups.confirmCopy.canCopyWithLearners);
-    assert.ok(page.subgroups.confirmCopy.canCopyWithoutLearners);
+    assert.strictEqual(page.details.subgroupList.groups.length, 1);
+    assert.strictEqual(page.details.subgroupList.groups[0].title, 'learner group 1');
+    assert.strictEqual(page.details.subgroupList.groups[0].members, '3');
+    assert.strictEqual(page.details.subgroupList.groups[0].subgroups, '2');
+    await page.details.subgroupList.groups[0].actions.copy();
+    assert.notOk(page.details.subgroupList.confirmCopy.canCopyWithLearners);
+    assert.ok(page.details.subgroupList.confirmCopy.canCopyWithoutLearners);
   });
 
   test('cannot copy learnergroup with learners in subgroup', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(6);
     const users = this.server.createList('user', 3);
     const programYear = this.server.create('programYear', { program: this.program });
     const cohort = this.server.create('cohort', {
@@ -253,17 +253,16 @@ module('Acceptance | Learnergroup', function (hooks) {
     });
 
     await page.visit({ learnerGroupId: 1 });
-    assert.strictEqual(page.subgroups.groups.length, 1);
-    assert.strictEqual(page.subgroups.groups[0].title, 'learner group 1');
-    assert.strictEqual(page.subgroups.groups[0].members, '0');
-    assert.strictEqual(page.subgroups.groups[0].subgroups, '2');
-    await page.subgroups.groups[0].actions.copy();
-    assert.notOk(page.subgroups.confirmCopy.canCopyWithLearners);
-    assert.ok(page.subgroups.confirmCopy.canCopyWithoutLearners);
+    assert.strictEqual(page.details.subgroupList.groups.length, 1);
+    assert.strictEqual(page.details.subgroupList.groups[0].title, 'learner group 1');
+    assert.strictEqual(page.details.subgroupList.groups[0].members, '0');
+    assert.strictEqual(page.details.subgroupList.groups[0].subgroups, '2');
+    await page.details.subgroupList.groups[0].actions.copy();
+    assert.notOk(page.details.subgroupList.confirmCopy.canCopyWithLearners);
+    assert.ok(page.details.subgroupList.confirmCopy.canCopyWithoutLearners);
   });
 
   test('Cohort members not in learner group appear after navigating to learner group #3428', async function (assert) {
-    assert.expect(5);
     this.server.create('programYear', { program: this.program });
     const cohort = this.server.create('cohort', {
       programYearId: 1,
@@ -286,8 +285,8 @@ module('Acceptance | Learnergroup', function (hooks) {
     assert.strictEqual(learnerGroupsPage.list.items[0].title, 'learner group 0');
     await learnerGroupsPage.list.items[0].clickTitle();
     assert.strictEqual(currentURL(), '/learnergroups/1');
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 5);
-    assert.strictEqual(page.usersInCohort.list.length, 5);
+    assert.strictEqual(page.details.userManager.usersInCurrentGroup.length, 5);
+    assert.strictEqual(page.details.cohortUserManager.users.length, 5);
   });
 
   test('learner group calendar', async function (assert) {
@@ -302,25 +301,23 @@ module('Acceptance | Learnergroup', function (hooks) {
       endDate: moment().hour(8).add(1, 'hour').toDate(),
       learnerGroups: [learnerGroup],
     });
-
     this.server.create('offering');
 
     await page.visit({ learnerGroupId: 1 });
-    assert.ok(page.overview.displayToggle.firstButton.isChecked);
-    assert.notOk(page.overview.calendar.isVisible);
-    assert.strictEqual(page.overview.calendar.events.length, 0);
-    await page.overview.displayToggle.secondButton.click();
-    assert.ok(page.overview.displayToggle.secondButton.isChecked);
-    assert.ok(page.overview.calendar.isVisible);
-    assert.strictEqual(page.overview.calendar.events.length, 1);
-    await page.overview.displayToggle.firstButton.click();
-    assert.ok(page.overview.displayToggle.firstButton.isChecked);
-    assert.notOk(page.overview.calendar.isVisible);
-    assert.strictEqual(page.overview.calendar.events.length, 0);
+    assert.ok(page.details.actions.buttons.toggle.firstButton.isChecked);
+    assert.notOk(page.details.calendar.isVisible);
+    assert.strictEqual(page.details.calendar.calendar.events.length, 0);
+    await page.details.actions.buttons.toggle.secondButton.click();
+    assert.ok(page.details.actions.buttons.toggle.secondButton.isChecked);
+    assert.ok(page.details.calendar.isVisible);
+    assert.strictEqual(page.details.calendar.calendar.events.length, 1);
+    await page.details.actions.buttons.toggle.firstButton.click();
+    assert.ok(page.details.actions.buttons.toggle.firstButton.isChecked);
+    assert.notOk(page.details.calendar.isVisible);
+    assert.strictEqual(page.details.calendar.calendar.events.length, 0);
   });
 
   test('learner group calendar with subgroup events', async function (assert) {
-    assert.expect(5);
     const programYear = this.server.create('programYear', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     const learnerGroup = this.server.create('learnerGroup', { cohort });
@@ -342,22 +339,20 @@ module('Acceptance | Learnergroup', function (hooks) {
       endDate: moment().hour(8).add(1, 'hour').toDate(),
       learnerGroups: [subgroup],
     });
-
     this.server.create('offering');
 
     await page.visit({ learnerGroupId: 1 });
-    assert.strictEqual(page.overview.calendar.events.length, 0);
-    assert.notOk(page.overview.calendar.isVisible);
-    await page.overview.displayToggle.secondButton.click();
-    assert.strictEqual(page.overview.calendar.events.length, 1);
-    assert.ok(page.overview.calendar.isVisible);
-    await page.overview.calendar.toggleSubgroupEvents();
-    assert.strictEqual(page.overview.calendar.events.length, 2);
+    assert.strictEqual(page.details.calendar.calendar.events.length, 0);
+    assert.notOk(page.details.calendar.calendar.isVisible);
+    await page.details.actions.buttons.toggle.secondButton.click();
+    assert.strictEqual(page.details.calendar.calendar.events.length, 1);
+    assert.ok(page.details.calendar.calendar.isVisible);
+    await page.details.calendar.showSubgroups.toggle.handle.click();
+    assert.strictEqual(page.details.calendar.calendar.events.length, 2);
   });
 
   test('Learners with missing parent group affiliation still appear in subgroup manager #3476', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    assert.expect(4);
     this.server.create('programYear', { program: this.program });
     const cohort = this.server.create('cohort', {
       programYearId: 1,
@@ -380,14 +375,13 @@ module('Acceptance | Learnergroup', function (hooks) {
 
     await page.visit({ learnerGroupId: 2 });
     assert.strictEqual(currentURL(), '/learnergroups/2');
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 1);
-    await page.overview.manage();
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 1);
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersNotInCurrentGroup.length, 2);
+    assert.strictEqual(page.details.userManager.usersInCurrentGroup.length, 1);
+    await page.details.actions.buttons.manageUsers.click();
+    assert.strictEqual(page.details.userManager.usersInCurrentGroup.length, 1);
+    assert.strictEqual(page.details.userManager.usersNotInCurrentGroup.length, 2);
   });
 
   test('moving learners to group updates count #3570', async function (assert) {
-    assert.expect(6);
     this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('programYear', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
@@ -399,20 +393,17 @@ module('Acceptance | Learnergroup', function (hooks) {
     this.server.createList('user', 2, { cohorts: [cohort] });
 
     await page.visit({ learnerGroupId: 1 });
-    await page.overview.manage();
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 2);
-    assert.strictEqual(page.usersInCohort.list.length, 2);
-    assert.strictEqual(page.header.members, 'Members: 2 / 4');
-
-    await page.usersInCohort.list[0].add();
-
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 3);
-    assert.strictEqual(page.usersInCohort.list.length, 1);
-    assert.strictEqual(page.header.members, 'Members: 3 / 4');
+    await page.details.actions.buttons.manageUsers.click();
+    assert.strictEqual(page.details.userManager.usersInCurrentGroup.length, 2);
+    assert.strictEqual(page.details.cohortUserManager.users.length, 2);
+    assert.strictEqual(page.details.header.members, 'Members: 2 / 4');
+    await page.details.cohortUserManager.users[0].add();
+    assert.strictEqual(page.details.userManager.usersInCurrentGroup.length, 3);
+    assert.strictEqual(page.details.cohortUserManager.users.length, 1);
+    assert.strictEqual(page.details.header.members, 'Members: 3 / 4');
   });
 
   test('moving learners out of group updates count #3570', async function (assert) {
-    assert.expect(6);
     this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('programYear', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
@@ -424,16 +415,15 @@ module('Acceptance | Learnergroup', function (hooks) {
     this.server.createList('user', 2, { cohorts: [cohort] });
 
     await page.visit({ learnerGroupId: 1 });
-    await page.overview.manage();
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 2);
-    assert.strictEqual(page.usersInCohort.list.length, 2);
-    assert.strictEqual(page.header.members, 'Members: 2 / 4');
+    await page.details.actions.buttons.manageUsers.click();
+    assert.strictEqual(page.details.userManager.usersInCurrentGroup.length, 2);
+    assert.strictEqual(page.details.cohortUserManager.users.length, 2);
+    assert.strictEqual(page.details.header.members, 'Members: 2 / 4');
 
-    await page.overview.learnerGroupUserManager.usersInCurrentGroup[0].remove();
-
-    assert.strictEqual(page.overview.learnerGroupUserManager.usersInCurrentGroup.length, 1);
-    assert.strictEqual(page.usersInCohort.list.length, 3);
-    assert.strictEqual(page.header.members, 'Members: 1 / 4');
+    await page.details.userManager.usersInCurrentGroup[0].remove();
+    assert.strictEqual(page.details.userManager.usersInCurrentGroup.length, 1);
+    assert.strictEqual(page.details.cohortUserManager.users.length, 3);
+    assert.strictEqual(page.details.header.members, 'Members: 1 / 4');
   });
 
   test('manage subgroup members does not duplicate members #3936', async function (assert) {
@@ -444,11 +434,9 @@ module('Acceptance | Learnergroup', function (hooks) {
     const child = this.server.create('learnerGroup', { cohort, parent });
     this.server.createList('user', 2, { cohorts: [cohort], learnerGroups: [parent, child] });
 
-    assert.expect(3);
-
     await page.visit({ learnerGroupId: child.id });
-    await page.overview.manage();
-    const users = page.overview.learnerGroupUserManager.usersInCurrentGroup;
+    await page.details.actions.buttons.manageUsers.click();
+    const users = page.details.userManager.usersInCurrentGroup;
     assert.strictEqual(users.length, 2);
     assert.strictEqual(users[0].name.userNameInfo.fullName, '1 guy M. Mc1son');
     assert.strictEqual(users[1].name.userNameInfo.fullName, '2 guy M. Mc2son');

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -1,7 +1,6 @@
 import { currentRouteName, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'ilios/tests/pages/learner-groups';
@@ -494,13 +493,13 @@ module('Acceptance | Learner Groups', function (hooks) {
     await page.list.items[1].clickTitle();
     assert.strictEqual(currentURL(), '/learnergroups/5');
 
-    assert.strictEqual(learnerGroupPage.subgroups.groups.length, 2);
-    assert.strictEqual(learnerGroupPage.subgroups.groups[0].title, 'learner group 1');
-    assert.strictEqual(learnerGroupPage.subgroups.groups[0].members, '0');
-    assert.strictEqual(learnerGroupPage.subgroups.groups[0].subgroups, '1');
-    assert.strictEqual(learnerGroupPage.subgroups.groups[1].title, 'learner group 2');
-    assert.strictEqual(learnerGroupPage.subgroups.groups[1].members, '0');
-    assert.strictEqual(learnerGroupPage.subgroups.groups[1].subgroups, '0');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups.length, 2);
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[0].title, 'learner group 1');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[0].members, '0');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[0].subgroups, '1');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[1].title, 'learner group 2');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[1].members, '0');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[1].subgroups, '0');
   });
 
   test('copy learnergroup with learners', async function (assert) {
@@ -557,12 +556,12 @@ module('Acceptance | Learner Groups', function (hooks) {
     await page.list.items[1].clickTitle();
     assert.strictEqual(currentURL(), '/learnergroups/5');
 
-    assert.strictEqual(learnerGroupPage.subgroups.groups.length, 2);
-    assert.strictEqual(learnerGroupPage.subgroups.groups[0].title, 'learner group 1');
-    assert.strictEqual(learnerGroupPage.subgroups.groups[0].members, '1');
-    assert.strictEqual(learnerGroupPage.subgroups.groups[0].subgroups, '1');
-    assert.strictEqual(learnerGroupPage.subgroups.groups[1].title, 'learner group 2');
-    assert.strictEqual(learnerGroupPage.subgroups.groups[1].members, '3');
-    assert.strictEqual(learnerGroupPage.subgroups.groups[1].subgroups, '0');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups.length, 2);
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[0].title, 'learner group 1');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[0].members, '1');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[0].subgroups, '1');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[1].title, 'learner group 2');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[1].members, '3');
+    assert.strictEqual(learnerGroupPage.details.subgroupList.groups[1].subgroups, '0');
   });
 });

--- a/tests/integration/components/learnergroup-user-manager-test.js
+++ b/tests/integration/components/learnergroup-user-manager-test.js
@@ -63,7 +63,6 @@ module('Integration | Component | learnergroup user manager', function (hooks) {
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
     />`);
-    assert.strictEqual(component.title, 'Members (2)');
     assert.strictEqual(component.usersInCurrentGroup.length, 2);
     assert.strictEqual(
       component.usersInCurrentGroup[0].name.userNameInfo.fullName,

--- a/tests/pages/components/learnergroup-calendar.js
+++ b/tests/pages/components/learnergroup-calendar.js
@@ -1,0 +1,30 @@
+import { attribute, create } from 'ember-cli-page-object';
+import toggle from 'ilios-common/page-objects/components/toggle-yesno';
+import calendar from 'ilios-common/page-objects/components/weekly-calendar';
+
+const definition = {
+  scope: '[data-test-learnergroup-calendar]',
+  showSubgroups: {
+    scope: '[data-test-learnergroup-calendar-toggle-subgroup-events]',
+    toggle,
+    label: {
+      scope: 'label',
+    },
+  },
+  goBack: {
+    scope: '[data-test-go-back]',
+    linksTo: attribute('href'),
+  },
+  goToToday: {
+    scope: '[data-test-go-today]',
+    linksTo: attribute('href'),
+  },
+  goForward: {
+    scope: '[data-test-go-forward]',
+    linksTo: attribute('href'),
+  },
+  calendar,
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/learnergroup-header.js
+++ b/tests/pages/components/learnergroup-header.js
@@ -1,0 +1,31 @@
+import {
+  collection,
+  clickable,
+  create,
+  fillable,
+  hasClass,
+  text,
+  value,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-learnergroup-header]',
+  title: {
+    scope: '[data-test-title]',
+    edit: clickable('[data-test-edit]'),
+    set: fillable('input'),
+    value: value('input'),
+    errors: collection('.validation-error-message'),
+    cancel: clickable('.cancel'),
+    save: clickable('.done'),
+    isEditable: hasClass('editinplace'),
+  },
+  members: text('[data-test-members]'),
+  breadcrumb: {
+    scope: '[data-test-breadcrumb]',
+    crumbs: collection('span'),
+  },
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/learnergroup-summary.js
+++ b/tests/pages/components/learnergroup-summary.js
@@ -1,0 +1,84 @@
+import {
+  attribute,
+  clickable,
+  collection,
+  create,
+  fillable,
+  isPresent,
+  text,
+  value,
+} from 'ember-cli-page-object';
+import header from './learnergroup-header';
+import cohortUserManager from './learnergroup-cohort-user-manager';
+import instructorManager from './learnergroup-instructor-manager';
+import bulkAssignment from './learnergroup-bulk-assign';
+import userManager from './learnergroup-user-manager';
+import subgroupList from './learnergroup-subgroup-list';
+import calendar from './learnergroup-calendar';
+import toggleButtons from 'ilios-common/page-objects/components/toggle-buttons';
+import toggleYesNo from 'ilios-common/page-objects/components/toggle-yesno';
+
+const definition = {
+  scope: '[data-test-learnergroup-summary]',
+  header,
+  needsAccommodation: {
+    scope: '[data-test-needs-accommodation]',
+    label: text('label'),
+    toggle: toggleYesNo,
+  },
+  defaultLocation: {
+    scope: '[data-test-location]',
+    label: text('label'),
+    edit: clickable('[data-test-edit]'),
+    set: fillable('input'),
+    value: value('input'),
+    errors: collection('.validation-error-message'),
+    cancel: clickable('.cancel'),
+    save: clickable('.done'),
+    isEditable: isPresent('[data-test-edit]'),
+  },
+  defaultUrl: {
+    scope: '[data-test-url]',
+    label: text('label'),
+    edit: clickable('[data-test-edit]'),
+    set: fillable('input'),
+    value: value('input'),
+    errors: collection('.validation-error-message'),
+    cancel: clickable('.cancel'),
+    save: clickable('.done'),
+    isEditable: isPresent('[data-test-edit]'),
+  },
+  associatedCourses: {
+    scope: '[data-test-courses]',
+    label: text('label'),
+    courses: collection('li', {
+      linksTo: attribute('href', 'a'),
+    }),
+  },
+  instructorManager,
+  actions: {
+    scope: '[data-test-overview-actions]',
+    title: text('[data-test-title]'),
+    buttons: {
+      scope: '[data-test-buttons]',
+      close: {
+        scope: '[data-test-close]',
+      },
+      toggle: toggleButtons,
+      bulkAssignment: {
+        scope: '[data-test-activate-bulk-assign]',
+      },
+      manageUsers: {
+        scope: '[data-test-manage]',
+      },
+    },
+  },
+  bulkAssignment,
+  userManager,
+  calendar,
+  subgroupList,
+  cohortUserManager,
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/learnergroup-user-manager.js
+++ b/tests/pages/components/learnergroup-user-manager.js
@@ -12,7 +12,6 @@ import userNameInfo from 'ilios-common/page-objects/components/user-name-info';
 const definition = {
   scope: '[data-test-learnergroup-user-manager]',
   filter: fillable('[data-test-filter]'),
-  title: text('[data-test-title]'),
   groupMembers: text('[data-test-group-members]'),
   allOtherMembers: text('[data-test-all-other-members]'),
   selectAll: {

--- a/tests/pages/learner-group.js
+++ b/tests/pages/learner-group.js
@@ -1,43 +1,7 @@
-import { create, clickable, collection, text, visitable } from 'ember-cli-page-object';
-import learnerGroupUserManager from './components/learnergroup-user-manager';
-import learnergroupSubgroupList from './components/learnergroup-subgroup-list';
-import bulkAssign from './components/learnergroup-bulk-assign';
-import userNameInfo from 'ilios-common/page-objects/components/user-name-info';
-import displayToggle from 'ilios-common/page-objects/components/toggle-buttons';
+import { create, visitable } from 'ember-cli-page-object';
+import details from './components/learnergroup-summary';
 
 export default create({
   visit: visitable('/learnergroups/:learnerGroupId'),
-  header: {
-    scope: '[data-test-learnergroup-header]',
-    members: text('[data-test-members]'),
-  },
-  overview: {
-    scope: '[data-test-overview]',
-    manage: clickable('[data-test-overview-actions] [data-test-manage]'),
-    learnerGroupUserManager,
-    displayToggle,
-    calendar: {
-      scope: '[data-test-learnergroup-calendar]',
-      toggleSubgroupEvents: clickable(
-        '[data-test-learnergroup-calendar-toggle-subgroup-events] [data-test-toggle-yesno] [data-test-handle]'
-      ),
-      events: collection('[data-test-calendar-event]'),
-    },
-  },
-  activateBulkAssign: clickable('[data-test-activate-bulk-assign]'),
-  bulkAssign,
-  subgroups: learnergroupSubgroupList,
-  usersInCohort: {
-    scope: '.cohortmembers',
-    list: collection('tbody tr', {
-      scope: '.list',
-      name: {
-        scope: 'td:eq(1)',
-        userNameInfo,
-      },
-      campusId: text('td', { at: 2 }),
-      email: text('td', { at: 3 }),
-      add: clickable('[data-test-add-user]'),
-    }),
-  },
+  details,
 });

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -189,6 +189,7 @@ general:
   manage: Manage
   manageAPITokens: "Manage API Tokens"
   manageCompetencies: "Manage Competencies"
+  manageGroupMembership: "Manage Group Membership"
   manageInstitutionalInfo: "Manage CIR Institutional Info"
   manageSessionAttributes: "Manage Session Attributes"
   manageUsers: "Manage Users"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -189,6 +189,7 @@ general:
   manage: Manejar
   manageAPITokens: "Maneje Tokens de la API"
   manageCompetencies: "Maneje Competencias"
+  manageGroupMembership: "Administrar membresía de grupo"
   manageInstitutionalInfo: "Administrar información institucional del CIR"
   manageSessionAttributes: "Maneje Atributos de la Sesión"
   manageUsers: "Administrar Usuarios"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -189,6 +189,7 @@ general:
   manage: Administrer
   manageAPITokens: "Gérer des jetons de l’API"
   manageCompetencies: "Manager des Compétences"
+  manageGroupMembership: "Gérer l'appartenance au groupe"
   manageInstitutionalInfo: "Manager les informations institutionnelles du CIR"
   manageSessionAttributes: "Gérer Attributs de Séance"
   manageUsers: "Gérer les utilisateurs"


### PR DESCRIPTION
fixes https://github.com/ilios/frontend/issues/6737

this presented an opportunity to use page objects for test coverage here, so this also refs #6581 

while viewing:
![image](https://user-images.githubusercontent.com/1410427/176043629-843e49ad-e72f-47fb-90d1-be45d8e800b6.png)

while managing membership:
![image](https://user-images.githubusercontent.com/1410427/176043710-4935329f-fada-4878-a218-64b2a6dffa33.png)


while bulk assigning:

![image](https://user-images.githubusercontent.com/1410427/176043806-ca6a7b76-78a2-4806-9784-cc50235bb51a.png)
