### PR TITLE
Skip tests when deploying staging builds

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -9,23 +9,8 @@ env:
   COVERAGE: false
 
 jobs:
-  test:
-    name: Run Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run test:ember
-        env:
-          SW_DISABLED: true
-
   deploy:
     name: Deploy
-    needs: test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
I'm confident that this is well tested at this point, let's just deploy and save some carbon plus remove an annoying point of failure.