### PR TITLE
Remove Unneeded Content from Courses List

### DIFF
--- a/app/components/ilios-course-list.hbs
+++ b/app/components/ilios-course-list.hbs
@@ -1,6 +1,5 @@
 <div
   data-test-ilios-course-list
-  {{did-insert (perform this.load)}}
   ...attributes
 >
   {{#unless this.load.isRunning}}
@@ -9,22 +8,16 @@
         <tr data-test-course-headings>
           <SortableTh
             data-test-course-title-heading
-            @colspan={{3}}
+            @colspan="8"
             @sortedAscending={{this.sortedAscending}}
             @sortedBy={{or (eq @sortBy "title") (eq @sortBy "title:desc")}}
             @onClick={{fn this.setSortBy "title"}}
           >
             {{t "general.courseTitle"}}
           </SortableTh>
-          <th class="text-center hide-from-small-screen" colspan="2">
-            {{t "general.school"}}
-          </th>
-          <th class="text-center hide-from-small-screen" colspan="2">
-            {{t "general.year"}}
-          </th>
           <SortableTh
             @align="center"
-            @colspan={{1}}
+            @colspan="1"
             @hideFromSmallScreen={{true}}
             @sortedAscending={{this.sortedAscending}}
             @sortedBy={{or (eq @sortBy "level") (eq @sortBy "level:desc")}}
@@ -56,7 +49,8 @@
             {{t "general.endDate"}}
           </SortableTh>
           <SortableTh
-            @colspan="3"
+            @align="right"
+            @colspan="2"
             @sortedAscending={{this.sortedAscending}}
             @sortedBy={{or (eq @sortBy "status") (eq @sortBy "status:desc")}}
             @onClick={{fn this.setSortBy "status"}}
@@ -71,7 +65,7 @@
             class={{if (includes course.id this.coursesForRemovalConfirmation) "confirm-removal"}}
             data-test-active-row
           >
-            <td class="text-left" colspan="3">
+            <td class="text-left" colspan="8" data-test-course-title>
               <LinkTo @route="course" @model={{course}}>
                 {{course.title}}
                 {{#if course.externalId}}
@@ -79,30 +73,20 @@
                 {{/if}}
               </LinkTo>
             </td>
-            <td class="text-center hide-from-small-screen" colspan="2">
-              {{course.school.title}}
-            </td>
-            <td class="text-center hide-from-small-screen" colspan="2">
-              {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                {{course.year}} - {{add course.year 1}}
-              {{else}}
-                {{course.year}}
-              {{/if}}
-            </td>
-            <td class="text-center hide-from-small-screen" colspan="1">
+            <td class="text-center hide-from-small-screen" colspan="1" data-test-level>
               {{course.level}}
             </td>
-            <td class="text-center hide-from-small-screen" colspan="2">
+            <td class="text-center hide-from-small-screen" colspan="2" data-test-start-date>
               {{moment-format course.startDate "L"}}
             </td>
-            <td class="text-center hide-from-small-screen" colspan="2">
+            <td class="text-center hide-from-small-screen" colspan="2" data-test-end-date>
               {{moment-format course.endDate "L"}}
             </td>
-            <td class="text-left" colspan="3">
+            <td class="text-right" colspan="2" data-test-status>
               {{#if (includes course.id this.savingCourseIds)}}
                 <LoadingSpinner />
               {{else}}
-                <PublicationStatus @item={{course}} @showText={{true}} @showIcon={{false}} />
+                <PublicationStatus @item={{course}} @showText={{media "isLaptopAndUp"}} @showIcon={{not (media "isLaptopAndUp")}} />
                 {{#if course.locked}}
                   {{#if (await (compute this.canUnlock course))}}
                     <button
@@ -148,7 +132,7 @@
           </tr>
           {{#if (includes course.id this.coursesForRemovalConfirmation)}}
             <tr class="confirm-removal">
-              <td colspan={{if (media "isLaptopAndUp") "15" "6"}}>
+              <td colspan={{if (media "isLaptopAndUp") "15" "10"}}>
                 <div class="confirm-message">
                   {{t
                     "general.confirmRemoveCourse"
@@ -173,7 +157,7 @@
           {{/if}}
         {{else}}
           <tr data-test-empty-list>
-            <td class="text-center" colspan={{if (media "isLaptopAndUp") "15" "6"}}>
+            <td class="text-center" colspan={{if (media "isLaptopAndUp") "15" "10"}}>
               {{if @query (t "general.noResultsFound") (t "general.none")}}
             </td>
           </tr>

--- a/app/components/ilios-course-list.js
+++ b/app/components/ilios-course-list.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { restartableTask, task } from 'ember-concurrency';
+import { task } from 'ember-concurrency';
 
 export default class IliosCourseListComponent extends Component {
   @service intl;
@@ -11,7 +11,6 @@ export default class IliosCourseListComponent extends Component {
 
   @tracked coursesForRemovalConfirmation = [];
   @tracked savingCourseIds = [];
-  @tracked academicYearCrossesCalendarYearBoundaries = false;
 
   get sortedAscending() {
     return !this.args.sortBy.includes(':desc');
@@ -38,13 +37,6 @@ export default class IliosCourseListComponent extends Component {
       translation += 'notPublished';
     }
     return this.intl.t(translation);
-  }
-
-  @restartableTask
-  *load() {
-    this.academicYearCrossesCalendarYearBoundaries = yield this.iliosConfig.itemFromConfig(
-      'academicYearCrossesCalendarYearBoundaries'
-    );
   }
 
   @task

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -294,8 +294,6 @@ module('Acceptance | Courses', function (hooks) {
     assert.strictEqual(page.courses.courses.length, 1);
     assert.strictEqual(page.newCourseLink, 'Course 1', 'new course link');
     assert.strictEqual(page.courses.courses[0].title, 'Course 1', 'course title is correct');
-    assert.strictEqual(page.courses.courses[0].school, 'school 0', 'school is correct');
-    assert.strictEqual(parseInt(page.courses.courses[0].year, 10), year, 'year is correct');
   });
 
   test('new course toggle does not show up for unprivileged users', async function (assert) {
@@ -732,24 +730,6 @@ module('Acceptance | Courses', function (hooks) {
     assert.ok(page.yearFilters[0].selected);
     assert.strictEqual(page.yearFilters[0].value, year.toString());
     unfreezeDate();
-  });
-
-  test('courses show academic-year as range if applicable by configuration', async function (assert) {
-    this.server.get('application/config', function () {
-      return {
-        config: {
-          academicYearCrossesCalendarYearBoundaries: true,
-        },
-      };
-    });
-    this.server.create('academicYear', { id: 2014 });
-    this.server.create('course', {
-      year: 2014,
-      schoolId: 1,
-    });
-    await page.visit({ year: 2014 });
-    assert.strictEqual(page.courses.courses.length, 1);
-    assert.strictEqual(page.courses.courses[0].year, `2014 - 2015`, 'course year shows as range');
   });
 
   test('title filter does not lose focus #6417', async function (assert) {

--- a/tests/pages/components/ilios-course-list.js
+++ b/tests/pages/components/ilios-course-list.js
@@ -11,28 +11,26 @@ import {
 const definition = {
   scope: '[data-test-ilios-course-list]',
   courses: collection('[data-test-active-row]', {
-    title: text('td', { at: 0 }),
-    school: text('td', { at: 1 }),
-    year: text('td', { at: 2 }),
-    level: text('td', { at: 3 }),
-    startDate: text('td', { at: 4 }),
-    endDate: text('td', { at: 5 }),
-    status: text('td', { at: 6 }),
-    isLocked: hasClass('fa-lock', 'svg', { scope: 'td:eq(6)', at: 0 }),
-    isUnlocked: hasClass('fa-unlock', 'svg', { scope: 'td:eq(6)', at: 0 }),
-    lock: clickable('[data-test-lock]', { scope: 'td:eq(6)' }),
-    canLock: isVisible('[data-test-lock]', { scope: 'td:eq(6)' }),
-    canUnlock: isVisible('[data-test-unlock]', { scope: 'td:eq(6)' }),
-    unLock: clickable('[data-test-unlock]', { scope: 'td:eq(6)' }),
-    remove: clickable('[data-test-remove]', { scope: 'td:eq(6)' }),
-    removeActionCount: count('[data-test-remove]', { scope: 'td:eq(6)' }),
+    title: text('[data-test-course-title]'),
+    level: text('[data-test-level]'),
+    startDate: text('[data-test-start-date]'),
+    endDate: text('[data-test-end-date]'),
+    status: text('[data-test-status]'),
+    isLocked: hasClass('fa-lock', 'svg', { scope: '[data-test-status]', at: 1 }),
+    isUnlocked: hasClass('fa-unlock', 'svg', { scope: '[data-test-status]', at: 1 }),
+    lock: clickable('[data-test-lock]', { scope: '[data-test-status]' }),
+    canLock: isVisible('[data-test-lock]', { scope: '[data-test-status]' }),
+    canUnlock: isVisible('[data-test-unlock]', { scope: '[data-test-status]' }),
+    unLock: clickable('[data-test-unlock]', { scope: '[data-test-status]' }),
+    remove: clickable('[data-test-remove]', { scope: '[data-test-status]' }),
+    removeActionCount: count('[data-test-remove]', { scope: '[data-test-status]' }),
   }),
   emptyListRowIsVisible: isVisible('[data-test-empty-list]'),
   sortByTitle: clickable('button', { scope: '[data-test-course-headings] th:nth-of-type(1)' }),
-  sortByLevel: clickable('button', { scope: '[data-test-course-headings] th:nth-of-type(4)' }),
-  sortByStartDate: clickable('button', { scope: '[data-test-course-headings] th:nth-of-type(5)' }),
-  sortByEndDate: clickable('button', { scope: '[data-test-course-headings] th:nth-of-type(6)' }),
-  sortByStatus: clickable('button', { scope: '[data-test-course-headings] th:nth-of-type(7)' }),
+  sortByLevel: clickable('button', { scope: '[data-test-course-headings] th:nth-of-type(2)' }),
+  sortByStartDate: clickable('button', { scope: '[data-test-course-headings] th:nth-of-type(3)' }),
+  sortByEndDate: clickable('button', { scope: '[data-test-course-headings] th:nth-of-type(4)' }),
+  sortByStatus: clickable('button', { scope: '[data-test-course-headings] th:nth-of-type(5)' }),
   confirmCourseRemoval: clickable('[data-test-courses] .confirm-removal button.remove'),
   isSortedByTitleAscending: hasClass(
     'fa-arrow-down-a-z',
@@ -44,35 +42,35 @@ const definition = {
   ),
   isSortedByLevelAscending: hasClass(
     'fa-arrow-down-1-9',
-    '[data-test-course-headings] th:eq(3) svg'
+    '[data-test-course-headings] th:eq(1) svg'
   ),
   isSortedByLevelDescending: hasClass(
     'fa-arrow-down-9-1',
-    '[data-test-course-headings] th:eq(3) svg'
+    '[data-test-course-headings] th:eq(1) svg'
   ),
   isSortedByStartDateAscending: hasClass(
     'fa-arrow-down-1-9',
-    '[data-test-course-headings] th:eq(4) svg'
+    '[data-test-course-headings] th:eq(2) svg'
   ),
   isSortedByStartDateDescending: hasClass(
     'fa-arrow-down-9-1',
-    '[data-test-course-headings] th:eq(4) svg'
+    '[data-test-course-headings] th:eq(2) svg'
   ),
   isSortedByEndDateAscending: hasClass(
     'fa-arrow-down-1-9',
-    '[data-test-course-headings] th:eq(5) svg'
+    '[data-test-course-headings] th:eq(3) svg'
   ),
   isSortedByEndDateDescending: hasClass(
     'fa-arrow-down-9-1',
-    '[data-test-course-headings] th:eq(5) svg'
+    '[data-test-course-headings] th:eq(3) svg'
   ),
   isSortedByStatusAscending: hasClass(
     'fa-arrow-down-a-z',
-    '[data-test-course-headings] th:eq(6) svg'
+    '[data-test-course-headings] th:eq(4) svg'
   ),
   isSortedByStatusDescending: hasClass(
     'fa-arrow-down-z-a',
-    '[data-test-course-headings] th:eq(6) svg'
+    '[data-test-course-headings] th:eq(4) svg'
   ),
 };
 


### PR DESCRIPTION
The school and year are provided in the filter, we may add some more
clarification about this later, but for now just pull these columns out
and leave more space for the course.

Fixes ilios/ilios#4190