### PR TITLE
Replace moment with luxon

### DIFF
--- a/app/components/curriculum-inventory/report-list-item.hbs
+++ b/app/components/curriculum-inventory/report-list-item.hbs
@@ -31,14 +31,14 @@
     colspan="2"
     data-test-start-date
   >
-    {{moment-format @report.startDate "L"}}
+    {{format-date @report.startDate}}
   </td>
   <td
     class="text-center hide-from-small-screen"
     colspan="2"
     data-test-end-date
   >
-    {{moment-format @report.endDate "L"}}
+    {{format-date @report.endDate}}
   </td>
   <td
     class="text-center"

--- a/app/components/curriculum-inventory/sequence-block-list-item.hbs
+++ b/app/components/curriculum-inventory/sequence-block-list-item.hbs
@@ -25,14 +25,14 @@
   </td>
   <td class="text-center hide-from-small-screen" colspan="2" data-test-start-date>
     {{#if @sequenceBlock.startDate}}
-      {{moment-format @sequenceBlock.startDate "L"}}
+      {{format-date @sequenceBlock.startDate}}
     {{else}}
       {{t "general.notApplicableAbbr"}}
     {{/if}}
   </td>
   <td class="text-center hide-from-small-screen" colspan="2" data-test-end-date>
     {{#if @sequenceBlock.endDate}}
-      {{moment-format @sequenceBlock.endDate "L"}}
+      {{format-date @sequenceBlock.endDate}}
     {{else}}
       {{t "general.notApplicableAbbr"}}
     {{/if}}

--- a/app/components/curriculum-inventory/sequence-block-overview.hbs
+++ b/app/components/curriculum-inventory/sequence-block-overview.hbs
@@ -39,8 +39,8 @@
             {{#if this.course}}
               <span class="details" data-test-course-details>
                 {{t "general.level"}}: {{this.course.level}},
-                {{t "general.startDate"}}: {{moment-format this.course.startDate "YYYY-MM-DD"}},
-                {{t "general.endDate"}}: {{moment-format this.course.endDate "YYYY-MM-DD"}}
+                {{t "general.startDate"}}: {{format-date this.course.startDate}},
+                {{t "general.endDate"}}: {{format-date this.course.endDate}}
                 {{#if this.course.clerkshipType}}
                   - {{t "general.clerkship"}} ({{this.course.clerkshipType.title}})
                 {{/if}}
@@ -177,7 +177,7 @@
                     data-test-edit
                   >
                     {{#if @sequenceBlock.startDate}}
-                      {{moment-format @sequenceBlock.startDate "L"}}
+                      {{format-date @sequenceBlock.startDate}}
                     {{else}}
                       {{t "general.clickToEdit"}}
                     {{/if}}
@@ -186,7 +186,7 @@
               {{else}}
                 <span>
                   {{#if @sequenceBlock.startDate}}
-                    {{moment-format @sequenceBlock.startDate "L"}}
+                    {{format-date @sequenceBlock.startDate}}
                   {{else}}
                     {{t "general.notApplicableAbbr"}}
                   {{/if}}
@@ -204,7 +204,7 @@
                     data-test-edit
                   >
                     {{#if @sequenceBlock.endDate}}
-                      {{moment-format @sequenceBlock.endDate "L"}}
+                      {{format-date @sequenceBlock.endDate}}
                     {{else}}
                       {{t "general.clickToEdit"}}
                     {{/if}}
@@ -213,7 +213,7 @@
               {{else}}
                 <span>
                   {{#if @sequenceBlock.endDate}}
-                    {{moment-format @sequenceBlock.endDate "L"}}
+                    {{format-date @sequenceBlock.endDate}}
                   {{else}}
                     {{t "general.notApplicableAbbr"}}
                   {{/if}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -2,7 +2,7 @@ import commonRoutes from './routes';
 import ENV from 'ilios/config/environment';
 import { discoverEmberDataModels } from 'ember-cli-mirage';
 import { createServer, Response } from 'miragejs';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 
 const { apiVersion } = ENV;
 
@@ -27,12 +27,10 @@ export default function (config) {
         const username = attrs.username.toLowerCase();
         if (errors.length === 0) {
           if (username === 'demo' && attrs.password === 'demo') {
-            const now = moment();
-            const nextWeek = now.clone().add(1, 'week');
+            const now = DateTime.now();
+            const nextWeek = now.plus({ weeks: 1 });
             const header = '{"alg":"none"}';
-            const body = `{"iss": "ilios","aud": "ilios","iat": "${now.format(
-              'X'
-            )}","exp": "${nextWeek.format('X')}","user_id": 4136}`;
+            const body = `{"iss": "ilios","aud": "ilios","iat": "${now.toUnixInteger()}","exp": "${nextWeek.toUnixInteger()}","user_id": 4136}`;
 
             const encodedData = window.btoa(header) + '.' + window.btoa(body) + '.';
             return {
@@ -74,12 +72,10 @@ export default function (config) {
         // return {
         //   jwt: null
         // };
-        const now = moment();
-        const nextWeek = now.clone().add(1, 'week');
+        const now = DateTime.now();
+        const nextWeek = now.plus({ weeks: 1 });
         const header = '{"alg":"none"}';
-        const body = `{"iss": "ilios","aud": "ilios","iat": "${now.format(
-          'X'
-        )}","exp": "${nextWeek.format('X')}","user_id": 4136}`;
+        const body = `{"iss": "ilios","aud": "ilios","iat": "${now.toUnixInteger()}","exp": "${nextWeek.toUnixInteger()}","user_id": 4136}`;
 
         const encodedData = window.btoa(header) + '.' + window.btoa(body) + '.';
         return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "file-saver": "^2.0.5",
         "ilios-common": "^71.1.1",
         "loader.js": "^4.7.0",
+        "luxon": "^3.0.4",
         "miragejs": "^0.1.45",
         "mockdate": "^3.0.5",
         "moment-timezone": "^0.5.37",
@@ -15301,6 +15302,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/ember-cli-deploy-display-revisions/node_modules/luxon": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ember-cli-deploy-display-revisions/node_modules/rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -27790,15 +27800,6 @@
         "validator": "^13.1.1"
       }
     },
-    "node_modules/ilios-common/node_modules/luxon": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
-      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/immutable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
@@ -29746,12 +29747,12 @@
       }
     },
     "node_modules/luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
+      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -51095,6 +51096,12 @@
         "rsvp": "^4.8.5"
       },
       "dependencies": {
+        "luxon": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+          "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+          "dev": true
+        },
         "rsvp": {
           "version": "4.8.5",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -61002,14 +61009,6 @@
         "typeface-nunito": "1.1.13",
         "typeface-nunito-sans": "1.1.13",
         "validator": "^13.1.1"
-      },
-      "dependencies": {
-        "luxon": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
-          "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==",
-          "dev": true
-        }
       }
     },
     "immutable": {
@@ -62632,9 +62631,9 @@
       }
     },
     "luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
+      "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==",
       "dev": true
     },
     "magic-string": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "file-saver": "^2.0.5",
     "ilios-common": "^71.1.1",
     "loader.js": "^4.7.0",
+    "luxon": "^3.0.4",
     "miragejs": "^0.1.45",
     "mockdate": "^3.0.5",
     "moment-timezone": "^0.5.37",

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -1,7 +1,7 @@
 import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import page from 'ilios/tests/pages/courses';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -284,7 +284,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('new course', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const year = moment().year();
+    const year = DateTime.now().year;
     this.server.create('academicYear', { id: year });
     await page.visit({ year });
     await page.toggleNewCourseForm();
@@ -297,7 +297,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('new course toggle does not show up for unprivileged users', async function (assert) {
-    const year = moment().year();
+    const year = DateTime.now().year;
     this.server.create('academicYear', { id: year });
     assert.expect(1);
     await page.visit({ year });
@@ -323,7 +323,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('new course does not appear twice when navigating back', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const year = moment().year();
+    const year = DateTime.now().year;
     this.server.create('academicYear', { id: year });
     assert.expect(4);
 
@@ -345,7 +345,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('new course can be deleted', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const year = moment().year();
+    const year = DateTime.now().year;
     this.server.create('academicYear', { id: year });
     this.server.create('userRole', {
       title: 'Developer',
@@ -404,7 +404,7 @@ module('Acceptance | Courses', function (hooks) {
     await page.visit();
     await page.toggleNewCourseForm();
 
-    const thisYear = parseInt(moment().format('YYYY'), 10);
+    const thisYear = DateTime.now().year;
     const years = [thisYear - 2, thisYear - 1, thisYear, thisYear + 1, thisYear + 2];
 
     assert.strictEqual(page.newCourse.years.length, years.length + 1);
@@ -465,12 +465,12 @@ module('Acceptance | Courses', function (hooks) {
     const firstCourse = this.server.create('course', {
       year: 2014,
       schoolId: 1,
-      startDate: moment().toDate(),
+      startDate: DateTime.fromObject({ hour: 8 }).toJSDate(),
     });
     const secondCourse = this.server.create('course', {
       year: 2014,
       schoolId: 1,
-      startDate: moment().add(1, 'day').toDate(),
+      startDate: DateTime.fromObject({ hour: 8 }).plus({ days: 1 }).toJSDate(),
     });
 
     await page.visit();
@@ -490,12 +490,12 @@ module('Acceptance | Courses', function (hooks) {
     const firstCourse = this.server.create('course', {
       year: 2014,
       schoolId: 1,
-      endDate: moment().toDate(),
+      endDate: DateTime.fromObject({ hour: 8 }).toJSDate(),
     });
     const secondCourse = this.server.create('course', {
       year: 2014,
       schoolId: 1,
-      endDate: moment().add(1, 'day').toDate(),
+      endDate: DateTime.fromObject({ hour: 8 }).plus({ days: 1 }).toJSDate(),
     });
 
     await page.visit();
@@ -621,7 +621,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('can not delete course with descendants #3620', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const year = moment().year().toString();
+    const year = DateTime.now().year.toString();
     this.server.create('academicYear', { id: year });
     const course1 = this.server.create('course', {
       year,
@@ -652,7 +652,7 @@ module('Acceptance | Courses', function (hooks) {
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
     this.user.update({ administeredSchools: [this.school] });
     freezeDateAt(new Date('1/1/2021'));
-    const year = moment().year();
+    const year = DateTime.now().year;
     this.server.create('academicYear', { id: year - 1 });
     this.server.create('academicYear', { id: year });
     this.server.get('application/config', function () {
@@ -673,7 +673,7 @@ module('Acceptance | Courses', function (hooks) {
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
     this.user.update({ administeredSchools: [this.school] });
     freezeDateAt(new Date('10/10/2021'));
-    const year = moment().year();
+    const year = DateTime.now().year;
     this.server.create('academicYear', { id: year - 1 });
     this.server.create('academicYear', { id: year });
     this.server.get('application/config', function () {
@@ -694,7 +694,7 @@ module('Acceptance | Courses', function (hooks) {
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
     this.user.update({ administeredSchools: [this.school] });
     freezeDateAt(new Date('1/1/2021'));
-    const year = moment().year();
+    const year = DateTime.now().year;
     this.server.create('academicYear', { id: year - 1 });
     this.server.create('academicYear', { id: year });
     this.server.get('application/config', function () {
@@ -715,7 +715,7 @@ module('Acceptance | Courses', function (hooks) {
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
     this.user.update({ administeredSchools: [this.school] });
     freezeDateAt(new Date('10/10/2021'));
-    const year = moment().year();
+    const year = DateTime.now().year;
     this.server.create('academicYear', { id: year - 1 });
     this.server.create('academicYear', { id: year });
     this.server.get('application/config', function () {

--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -1,7 +1,7 @@
 import { currentURL } from '@ember/test-helpers';
 import { test, module } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from '../pages/learner-group';
@@ -297,8 +297,8 @@ module('Acceptance | Learnergroup', function (hooks) {
     const session = this.server.create('session', { course });
     this.server.create('offering', {
       session,
-      startDate: moment().hour(8).toDate(),
-      endDate: moment().hour(8).add(1, 'hour').toDate(),
+      startDate: DateTime.fromObject({ hour: 8 }).toJSDate(),
+      endDate: DateTime.fromObject({ hour: 9 }).toJSDate(),
       learnerGroups: [learnerGroup],
     });
     this.server.create('offering');
@@ -329,14 +329,14 @@ module('Acceptance | Learnergroup', function (hooks) {
     });
     this.server.create('offering', {
       session,
-      startDate: moment().hour(8).toDate(),
-      endDate: moment().hour(8).add(1, 'hour').toDate(),
+      startDate: DateTime.fromObject({ hour: 8 }).toJSDate(),
+      endDate: DateTime.fromObject({ hour: 9 }).toJSDate(),
       learnerGroups: [learnerGroup],
     });
     this.server.create('offering', {
       session,
-      startDate: moment().hour(8).toDate(),
-      endDate: moment().hour(8).add(1, 'hour').toDate(),
+      startDate: DateTime.fromObject({ hour: 8 }).toJSDate(),
+      endDate: DateTime.fromObject({ hour: 9 }).toJSDate(),
       learnerGroups: [subgroup],
     });
     this.server.create('offering');

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -1,5 +1,5 @@
 import { currentRouteName } from '@ember/test-helpers';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
@@ -170,7 +170,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
     const competencies = this.server.createList('competency', 3);
     const vocabulary = this.server.create('vocabulary', { school: this.school });
     const terms = this.server.createList('term', 3, { vocabulary });
-    const currentYear = parseInt(moment().format('YYYY'), 10);
+    const currentYear = DateTime.now().year;
     const programYear = this.server.create('programYear', {
       program: this.program,
       startYear: currentYear,

--- a/tests/integration/components/bulk-new-users-test.js
+++ b/tests/integration/components/bulk-new-users-test.js
@@ -13,7 +13,7 @@ import {
   waitFor,
 } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { Response } from 'miragejs';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -29,7 +29,7 @@ module('Integration | Component | bulk new users', function (hooks) {
     this.server.create('school', { title: 'third' });
 
     const program = this.server.create('program', { id: 1, title: 'Program', duration, school });
-    const startYear = moment().format('YYYY');
+    const startYear = DateTime.now().year;
     const py1 = this.server.create('program-year', { program, startYear });
     const py2 = this.server.create('program-year', { program, startYear });
     this.server.create('cohort', { id: 2, title: 'second', programYear: py1 });

--- a/tests/integration/components/curriculum-inventory/new-report-test.js
+++ b/tests/integration/components/curriculum-inventory/new-report-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/new-report';
 
@@ -15,7 +15,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
   test('it renders', async function (assert) {
     const program = this.server.create('program', { id: 1, title: 'Doctor of Medicine' });
     const programModel = await this.owner.lookup('service:store').find('program', program.id);
-    const currentYear = parseInt(moment().format('YYYY'), 10);
+    const currentYear = DateTime.fromObject({ hour: 8 }).year;
 
     this.set('program', programModel);
     await render(
@@ -76,7 +76,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
   test('academic year options labeled as range when app configuration is set to cross calendar-year boundaries', async function (assert) {
     const program = this.server.create('program', { id: 1, title: 'Doctor of Medicine' });
     const programModel = await this.owner.lookup('service:store').find('program', program.id);
-    const currentYear = parseInt(moment().format('YYYY'), 10);
+    const currentYear = DateTime.fromObject({ hour: 8 }).year;
 
     this.server.get('application/config', function () {
       return {
@@ -107,7 +107,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
     assert.expect(6);
     const program = this.server.create('program', { id: 1, title: 'Doctor of Medicine' });
     const programModel = await this.owner.lookup('service:store').find('program', program.id);
-    const currentYear = parseInt(moment().format('YYYY'), 10);
+    const currentYear = DateTime.fromObject({ hour: 8 }).year;
     const expectedSelectedYear = currentYear - 5;
 
     this.set('program', programModel);
@@ -120,12 +120,12 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
         'Selected academic year gets passed.'
       );
       assert.strictEqual(
-        moment(report.get('startDate')).format('YYYY-MM-DD'),
+        DateTime.fromJSDate(report.get('startDate')).toFormat('yyyy-MM-dd'),
         `${expectedSelectedYear}-01-01`,
         'Start date gets calculated and passed.'
       );
       assert.strictEqual(
-        moment(report.get('endDate')).format('YYYY-MM-DD'),
+        DateTime.fromJSDate(report.get('endDate')).toFormat('yyyy-MM-dd'),
         `${expectedSelectedYear}-12-31`,
         'End date gets calculated and passed.'
       );
@@ -146,7 +146,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
     assert.expect(2);
     const program = this.server.create('program', { id: 1, title: 'Doctor of Medicine' });
     const programModel = await this.owner.lookup('service:store').find('program', program.id);
-    const currentYear = parseInt(moment().format('YYYY'), 10);
+    const currentYear = DateTime.fromObject({ hour: 8 }).year;
     const expectedSelectedYear = currentYear - 5;
 
     this.server.get('application/config', function () {
@@ -159,12 +159,12 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
     this.set('program', programModel);
     this.set('save', (report) => {
       assert.strictEqual(
-        moment(report.get('startDate')).format('YYYY-MM-DD'),
+        DateTime.fromJSDate(report.get('startDate')).toFormat('yyyy-MM-dd'),
         `${expectedSelectedYear}-07-01`,
         'Start date gets calculated and passed.'
       );
       assert.strictEqual(
-        moment(report.get('endDate')).format('YYYY-MM-DD'),
+        DateTime.fromJSDate(report.get('endDate')).toFormat('yyyy-MM-dd'),
         `${expectedSelectedYear + 1}-06-30`,
         'End date gets calculated and passed.'
       );

--- a/tests/integration/components/curriculum-inventory/new-sequence-block-test.js
+++ b/tests/integration/components/curriculum-inventory/new-sequence-block-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/new-sequence-block';
 
@@ -361,8 +361,14 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     assert.strictEqual(component.endDate.value, '');
     await component.startDate.set(newStartDate);
     await component.endDate.set(newEndDate);
-    assert.strictEqual(component.startDate.value, moment(newStartDate).format('M/D/YYYY'));
-    assert.strictEqual(component.endDate.value, moment(newEndDate).format('M/D/YYYY'));
+    assert.strictEqual(
+      component.startDate.value,
+      DateTime.fromJSDate(newStartDate).toFormat('M/d/yyyy')
+    );
+    assert.strictEqual(
+      component.endDate.value,
+      DateTime.fromJSDate(newEndDate).toFormat('M/d/yyyy')
+    );
     await component.clearDates();
     assert.strictEqual(component.startDate.value, '');
     assert.strictEqual(component.endDate.value, '');

--- a/tests/integration/components/curriculum-inventory/report-details-test.js
+++ b/tests/integration/components/curriculum-inventory/report-details-test.js
@@ -3,7 +3,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render, click, find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import Service from '@ember/service';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/report-details';
@@ -34,8 +34,8 @@ module('Integration | Component | curriculum-inventory/report-details', function
       program,
       isFinalized: false,
       name: 'Lorem Ipsum',
-      startDate: moment('2015-06-12').toDate(),
-      endDate: moment('2016-04-11').toDate(),
+      startDate: DateTime.fromObject({ year: 2015, month: 6, day: 12 }),
+      endDate: DateTime.fromObject({ year: 2016, month: 4, day: 11 }),
       description: 'Lorem Ipsum',
     });
     const reportModel = await this.owner
@@ -66,8 +66,8 @@ module('Integration | Component | curriculum-inventory/report-details', function
       program,
       isFinalized: false,
       name: 'Lorem Ipsum',
-      startDate: moment('2015-06-12').toDate(),
-      endDate: moment('2016-04-11').toDate(),
+      startDate: DateTime.fromObject({ year: 2015, month: 6, day: 12 }),
+      endDate: DateTime.fromObject({ year: 2016, month: 4, day: 11 }),
       description: 'Lorem Ipsum',
     });
     const reportModel = await this.owner
@@ -125,8 +125,8 @@ module('Integration | Component | curriculum-inventory/report-details', function
       program,
       isFinalized: false,
       name: 'Lorem Ipsum',
-      startDate: moment('2015-06-12').toDate(),
-      endDate: moment('2016-04-11').toDate(),
+      startDate: DateTime.fromObject({ year: 2015, month: 6, day: 12 }),
+      endDate: DateTime.fromObject({ year: 2016, month: 4, day: 11 }),
       description: 'Lorem Ipsum',
     });
     const report = await this.owner.lookup('service:store').find('curriculum-inventory-report', 1);

--- a/tests/integration/components/curriculum-inventory/report-list-item-test.js
+++ b/tests/integration/components/curriculum-inventory/report-list-item-test.js
@@ -4,7 +4,6 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/report-list-item';
 
@@ -44,8 +43,8 @@ module('Integration | Component | curriculum-inventory/report-list-item', functi
     assert.strictEqual(component.name, 'CI Report');
     assert.strictEqual(component.program, 'program 0');
     assert.strictEqual(component.year, '2017');
-    assert.strictEqual(component.startDate, moment(this.report.startDate).format('L'));
-    assert.strictEqual(component.endDate, moment(this.report.endDate).format('L'));
+    assert.strictEqual(component.startDate, this.intl.formatDate(this.report.startDate));
+    assert.strictEqual(component.endDate, this.intl.formatDate(this.report.endDate));
     assert.strictEqual(component.status, 'Draft');
     assert.ok(component.isDeletable);
     assert.notOk(component.confirmRemoval.isVisible);

--- a/tests/integration/components/curriculum-inventory/report-list-test.js
+++ b/tests/integration/components/curriculum-inventory/report-list-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/report-list';
 
@@ -29,8 +29,8 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
       program: this.program,
       name: 'Zeppelin',
       year: 2017,
-      startDate: moment('2017-07-01').toDate(),
-      endDate: moment('2018-06-30').toDate(),
+      startDate: DateTime.fromObject({ year: 2017, month: 7, day: 1 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: 2018, month: 6, day: 30 }).toJSDate(),
     });
     const reportExport = this.server.create('curriculum-inventory-export');
     const report2 = this.server.create('curriculum-inventory-report', {
@@ -38,8 +38,8 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
       export: reportExport,
       name: 'Aardvark',
       year: 2016,
-      startDate: moment('2016-07-01').toDate(),
-      endDate: moment('2017-06-30').toDate(),
+      startDate: DateTime.fromObject({ year: 2016, month: 7, day: 1 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: 2017, month: 6, day: 30 }).toJSDate(),
     });
 
     const reportModel1 = await this.owner
@@ -96,12 +96,12 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
     assert.strictEqual(component.reports[0].year, '2016', 'Academic year shows.');
     assert.strictEqual(
       component.reports[0].startDate,
-      moment(reportModel2.startDate).format('L'),
+      this.intl.formatDate(reportModel2.startDate),
       'Start date shows.'
     );
     assert.strictEqual(
       component.reports[0].endDate,
-      moment(reportModel2.endDate).format('L'),
+      this.intl.formatDate(reportModel2.endDate),
       'End date shows.'
     );
     assert.strictEqual(component.reports[0].status, 'Finalized', 'Status shows.');
@@ -110,12 +110,12 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
     assert.strictEqual(component.reports[1].year, '2017', 'Academic year shows.');
     assert.strictEqual(
       component.reports[1].startDate,
-      moment(reportModel1.startDate).format('L'),
+      this.intl.formatDate(reportModel1.startDate),
       'Start date shows.'
     );
     assert.strictEqual(
       component.reports[1].endDate,
-      moment(reportModel1.endDate).format('L'),
+      this.intl.formatDate(reportModel1.endDate),
       'End date shows.'
     );
     assert.strictEqual(component.reports[1].status, 'Draft', 'Status shows.');
@@ -126,8 +126,8 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
       program: this.program,
       name: 'Zeppelin',
       year: 2017,
-      startDate: moment('2017-07-01').toDate(),
-      endDate: moment('2018-06-30').toDate(),
+      startDate: DateTime.fromObject({ year: 2017, month: 7, day: 1 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: 2018, month: 6, day: 30 }).toJSDate(),
     });
     const reportModel = await this.owner
       .lookup('service:store')
@@ -153,8 +153,8 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
       name: 'Zeppelin',
       year: 2017,
       export: reportExport,
-      startDate: moment('2017-07-01').toDate(),
-      endDate: moment('2018-06-30').toDate(),
+      startDate: DateTime.fromObject({ year: 2017, month: 7, day: 1 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: 2018, month: 6, day: 30 }).toJSDate(),
     });
     const reportModel = await this.owner
       .lookup('service:store')
@@ -256,8 +256,8 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
       program: this.program,
       name: 'Zeppelin',
       year: 2017,
-      startDate: moment('2017-07-01').toDate(),
-      endDate: moment('2018-06-30').toDate(),
+      startDate: DateTime.fromObject({ year: 2017, month: 7, day: 1 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: 2018, month: 6, day: 30 }).toJSDate(),
     });
 
     const reportModel1 = await this.owner

--- a/tests/integration/components/curriculum-inventory/report-overview-test.js
+++ b/tests/integration/components/curriculum-inventory/report-overview-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/report-overview';
@@ -15,7 +15,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
 
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
-    const currentYear = new Date().getFullYear();
+    const currentYear = DateTime.fromObject({ hour: 8 }).year;
     const academicLevels = this.server.createList('curriculum-inventory-academic-level', 10);
     this.program = this.server.create('program', {
       school,
@@ -28,8 +28,8 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       program: this.program,
       isFinalized: false,
       name: 'Lorem Ipsum',
-      startDate: moment(`${currentYear - 1}-06-12`).toDate(),
-      endDate: moment(`${currentYear}-04-11`).toDate(),
+      startDate: DateTime.fromObject({ year: currentYear - 1, month: 6, day: 12 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: currentYear, month: 4, day: 11 }).toJSDate(),
       description: 'Lorem Ipsum',
     });
     this.permissionCheckerMock = Service.extend({
@@ -196,8 +196,8 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       this.intl.formatDate(reportModel.startDate),
       "The report's current start date is pre-selected in date picker."
     );
-    const newVal = moment(reportModel.startDate).add(1, 'day');
-    await component.startDate.set(newVal.toDate());
+    const newVal = DateTime.fromJSDate(reportModel.startDate).plus({ days: 1 });
+    await component.startDate.set(newVal.toJSDate());
     await component.startDate.save();
     assert.strictEqual(
       component.startDate.text,
@@ -220,9 +220,9 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     await component.startDate.edit();
-    const newVal = moment(reportModel.endDate).add(1, 'day');
+    const newVal = DateTime.fromJSDate(reportModel.endDate).plus({ days: 1 });
     assert.notOk(component.startDate.hasError, 'Initially, no validation error is visible.');
-    await component.startDate.set(newVal.toDate());
+    await component.startDate.set(newVal.toJSDate());
     await component.startDate.save();
     assert.ok(component.startDate.hasError, 'Validation failed, error message is visible.');
   });
@@ -241,8 +241,8 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       this.intl.formatDate(reportModel.endDate),
       "The report's current end date is pre-selected in date picker."
     );
-    const newVal = moment(reportModel.endDate).add(1, 'day');
-    await component.endDate.set(newVal.toDate());
+    const newVal = DateTime.fromJSDate(reportModel.endDate).plus({ days: 1 });
+    await component.endDate.set(newVal.toJSDate());
     await component.endDate.save();
     assert.strictEqual(
       component.endDate.text,
@@ -265,9 +265,9 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     await component.endDate.edit();
-    const newVal = moment(reportModel.startDate).subtract(1, 'day');
+    const newVal = DateTime.fromJSDate(reportModel.startDate).minus({ days: 1 });
     assert.notOk(component.endDate.hasError, 'Initially, no validation error is visible.');
-    await component.endDate.set(newVal.toDate());
+    await component.endDate.set(newVal.toJSDate());
     await component.endDate.save();
     assert.ok(component.endDate.hasError, 'Validation failed, error message is visible.');
   });

--- a/tests/integration/components/curriculum-inventory/report-rollover-test.js
+++ b/tests/integration/components/curriculum-inventory/report-rollover-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import queryString from 'query-string';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/report-rollover';
@@ -14,7 +14,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
   setupMirage(hooks);
 
   test('it renders', async function (assert) {
-    const thisYear = parseInt(moment().format('YYYY'), 10);
+    const thisYear = DateTime.fromObject({ hour: 8 }).year;
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
     const report = this.server.create('curriculum-inventory-report', {
@@ -48,7 +48,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
         },
       };
     });
-    const thisYear = parseInt(moment().format('YYYY'), 10);
+    const thisYear = DateTime.fromObject({ hour: 8 }).year;
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
     const report = this.server.create('curriculum-inventory-report', {
@@ -75,7 +75,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
     assert.expect(6);
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const thisYear = parseInt(moment().format('YYYY'), 10);
+    const thisYear = DateTime.fromObject({ hour: 8 }).year;
     const report = this.server.create('curriculum-inventory-report', {
       name: 'old report',
       description: 'this is an old report',
@@ -117,7 +117,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
     assert.expect(1);
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const thisYear = parseInt(moment().format('YYYY'), 10);
+    const thisYear = DateTime.fromObject({ hour: 8 }).year;
     const report = this.server.create('curriculum-inventory-report', {
       name: 'old report',
       description: 'this is an old report',
@@ -150,7 +150,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
     const school = this.server.create('school');
     const program = this.server.create('program', { school, title: 'doctor of rocket surgery' });
     const otherProgram = this.server.create('program', { school, title: 'doktor eisenbart' });
-    const thisYear = parseInt(moment().format('YYYY'), 10);
+    const thisYear = DateTime.fromObject({ hour: 8 }).year;
     const report = this.server.create('curriculum-inventory-report', {
       name: 'old report',
       description: 'this is an old report',

--- a/tests/integration/components/curriculum-inventory/sequence-block-details-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-details-test.js
@@ -2,7 +2,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-details';
@@ -40,8 +40,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-details', 
       report,
       parent: parentBlock,
       duration: 12,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: DateTime.fromObject({ year: 2015, month: 1, day: 2 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: 2015, month: 4, day: 30 }).toJSDate(),
       childSequenceOrder: 1,
       orderInSequence: 1,
       required: 2,

--- a/tests/integration/components/curriculum-inventory/sequence-block-list-item-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-list-item-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-list-item';
 
@@ -60,8 +60,14 @@ module('Integration | Component | curriculum-inventory/sequence-block-list-item'
     assert.strictEqual(component.startLevel, '5');
     assert.strictEqual(component.endLevel, '6');
     assert.strictEqual(component.orderInSequence, '3');
-    assert.strictEqual(component.startDate, moment('2021-03-17').format('L'));
-    assert.strictEqual(component.endDate, moment('2021-05-22').format('L'));
+    assert.strictEqual(
+      component.startDate,
+      this.intl.formatDate(DateTime.fromObject({ year: 2021, month: 3, day: 17 }).toJSDate())
+    );
+    assert.strictEqual(
+      component.endDate,
+      this.intl.formatDate(DateTime.fromObject({ year: 2021, month: 5, day: 22 }).toJSDate())
+    );
     assert.strictEqual(component.course, 'course 0');
     assert.ok(component.isDeletable);
   });

--- a/tests/integration/components/curriculum-inventory/sequence-block-list-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-list-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-list';
 
@@ -24,8 +24,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-list', fun
       year: '2016',
       program,
       name: 'Lorem Ipsum',
-      startDate: moment('2015-06-12').toDate(),
-      endDate: moment('2016-04-11').toDate(),
+      startDate: DateTime.fromObject({ year: 2015, month: 6, day: 12 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: 2016, month: 4, day: 11 }).toJSDate(),
       description: 'Lorem Ipsum',
     });
 
@@ -33,8 +33,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-list', fun
       startingAcademicLevel: academicLevel1,
       endingAcademicLevel: academicLevel2,
       title: 'Foo',
-      startDate: moment('2015-02-23').toDate(),
-      endDate: moment('2016-12-03').toDate(),
+      startDate: DateTime.fromObject({ year: 2015, month: 2, day: 23 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: 2016, month: 12, day: 3 }).toJSDate(),
       course,
       orderInSequence: 0,
       report,
@@ -144,11 +144,11 @@ module('Integration | Component | curriculum-inventory/sequence-block-list', fun
     assert.strictEqual(component.list.items[1].orderInSequence, 'n/a');
     assert.strictEqual(
       component.list.items[1].startDate,
-      moment(this.sequenceBlock1.startDate).format('L')
+      this.intl.formatDate(this.sequenceBlock1.startDate)
     );
     assert.strictEqual(
       component.list.items[1].endDate,
-      moment(this.sequenceBlock1.endDate).format('L')
+      this.intl.formatDate(this.sequenceBlock1.endDate)
     );
     assert.strictEqual(component.list.items[1].course, this.course.title);
     assert.ok(component.list.items[1].isDeletable);
@@ -190,11 +190,11 @@ module('Integration | Component | curriculum-inventory/sequence-block-list', fun
     assert.strictEqual(component.list.items[1].orderInSequence, 'n/a');
     assert.strictEqual(
       component.list.items[1].startDate,
-      moment(this.sequenceBlock1.startDate).format('L')
+      this.intl.formatDate(this.sequenceBlock1.startDate)
     );
     assert.strictEqual(
       component.list.items[1].endDate,
-      moment(this.sequenceBlock1.endDate).format('L')
+      this.intl.formatDate(this.sequenceBlock1.endDate)
     );
     assert.strictEqual(component.list.items[1].course, this.course.title);
     assert.ok(component.list.items[1].isDeletable);

--- a/tests/integration/components/curriculum-inventory/sequence-block-overview-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-overview-test.js
@@ -3,9 +3,18 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-overview';
+
+const jan2nd2015 = DateTime.fromObject({ year: 2015, month: 1, day: 2 });
+const feb2nd2015 = DateTime.fromObject({ year: 2015, month: 2, day: 2 });
+const mar30th2015 = DateTime.fromObject({ year: 2015, month: 3, day: 30 });
+const apr30th2015 = DateTime.fromObject({ year: 2015, month: 4, day: 30 });
+const apr232016 = DateTime.fromObject({ year: 2016, month: 4, day: 23 }).startOf('day');
+const june2nd2016 = DateTime.fromObject({ year: 2016, month: 6, day: 2 }).startOf('day');
+const oct30th2016 = DateTime.fromObject({ year: 2016, month: 10, day: 30 }).startOf('day');
+const nov2nd2016 = DateTime.fromObject({ year: 2016, month: 11, day: 2 }).startOf('day');
 
 module('Integration | Component | curriculum-inventory/sequence-block-overview', function (hooks) {
   setupRenderingTest(hooks);
@@ -41,8 +50,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     const clerkshipType = this.server.create('course-clerkship-type', { title: 'Block' });
     const course = this.server.create('course', {
       title: 'Course A',
-      startDate: new Date('2015-02-02'),
-      endDate: new Date('2015-03-30'),
+      startDate: feb2nd2015.toJSDate(),
+      endDate: mar30th2015.toJSDate(),
       clerkshipType,
       level: 4,
       school: this.school,
@@ -80,8 +89,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       report: this.report,
       parent: parentBlock,
       duration: 12,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       childSequenceOrder: 1,
       orderInSequence: 1,
       course,
@@ -117,7 +126,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     assert.ok(component.description.isEditable);
     assert.strictEqual(
       component.course.text,
-      'Course: Course A Level: 4, Start Date: 2015-02-02, End Date: 2015-03-30 - Clerkship (Block)'
+      'Course: Course A Level: 4, Start Date: 2/2/2015, End Date: 3/30/2015 - Clerkship (Block)'
     );
     assert.ok(component.course.isEditable);
     const startLevel = await sequenceBlockModel.startingAcademicLevel;
@@ -133,12 +142,12 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     assert.ok(component.track.isEditable);
     assert.strictEqual(
       component.startDate.text,
-      'Start: ' + moment(sequenceBlockModel.startDate).format('L')
+      'Start: ' + this.intl.formatDate(sequenceBlockModel.startDate)
     );
     assert.ok(component.startDate.isEditable);
     assert.strictEqual(
       component.endDate.text,
-      'End: ' + moment(sequenceBlockModel.endDate).format('L')
+      'End: ' + this.intl.formatDate(sequenceBlockModel.endDate)
     );
     assert.ok(component.endDate.isEditable);
     assert.strictEqual(
@@ -247,8 +256,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       clerkshipType,
       published: true,
       year: '2016',
-      startDate: new Date('2016-01-01'),
-      endDate: new Date('2016-01-02'),
+      startDate: DateTime.fromObject({ year: 2016, month: 1, day: 1 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: 2016, month: 1, day: 2 }).toJSDate(),
     });
     this.server.create('course', {
       title: 'Beta',
@@ -256,8 +265,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       clerkshipType,
       published: true,
       year: '2016',
-      startDate: new Date('2016-02-01'),
-      endDate: new Date('2016-02-02'),
+      startDate: DateTime.fromObject({ year: 2016, month: 2, day: 1 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: 2016, month: 2, day: 2 }).toJSDate(),
     });
     const newCourse = this.server.create('course', {
       title: 'Gamma',
@@ -265,8 +274,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       clerkshipType,
       published: true,
       year: '2016',
-      startDate: new Date('2016-03-01'),
-      endDate: new Date('2016-03-02'),
+      startDate: DateTime.fromObject({ year: 2016, month: 3, day: 1 }).toJSDate(),
+      endDate: DateTime.fromObject({ year: 2016, month: 3, day: 2 }).toJSDate(),
     });
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
@@ -303,7 +312,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
 
     assert.strictEqual(
       component.course.text,
-      'Course: Alpha Level: 1, Start Date: 2016-01-01, End Date: 2016-01-02 - Clerkship (clerkship type 0)'
+      'Course: Alpha Level: 1, Start Date: 1/1/2016, End Date: 1/2/2016 - Clerkship (clerkship type 0)'
     );
     await component.course.edit();
     assert.strictEqual(component.course.options.length, 4);
@@ -311,7 +320,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     assert.strictEqual(component.course.options[1].text, 'Alpha');
     assert.strictEqual(
       component.course.details,
-      'Level: 1, Start Date: 2016-01-01, End Date: 2016-01-02 - Clerkship (clerkship type 0)'
+      'Level: 1, Start Date: 1/1/2016, End Date: 1/2/2016 - Clerkship (clerkship type 0)'
     );
     assert.strictEqual(component.course.options[1].value, courseModel.id);
     assert.ok(component.course.options[1].isSelected);
@@ -320,12 +329,12 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     await component.course.select(newCourseModel.id);
     assert.strictEqual(
       component.course.details,
-      'Level: 1, Start Date: 2016-03-01, End Date: 2016-03-02 - Clerkship (clerkship type 0)'
+      'Level: 1, Start Date: 3/1/2016, End Date: 3/2/2016 - Clerkship (clerkship type 0)'
     );
     await component.course.save();
     assert.strictEqual(
       component.course.text,
-      'Course: Gamma Level: 1, Start Date: 2016-03-01, End Date: 2016-03-02 - Clerkship (clerkship type 0)'
+      'Course: Gamma Level: 1, Start Date: 3/1/2016, End Date: 3/2/2016 - Clerkship (clerkship type 0)'
     );
     const blockCourse = await sequenceBlockModel.course;
     assert.strictEqual(blockCourse.id, newCourse.id);
@@ -497,8 +506,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       report: this.report,
       parent,
       duration: 12,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       childSequenceOrder: 1,
       orderInSequence: 1,
       required: 2,
@@ -550,8 +559,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       duration: 0,
       childSequenceOrder: 1,
       orderInSequence: 0,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       required: 2,
       track: true,
       minimum: 0,
@@ -593,8 +602,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       duration: 0,
       childSequenceOrder: 1,
       orderInSequence: 0,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       required: 2,
       track: true,
       minimum: 0,
@@ -633,8 +642,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     const clerkshipType = this.server.create('course-clerkship-type', { title: 'Block' });
     const course = this.server.create('course', {
       title: 'Course A',
-      startDate: new Date('2015-02-02'),
-      endDate: new Date('2015-03-30'),
+      startDate: feb2nd2015.toJSDate(),
+      endDate: mar30th2015.toJSDate(),
       clerkshipType,
       level: 4,
       school: this.school,
@@ -661,8 +670,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       report: this.report,
       parent: parentBlock,
       duration: 12,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       childSequenceOrder: 1,
       orderInSequence: 1,
       course,
@@ -704,8 +713,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     const clerkshipType = this.server.create('course-clerkship-type', { title: 'Block' });
     const course = this.server.create('course', {
       title: 'Course A',
-      startDate: new Date('2015-02-02'),
-      endDate: new Date('2015-03-30'),
+      startDate: feb2nd2015.toJSDate(),
+      endDate: mar30th2015.toJSDate(),
       clerkshipType,
       level: 4,
       school: this.school,
@@ -741,8 +750,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       report: this.report,
       parent: parentBlock,
       duration: 12,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       childSequenceOrder: 1,
       orderInSequence: 1,
       course,
@@ -778,7 +787,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     assert.notOk(component.description.isEditable);
     assert.strictEqual(
       component.course.text,
-      'Course: Course A Level: 4, Start Date: 2015-02-02, End Date: 2015-03-30 - Clerkship (Block)'
+      'Course: Course A Level: 4, Start Date: 2/2/2015, End Date: 3/30/2015 - Clerkship (Block)'
     );
     assert.notOk(component.course.isEditable);
     assert.strictEqual(component.startLevel.text, 'Start Level: Year 1');
@@ -791,12 +800,12 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     assert.notOk(component.track.isEditable);
     assert.strictEqual(
       component.startDate.text,
-      'Start: ' + moment(sequenceBlockModel.startDate).format('L')
+      'Start: ' + this.intl.formatDate(sequenceBlockModel.startDate)
     );
     assert.notOk(component.startDate.isEditable);
     assert.strictEqual(
       component.endDate.text,
-      'End: ' + moment(sequenceBlockModel.endDate).format('L')
+      'End: ' + this.intl.formatDate(sequenceBlockModel.endDate)
     );
     assert.notOk(component.endDate.isEditable);
     assert.strictEqual(
@@ -824,8 +833,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('flagging block as elective sets minimum value to 0', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       duration: 0,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -866,8 +875,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
       duration: 10,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       childSequenceOrder: 1,
       orderInSequence: 0,
       required: 1,
@@ -926,8 +935,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('edit minimum and maximum values, then save', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       duration: 10,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -971,8 +980,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('edit minimum and maximum values, then cancel', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       duration: 10,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1016,8 +1025,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('save fails when minimum is larger than maximum', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       duration: 10,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1061,8 +1070,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('save fails when minimum is less than zero', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       duration: 10,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1101,8 +1110,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('save fails when minimum is empty', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       duration: 10,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1141,8 +1150,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('save fails when maximum is empty', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       duration: 10,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1181,8 +1190,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('minimum field is set to 0 and disabled for electives', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       duration: 10,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1218,13 +1227,13 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   });
 
   test('edit duration and start/end date, then save', async function (assert) {
-    const newStartDate = new Date('2016-10-30T00:00:00');
-    const newEndDate = new Date('2016-11-02T00:00:00');
+    const newStartDate = oct30th2016.toJSDate();
+    const newEndDate = nov2nd2016.toJSDate();
     const newDuration = 15;
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: new Date('2016-04-23T00:00:00'),
-      endDate: new Date('2016-06-02T00:00:00'),
+      startDate: apr232016.toJSDate(),
+      endDate: june2nd2016.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1260,12 +1269,12 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     await component.durationEditor.save();
     assert.strictEqual(
       component.startDate.text,
-      'Start: ' + moment(sequenceBlockModel.startDate).format('L')
+      'Start: ' + this.intl.formatDate(sequenceBlockModel.startDate)
     );
     assert.ok(component.startDate.isEditable);
     assert.strictEqual(
       component.endDate.text,
-      'End: ' + moment(sequenceBlockModel.endDate).format('L')
+      'End: ' + this.intl.formatDate(sequenceBlockModel.endDate)
     );
     assert.ok(component.endDate.isEditable);
     assert.strictEqual(
@@ -1278,13 +1287,13 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   });
 
   test('save with date range and a zero duration', async function (assert) {
-    const newStartDate = new Date('2016-10-30T00:00:00');
-    const newEndDate = new Date('2016-11-02T00:00:00');
+    const newStartDate = oct30th2016.toJSDate();
+    const newEndDate = nov2nd2016.toJSDate();
     const newDuration = 0;
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: new Date('2016-04-23T00:00:00'),
-      endDate: new Date('2016-06-02T00:00:00'),
+      startDate: apr232016.toJSDate(),
+      endDate: june2nd2016.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1320,12 +1329,12 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     await component.durationEditor.save();
     assert.strictEqual(
       component.startDate.text,
-      'Start: ' + moment(sequenceBlockModel.startDate).format('L')
+      'Start: ' + this.intl.formatDate(sequenceBlockModel.startDate)
     );
     assert.ok(component.startDate.isEditable);
     assert.strictEqual(
       component.endDate.text,
-      'End: ' + moment(sequenceBlockModel.endDate).format('L')
+      'End: ' + this.intl.formatDate(sequenceBlockModel.endDate)
     );
     assert.strictEqual(component.duration.text, `Duration (in Days): Click to edit`);
     assert.strictEqual(newStartDate.getTime(), sequenceBlockModel.startDate.getTime());
@@ -1382,13 +1391,13 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   });
 
   test('edit duration and start/end date, then cancel', async function (assert) {
-    const newStartDate = new Date('2016-10-30T00:00:00');
-    const newEndDate = new Date('2016-11-02T00:00:00');
+    const newStartDate = oct30th2016.toJSDate();
+    const newEndDate = nov2nd2016.toJSDate();
     const newDuration = 20;
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: new Date('2016-04-23T00:00:00'),
-      endDate: new Date('2016-06-02T00:00:00'),
+      startDate: apr232016.toJSDate(),
+      endDate: june2nd2016.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1419,12 +1428,12 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
 
     assert.strictEqual(
       component.startDate.text,
-      'Start: ' + moment(sequenceBlockModel.startDate).format('L')
+      'Start: ' + this.intl.formatDate(sequenceBlockModel.startDate)
     );
     assert.ok(component.startDate.isEditable);
     assert.strictEqual(
       component.endDate.text,
-      'End: ' + moment(sequenceBlockModel.endDate).format('L')
+      'End: ' + this.intl.formatDate(sequenceBlockModel.endDate)
     );
     assert.strictEqual(
       component.duration.text,
@@ -1437,12 +1446,12 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     await component.durationEditor.cancel();
     assert.strictEqual(
       component.startDate.text,
-      'Start: ' + moment(sequenceBlockModel.startDate).format('L')
+      'Start: ' + this.intl.formatDate(sequenceBlockModel.startDate)
     );
     assert.ok(component.startDate.isEditable);
     assert.strictEqual(
       component.endDate.text,
-      'End: ' + moment(sequenceBlockModel.endDate).format('L')
+      'End: ' + this.intl.formatDate(sequenceBlockModel.endDate)
     );
     assert.strictEqual(
       component.duration.text,
@@ -1451,12 +1460,19 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   });
 
   test('save fails if end-date is older than start-date', async function (assert) {
-    const newStartDate = new Date('2016-10-30T00:00:00');
-    const newEndDate = new Date('2013-11-02T00:00:00');
+    const newStartDate = oct30th2016.toJSDate();
+    const newEndDate = DateTime.fromObject({
+      year: 2013,
+      month: 11,
+      day: 2,
+      hour: 0,
+      minute: 0,
+      second: 0,
+    }).toJSDate();
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: new Date('2016-04-23T00:00:00'),
-      endDate: new Date('2016-06-02T00:00:00'),
+      startDate: apr232016.toJSDate(),
+      endDate: june2nd2016.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1496,8 +1512,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('save fails on missing duration', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: new Date('2016-04-23T00:00:00'),
-      endDate: new Date('2016-06-02T00:00:00'),
+      startDate: apr232016.toJSDate(),
+      endDate: june2nd2016.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1536,8 +1552,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('save fails on invalid duration', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: new Date('2016-04-23T00:00:00'),
-      endDate: new Date('2016-06-02T00:00:00'),
+      startDate: apr232016.toJSDate(),
+      endDate: june2nd2016.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1620,8 +1636,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     const clerkshipType = this.server.create('course-clerkship-type', { title: 'Block' });
     const course = this.server.create('course', {
       title: 'Course A',
-      startDate: new Date('2015-02-02'),
-      endDate: new Date('2015-03-30'),
+      startDate: feb2nd2015.toJSDate(),
+      endDate: mar30th2015.toJSDate(),
       clerkshipType,
       level: 4,
       school: this.school,
@@ -1629,8 +1645,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
       course,
-      startDate: new Date('2015-02-02'),
-      endDate: new Date('2015-03-30'),
+      startDate: feb2nd2015.toJSDate(),
+      endDate: mar30th2015.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1675,8 +1691,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     const clerkshipType = this.server.create('course-clerkship-type', { title: 'Block' });
     const course = this.server.create('course', {
       title: 'Course A',
-      startDate: new Date('2015-02-02'),
-      endDate: new Date('2015-03-30'),
+      startDate: feb2nd2015.toJSDate(),
+      endDate: mar30th2015.toJSDate(),
       clerkshipType,
       level: 4,
       school: this.school,
@@ -1684,8 +1700,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
       course,
-      startDate: new Date('2015-02-02'),
-      endDate: new Date('2015-03-30'),
+      startDate: feb2nd2015.toJSDate(),
+      endDate: mar30th2015.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1772,8 +1788,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('cancel editing on escape in minimum input', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: new Date('2016-04-23T00:00:00'),
-      endDate: new Date('2016-06-02T00:00:00'),
+      startDate: apr232016.toJSDate(),
+      endDate: june2nd2016.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1813,8 +1829,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('save on enter in minimum input', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: new Date('2016-04-23T00:00:00'),
-      endDate: new Date('2016-06-02T00:00:00'),
+      startDate: apr232016.toJSDate(),
+      endDate: june2nd2016.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1854,8 +1870,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('cancel editing on escape in maximum input', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: new Date('2016-04-23T00:00:00'),
-      endDate: new Date('2016-06-02T00:00:00'),
+      startDate: apr232016.toJSDate(),
+      endDate: june2nd2016.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1895,8 +1911,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('save on enter in maximum input', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: new Date('2016-04-23T00:00:00'),
-      endDate: new Date('2016-06-02T00:00:00'),
+      startDate: apr232016.toJSDate(),
+      endDate: june2nd2016.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -1975,8 +1991,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('save on enter in duration input', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: new Date('2016-04-23T00:00:00'),
-      endDate: new Date('2016-06-02T00:00:00'),
+      startDate: apr232016.toJSDate(),
+      endDate: june2nd2016.toJSDate(),
       duration: 5,
       childSequenceOrder: 1,
       orderInSequence: 0,
@@ -2088,8 +2104,8 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
   test('zero duration renders as n/a in read-only mode', async function (assert) {
     const block = this.server.create('curriculum-inventory-sequence-block', {
       report: this.report,
-      startDate: moment('2015-01-02'),
-      endDate: moment('2015-04-30'),
+      startDate: jan2nd2015.toJSDate(),
+      endDate: apr30th2015.toJSDate(),
       duration: 0,
       childSequenceOrder: 1,
       orderInSequence: 0,

--- a/tests/integration/components/curriculum-inventory/sequence-block-session-list-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-session-list-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-session-list';
 
 module(
@@ -15,9 +15,9 @@ module(
     setupMirage(hooks);
 
     test('it renders', async function (assert) {
-      const now = moment().toDate();
-      const in15Hours = moment().add(15, 'hours').toDate();
-      const in30Hours = moment().add(30, 'hours').toDate();
+      const now = DateTime.now();
+      const in15Hours = now.plus({ hours: 15 }).toJSDate();
+      const in30Hours = now.plus({ hours: 30 }).toJSDate();
 
       const offering1 = this.server.create('offering', {
         startDate: now,

--- a/tests/integration/components/curriculum-inventory/sequence-block-session-manager-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-session-manager-test.js
@@ -3,7 +3,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-session-manager';
 
@@ -15,19 +15,19 @@ module(
     setupMirage(hooks);
 
     test('it renders', async function (assert) {
-      const now = moment().toDate();
-      const in15Hours = moment().add(15, 'hours').toDate();
-      const in30Hours = moment().add(30, 'hours').toDate();
+      const now = DateTime.now();
+      const in15Hours = now.plus({ hours: 15 }).toJSDate();
+      const in30Hours = now.plus({ hours: 30 }).toJSDate();
       const offering1 = this.server.create('offering', {
-        startDate: now,
+        startDate: now.toJSDate(),
         endDate: in30Hours,
       });
       const offering2 = this.server.create('offering', {
-        startDate: now,
+        startDate: now.toJSDate(),
         endDate: in15Hours,
       });
       const offering3 = this.server.create('offering', {
-        startDate: now,
+        startDate: now.toJSDate(),
         endDate: in15Hours,
       });
       const sessionType1 = this.server.create('session-type', { title: 'Lecture' });
@@ -315,15 +315,15 @@ module(
     });
 
     test('change count as one offering', async function (assert) {
-      const now = moment().toDate();
-      const in15Hours = moment().add(15, 'hours').toDate();
-      const in30Hours = moment().add(30, 'hours').toDate();
+      const now = DateTime.now();
+      const in15Hours = now.plus({ hours: 15 }).toJSDate();
+      const in30Hours = now.plus({ hours: 30 }).toJSDate();
       const offering1 = this.server.create('offering', {
-        startDate: now,
+        startDate: now.toJSDate(),
         endDate: in30Hours,
       });
       const offering2 = this.server.create('offering', {
-        startDate: now,
+        startDate: now.toJSDate(),
         endDate: in15Hours,
       });
       const sessionType = this.server.create('session-type');
@@ -362,23 +362,23 @@ module(
     });
 
     test('check all/uncheck count offerings as one', async function (assert) {
-      const now = moment().toDate();
-      const in15Hours = moment().add(15, 'hours').toDate();
-      const in30Hours = moment().add(30, 'hours').toDate();
+      const now = DateTime.now();
+      const in15Hours = now.plus({ hours: 15 }).toJSDate();
+      const in30Hours = now.plus({ hours: 30 }).toJSDate();
       const offering1 = this.server.create('offering', {
-        startDate: now,
+        startDate: now.toJSDate(),
         endDate: in30Hours,
       });
       const offering2 = this.server.create('offering', {
-        startDate: now,
+        startDate: now.toJSDate(),
         endDate: in15Hours,
       });
       const offering3 = this.server.create('offering', {
-        startDate: now,
+        startDate: now.toJSDate(),
         endDate: in30Hours,
       });
       const offering4 = this.server.create('offering', {
-        startDate: now,
+        startDate: now.toJSDate(),
         endDate: in30Hours,
       });
       const sessionType = this.server.create('session-type');

--- a/tests/integration/components/learnergroup-calendar-test.js
+++ b/tests/integration/components/learnergroup-calendar-test.js
@@ -5,7 +5,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios/tests/pages/components/learnergroup-calendar';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 
 module('Integration | Component | learnergroup calendar', function (hooks) {
   setupRenderingTest(hooks);
@@ -13,7 +13,7 @@ module('Integration | Component | learnergroup calendar', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const today = moment().hour(8);
+    const today = DateTime.fromObject({ hour: 8 });
     const course = this.server.create('course', {
       title: 'course title',
     });
@@ -22,14 +22,14 @@ module('Integration | Component | learnergroup calendar', function (hooks) {
       course,
     });
     const offering1 = this.server.create('offering', {
-      startDate: today.format(),
-      endDate: today.clone().add('1', 'hour').format(),
+      startDate: today.toJSON(),
+      endDate: today.plus({ hour: 1 }).toJSDate(),
       location: '123',
       session,
     });
     const offering2 = this.server.create('offering', {
-      startDate: today.format(),
-      endDate: today.clone().add('1', 'hour').format(),
+      startDate: today.toJSON(),
+      endDate: today.plus({ hour: 1 }).toJSDate(),
       location: '123',
       session,
     });

--- a/tests/integration/components/my-profile-test.js
+++ b/tests/integration/components/my-profile-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import moment from 'moment';
+import { DateTime, Duration } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/my-profile';
 
@@ -87,11 +87,11 @@ module('Integration | Component | my profile', function (hooks) {
 
     this.server.get(`/auth/token`, (scheme, { queryParams }) => {
       assert.ok('ttl' in queryParams);
-      const duration = moment.duration(queryParams.ttl);
-      assert.strictEqual(duration.weeks(), 2);
-      assert.ok(duration.hours() < 24);
-      assert.ok(duration.minutes() < 60);
-      assert.ok(duration.seconds() < 60);
+      const duration = Duration.fromISO(queryParams.ttl);
+      assert.strictEqual(duration.days, 14);
+      assert.ok(duration.hours < 24);
+      assert.ok(duration.minutes < 60);
+      assert.ok(duration.seconds < 60);
 
       return {
         jwt: 'new token',
@@ -168,11 +168,11 @@ module('Integration | Component | my profile', function (hooks) {
 
     this.server.get(`/auth/token`, (scheme, { queryParams }) => {
       assert.ok('ttl' in queryParams);
-      const duration = moment.duration(queryParams.ttl);
-      assert.ok(duration.days() < 41);
-      assert.ok(duration.hours() < 24);
-      assert.ok(duration.minutes() < 60);
-      assert.ok(duration.seconds() < 60);
+      const duration = Duration.fromISO(queryParams.ttl);
+      assert.strictEqual(duration.days, 41);
+      assert.ok(duration.hours < 24);
+      assert.ok(duration.minutes < 60);
+      assert.ok(duration.seconds < 60);
 
       return {
         jwt: 'new token',
@@ -191,8 +191,8 @@ module('Integration | Component | my profile', function (hooks) {
       @toggleShowInvalidateTokens={{(noop)}}
     />`);
 
-    const m = moment().add(41, 'days');
-    await component.newTokenForm.setDate(m.toDate());
+    const dt = DateTime.fromObject({ hours: 8 }).plus({ days: 41 }).toJSDate();
+    await component.newTokenForm.setDate(dt);
     await component.newTokenForm.submit();
   });
 

--- a/tests/integration/components/user-profile-permissions-test.js
+++ b/tests/integration/components/user-profile-permissions-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { component } from 'ilios/tests/pages/components/user-profile-permissions';
 import { freezeDateAt, unfreezeDate } from 'ilios-common';
 
@@ -15,7 +15,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.schools = this.server.createList('school', 2);
-    this.thisYear = parseInt(moment().format('YYYY'), 10);
+    this.thisYear = DateTime.now().year;
     this.currentAcademicYear = this.thisYear;
     this.server.create('academic-year', { id: this.thisYear - 1 });
     this.server.create('academic-year', { id: this.thisYear });


### PR DESCRIPTION
Luxon is the modern moment replacement and we need to move to it everywhere, this mainly focuses on tests except for some CI templates where the data formatting was being done by moment instead of our internationalization library. There is one small UI change in a sequence block course summary from `yyyy-mm-dd` format to localized format.