### PR TITLE
Stop Testing Before Deploying

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -11,20 +11,6 @@ env:
   SENTRY_PROJECT: frontend
 
 jobs:
-  test:
-    name: Run Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run test:ember
-        env:
-          SW_DISABLED: true
-
   deploy:
     name: Deploy and Create Sentry Release
     needs: test


### PR DESCRIPTION
All of our commits get tested as they get merged having this extra step was a nice bit of additional checking, but it's slowing down releases and if we have a flaky test it is a real problem. So, I'm switching off test tests, we'll only worry about deploying.