### PR TITLE
Fix box shadow on header menus

### DIFF
--- a/app/styles/mixins/header-menu.scss
+++ b/app/styles/mixins/header-menu.scss
@@ -18,7 +18,7 @@ $header-menu-background-color: color.adjust($slightWhite, $lightness: -3%);
 
   .menu {
     background-color: $header-menu-background-color;
-    box-shadow: 0 2px 2px color.adjust($black, $alpha: .8);
+    box-shadow: 0 2px 2px color.adjust($black, $alpha: -.8);
     display: flex;
     flex-direction: column;
     list-style-type: none;


### PR DESCRIPTION
Both the user menu and local chooser had a deep black line underneath
them caused by a miss-applied alpha transparency, now it is adjusted to
be more pleasing