### PR TITLE
Add banner role to error element

### DIFF
--- a/lib/ilios-error/index.js
+++ b/lib/ilios-error/index.js
@@ -40,6 +40,7 @@ module.exports = {
           document.getElementsByTagName( "head" )[0].appendChild( link );
           var errorContainer = document.createElement('div');
           errorContainer.id = 'ilios-loading-error';
+          errorContainer.setAttribute('role', 'banner');
           errorContainer.innerHTML = '' +
             '<h1>' +
               'It is possible that your browser is not supported by Ilios. ' +


### PR DESCRIPTION
This ensures it's a11y compatible by placing it within a banner landmark
on the page.