### PR TITLE
Give the logo a max height

### DIFF
--- a/app/styles/components/ilios-logo.scss
+++ b/app/styles/components/ilios-logo.scss
@@ -8,5 +8,6 @@
     img {
         display: block;
         height: 95%;
+        max-height: 4rem;
     }
 }


### PR DESCRIPTION
At sizes greater than a phone, but less than a table the logo was
growing to fill space we didn't need filled. I've added a max-height to
the image to ensure it stays in it's lane.

From:
<img width="856" alt="Screen Shot 2022-06-28 at 10 45 46 PM" src="https://user-images.githubusercontent.com/349624/176360995-b8de3936-75a2-4d1c-a53f-9fc8bc5a0138.png">

To:
<img width="830" alt="Screen Shot 2022-06-28 at 10 46 06 PM" src="https://user-images.githubusercontent.com/349624/176361017-38fedb46-719e-47f9-a92f-cda6304a67c3.png">

