### PR TITLE
Remove unique-id polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
         "ember-service-worker-cache-first": "^0.6.2",
         "ember-source": "4.8.0",
         "ember-template-lint": "^4.16.1",
-        "ember-unique-id-helper-polyfill": "^1.2.2",
         "ember-web-app": "^5.0.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.5.0",
@@ -23338,20 +23337,6 @@
       },
       "engines": {
         "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-unique-id-helper-polyfill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ember-unique-id-helper-polyfill/-/ember-unique-id-helper-polyfill-1.2.2.tgz",
-      "integrity": "sha512-gjcwTBkCDUA0iYFS7aArfJub+eos/itxEsC399JUbdKNIBJLesB/1OHnmxLLwExZHp7gyHuiDFOPcknafhFm3g==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-funnel": "^3.0.8",
-        "ember-cli-babel": "^7.26.10",
-        "ember-cli-version-checker": "^5.1.2"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-web-app": {
@@ -56568,17 +56553,6 @@
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.22.1"
-      }
-    },
-    "ember-unique-id-helper-polyfill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ember-unique-id-helper-polyfill/-/ember-unique-id-helper-polyfill-1.2.2.tgz",
-      "integrity": "sha512-gjcwTBkCDUA0iYFS7aArfJub+eos/itxEsC399JUbdKNIBJLesB/1OHnmxLLwExZHp7gyHuiDFOPcknafhFm3g==",
-      "dev": true,
-      "requires": {
-        "broccoli-funnel": "^3.0.8",
-        "ember-cli-babel": "^7.26.10",
-        "ember-cli-version-checker": "^5.1.2"
       }
     },
     "ember-web-app": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "ember-service-worker-cache-first": "^0.6.2",
     "ember-source": "4.8.0",
     "ember-template-lint": "^4.16.1",
-    "ember-unique-id-helper-polyfill": "^1.2.2",
     "ember-web-app": "^5.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
This is provided in Ember 4.4+ so we don't need it here anymore.