### PR TITLE
wraps "back to admin dashboard" link into a component and styles it.

### DIFF
--- a/app/components/back-to-admin-dashboard.hbs
+++ b/app/components/back-to-admin-dashboard.hbs
@@ -1,0 +1,5 @@
+<div class="back-to-admin-dashboard" data-test-back-to-admin-dashboard ...attributes>
+  <LinkTo @route="admin-dashboard">
+    {{t "general.backToAdminDashboard"}}
+  </LinkTo>
+</div>

--- a/app/styles/components.scss
+++ b/app/styles/components.scss
@@ -1,6 +1,7 @@
 @import 'components/admin-dashboard';
 @import 'components/api-version-check';
 @import 'components/assign-students';
+@import 'components/back-to-admin-dashboard';
 @import 'components/bulk-new-users';
 @import 'components/connection-status';
 @import 'components/course-director-manager';

--- a/app/styles/components/back-to-admin-dashboard.scss
+++ b/app/styles/components/back-to-admin-dashboard.scss
@@ -1,0 +1,3 @@
+.back-to-admin-dashboard {
+  @include main-section;
+}

--- a/app/templates/assign-students.hbs
+++ b/app/templates/assign-students.hbs
@@ -1,7 +1,5 @@
 {{page-title (t "general.admin")}}
-<LinkTo @route="admin-dashboard" data-test-back-to-admin>
-  {{t "general.backToAdminDashboard"}}
-</LinkTo>
+<BackToAdminDashboard />
 <section class="assign-students">
   <div class="filters">
     <div class="schoolsfilter" data-test-school-filter>

--- a/app/templates/pending-user-updates.hbs
+++ b/app/templates/pending-user-updates.hbs
@@ -1,7 +1,5 @@
 {{page-title (t "general.admin")}}
-<LinkTo @route="admin-dashboard">
-  {{t "general.backToAdminDashboard"}}
-</LinkTo>
+<BackToAdminDashboard />
 <section class="pending-user-updates">
   <div class="filters">
     <div class="schoolsfilter" data-test-school-filter>

--- a/app/templates/users.hbs
+++ b/app/templates/users.hbs
@@ -1,7 +1,5 @@
 {{page-title (t "general.admin")}}
-<LinkTo @route="admin-dashboard">
-  {{t "general.backToAdminDashboard"}}
-</LinkTo>
+<BackToAdminDashboard />
 <IliosUsers
   @offset={{this.offset}}
   @setOffset={{set this.offset}}

--- a/tests/integration/components/back-to-admin-dashboard-test.js
+++ b/tests/integration/components/back-to-admin-dashboard-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupIntl } from 'ember-intl/test-support';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { component } from 'ilios/tests/pages/components/back-to-admin-dashboard';
+
+module('Integration | Component | back-to-admin-dashboard', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us');
+
+  test('it renders', async function (assert) {
+    await render(hbs`<BackToAdminDashboard />`);
+    assert.strictEqual(component.text, 'Back to Admin Dashboard');
+    assert.ok(component.url.endsWith('/admin'));
+  });
+});

--- a/tests/pages/components/back-to-admin-dashboard.js
+++ b/tests/pages/components/back-to-admin-dashboard.js
@@ -1,0 +1,9 @@
+import { create, property } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-back-to-admin-dashboard]',
+  url: property('href', 'a'),
+};
+
+export default definition;
+export const component = create(definition);


### PR DESCRIPTION
fixes #6771 

this applies the same padding as the "Back to Courses" link does.