### PR TITLE
Unpin Ember Version (and update to 4.8.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "ember-responsive": "^5.0.0",
         "ember-service-worker": "^9.0.1",
         "ember-service-worker-cache-first": "^0.6.2",
-        "ember-source": "4.8.0",
+        "ember-source": "~4.8.2",
         "ember-template-lint": "^4.16.1",
         "ember-unique-id-helper-polyfill": "^1.2.2",
         "ember-web-app": "^5.0.0",
@@ -22719,9 +22719,9 @@
       }
     },
     "node_modules/ember-source": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-4.8.0.tgz",
-      "integrity": "sha512-YvVJNia7gDgzKntRWoMz7hdme32GozXnZDYW5kyZLoGq0O5M2hL8D9KHAcEeqCC1UfFjMjtMw4RgA65yPCDx5Q==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-4.8.2.tgz",
+      "integrity": "sha512-YU/ytPaua+QOw+2qRrZM7qahAmxv+N8Utv/Xz2e01NQci6KTaY3AXx6SS3ge0G/KlGyL9ouaHLyHqv7xkcV2ww==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
@@ -56114,9 +56114,9 @@
       }
     },
     "ember-source": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-4.8.0.tgz",
-      "integrity": "sha512-YvVJNia7gDgzKntRWoMz7hdme32GozXnZDYW5kyZLoGq0O5M2hL8D9KHAcEeqCC1UfFjMjtMw4RgA65yPCDx5Q==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-4.8.2.tgz",
+      "integrity": "sha512-YU/ytPaua+QOw+2qRrZM7qahAmxv+N8Utv/Xz2e01NQci6KTaY3AXx6SS3ge0G/KlGyL9ouaHLyHqv7xkcV2ww==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ember-responsive": "^5.0.0",
     "ember-service-worker": "^9.0.1",
     "ember-service-worker-cache-first": "^0.6.2",
-    "ember-source": "4.8.0",
+    "ember-source": "~4.8.2",
     "ember-template-lint": "^4.16.1",
     "ember-unique-id-helper-polyfill": "^1.2.2",
     "ember-web-app": "^5.0.0",


### PR DESCRIPTION
4.8.2 [contains a security fix](https://blog.emberjs.com/ember-4-8-1-released/) which we wouldn't have picked up in
  our normal transitive dependency update process because we were
pinned, I've followed the ember-cli recommendations and used a tilde here to get the best range and forced a minimum version with the security fix.