### PR TITLE
Pin ubuntu in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
   test:
     name: "Test"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 #https://github.com/actions/runner-images/issues/6399
     timeout-minutes: 15
 
     strategy:


### PR DESCRIPTION
Ubuntu 22.04 doesn't have FF built in, hopefully github will resolve this in the runner, if not we'll have to sort out how to do this install ourselves.