### PR TITLE
put instructor count into component title.

### DIFF
--- a/app/components/learnergroup-instructor-manager.hbs
+++ b/app/components/learnergroup-instructor-manager.hbs
@@ -7,7 +7,11 @@
   {{#unless this.load.isRunning}}
     <div class="detail-header">
       <div class="title" data-test-title>
-        {{t "general.defaultInstructors"}}
+        {{#if this.isManaging}}
+          {{t "general.manageDefaultInstructors"}}
+        {{else}}
+          {{t "general.defaultInstructors"}} ({{get (await @learnerGroup.allInstructors) "length"}})
+        {{/if}}
       </div>
       {{#if this.isManaging}}
         <div class="actions">
@@ -96,10 +100,6 @@
               </li>
             {{/each}}
           </ul>
-        {{else}}
-          <span data-test-no-assigned-instructors>
-            {{t "general.none"}}
-          </span>
         {{/if}}
       {{/if}}
     </div>

--- a/tests/integration/components/learnergroup-instructor-manager-test.js
+++ b/tests/integration/components/learnergroup-instructor-manager-test.js
@@ -56,7 +56,7 @@ module('Integration | Component | learnergroup instructor manager', function (ho
       @canUpdate={{true}}
     />`);
 
-    assert.strictEqual(component.title, 'Default Instructors');
+    assert.strictEqual(component.title, 'Default Instructors (3)');
     assert.strictEqual(component.assignedInstructors.length, 3);
     assert.strictEqual(component.assignedInstructors[0].userNameInfo.fullName, 'aardvark');
     assert.dom(component.assignedInstructors[0].userNameInfo.hasAdditionalInfo);
@@ -68,6 +68,7 @@ module('Integration | Component | learnergroup instructor manager', function (ho
     assert.notOk(component.cancelButton.isVisible);
     assert.strictEqual(component.manageButton.text, 'Manage Instructors');
     await component.manage();
+    assert.strictEqual(component.title, 'Manage Default Instructors');
     assert.strictEqual(component.selectedInstructors.length, 2);
     assert.strictEqual(component.selectedInstructors[0].userNameInfo.fullName, 'aardvark');
     assert.dom(component.selectedInstructors[0].userNameInfo.hasAdditionalInfo);
@@ -100,8 +101,8 @@ module('Integration | Component | learnergroup instructor manager', function (ho
       @save={{(noop)}}
       @canUpdate={{true}}
     />`);
+    assert.strictEqual(component.title, 'Default Instructors (0)');
     assert.strictEqual(component.selectedInstructors.length, 0);
-    assert.ok(component.hasNoAssignedInstructors);
   });
 
   test('read-only mode', async function (assert) {

--- a/tests/pages/components/learnergroup-instructor-manager.js
+++ b/tests/pages/components/learnergroup-instructor-manager.js
@@ -1,12 +1,4 @@
-import {
-  clickable,
-  collection,
-  create,
-  fillable,
-  hasClass,
-  isVisible,
-  text,
-} from 'ember-cli-page-object';
+import { clickable, collection, create, fillable, hasClass, text } from 'ember-cli-page-object';
 import userNameInfo from 'ilios-common/page-objects/components/user-name-info';
 
 const definition = {
@@ -24,7 +16,6 @@ const definition = {
   saveButton: {
     scope: '[data-test-save]',
   },
-  hasNoAssignedInstructors: isVisible('[data-test-no-assigned-instructors]'),
   assignedInstructors: collection('[data-test-assigned-instructor]', {
     userNameInfo,
   }),

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -189,6 +189,7 @@ general:
   manage: Manage
   manageAPITokens: "Manage API Tokens"
   manageCompetencies: "Manage Competencies"
+  manageDefaultInstructors: "Manage Default Instructors"
   manageGroupMembership: "Manage Group Membership"
   manageInstitutionalInfo: "Manage CIR Institutional Info"
   manageSessionAttributes: "Manage Session Attributes"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -189,6 +189,7 @@ general:
   manage: Manejar
   manageAPITokens: "Maneje Tokens de la API"
   manageCompetencies: "Maneje Competencias"
+  manageDefaultInstructors: "Maneje instructores predeterminados"
   manageGroupMembership: "Administrar membresía de grupo"
   manageInstitutionalInfo: "Administrar información institucional del CIR"
   manageSessionAttributes: "Maneje Atributos de la Sesión"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -189,6 +189,7 @@ general:
   manage: Administrer
   manageAPITokens: "Gérer des jetons de l’API"
   manageCompetencies: "Manager des Compétences"
+  manageDefaultInstructors: "Gérer les instructeurs par défaut"
   manageGroupMembership: "Gérer l'appartenance au groupe"
   manageInstitutionalInfo: "Manager les informations institutionnelles du CIR"
   manageSessionAttributes: "Gérer Attributs de Séance"


### PR DESCRIPTION
provide a different component title while in edit mode.
drop "none" output if no instructors are associated to the given learner
group.

fixes #6813 