### PR TITLE
fixes save-and-close objective sort manager bug.

### DIFF
--- a/app/components/program-year/objective-list.hbs
+++ b/app/components/program-year/objective-list.hbs
@@ -2,7 +2,7 @@
   class="program-year-objective-list"
   data-test-program-year-objective-list
 >
-  {{#if (and (is-array @programYear.sortedProgramYearObjectives) this.isSorting)}}
+  {{#if this.isSorting}}
     <ObjectiveSortManager
       @subject={{@programYear}}
       @close={{set this.isSorting false}}


### PR DESCRIPTION
removing the array check from the conditional and just checking is-sorting state fixes the issue of the order manager component not closing after saving.

refs https://github.com/ilios/ilios/issues/4502