### PR TITLE
Ensure the skip link is first in the tab order

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -8,12 +8,12 @@
   class="application-wrapper
     {{if this.currentUser.performsNonLearnerFunction "show-navigation"}}"
 >
+  <IliosHeader />
   <div class="ilios-logo">
     <LinkTo @route="dashboard" title={{t "general.dashboard"}}>
       <img role="presentation" src="/assets/images/ilios-logo.svg" alt="">
     </LinkTo>
   </div>
-  <IliosHeader />
   {{#if this.session.isAuthenticated}}
     <IliosNavigation />
   {{/if}}

--- a/tests/acceptance/dashboard/accessibility-test.js
+++ b/tests/acceptance/dashboard/accessibility-test.js
@@ -20,4 +20,10 @@ module('Acceptance | dashboard accessibility', function (hooks) {
     await a11yAudit();
     assert.ok(true);
   });
+
+  test('skip link is first in tab order', async function (assert) {
+    await visit('/');
+    assert.dom('#ember-a11y-refocus-skip-link').exists();
+    assert.dom('#ember-a11y-refocus-skip-link').hasProperty('tabIndex', 0);
+  });
 });


### PR DESCRIPTION
Didn't actually need to move the header because this was already true,
but in fighting with the a11y tools this seems like a good way forward.

It's important that the skip link be the first thing a screen reader encounters so they can move straight to the good stuff.