### PR TITLE
Hide the navigation block when it's not in use

### DIFF
--- a/app/styles/layout/_layout.scss
+++ b/app/styles/layout/_layout.scss
@@ -17,6 +17,10 @@
     grid-area: header;
   }
 
+  & > nav {
+    display: none;
+  }
+
   & > main {
     background-color: $white;
     grid-area: main;
@@ -59,8 +63,10 @@
     }
 
     & > nav {
+      display: grid;
       grid-area: nav;
       @include for-laptop-and-up {
+        display: block;
         z-index: 5;
       }
     }


### PR DESCRIPTION
Otherwise it will break the flow under the dashboard or any main page where the content doesn't fill the entire vertical space.