### PR TITLE
Skip Linting for Integration Tests

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -9,4 +9,5 @@ module.exports = {
       allow: ['noop'],
     },
   },
+  ignore: ['tests/integration/**'],
 };

--- a/tests/integration/components/assign-students-test.js
+++ b/tests/integration/components/assign-students-test.js
@@ -49,8 +49,7 @@ module('Integration | Component | assign students', function (hooks) {
       @limit={{10}}
       @setOffset={{(noop)}}
       @setLimit={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.cohorts.options.length, 1);
     assert.strictEqual(component.cohorts.options[0].text, 'program title test cohort');
@@ -81,8 +80,7 @@ module('Integration | Component | assign students', function (hooks) {
       @limit={{10}}
       @setOffset={{(noop)}}
       @setLimit={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.isToggleAllChecked);
     assert.notOk(component.students[0].isToggleChecked);
     await component.toggleAll();
@@ -114,8 +112,7 @@ module('Integration | Component | assign students', function (hooks) {
       @limit={{10}}
       @setOffset={{(noop)}}
       @setLimit={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.isToggleAllChecked, 'check all is not initially checked');
     assert.notOk(component.isToggleAllIndeterminate, 'check all is not initially indeterminate');
@@ -161,8 +158,7 @@ module('Integration | Component | assign students', function (hooks) {
       @limit={{10}}
       @setOffset={{(noop)}}
       @setLimit={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.isToggleAllChecked, 'check all is not initially checked');
     assert.notOk(component.students[0].isToggleChecked, 'first student is not initially checked');
     assert.notOk(component.students[1].isToggleChecked, 'second student is not initially checked');
@@ -214,8 +210,7 @@ module('Integration | Component | assign students', function (hooks) {
       @limit={{10}}
       @setOffset={{(noop)}}
       @setLimit={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(this.server.db.users[0].primaryCohortId, null);
     await component.toggleAll();

--- a/tests/integration/components/back-to-admin-dashboard-test.js
+++ b/tests/integration/components/back-to-admin-dashboard-test.js
@@ -10,8 +10,7 @@ module('Integration | Component | back-to-admin-dashboard', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
-    await render(hbs`<BackToAdminDashboard />
-`);
+    await render(hbs`<BackToAdminDashboard />`);
     assert.strictEqual(component.text, 'Back to Admin Dashboard');
     assert.ok(component.url.endsWith('/admin'));
   });

--- a/tests/integration/components/bulk-new-users-test.js
+++ b/tests/integration/components/bulk-new-users-test.js
@@ -83,8 +83,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   test('it renders', async function (assert) {
     assert.expect(6);
 
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const content = this.element.textContent.trim();
     assert.notEqual(content.search(/File with user data/), -1);
@@ -101,8 +100,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   test('select student mode display cohort', async function (assert) {
     assert.expect(10);
 
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
     await click('.click-choice-buttons .second-button');
     const content = this.element.textContent.trim();
     assert.notEqual(content.search(/File with user data/), -1);
@@ -124,8 +122,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   });
 
   test('parses file into table', async function (assert) {
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -181,8 +178,7 @@ module('Integration | Component | bulk new users', function (hooks) {
     assert.expect(30);
     this.server.create('user-role', { id: 4 });
 
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -250,8 +246,7 @@ module('Integration | Component | bulk new users', function (hooks) {
     assert.expect(28);
     this.server.create('user-role', { id: 4 });
 
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
     await click('.click-choice-buttons .second-button');
 
     const users = [
@@ -320,14 +315,12 @@ module('Integration | Component | bulk new users', function (hooks) {
     this.set('close', () => {
       assert.ok(true);
     });
-    await render(hbs`<BulkNewUsers @close={{this.close}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{this.close}} />`);
     await click('.cancel');
   });
 
   test('validate firstName', async function (assert) {
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -366,8 +359,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   });
 
   test('validate lastName', async function (assert) {
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -406,8 +398,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   });
 
   test('validate middleName', async function (assert) {
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -447,8 +438,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   });
 
   test('validate email address', async function (assert) {
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -487,8 +477,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   });
 
   test('validate campusId', async function (assert) {
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -527,8 +516,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   });
 
   test('validate otherId', async function (assert) {
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -567,8 +555,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   });
 
   test('validate username length', async function (assert) {
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -609,8 +596,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   test('validate username uniqueness', async function (assert) {
     const user = this.server.create('user');
     this.server.create('authentication', { user, username: 'existingName' });
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -653,8 +639,7 @@ module('Integration | Component | bulk new users', function (hooks) {
       return new Response(500);
     });
     const user = this.server.create('user');
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -682,8 +667,7 @@ module('Integration | Component | bulk new users', function (hooks) {
     this.server.post('api/users', function () {
       return new Response(500);
     });
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -706,8 +690,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   });
 
   test('username not required', async function (assert) {
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -731,8 +714,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   });
 
   test('password not required if username is blank', async function (assert) {
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -759,8 +741,7 @@ module('Integration | Component | bulk new users', function (hooks) {
     assert.expect(2);
     const proposedNewUsers = '[data-test-proposed-new-users]';
     const waitSaving = '[data-test-wait-saving]';
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       [
@@ -786,8 +767,7 @@ module('Integration | Component | bulk new users', function (hooks) {
   });
 
   test('ignore header row', async function (assert) {
-    await render(hbs`<BulkNewUsers @close={{(noop)}} />
-`);
+    await render(hbs`<BulkNewUsers @close={{(noop)}} />`);
 
     const users = [
       ['First', 'Last', 'middle', '12345', 'jj@example.com', '1234Campus', '1234Other', '', ''],

--- a/tests/integration/components/competency-title-editor-test.js
+++ b/tests/integration/components/competency-title-editor-test.js
@@ -18,8 +18,7 @@ module('Integration | Component | competency title editor', function (hooks) {
       .findRecord('competency', competency.id);
     this.set('competency', competencyModel);
     await render(
-      hbs`<CompetencyTitleEditor @competency={{this.competency}} @canUpdate={{true}} />
-`
+      hbs`<CompetencyTitleEditor @competency={{this.competency}} @canUpdate={{true}} />`
     );
     assert.notOk(component.hasError);
   });
@@ -31,8 +30,7 @@ module('Integration | Component | competency title editor', function (hooks) {
       .findRecord('competency', competency.id);
     this.set('competency', competencyModel);
     await render(
-      hbs`<CompetencyTitleEditor @competency={{this.competency}} @canUpdate={{true}} />
-`
+      hbs`<CompetencyTitleEditor @competency={{this.competency}} @canUpdate={{true}} />`
     );
     await component.title.edit();
     await component.title.set('');
@@ -47,8 +45,7 @@ module('Integration | Component | competency title editor', function (hooks) {
       .findRecord('competency', competency.id);
     this.set('competency', competencyModel);
     await render(
-      hbs`<CompetencyTitleEditor @competency={{this.competency}} @canUpdate={{true}} />
-`
+      hbs`<CompetencyTitleEditor @competency={{this.competency}} @canUpdate={{true}} />`
     );
     await component.title.edit();
     await component.title.set('tooLong'.repeat(50));

--- a/tests/integration/components/connection-status-test.js
+++ b/tests/integration/components/connection-status-test.js
@@ -10,8 +10,7 @@ module('Integration | Component | connection status', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   test('it renders offline and therefor hidden', async function (assert) {
-    await render(hbs`<ConnectionStatus />
-`);
+    await render(hbs`<ConnectionStatus />`);
     assert.dom(this.element).hasNoClass('offline');
 
     a11yAudit(this.element);

--- a/tests/integration/components/course-search-result-test.js
+++ b/tests/integration/components/course-search-result-test.js
@@ -37,8 +37,7 @@ module('Integration | Component | course-search-result', function (hooks) {
       ],
     };
     this.set('course', course);
-    await render(hbs`<CourseSearchResult @course={{this.course}} />
-`);
+    await render(hbs`<CourseSearchResult @course={{this.course}} />`);
     assert.strictEqual(component.courseTitle, '1980 Course 1');
     assert.strictEqual(component.schoolTitle, 'Medicine');
     assert.strictEqual(component.sessions[0].text, 'Session 1');

--- a/tests/integration/components/curriculum-inventory/leadership-expanded-test.js
+++ b/tests/integration/components/curriculum-inventory/leadership-expanded-test.js
@@ -27,8 +27,7 @@ module('Integration | Component | curriculum-inventory/leadership-expanded', fun
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.collapse.text, 'Curriculum Inventory Report Leadership');
     assert.strictEqual(component.leadershipList.administrators.length, 2);
     assert.strictEqual(component.leadershipList.administrators[0].text, '0 guy M. Mc0son');
@@ -53,8 +52,7 @@ module('Integration | Component | curriculum-inventory/leadership-expanded', fun
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{(noop)}}
-    />
-`);
+    />`);
     await component.collapse.click();
   });
 
@@ -76,8 +74,7 @@ module('Integration | Component | curriculum-inventory/leadership-expanded', fun
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{this.manage}}
-    />
-`);
+    />`);
     await component.manage.click();
   });
 });

--- a/tests/integration/components/curriculum-inventory/new-report-test.js
+++ b/tests/integration/components/curriculum-inventory/new-report-test.js
@@ -19,8 +19,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
 
     this.set('program', programModel);
     await render(
-      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     assert.strictEqual(
@@ -89,8 +88,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
     this.set('program', programModel);
 
     await render(
-      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     assert.strictEqual(
@@ -136,8 +134,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
     });
 
     await render(
-      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{this.save}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{this.save}} @cancel={{(noop)}} />`
     );
     await component.name.set('new report');
     await component.description.set('lorem ipsum');
@@ -175,8 +172,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
     });
 
     await render(
-      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{this.save}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{this.save}} @cancel={{(noop)}} />`
     );
     await component.name.set('new report');
     await component.description.set('lorem ipsum');
@@ -194,8 +190,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
       assert.ok(true, 'Cancel action got invoked.');
     });
     await render(
-      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @cancel={{this.cancel}} @save={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @cancel={{this.cancel}} @save={{(noop)}} />`
     );
     await component.cancel();
   });
@@ -212,8 +207,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
     });
 
     await render(
-      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{this.save}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{this.save}} @cancel={{(noop)}} />`
     );
     await component.name.set('new report');
     await component.name.submit();
@@ -224,8 +218,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
     const programModel = await this.owner.lookup('service:store').findRecord('program', program.id);
     this.set('program', programModel);
     await render(
-      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}}/>
-`
+      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}}/>`
     );
     assert.notOk(component.name.hasError);
   });
@@ -235,8 +228,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
     const programModel = await this.owner.lookup('service:store').findRecord('program', program.id);
     this.set('program', programModel);
     await render(
-      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}}/>
-`
+      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}}/>`
     );
     await component.save();
     assert.ok(component.name.hasError);
@@ -248,8 +240,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
 
     this.set('program', programModel);
     await render(
-      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}}/>
-`
+      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}}/>`
     );
     await component.name.set('0123456789'.repeat(7));
     await component.save();
@@ -262,8 +253,7 @@ module('Integration | Component | curriculum-inventory/new-report', function (ho
     this.set('program', programModel);
 
     await render(
-      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}}/>
-`
+      hbs`<CurriculumInventory::NewReport @currentProgram={{this.program}} @save={{(noop)}} @cancel={{(noop)}}/>`
     );
 
     assert.notOk(component.description.hasError);

--- a/tests/integration/components/curriculum-inventory/new-sequence-block-test.js
+++ b/tests/integration/components/curriculum-inventory/new-sequence-block-test.js
@@ -65,8 +65,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @cancel={{(noop)}} @save={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @cancel={{(noop)}} @save={{(noop)}} />`
     );
 
     assert.strictEqual(component.title.label, 'Title:');
@@ -153,8 +152,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('parentBlock', parentModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @parent={{this.parentBlock}} @cancel={{(noop)}} @save={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @parent={{this.parentBlock}} @cancel={{(noop)}} @save={{(noop)}} />`
     );
 
     assert.ok(component.orderInSequence.isVisible);
@@ -184,8 +182,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @cancel={{(noop)}} @save={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @cancel={{(noop)}} @save={{(noop)}} />`
     );
 
     assert.notOk(component.course.details.isVisible);
@@ -227,8 +224,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     });
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{this.save}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{this.save}} @cancel={{(noop)}} />`
     );
 
     await component.title.set(newTitle);
@@ -270,8 +266,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     });
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{this.save}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{this.save}} @cancel={{(noop)}} />`
     );
 
     await component.title.set('foo bar');
@@ -322,8 +317,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
       @parent={{this.parentBlock}}
       @save={{this.save}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
 
     await component.title.set('Foo Bar');
     await component.description.set('Lorem Ipsum');
@@ -345,8 +339,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     });
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{this.cancel}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{this.cancel}} />`
     );
 
     await component.cancel();
@@ -361,8 +354,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     assert.strictEqual(component.startDate.value, '');
@@ -389,8 +381,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     assert.strictEqual(component.maximum.errors.length, 0);
@@ -411,8 +402,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     assert.strictEqual(component.minimum.errors.length, 0);
@@ -428,8 +418,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     assert.strictEqual(component.minimum.errors.length, 0);
@@ -445,8 +434,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     assert.strictEqual(component.maximum.errors.length, 0);
@@ -471,8 +459,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     });
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{this.save}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{this.save}} @cancel={{(noop)}} />`
     );
     await component.title.set('Foo Bar');
     await component.description.set('Lorem Ipsum');
@@ -495,8 +482,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
       assert.strictEqual(parseInt(block.duration, 10), newDuration);
     });
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{this.save}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{this.save}} @cancel={{(noop)}} />`
     );
     await component.title.set('Foo Bar');
     await component.description.set('Lorem Ipsum');
@@ -511,8 +497,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     await component.title.set('Foo Bar');
@@ -531,8 +516,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     await component.title.set('Foo Bar');
@@ -551,8 +535,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     await component.title.set('Foo Bar');
@@ -571,8 +554,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     await component.title.set('Foo Bar');
@@ -600,8 +582,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
     await component.title.set('Foo Bar');
     await component.description.set('Lorem Ipsum');
@@ -631,8 +612,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
     await component.title.set('Foo Bar');
     await component.description.set('Lorem Ipsum');
@@ -657,8 +637,7 @@ module('Integration | Component | curriculum-inventory/new-sequence-block', func
     this.set('report', reportModel);
 
     await render(
-      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<CurriculumInventory::NewSequenceBlock @report={{this.report}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
 
     await component.title.set('Foo Bar');

--- a/tests/integration/components/curriculum-inventory/report-details-test.js
+++ b/tests/integration/components/curriculum-inventory/report-details-test.js
@@ -48,8 +48,7 @@ module('Integration | Component | curriculum-inventory/report-details', function
       @setLeadershipDetails={{(noop)}}
       @setManageLeadership={{(noop)}}
       @setIsFinalized={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.header.name.text, reportModel.name);
     assert.strictEqual(component.overview.description.text, reportModel.description);
   });
@@ -85,8 +84,7 @@ module('Integration | Component | curriculum-inventory/report-details', function
       @setLeadershipDetails={{(noop)}}
       @setManageLeadership={{(noop)}}
       @setIsFinalized={{this.setIsFinalized}}
-    />
-`);
+    />`);
 
     assert.notOk(
       component.finalizeConfirmation.isVisible,
@@ -143,8 +141,7 @@ module('Integration | Component | curriculum-inventory/report-details', function
       @setLeadershipDetails={{(noop)}}
       @setManageLeadership={{(noop)}}
       @setIsFinalized={{(noop)}}
-    />
-`);
+    />`);
 
     await click('.curriculum-inventory-report-header .finalize');
     await click('.confirm-finalize .confirm-buttons .done');

--- a/tests/integration/components/curriculum-inventory/report-header-test.js
+++ b/tests/integration/components/curriculum-inventory/report-header-test.js
@@ -26,8 +26,7 @@ module('Integration | Component | curriculum-inventory/report-header', function 
       @report={{this.report}}
       @canUpdate={{true}}
       @finalize={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(this.report.name, component.name.value, 'Report name shows.');
     assert.ok(component.name.isEditable, 'Report name is editable.');
     assert.notOk(component.finalizeButtonIsDisabled, 'Finalize button is not disabled.');
@@ -44,8 +43,7 @@ module('Integration | Component | curriculum-inventory/report-header', function 
       @report={{this.report}}
       @canUpdate={{false}}
       @finalize={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(this.report.name, component.lockedName);
     assert.ok(component.hasLockOnName, 'Lock icon is showing with name.');
     assert.notOk(component.name.isEditable, 'Report name is not editable.');
@@ -59,8 +57,7 @@ module('Integration | Component | curriculum-inventory/report-header', function 
       @report={{this.report}}
       @canUpdate={{true}}
       @finalize={{(noop)}}
-    />
-`);
+    />`);
     await component.name.edit();
     assert.notOk(component.name.hasError);
     await component.name.set(newName);
@@ -75,8 +72,7 @@ module('Integration | Component | curriculum-inventory/report-header', function 
       @report={{this.report}}
       @canUpdate={{true}}
       @finalize={{(noop)}}
-    />
-`);
+    />`);
     await component.name.edit();
     assert.notOk(component.name.hasError);
     await component.name.set('');
@@ -90,8 +86,7 @@ module('Integration | Component | curriculum-inventory/report-header', function 
       @report={{this.report}}
       @canUpdate={{true}}
       @finalize={{(noop)}}
-    />
-`);
+    />`);
     await component.name.edit();
     assert.notOk(component.name.hasError);
     await component.name.set('ab');
@@ -105,8 +100,7 @@ module('Integration | Component | curriculum-inventory/report-header', function 
       @report={{this.report}}
       @canUpdate={{true}}
       @finalize={{(noop)}}
-    />
-`);
+    />`);
     await component.name.edit();
     assert.notOk(component.name.hasError);
     await component.name.set('01234567890'.repeat(21));
@@ -123,8 +117,7 @@ module('Integration | Component | curriculum-inventory/report-header', function 
       @report={{this.report}}
       @canUpdate={{true}}
       @finalize={{this.finalize}}
-    />
-`);
+    />`);
     await component.finalize();
   });
 });

--- a/tests/integration/components/curriculum-inventory/report-list-item-test.js
+++ b/tests/integration/components/curriculum-inventory/report-list-item-test.js
@@ -37,8 +37,7 @@ module('Integration | Component | curriculum-inventory/report-list-item', functi
     this.set('report', this.report);
 
     await render(
-      hbs`<CurriculumInventory::ReportListItem @report={{this.report}} @remove={{(noop)}}/>
-`
+      hbs`<CurriculumInventory::ReportListItem @report={{this.report}} @remove={{(noop)}}/>`
     );
 
     assert.strictEqual(component.name, 'CI Report');
@@ -58,8 +57,7 @@ module('Integration | Component | curriculum-inventory/report-list-item', functi
       assert.strictEqual(r, this.report);
     });
     await render(
-      hbs`<CurriculumInventory::ReportListItem @report={{this.report}} @remove={{this.remove}}/>
-`
+      hbs`<CurriculumInventory::ReportListItem @report={{this.report}} @remove={{this.remove}}/>`
     );
     assert.notOk(component.confirmRemoval.isVisible);
     await component.remove();
@@ -76,8 +74,7 @@ module('Integration | Component | curriculum-inventory/report-list-item', functi
     this.set('report', this.report);
 
     await render(
-      hbs`<CurriculumInventory::ReportListItem @report={{this.report}} @remove={{this.remove}}/>
-`
+      hbs`<CurriculumInventory::ReportListItem @report={{this.report}} @remove={{this.remove}}/>`
     );
 
     assert.notOk(component.isDeletable);
@@ -91,8 +88,7 @@ module('Integration | Component | curriculum-inventory/report-list-item', functi
     this.set('report', this.report);
 
     await render(
-      hbs`<CurriculumInventory::ReportListItem @report={{this.report}} @remove={{(noop)}}/>
-`
+      hbs`<CurriculumInventory::ReportListItem @report={{this.report}} @remove={{(noop)}}/>`
     );
 
     assert.strictEqual(component.status, 'Finalized');
@@ -109,8 +105,7 @@ module('Integration | Component | curriculum-inventory/report-list-item', functi
     this.set('report', this.report);
 
     await render(
-      hbs`<CurriculumInventory::ReportListItem @report={{this.report}} @remove={{(noop)}}/>
-`
+      hbs`<CurriculumInventory::ReportListItem @report={{this.report}} @remove={{(noop)}}/>`
     );
 
     assert.strictEqual(component.year, '2017 - 2018');

--- a/tests/integration/components/curriculum-inventory/report-list-test.js
+++ b/tests/integration/components/curriculum-inventory/report-list-test.js
@@ -55,8 +55,7 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
 
     this.set('reports', reports);
     await render(
-      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{(noop)}} />
-`
+      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{(noop)}} />`
     );
     assert.strictEqual(
       component.headers.name,
@@ -138,8 +137,7 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
     this.set('reports', [reportModel]);
 
     await render(
-      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{(noop)}} />
-`
+      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{(noop)}} />`
     );
 
     assert.ok(component.reports[0].isDeletable);
@@ -166,16 +164,14 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
     this.set('reports', [reportModel]);
 
     await render(
-      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{(noop)}} />
-`
+      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{(noop)}} />`
     );
 
     assert.notOk(component.reports[0].isDeletable);
   });
 
   test('empty list', async function (assert) {
-    await render(hbs`<CurriculumInventory::ReportList @reports={{(array)}} @remove={{(noop)}}/>
-`);
+    await render(hbs`<CurriculumInventory::ReportList @reports={{(array)}} @remove={{(noop)}}/>`);
     assert.strictEqual(component.emptyList.text, 'None');
   });
 
@@ -193,8 +189,7 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
       assert.strictEqual(report.id, obj.id, 'Report is passed to remove action.');
     });
     await render(
-      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{this.removeAction}} />
-`
+      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{this.removeAction}} />`
     );
     assert.notOk(component.confirmRemoval.isVisible, 'Confirm dialog is initially not visible.');
     await component.reports[0].remove();
@@ -217,8 +212,7 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
       assert.ok(false, 'Remove action should not have been invoked.');
     });
     await render(
-      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{this.removeAction}} />
-`
+      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{this.removeAction}} />`
     );
     assert.notOk(component.confirmRemoval.isVisible, 'Confirm dialog is initially not visible.');
     await component.reports[0].remove();
@@ -252,8 +246,7 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
       @setSortBy={{this.setSortBy}}
       @sortBy={{this.sortBy}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
     await component.headers.clickOnName();
     await component.headers.clickOnName();
     await component.headers.clickOnYear();
@@ -282,8 +275,7 @@ module('Integration | Component | curriculum-inventory/report-list', function (h
     });
     this.set('reports', reports);
     await render(
-      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{(noop)}} />
-`
+      hbs`<CurriculumInventory::ReportList @reports={{this.reports}} @remove={{(noop)}} />`
     );
     assert.strictEqual(component.reports[0].year, '2017 - 2018', 'Academic year shows range.');
   });

--- a/tests/integration/components/curriculum-inventory/report-overview-test.js
+++ b/tests/integration/components/curriculum-inventory/report-overview-test.js
@@ -49,8 +49,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       .findRecord('program', this.program.id);
     this.set('report', reportModel);
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     assert.strictEqual(component.title, 'Overview', 'Component title is visible.');
     assert.ok(component.rolloverLink.isVisible, 'Rollover course button is visible.');
@@ -100,8 +99,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       .findRecord('program', this.program.id);
     this.set('report', reportModel);
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{false}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{false}} />`
     );
     assert.strictEqual(
       component.startDate.readOnlyText,
@@ -143,8 +141,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       };
     });
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     assert.strictEqual(
       component.academicYear.text,
@@ -165,8 +162,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       };
     });
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{false}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{false}} />`
     );
     assert.strictEqual(
       component.academicYear.readOnlyText,
@@ -185,8 +181,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       },
     });
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     assert.notOk(component.rolloverLink.isVisible, 'Rollover course button is not visible.');
   });
@@ -197,8 +192,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       .findRecord('curriculum-inventory-report', this.report.id);
     this.set('report', reportModel);
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     await component.startDate.edit();
     assert.strictEqual(
@@ -227,8 +221,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       .findRecord('curriculum-inventory-report', this.report.id);
     this.set('report', reportModel);
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     await component.startDate.edit();
     const newVal = DateTime.fromJSDate(reportModel.endDate).plus({ days: 1 });
@@ -244,8 +237,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       .findRecord('curriculum-inventory-report', this.report.id);
     this.set('report', reportModel);
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     await component.endDate.edit();
     assert.strictEqual(
@@ -274,8 +266,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       .findRecord('curriculum-inventory-report', this.report.id);
     this.set('report', reportModel);
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     await component.endDate.edit();
     const newVal = DateTime.fromJSDate(reportModel.startDate).minus({ days: 1 });
@@ -291,8 +282,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       .findRecord('curriculum-inventory-report', this.report.id);
     this.set('report', reportModel);
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     await component.academicYear.edit();
     assert.strictEqual(
@@ -323,8 +313,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       .findRecord('curriculum-inventory-report', this.report.id);
     this.set('report', reportModel);
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     assert.strictEqual(
       component.academicYear.readOnlyText,
@@ -340,8 +329,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
     reportModel.description = null;
     this.set('report', reportModel);
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     assert.strictEqual(component.description.text, 'Click to edit');
     await component.description.edit();
@@ -359,8 +347,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
     this.set('report', reportModel);
     reportModel.description = null;
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     assert.strictEqual(component.description.text, 'Click to edit');
     await component.description.edit();
@@ -377,8 +364,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       .findRecord('curriculum-inventory-report', this.report.id);
     this.set('report', reportModel);
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     assert.strictEqual(component.description.text, 'Lorem Ipsum');
     await component.description.edit();
@@ -395,8 +381,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
     this.set('report', reportModel);
     this.program.shortTitle = null;
     await render(
-      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`
     );
     assert.strictEqual(component.program.text, 'Doctor of Rocket Surgery');
   });

--- a/tests/integration/components/curriculum-inventory/report-rollover-test.js
+++ b/tests/integration/components/curriculum-inventory/report-rollover-test.js
@@ -28,8 +28,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
       .findRecord('curriculum-inventory-report', report.id);
     this.set('report', reportModel);
 
-    await render(hbs`<CurriculumInventory::ReportRollover @report={{this.report}} />
-`);
+    await render(hbs`<CurriculumInventory::ReportRollover @report={{this.report}} />`);
 
     assert.strictEqual(component.years.options.length, 4);
     assert.strictEqual(component.years.options[0].text, `${thisYear + 1}`);
@@ -63,8 +62,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
       .findRecord('curriculum-inventory-report', report.id);
     this.set('report', reportModel);
 
-    await render(hbs`<CurriculumInventory::ReportRollover @report={{this.report}} />
-`);
+    await render(hbs`<CurriculumInventory::ReportRollover @report={{this.report}} />`);
 
     assert.strictEqual(component.years.options.length, 4);
     assert.strictEqual(component.years.options[0].text, `${thisYear + 1} - ${thisYear + 2}`);
@@ -110,8 +108,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
       assert.strictEqual(parseInt(newReport.id, 10), 14);
     });
     await render(
-      hbs`<CurriculumInventory::ReportRollover @report={{this.report}} @visit={{this.visit}} />
-`
+      hbs`<CurriculumInventory::ReportRollover @report={{this.report}} @visit={{this.visit}} />`
     );
     await component.save();
   });
@@ -143,8 +140,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
       assert.strictEqual(parseInt(newReport.id, 10), 14);
     });
     await render(
-      hbs`<CurriculumInventory::ReportRollover @report={{this.report}} @visit={{this.visit}} />
-`
+      hbs`<CurriculumInventory::ReportRollover @report={{this.report}} @visit={{this.visit}} />`
     );
     await component.name.submit();
   });
@@ -189,8 +185,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
 
     this.set('report', reportModel);
     await render(
-      hbs`<CurriculumInventory::ReportRollover @report={{this.report}} @visit={{(noop)}} />
-`
+      hbs`<CurriculumInventory::ReportRollover @report={{this.report}} @visit={{(noop)}} />`
     );
 
     await component.name.set(newName);
@@ -214,8 +209,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
       .findRecord('curriculum-inventory-report', report.id);
     this.set('report', reportModel);
 
-    await render(hbs`<CurriculumInventory::ReportRollover @report={{this.report}} />
-`);
+    await render(hbs`<CurriculumInventory::ReportRollover @report={{this.report}} />`);
     assert.notOk(component.name.hasValidationError);
   });
 
@@ -228,8 +222,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
       .findRecord('curriculum-inventory-report', report.id);
     this.set('report', reportModel);
 
-    await render(hbs`<CurriculumInventory::ReportRollover @report={{this.report}} />
-`);
+    await render(hbs`<CurriculumInventory::ReportRollover @report={{this.report}} />`);
 
     await component.name.set('');
     await component.save();
@@ -248,8 +241,7 @@ module('Integration | Component | curriculum-inventory/report-rollover', functio
       .findRecord('curriculum-inventory-report', report.id);
     this.set('report', reportModel);
 
-    await render(hbs`<CurriculumInventory::ReportRollover @report={{this.report}} />
-`);
+    await render(hbs`<CurriculumInventory::ReportRollover @report={{this.report}} />`);
     assert.notOk(component.description.hasValidationError);
     await component.description.set('');
     await component.save();

--- a/tests/integration/components/curriculum-inventory/reports-test.js
+++ b/tests/integration/components/curriculum-inventory/reports-test.js
@@ -58,8 +58,7 @@ module('Integration | Component | curriculum-inventory/reports', function (hooks
       @setSortBy={{(noop)}}
       @setSchoolId={{(noop)}}
       @setProgramId={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.newReport.isVisible);
     assert.ok(component.reports.isVisible);
     assert.strictEqual(component.schools.options.length, 3);
@@ -75,8 +74,7 @@ module('Integration | Component | curriculum-inventory/reports', function (hooks
       @setSortBy={{(noop)}}
       @setSchoolId={{(noop)}}
       @setProgramId={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.schools.options.length, 3);
     assert.ok(component.schools.options[0].isSelected);
     assert.strictEqual(component.programs.options.length, 2);
@@ -92,8 +90,7 @@ module('Integration | Component | curriculum-inventory/reports', function (hooks
       @setSortBy={{(noop)}}
       @setSchoolId={{(noop)}}
       @setProgramId={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.schools.options.length, 3);
     assert.ok(component.schools.options[1].isSelected);
     assert.strictEqual(component.programs.options.length, 1);
@@ -108,8 +105,7 @@ module('Integration | Component | curriculum-inventory/reports', function (hooks
       @setSortBy={{(noop)}}
       @setSchoolId={{(noop)}}
       @setProgramId={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.schools.options.length, 3);
     assert.ok(component.schools.options[2].isSelected);
     assert.strictEqual(component.programs.options.length, 0);
@@ -127,8 +123,7 @@ module('Integration | Component | curriculum-inventory/reports', function (hooks
       @setSortBy={{(noop)}}
       @setSchoolId={{this.setSchoolId}}
       @setProgramId={{(noop)}}
-    />
-`);
+    />`);
     await component.schools.select(this.schoolWithOneProgram.id);
   });
 
@@ -143,8 +138,7 @@ module('Integration | Component | curriculum-inventory/reports', function (hooks
       @setSortBy={{(noop)}}
       @setSchoolId={{(noop)}}
       @setProgramId={{this.setProgramId}}
-    />
-`);
+    />`);
     await component.programs.select(this.program2.id);
   });
 
@@ -155,8 +149,7 @@ module('Integration | Component | curriculum-inventory/reports', function (hooks
       @setSortBy={{(noop)}}
       @setSchoolId={{(noop)}}
       @setProgramId={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.newReport.isVisible);
     await component.toggleNewReportForm();
     assert.ok(component.newReport.isVisible);

--- a/tests/integration/components/curriculum-inventory/sequence-block-details-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-details-test.js
@@ -73,8 +73,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-details', 
       @canUpdate={{this.canUpdate}}
       @sortSessionsBy={{this.sortBy}}
       @setSortSessionBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.header.title.value, blockModel.title);
     assert.strictEqual(
       component.overview.description.text,

--- a/tests/integration/components/curriculum-inventory/sequence-block-header-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-header-test.js
@@ -23,8 +23,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-header', f
   test('it renders', async function (assert) {
     this.set('sequenceBlock', this.blockModel);
     await render(
-      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />`
     );
     assert.ok(component.title.isVisible);
     assert.strictEqual(component.title.value, this.blockModel.title);
@@ -34,8 +33,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-header', f
   test('read-only mode for block in when it can not be updated', async function (assert) {
     this.set('sequenceBlock', this.blockModel);
     await render(
-      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{false}} />
-`
+      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{false}} />`
     );
     assert.notOk(component.title.isEditable, 'Block title is not editable.');
   });
@@ -44,8 +42,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-header', f
     const newTitle = 'new title';
     this.set('sequenceBlock', this.blockModel);
     await render(
-      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />`
     );
     await component.title.edit();
     assert.notOk(component.title.hasError);
@@ -58,8 +55,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-header', f
   test('change title fails on empty value', async function (assert) {
     this.set('sequenceBlock', this.blockModel);
     await render(
-      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />`
     );
     await component.title.edit();
     assert.notOk(component.title.hasError);
@@ -71,8 +67,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-header', f
   test('change title fails on too-short value', async function (assert) {
     this.set('sequenceBlock', this.blockModel);
     await render(
-      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />`
     );
     await component.title.edit();
     assert.notOk(component.title.hasError);
@@ -84,8 +79,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-header', f
   test('change title fails on overlong value', async function (assert) {
     this.set('sequenceBlock', this.blockModel);
     await render(
-      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />`
     );
     await component.title.edit();
     assert.notOk(component.title.hasError);
@@ -97,8 +91,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-header', f
   test('cancel title changes', async function (assert) {
     this.set('sequenceBlock', this.blockModel);
     await render(
-      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />
-`
+      hbs`<CurriculumInventory::SequenceBlockHeader @sequenceBlock={{this.sequenceBlock}} @canUpdate={{true}} />`
     );
     await component.title.edit();
     await component.title.set('some other title');

--- a/tests/integration/components/curriculum-inventory/sequence-block-list-item-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-list-item-test.js
@@ -53,8 +53,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-list-item'
         @canUpdate={{true}}
         @remove={{(noop)}}
         @isInOrderedSequence={{true}}
-      />
-`
+      />`
     );
 
     assert.strictEqual(component.title, 'block 1');
@@ -86,8 +85,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-list-item'
         @canUpdate={{true}}
         @remove={{(noop)}}
         @isInOrderedSequence={{false}}
-      />
-`
+      />`
     );
 
     assert.strictEqual(component.orderInSequence, 'n/a');
@@ -106,8 +104,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-list-item'
         @canUpdate={{false}}
         @remove={{(noop)}}
         @isInOrderedSequence={{false}}
-      />
-`
+      />`
     );
 
     assert.notOk(component.isDeletable);
@@ -130,8 +127,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-list-item'
         @canUpdate={{true}}
         @remove={{this.remove}}
         @isInOrderedSequence={{false}}
-      />
-`
+      />`
     );
 
     assert.notOk(component.confirmRemoval.isVisible);

--- a/tests/integration/components/curriculum-inventory/sequence-block-list-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-list-test.js
@@ -81,8 +81,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-list', fun
       @sequenceBlocks={{await this.report.topLevelSequenceBlocks}}
       @canUpdate={{true}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(
       component.header.title,
@@ -170,8 +169,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-list', fun
       @sequenceBlocks={{await this.parent.children}}
       @canUpdate={{true}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(
       component.header.title,
@@ -208,8 +206,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-list', fun
       @sequenceBlocks={{await this.report.topLevelSequenceBlocks}}
       @canUpdate={{false}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.header.expandCollapse.isVisible, 'Add new button is not visible.');
     assert.notOk(component.list.items[0].isDeletable);
@@ -226,8 +223,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-list', fun
       @sequenceBlocks={{await this.report.topLevelSequenceBlocks}}
       @canUpdate={{true}}
       @remove={{this.remove}}
-    />
-`);
+    />`);
 
     assert.notOk(component.list.items[0].confirmRemoval.isVisible);
     await component.list.items[0].remove();
@@ -241,8 +237,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-list', fun
       @sequenceBlocks={{await this.report.topLevelSequenceBlocks}}
       @canUpdate={{true}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.list.items[0].confirmRemoval.isVisible);
     await component.list.items[0].remove();
@@ -256,8 +251,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-list', fun
       @report={{this.report}}
       @canUpdate={{true}}
       @sequenceBlocks={{(array)}}
-    />
-`);
+    />`);
     assert.strictEqual(
       component.header.title,
       'Sequence Blocks (0)',
@@ -280,8 +274,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-list', fun
       @parent={{this.parent}}
       @report={{await this.parent.report}}
       @sequenceBlocks={{(array)}}
-    />
-`);
+    />`);
     assert.strictEqual(
       component.header.title,
       'Sequence Blocks (0)',

--- a/tests/integration/components/curriculum-inventory/sequence-block-overview-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-overview-test.js
@@ -117,8 +117,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(
       component.description.text,
@@ -203,8 +202,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.orderInSequence.text, 'Order in Sequence: n/a');
   });
@@ -245,8 +243,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.orderInSequence.text, 'Order in Sequence: n/a');
   });
@@ -313,8 +310,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(
       component.course.text,
@@ -376,8 +372,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.description.text, 'Description: Click to add a description.');
     await component.description.edit();
@@ -416,8 +411,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.required.text, 'Required: Optional (elective)');
     await component.required.edit();
@@ -456,8 +450,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.track.yesNoToggle.checked, 'true');
     await component.track.yesNoToggle.click();
@@ -495,8 +488,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.childSequenceOrder.text, 'Child Sequence Order: Ordered');
     await component.childSequenceOrder.edit();
@@ -548,8 +540,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.orderInSequence.text, 'Order in Sequence: 1');
     await component.orderInSequence.edit();
@@ -595,8 +586,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.startLevel.text, 'Start Level: Year 1');
     await component.startLevel.edit();
@@ -639,8 +629,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.endLevel.text, 'End Level: Year 10');
     await component.endLevel.edit();
@@ -711,8 +700,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.sessionManager.isVisible);
     assert.ok(component.sessionList.isVisible);
@@ -792,8 +780,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{false}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(
       component.description.text,
@@ -876,8 +863,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.minimum.text, 'Minimum: 10');
     assert.ok(component.minimum.isEditable);
@@ -918,8 +904,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.required.text, 'Required: Required');
     assert.strictEqual(component.minimum.text, 'Minimum: 10');
     assert.notOk(component.isSelective.isHidden);
@@ -980,8 +965,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.minimum.text, 'Minimum: 10');
     assert.strictEqual(component.maximum.text, 'Maximum: 20');
@@ -1026,8 +1010,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.minimum.text, 'Minimum: 10');
     assert.strictEqual(component.maximum.text, 'Maximum: 20');
@@ -1072,8 +1055,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.minimum.edit();
     assert.strictEqual(component.minMaxEditor.maximum.errors.length, 0);
@@ -1118,8 +1100,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.minimum.edit();
     assert.strictEqual(component.minMaxEditor.minimum.errors.length, 0);
@@ -1159,8 +1140,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.minimum.edit();
     assert.strictEqual(component.minMaxEditor.minimum.errors.length, 0);
@@ -1200,8 +1180,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.maximum.edit();
     assert.strictEqual(component.minMaxEditor.maximum.errors.length, 0);
@@ -1241,8 +1220,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.minimum.isEditable);
     await component.maximum.edit();
@@ -1284,8 +1262,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.startDate.edit();
     await component.durationEditor.startDate.set(newStartDate);
@@ -1345,8 +1322,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.startDate.edit();
     await component.durationEditor.startDate.set(newStartDate);
@@ -1398,8 +1374,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.startDate.edit();
     await component.durationEditor.duration.set(newDuration);
@@ -1451,8 +1426,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(
       component.startDate.text,
@@ -1527,8 +1501,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.endDate.edit();
     assert.strictEqual(component.durationEditor.endDate.errors.length, 0);
@@ -1569,8 +1542,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.duration.edit();
     assert.strictEqual(component.durationEditor.duration.errors.length, 0);
@@ -1610,8 +1582,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.duration.edit();
     assert.strictEqual(component.durationEditor.duration.errors.length, 0);
@@ -1651,8 +1622,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.duration.edit();
     assert.strictEqual(component.durationEditor.startDate.errors.length, 0);
@@ -1705,8 +1675,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.duration.edit();
     assert.strictEqual(component.durationEditor.startDate.errors.length, 0);
@@ -1761,8 +1730,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.duration.edit();
     assert.strictEqual(component.durationEditor.startDate.errors.length, 0);
@@ -1810,8 +1778,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     await component.startDate.edit();
     assert.strictEqual(component.durationEditor.endDate.errors.length, 0);
@@ -1851,8 +1818,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.minimum.text, 'Minimum: 5');
     await component.minimum.edit();
@@ -1893,8 +1859,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.minimum.text, 'Minimum: 5');
     await component.minimum.edit();
@@ -1935,8 +1900,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.maximum.text, 'Maximum: 20');
     await component.maximum.edit();
@@ -1977,8 +1941,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.maximum.text, 'Maximum: 20');
     await component.maximum.edit();
@@ -2017,8 +1980,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.duration.text, 'Duration: 5');
     await component.duration.edit();
@@ -2059,8 +2021,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.duration.text, 'Duration: 5');
     await component.duration.edit();
@@ -2099,8 +2060,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.sessions.label, 'Sessions (0)');
     assert.notOk(component.sessions.editButton.isVisible);
@@ -2137,8 +2097,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{true}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.sessions.label, 'Sessions (0)');
     assert.notOk(component.sessions.editButton.isVisible);
@@ -2175,8 +2134,7 @@ module('Integration | Component | curriculum-inventory/sequence-block-overview',
       @canUpdate={{false}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.duration.text, 'Duration (in Days): n/a');
   });

--- a/tests/integration/components/curriculum-inventory/sequence-block-session-list-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-session-list-test.js
@@ -79,8 +79,7 @@ module(
       @sequenceBlock={{this.sequenceBlock}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
       assert.strictEqual(
         component.header.countAsOneOffering.text,
         'Count as one offering',
@@ -204,8 +203,7 @@ module(
       @sequenceBlock={{this.sequenceBlock}}
       @sortBy={{this.sortBy}}
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
       assert.ok(component.header.exclude.isVisible, 'Table header is visible,');
       assert.strictEqual(component.sessions.length, 0, 'but table body is empty.');
     });
@@ -235,8 +233,7 @@ module(
       @sequenceBlock={{this.sequenceBlock}}
       @sortBy={{this.sortBy}}
       @setSortBy={{this.setSortBy}}
-    />
-`);
+    />`);
       await component.header.title.click();
     });
 
@@ -269,8 +266,7 @@ module(
         @sequenceBlock={{this.sequenceBlock}}
         @sortBy={{this.sortBy}}
         @setSortBy={{this.setSortBy}}
-      />
-`);
+      />`);
       await component.header.sessionType.click();
     });
 
@@ -303,8 +299,7 @@ module(
       @sequenceBlock={{this.sequenceBlock}}
       @sortBy={{this.sortBy}}
       @setSortBy={{this.setSortBy}}
-    />
-`);
+    />`);
       await component.header.offeringsCount.click();
     });
   }

--- a/tests/integration/components/curriculum-inventory/sequence-block-session-manager-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-session-manager-test.js
@@ -74,8 +74,7 @@ module(
         @sequenceBlock={{this.sequenceBlock}}
         @sortBy={{this.sortBy}}
         @setSortBy={{(noop)}}
-      />
-`);
+      />`);
 
       assert.strictEqual(
         component.header.countAsOneOffering.text,
@@ -205,8 +204,7 @@ module(
         @sequenceBlock={{this.sequenceBlock}}
         @sortBy={{this.sortBy}}
         @setSortBy={{(noop)}}
-      />
-`);
+      />`);
 
       assert.ok(component.header.isVisible);
       assert.strictEqual(component.sessions.length, 0);
@@ -239,8 +237,7 @@ module(
         @sequenceBlock={{this.sequenceBlock}}
         @sortBy={{this.sortBy}}
         @setSortBy={{this.setSortBy}}
-      />
-`);
+      />`);
 
       await component.header.title.click();
     });
@@ -276,8 +273,7 @@ module(
         @sequenceBlock={{this.sequenceBlock}}
         @sortBy={{this.sortBy}}
         @setSortBy={{this.setSortBy}}
-      />
-`);
+      />`);
 
       await component.header.sessionType.click();
     });
@@ -313,8 +309,7 @@ module(
         @sequenceBlock={{this.sequenceBlock}}
         @sortBy={{this.sortBy}}
         @setSortBy={{this.setSortBy}}
-      />
-`);
+      />`);
 
       await component.header.offeringsCount.click();
     });
@@ -353,8 +348,7 @@ module(
         @sequenceBlock={{this.sequenceBlock}}
         @sortBy={{this.sortBy}}
         @setSortBy={{(noop)}}
-      />
-`);
+      />`);
 
       assert.strictEqual(component.sessions[0].totalTime.text, '30.00');
       assert.ok(component.header.countAsOneOffering.isChecked);
@@ -414,8 +408,7 @@ module(
         @sequenceBlock={{this.sequenceBlock}}
         @sortBy={{this.sortBy}}
         @setSortBy={{(noop)}}
-      />
-`);
+      />`);
 
       assert.notOk(component.header.countAsOneOffering.isChecked);
       assert.ok(component.header.countAsOneOffering.isPartiallyChecked);
@@ -467,8 +460,7 @@ module(
         @sortBy={{this.sortBy}}
         @setSortBy={{(noop)}}
         @save={{this.save}}
-      />
-`);
+      />`);
 
       assert.notOk(component.header.exclude.isChecked);
       assert.ok(component.header.exclude.isPartiallyChecked);
@@ -521,8 +513,7 @@ module(
         @sortBy={{this.sortBy}}
         @setSortBy={{(noop)}}
         @save={{this.save}}
-      />
-`);
+      />`);
 
       assert.ok(component.sessions[0].countAsOneOffering.isChecked);
       assert.notOk(component.sessions[0].exclude.isChecked);
@@ -553,8 +544,7 @@ module(
         @sequenceBlock={{this.sequenceBlock}}
         @sortBy={{this.sortBy}}
         @cancel={{this.cancel}}
-      />
-`);
+      />`);
 
       await component.cancel();
     });

--- a/tests/integration/components/curriculum-inventory/verification-preview-header-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-header-test.js
@@ -22,8 +22,7 @@ module(
         .lookup('service:store')
         .findRecord('curriculum-inventory-report', 1);
       this.set('report', report);
-      await render(hbs`<CurriculumInventory::VerificationPreviewHeader @report={{this.report}} />
-`);
+      await render(hbs`<CurriculumInventory::VerificationPreviewHeader @report={{this.report}} />`);
       assert.strictEqual(component.title, 'Verification Preview for Foo Bar 2019');
     });
   }

--- a/tests/integration/components/curriculum-inventory/verification-preview-table1-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table1-test.js
@@ -18,8 +18,7 @@ module(
         { title: 'foo', pcrs: [] },
       ];
       this.set('data', data);
-      await render(hbs`<CurriculumInventory::VerificationPreviewTable1 @data={{this.data}} />
-`);
+      await render(hbs`<CurriculumInventory::VerificationPreviewTable1 @data={{this.data}} />`);
       assert.strictEqual(component.title, 'Table 1: Program Expectations Mapped to PCRS');
       assert.strictEqual(component.table.headings.length, 3);
       assert.strictEqual(component.table.headings[0].text, 'Program Expectations ID');

--- a/tests/integration/components/curriculum-inventory/verification-preview-table2-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table2-test.js
@@ -37,8 +37,7 @@ module(
       };
 
       this.set('data', data);
-      await render(hbs`<CurriculumInventory::VerificationPreviewTable2 @data={{this.data}} />
-`);
+      await render(hbs`<CurriculumInventory::VerificationPreviewTable2 @data={{this.data}} />`);
       assert.strictEqual(
         component.title,
         'Table 2: Primary Instructional Method by Non-Clerkship Sequence Block'

--- a/tests/integration/components/curriculum-inventory/verification-preview-table3a-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table3a-test.js
@@ -18,8 +18,7 @@ module(
         { title: 'bar', starting_level: 4, ending_level: 5, weeks: 1.5, avg: 20.33 },
       ];
       this.set('data', data);
-      await render(hbs`<CurriculumInventory::VerificationPreviewTable3a @data={{this.data}} />
-`);
+      await render(hbs`<CurriculumInventory::VerificationPreviewTable3a @data={{this.data}} />`);
       assert.strictEqual(
         component.title,
         'Table 3-A: Non-Clerkship Sequence Block Instructional Time'

--- a/tests/integration/components/curriculum-inventory/verification-preview-table3b-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table3b-test.js
@@ -18,8 +18,7 @@ module(
         { title: 'bar', starting_level: 4, ending_level: 5, weeks: 1.5, avg: 20.33 },
       ];
       this.set('data', data);
-      await render(hbs`<CurriculumInventory::VerificationPreviewTable3b @data={{this.data}} />
-`);
+      await render(hbs`<CurriculumInventory::VerificationPreviewTable3b @data={{this.data}} />`);
       assert.strictEqual(component.title, 'Table 3-B: Clerkship Sequence Block Instructional Time');
       assert.strictEqual(component.table.headings.length, 4);
       assert.strictEqual(component.table.headings[0].text, 'Clerkship Sequence Blocks');

--- a/tests/integration/components/curriculum-inventory/verification-preview-table4-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table4-test.js
@@ -31,8 +31,7 @@ module(
       ];
 
       this.set('data', data);
-      await render(hbs`<CurriculumInventory::VerificationPreviewTable4 @data={{this.data}} />
-`);
+      await render(hbs`<CurriculumInventory::VerificationPreviewTable4 @data={{this.data}} />`);
       assert.strictEqual(component.title, 'Table 4: Instructional Method Counts');
       assert.strictEqual(component.table.headings.length, 4);
       assert.strictEqual(component.table.headings[0].text, 'Item Code');

--- a/tests/integration/components/curriculum-inventory/verification-preview-table5-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table5-test.js
@@ -46,8 +46,7 @@ module(
       };
 
       this.set('data', data);
-      await render(hbs`<CurriculumInventory::VerificationPreviewTable5 @data={{this.data}} />
-`);
+      await render(hbs`<CurriculumInventory::VerificationPreviewTable5 @data={{this.data}} />`);
       assert.strictEqual(
         component.title,
         'Table 5: Non-Clerkship Sequence Block Assessment Methods'

--- a/tests/integration/components/curriculum-inventory/verification-preview-table6-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table6-test.js
@@ -46,8 +46,7 @@ module(
       };
 
       this.set('data', data);
-      await render(hbs`<CurriculumInventory::VerificationPreviewTable6 @data={{this.data}} />
-`);
+      await render(hbs`<CurriculumInventory::VerificationPreviewTable6 @data={{this.data}} />`);
       assert.strictEqual(component.title, 'Table 6: Clerkship Sequence Block Assessment Methods');
       assert.strictEqual(component.table.firstHeadings.length, 4);
       assert.strictEqual(component.table.firstHeadings[0].text, 'Clerkship Sequence Blocks');

--- a/tests/integration/components/curriculum-inventory/verification-preview-table7-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table7-test.js
@@ -19,8 +19,7 @@ module(
         { id: 'AM003', title: 'bar', num_summative_assessments: 5, num_formative_assessments: 0 },
       ];
       this.set('data', data);
-      await render(hbs`<CurriculumInventory::VerificationPreviewTable7 @data={{this.data}} />
-`);
+      await render(hbs`<CurriculumInventory::VerificationPreviewTable7 @data={{this.data}} />`);
       assert.strictEqual(
         component.title,
         'Table 7: All Events with Assessments Tagged as Formative or Summative'

--- a/tests/integration/components/curriculum-inventory/verification-preview-table8-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table8-test.js
@@ -18,8 +18,7 @@ module(
         { id: '003', title: 'bar', count: 5 },
       ];
       this.set('data', data);
-      await render(hbs`<CurriculumInventory::VerificationPreviewTable8 @data={{this.data}} />
-`);
+      await render(hbs`<CurriculumInventory::VerificationPreviewTable8 @data={{this.data}} />`);
       assert.strictEqual(component.title, 'Table 8: All Resource Types');
       assert.strictEqual(component.table.headings.length, 3);
       assert.strictEqual(component.table.headings[0].text, 'Item Code');

--- a/tests/integration/components/curriculum-inventory/verification-preview-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-test.js
@@ -47,8 +47,7 @@ module('Integration | Component | curriculum-inventory/verification-preview', fu
     );
 
     this.set('report', report);
-    await render(hbs`<CurriculumInventory::VerificationPreview @report={{this.report}} />
-`);
+    await render(hbs`<CurriculumInventory::VerificationPreview @report={{this.report}} />`);
     assert.strictEqual(component.tableOfContents.items.length, 9);
     assert.strictEqual(
       component.tableOfContents.items[0].text,

--- a/tests/integration/components/dashboard-loading-test.js
+++ b/tests/integration/components/dashboard-loading-test.js
@@ -9,8 +9,7 @@ module('Integration | Component | dashboard loading', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
-    await render(hbs`<DashboardLoading />
-`);
+    await render(hbs`<DashboardLoading />`);
 
     assert.dom(this.element).hasText('');
   });

--- a/tests/integration/components/error-display-test.js
+++ b/tests/integration/components/error-display-test.js
@@ -18,8 +18,7 @@ module('Integration | Component | error display', function (hooks) {
     ];
 
     this.set('errors', errors);
-    await render(hbs`<ErrorDisplay @errors={{this.errors}} @clearErrors={{(noop)}} />
-`);
+    await render(hbs`<ErrorDisplay @errors={{this.errors}} @clearErrors={{(noop)}} />`);
 
     assert.dom('.error-detail-action').hasText('Hide Details');
     assert.dom('.timestamp').includesText(new Intl.DateTimeFormat('en-US').format(new Date()));
@@ -39,8 +38,7 @@ module('Integration | Component | error display', function (hooks) {
     ];
 
     this.set('errors', errors);
-    await render(hbs`<ErrorDisplay @errors={{this.errors}} @clearErrors={{(noop)}} />
-`);
+    await render(hbs`<ErrorDisplay @errors={{this.errors}} @clearErrors={{(noop)}} />`);
 
     assert.dom('.error-main').includesText('Rats!');
   });
@@ -58,8 +56,7 @@ module('Integration | Component | error display', function (hooks) {
     this.set('clearErrors', () => {
       assert.ok(true, 'action was fired');
     });
-    await render(hbs`<ErrorDisplay @errors={{this.errors}} @clearErrors={{this.clearErrors}} />
-`);
+    await render(hbs`<ErrorDisplay @errors={{this.errors}} @clearErrors={{this.clearErrors}} />`);
     await click('.clear-errors button');
   });
 });

--- a/tests/integration/components/flash-messages-test.js
+++ b/tests/integration/components/flash-messages-test.js
@@ -18,8 +18,7 @@ module('Integration | Component | flash-messages', function (hooks) {
   test('it renders', async function (assert) {
     const flashMessages = this.owner.lookup('service:flash-messages');
     flashMessages.success('general.course');
-    await render(hbs`<FlashMessages />
-`);
+    await render(hbs`<FlashMessages />`);
     assert.strictEqual(component.messages.length, 1);
     assert.strictEqual(component.messages[0].text, 'Course');
   });

--- a/tests/integration/components/global-search-box-test.js
+++ b/tests/integration/components/global-search-box-test.js
@@ -23,15 +23,13 @@ module('Integration | Component | global search box', function (hooks) {
   });
 
   test('it renders and is accessible', async function (assert) {
-    await render(hbs`<GlobalSearchBox @search={{(noop)}} />
-`);
+    await render(hbs`<GlobalSearchBox @search={{(noop)}} />`);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
 
   test('clicking search icon focuses input', async function (assert) {
-    await render(hbs`<GlobalSearchBox @search={{(noop)}} />
-`);
+    await render(hbs`<GlobalSearchBox @search={{(noop)}} />`);
     assert.notOk(component.inputHasFocus);
     await component.clickIcon();
     assert.ok(component.inputHasFocus);
@@ -40,15 +38,13 @@ module('Integration | Component | global search box', function (hooks) {
   test('clicking search searches if there is content', async function (assert) {
     assert.expect(1);
     this.set('search', (value) => assert.strictEqual(value, 'typed it'));
-    await render(hbs`<GlobalSearchBox @search={{this.search}} />
-`);
+    await render(hbs`<GlobalSearchBox @search={{this.search}} />`);
     await component.input('typed it');
     await component.clickIcon();
   });
 
   test('displays initial passed down value', async function (assert) {
-    await render(hbs`<GlobalSearchBox @query="course" />
-`);
+    await render(hbs`<GlobalSearchBox @query="course" />`);
     assert.strictEqual(component.inputValue, 'course');
   });
 
@@ -71,8 +67,7 @@ module('Integration | Component | global search box', function (hooks) {
     this.set('search', (value) => {
       assert.strictEqual(value, input);
     });
-    await render(hbs`<GlobalSearchBox @search={{this.search}} />
-`);
+    await render(hbs`<GlobalSearchBox @search={{this.search}} />`);
     await component.input(input);
     await component.triggerInput();
     assert.strictEqual(component.autocompleteResults.length, 3);
@@ -84,16 +79,14 @@ module('Integration | Component | global search box', function (hooks) {
       assert.strictEqual(value, 'typed it');
       assert.ok(true, 'search action gets called');
     });
-    await render(hbs`<GlobalSearchBox @search={{this.search}} />
-`);
+    await render(hbs`<GlobalSearchBox @search={{this.search}} />`);
     await component.input('typed it');
     await component.keyUp.enter();
     assert.strictEqual(component.autocompleteResults.length, 0);
   });
 
   test('escape calls clears query', async function (assert) {
-    await render(hbs`<GlobalSearchBox @search={{(noop)}} />
-`);
+    await render(hbs`<GlobalSearchBox @search={{(noop)}} />`);
     await component.input('typed it');
     assert.strictEqual(component.autocompleteResults.length, 3);
     await component.keyUp.escape();
@@ -108,8 +101,7 @@ module('Integration | Component | global search box', function (hooks) {
       assert.strictEqual(value, inputValue);
       assert.ok(true, 'search action gets called');
     });
-    await render(hbs`<GlobalSearchBox @search={{this.search}} />
-`);
+    await render(hbs`<GlobalSearchBox @search={{this.search}} />`);
     await component.input('typed it');
     await component.keyUp.down();
     assert.ok(component.resultsRow1HasActiveClass);
@@ -166,8 +158,7 @@ module('Integration | Component | global search box', function (hooks) {
 
   test('can empty with backspace', async function (assert) {
     this.set('query', 'test value');
-    await render(hbs`<GlobalSearchBox @query={{this.query}} />
-`);
+    await render(hbs`<GlobalSearchBox @query={{this.query}} />`);
     assert.strictEqual(component.inputValue, 'test value');
     await component.input('typed it');
     assert.strictEqual(component.inputValue, 'typed it');
@@ -177,8 +168,7 @@ module('Integration | Component | global search box', function (hooks) {
 
   test('can empty with backspace after choosing autocomplete', async function (assert) {
     this.set('query', 'test value');
-    await render(hbs`<GlobalSearchBox @query={{this.query}} />
-`);
+    await render(hbs`<GlobalSearchBox @query={{this.query}} />`);
     assert.strictEqual(component.inputValue, 'test value');
     await component.input('typed it');
     assert.strictEqual(component.inputValue, 'typed it');
@@ -194,8 +184,7 @@ module('Integration | Component | global search box', function (hooks) {
     this.set('search', () => {
       assert.ok(false, 'search should not be called');
     });
-    await render(hbs`<GlobalSearchBox @search={{this.search}} />
-`);
+    await render(hbs`<GlobalSearchBox @search={{this.search}} />`);
     await component.input(input);
     await component.triggerInput();
     assert.strictEqual(component.autocompleteResults.length, 1);

--- a/tests/integration/components/global-search-tags-test.js
+++ b/tests/integration/components/global-search-tags-test.js
@@ -12,8 +12,7 @@ module('Integration | Component | global-search-tags', function (hooks) {
 
   test('it renders and is accessible', async function (assert) {
     this.set('tags', ['terms', 'meshdescriptors', 'id', 'learningmaterials']);
-    await render(hbs`<GlobalSearchTags @tags={{this.tags}} />
-`);
+    await render(hbs`<GlobalSearchTags @tags={{this.tags}} />`);
     assert.strictEqual(component.tags.length, 4);
     assert.strictEqual(component.tags[0].text, 'Terms');
     assert.strictEqual(component.tags[1].text, 'MeSH');

--- a/tests/integration/components/global-search-test.js
+++ b/tests/integration/components/global-search-test.js
@@ -18,8 +18,7 @@ module('Integration | Component | global-search', function (hooks) {
       @onQuery={{(noop)}}
       @onSelectPage={{(noop)}}
       @setSelectedYear={{(noop)}}
-    />
-`);
+    />`);
     assert.dom('[data-test-global-search-box]').exists({ count: 1 });
   });
 
@@ -42,8 +41,7 @@ module('Integration | Component | global-search', function (hooks) {
       @onQuery={{(noop)}}
       @onSelectPage={{(noop)}}
       @setSelectedYear={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.noResultsIsVisible);
     this.set('query', 'hello world');
     assert.notOk(component.noResultsIsVisible);
@@ -67,8 +65,7 @@ module('Integration | Component | global-search', function (hooks) {
       @onQuery={{this.query}}
       @onSelectPage={{(noop)}}
       @setSelectedYear={{(noop)}}
-    />
-`);
+    />`);
     await component.searchBox.input('typed it');
     await component.searchBox.clickIcon();
   });
@@ -115,8 +112,7 @@ module('Integration | Component | global-search', function (hooks) {
       @onSelectPage={{(noop)}}
       @selectedYear={{this.selectedYear}}
       @setSelectedYear={{set this.selectedYear}}
-    />
-`);
+    />`);
     assert.strictEqual(component.academicYear, '');
     assert.strictEqual(
       component.academicYearOptions,
@@ -190,8 +186,7 @@ module('Integration | Component | global-search', function (hooks) {
       @onSelectPage={{(noop)}}
       @ignoredSchoolIds={{this.ignoredSchoolIds}}
       @setIgnoredSchoolIds={{set this.ignoredSchoolIds}}
-    />
-`);
+    />`);
     assert.strictEqual(component.searchResults.length, 4);
     assert.strictEqual(component.searchResults[0].courseTitle, '2019 Course 1');
     assert.strictEqual(component.searchResults[1].courseTitle, '2020 Course 2');
@@ -286,8 +281,7 @@ module('Integration | Component | global-search', function (hooks) {
       @onQuery={{(noop)}}
       @onSelectPage={{(noop)}}
       @setSelectedYear={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.searchResults.length, 1);
     assert.strictEqual(component.searchResults[0].courseTitle, '2019 Course 1');
     assert.strictEqual(component.schoolFilters.length, 3);
@@ -326,8 +320,7 @@ module('Integration | Component | global-search', function (hooks) {
       @onQuery={{(noop)}}
       @onSelectPage={{(noop)}}
       @setSelectedYear={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.searchResults.length, 1);
     assert.strictEqual(component.searchResults[0].courseTitle, '2019 Course 1');
     assert.strictEqual(component.schoolFilters.length, 0);

--- a/tests/integration/components/ilios-header-test.js
+++ b/tests/integration/components/ilios-header-test.js
@@ -17,8 +17,7 @@ module('Integration | Component | ilios-header', function (hooks) {
     await render(hbs`
       {{page-title this.title}}
       <IliosHeader />
-    
-`);
+    `);
     assert.ok(component.isPresent);
     assert.strictEqual(component.title, 'test');
 

--- a/tests/integration/components/ilios-navigation-test.js
+++ b/tests/integration/components/ilios-navigation-test.js
@@ -17,8 +17,7 @@ module('Integration | Component | ilios-navigation', function (hooks) {
     });
     this.owner.register('service:currentUser', currentUserMock);
 
-    await render(hbs`<IliosNavigation />
-`);
+    await render(hbs`<IliosNavigation />`);
     await a11yAudit(this.element);
 
     assert.ok(component.expandCollapse.isPresent);
@@ -39,8 +38,7 @@ module('Integration | Component | ilios-navigation', function (hooks) {
     });
     this.owner.register('service:currentUser', currentUserMock);
 
-    await render(hbs`<IliosNavigation />
-`);
+    await render(hbs`<IliosNavigation />`);
     await a11yAudit(this.element);
 
     assert.notOk(component.expandCollapse.isPresent);
@@ -54,8 +52,7 @@ module('Integration | Component | ilios-navigation', function (hooks) {
     });
     this.owner.register('service:currentUser', currentUserMock);
 
-    await render(hbs`<IliosNavigation />
-`);
+    await render(hbs`<IliosNavigation />`);
     await a11yAudit(this.element);
 
     assert.strictEqual(component.links.length, 9);

--- a/tests/integration/components/ilios-users-test.js
+++ b/tests/integration/components/ilios-users-test.js
@@ -25,8 +25,7 @@ module('Integration | Component | ilios users', function (hooks) {
       @setShowBulkNewUserForm={{(noop)}}
       @setSearchTerms={{(noop)}}
       @transitionToUser={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title.text, 'Users');
   });
 
@@ -51,8 +50,7 @@ module('Integration | Component | ilios users', function (hooks) {
       @setShowBulkNewUserForm={{(noop)}}
       @setSearchTerms={{(noop)}}
       @transitionToUser={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.search.value, value);
     await component.search.set(newValue);
@@ -97,8 +95,7 @@ module('Integration | Component | ilios users', function (hooks) {
       @setShowBulkNewUserForm={{(noop)}}
       @setSearchTerms={{(noop)}}
       @transitionToUser={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.newUserForm.isPresent, 'the new user form is present');
     assert.notOk(
       component.newDirectoryUserForm.isPresent,
@@ -146,8 +143,7 @@ module('Integration | Component | ilios users', function (hooks) {
       @setShowBulkNewUserForm={{(noop)}}
       @setSearchTerms={{(noop)}}
       @transitionToUser={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.newUserForm.isPresent, 'the new user form is not present');
     assert.ok(component.newDirectoryUserForm.isPresent, 'the new directory form is present');
   });
@@ -194,8 +190,7 @@ module('Integration | Component | ilios users', function (hooks) {
       @setShowBulkNewUserForm={{this.setShowBulkNewUserForm}}
       @setSearchTerms={{(noop)}}
       @transitionToUser={{(noop)}}
-    />
-`);
+    />`);
     await component.newBulkUserForm.cancel();
   });
 
@@ -240,8 +235,7 @@ module('Integration | Component | ilios users', function (hooks) {
       @setShowBulkNewUserForm={{(noop)}}
       @setSearchTerms={{(noop)}}
       @transitionToUser={{(noop)}}
-    />
-`);
+    />`);
     await component.newUserForm.cancel();
   });
 
@@ -288,8 +282,7 @@ module('Integration | Component | ilios users', function (hooks) {
       @setShowBulkNewUserForm={{this.setShowBulkNewUserForm}}
       @setSearchTerms={{(noop)}}
       @transitionToUser={{(noop)}}
-    />
-`);
+    />`);
     await component.collapseForm();
   });
 });

--- a/tests/integration/components/instructor-group/courses-test.js
+++ b/tests/integration/components/instructor-group/courses-test.js
@@ -40,8 +40,7 @@ module('Integration | Component | instructor-group/courses', function (hooks) {
       .lookup('service:store')
       .findRecord('instructor-group', instructorGroup.id);
     this.set('instructorGroup', instructorGroupModel);
-    await render(hbs`<InstructorGroup::Courses @instructorGroup={{this.instructorGroup}} />
-`);
+    await render(hbs`<InstructorGroup::Courses @instructorGroup={{this.instructorGroup}} />`);
     assert.strictEqual(component.title, 'Associated Courses (3)');
     assert.strictEqual(component.courses.length, 3);
     assert.strictEqual(component.courses[0].text, 'course 0');
@@ -60,8 +59,7 @@ module('Integration | Component | instructor-group/courses', function (hooks) {
       .lookup('service:store')
       .findRecord('instructor-group', instructorGroup.id);
     this.set('instructorGroup', instructorGroupModel);
-    await render(hbs`<InstructorGroup::Courses @instructorGroup={{this.instructorGroup}} />
-`);
+    await render(hbs`<InstructorGroup::Courses @instructorGroup={{this.instructorGroup}} />`);
     assert.strictEqual(component.title, 'Associated Courses (0)');
     assert.strictEqual(component.courses.length, 0);
   });

--- a/tests/integration/components/instructor-group/header-test.js
+++ b/tests/integration/components/instructor-group/header-test.js
@@ -30,8 +30,7 @@ module('Integration | Component | instructor-group/header', function (hooks) {
     this.set('canUpdate', true);
 
     await render(
-      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
@@ -50,8 +49,7 @@ module('Integration | Component | instructor-group/header', function (hooks) {
     this.set('canUpdate', false);
 
     await render(
-      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
@@ -67,8 +65,7 @@ module('Integration | Component | instructor-group/header', function (hooks) {
     this.set('canUpdate', true);
 
     await render(
-      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
@@ -84,8 +81,7 @@ module('Integration | Component | instructor-group/header', function (hooks) {
     this.set('canUpdate', true);
 
     await render(
-      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
@@ -102,8 +98,7 @@ module('Integration | Component | instructor-group/header', function (hooks) {
     this.set('canUpdate', true);
 
     await render(
-      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
@@ -120,8 +115,7 @@ module('Integration | Component | instructor-group/header', function (hooks) {
     this.set('canUpdate', true);
 
     await render(
-      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
@@ -138,8 +132,7 @@ module('Integration | Component | instructor-group/header', function (hooks) {
     this.set('canUpdate', true);
 
     await render(
-      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<InstructorGroup::Header @instructorGroup={{this.instructorGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');

--- a/tests/integration/components/instructor-group/instructor-manager-test.js
+++ b/tests/integration/components/instructor-group/instructor-manager-test.js
@@ -26,8 +26,7 @@ module('Integration | Component | instructor-group/instructor-manager', function
     const instructors = [this.user1, this.user2, this.user3];
     this.set('instructors', instructors);
     await render(
-      hbs`<InstructorGroup::InstructorManager @instructors={{this.instructors}} @add={{(noop)}} @remove={{(noop)}} />
-`
+      hbs`<InstructorGroup::InstructorManager @instructors={{this.instructors}} @add={{(noop)}} @remove={{(noop)}} />`
     );
     assert.strictEqual(component.selectedInstructors.label, 'Selected Instructors:');
     assert.strictEqual(component.selectedInstructors.users.length, 3);
@@ -52,8 +51,7 @@ module('Integration | Component | instructor-group/instructor-manager', function
   test('it renders without selected instructors', async function (assert) {
     this.set('instructors', []);
     await render(
-      hbs`<InstructorGroup::InstructorManager @instructors={{this.instructors}} @add={{(noop)}} @remove={{(noop)}} />
-`
+      hbs`<InstructorGroup::InstructorManager @instructors={{this.instructors}} @add={{(noop)}} @remove={{(noop)}} />`
     );
     assert.strictEqual(component.selectedInstructors.label, 'Selected Instructors:');
     assert.strictEqual(component.selectedInstructors.users.length, 0);
@@ -68,8 +66,7 @@ module('Integration | Component | instructor-group/instructor-manager', function
     });
     this.set('instructors', []);
     await render(
-      hbs`<InstructorGroup::InstructorManager @instructors={{this.instructors}} @add={{this.add}} @remove={{(noop)}} />
-`
+      hbs`<InstructorGroup::InstructorManager @instructors={{this.instructors}} @add={{this.add}} @remove={{(noop)}} />`
     );
     await component.availableInstructors.userSearch.searchBox.set('guy');
     assert.strictEqual(component.availableInstructors.userSearch.results.items.length, 3);
@@ -88,8 +85,7 @@ module('Integration | Component | instructor-group/instructor-manager', function
     const instructors = [this.user1, this.user2];
     this.set('instructors', instructors);
     await render(
-      hbs`<InstructorGroup::InstructorManager @instructors={{this.instructors}} @add={{(noop)}} @remove={{this.remove}} />
-`
+      hbs`<InstructorGroup::InstructorManager @instructors={{this.instructors}} @add={{(noop)}} @remove={{this.remove}} />`
     );
     assert.strictEqual(component.selectedInstructors.users.length, 2);
     assert.strictEqual(

--- a/tests/integration/components/instructor-group/root-test.js
+++ b/tests/integration/components/instructor-group/root-test.js
@@ -39,8 +39,7 @@ module('Integration | Component | instructor-group/root', function (hooks) {
   test('it renders', async function (assert) {
     this.set('group', this.instructorGroup);
     await render(
-      hbs`<InstructorGroup::Root @instructorGroup={{this.group}} @canUpdate={{true}} />
-`
+      hbs`<InstructorGroup::Root @instructorGroup={{this.group}} @canUpdate={{true}} />`
     );
     assert.strictEqual(component.header.title.text, 'instructor group 0');
     assert.strictEqual(component.header.members, 'Members: 2');
@@ -66,8 +65,7 @@ module('Integration | Component | instructor-group/root', function (hooks) {
   test('it renders in read-only mode', async function (assert) {
     this.set('group', this.instructorGroup);
     await render(
-      hbs`<InstructorGroup::Root @instructorGroup={{this.group}} @canUpdate={{false}} />
-`
+      hbs`<InstructorGroup::Root @instructorGroup={{this.group}} @canUpdate={{false}} />`
     );
     assert.strictEqual(component.header.title.text, 'instructor group 0');
     assert.strictEqual(component.header.members, 'Members: 2');

--- a/tests/integration/components/instructor-group/users-test.js
+++ b/tests/integration/components/instructor-group/users-test.js
@@ -20,8 +20,7 @@ module('Integration | Component | instructor-group/users', function (hooks) {
       .findRecord('instructor-group', instructorGroup.id);
     this.set('instructorGroup', instructorGroupModel);
     await render(
-      hbs`<InstructorGroup::Users @instructorGroup={{this.instructorGroup}} @canUpdate={{true}} />
-`
+      hbs`<InstructorGroup::Users @instructorGroup={{this.instructorGroup}} @canUpdate={{true}} />`
     );
     assert.strictEqual(component.title, 'Instructors (3)');
     assert.ok(component.manage.isVisible);
@@ -45,8 +44,7 @@ module('Integration | Component | instructor-group/users', function (hooks) {
       .findRecord('instructor-group', instructorGroup.id);
     this.set('instructorGroup', instructorGroupModel);
     await render(
-      hbs`<InstructorGroup::Users @instructorGroup={{this.instructorGroup}} @canUpdate={{false}} />
-`
+      hbs`<InstructorGroup::Users @instructorGroup={{this.instructorGroup}} @canUpdate={{false}} />`
     );
     assert.strictEqual(component.title, 'Instructors (3)');
     assert.notOk(component.manage.isVisible);
@@ -68,8 +66,7 @@ module('Integration | Component | instructor-group/users', function (hooks) {
       .findRecord('instructor-group', instructorGroup.id);
     this.set('instructorGroup', instructorGroupModel);
     await render(
-      hbs`<InstructorGroup::Users @instructorGroup={{this.instructorGroup}} @canUpdate={{true}} />
-`
+      hbs`<InstructorGroup::Users @instructorGroup={{this.instructorGroup}} @canUpdate={{true}} />`
     );
     assert.strictEqual(component.title, 'Instructors (0)');
     assert.ok(component.manage.isVisible);
@@ -90,8 +87,7 @@ module('Integration | Component | instructor-group/users', function (hooks) {
     await render(hbs`<InstructorGroup::Users
       @instructorGroup={{this.instructorGroup}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.users.length, 3);
     assert.strictEqual(component.title, 'Instructors (3)');
     await component.manage.click();
@@ -118,8 +114,7 @@ module('Integration | Component | instructor-group/users', function (hooks) {
     await render(hbs`<InstructorGroup::Users
       @instructorGroup={{this.instructorGroup}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.users.length, 3);
     assert.strictEqual(component.title, 'Instructors (3)');
     await component.manage.click();
@@ -148,8 +143,7 @@ module('Integration | Component | instructor-group/users', function (hooks) {
     await render(hbs`<InstructorGroup::Users
       @instructorGroup={{this.instructorGroup}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.users.length, 2);
     assert.strictEqual(component.title, 'Instructors (2)');
     await component.manage.click();
@@ -179,8 +173,7 @@ module('Integration | Component | instructor-group/users', function (hooks) {
     await render(hbs`<InstructorGroup::Users
       @instructorGroup={{this.instructorGroup}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.users.length, 2);
     assert.strictEqual(component.title, 'Instructors (2)');
     await component.manage.click();

--- a/tests/integration/components/instructor-groups/list-item-test.js
+++ b/tests/integration/components/instructor-groups/list-item-test.js
@@ -32,8 +32,7 @@ module('Integration | Component | instructor-groups/list-item', function (hooks)
       .lookup('service:store')
       .findRecord('instructor-group', this.instructorGroup.id);
     this.set('instructorGroup', instructorGroupModel);
-    await render(hbs`<InstructorGroups::ListItem @instructorGroup={{this.instructorGroup}} />
-`);
+    await render(hbs`<InstructorGroups::ListItem @instructorGroup={{this.instructorGroup}} />`);
     assert.strictEqual(component.title, 'instructor group 0');
     assert.strictEqual(component.users, '3');
     assert.strictEqual(component.courses, '0');
@@ -51,8 +50,7 @@ module('Integration | Component | instructor-groups/list-item', function (hooks)
       .lookup('service:store')
       .findRecord('instructor-group', this.instructorGroup.id);
     this.set('instructorGroup', instructorGroupModel);
-    await render(hbs`<InstructorGroups::ListItem @instructorGroup={{this.instructorGroup}} />
-`);
+    await render(hbs`<InstructorGroups::ListItem @instructorGroup={{this.instructorGroup}} />`);
     assert.strictEqual(component.title, 'instructor group 0');
     assert.notOk(component.canBeDeleted);
     await a11yAudit(this.element);
@@ -85,8 +83,7 @@ module('Integration | Component | instructor-groups/list-item', function (hooks)
       .lookup('service:store')
       .findRecord('instructor-group', this.instructorGroup.id);
     this.set('instructorGroup', instructorGroupModel);
-    await render(hbs`<InstructorGroups::ListItem @instructorGroup={{this.instructorGroup}} />
-`);
+    await render(hbs`<InstructorGroups::ListItem @instructorGroup={{this.instructorGroup}} />`);
     assert.strictEqual(component.title, 'instructor group 0');
     assert.strictEqual(component.courses, '3');
     assert.notOk(component.canBeDeleted);

--- a/tests/integration/components/instructor-groups/list-test.js
+++ b/tests/integration/components/instructor-groups/list-test.js
@@ -33,8 +33,7 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
       @instructorGroups={{this.instructorGroups}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.header.title.text, 'Instructor Group Title');
     assert.strictEqual(component.header.members.text, 'Members');
     assert.strictEqual(component.items.length, 3);
@@ -52,8 +51,7 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
       @instructorGroups={{(array)}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.items.length, 0);
     assert.ok(component.isEmpty);
@@ -70,8 +68,7 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
       @instructorGroups={{this.instructorGroups}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(this.server.db.instructorGroups.length, 3);
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].title, 'instructor group 0');
@@ -93,8 +90,7 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
       @instructorGroups={{this.instructorGroups}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(this.server.db.instructorGroups.length, 3);
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].title, 'instructor group 0');
@@ -145,8 +141,7 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
       @instructorGroups={{this.instructorGroups}}
       @sortBy={{this.sortBy}}
       @setSortBy={{set this.sortBy}}
-    />
-`);
+    />`);
     assert.strictEqual(component.items.length, 3);
     assert.ok(component.header.title.isSortedAscending);
     assert.ok(component.header.members.isNotSorted);

--- a/tests/integration/components/instructor-groups/loading-test.js
+++ b/tests/integration/components/instructor-groups/loading-test.js
@@ -10,8 +10,7 @@ module('Integration | Component | instructor-groups/loading', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
-    await render(hbs`<InstructorGroups::Loading @count={{4}} />
-`);
+    await render(hbs`<InstructorGroups::Loading @count={{4}} />`);
     assert.dom('tbody tr').exists({ count: 4 });
     await a11yAudit(this.element);
   });

--- a/tests/integration/components/instructor-groups/new-test.js
+++ b/tests/integration/components/instructor-groups/new-test.js
@@ -14,8 +14,7 @@ module('Integration | Component | instructor-groups/new', function (hooks) {
     await render(hbs`<InstructorGroups::New
       @save={{(noop)}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title.label, 'Title:');
     assert.strictEqual(component.done.text, 'Done');
     assert.strictEqual(component.cancel.text, 'Cancel');
@@ -30,8 +29,7 @@ module('Integration | Component | instructor-groups/new', function (hooks) {
     await render(hbs`<InstructorGroups::New
       @save={{(noop)}}
       @cancel={{this.cancel}}
-    />
-`);
+    />`);
     await component.cancel.click();
   });
 
@@ -41,8 +39,7 @@ module('Integration | Component | instructor-groups/new', function (hooks) {
     await render(hbs`<InstructorGroups::New
       @save={{(noop)}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title.errors.length, 0);
     await component.done.click();
     assert.strictEqual(component.title.errors.length, 1);
@@ -55,8 +52,7 @@ module('Integration | Component | instructor-groups/new', function (hooks) {
     await render(hbs`<InstructorGroups::New
       @save={{(noop)}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title.errors.length, 0);
     await component.title.set('Aa');
     await component.done.click();
@@ -73,8 +69,7 @@ module('Integration | Component | instructor-groups/new', function (hooks) {
     await render(hbs`<InstructorGroups::New
       @save={{(noop)}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title.errors.length, 0);
     await component.title.set('0123456789'.repeat(21));
     await component.done.click();
@@ -94,8 +89,7 @@ module('Integration | Component | instructor-groups/new', function (hooks) {
     await render(hbs`<InstructorGroups::New
       @save={{this.save}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     await component.title.set('Jayden Rules!');
     await component.done.click();
   });

--- a/tests/integration/components/instructor-groups/root-test.js
+++ b/tests/integration/components/instructor-groups/root-test.js
@@ -49,8 +49,7 @@ module('Integration | Component | instructor-groups/root', function (hooks) {
       @schools={{this.schools}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.headerTitle, 'Instructor Groups (3)');
     assert.strictEqual(component.list.items.length, 3);
     assert.strictEqual(component.list.items[0].title, 'instructor group 3');
@@ -78,8 +77,7 @@ module('Integration | Component | instructor-groups/root', function (hooks) {
       @schoolId={{this.schoolId}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.headerTitle, 'Instructor Groups (3)');
     assert.strictEqual(component.schoolFilter.selectedSchool, '2');
     assert.strictEqual(component.list.items.length, 3);
@@ -110,8 +108,7 @@ module('Integration | Component | instructor-groups/root', function (hooks) {
       @titleFilter={{this.titleFilter}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.headerTitle, 'Instructor Groups (3)');
     assert.strictEqual(component.list.items.length, 3);
     assert.strictEqual(component.list.items[0].title, 'instructor group 3');
@@ -138,8 +135,7 @@ module('Integration | Component | instructor-groups/root', function (hooks) {
       @schools={{this.schools}}
       @sortBy={{this.sortBy}}
       @setSortBy={{this.setSortBy}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.list.items.length, 3);
     assert.strictEqual(component.list.items[0].title, 'instructor group 3');

--- a/tests/integration/components/learner-group/calendar-test.js
+++ b/tests/integration/components/learner-group/calendar-test.js
@@ -47,16 +47,14 @@ module('Integration | Component | learner-group/calendar', function (hooks) {
 
   test('shows events', async function (assert) {
     this.set('learnerGroup', this.learnerGroup);
-    await render(hbs`<LearnerGroup::Calendar @learnerGroup={{this.learnerGroup}} />
-`);
+    await render(hbs`<LearnerGroup::Calendar @learnerGroup={{this.learnerGroup}} />`);
     assert.strictEqual(component.calendar.events.length, 1);
   });
 
   // @todo this interaction is currently untestable using mirage/models. fix this [ST 2022/06/29]
   skip('shows subgroup events', async function (assert) {
     this.set('learnerGroup', this.learnerGroup);
-    await render(hbs`<LearnerGroup::Calendar @learnerGroup={{this.learnerGroup}} />
-`);
+    await render(hbs`<LearnerGroup::Calendar @learnerGroup={{this.learnerGroup}} />`);
     assert.strictEqual(component.calendar.events.length, 1);
     await component.showSubgroups.toggle.click();
     assert.strictEqual(component.calendar.events.length, 2);

--- a/tests/integration/components/learner-group/cohort-user-manager-test.js
+++ b/tests/integration/components/learner-group/cohort-user-manager-test.js
@@ -41,8 +41,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title, 'Cohort Members NOT assigned to top level group (2)');
     assert.strictEqual(component.users.length, 2);
@@ -81,8 +80,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.users.length, 3);
     assert.strictEqual(component.users[0].name.userNameInfo.fullName, 'Captain J');
@@ -110,8 +108,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{this.addMany}}
-    />
-`);
+    />`);
 
     assert.notOk(component.membersCanBeAdded);
     await component.users[0].select();
@@ -141,8 +138,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{this.addOne}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
 
     await component.users[0].add();
   });
@@ -164,8 +160,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.users[0].canBeAdded);
     await component.users[0].select();
@@ -195,8 +190,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{this.addMany}}
-    />
-`);
+    />`);
 
     assert.notOk(component.users[0].isSelected);
     assert.notOk(component.users[0].isSelected);
@@ -224,8 +218,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.users[0].isSelected);
     assert.notOk(component.users[1].isSelected);
@@ -263,8 +256,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.users.length, 3);
     assert.strictEqual(component.users[0].name.userNameInfo.fullName, 'Alpha');
@@ -344,8 +336,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.users[0].canBeSelected, 'Checkbox visible');
     assert.ok(component.users[0].name.isClickable);
@@ -374,8 +365,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.users[0].canBeSelected, 'Checkbox visible');
     assert.notOk(component.users[0].name.isClickable);
@@ -415,8 +405,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.users.length, 3);
     assert.strictEqual(component.users[0].name.userNameInfo.fullName, 'Jasper M. Dog');
@@ -445,8 +434,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.users[0].isSelected);
     await component.users[0].name.click();
     assert.ok(component.users[0].isSelected);
@@ -465,8 +453,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.users[0].isSelected);
     await component.users[0].campusId.click();
     assert.ok(component.users[0].isSelected);
@@ -485,8 +472,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       @setSortBy={{(noop)}}
       @addUserToGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.users[0].isSelected);
     await component.users[0].email.click();
     assert.ok(component.users[0].isSelected);

--- a/tests/integration/components/learner-group/header-test.js
+++ b/tests/integration/components/learner-group/header-test.js
@@ -32,8 +32,7 @@ module('Integration | Component | learner-group/header', function (hooks) {
     this.set('learnerGroup', this.learnerGroup);
     this.set('canUpdate', true);
     await render(
-      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />`
     );
     assert.strictEqual(component.title.text, 'lorem ipsum');
     assert.ok(component.title.isEditable);
@@ -50,8 +49,7 @@ module('Integration | Component | learner-group/header', function (hooks) {
     this.set('canUpdate', false);
 
     await render(
-      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
@@ -67,8 +65,7 @@ module('Integration | Component | learner-group/header', function (hooks) {
     this.set('canUpdate', true);
 
     await render(
-      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
@@ -84,8 +81,7 @@ module('Integration | Component | learner-group/header', function (hooks) {
     this.set('canUpdate', true);
 
     await render(
-      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
@@ -102,8 +98,7 @@ module('Integration | Component | learner-group/header', function (hooks) {
     this.set('canUpdate', true);
 
     await render(
-      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
@@ -120,8 +115,7 @@ module('Integration | Component | learner-group/header', function (hooks) {
     this.set('canUpdate', true);
 
     await render(
-      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
@@ -138,8 +132,7 @@ module('Integration | Component | learner-group/header', function (hooks) {
     this.set('canUpdate', true);
 
     await render(
-      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />
-`
+      hbs`<LearnerGroup::Header @learnerGroup={{this.learnerGroup}} @canUpdate={{this.canUpdate}} />`
     );
 
     assert.strictEqual(component.title.text, 'lorem ipsum');

--- a/tests/integration/components/learner-group/instructor-manager-test.js
+++ b/tests/integration/components/learner-group/instructor-manager-test.js
@@ -54,8 +54,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
       @learnerGroup={{this.learnerGroup}}
       @save={{(noop)}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title, 'Default Instructors (3)');
     assert.strictEqual(component.assignedInstructors.length, 3);
@@ -101,8 +100,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
       @learnerGroup={{this.learnerGroup}}
       @save={{(noop)}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, 'Default Instructors (0)');
     assert.strictEqual(component.selectedInstructors.length, 0);
   });
@@ -132,8 +130,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
       @learnerGroup={{this.learnerGroup}}
       @save={{(noop)}}
       @canUpdate={{false}}
-    />
-`);
+    />`);
     assert.strictEqual(component.assignedInstructors.length, 2);
     assert.notOk(component.manageButton.isVisible);
   });
@@ -164,8 +161,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
       @learnerGroup={{this.learnerGroup}}
       @save={{(noop)}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.assignedInstructors.length, 2);
     await component.manage();
     assert.strictEqual(component.selectedInstructors.length, 2);
@@ -219,8 +215,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
       @learnerGroup={{this.learnerGroup}}
       @save={{this.save}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.assignedInstructors.length, 3);
     await component.manage();
@@ -248,8 +243,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
       @learnerGroup={{this.learnerGroup}}
       @save={{(noop)}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     await component.manage();
     assert.strictEqual(component.selectedInstructorGroups.length, 0);
     await component.search('test group');
@@ -277,8 +271,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
       @learnerGroup={{this.learnerGroup}}
       @save={{(noop)}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     await component.manage();
     assert.strictEqual(component.selectedInstructors.length, 0);
     await component.search('test group');

--- a/tests/integration/components/learner-group/list-item-test.js
+++ b/tests/integration/components/learner-group/list-item-test.js
@@ -40,8 +40,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
       .lookup('service:store')
       .findRecord('learner-group', this.learnerGroup.id);
     this.set('learnerGroup', learnerGroupModel);
-    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />
-`);
+    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />`);
     assert.strictEqual(component.title, 'learner group 0');
     assert.strictEqual(component.users, '0');
     assert.strictEqual(component.children, '3');
@@ -60,8 +59,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
       .lookup('service:store')
       .findRecord('learner-group', this.learnerGroup.id);
     this.set('learnerGroup', learnerGroupModel);
-    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />
-`);
+    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />`);
     assert.strictEqual(component.title, 'learner group 0');
     assert.notOk(component.canBeDeleted);
     assert.ok(component.canBeCopied);
@@ -78,8 +76,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
       .lookup('service:store')
       .findRecord('learner-group', this.learnerGroup.id);
     this.set('learnerGroup', learnerGroupModel);
-    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />
-`);
+    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />`);
     assert.strictEqual(component.title, 'learner group 0');
     assert.ok(component.canBeDeleted);
     assert.notOk(component.canBeCopied);
@@ -93,8 +90,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
       .lookup('service:store')
       .findRecord('learner-group', this.learnerGroup.id);
     this.set('learnerGroup', learnerGroupModel);
-    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />
-`);
+    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />`);
     assert.strictEqual(component.title, 'learner group 0');
     assert.strictEqual(component.users, '1');
     assert.ok(component.canBeDeleted);
@@ -111,8 +107,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
       .lookup('service:store')
       .findRecord('learner-group', this.learnerGroup.id);
     this.set('learnerGroup', learnerGroupModel);
-    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />
-`);
+    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />`);
     assert.strictEqual(component.title, 'learner group 0');
     assert.strictEqual(component.children, '1');
     assert.strictEqual(component.users, '0');
@@ -127,8 +122,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
       .lookup('service:store')
       .findRecord('learner-group', this.learnerGroup.id);
     this.set('learnerGroup', learnerGroupModel);
-    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />
-`);
+    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />`);
     assert.strictEqual(component.title, 'learner group 0');
     assert.notOk(component.canBeDeleted);
   });
@@ -144,8 +138,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
       .lookup('service:store')
       .find('learner-group', this.learnerGroup.id);
     this.set('learnerGroup', learnerGroupModel);
-    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />
-`);
+    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />`);
     assert.strictEqual(component.title, 'learner group 0');
     assert.notOk(component.canBeDeleted);
   });
@@ -158,8 +151,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
       .lookup('service:store')
       .find('learner-group', this.learnerGroup.id);
     this.set('learnerGroup', learnerGroupModel);
-    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />
-`);
+    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />`);
     assert.strictEqual(component.title, 'learner group 0');
     assert.notOk(component.canBeDeleted);
   });
@@ -175,8 +167,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
       .lookup('service:store')
       .find('learner-group', this.learnerGroup.id);
     this.set('learnerGroup', learnerGroupModel);
-    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />
-`);
+    await render(hbs`<LearnerGroup::ListItem @learnerGroup={{this.learnerGroup}} />`);
     assert.strictEqual(component.title, 'learner group 0');
     assert.notOk(component.canBeDeleted);
   });

--- a/tests/integration/components/learner-group/list-test.js
+++ b/tests/integration/components/learner-group/list-test.js
@@ -44,8 +44,7 @@ module('Integration | Component | learner-group/list', function (hooks) {
       @learnerGroups={{this.learnerGroups}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].title, 'learner group 0');
@@ -88,8 +87,7 @@ module('Integration | Component | learner-group/list', function (hooks) {
       @learnerGroups={{this.learnerGroups}}
       @sortBy={{this.sortBy}}
       @setSortBy={{set this.sortBy}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.items.length, 3);
     assert.ok(component.header.title.isSortedAscending);
@@ -154,8 +152,7 @@ module('Integration | Component | learner-group/list', function (hooks) {
       @learnerGroups={{this.learnerGroups}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(this.server.db.learnerGroups.length, 3);
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].title, 'learner group 0');
@@ -174,8 +171,7 @@ module('Integration | Component | learner-group/list', function (hooks) {
       @learnerGroups={{this.learnerGroups}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(this.server.db.learnerGroups.length, 3);
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].title, 'learner group 0');
@@ -201,8 +197,7 @@ module('Integration | Component | learner-group/list', function (hooks) {
       @copyGroup={{this.copyGroup}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     await component.items[0].copy();
     assert.ok(component.confirmCopy.canCopyWithLearners);
     await component.confirmCopy.copyWithLearners();
@@ -223,8 +218,7 @@ module('Integration | Component | learner-group/list', function (hooks) {
       @copyGroup={{this.copyGroup}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     await component.items[0].copy();
     assert.ok(component.confirmCopy.canCopyWithLearners);
     await component.confirmCopy.copyWithoutLearners();
@@ -245,8 +239,7 @@ module('Integration | Component | learner-group/list', function (hooks) {
       @copyGroup={{this.copyGroup}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     await component.items[0].copy();
     assert.notOk(component.confirmCopy.canCopyWithLearners);
     await component.confirmCopy.copyWithoutLearners();
@@ -266,8 +259,7 @@ module('Integration | Component | learner-group/list', function (hooks) {
       @copyGroup={{this.copyGroup}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     await component.items[0].copy();
     assert.ok(component.confirmCopy.isPresent);
     assert.ok(component.confirmCopy.canCopyWithLearners);
@@ -289,8 +281,7 @@ module('Integration | Component | learner-group/list', function (hooks) {
       @copyGroup={{this.copyGroup}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     await component.items[0].copy();
     assert.ok(component.confirmCopy.isPresent);
     assert.notOk(component.confirmCopy.canCopyWithLearners);

--- a/tests/integration/components/learner-group/new-multiple-test.js
+++ b/tests/integration/components/learner-group/new-multiple-test.js
@@ -14,8 +14,7 @@ module('Integration | Component | learner-group/new-multiple', function (hooks) 
     await render(hbs`<LearnerGroup::NewMultiple
       @cancel={{(noop)}}
       @generateNewLearnerGroups={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.isVisible);
     await a11yAudit(this.element);
   });
@@ -28,8 +27,7 @@ module('Integration | Component | learner-group/new-multiple', function (hooks) 
     await render(hbs`<LearnerGroup::NewMultiple
       @generateNewLearnerGroups={{this.save}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     await component.setNumberOfGroups(13);
     await component.save();
   });

--- a/tests/integration/components/learner-group/new-single-test.js
+++ b/tests/integration/components/learner-group/new-single-test.js
@@ -14,8 +14,7 @@ module('Integration | Component | learner-group/new-single', function (hooks) {
     await render(hbs`<LearnerGroup::NewSingle
       @save={{(noop)}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.isVisible);
     assert.notOk(component.canFill);
     await a11yAudit(this.element);
@@ -26,8 +25,7 @@ module('Integration | Component | learner-group/new-single', function (hooks) {
       @save={{(noop)}}
       @cancel={{(noop)}}
       @fillModeSupported={{false}}
-    />
-`);
+    />`);
     assert.ok(component.isVisible);
     assert.notOk(component.canFill);
     await a11yAudit(this.element);
@@ -43,8 +41,7 @@ module('Integration | Component | learner-group/new-single', function (hooks) {
       @save={{this.save}}
       @cancel={{(noop)}}
       @fillModeSupported={{true}}
-    />
-`);
+    />`);
     await component.title('new group');
     await component.save();
   });
@@ -59,8 +56,7 @@ module('Integration | Component | learner-group/new-single', function (hooks) {
       @save={{this.save}}
       @cancel={{(noop)}}
       @fillModeSupported={{true}}
-    />
-`);
+    />`);
     await component.title('new group');
     assert.ok(component.canFill);
     await component.fillWithCohort();

--- a/tests/integration/components/learner-group/new-test.js
+++ b/tests/integration/components/learner-group/new-test.js
@@ -15,8 +15,7 @@ module('Integration | Component | learner-group/new', function (hooks) {
       @save={{(noop)}}
       @cancel={{(noop)}}
       @fillModeSupported={{true}}
-    />
-`);
+    />`);
     assert.ok(component.single.isVisible);
     await a11yAudit(this.element);
   });
@@ -27,8 +26,7 @@ module('Integration | Component | learner-group/new', function (hooks) {
       @cancel={{(noop)}}
       @generateNewLearnerGroups={{(noop)}}
       @multiModeSupported={{true}}
-    />
-`);
+    />`);
     await component.chooseMultipleGroups();
     assert.ok(component.multiple.isVisible);
     await a11yAudit(this.element);

--- a/tests/integration/components/learner-group/root-test.js
+++ b/tests/integration/components/learner-group/root-test.js
@@ -89,8 +89,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @learnerGroup={{this.learnerGroup}}
       @isEditing={{false}}
       @isBulkAssigning={{false}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.defaultLocation.text, 'Default Location: test location');
     assert.strictEqual(component.instructorManager.assignedInstructors.length, 2);
@@ -138,8 +137,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @learnerGroup={{this.learnerGroup}}
       @isEditing={{false}}
       @isBulkAssigning={{false}}
-    />
-`);
+    />`);
 
     assert.ok(component.actions.buttons.toggle.isVisible);
     assert.notOk(component.actions.buttons.bulkAssignment.isVisible);
@@ -165,8 +163,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @isEditing={{false}}
       @isBulkAssigning={{false}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.needsAccommodation.toggle.checked, 'true');
   });
 
@@ -187,8 +184,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @isEditing={{false}}
       @isBulkAssigning={{false}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.needsAccommodation.toggle.checked, 'false');
   });
 
@@ -209,8 +205,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @isEditing={{false}}
       @isBulkAssigning={{false}}
       @canUpdate={{false}}
-    />
-`);
+    />`);
     assert.strictEqual(
       component.needsAccommodation.text,
       'Accommodation is required for learners in this group: Yes'
@@ -234,8 +229,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @isEditing={{false}}
       @isBulkAssigning={{false}}
       @canUpdate={{false}}
-    />
-`);
+    />`);
     assert.strictEqual(
       component.needsAccommodation.text,
       'Accommodation is required for learners in this group: No'
@@ -259,8 +253,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @isEditing={{false}}
       @isBulkAssigning={{false}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.needsAccommodation.toggle.checked, 'false');
     await component.needsAccommodation.toggle.click();
     assert.strictEqual(component.needsAccommodation.toggle.checked, 'true');
@@ -284,8 +277,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @learnerGroup={{this.learnerGroup}}
       @isEditing={{false}}
       @isBulkAssigning={{false}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.defaultLocation.text, 'Default Location: test location');
     await component.defaultLocation.edit();
@@ -312,8 +304,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @learnerGroup={{this.learnerGroup}}
       @isEditing={{false}}
       @isBulkAssigning={{false}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.defaultLocation.text, 'Default Location: test location');
     await component.defaultLocation.edit();
@@ -360,8 +351,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @learnerGroup={{this.learnerGroup}}
       @isEditing={{false}}
       @isBulkAssigning={{false}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.associatedCourses.courses.length, 1);
     assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0');
@@ -397,8 +387,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @learnerGroup={{this.learnerGroup}}
       @isEditing={{false}}
       @isBulkAssigning={{false}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.associatedCourses.courses.length, 2);
     assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0');
@@ -427,8 +416,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @learnerGroup={{this.learnerGroup}}
       @isEditing={{false}}
       @isBulkAssigning={{false}}
-    />
-`);
+    />`);
 
     assert.strictEqual(
       component.defaultUrl.text,
@@ -460,8 +448,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @learnerGroup={{this.learnerGroup}}
       @isEditing={{false}}
       @isBulkAssigning={{false}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.defaultUrl.text, 'Default Virtual Learning Link: Click to edit');
     await component.defaultUrl.edit();
@@ -509,8 +496,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @learnerGroup={{this.learnerGroup}}
       @isEditing={{false}}
       @isBulkAssigning={{false}}
-    />
-`);
+    />`);
 
     assert.notOk(component.calendar.isVisible);
     assert.strictEqual(component.actions.buttons.toggle.firstLabel.text, 'Hide Calendar');
@@ -539,8 +525,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @learnerGroup={{this.learnerGroup}}
       @isEditing={{true}}
       @isBulkAssigning={{false}}
-    />
-`);
+    />`);
 
     assert.notOk(component.actions.buttons.toggle.isVisible);
     assert.notOk(component.actions.buttons.bulkAssignment.isVisible);
@@ -569,8 +554,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       @learnerGroup={{this.learnerGroup}}
       @isEditing={{false}}
       @isBulkAssigning={{this.isBulkAssigning}}
-    />
-`);
+    />`);
     await component.actions.buttons.bulkAssignment.click();
     assert.notOk(component.actions.buttons.toggle.isVisible);
     assert.notOk(component.actions.buttons.bulkAssignment.isVisible);

--- a/tests/integration/components/learner-group/user-manager-test.js
+++ b/tests/integration/components/learner-group/user-manager-test.js
@@ -62,8 +62,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.usersInCurrentGroup.length, 2);
     assert.strictEqual(
       component.usersInCurrentGroup[0].name.userNameInfo.fullName,
@@ -136,8 +135,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.groupMembers, 'Members of current group (2)');
     assert.strictEqual(component.allOtherMembers, 'All other members of top group (0)');
@@ -219,8 +217,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.usersNotInCurrentGroup.length, 3);
     assert.strictEqual(component.usersNotInCurrentGroup[0].name.userNameInfo.fullName, 'Captain J');
@@ -266,8 +263,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{this.addMany}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.membersCanBeAdded);
     await component.usersInCurrentGroup[0].select();
@@ -309,8 +305,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{this.removeMany}}
-    />
-`);
+    />`);
 
     assert.notOk(component.membersCanBeRemoved);
     await component.usersInCurrentGroup[0].select();
@@ -354,8 +349,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{this.removeOne}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     await component.usersInCurrentGroup[0].remove();
   });
@@ -398,8 +392,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
     await component.usersNotInCurrentGroup[0].add();
   });
 
@@ -442,8 +435,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.usersInCurrentGroup[0].canBeRemoved);
     assert.ok(component.usersNotInCurrentGroup[0].canBeAdded);
@@ -493,8 +485,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{this.addMany}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.usersInCurrentGroup[0].isSelected);
     assert.notOk(component.usersInCurrentGroup[0].isSelected);
     await component.selectAll.toggle();
@@ -540,8 +531,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.usersInCurrentGroup[0].isSelected);
     assert.notOk(component.usersInCurrentGroup[1].isSelected);
@@ -605,8 +595,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.usersInCurrentGroup.length, 3);
     assert.strictEqual(component.usersInCurrentGroup[0].name.userNameInfo.fullName, 'Alpha');
@@ -700,8 +689,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.usersInCurrentGroup[0].canBeSelected, 'Checkbox visible');
     assert.ok(component.usersInCurrentGroup[0].isDisabled, 'User is labeled as disabled.');
@@ -740,8 +728,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.usersInCurrentGroup[0].canBeSelected, 'Checkbox visible');
     assert.ok(component.usersInCurrentGroup[0].isDisabled, 'User is labeled as disabled.');
@@ -805,8 +792,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.usersInCurrentGroup.length, 3);
     assert.strictEqual(
@@ -866,8 +852,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.usersNotInCurrentGroup[0].isSelected);
     await component.usersNotInCurrentGroup[0].name.click();
@@ -906,8 +891,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.usersNotInCurrentGroup[0].isSelected);
     await component.usersNotInCurrentGroup[0].campusId.click();
@@ -946,8 +930,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.usersNotInCurrentGroup[0].isSelected);
     await component.usersNotInCurrentGroup[0].email.click();
@@ -982,8 +965,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.usersInCurrentGroup[0].isSelected);
     await component.usersInCurrentGroup[0].name.click();
@@ -1018,8 +1000,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.usersInCurrentGroup[0].isSelected);
     await component.usersInCurrentGroup[0].campusId.click();
@@ -1054,8 +1035,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
       @removeUserFromGroup={{(noop)}}
       @addUsersToGroup={{(noop)}}
       @removeUsersFromGroup={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.usersInCurrentGroup[0].isSelected);
     await component.usersInCurrentGroup[0].email.click();

--- a/tests/integration/components/learner-groups/root-test.js
+++ b/tests/integration/components/learner-groups/root-test.js
@@ -65,8 +65,7 @@ module('Integration | Component | learner-groups/root', function (hooks) {
       @schools={{this.schools}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.headerTitle, 'Learner Groups (2)');
     assert.strictEqual(component.list.items.length, 2);
     assert.strictEqual(component.list.items[0].title, 'learner group 2');
@@ -119,8 +118,7 @@ module('Integration | Component | learner-groups/root', function (hooks) {
       @programYearId={{this.programYearId}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.schoolFilter.selectedSchool, '2');
     assert.strictEqual(component.programFilter.selectedProgram, '4');
     assert.strictEqual(component.programYearFilter.selectedProgramYear, '6');
@@ -163,8 +161,7 @@ module('Integration | Component | learner-groups/root', function (hooks) {
       @programYearId={{this.programYearId}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.schoolFilter.selectedSchool, '2');
     assert.strictEqual(component.programFilter.selectedProgram, '4');
     assert.strictEqual(component.programYearFilter.selectedProgramYear, '6');
@@ -205,8 +202,7 @@ module('Integration | Component | learner-groups/root', function (hooks) {
       @programYearId={{this.programYearId}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.schoolFilter.selectedSchool, '2');
     assert.strictEqual(component.programFilter.selectedProgram, '4');
     assert.strictEqual(component.programYearFilter.selectedProgramYear, '6');
@@ -235,8 +231,7 @@ module('Integration | Component | learner-groups/root', function (hooks) {
       @titleFilter={{this.titleFilter}}
       @sortBy="title"
       @setSortBy={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.headerTitle, 'Learner Groups (2)');
     assert.strictEqual(component.list.items.length, 2);
     assert.strictEqual(component.list.items[0].title, 'learner group 2');
@@ -262,8 +257,7 @@ module('Integration | Component | learner-groups/root', function (hooks) {
       @schools={{this.schools}}
       @sortBy={{this.sortBy}}
       @setSortBy={{this.setSortBy}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.list.items.length, 2);
     assert.strictEqual(component.list.items[0].title, 'learner group 2');

--- a/tests/integration/components/link-to-with-action-test.js
+++ b/tests/integration/components/link-to-with-action-test.js
@@ -28,9 +28,7 @@ module('Integration | Component | link-to-with-action', function (hooks) {
     await render(hbs`
       <LinkToWithAction @route="somewhere">
         {{this.content}}
-      </LinkToWithAction>
-
-`);
+      </LinkToWithAction>`);
 
     assert.strictEqual(this.element.textContent.trim(), 'Link Text');
     assert.strictEqual(this.element.querySelector('a').getAttribute('href'), '/here/somewhere');
@@ -52,9 +50,7 @@ module('Integration | Component | link-to-with-action', function (hooks) {
     await render(hbs`
       <LinkToWithAction @route="somewhere">
         {{this.content}}
-      </LinkToWithAction>
-
-`);
+      </LinkToWithAction>`);
 
     assert.strictEqual(this.element.textContent.trim(), 'More Link Text');
     assert.ok(this.element.querySelector('a').classList.contains('active'));

--- a/tests/integration/components/locale-chooser-test.js
+++ b/tests/integration/components/locale-chooser-test.js
@@ -11,8 +11,7 @@ module('Integration | Component | locale-chooser', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   test('it renders and is accessible', async function (assert) {
-    await render(hbs`<LocaleChooser />
-`);
+    await render(hbs`<LocaleChooser />`);
 
     await a11yAudit(this.element);
     assert.strictEqual(component.text, 'English (en)');
@@ -23,8 +22,7 @@ module('Integration | Component | locale-chooser', function (hooks) {
   });
 
   test('click opens menu', async function (assert) {
-    await render(hbs`<LocaleChooser />
-`);
+    await render(hbs`<LocaleChooser />`);
 
     assert.strictEqual(component.locales.length, 0);
     await component.toggle.click();
@@ -32,8 +30,7 @@ module('Integration | Component | locale-chooser', function (hooks) {
   });
 
   test('down opens menu', async function (assert) {
-    await render(hbs`<LocaleChooser />
-`);
+    await render(hbs`<LocaleChooser />`);
 
     assert.strictEqual(component.locales.length, 0);
     await component.toggle.down();
@@ -41,8 +38,7 @@ module('Integration | Component | locale-chooser', function (hooks) {
   });
 
   test('escape closes menu', async function (assert) {
-    await render(hbs`<LocaleChooser />
-`);
+    await render(hbs`<LocaleChooser />`);
 
     await component.toggle.down();
     assert.strictEqual(component.locales.length, 3);
@@ -51,8 +47,7 @@ module('Integration | Component | locale-chooser', function (hooks) {
   });
 
   test('click closes menu', async function (assert) {
-    await render(hbs`<LocaleChooser />
-`);
+    await render(hbs`<LocaleChooser />`);
 
     await component.toggle.down();
     assert.strictEqual(component.locales.length, 3);
@@ -61,8 +56,7 @@ module('Integration | Component | locale-chooser', function (hooks) {
   });
 
   test('change locale closes menu', async function (assert) {
-    await render(hbs`<LocaleChooser />
-`);
+    await render(hbs`<LocaleChooser />`);
 
     await component.toggle.click();
     await component.locales[1].click();

--- a/tests/integration/components/login-form-test.js
+++ b/tests/integration/components/login-form-test.js
@@ -12,8 +12,7 @@ module('Integration | Component | login-form', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
-    await render(hbs`<LoginForm />
-`);
+    await render(hbs`<LoginForm />`);
     assert.strictEqual(component.errors.length, 0);
     assert.ok(component.form.isPresent);
     assert.strictEqual(component.form.username.label, 'Username:');
@@ -29,8 +28,7 @@ module('Integration | Component | login-form', function (hooks) {
     this.set('account', accountName);
     this.set('error', true);
     await render(
-      hbs`<LoginForm @noAccountExistsError={{this.error}} @noAccountExistsAccount={{this.account}} />
-`
+      hbs`<LoginForm @noAccountExistsError={{this.error}} @noAccountExistsAccount={{this.account}} />`
     );
     assert.strictEqual(component.errors.length, 1);
     assert.strictEqual(
@@ -53,8 +51,7 @@ module('Integration | Component | login-form', function (hooks) {
       }
     };
     this.owner.register('service:session', sessionMock);
-    await render(hbs`<LoginForm />
-`);
+    await render(hbs`<LoginForm />`);
     assert.strictEqual(component.errors.length, 0);
     await component.form.username.set(username);
     await component.form.password.set(password);
@@ -74,8 +71,7 @@ module('Integration | Component | login-form', function (hooks) {
       }
     };
     this.owner.register('service:session', sessionMock);
-    await render(hbs`<LoginForm />
-`);
+    await render(hbs`<LoginForm />`);
     assert.strictEqual(component.errors.length, 0);
     await component.form.username.set(username);
     await component.form.password.set(password);
@@ -94,8 +90,7 @@ module('Integration | Component | login-form', function (hooks) {
       }
     };
     this.owner.register('service:session', sessionMock);
-    await render(hbs`<LoginForm />
-`);
+    await render(hbs`<LoginForm />`);
     await component.form.username.set(username);
     await component.form.password.set(password);
     await component.form.username.submit();
@@ -112,8 +107,7 @@ module('Integration | Component | login-form', function (hooks) {
       }
     };
     this.owner.register('service:session', sessionMock);
-    await render(hbs`<LoginForm />
-`);
+    await render(hbs`<LoginForm />`);
     await component.form.username.set(username);
     await component.form.password.set(password);
     await component.form.password.submit();
@@ -130,8 +124,7 @@ module('Integration | Component | login-form', function (hooks) {
       }
     };
     this.owner.register('service:session', sessionMock);
-    await render(hbs`<LoginForm />
-`);
+    await render(hbs`<LoginForm />`);
     assert.strictEqual(component.form.username.errors.length, 0);
     assert.strictEqual(component.form.password.errors.length, 0);
     await component.form.password.submit();

--- a/tests/integration/components/manage-users-summary-test.js
+++ b/tests/integration/components/manage-users-summary-test.js
@@ -22,8 +22,7 @@ module('Integration | Component | manage users summary', function (hooks) {
   });
 
   test('it renders', async function (assert) {
-    await render(hbs`<ManageUsersSummary @canCreate={{true}} />
-`);
+    await render(hbs`<ManageUsersSummary @canCreate={{true}} />`);
 
     assert.ok(find('h2').textContent.trim().startsWith('Ilios Users'));
     assert.ok(find('h2').textContent.includes('View All'));
@@ -37,8 +36,7 @@ module('Integration | Component | manage users summary', function (hooks) {
    * [JJ 3/2017]
    */
   skip('it renders URLs', function (assert) {
-    render(hbs`<ManageUsersSummary />
-`);
+    render(hbs`<ManageUsersSummary />`);
 
     assert.notEqual(find('a').href.search(/\/users$/), -1, `${find('a').href} links to /users`);
     assert.notEqual(
@@ -54,8 +52,7 @@ module('Integration | Component | manage users summary', function (hooks) {
   });
 
   test('show more input prompt', async function (assert) {
-    await render(hbs`<ManageUsersSummary />
-`);
+    await render(hbs`<ManageUsersSummary />`);
 
     const userSearch = '.user-search input';
     const results = '.user-search .results li';

--- a/tests/integration/components/my-profile-test.js
+++ b/tests/integration/components/my-profile-test.js
@@ -49,8 +49,7 @@ module('Integration | Component | my profile', function (hooks) {
       @user={{this.user}}
       @toggleShowCreateNewToken={{(noop)}}
       @toggleShowInvalidateTokens={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.name, 'test name');
     assert.ok(component.userIsStudent);
@@ -74,8 +73,7 @@ module('Integration | Component | my profile', function (hooks) {
       @user={{this.user}}
       @toggleShowCreateNewToken={{(noop)}}
       @toggleShowInvalidateTokens={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.userIsStudent);
     assert.strictEqual(component.primarySchool, 'Unassigned');
@@ -110,8 +108,7 @@ module('Integration | Component | my profile', function (hooks) {
       @showCreateNewToken={{true}}
       @toggleShowCreateNewToken={{(noop)}}
       @toggleShowInvalidateTokens={{(noop)}}
-    />
-`);
+    />`);
 
     await component.newTokenForm.submit();
     assert.strictEqual(component.newTokenResult.value, 'new token');
@@ -138,8 +135,7 @@ module('Integration | Component | my profile', function (hooks) {
       @user={{this.user}}
       @showCreateNewToken={{true}}
       @toggleShowCreateNewToken={{this.toggle}}
-    />
-`);
+    />`);
 
     await component.newTokenForm.submit();
     assert.strictEqual(component.newTokenResult.value, 'new token');
@@ -162,8 +158,7 @@ module('Integration | Component | my profile', function (hooks) {
       @user={{this.user}}
       @toggleShowCreateNewToken={{this.toggle}}
       @toggleShowInvalidateTokens={{(noop)}}
-    />
-`);
+    />`);
 
     await component.showCreateNewTokenForm();
   });
@@ -194,8 +189,7 @@ module('Integration | Component | my profile', function (hooks) {
       @showCreateNewToken={{true}}
       @toggleShowCreateNewToken={{(noop)}}
       @toggleShowInvalidateTokens={{(noop)}}
-    />
-`);
+    />`);
 
     const dt = DateTime.fromObject({ hours: 8 }).plus({ days: 41 }).toJSDate();
     await component.newTokenForm.setDate(dt);
@@ -216,8 +210,7 @@ module('Integration | Component | my profile', function (hooks) {
       @user={{this.user}}
       @toggleShowCreateNewToken={{(noop)}}
       @toggleShowInvalidateTokens={{this.toggle}}
-    />
-`);
+    />`);
 
     await component.showInvalidateTokensForm();
   });
@@ -251,8 +244,7 @@ module('Integration | Component | my profile', function (hooks) {
       @showInvalidateTokens={{true}}
       @toggleShowCreateNewToken={{(noop)}}
       @toggleShowInvalidateTokens={{(noop)}}
-    />
-`);
+    />`);
 
     await component.invalidateTokensForm.submit();
   });

--- a/tests/integration/components/new-competency-test.js
+++ b/tests/integration/components/new-competency-test.js
@@ -15,15 +15,13 @@ module('Integration | Component | new competency', function (hooks) {
     this.set('add', (value) => {
       assert.strictEqual(value, title);
     });
-    await render(hbs`<NewCompetency @add={{this.add}} />
-`);
+    await render(hbs`<NewCompetency @add={{this.add}} />`);
     await component.title.set(title);
     await component.save();
   });
 
   test('validation fails if title is too short', async function (assert) {
-    await render(hbs`<NewCompetency @add={{(noop)}}/>
-`);
+    await render(hbs`<NewCompetency @add={{(noop)}}/>`);
     assert.notOk(component.hasError);
     await component.title.set('');
     await component.title.submit();
@@ -31,8 +29,7 @@ module('Integration | Component | new competency', function (hooks) {
   });
 
   test('validation fails if title is too long', async function (assert) {
-    await render(hbs`<NewCompetency @add={{(noop)}}/>
-`);
+    await render(hbs`<NewCompetency @add={{(noop)}}/>`);
     assert.notOk(component.hasError);
     await component.title.set('0123456789'.repeat(21));
     await component.title.submit();
@@ -40,8 +37,7 @@ module('Integration | Component | new competency', function (hooks) {
   });
 
   test('pressing escape in input element clears value and error messages', async function (assert) {
-    await render(hbs`<NewCompetency @add={{(noop)}}/>
-`);
+    await render(hbs`<NewCompetency @add={{(noop)}}/>`);
     assert.notOk(component.hasError);
     await component.title.set('0123456789'.repeat(21));
     await component.title.submit();

--- a/tests/integration/components/new-course-test.js
+++ b/tests/integration/components/new-course-test.js
@@ -19,8 +19,7 @@ module('Integration | Component | new course', function (hooks) {
   test('it renders', async function (assert) {
     const thisYear = new Date().getFullYear();
     await render(
-      hbs`<NewCourse @currentSchool={{this.school}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<NewCourse @currentSchool={{this.school}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
     assert.strictEqual(component.years.length, 6);
     assert.strictEqual(component.years[0].text, 'Select Academic Year');
@@ -45,8 +44,7 @@ module('Integration | Component | new course', function (hooks) {
       .findRecord('academic-year', academicYear.id);
     this.set('year', academicYearModel);
     await render(
-      hbs`<NewCourse @currentSchool={{this.school}} @save={{(noop)}} @cancel={{(noop)}} @currentYear={{this.year}} />
-`
+      hbs`<NewCourse @currentSchool={{this.school}} @save={{(noop)}} @cancel={{(noop)}} @currentYear={{this.year}} />`
     );
     assert.notOk(component.years[0].selected);
     assert.notOk(component.years[1].selected);
@@ -64,8 +62,7 @@ module('Integration | Component | new course', function (hooks) {
       .findRecord('academic-year', academicYear.id);
     this.set('year', academicYearModel);
     await render(
-      hbs`<NewCourse @currentSchool={{this.school}} @save={{(noop)}} @cancel={{(noop)}} @currentYear={{this.year}} />
-`
+      hbs`<NewCourse @currentSchool={{this.school}} @save={{(noop)}} @cancel={{(noop)}} @currentYear={{this.year}} />`
     );
     assert.ok(component.years[0].selected);
     assert.notOk(component.years[1].selected);
@@ -86,8 +83,7 @@ module('Integration | Component | new course', function (hooks) {
     });
     const thisYear = new Date().getFullYear();
     await render(
-      hbs`<NewCourse @currentSchool={{this.school}} @save={{(noop)}} @cancel={{(noop)}} />
-`
+      hbs`<NewCourse @currentSchool={{this.school}} @save={{(noop)}} @cancel={{(noop)}} />`
     );
     assert.strictEqual(component.years[1].text, `${thisYear - 2} - ${thisYear - 1}`);
     assert.strictEqual(component.years[2].text, `${thisYear - 1} - ${thisYear}`);
@@ -102,8 +98,7 @@ module('Integration | Component | new course', function (hooks) {
       assert.ok(true);
     });
     await render(
-      hbs`<NewCourse @currentSchool={{this.school}} @save={{(noop)}} @cancel={{this.cancel}} />
-`
+      hbs`<NewCourse @currentSchool={{this.school}} @save={{(noop)}} @cancel={{this.cancel}} />`
     );
     await component.cancel();
   });
@@ -124,8 +119,7 @@ module('Integration | Component | new course', function (hooks) {
       assert.strictEqual(school.id, this.school.id);
     });
     await render(
-      hbs`<NewCourse @currentSchool={{this.school}} @save={{this.save}} @cancel={{(noop)}} @currentYear={{this.year}} />
-`
+      hbs`<NewCourse @currentSchool={{this.school}} @save={{this.save}} @cancel={{(noop)}} @currentYear={{this.year}} />`
     );
     await component.title('test course');
     await component.save();
@@ -147,8 +141,7 @@ module('Integration | Component | new course', function (hooks) {
       assert.strictEqual(school.id, this.school.id);
     });
     await render(
-      hbs`<NewCourse @currentSchool={{this.school}} @save={{this.save}} @cancel={{(noop)}} @currentYear={{this.year}} />
-`
+      hbs`<NewCourse @currentSchool={{this.school}} @save={{this.save}} @cancel={{(noop)}} @currentYear={{this.year}} />`
     );
     await component.title('test course');
     await component.submitOnEnter();
@@ -166,8 +159,7 @@ module('Integration | Component | new course', function (hooks) {
       assert.ok(false, 'this code should never be invoked.');
     });
     await render(
-      hbs`<NewCourse @currentSchool={{this.school}} @save={{this.save}} @cancel={{(noop)}} @currentYear={{this.year}} />
-`
+      hbs`<NewCourse @currentSchool={{this.school}} @save={{this.save}} @cancel={{(noop)}} @currentYear={{this.year}} />`
     );
     assert.notOk(component.titleHasValidationError);
     await component.title('fo');
@@ -187,8 +179,7 @@ module('Integration | Component | new course', function (hooks) {
       assert.ok(false, 'this code should never be invoked.');
     });
     await render(
-      hbs`<NewCourse @currentSchool={{this.school}} @save={{this.save}} @cancel={{(noop)}} @currentYear={{this.year}} />
-`
+      hbs`<NewCourse @currentSchool={{this.school}} @save={{this.save}} @cancel={{(noop)}} @currentYear={{this.year}} />`
     );
     assert.notOk(component.titleHasValidationError);
     await component.title('0123456789'.repeat(21));

--- a/tests/integration/components/new-directory-user-test.js
+++ b/tests/integration/components/new-directory-user-test.js
@@ -36,8 +36,7 @@ module('Integration | Component | new directory user', function (hooks) {
   });
 
   test('it renders and is accessible', async function (assert) {
-    await render(hbs`<NewDirectoryUser @close={{(noop)}} @setSearchTerms={{(noop)}} />
-`);
+    await render(hbs`<NewDirectoryUser @close={{(noop)}} @setSearchTerms={{(noop)}} />`);
     await a11yAudit();
     assert.ok(true, 'no a11y errors found.');
   });
@@ -52,8 +51,7 @@ module('Integration | Component | new directory user', function (hooks) {
       @close={{(noop)}}
       @setSearchTerms={{this.setSearchTerms}}
       @searchTerms={{this.startingSearchTerms}}
-    />
-`);
+    />`);
     await component.search.set(searchTerm);
     await component.search.submit();
   });
@@ -75,8 +73,7 @@ module('Integration | Component | new directory user', function (hooks) {
       @close={{(noop)}}
       @setSearchTerms={{(noop)}}
       @searchTerms={{this.startingSearchTerms}}
-    />
-`);
+    />`);
     assert.strictEqual(component.search.value, startingSearchTerms);
   });
 
@@ -164,8 +161,7 @@ module('Integration | Component | new directory user', function (hooks) {
       @setSearchTerms={{(noop)}}
       @transitionToUser={{this.transitionToUser}}
       @searchTerms="searchterm"
-    />
-`);
+    />`);
 
     assert.strictEqual(component.searchResults.length, 3);
     assert.ok(component.searchResults[0].userCanBeAdded);

--- a/tests/integration/components/new-user-test.js
+++ b/tests/integration/components/new-user-test.js
@@ -44,8 +44,7 @@ module('Integration | Component | new user', function (hooks) {
   });
 
   test('it renders', async function (assert) {
-    await render(hbs`<NewUser @close={{(noop)}} />
-`);
+    await render(hbs`<NewUser @close={{(noop)}} />`);
 
     await component.clickChoiceButtons.firstButton.isActive;
     assert.strictEqual(component.school.options.length, 3);
@@ -55,8 +54,7 @@ module('Integration | Component | new user', function (hooks) {
   });
 
   test('errors do not show up initially', async function (assert) {
-    await render(hbs`<NewUser @close={{(noop)}} />
-`);
+    await render(hbs`<NewUser @close={{(noop)}} />`);
 
     assert.notOk(component.firstName.hasError);
     assert.notOk(component.middleName.hasError);
@@ -70,8 +68,7 @@ module('Integration | Component | new user', function (hooks) {
   });
 
   test('submit empty form', async function (assert) {
-    await render(hbs`<NewUser @close={{(noop)}} />
-`);
+    await render(hbs`<NewUser @close={{(noop)}} />`);
     await component.submit();
 
     assert.ok(component.firstName.hasError);
@@ -95,8 +92,7 @@ module('Integration | Component | new user', function (hooks) {
     this.set('transitionToUser', (userId) => {
       assert.strictEqual(parseInt(userId, 10), 2);
     });
-    await render(hbs`<NewUser @close={{(noop)}} @transitionToUser={{this.transitionToUser}} />
-`);
+    await render(hbs`<NewUser @close={{(noop)}} @transitionToUser={{this.transitionToUser}} />`);
 
     await component.firstName.set('first');
     await component.middleName.set('middle');
@@ -141,8 +137,7 @@ module('Integration | Component | new user', function (hooks) {
     this.set('transitionToUser', (userId) => {
       assert.strictEqual(parseInt(userId, 10), 2);
     });
-    await render(hbs`<NewUser @close={{(noop)}} @transitionToUser={{this.transitionToUser}} />
-`);
+    await render(hbs`<NewUser @close={{(noop)}} @transitionToUser={{this.transitionToUser}} />`);
     await component.clickChoiceButtons.secondButton.click();
     await component.firstName.set('first');
     await component.middleName.set('middle');
@@ -179,8 +174,7 @@ module('Integration | Component | new user', function (hooks) {
     this.set('cancel', () => {
       assert.ok(true, 'cancel event fired.');
     });
-    await render(hbs`<NewUser @close={{this.cancel}}  />
-`);
+    await render(hbs`<NewUser @close={{this.cancel}}  />`);
     await component.cancel();
   });
 
@@ -206,8 +200,7 @@ module('Integration | Component | new user', function (hooks) {
     });
     this.server.create('cohort', { programYear: programYear3 });
 
-    await render(hbs`<NewUser @close={{(noop)}}  />
-`);
+    await render(hbs`<NewUser @close={{(noop)}}  />`);
     await component.cancel();
     await component.clickChoiceButtons.secondButton.click();
 
@@ -225,8 +218,7 @@ module('Integration | Component | new user', function (hooks) {
   });
 
   test('validate email address', async function (assert) {
-    await render(hbs`<NewUser @close={{(noop)}}  />
-`);
+    await render(hbs`<NewUser @close={{(noop)}}  />`);
     await component.cancel();
     assert.notOk(component.email.hasError);
     await component.email.set('thisisnotanemailaddress');

--- a/tests/integration/components/pagination-links-test.js
+++ b/tests/integration/components/pagination-links-test.js
@@ -20,8 +20,7 @@ module('Integration | Component | pagination-links', function (hooks) {
       @results={{this.results}}
       @size={{this.size}}
       @onSelectPage={{set this.page}}
-    />
-`);
+    />`);
     assert.ok(
       component.nextIsHidden,
       'results array length needs to be greater than size for pagination to show'

--- a/tests/integration/components/pending-single-user-update-test.js
+++ b/tests/integration/components/pending-single-user-update-test.js
@@ -23,8 +23,7 @@ module('Integration | Component | pending single user update', function (hooks) 
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
 
     this.set('user', userModel);
-    await render(hbs`<PendingSingleUserUpdate @user={{this.user}} />
-`);
+    await render(hbs`<PendingSingleUserUpdate @user={{this.user}} />`);
     assert.strictEqual(component.updates.length, 1);
     assert.strictEqual(
       component.updates[0].explanation,
@@ -48,8 +47,7 @@ module('Integration | Component | pending single user update', function (hooks) 
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
 
     this.set('user', userModel);
-    await render(hbs`<PendingSingleUserUpdate @user={{this.user}} />
-`);
+    await render(hbs`<PendingSingleUserUpdate @user={{this.user}} />`);
     assert.strictEqual(component.updates.length, 1);
     assert.strictEqual(
       component.updates[0].explanation,
@@ -75,8 +73,7 @@ module('Integration | Component | pending single user update', function (hooks) 
     assert.strictEqual(this.server.db.users[0].email, 'user-email');
     assert.strictEqual(this.server.db.pendingUserUpdates.length, 1);
     this.set('user', userModel);
-    await render(hbs`<PendingSingleUserUpdate @user={{this.user}} />
-`);
+    await render(hbs`<PendingSingleUserUpdate @user={{this.user}} />`);
     assert.strictEqual(component.updates.length, 1);
     assert.ok(component.updates[0].hasUpdateEmailButton);
     await component.updates[0].updateEmail();
@@ -101,8 +98,7 @@ module('Integration | Component | pending single user update', function (hooks) 
     assert.ok(this.server.db.users[0].enabled);
     assert.strictEqual(this.server.db.pendingUserUpdates.length, 1);
     this.set('user', userModel);
-    await render(hbs`<PendingSingleUserUpdate @user={{this.user}} />
-`);
+    await render(hbs`<PendingSingleUserUpdate @user={{this.user}} />`);
     assert.strictEqual(component.updates.length, 1);
     assert.ok(component.updates[0].hasUpdateEmailButton);
     await component.updates[0].disable();
@@ -127,8 +123,7 @@ module('Integration | Component | pending single user update', function (hooks) 
     assert.notOk(this.server.db.users[0].userSyncIgnore);
     assert.strictEqual(this.server.db.pendingUserUpdates.length, 1);
     this.set('user', userModel);
-    await render(hbs`<PendingSingleUserUpdate @user={{this.user}} />
-`);
+    await render(hbs`<PendingSingleUserUpdate @user={{this.user}} />`);
     assert.strictEqual(component.updates.length, 1);
     assert.ok(component.updates[0].hasUpdateEmailButton);
     await component.updates[0].excludeFromSync();

--- a/tests/integration/components/pending-updates-summary-test.js
+++ b/tests/integration/components/pending-updates-summary-test.js
@@ -32,8 +32,7 @@ module('Integration | Component | pending updates summary', function (hooks) {
 
     const schools = await this.owner.lookup('service:store').findAll('school');
     this.set('schools', schools);
-    await render(hbs`<PendingUpdatesSummary @schools={{this.schools}} />
-`);
+    await render(hbs`<PendingUpdatesSummary @schools={{this.schools}} />`);
     assert.strictEqual(component.title, 'Updates from the Campus Directory');
     assert.strictEqual(component.summary, 'There are 5 users needing attention');
     assert.ok(component.schoolFilter.hasMultiple);
@@ -63,8 +62,7 @@ module('Integration | Component | pending updates summary', function (hooks) {
 
     const schools = await this.owner.lookup('service:store').findAll('school');
     this.set('schools', schools);
-    await render(hbs`<PendingUpdatesSummary @schools={{this.schools}} />
-`);
+    await render(hbs`<PendingUpdatesSummary @schools={{this.schools}} />`);
     assert.strictEqual(component.title, 'Updates from the Campus Directory');
     assert.strictEqual(component.summary, 'There are 5 users needing attention');
     assert.notOk(component.schoolFilter.hasMultiple);
@@ -90,8 +88,7 @@ module('Integration | Component | pending updates summary', function (hooks) {
 
     const schools = await this.owner.lookup('service:store').findAll('school');
     this.set('schools', schools);
-    await render(hbs`<PendingUpdatesSummary @schools={{this.schools}} />
-`);
+    await render(hbs`<PendingUpdatesSummary @schools={{this.schools}} />`);
 
     assert.strictEqual(component.title, 'Updates from the Campus Directory');
     assert.strictEqual(component.summary, 'There are 0 users needing attention');
@@ -125,8 +122,7 @@ module('Integration | Component | pending updates summary', function (hooks) {
 
     const schoolModels = await this.owner.lookup('service:store').findAll('school');
     this.set('schools', schoolModels);
-    await render(hbs`<PendingUpdatesSummary @schools={{this.schools}} />
-`);
+    await render(hbs`<PendingUpdatesSummary @schools={{this.schools}} />`);
 
     assert.strictEqual(component.title, 'Updates from the Campus Directory');
     assert.strictEqual(component.summary, 'There are 2 users needing attention');

--- a/tests/integration/components/program-year/collapsed-objectives-test.js
+++ b/tests/integration/components/program-year/collapsed-objectives-test.js
@@ -38,8 +38,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
 
     this.set('programYear', programYearModel);
     await render(
-      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
-`
+      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />`
     );
 
     assert.strictEqual(component.title, 'Objectives (4)');
@@ -65,8 +64,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
       assert.ok(true);
     });
     await render(
-      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{this.click}} />
-`
+      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{this.click}} />`
     );
 
     assert.strictEqual(component.title, 'Objectives (0)');
@@ -83,8 +81,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
 
     this.set('programYear', programYearModel);
     await render(
-      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
-`
+      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />`
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.parentStatus.complete);
@@ -100,8 +97,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
 
     this.set('programYear', programYearModel);
     await render(
-      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
-`
+      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />`
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.parentStatus.none);
@@ -117,8 +113,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
 
     this.set('programYear', programYearModel);
     await render(
-      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
-`
+      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />`
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.meshStatus.complete);
@@ -134,8 +129,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
 
     this.set('programYear', programYearModel);
     await render(
-      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
-`
+      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />`
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.meshStatus.none);
@@ -151,8 +145,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
 
     this.set('programYear', programYearModel);
     await render(
-      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
-`
+      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />`
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.termStatus.complete);
@@ -168,8 +161,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
 
     this.set('programYear', programYearModel);
     await render(
-      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
-`
+      hbs`<ProgramYear::CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />`
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.termStatus.none);

--- a/tests/integration/components/program-year/competencies-test.js
+++ b/tests/integration/components/program-year/competencies-test.js
@@ -44,8 +44,7 @@ module('Integration | Component | program-year/competencies', function (hooks) {
       @collapse={{(noop)}}
       @expand={{(noop)}}
       @setIsManaging={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title, 'Competencies (3)');
     assert.ok(component.canManage);
@@ -74,8 +73,7 @@ module('Integration | Component | program-year/competencies', function (hooks) {
       @collapse={{(noop)}}
       @expand={{(noop)}}
       @setIsManaging={{this.setIsManaging}}
-    />
-`);
+    />`);
 
     await component.manage();
   });
@@ -94,8 +92,7 @@ module('Integration | Component | program-year/competencies', function (hooks) {
       @collapse={{this.collapse}}
       @expand={{(noop)}}
       @setIsManaging={{(noop)}}
-    />
-`);
+    />`);
     await component.clickTitle();
   });
 });

--- a/tests/integration/components/program-year/header-test.js
+++ b/tests/integration/components/program-year/header-test.js
@@ -28,8 +28,7 @@ module('Integration | Component | program-year/header', function (hooks) {
       .lookup('service:store')
       .findRecord('program-year', programYear.id);
     this.set('programYear', programYearModel);
-    await render(hbs`<ProgramYear::Header @programYear={{this.programYear}} />
-`);
+    await render(hbs`<ProgramYear::Header @programYear={{this.programYear}} />`);
     assert.strictEqual(component.backToProgram.text, 'Back to Program Years');
     assert.notOk(component.isLocked);
     assert.strictEqual(component.matriculationYear, 'Matriculation Year 2019');
@@ -60,8 +59,7 @@ module('Integration | Component | program-year/header', function (hooks) {
       .lookup('service:store')
       .findRecord('program-year', programYear.id);
     this.set('programYear', programYearModel);
-    await render(hbs`<ProgramYear::Header @programYear={{this.programYear}} />
-`);
+    await render(hbs`<ProgramYear::Header @programYear={{this.programYear}} />`);
     assert.strictEqual(component.matriculationYear, 'Matriculation Year 2019 - 2020');
   });
 
@@ -83,8 +81,7 @@ module('Integration | Component | program-year/header', function (hooks) {
       .lookup('service:store')
       .findRecord('program-year', programYear.id);
     this.set('programYear', programYearModel);
-    await render(hbs`<ProgramYear::Header @programYear={{this.programYear}} />
-`);
+    await render(hbs`<ProgramYear::Header @programYear={{this.programYear}} />`);
     assert.strictEqual(component.cohort, '(Class of 2023)');
   });
 
@@ -107,8 +104,7 @@ module('Integration | Component | program-year/header', function (hooks) {
       .lookup('service:store')
       .findRecord('program-year', programYear.id);
     this.set('programYear', programYearModel);
-    await render(hbs`<ProgramYear::Header @programYear={{this.programYear}} />
-`);
+    await render(hbs`<ProgramYear::Header @programYear={{this.programYear}} />`);
     assert.ok(component.isLocked);
   });
 });

--- a/tests/integration/components/program-year/leadership-expanded-test.js
+++ b/tests/integration/components/program-year/leadership-expanded-test.js
@@ -38,8 +38,7 @@ module('Integration | Component | program-year/leadership-expanded', function (h
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, 'Program Year Leadership');
     assert.strictEqual(component.leadershipList.directors.length, 2);
     assert.strictEqual(component.leadershipList.directors[0].text, 'a M. person');
@@ -66,8 +65,7 @@ module('Integration | Component | program-year/leadership-expanded', function (h
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{(noop)}}
-    />
-`);
+    />`);
     await component.collapse();
   });
 
@@ -91,8 +89,7 @@ module('Integration | Component | program-year/leadership-expanded', function (h
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{this.click}}
-    />
-`);
+    />`);
     await component.manage();
   });
 });

--- a/tests/integration/components/program-year/list-item-test.js
+++ b/tests/integration/components/program-year/list-item-test.js
@@ -40,8 +40,7 @@ module('Integration | Component | program-year/list-item', function (hooks) {
     await render(hbs`<ProgramYear::ListItem
       @programYear={{this.programYear}}
       @academicYearCrossesCalendarYearBoundaries={{false}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, 'cohort 0');
   });
 
@@ -58,8 +57,7 @@ module('Integration | Component | program-year/list-item', function (hooks) {
     await render(hbs`<ProgramYear::ListItem
       @programYear={{this.programYear}}
       @academicYearCrossesCalendarYearBoundaries={{false}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, 'Class of 2016');
   });
 
@@ -76,8 +74,7 @@ module('Integration | Component | program-year/list-item', function (hooks) {
     await render(hbs`<ProgramYear::ListItem
       @programYear={{this.programYear}}
       @academicYearCrossesCalendarYearBoundaries={{false}}
-    />
-`);
+    />`);
     assert.strictEqual(component.link.text, '2012');
   });
 
@@ -94,8 +91,7 @@ module('Integration | Component | program-year/list-item', function (hooks) {
     await render(hbs`<ProgramYear::ListItem
       @programYear={{this.programYear}}
       @academicYearCrossesCalendarYearBoundaries={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.link.text, '2012 - 2013');
   });
 
@@ -112,8 +108,7 @@ module('Integration | Component | program-year/list-item', function (hooks) {
     await render(hbs`<ProgramYear::ListItem
       @programYear={{this.programYear}}
       @academicYearCrossesCalendarYearBoundaries={{false}}
-    />
-`);
+    />`);
     assert.ok(component.canBeRemoved);
   });
 
@@ -135,8 +130,7 @@ module('Integration | Component | program-year/list-item', function (hooks) {
     await render(hbs`<ProgramYear::ListItem
       @programYear={{this.programYear}}
       @academicYearCrossesCalendarYearBoundaries={{false}}
-    />
-`);
+    />`);
     assert.notOk(component.canBeRemoved);
   });
 });

--- a/tests/integration/components/program-year/list-test.js
+++ b/tests/integration/components/program-year/list-test.js
@@ -65,8 +65,7 @@ module('Integration | Component | program-year/list', function (hooks) {
       };
     });
     this.set('program', this.programModel);
-    await render(hbs`<ProgramYear::List @canUpdate={{false}} @program={{this.program}} />
-`);
+    await render(hbs`<ProgramYear::List @canUpdate={{false}} @program={{this.program}} />`);
 
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].link.text, '2001');
@@ -83,8 +82,7 @@ module('Integration | Component | program-year/list', function (hooks) {
       };
     });
     this.set('program', this.programModel);
-    await render(hbs`<ProgramYear::List @canUpdate={{false}} @program={{this.program}} />
-`);
+    await render(hbs`<ProgramYear::List @canUpdate={{false}} @program={{this.program}} />`);
 
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].link.text, '2001 - 2002');
@@ -95,8 +93,7 @@ module('Integration | Component | program-year/list', function (hooks) {
   test('create new program year', async function (assert) {
     const thisYear = new Date().getFullYear();
     this.set('program', this.programModel);
-    await render(hbs`<ProgramYear::List @canCreate={{true}} @program={{this.program}} />
-`);
+    await render(hbs`<ProgramYear::List @canCreate={{true}} @program={{this.program}} />`);
     await component.expandCollapse.toggle();
     await component.newProgramYear.years.select(thisYear);
     await component.newProgramYear.done.click();

--- a/tests/integration/components/program-year/manage-objective-competency-test.js
+++ b/tests/integration/components/program-year/manage-objective-competency-test.js
@@ -51,8 +51,7 @@ module('Integration | Component | program-year/manage-objective-competency', fun
       @selected={{null}}
       @add={{(noop)}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.domains.length, 1);
     assert.strictEqual(component.domains[0].title, this.domainModel1.title);
     assert.ok(component.domains[0].notSelected);
@@ -85,8 +84,7 @@ module('Integration | Component | program-year/manage-objective-competency', fun
       @selected={{this.selected}}
       @add={{(noop)}}
       @remove={{this.remove}}
-    />
-`);
+    />`);
     assert.ok(component.domains[0].selected);
     await component.domains[0].toggle();
   });
@@ -111,8 +109,7 @@ module('Integration | Component | program-year/manage-objective-competency', fun
       @selected={{null}}
       @add={{this.add}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.domains[0].notSelected);
     await component.domains[0].toggle();
   });
@@ -138,8 +135,7 @@ module('Integration | Component | program-year/manage-objective-competency', fun
       @selected={{null}}
       @add={{(noop)}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.domains[0].title, this.domainModel2.title);
     assert.strictEqual(component.domains[1].title, this.domainModel1.title);
   });
@@ -166,8 +162,7 @@ module('Integration | Component | program-year/manage-objective-competency', fun
       @selected={{this.selected}}
       @add={{(noop)}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.domains[0].selected);
     await component.domains[0].toggle();
     assert.notOk(component.domains[0].selectable);
@@ -195,8 +190,7 @@ module('Integration | Component | program-year/manage-objective-competency', fun
       @selected={{this.selected}}
       @add={{(noop)}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.domains[0].competencies[0].selected);
     await component.domains[0].competencies[0].toggle();
     assert.notOk(component.domains[0].competencies[0].selectable);

--- a/tests/integration/components/program-year/manage-objective-descriptors-test.js
+++ b/tests/integration/components/program-year/manage-objective-descriptors-test.js
@@ -22,8 +22,7 @@ module('Integration | Component | program-year/manage-objective-descriptors', fu
       @add={{(noop)}}
       @remove={{(noop)}}
       @editable={{true}}
-    />
-`);
+    />`);
     const m = component.meshManager;
 
     assert.strictEqual(m.selectedTerms.length, 1);
@@ -56,8 +55,7 @@ module('Integration | Component | program-year/manage-objective-descriptors', fu
       @add={{this.add}}
       @remove={{(noop)}}
       @editable={{true}}
-    />
-`);
+    />`);
     const m = component.meshManager;
 
     assert.strictEqual(m.selectedTerms.length, 1);
@@ -97,8 +95,7 @@ module('Integration | Component | program-year/manage-objective-descriptors', fu
       @add={{(noop)}}
       @remove={{this.remove}}
       @editable={{true}}
-    />
-`);
+    />`);
     const m = component.meshManager;
 
     assert.strictEqual(m.selectedTerms.length, 1);

--- a/tests/integration/components/program-year/new-test.js
+++ b/tests/integration/components/program-year/new-test.js
@@ -21,8 +21,7 @@ module('Integration | Component | program-year/new', function (hooks) {
       @save={{(noop)}}
       @cancel={{(noop)}}
       @academicYearCrossesCalendarYearBoundaries={{false}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title, 'New Program Year');
     const { options } = component.years;
@@ -52,8 +51,7 @@ module('Integration | Component | program-year/new', function (hooks) {
       @save={{(noop)}}
       @cancel={{this.cancel}}
       @academicYearCrossesCalendarYearBoundaries={{false}}
-    />
-`);
+    />`);
     await component.cancel.click();
   });
 
@@ -67,8 +65,7 @@ module('Integration | Component | program-year/new', function (hooks) {
       @save={{this.save}}
       @cancel={{(noop)}}
       @academicYearCrossesCalendarYearBoundaries={{false}}
-    />
-`);
+    />`);
     await component.done.click();
   });
 
@@ -83,8 +80,7 @@ module('Integration | Component | program-year/new', function (hooks) {
       @save={{this.save}}
       @cancel={{(noop)}}
       @academicYearCrossesCalendarYearBoundaries={{false}}
-    />
-`);
+    />`);
     assert.notOk(component.years.options[5].isSelected);
     await component.years.select(year);
     assert.ok(component.years.options[5].isSelected);
@@ -97,8 +93,7 @@ module('Integration | Component | program-year/new', function (hooks) {
       @save={{(noop)}}
       @cancel={{(noop)}}
       @academicYearCrossesCalendarYearBoundaries={{true}}
-    />
-`);
+    />`);
     const { options } = component.years;
     assert.strictEqual(options.length, 10);
     assert.strictEqual(options[0].text, `${this.currentYear - 5} - ${this.currentYear - 4}`);

--- a/tests/integration/components/program-year/objective-list-item-competency-test.js
+++ b/tests/integration/components/program-year/objective-list-item-competency-test.js
@@ -21,8 +21,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.canSave);
     assert.ok(component.canCancel);
     await a11yAudit(this.element);
@@ -43,8 +42,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.text, 'None');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -66,8 +64,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.text, 'competency 1 (competency 0)');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -88,8 +85,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.text, 'competency 0');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -113,8 +109,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.text, 'competency 1 (competency 0)');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -137,8 +132,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.text, 'competency 0');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -166,8 +160,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
       @save={{this.save}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     await component.save();
   });
 
@@ -193,8 +186,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{this.cancel}}
-    />
-`);
+    />`);
     await component.cancel();
   });
 
@@ -220,8 +212,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     await component.manage();
   });
 });

--- a/tests/integration/components/program-year/objective-list-item-descriptors-test.js
+++ b/tests/integration/components/program-year/objective-list-item-descriptors-test.js
@@ -21,8 +21,7 @@ module('Integration | Component | program-year/objective-list-item-descriptors',
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.canSave);
     assert.ok(component.canCancel);
     await a11yAudit(this.element);
@@ -43,8 +42,7 @@ module('Integration | Component | program-year/objective-list-item-descriptors',
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.text, 'None');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -67,8 +65,7 @@ module('Integration | Component | program-year/objective-list-item-descriptors',
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.list.length, 2);
     assert.strictEqual(component.list[0].title, 'descriptor 0');
     assert.strictEqual(component.list[1].title, 'descriptor 1');
@@ -93,8 +90,7 @@ module('Integration | Component | program-year/objective-list-item-descriptors',
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.list.length, 2);
     assert.strictEqual(component.list[0].title, 'descriptor 0');
     assert.strictEqual(component.list[1].title, 'descriptor 1');
@@ -123,8 +119,7 @@ module('Integration | Component | program-year/objective-list-item-descriptors',
       @save={{this.save}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     await component.save();
   });
 
@@ -149,8 +144,7 @@ module('Integration | Component | program-year/objective-list-item-descriptors',
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{this.cancel}}
-    />
-`);
+    />`);
     await component.cancel();
   });
 
@@ -175,8 +169,7 @@ module('Integration | Component | program-year/objective-list-item-descriptors',
       @save={{(noop)}}
       @isSaving={{false}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     await component.list[0].manage();
   });
 });

--- a/tests/integration/components/program-year/objective-list-item-expanded-test.js
+++ b/tests/integration/components/program-year/objective-list-item-expanded-test.js
@@ -32,8 +32,7 @@ module('Integration | Component | program-year/objective-list-item-expanded', fu
       .findRecord('program-year-objective', programYearObjective.id);
     this.set('objective', model);
 
-    await render(hbs`<ProgramYear::ObjectiveListItemExpanded @objective={{this.objective}} />
-`);
+    await render(hbs`<ProgramYear::ObjectiveListItemExpanded @objective={{this.objective}} />`);
     assert.strictEqual(component.headers[0].text, 'Courses');
     assert.strictEqual(component.headers[1].text, 'Objectives');
 
@@ -61,8 +60,7 @@ module('Integration | Component | program-year/objective-list-item-expanded', fu
       .lookup('service:store')
       .findRecord('program-year-objective', programYearObjective.id);
     this.set('objective', model);
-    await render(hbs`<ProgramYear::ObjectiveListItemExpanded @objective={{this.objective}} />
-`);
+    await render(hbs`<ProgramYear::ObjectiveListItemExpanded @objective={{this.objective}} />`);
     assert.strictEqual(component.headers[0].text, 'Courses');
     assert.strictEqual(component.headers[1].text, 'Objectives');
     assert.ok(component.hasNone);

--- a/tests/integration/components/program-year/objective-list-item-test.js
+++ b/tests/integration/components/program-year/objective-list-item-test.js
@@ -30,8 +30,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
         @editable={{true}}
         @domainTrees={{(array)}}
         @programYearCompetencies={{(array)}}
-      />
-`
+      />`
     );
     assert.notOk(component.hasRemoveConfirmation);
     assert.strictEqual(component.description.text, 'program-year objective 0');
@@ -49,8 +48,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
       hbs`<ProgramYear::ObjectiveListItem
         @programYearObjective={{this.programYearObjective}}
         @editable={{true}}
-      />
-`
+      />`
     );
     const newDescription = 'Pluto Visits Earth';
     assert.strictEqual(component.description.text, 'program-year objective 0');
@@ -68,8 +66,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
         @editable={{true}}
         @domainTrees={{(array)}}
         @programYearCompetencies={{(array)}}
-      />
-`
+      />`
     );
     await component.competency.manage();
     assert.ok(component.competencyManager.isPresent);
@@ -84,8 +81,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
         @editable={{true}}
         @domainTrees={{(array)}}
         @programYearCompetencies={{(array)}}
-      />
-`
+      />`
     );
     await component.meshDescriptors.list[0].manage();
     assert.ok(component.meshManager.isPresent);
@@ -100,8 +96,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
         @editable={{true}}
         @domainTrees={{(array)}}
         @programYearCompetencies={{(array)}}
-      />
-`
+      />`
     );
     assert.notOk(component.taxonomyManager.isPresent);
     await component.selectedTerms.manage();
@@ -117,8 +112,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
         @editable={{true}}
         @domainTrees={{(array)}}
         @programYearCompetencies={{(array)}}
-      />
-`
+      />`
     );
     await component.remove();
     assert.ok(component.hasRemoveConfirmation);
@@ -133,8 +127,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
         @editable={{true}}
         @domainTrees={{(array)}}
         @programYearCompetencies={{(array)}}
-      />
-`
+      />`
     );
     assert.ok(component.isActive);
     await component.deactivate();
@@ -151,8 +144,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
         @editable={{true}}
         @domainTrees={{(array)}}
         @programYearCompetencies={{(array)}}
-      />
-`
+      />`
     );
     assert.ok(component.isInactive);
     await component.activate();

--- a/tests/integration/components/program-year/objective-list-loading-test.js
+++ b/tests/integration/components/program-year/objective-list-loading-test.js
@@ -9,8 +9,7 @@ module('Integration | Component | program-year/objective-list-loading', function
   setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
-    await render(hbs`<ProgramYear::ObjectiveListLoading @count={{9}} />
-`);
+    await render(hbs`<ProgramYear::ObjectiveListLoading @count={{9}} />`);
 
     assert.dom('.grid-row').exists({ count: 9 });
   });

--- a/tests/integration/components/program-year/objective-list-test.js
+++ b/tests/integration/components/program-year/objective-list-test.js
@@ -40,8 +40,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
       hbs`<ProgramYear::ObjectiveList
         @editable={{true}}
         @programYear={{this.programYear}}
-      />
-`
+      />`
     );
     assert.ok(component.sortIsVisible, 'Sort Objectives button is visible');
     assert.strictEqual(component.headers[0].text, 'Description');
@@ -81,8 +80,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
       hbs`<ProgramYear::ObjectiveList
         @editable={{true}}
         @programYear={{this.programYear}}
-      />
-`
+      />`
     );
     assert.notOk(component.sortIsVisible);
     assert.strictEqual(component.text, '');
@@ -102,8 +100,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
       hbs`<ProgramYear::ObjectiveList
         @editable={{true}}
         @programYear={{this.programYear}}
-      />
-`
+      />`
     );
     assert.notOk(component.sortIsVisible, 'Sort Objectives button is visible');
     assert.strictEqual(component.objectives.length, 1);
@@ -133,8 +130,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
       hbs`<ProgramYear::ObjectiveList
         @editable={{true}}
         @programYear={{this.programYear}}
-      />
-`
+      />`
     );
     await component.objectives[0].competency.manage();
     assert.strictEqual(component.objectives[0].competencyManager.domains.length, 2);

--- a/tests/integration/components/program-year/objectives-test.js
+++ b/tests/integration/components/program-year/objectives-test.js
@@ -34,8 +34,7 @@ module('Integration | Component | program-year/objectives', function (hooks) {
       @editable={{true}}
       @collapse={{(noop)}}
       @expand={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.objectiveList.objectives.length, 2);
     assert.strictEqual(
@@ -106,8 +105,7 @@ module('Integration | Component | program-year/objectives', function (hooks) {
       @editable={{true}}
       @collapse={{(noop)}}
       @expand={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.objectiveList.objectives.length, 1);
     assert.strictEqual(

--- a/tests/integration/components/program-year/overview-test.js
+++ b/tests/integration/components/program-year/overview-test.js
@@ -22,8 +22,7 @@ module('Integration | Component | program-year/overview', function (hooks) {
     this.set('program', programYearModel);
     await render(hbs`<ProgramYear::Overview
       @programYear={{this.programYear}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, 'Overview');
     assert.notOk(component.actions.visualizations.isPresent);
     await a11yAudit(this.element);
@@ -41,8 +40,7 @@ module('Integration | Component | program-year/overview', function (hooks) {
     this.set('program', programYearModel);
     await render(hbs`<ProgramYear::Overview
       @programYear={{this.programYear}}
-    />
-`);
+    />`);
     assert.ok(component.actions.visualizations.isPresent);
   });
 });

--- a/tests/integration/components/program-year/visualize-objectives-test.js
+++ b/tests/integration/components/program-year/visualize-objectives-test.js
@@ -71,8 +71,7 @@ module('Integration | Component | program-year/visualize-objectives', function (
       .lookup('service:store')
       .findRecord('programYear', programYear.id);
     this.set('model', programYearModel);
-    await render(hbs`<ProgramYear::VisualizeObjectives @model={{this.model}}/>
-`);
+    await render(hbs`<ProgramYear::VisualizeObjectives @model={{this.model}}/>`);
     assert.strictEqual(component.title.text, 'program 0 Class of 2022');
     assert.strictEqual(component.title.link, '/programs/1/programyears/1');
     assert.strictEqual(component.breadcrumb.crumbs.length, 2);

--- a/tests/integration/components/program/header-test.js
+++ b/tests/integration/components/program/header-test.js
@@ -22,8 +22,7 @@ module('Integration | Component | program/header', function (hooks) {
 
     this.set('program', programModel);
 
-    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />
-`);
+    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />`);
     assert.strictEqual(component.title.text, 'Aardvark');
     assert.ok(component.title.canEdit);
   });
@@ -39,8 +38,7 @@ module('Integration | Component | program/header', function (hooks) {
 
     this.set('program', programModel);
 
-    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{false}} />
-`);
+    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{false}} />`);
     assert.strictEqual(component.title.text, 'Aardvark');
     assert.notOk(component.title.canEdit);
   });
@@ -56,8 +54,7 @@ module('Integration | Component | program/header', function (hooks) {
 
     this.set('program', programModel);
 
-    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />
-`);
+    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />`);
     assert.strictEqual(component.title.text, 'Aardvark');
     assert.ok(component.title.canEdit);
     await component.title.edit();
@@ -82,8 +79,7 @@ module('Integration | Component | program/header', function (hooks) {
 
     this.set('program', programModel);
 
-    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />
-`);
+    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />`);
     assert.strictEqual(component.title.text, 'Aardvark');
     assert.ok(component.title.canEdit);
     await component.title.edit();
@@ -105,8 +101,7 @@ module('Integration | Component | program/header', function (hooks) {
 
     this.set('program', programModel);
 
-    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />
-`);
+    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />`);
     assert.strictEqual(component.title.text, 'Aardvark');
     assert.ok(component.title.canEdit);
     await component.title.edit();
@@ -131,8 +126,7 @@ module('Integration | Component | program/header', function (hooks) {
 
     this.set('program', programModel);
 
-    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />
-`);
+    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />`);
     assert.strictEqual(programModel.get('title'), 'Aardvark');
     assert.strictEqual(component.title.text, 'Aardvark');
     assert.ok(component.title.canEdit);
@@ -155,8 +149,7 @@ module('Integration | Component | program/header', function (hooks) {
 
     this.set('program', programModel);
 
-    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />
-`);
+    await render(hbs`<Program::Header @program={{this.program}} @canUpdate={{true}} />`);
     assert.strictEqual(programModel.get('title'), 'Aardvark');
     assert.strictEqual(component.title.text, 'Aardvark');
     assert.ok(component.title.canEdit);

--- a/tests/integration/components/program/leadership-expanded-test.js
+++ b/tests/integration/components/program/leadership-expanded-test.js
@@ -35,8 +35,7 @@ module('Integration | Component | program/leadership expanded', function (hooks)
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, 'Program Leadership');
     assert.strictEqual(component.leadershipList.directors.length, 2);
     assert.strictEqual(component.leadershipList.directors[0].text, 'a M. person');
@@ -59,8 +58,7 @@ module('Integration | Component | program/leadership expanded', function (hooks)
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{(noop)}}
-    />
-`);
+    />`);
     await component.collapse();
   });
 
@@ -80,8 +78,7 @@ module('Integration | Component | program/leadership expanded', function (hooks)
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{this.click}}
-    />
-`);
+    />`);
     await component.manage();
   });
 });

--- a/tests/integration/components/program/new-test.js
+++ b/tests/integration/components/program/new-test.js
@@ -10,8 +10,7 @@ module('Integration | Component | program/new', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
-    await render(hbs`<Program::New @save={{(noop)}} @cancel={{(noop)}} />
-`);
+    await render(hbs`<Program::New @save={{(noop)}} @cancel={{(noop)}} />`);
     assert.strictEqual(component.title.label, 'Title:');
     assert.strictEqual(component.done.text, 'Done');
     assert.strictEqual(component.cancel.text, 'Cancel');
@@ -22,16 +21,14 @@ module('Integration | Component | program/new', function (hooks) {
     this.set('cancel', () => {
       assert.ok(true, 'cancel fired.');
     });
-    await render(hbs`<Program::New @save={{(noop)}} @cancel={{this.cancel}} />
-`);
+    await render(hbs`<Program::New @save={{(noop)}} @cancel={{this.cancel}} />`);
     await component.cancel.click();
   });
 
   test('validation fails, no title', async function (assert) {
     assert.expect(3);
 
-    await render(hbs`<Program::New @save={{(noop)}} @cancel={{(noop)}} />
-`);
+    await render(hbs`<Program::New @save={{(noop)}} @cancel={{(noop)}} />`);
     assert.strictEqual(component.title.errors.length, 0);
     await component.done.click();
     assert.strictEqual(component.title.errors.length, 1);
@@ -41,8 +38,7 @@ module('Integration | Component | program/new', function (hooks) {
   test('validation fails, title too short', async function (assert) {
     assert.expect(3);
 
-    await render(hbs`<Program::New @save={{(noop)}} @cancel={{(noop)}} />
-`);
+    await render(hbs`<Program::New @save={{(noop)}} @cancel={{(noop)}} />`);
     assert.strictEqual(component.title.errors.length, 0);
     await component.title.set('Aa');
     await component.done.click();
@@ -56,8 +52,7 @@ module('Integration | Component | program/new', function (hooks) {
   test('validation fails, title too long', async function (assert) {
     assert.expect(3);
 
-    await render(hbs`<Program::New @save={{(noop)}} @cancel={{(noop)}} />
-`);
+    await render(hbs`<Program::New @save={{(noop)}} @cancel={{(noop)}} />`);
     assert.strictEqual(component.title.errors.length, 0);
     await component.title.set('0123456789'.repeat(21));
     await component.done.click();
@@ -74,8 +69,7 @@ module('Integration | Component | program/new', function (hooks) {
       assert.strictEqual(program.title, 'Jayden Rules!');
     });
 
-    await render(hbs`<Program::New @save={{this.save}} @cancel={{(noop)}} />
-`);
+    await render(hbs`<Program::New @save={{this.save}} @cancel={{(noop)}} />`);
     await component.title.set('Jayden Rules!');
     await component.done.click();
   });

--- a/tests/integration/components/programs/list-item-test.js
+++ b/tests/integration/components/programs/list-item-test.js
@@ -28,8 +28,7 @@ module('Integration | Component | programs/list-item', function (hooks) {
       .lookup('service:store')
       .findRecord('program', this.program.id);
     this.set('program', programModel);
-    await render(hbs`<Programs::ListItem @program={{this.program}} />
-`);
+    await render(hbs`<Programs::ListItem @program={{this.program}} />`);
     assert.strictEqual(component.title, 'program 0');
     assert.strictEqual(component.school, 'school 0');
     assert.ok(component.canBeRemoved);
@@ -45,8 +44,7 @@ module('Integration | Component | programs/list-item', function (hooks) {
       .lookup('service:store')
       .findRecord('program', this.program.id);
     this.set('program', programModel);
-    await render(hbs`<Programs::ListItem @program={{this.program}} />
-`);
+    await render(hbs`<Programs::ListItem @program={{this.program}} />`);
     assert.strictEqual(component.title, 'program 0');
     assert.notOk(component.canBeRemoved);
   });
@@ -57,8 +55,7 @@ module('Integration | Component | programs/list-item', function (hooks) {
       .lookup('service:store')
       .findRecord('program', this.program.id);
     this.set('program', programModel);
-    await render(hbs`<Programs::ListItem @program={{this.program}} />
-`);
+    await render(hbs`<Programs::ListItem @program={{this.program}} />`);
     assert.strictEqual(component.title, 'program 0');
     assert.notOk(component.canBeRemoved);
   });
@@ -69,8 +66,7 @@ module('Integration | Component | programs/list-item', function (hooks) {
       .lookup('service:store')
       .findRecord('program', this.program.id);
     this.set('program', programModel);
-    await render(hbs`<Programs::ListItem @program={{this.program}} />
-`);
+    await render(hbs`<Programs::ListItem @program={{this.program}} />`);
     assert.strictEqual(component.title, 'program 0');
     assert.notOk(component.canBeRemoved);
   });

--- a/tests/integration/components/programs/list-test.js
+++ b/tests/integration/components/programs/list-test.js
@@ -26,8 +26,7 @@ module('Integration | Component | programs/list', function (hooks) {
     this.server.createList('program', 3, { school });
     const programModels = await this.owner.lookup('service:store').findAll('program');
     this.set('programs', programModels);
-    await render(hbs`<Programs::List @programs={{this.programs}} />
-`);
+    await render(hbs`<Programs::List @programs={{this.programs}} />`);
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].title, 'program 0');
     assert.strictEqual(component.items[0].school, 'school 0');
@@ -38,8 +37,7 @@ module('Integration | Component | programs/list', function (hooks) {
   });
 
   test('it renders empty', async function (assert) {
-    await render(hbs`<Programs::List @programs={{(array)}} />
-`);
+    await render(hbs`<Programs::List @programs={{(array)}} />`);
     assert.strictEqual(component.items.length, 0);
     assert.ok(component.isEmpty);
   });
@@ -49,8 +47,7 @@ module('Integration | Component | programs/list', function (hooks) {
     this.server.createList('program', 3, { school });
     const programModels = await this.owner.lookup('service:store').findAll('program');
     this.set('programs', programModels);
-    await render(hbs`<Programs::List @programs={{this.programs}} />
-`);
+    await render(hbs`<Programs::List @programs={{this.programs}} />`);
     assert.strictEqual(this.server.db.programs.length, 3);
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].title, 'program 0');
@@ -65,8 +62,7 @@ module('Integration | Component | programs/list', function (hooks) {
     this.server.createList('program', 3, { school });
     const programModels = await this.owner.lookup('service:store').findAll('program');
     this.set('programs', programModels);
-    await render(hbs`<Programs::List @programs={{this.programs}} />
-`);
+    await render(hbs`<Programs::List @programs={{this.programs}} />`);
     assert.strictEqual(this.server.db.programs.length, 3);
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].title, 'program 0');

--- a/tests/integration/components/programs/root-test.js
+++ b/tests/integration/components/programs/root-test.js
@@ -44,8 +44,7 @@ module('Integration | Component | programs/root', function (hooks) {
   test('it renders', async function (assert) {
     setupPermissionChecker(this, true);
     this.set('schools', this.schools);
-    await render(hbs`<Programs::Root @schools={{this.schools}} />
-`);
+    await render(hbs`<Programs::Root @schools={{this.schools}} />`);
     assert.strictEqual(component.list.items.length, 3);
     assert.strictEqual(component.list.items[0].title, 'program 3');
     assert.strictEqual(component.list.items[1].title, 'program 4');
@@ -60,8 +59,7 @@ module('Integration | Component | programs/root', function (hooks) {
   test('school filter works', async function (assert) {
     setupPermissionChecker(this, true);
     this.set('schools', this.schools);
-    await render(hbs`<Programs::Root @schools={{this.schools}} />
-`);
+    await render(hbs`<Programs::Root @schools={{this.schools}} />`);
     assert.strictEqual(component.schoolFilter.selectedSchool, '2');
     assert.strictEqual(component.list.items.length, 3);
     assert.strictEqual(component.list.items[0].title, 'program 3');

--- a/tests/integration/components/reports/new-subject-test.js
+++ b/tests/integration/components/reports/new-subject-test.js
@@ -24,8 +24,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     }
 
     context.owner.register('service:current-user', CurrentUserMock);
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />
-`);
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
     assert.strictEqual(component.subjects.items[subjectNum].value, subjectVal);
     await component.subjects.choose(subjectVal);
     await component.objects.choose('null');
@@ -51,8 +50,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     }
     this.owner.register('service:current-user', CurrentUserMock);
 
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />
-`);
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
 
     assert.strictEqual(component.componentTitle, 'New Report');
     assert.strictEqual(component.schools.items.length, 4);
@@ -106,8 +104,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
 
   test('selecting and de-selecting a MeSH term as prepositional object', async function (assert) {
     this.server.create('mesh-descriptor');
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />
-`);
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
     await component.objects.choose('mesh term');
     assert.notOk(component.selectedMeshTerm.isVisible);
     await component.mesh.manager.search.set('descriptor 0');
@@ -119,8 +116,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
 
   test('selecting and de-selecting an instructor as prepositional object', async function (assert) {
     this.server.create('user', { firstName: 'Rusty' });
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />
-`);
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
 
     await component.objects.choose('instructor');
     assert.notOk(component.selectedInstructor.isVisible);
@@ -261,8 +257,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       email: 'test@example.com',
       displayName: 'Aardvark',
     });
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />
-`);
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
     assert.notOk(component.instructors.search.isVisible);
     assert.notOk(component.selectedInstructor.isVisible);
     await component.schools.choose('null');
@@ -287,8 +282,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     this.set('close', () => {
       assert.ok(true);
     });
-    await render(hbs`<Reports::NewSubject @close={{this.close}} />
-`);
+    await render(hbs`<Reports::NewSubject @close={{this.close}} />`);
     await component.cancel();
   });
 
@@ -308,8 +302,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
         assert.strictEqual(report.title, 'lorem ipsum');
       },
     });
-    await render(hbs`<Reports::NewSubject @save={{this.save}} @close={{(noop)}} />
-`);
+    await render(hbs`<Reports::NewSubject @save={{this.save}} @close={{(noop)}} />`);
     await component.title.set('lorem ipsum');
     await component.save();
   });
@@ -324,8 +317,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       }
     }
     this.owner.register('service:current-user', CurrentUserMock);
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />
-`);
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
     assert.strictEqual(component.title.errors.length, 0);
     await component.title.set('0123456789'.repeat(25));
     await component.save();
@@ -342,8 +334,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       }
     }
     this.owner.register('service:current-user', CurrentUserMock);
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />
-`);
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
     await component.objects.choose('instructor');
     assert.strictEqual(component.instructors.errors.length, 0);
     await component.save();
@@ -361,8 +352,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       }
     }
     this.owner.register('service:current-user', CurrentUserMock);
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />
-`);
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
     await component.objects.choose('mesh term');
     assert.strictEqual(component.mesh.errors.length, 0);
     await component.save();
@@ -380,8 +370,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       }
     }
     this.owner.register('service:current-user', CurrentUserMock);
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />
-`);
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
     await component.subjects.choose('mesh term');
     assert.strictEqual(component.objects.errors.length, 0);
     await component.save();
@@ -402,8 +391,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       }
     }
     this.owner.register('service:current-user', CurrentUserMock);
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />
-`);
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
     await component.subjects.choose('instructor');
     assert.strictEqual(component.objects.errors.length, 0);
     await component.save();

--- a/tests/integration/components/reports/subject-test.js
+++ b/tests/integration/components/reports/subject-test.js
@@ -55,8 +55,7 @@ module('Integration | Component | reports/subject', function (hooks) {
       @selectedReport={{this.selectedReport}}
       @selectedYear={{this.selectedYear}}
       @onReportYearSelect={{this.setReportYear}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, 'my report 0');
     assert.strictEqual(component.results.length, 2);
     assert.strictEqual(component.results[0].text, '2015 course 0');
@@ -93,8 +92,7 @@ module('Integration | Component | reports/subject', function (hooks) {
       @selectedReport={{this.selectedReport}}
       @selectedYear={{this.selectedYear}}
       @onReportYearSelect={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.results[0].text, '2016 - 2017 course 0');
   });
 
@@ -120,8 +118,7 @@ module('Integration | Component | reports/subject', function (hooks) {
       @selectedReport={{this.selectedReport}}
       @selectedYear={{this.selectedYear}}
       @onReportYearSelect={{this.setReportYear}}
-    />
-`);
+    />`);
     assert.strictEqual(component.academicYears.value, '');
     assert.strictEqual(component.results.length, 1);
     await component.academicYears.choose('2015');

--- a/tests/integration/components/reports/subjects-test.js
+++ b/tests/integration/components/reports/subjects-test.js
@@ -35,8 +35,7 @@ module('Integration | Component | reports/subjects', function (hooks) {
       prepositionalObjectTableRowId: session.id,
       user: this.user,
     });
-    await render(hbs`<Reports::Subjects />
-`);
+    await render(hbs`<Reports::Subjects />`);
     assert.strictEqual(component.title, 'Subject Reports');
     assert.strictEqual(component.reports.length, 2);
     assert.strictEqual(component.reports[0].title, 'report 0');
@@ -46,8 +45,7 @@ module('Integration | Component | reports/subjects', function (hooks) {
 
   test('it renders empty', async function (assert) {
     assert.expect(3);
-    await render(hbs`<Reports::Subjects />
-`);
+    await render(hbs`<Reports::Subjects />`);
     assert.strictEqual(component.title, 'Subject Reports');
     assert.strictEqual(component.reports.length, 1);
     assert.strictEqual(component.reports[0].text, 'None');
@@ -55,8 +53,7 @@ module('Integration | Component | reports/subjects', function (hooks) {
   });
 
   test('toggle new report form', async function (assert) {
-    await render(hbs`<Reports::Subjects />
-`);
+    await render(hbs`<Reports::Subjects />`);
     assert.notOk(component.newReport.isVisible);
     await component.newReportFormToggle.click();
     assert.ok(component.newReport.isVisible);

--- a/tests/integration/components/school-competencies-collapsed-test.js
+++ b/tests/integration/components/school-competencies-collapsed-test.js
@@ -21,8 +21,7 @@ module('Integration | Component | school competencies collapsed', function (hook
     const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
 
     this.set('school', schoolModel);
-    await render(hbs`<SchoolCompetenciesCollapsed @school={{this.school}} @expand={{(noop)}} />
-`);
+    await render(hbs`<SchoolCompetenciesCollapsed @school={{this.school}} @expand={{(noop)}} />`);
 
     assert.strictEqual(component.expandButton.text, 'Competencies (3/4)');
     assert.strictEqual(component.domains.length, 3);
@@ -42,8 +41,7 @@ module('Integration | Component | school competencies collapsed', function (hook
     this.set('school', schoolModel);
     this.set('expand', () => assert.ok(true));
     await render(
-      hbs`<SchoolCompetenciesCollapsed @school={{this.school}} @expand={{this.expand}} />
-`
+      hbs`<SchoolCompetenciesCollapsed @school={{this.school}} @expand={{this.expand}} />`
     );
     await component.expandButton.click();
   });

--- a/tests/integration/components/school-competencies-expanded-test.js
+++ b/tests/integration/components/school-competencies-expanded-test.js
@@ -39,8 +39,7 @@ module('Integration | Component | school competencies expanded', function (hooks
       @expand={{(noop)}}
       @isManaging={{false}}
       @setSchoolManageCompetencies={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.collapser.text, 'Competencies (1/2)');
     assert.strictEqual(component.competenciesList.items.length, 3);
     assert.strictEqual(component.competenciesList.items[0].title.text, 'domain 0');
@@ -63,8 +62,7 @@ module('Integration | Component | school competencies expanded', function (hooks
       @expand={{(noop)}}
       @isManaging={{false}}
       @setSchoolManageCompetencies={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.competenciesList.isHidden);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');

--- a/tests/integration/components/school-competencies-list-item-pcrs-test.js
+++ b/tests/integration/components/school-competencies-list-item-pcrs-test.js
@@ -38,8 +38,7 @@ module('Integration | Component | school-competencies-list-item-pcrs', function 
       @isManaging={{false}}
       @save={{(noop)}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.items.length, 2);
     assert.strictEqual(component.items[0].text, '1 Zylinder');
     assert.strictEqual(component.items[1].text, '2 Alfons');
@@ -58,8 +57,7 @@ module('Integration | Component | school-competencies-list-item-pcrs', function 
       @isManaging={{true}}
       @save={{(noop)}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.items.length, 0);
     assert.ok(component.save.isVisible);
     assert.ok(component.cancel.isVisible);
@@ -81,8 +79,7 @@ module('Integration | Component | school-competencies-list-item-pcrs', function 
       @isManaging={{false}}
       @save={{(noop)}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     await component.items[0].edit();
   });
 
@@ -100,8 +97,7 @@ module('Integration | Component | school-competencies-list-item-pcrs', function 
       @isManaging={{true}}
       @save={{(noop)}}
       @cancel={{this.cancel}}
-    />
-`);
+    />`);
     await component.cancel.click();
   });
 
@@ -119,8 +115,7 @@ module('Integration | Component | school-competencies-list-item-pcrs', function 
       @isManaging={{true}}
       @save={{this.save}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     await component.save.click();
   });
 
@@ -134,8 +129,7 @@ module('Integration | Component | school-competencies-list-item-pcrs', function 
       @isManaging={{false}}
       @save={{(noop)}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.items.length, 1);
     assert.strictEqual(component.items[0].text, 'Click to edit');
   });
@@ -150,8 +144,7 @@ module('Integration | Component | school-competencies-list-item-pcrs', function 
       @isManaging={{false}}
       @save={{(noop)}}
       @cancel={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.items.length, 1);
     assert.strictEqual(component.items[0].text, 'None');
   });

--- a/tests/integration/components/school-competencies-list-item-test.js
+++ b/tests/integration/components/school-competencies-list-item-test.js
@@ -39,8 +39,7 @@ module('Integration | Component | school-competencies-list-item', function (hook
       @competency={{this.competency}}
       @isDomain={{true}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title.text, 'competency 0');
     assert.notOk(component.title.isCompetency);
     assert.ok(component.title.isDomain);
@@ -57,8 +56,7 @@ module('Integration | Component | school-competencies-list-item', function (hook
       @competency={{this.competency}}
       @isDomain={{false}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title.text, 'competency 1');
     assert.ok(component.title.isCompetency);
     assert.notOk(component.title.isDomain);

--- a/tests/integration/components/school-competencies-list-test.js
+++ b/tests/integration/components/school-competencies-list-test.js
@@ -32,8 +32,7 @@ module('Integration | Component | school competencies list', function (hooks) {
       .findRecord('competency', domain.id);
 
     this.set('domains', [domainModel]);
-    await render(hbs`<SchoolCompetenciesList @domains={{this.domains}} />
-`);
+    await render(hbs`<SchoolCompetenciesList @domains={{this.domains}} />`);
     assert.strictEqual(component.items.length, 3);
     assert.strictEqual(component.items[0].title.text, 'domain 0');
     assert.strictEqual(component.items[0].pcrs.items.length, 1);

--- a/tests/integration/components/school-competencies-manager-test.js
+++ b/tests/integration/components/school-competencies-manager-test.js
@@ -41,8 +41,7 @@ module('Integration | Component | school competencies manager', function (hooks)
       @add={{(noop)}}
       @remove={{(noop)}}
       @competencies={{this.competencies}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.domains.length, 1);
     assert.strictEqual(component.domains[0].details.editor.text, 'domain1');
@@ -73,8 +72,7 @@ module('Integration | Component | school competencies manager', function (hooks)
       @add={{(noop)}}
       @remove={{this.remove}}
       @competencies={{this.competencies}}
-    />
-`);
+    />`);
 
     await component.domains[0].remove();
   });
@@ -100,8 +98,7 @@ module('Integration | Component | school competencies manager', function (hooks)
       @add={{this.add}}
       @remove={{(noop)}}
       @competencies={{this.competencies}}
-    />
-`);
+    />`);
 
     await component.newDomain.newCompetency.title.set(newTitle);
     await component.newDomain.newCompetency.save();
@@ -128,8 +125,7 @@ module('Integration | Component | school competencies manager', function (hooks)
       @add={{this.add}}
       @remove={{(noop)}}
       @competencies={{this.competencies}}
-    />
-`);
+    />`);
 
     await component.domains[0].newCompetency.title.set(newTitle);
     await component.domains[0].newCompetency.save();

--- a/tests/integration/components/school-competencies-pcrs-mapper-test.js
+++ b/tests/integration/components/school-competencies-pcrs-mapper-test.js
@@ -51,8 +51,7 @@ module('Integration | Component | school-competencies-pcrs-mapper', function (ho
       @selectedPcrses={{this.selectedPcrses}}
       @add={{(noop)}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.pcrs.length, 5);
     assert.notOk(component.pcrs[0].isChecked);
@@ -80,8 +79,7 @@ module('Integration | Component | school-competencies-pcrs-mapper', function (ho
       @selectedPcrses={{(array)}}
       @add={{this.add}}
       @remove={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.pcrs[0].isChecked);
     await component.pcrs[0].click();
   });
@@ -99,8 +97,7 @@ module('Integration | Component | school-competencies-pcrs-mapper', function (ho
       @selectedPcrses={{this.selectedPcrses}}
       @add={{(noop)}}
       @remove={{this.remove}}
-    />
-`);
+    />`);
     assert.ok(component.pcrs[0].isChecked);
     await component.pcrs[0].click();
   });

--- a/tests/integration/components/school-curriculum-inventory-institution-details-test.js
+++ b/tests/integration/components/school-curriculum-inventory-institution-details-test.js
@@ -35,8 +35,7 @@ module(
       @school={{this.school}}
       @canUpdate={{this.canUpdate}}
       @manage={{this.manage}}
-    />
-`);
+    />`);
 
       assert.strictEqual(component.header.title, 'Curriculum Inventory Institutional Information');
       assert.strictEqual(component.header.manageTitle, 'Manage CIR Institutional Info');
@@ -74,8 +73,7 @@ module(
       @school={{this.school}}
       @canUpdate={{this.canUpdate}}
       @manage={{this.manage}}
-    />
-`);
+    />`);
       assert.notOk(component.header.hasManageAction);
     });
 
@@ -97,8 +95,7 @@ module(
       @school={{this.school}}
       @canUpdate={{this.canUpdate}}
       @manage={{this.manage}}
-    />
-`);
+    />`);
       await component.header.manage();
     });
 
@@ -114,8 +111,7 @@ module(
       @school={{this.school}}
       @canUpdate={{this.canUpdate}}
       @manage={{this.manage}}
-    />
-`);
+    />`);
       await assert.strictEqual(
         component.content.noInfo,
         'No institutional information has been configured for this school.'

--- a/tests/integration/components/school-curriculum-inventory-institution-manager-test.js
+++ b/tests/integration/components/school-curriculum-inventory-institution-manager-test.js
@@ -34,8 +34,7 @@ module(
       @institution={{await this.school.curriculumInventoryInstitution}}
       @canUpdate={{this.canUpdate}}
       @manage={{(noop)}}
-    />
-`);
+    />`);
 
       assert.strictEqual(component.header.title, 'Curriculum Inventory Institutional Information');
       assert.ok(component.header.hasSaveButton);
@@ -68,8 +67,7 @@ module(
       @institution={{await this.school.curriculumInventoryInstitution}}
       @canUpdate={{this.canUpdate}}
       @manage={{(noop)}}
-    />
-`);
+    />`);
 
       assert.strictEqual(component.content.name.value, '');
       assert.strictEqual(component.content.aamcCode.value, '');
@@ -98,8 +96,7 @@ module(
       @institution={{await this.school.curriculumInventoryInstitution}}
       @canUpdate={{this.canUpdate}}
       @manage={{this.manage}}
-    />
-`);
+    />`);
       await component.header.cancel();
     });
 
@@ -144,8 +141,7 @@ module(
       @canUpdate={{this.canUpdate}}
       @manage={{(noop)}}
       @save={{this.saveInstitution}}
-    />
-`);
+    />`);
 
       component.content.name.change(newName);
       component.content.aamcCode.change(newAamcCode);
@@ -188,8 +184,7 @@ module(
       @canUpdate={{this.canUpdate}}
       @manage={{(noop)}}
       @save={{this.saveInstitution}}
-    />
-`);
+    />`);
 
       component.content.name.change(newName);
       component.content.aamcCode.change(newAamcCode);
@@ -213,8 +208,7 @@ module(
       @institution={{await this.school.curriculumInventoryInstitution}}
       @canUpdate={{this.canUpdate}}
       @manage={{(noop)}}
-    />
-`);
+    />`);
 
       assert.notOk(component.content.name.hasError);
       assert.notOk(component.content.aamcCode.hasError);
@@ -272,8 +266,7 @@ module(
       @institution={{await this.school.curriculumInventoryInstitution}}
       @canUpdate={{this.canUpdate}}
       @manage={{(noop)}}
-    />
-`);
+    />`);
       assert.notOk(component.header.hasSaveButton);
     });
   }

--- a/tests/integration/components/school-leadership-expanded-test.js
+++ b/tests/integration/components/school-leadership-expanded-test.js
@@ -28,8 +28,7 @@ module('Integration | Component | school leadership expanded', function (hooks) 
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, 'School Leadership');
     assert.strictEqual(component.leadershipList.directors.length, 1);
     assert.strictEqual(component.leadershipList.directors[0].text, '0 guy M. Mc0son');
@@ -53,8 +52,7 @@ module('Integration | Component | school leadership expanded', function (hooks) 
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{(noop)}}
-    />
-`);
+    />`);
 
     await component.collapse();
   });
@@ -74,8 +72,7 @@ module('Integration | Component | school leadership expanded', function (hooks) 
       @expand={{(noop)}}
       @isManaging={{false}}
       @setIsManaging={{this.manage}}
-    />
-`);
+    />`);
 
     await component.manage();
   });
@@ -92,8 +89,7 @@ module('Integration | Component | school leadership expanded', function (hooks) 
       @expand={{(noop)}}
       @isManaging={{true}}
       @setIsManaging={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.leadershipManager.isVisible);
   });

--- a/tests/integration/components/school-list-test.js
+++ b/tests/integration/components/school-list-test.js
@@ -21,8 +21,7 @@ module('Integration | Component | school list', function (hooks) {
 
   test('it renders', async function (assert) {
     this.set('schools', [this.school1, this.school2]);
-    await render(hbs`<SchoolList @schools={{this.schools}} />
-`);
+    await render(hbs`<SchoolList @schools={{this.schools}} />`);
     assert.strictEqual(component.schools.length, 2);
     assert.strictEqual(component.schools[0].title, 'school 0');
     assert.strictEqual(component.schools[1].title, 'school 1');
@@ -34,8 +33,7 @@ module('Integration | Component | school list', function (hooks) {
     });
     this.owner.register('service:current-user', currentUserMock);
     this.set('schools', []);
-    await render(hbs`<SchoolList @schools={{this.schools}} />
-`);
+    await render(hbs`<SchoolList @schools={{this.schools}} />`);
     assert.ok(component.expandCollapseButton.isVisible);
   });
 
@@ -45,8 +43,7 @@ module('Integration | Component | school list', function (hooks) {
     });
     this.owner.register('service:current-user', currentUserMock);
     this.set('schools', []);
-    await render(hbs`<SchoolList @schools={{this.schools}} />
-`);
+    await render(hbs`<SchoolList @schools={{this.schools}} />`);
     assert.notOk(component.expandCollapseButton.isVisible);
   });
 
@@ -56,8 +53,7 @@ module('Integration | Component | school list', function (hooks) {
     });
     this.owner.register('service:current-user', currentUserMock);
     this.set('schools', []);
-    await render(hbs`<SchoolList @schools={{this.schools}} />
-`);
+    await render(hbs`<SchoolList @schools={{this.schools}} />`);
     assert.notOk(component.newSchoolForm.isVisible);
     await component.expandCollapseButton.toggle();
     assert.ok(component.newSchoolForm.isVisible);
@@ -75,8 +71,7 @@ module('Integration | Component | school list', function (hooks) {
     });
     this.owner.register('service:current-user', currentUserMock);
     this.set('schools', []);
-    await render(hbs`<SchoolList @schools={{this.schools}} />
-`);
+    await render(hbs`<SchoolList @schools={{this.schools}} />`);
     await component.expandCollapseButton.toggle();
 
     let schools = (await this.owner.lookup('service:store').findAll('school')).slice();
@@ -99,8 +94,7 @@ module('Integration | Component | school list', function (hooks) {
     });
     this.owner.register('service:current-user', currentUserMock);
     this.set('schools', []);
-    await render(hbs`<SchoolList @schools={{this.schools}} />
-`);
+    await render(hbs`<SchoolList @schools={{this.schools}} />`);
     await component.expandCollapseButton.toggle();
     assert.notOk(component.newSchoolForm.title.hasError);
     assert.notOk(component.newSchoolForm.email.hasError);
@@ -115,8 +109,7 @@ module('Integration | Component | school list', function (hooks) {
     });
     this.owner.register('service:current-user', currentUserMock);
     this.set('schools', []);
-    await render(hbs`<SchoolList @schools={{this.schools}} />
-`);
+    await render(hbs`<SchoolList @schools={{this.schools}} />`);
     await component.expandCollapseButton.toggle();
     assert.notOk(component.newSchoolForm.email.hasError);
     await component.newSchoolForm.email.set('thisisnotanemailaddress');

--- a/tests/integration/components/school-manager-test.js
+++ b/tests/integration/components/school-manager-test.js
@@ -68,8 +68,7 @@ module('Integration | Component | school manager', function (hooks) {
       @setSchoolManageInstitution={{(noop)}}
       @schoolNewVocabulary={{true}}
       @setSchoolNewVocabulary={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.schoolLeadershipExpanded.isVisible);
     assert.notOk(component.schoolLeadershipCollapsed.isVisible);
@@ -131,8 +130,7 @@ module('Integration | Component | school manager', function (hooks) {
       @setSchoolManageInstitution={{(noop)}}
       @schoolNewVocabulary={{false}}
       @setSchoolNewVocabulary={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.schoolLeadershipExpanded.isVisible);
     assert.ok(component.schoolLeadershipCollapsed.isVisible);
@@ -197,8 +195,7 @@ module('Integration | Component | school manager', function (hooks) {
       @setSchoolManageInstitution={{(noop)}}
       @schoolNewVocabulary={{false}}
       @setSchoolNewVocabulary={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title.text, 'school 0');
     assert.notOk(component.title.hasError);
@@ -259,8 +256,7 @@ module('Integration | Component | school manager', function (hooks) {
       @setSchoolManageInstitution={{(noop)}}
       @schoolNewVocabulary={{false}}
       @setSchoolNewVocabulary={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title.text, 'school 0');
     await component.title.edit();
@@ -318,8 +314,7 @@ module('Integration | Component | school manager', function (hooks) {
       @setSchoolManageInstitution={{(noop)}}
       @schoolNewVocabulary={{false}}
       @setSchoolNewVocabulary={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title.text, 'school 0');
     assert.notOk(component.title.hasError);
@@ -377,8 +372,7 @@ module('Integration | Component | school manager', function (hooks) {
       @setSchoolManageInstitution={{(noop)}}
       @schoolNewVocabulary={{false}}
       @setSchoolNewVocabulary={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title.text, 'school 0');
     assert.notOk(component.title.hasError);

--- a/tests/integration/components/school-new-vocabulary-form-test.js
+++ b/tests/integration/components/school-new-vocabulary-form-test.js
@@ -20,8 +20,7 @@ module('Integration | Component | school-new-vocabulary-form', function (hooks) 
 
   test('it renders', async function (assert) {
     this.set('school', this.schoolModel);
-    await render(hbs`<SchoolNewVocabularyForm @school={{this.school}} @close={{(noop)}} />
-`);
+    await render(hbs`<SchoolNewVocabularyForm @school={{this.school}} @close={{(noop)}} />`);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
     assert.strictEqual(component.title.label, 'Title:');
@@ -32,8 +31,7 @@ module('Integration | Component | school-new-vocabulary-form', function (hooks) 
 
   test('validation fails if title is blank', async function (assert) {
     this.set('school', this.schoolModel);
-    await render(hbs`<SchoolNewVocabularyForm @school={{this.school}} @close={{(noop)}} />
-`);
+    await render(hbs`<SchoolNewVocabularyForm @school={{this.school}} @close={{(noop)}} />`);
     assert.notOk(component.title.hasError);
     await component.title.set('');
     await component.submit.click();
@@ -42,8 +40,7 @@ module('Integration | Component | school-new-vocabulary-form', function (hooks) 
 
   test('validation fails if title is too long', async function (assert) {
     this.set('school', this.schoolModel);
-    await render(hbs`<SchoolNewVocabularyForm @school={{this.school}} @close={{(noop)}} />
-`);
+    await render(hbs`<SchoolNewVocabularyForm @school={{this.school}} @close={{(noop)}} />`);
     assert.notOk(component.title.hasError);
     await component.title.set('0123456789'.repeat(21));
     await component.submit.click();
@@ -53,8 +50,7 @@ module('Integration | Component | school-new-vocabulary-form', function (hooks) 
   test('validation fails if title is not unique', async function (assert) {
     this.set('school', this.schoolModel);
     const vocabularies = (await this.schoolModel.vocabularies).slice();
-    await render(hbs`<SchoolNewVocabularyForm @school={{this.school}} @close={{(noop)}} />
-`);
+    await render(hbs`<SchoolNewVocabularyForm @school={{this.school}} @close={{(noop)}} />`);
     assert.notOk(component.title.hasError);
     assert.expect(vocabularies[0].title, 'Vocab A');
     await component.title.set(vocabularies[0].title);
@@ -68,8 +64,7 @@ module('Integration | Component | school-new-vocabulary-form', function (hooks) 
     this.set('close', () => {
       assert.ok(true, 'close action fires.');
     });
-    await render(hbs`<SchoolNewVocabularyForm @school={{this.school}} @close={{this.close}} />
-`);
+    await render(hbs`<SchoolNewVocabularyForm @school={{this.school}} @close={{this.close}} />`);
     await component.cancel.click();
   });
 
@@ -92,8 +87,7 @@ module('Integration | Component | school-new-vocabulary-form', function (hooks) 
       @school={{this.school}}
       @close={{(noop)}}
       @save={{this.save}}
-    />
-`);
+    />`);
     await component.title.set(newTitle);
     await component.submit.click();
   });

--- a/tests/integration/components/school-session-attributes-collapsed-test.js
+++ b/tests/integration/components/school-session-attributes-collapsed-test.js
@@ -20,8 +20,7 @@ module('Integration | Component | school session attributes collapsed', function
       @showSessionSpecialAttireRequired={{this.showSessionSpecialAttireRequired}}
       @showSessionSpecialEquipmentRequired={{this.showSessionSpecialEquipmentRequired}}
       @expand={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.attendanceRequired.label, 'Attendance Required');
     assert.ok(component.attendanceRequired.isDisabled);
@@ -44,8 +43,7 @@ module('Integration | Component | school session attributes collapsed', function
       @showSessionSpecialAttireRequired={{true}}
       @showSessionSpecialEquipmentRequired={{true}}
       @expand={{this.expand}}
-    />
-`);
+    />`);
 
     await component.expand();
   });

--- a/tests/integration/components/school-session-attributes-expanded-test.js
+++ b/tests/integration/components/school-session-attributes-expanded-test.js
@@ -21,8 +21,7 @@ module('Integration | Component | school session attributes expanded', function 
       @showSessionSpecialEquipmentRequired={{this.showSessionSpecialEquipmentRequired}}
       @collapse={{(noop)}}
       @manage={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.attributes.attendanceRequired.label, 'Attendance Required');
     assert.ok(component.attributes.attendanceRequired.isDisabled);
@@ -50,8 +49,7 @@ module('Integration | Component | school session attributes expanded', function 
       @showSessionSpecialEquipmentRequired={{true}}
       @collapse={{this.collapse}}
       @manage={{(noop)}}
-    />
-`);
+    />`);
 
     await component.collapse();
   });
@@ -69,8 +67,7 @@ module('Integration | Component | school session attributes expanded', function 
       @collapse={{(noop)}}
       @canUpdate={{true}}
       @manage={{this.manage}}
-    />
-`);
+    />`);
 
     await component.manage();
   });
@@ -92,8 +89,7 @@ module('Integration | Component | school session attributes expanded', function 
       @saveAll={{this.save}}
       @manage={{(noop)}}
       @isManaging={{true}}
-    />
-`);
+    />`);
 
     assert.notOk(component.manager.attendanceRequired.isChecked);
     assert.notOk(component.manager.supplemental.isChecked);

--- a/tests/integration/components/school-session-attributes-manager-test.js
+++ b/tests/integration/components/school-session-attributes-manager-test.js
@@ -21,8 +21,7 @@ module('Integration | Component | school session attributes manager', function (
       @showSessionSpecialEquipmentRequired={{this.showSessionSpecialEquipmentRequired}}
       @enable={{(noop)}}
       @disable={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.attendanceRequired.label, 'Attendance Required');
     assert.notOk(component.attendanceRequired.isChecked);
@@ -50,8 +49,7 @@ module('Integration | Component | school session attributes manager', function (
       @showSessionSpecialEquipmentRequired={{this.showSessionSpecialEquipmentRequired}}
       @enable={{this.enable}}
       @disable={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(attribute.isChecked);
     await attribute.check();
@@ -104,8 +102,7 @@ module('Integration | Component | school session attributes manager', function (
       @showSessionSpecialEquipmentRequired={{this.showSessionSpecialEquipmentRequired}}
       @enable={{(noop)}}
       @disable={{this.disable}}
-    />
-`);
+    />`);
 
     assert.ok(attribute.isChecked);
     await attribute.check();

--- a/tests/integration/components/school-session-attributes-test.js
+++ b/tests/integration/components/school-session-attributes-test.js
@@ -25,8 +25,7 @@ module('Integration | Component | school session attributes', function (hooks) {
       @manage={{(noop)}}
       @collapse={{(noop)}}
       @expand={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.expanded.isVisible);
     assert.notOk(component.collapsed.attendanceRequired.isEnabled);
@@ -50,8 +49,7 @@ module('Integration | Component | school session attributes', function (hooks) {
       @manage={{(noop)}}
       @collapse={{(noop)}}
       @expand={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.collapsed.isVisible);
     assert.notOk(component.expanded.attributes.attendanceRequired.isEnabled);
@@ -73,8 +71,7 @@ module('Integration | Component | school session attributes', function (hooks) {
       @manage={{(noop)}}
       @collapse={{(noop)}}
       @expand={{this.expand}}
-    />
-`);
+    />`);
 
     await component.collapsed.expand();
   });
@@ -93,8 +90,7 @@ module('Integration | Component | school session attributes', function (hooks) {
       @manage={{(noop)}}
       @collapse={{this.collapse}}
       @expand={{(noop)}}
-    />
-`);
+    />`);
 
     await component.expanded.collapse();
   });

--- a/tests/integration/components/school-session-type-form-test.js
+++ b/tests/integration/components/school-session-type-form-test.js
@@ -50,8 +50,7 @@ module('Integration | Component | school session type form', function (hooks) {
       @selectedAssessmentOptionId={{this.assessmentOptionId}}
       @save={{(noop)}}
       @close={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title.value, 'one');
     assert.strictEqual(component.aamcMethod.value, '');
@@ -105,8 +104,7 @@ module('Integration | Component | school session type form', function (hooks) {
       @assessmentOptions={{this.assessmentOptions}}
       @save={{(noop)}}
       @close={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.aamcMethod.value, '');
     assert.strictEqual(component.aamcMethod.options.length, 2);
@@ -136,8 +134,7 @@ module('Integration | Component | school session type form', function (hooks) {
       @canEditAssessmentOption={{true}}
       @save={{(noop)}}
       @close={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.assessment.isAssessment);
     assert.notOk(component.assessmentSelector.isVisible);
@@ -152,8 +149,7 @@ module('Integration | Component | school session type form', function (hooks) {
       @canUpdate={{true}}
       @save={{(noop)}}
       @close={{this.cancel}}
-    />
-`);
+    />`);
 
     await component.cancel.click();
   });
@@ -167,8 +163,7 @@ module('Integration | Component | school session type form', function (hooks) {
       @canUpdate={{false}}
       @save={{(noop)}}
       @close={{this.close}}
-    />
-`);
+    />`);
 
     await component.close.click();
   });
@@ -216,8 +211,7 @@ module('Integration | Component | school session type form', function (hooks) {
       @canUpdate={{true}}
       @save={{this.save}}
       @close={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.active.yesNoToggle.checked, 'true');
     await component.title.set('new title');
@@ -255,8 +249,7 @@ module('Integration | Component | school session type form', function (hooks) {
       @isActive={{true}}
       @save={{(noop)}}
       @close={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.title.inputControlIsVisible);
     assert.notOk(component.aamcMethod.inputControlIsVisible);
@@ -291,8 +284,7 @@ module('Integration | Component | school session type form', function (hooks) {
       @assessment={{true}}
       @save={{(noop)}}
       @close={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.aamcMethod.value, 'AM001');
     assert.strictEqual(component.aamcMethod.options[1].text, 'lorem ipsum (inactive)');
@@ -319,8 +311,7 @@ module('Integration | Component | school session type form', function (hooks) {
       @assessment={{true}}
       @save={{(noop)}}
       @close={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.aamcMethod.readonlyValue, 'lorem ipsum (inactive)');
   });
@@ -337,8 +328,7 @@ module('Integration | Component | school session type form', function (hooks) {
       @calendarColor="#ffffff"
       @save={{(noop)}}
       @close={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.calendarColor.value, '#ffffff');
     assert.notOk(component.calendarColor.hasError);

--- a/tests/integration/components/school-session-type-manager-test.js
+++ b/tests/integration/components/school-session-type-manager-test.js
@@ -36,8 +36,7 @@ module('Integration | Component | school session type manager', function (hooks)
       @canUpdate={{true}}
       @sessionType={{this.sessionType}}
       @close={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title, 'one');
     assert.strictEqual(component.form.title.value, 'one');
@@ -65,8 +64,7 @@ module('Integration | Component | school session type manager', function (hooks)
       @canUpdate={{true}}
       @sessionType={{this.sessionType}}
       @close={{this.close}}
-    />
-`);
+    />`);
 
     await component.form.cancel.click();
   });

--- a/tests/integration/components/school-session-types-collapsed-test.js
+++ b/tests/integration/components/school-session-types-collapsed-test.js
@@ -18,8 +18,7 @@ module('Integration | Component | school session types collapsed', function (hoo
     const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
     this.set('school', schoolModel);
 
-    await render(hbs`<SchoolSessionTypesCollapsed @school={{this.school}} @expand={{(noop)}} />
-`);
+    await render(hbs`<SchoolSessionTypesCollapsed @school={{this.school}} @expand={{(noop)}} />`);
 
     assert.strictEqual(parseInt(component.assessmentCount, 10), 1);
     assert.strictEqual(parseInt(component.instructionalCount, 10), 1);
@@ -35,8 +34,7 @@ module('Integration | Component | school session types collapsed', function (hoo
     });
 
     await render(
-      hbs`<SchoolSessionTypesCollapsed @school={{this.school}} @expand={{this.expand}} />
-`
+      hbs`<SchoolSessionTypesCollapsed @school={{this.school}} @expand={{this.expand}} />`
     );
 
     await component.expand();

--- a/tests/integration/components/school-session-types-expanded-test.js
+++ b/tests/integration/components/school-session-types-expanded-test.js
@@ -47,8 +47,7 @@ module('Integration | Component | school session types expanded', function (hook
       @managedSessionTypeId={{null}}
       @setSchoolManagedSessionType={{(noop)}}
       @setSchoolNewSessionType={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.list.sessionTypes.isVisible);
     assert.strictEqual(component.title, 'Session Types (0)');
@@ -66,8 +65,7 @@ module('Integration | Component | school session types expanded', function (hook
       @managedSessionTypeId={{null}}
       @setSchoolManagedSessionType={{(noop)}}
       @setSchoolNewSessionType={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.list.sessionTypes.length, 1);
     assert.strictEqual(component.title, 'Session Types (1)');
@@ -86,8 +84,7 @@ module('Integration | Component | school session types expanded', function (hook
       @managedSessionTypeId={{this.sessionType.id}}
       @setSchoolManagedSessionType={{(noop)}}
       @setSchoolNewSessionType={{(noop)}}
-    />
-`);
+    />`);
 
     assert.ok(component.manager.isVisible);
   });
@@ -108,8 +105,7 @@ module('Integration | Component | school session types expanded', function (hook
       @managedSessionTypeId={{null}}
       @setSchoolManagedSessionType={{this.click}}
       @setSchoolNewSessionType={{(noop)}}
-    />
-`);
+    />`);
 
     await component.list.sessionTypes[0].manage();
   });
@@ -130,8 +126,7 @@ module('Integration | Component | school session types expanded', function (hook
       @managedSessionTypeId={{null}}
       @setSchoolManagedSessionType={{(noop)}}
       @setSchoolNewSessionType={{this.click}}
-    />
-`);
+    />`);
 
     await component.createNew();
   });
@@ -153,8 +148,7 @@ module('Integration | Component | school session types expanded', function (hook
       @managedSessionTypeId={{this.sessionType.id}}
       @setSchoolManagedSessionType={{this.click}}
       @setSchoolNewSessionType={{(noop)}}
-    />
-`);
+    />`);
 
     await component.newSessionType.cancel.click();
   });
@@ -175,8 +169,7 @@ module('Integration | Component | school session types expanded', function (hook
       @managedSessionTypeId={{null}}
       @setSchoolManagedSessionType={{(noop)}}
       @setSchoolNewSessionType={{(noop)}}
-    />
-`);
+    />`);
 
     await component.collapse();
   });

--- a/tests/integration/components/school-session-types-list-item-test.js
+++ b/tests/integration/components/school-session-types-list-item-test.js
@@ -45,8 +45,7 @@ module('Integration | Component | school-session-types-list-item', function (hoo
       @sessionType={{this.sessionType}}
       @canDelete={{true}}
       @manageSessionType={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title.text, 'salt');
     assert.strictEqual(component.sessionCount, '2');
     assert.ok(component.isAssessment);
@@ -75,8 +74,7 @@ module('Integration | Component | school-session-types-list-item', function (hoo
       @sessionType={{this.sessionType}}
       @canDelete={{true}}
       @manageSessionType={{this.manageSessionType}}
-    />
-`);
+    />`);
     await component.manage();
   });
 
@@ -100,8 +98,7 @@ module('Integration | Component | school-session-types-list-item', function (hoo
       @sessionType={{this.sessionType}}
       @canDelete={{true}}
       @manageSessionType={{this.manageSessionType}}
-    />
-`);
+    />`);
     await component.title.edit();
   });
 
@@ -122,8 +119,7 @@ module('Integration | Component | school-session-types-list-item', function (hoo
       @sessionType={{this.sessionType}}
       @canDelete={{true}}
       @manageSessionType={{(noop)}}
-    />
-`);
+    />`);
     assert.ok(component.isDeletable);
   });
 
@@ -144,8 +140,7 @@ module('Integration | Component | school-session-types-list-item', function (hoo
       @sessionType={{this.sessionType}}
       @canDelete={{false}}
       @manageSessionType={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.isDeletable);
   });
 
@@ -167,8 +162,7 @@ module('Integration | Component | school-session-types-list-item', function (hoo
       @sessionType={{this.sessionType}}
       @canDelete={{true}}
       @manageSessionType={{(noop)}}
-    />
-`);
+    />`);
     assert.notOk(component.isDeletable);
   });
 });

--- a/tests/integration/components/school-session-types-list-test.js
+++ b/tests/integration/components/school-session-types-list-test.js
@@ -59,8 +59,7 @@ module('Integration | Component | school session types list', function (hooks) {
     const sessionTypeModels = await this.owner.lookup('service:store').findAll('session-type');
     this.set('sessionTypes', sessionTypeModels);
     await render(
-      hbs`<SchoolSessionTypesList @sessionTypes={{this.sessionTypes}} @manageSessionType={{(noop)}} />
-`
+      hbs`<SchoolSessionTypesList @sessionTypes={{this.sessionTypes}} @manageSessionType={{(noop)}} />`
     );
 
     assert.strictEqual(component.sessionTypes.length, 3);
@@ -105,8 +104,7 @@ module('Integration | Component | school session types list', function (hooks) {
     await render(hbs`<SchoolSessionTypesList
       @sessionTypes={{this.sessionTypes}}
       @manageSessionType={{this.manageSessionType}}
-    />
-`);
+    />`);
 
     await component.sessionTypes[0].manage();
   });
@@ -129,8 +127,7 @@ module('Integration | Component | school session types list', function (hooks) {
     await render(hbs`<SchoolSessionTypesList
       @sessionTypes={{this.sessionTypes}}
       @manageSessionType={{this.manageSessionType}}
-    />
-`);
+    />`);
 
     await component.sessionTypes[0].title.edit();
   });
@@ -159,8 +156,7 @@ module('Integration | Component | school session types list', function (hooks) {
       @sessionTypes={{this.sessionTypes}}
       @manageSessionType={{(noop)}}
       @canDelete={{true}}
-    />
-`);
+    />`);
 
     assert.notOk(component.sessionTypes[0].isDeletable);
     assert.ok(component.sessionTypes[1].isDeletable);
@@ -179,8 +175,7 @@ module('Integration | Component | school session types list', function (hooks) {
       @sessionTypes={{this.sessionTypes}}
       @manageSessionType={{(noop)}}
       @canDelete={{true}}
-    />
-`);
+    />`);
 
     assert.strictEqual(this.server.db.sessionTypes.length, 1);
     assert.notOk(component.sessionTypes[0].confirmRemoval.isVisible);

--- a/tests/integration/components/school-vocabularies-collapsed-test.js
+++ b/tests/integration/components/school-vocabularies-collapsed-test.js
@@ -30,8 +30,7 @@ module('Integration | Component | school vocabularies collapsed', function (hook
     const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
     this.set('school', schoolModel);
 
-    await render(hbs`<SchoolVocabulariesCollapsed @school={{this.school}} @expand={{(noop)}} />
-`);
+    await render(hbs`<SchoolVocabulariesCollapsed @school={{this.school}} @expand={{(noop)}} />`);
 
     assert.strictEqual(component.title, 'Vocabularies (2)');
     assert.strictEqual(component.vocabularies.length, 2);
@@ -54,8 +53,7 @@ module('Integration | Component | school vocabularies collapsed', function (hook
       assert.ok(true, 'expand triggered.');
     });
     await render(
-      hbs`<SchoolVocabulariesCollapsed @school={{this.school}} @expand={{this.expand}} />
-`
+      hbs`<SchoolVocabulariesCollapsed @school={{this.school}} @expand={{this.expand}} />`
     );
 
     await component.expand();

--- a/tests/integration/components/school-vocabularies-expanded-test.js
+++ b/tests/integration/components/school-vocabularies-expanded-test.js
@@ -22,8 +22,7 @@ module('Integration | Component | school vocabularies expanded', function (hooks
       @collapse={{(noop)}}
       @setSchoolManagedVocabulary={{(noop)}}
       @setSchoolManagedVocabularyTerm={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title, 'Vocabularies (2)');
     assert.strictEqual(component.vocabulariesList.vocabularies.length, 2);
@@ -48,8 +47,7 @@ module('Integration | Component | school vocabularies expanded', function (hooks
       @collapse={{this.collapse}}
       @setSchoolManagedVocabulary={{(noop)}}
       @setSchoolManagedVocabularyTerm={{(noop)}}
-    />
-`);
+    />`);
 
     await component.collapse();
   });
@@ -67,8 +65,7 @@ module('Integration | Component | school vocabularies expanded', function (hooks
       @managedVocabularyId={{this.vocabularyId}}
       @setSchoolManagedVocabulary={{(noop)}}
       @setSchoolManagedVocabularyTerm={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.vocabulariesList.isVisible);
     assert.ok(component.vocabularyManager.isVisible);
@@ -91,8 +88,7 @@ module('Integration | Component | school vocabularies expanded', function (hooks
       @managedVocabularyId={{this.vocabularyId}}
       @setSchoolManagedVocabulary={{(noop)}}
       @setSchoolManagedVocabularyTerm={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.vocabulariesList.isVisible);
     assert.notOk(component.vocabularyManager.isVisible);

--- a/tests/integration/components/school-vocabularies-list-test.js
+++ b/tests/integration/components/school-vocabularies-list-test.js
@@ -20,8 +20,7 @@ module('Integration | Component | school vocabularies list', function (hooks) {
 
     this.set('school', schoolModel);
     await render(
-      hbs`<SchoolVocabulariesList @school={{this.school}} @manageVocabulary={{(noop)}} />
-`
+      hbs`<SchoolVocabulariesList @school={{this.school}} @manageVocabulary={{(noop)}} />`
     );
     assert.strictEqual(component.vocabularies.length, 2);
     assert.strictEqual(component.vocabularies[0].title.text, 'Vocabulary 1');
@@ -42,8 +41,7 @@ module('Integration | Component | school vocabularies list', function (hooks) {
       @school={{this.school}}
       @manageVocabulary={{(noop)}}
       @canDelete={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.vocabularies.length, 3);
     assert.notOk(component.vocabularies[0].hasDeleteButton);
     assert.notOk(component.vocabularies[1].hasDeleteButton);
@@ -59,8 +57,7 @@ module('Integration | Component | school vocabularies list', function (hooks) {
       @school={{this.school}}
       @manageVocabulary={{(noop)}}
       @canDelete={{true}}
-    />
-`);
+    />`);
 
     assert.notOk(component.deletionConfirmation.isVisible);
     await component.vocabularies[0].delete();
@@ -81,8 +78,7 @@ module('Integration | Component | school vocabularies list', function (hooks) {
       assert.strictEqual(id, vocabularies[0].id);
     });
     await render(
-      hbs`<SchoolVocabulariesList @school={{this.school}} @manageVocabulary={{this.edit}} />
-`
+      hbs`<SchoolVocabulariesList @school={{this.school}} @manageVocabulary={{this.edit}} />`
     );
     await component.vocabularies[0].manage();
   });

--- a/tests/integration/components/school-vocabulary-manager-test.js
+++ b/tests/integration/components/school-vocabulary-manager-test.js
@@ -36,8 +36,7 @@ module('Integration | Component | school vocabulary manager', function (hooks) {
       @vocabulary={{this.vocabulary}}
       @manageTerm={{(noop)}}
       @manageVocabulary={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${vocabulary.title} (3 total)`);
     assert.strictEqual(component.breadcrumbs.all, 'All Vocabularies');
     assert.strictEqual(component.breadcrumbs.vocabulary, vocabulary.title);
@@ -63,8 +62,7 @@ module('Integration | Component | school vocabulary manager', function (hooks) {
       @manageTerm={{(noop)}}
       @manageVocabulary={{(noop)}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${vocabulary.title} (0 total)`);
     await component.editTitle();
     await component.changeTitle('new title');
@@ -87,8 +85,7 @@ module('Integration | Component | school vocabulary manager', function (hooks) {
       @manageTerm={{(noop)}}
       @manageVocabulary={{(noop)}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${vocabulary.title} (0 total)`);
     assert.notOk(component.hasError);
     await component.editTitle();
@@ -118,8 +115,7 @@ module('Integration | Component | school vocabulary manager', function (hooks) {
       @manageTerm={{(noop)}}
       @manageVocabulary={{(noop)}}
       @canUpdate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${vocabulary.title} (0 total)`);
     assert.notOk(component.hasError);
     await component.editTitle();
@@ -145,8 +141,7 @@ module('Integration | Component | school vocabulary manager', function (hooks) {
       @manageTerm={{(noop)}}
       @manageVocabulary={{(noop)}}
       @canCreate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${vocabulary.title} (0 total)`);
     assert.strictEqual(component.terms.list.length, 0);
 
@@ -173,8 +168,7 @@ module('Integration | Component | school vocabulary manager', function (hooks) {
       @manageTerm={{(noop)}}
       @manageVocabulary={{(noop)}}
       @canCreate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${vocabulary.title} (0 total)`);
     assert.strictEqual(component.terms.list.length, 0);
 
@@ -204,8 +198,7 @@ module('Integration | Component | school vocabulary manager', function (hooks) {
       @manageTerm={{(noop)}}
       @manageVocabulary={{(noop)}}
       @canCreate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${vocabulary.title} (1 total)`);
     assert.strictEqual(component.terms.list.length, 1);
 

--- a/tests/integration/components/school-vocabulary-new-term-test.js
+++ b/tests/integration/components/school-vocabulary-new-term-test.js
@@ -28,8 +28,7 @@ module('Integration | Component | school vocabulary new term', function (hooks) 
     await render(hbs`<SchoolVocabularyNewTerm
       @vocabulary={{this.vocabulary}}
       @createTerm={{this.createTerm}}
-    />
-`);
+    />`);
 
     await component.setTitle(newTitle);
     await component.save();
@@ -46,8 +45,7 @@ module('Integration | Component | school vocabulary new term', function (hooks) 
     await render(hbs`<SchoolVocabularyNewTerm
       @vocabulary={{this.vocabulary}}
       @createTerm={{true}}
-    />
-`);
+    />`);
 
     assert.notOk(component.hasError);
     await component.setTitle('');
@@ -72,8 +70,7 @@ module('Integration | Component | school vocabulary new term', function (hooks) 
     await render(hbs`<SchoolVocabularyNewTerm
       @vocabulary={{this.vocabulary}}
       @createTerm={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.hasError);
     await component.setTitle(title);
@@ -105,8 +102,7 @@ module('Integration | Component | school vocabulary new term', function (hooks) 
       @vocabulary={{this.vocabulary}}
       @term={{this.term}}
       @createTerm={{(noop)}}
-    />
-`);
+    />`);
 
     assert.notOk(component.hasError);
     await component.setTitle(title);

--- a/tests/integration/components/school-vocabulary-term-manager-test.js
+++ b/tests/integration/components/school-vocabulary-term-manager-test.js
@@ -57,8 +57,7 @@ module('Integration | Component | school vocabulary term manager', function (hoo
       @canUpdate={{true}}
       @canDelete={{true}}
       @canCreate={{true}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title, `Title: ${term.title}`);
     assert.strictEqual(component.description, `Description: ${term.description}`);
@@ -101,8 +100,7 @@ module('Integration | Component | school vocabulary term manager', function (hoo
       @canUpdate={{true}}
       @canDelete={{true}}
       @canCreate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.isActive.yesNoToggle.checked, 'false');
     await component.isActive.yesNoToggle.click();
     assert.strictEqual(component.isActive.yesNoToggle.checked, 'true');
@@ -131,8 +129,7 @@ module('Integration | Component | school vocabulary term manager', function (hoo
       @canUpdate={{true}}
       @canDelete={{true}}
       @canCreate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.isActive.yesNoToggle.checked, 'true');
     await component.isActive.yesNoToggle.click();
     assert.strictEqual(component.isActive.yesNoToggle.checked, 'false');
@@ -162,8 +159,7 @@ module('Integration | Component | school vocabulary term manager', function (hoo
       @canUpdate={{true}}
       @canDelete={{true}}
       @canCreate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${term.title}`);
     await component.editTitle();
     await component.changeTitle('new title');
@@ -194,8 +190,7 @@ module('Integration | Component | school vocabulary term manager', function (hoo
       @canUpdate={{true}}
       @canDelete={{true}}
       @canCreate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${term.title}`);
     assert.notOk(component.hasError);
     await component.editTitle();
@@ -234,8 +229,7 @@ module('Integration | Component | school vocabulary term manager', function (hoo
       @canUpdate={{true}}
       @canDelete={{true}}
       @canCreate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${term.title}`);
     assert.notOk(component.hasError);
     await component.editTitle();
@@ -268,8 +262,7 @@ module('Integration | Component | school vocabulary term manager', function (hoo
       @canUpdate={{true}}
       @canDelete={{true}}
       @canCreate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${term.title}`);
     assert.strictEqual(component.subTerms.list.length, 0);
 
@@ -303,8 +296,7 @@ module('Integration | Component | school vocabulary term manager', function (hoo
       @canUpdate={{true}}
       @canDelete={{true}}
       @canCreate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${term.title}`);
     assert.strictEqual(component.subTerms.list.length, 0);
 
@@ -344,8 +336,7 @@ module('Integration | Component | school vocabulary term manager', function (hoo
       @canUpdate={{true}}
       @canDelete={{true}}
       @canCreate={{true}}
-    />
-`);
+    />`);
     assert.strictEqual(component.title, `Title: ${term.title}`);
     assert.strictEqual(component.subTerms.list.length, 1);
 

--- a/tests/integration/components/unassigned-students-summary-test.js
+++ b/tests/integration/components/unassigned-students-summary-test.js
@@ -44,8 +44,7 @@ module('Integration | Component | unassigned students summary', function (hooks)
     });
 
     this.set('schools', schoolModels);
-    await render(hbs`<UnassignedStudentsSummary @schools={{this.schools}} />
-`);
+    await render(hbs`<UnassignedStudentsSummary @schools={{this.schools}} />`);
 
     assert.strictEqual(component.title, 'Students Requiring Cohort Assignment');
     assert.strictEqual(component.schools.length, 2);
@@ -71,8 +70,7 @@ module('Integration | Component | unassigned students summary', function (hooks)
     });
     const schoolModels = await this.owner.lookup('service:store').findAll('school');
     this.set('schools', schoolModels);
-    await render(hbs`<UnassignedStudentsSummary @schools={{this.schools}} />
-`);
+    await render(hbs`<UnassignedStudentsSummary @schools={{this.schools}} />`);
 
     assert.strictEqual(component.title, 'Students Requiring Cohort Assignment');
     assert.strictEqual(component.singleSelectedSchool, 'school 0');

--- a/tests/integration/components/update-notification-test.js
+++ b/tests/integration/components/update-notification-test.js
@@ -9,8 +9,7 @@ module('Integration | Component | update notification', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
-    await render(hbs`<UpdateNotification />
-`);
+    await render(hbs`<UpdateNotification />`);
     assert
       .dom(this.element)
       .hasText(

--- a/tests/integration/components/user-list-test.js
+++ b/tests/integration/components/user-list-test.js
@@ -26,8 +26,7 @@ module('Integration | Component | user list', function (hooks) {
     const userModel1 = await this.owner.lookup('service:store').findRecord('user', user1.id);
     const userModel2 = await this.owner.lookup('service:store').findRecord('user', user2.id);
     this.set('users', [userModel1, userModel2]);
-    await render(hbs`<UserList @users={{this.users}} />
-`);
+    await render(hbs`<UserList @users={{this.users}} />`);
     assert.strictEqual(component.users.length, 2);
     assert.ok(component.users[0].isDisabled);
     assert.ok(component.users[0].disabledUserIcon.isVisible);

--- a/tests/integration/components/user-menu-test.js
+++ b/tests/integration/components/user-menu-test.js
@@ -28,8 +28,7 @@ module('Integration | Component | user-menu', function (hooks) {
   });
 
   test('it renders and is accessible', async function (assert) {
-    await render(hbs`<UserMenu />
-`);
+    await render(hbs`<UserMenu />`);
 
     await a11yAudit(this.element);
     assert.strictEqual(component.text, '0 guy M. Mc0son');
@@ -40,8 +39,7 @@ module('Integration | Component | user-menu', function (hooks) {
   });
 
   test('click opens menu', async function (assert) {
-    await render(hbs`<UserMenu />
-`);
+    await render(hbs`<UserMenu />`);
 
     assert.strictEqual(component.links.length, 0);
     await component.toggle.click();
@@ -49,8 +47,7 @@ module('Integration | Component | user-menu', function (hooks) {
   });
 
   test('down opens menu', async function (assert) {
-    await render(hbs`<UserMenu />
-`);
+    await render(hbs`<UserMenu />`);
 
     assert.strictEqual(component.links.length, 0);
     await component.toggle.down();
@@ -58,8 +55,7 @@ module('Integration | Component | user-menu', function (hooks) {
   });
 
   test('escape closes menu', async function (assert) {
-    await render(hbs`<UserMenu />
-`);
+    await render(hbs`<UserMenu />`);
 
     await component.toggle.down();
     assert.strictEqual(component.links.length, 2);
@@ -68,8 +64,7 @@ module('Integration | Component | user-menu', function (hooks) {
   });
 
   test('click closes menu', async function (assert) {
-    await render(hbs`<UserMenu />
-`);
+    await render(hbs`<UserMenu />`);
 
     await component.toggle.down();
     assert.strictEqual(component.links.length, 2);

--- a/tests/integration/components/user-profile-bio-test.js
+++ b/tests/integration/components/user-profile-bio-test.js
@@ -61,8 +61,7 @@ module('Integration | Component | user profile bio', function (hooks) {
       .findRecord('authentication', this.authentication.id);
     this.set('user', userModel);
 
-    await render(hbs`<UserProfileBio @user={{this.user}} />
-`);
+    await render(hbs`<UserProfileBio @user={{this.user}} />`);
 
     assert.strictEqual(component.school, `Primary School: ${schoolModel.title}`);
     assert.strictEqual(component.firstName.text, `First Name: ${userModel.firstName}`);
@@ -95,8 +94,7 @@ module('Integration | Component | user profile bio', function (hooks) {
       .findRecord('authentication', this.authentication.id);
     this.set('user', userModel);
 
-    await render(hbs`<UserProfileBio @user={{this.user}} />
-`);
+    await render(hbs`<UserProfileBio @user={{this.user}} />`);
 
     assert.strictEqual(component.school, `Primary School: ${schoolModel.title}`);
     assert.strictEqual(component.firstName.text, `First Name: ${userModel.firstName}`);
@@ -127,8 +125,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @user={{this.user}} @isManageable={{true}} @setIsManaging={{this.manage}} />
-`
+      hbs`<UserProfileBio @user={{this.user}} @isManageable={{true}} @setIsManaging={{this.manage}} />`
     );
 
     await component.manage();
@@ -151,8 +148,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     await a11yAudit();
@@ -206,8 +202,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     await a11yAudit();
@@ -258,8 +253,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     await a11yAudit();
@@ -311,8 +305,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     await component.password.edit();
@@ -329,8 +322,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     await component.password.edit();
@@ -346,8 +338,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     await component.password.edit();
@@ -363,8 +354,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     await component.password.edit();
@@ -381,8 +371,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     await component.password.edit();
@@ -399,8 +388,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     await component.password.edit();
@@ -433,8 +421,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     });
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     assert.strictEqual(component.firstName.value, 'Test Person');
@@ -475,8 +462,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     assert.strictEqual(component.preferredEmail.value, 'test2@test.com');
@@ -491,8 +477,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     assert.strictEqual(component.displayName.value, 'Best Name');
@@ -507,8 +492,7 @@ module('Integration | Component | user profile bio', function (hooks) {
     this.set('user', userModel);
 
     await render(
-      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileBio @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     assert.strictEqual(component.pronouns.value, 'they/them/tay');

--- a/tests/integration/components/user-profile-calendar-test.js
+++ b/tests/integration/components/user-profile-calendar-test.js
@@ -71,8 +71,7 @@ module('Integration | Component | user profile calendar', function (hooks) {
       id: 13,
     });
     this.set('user', user);
-    await render(hbs`<UserProfileCalendar @user={{this.user}} />
-`);
+    await render(hbs`<UserProfileCalendar @user={{this.user}} />`);
     const events = '[data-test-calendar-event]';
     const firstEventTitle = `${events}:nth-of-type(1) [data-test-name]`;
     const secondEventTitle = `${events}:nth-of-type(2) [data-test-name]`;
@@ -109,8 +108,7 @@ module('Integration | Component | user profile calendar', function (hooks) {
       id: 13,
     });
     this.set('user', user);
-    await render(hbs`<UserProfileCalendar @user={{this.user}} />
-`);
+    await render(hbs`<UserProfileCalendar @user={{this.user}} />`);
     await click('[data-test-go-forward]');
   });
 
@@ -138,8 +136,7 @@ module('Integration | Component | user profile calendar', function (hooks) {
       id: 13,
     });
     this.set('user', user);
-    await render(hbs`<UserProfileCalendar @user={{this.user}} />
-`);
+    await render(hbs`<UserProfileCalendar @user={{this.user}} />`);
     await click('[data-test-go-back]');
   });
 });

--- a/tests/integration/components/user-profile-cohorts-test.js
+++ b/tests/integration/components/user-profile-cohorts-test.js
@@ -42,8 +42,7 @@ module('Integration | Component | user profile cohorts', function (hooks) {
 
   test('it renders', async function (assert) {
     this.set('user', this.user);
-    await render(hbs`<UserProfileCohorts @user={{this.user}} />
-`);
+    await render(hbs`<UserProfileCohorts @user={{this.user}} />`);
     assert.strictEqual(component.primaryCohort.text, 'Primary Cohort: school 0 program 0 cohort 0');
     assert.strictEqual(component.secondaryCohorts.length, 1);
     assert.strictEqual(component.secondaryCohorts[0].title, 'school 1 program 1 cohort 1');
@@ -56,8 +55,7 @@ module('Integration | Component | user profile cohorts', function (hooks) {
       assert.ok(what, 'recieved boolean true value');
     });
     await render(
-      hbs`<UserProfileCohorts @user={{this.user}} @isManageable={{true}} @setIsManaging={{this.click}} />
-`
+      hbs`<UserProfileCohorts @user={{this.user}} @isManageable={{true}} @setIsManaging={{this.click}} />`
     );
     await component.manage();
   });
@@ -80,8 +78,7 @@ module('Integration | Component | user profile cohorts', function (hooks) {
     });
 
     await render(
-      hbs`<UserProfileCohorts @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileCohorts @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
 
     assert.strictEqual(component.primaryCohort.title, 'school 0 program 0 cohort 0');

--- a/tests/integration/components/user-profile-ics-test.js
+++ b/tests/integration/components/user-profile-ics-test.js
@@ -34,8 +34,7 @@ module('Integration | Component | user profile ics', function (hooks) {
       assert.ok(what, 'received boolean true value');
     });
     await render(
-      hbs`<UserProfileIcs @user={{this.user}} @isManageable={{true}} @setIsManaging={{this.click}} />
-`
+      hbs`<UserProfileIcs @user={{this.user}} @isManageable={{true}} @setIsManaging={{this.click}} />`
     );
     await component.manage();
   });
@@ -44,8 +43,7 @@ module('Integration | Component | user profile ics', function (hooks) {
     const userModel = await this.owner.lookup('service:store').findRecord('user', this.user.id);
     this.set('user', userModel);
     await render(
-      hbs`<UserProfileIcs @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />
-`
+      hbs`<UserProfileIcs @isManaging={{true}} @user={{this.user}} @setIsManaging={{(noop)}} />`
     );
     const currentKey = this.user.icsFeedKey;
     assert.strictEqual(userModel.icsFeedKey, currentKey, 'icsFeedKey is correct');
@@ -62,8 +60,7 @@ module('Integration | Component | user profile ics', function (hooks) {
   skip('clicking copy displays message', async function (assert) {
     const userModel = await this.owner.lookup('service:store').findRecord('user', this.user.id);
     this.set('user', userModel);
-    await render(hbs`<UserProfileIcs @user={{this.user}} />
-`);
+    await render(hbs`<UserProfileIcs @user={{this.user}} />`);
     assert.notOk(component.key.copy.successMessage.isVisible);
     await component.key.copy.click();
     assert.ok(component.key.copy.successMessage.isVisible);

--- a/tests/integration/components/user-profile-learnergroups-test.js
+++ b/tests/integration/components/user-profile-learnergroups-test.js
@@ -55,8 +55,7 @@ module('Integration | Component | user profile learnergroups', function (hooks) 
     });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
-    await render(hbs`<UserProfileLearnergroups @user={{this.user}} />
-`);
+    await render(hbs`<UserProfileLearnergroups @user={{this.user}} />`);
     assert.strictEqual(component.groups.length, 2);
     assert.strictEqual(component.groups[0].text, 'SOD: Program2 Cohort2 — LearnerGroup2');
     assert.strictEqual(component.groups[1].text, 'SOM: Program1 Cohort1 — LearnerGroup1');

--- a/tests/integration/components/user-profile-permissions-test.js
+++ b/tests/integration/components/user-profile-permissions-test.js
@@ -32,8 +32,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @user={{this.user}}
       @setSchool={{(noop)}}
       @setYear={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.title, 'Permissions');
     assert.strictEqual(component.schools.length, 2);
@@ -83,8 +82,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @user={{this.user}}
       @setSchool={{this.setSchool}}
       @setYear={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(component.selectedSchool, '2');
     assert.strictEqual(component.school.title, 'School (school 1)');
     await component.changeSchool(1);
@@ -117,8 +115,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @user={{this.user}}
       @setSchool={{(noop)}}
       @setYear={{this.setYear}}
-    />
-`);
+    />`);
     assert.strictEqual(parseInt(component.selectedYear, 10), this.currentAcademicYear);
     await component.courses.toggle();
     assert.strictEqual(component.courses.directors.length, 1);
@@ -139,8 +136,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @user={{this.user}}
       @setSchool={{(noop)}}
       @setYear={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.school.director, 'Yes');
     assert.strictEqual(component.school.administrator, 'Yes');
@@ -168,8 +164,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @user={{this.user}}
       @setSchool={{(noop)}}
       @setYear={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.school.director, 'No');
     assert.strictEqual(component.school.administrator, 'No');
@@ -203,8 +198,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @user={{this.user}}
       @setSchool={{(noop)}}
       @setYear={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.school.director, 'No');
     assert.strictEqual(component.school.administrator, 'No');
@@ -252,8 +246,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @user={{this.user}}
       @setSchool={{(noop)}}
       @setYear={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.school.director, 'No');
     assert.strictEqual(component.school.administrator, 'No');
@@ -316,8 +309,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @user={{this.user}}
       @setSchool={{(noop)}}
       @setYear={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.school.director, 'No');
     assert.strictEqual(component.school.administrator, 'No');
@@ -373,8 +365,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @currentDate={{this.currentDate}}
       @setSchool={{(noop)}}
       @setYear={{(noop)}}
-    />
-`);
+    />`);
     assert.strictEqual(parseInt(component.selectedYear, 10), this.currentAcademicYear);
     unfreezeDate();
   });
@@ -411,8 +402,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
 
-    await render(hbs`<UserProfilePermissions @user={{this.user}} />
-`);
+    await render(hbs`<UserProfilePermissions @user={{this.user}} />`);
     assert.strictEqual(component.courses.administrators.length, 1);
     assert.strictEqual(
       component.courses.administrators[0].text,
@@ -460,8 +450,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @selectedYearId={{this.year}}
       @setSchool={{(noop)}}
       @setYear={{(noop)}}
-    />
-`);
+    />`);
 
     assert.strictEqual(component.selectedSchool, this.schools[1].id);
     assert.strictEqual(parseInt(component.selectedYear, 10), this.thisYear + 1);

--- a/tests/integration/components/user-profile-roles-test.js
+++ b/tests/integration/components/user-profile-roles-test.js
@@ -28,8 +28,7 @@ module('Integration | Component | user profile roles', function (hooks) {
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
 
     this.set('user', userModel);
-    await render(hbs`<UserProfileRoles @user={{this.user}} />
-`);
+    await render(hbs`<UserProfileRoles @user={{this.user}} />`);
 
     assert.strictEqual(component.student.value, 'Yes');
     assert.strictEqual(component.formerStudent.value, 'No');
@@ -52,8 +51,7 @@ module('Integration | Component | user profile roles', function (hooks) {
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
 
     this.set('user', userModel);
-    await render(hbs`<UserProfileRoles @user={{this.user}} />
-`);
+    await render(hbs`<UserProfileRoles @user={{this.user}} />`);
 
     assert.ok(component.root.yesNo.yes);
     assert.notOk(component.root.yesNo.no);
@@ -71,8 +69,7 @@ module('Integration | Component | user profile roles', function (hooks) {
       assert.ok(what, 'recieved boolean true value');
     });
     await render(
-      hbs`<UserProfileRoles @user={{this.user}} @isManageable={{true}} @setIsManaging={{this.click}} />
-`
+      hbs`<UserProfileRoles @user={{this.user}} @isManageable={{true}} @setIsManaging={{this.click}} />`
     );
     await component.manage.click();
   });
@@ -85,8 +82,7 @@ module('Integration | Component | user profile roles', function (hooks) {
     });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
-    await render(hbs`<UserProfileRoles @isManaging={{true}} @user={{this.user}} />
-`);
+    await render(hbs`<UserProfileRoles @isManaging={{true}} @user={{this.user}} />`);
 
     assert.notOk(component.formerStudent.isChecked);
     assert.ok(component.enabled.isChecked);

--- a/tests/integration/components/visualizer-program-year-objectives-test.js
+++ b/tests/integration/components/visualizer-program-year-objectives-test.js
@@ -76,8 +76,7 @@ module('Integration | Component | visualizer-program-year-objectives', function 
       .lookup('service:store')
       .findRecord('program-year', programYear.id);
     this.set('programYear', programYearModel);
-    await render(hbs`<VisualizerProgramYearObjectives @programYear={{this.programYear}} />
-`);
+    await render(hbs`<VisualizerProgramYearObjectives @programYear={{this.programYear}} />`);
 
     assert.dom('svg').exists({ count: 1 });
     assert.dom('svg g.links').exists({ count: 1 });

--- a/tests/integration/components/visualizer-session-type-terms-test.js
+++ b/tests/integration/components/visualizer-session-type-terms-test.js
@@ -36,8 +36,7 @@ module('Integration | Component | visualizer session type terms', function (hook
       .findRecord('session-type', vocabulary.id);
     this.set('vocabulary', vocabularyModel);
     await render(
-      hbs`<VisualizerSessionTypeTerms @sessionType={{this.sessionType}} @vocabulary={{this.vocabulary}} />
-`
+      hbs`<VisualizerSessionTypeTerms @sessionType={{this.sessionType}} @vocabulary={{this.vocabulary}} />`
     );
 
     assert.dom('svg').exists({ count: 1 });

--- a/tests/integration/components/visualizer-session-type-vocabularies-test.js
+++ b/tests/integration/components/visualizer-session-type-vocabularies-test.js
@@ -39,8 +39,7 @@ module('Integration | Component | visualizer session type vocabularies', functio
       .lookup('service:store')
       .findRecord('session-type', sessionType.id);
     this.set('sessionType', sessionTypeModel);
-    await render(hbs`<VisualizerSessionTypeVocabularies @sessionType={{this.sessionType}} />
-`);
+    await render(hbs`<VisualizerSessionTypeVocabularies @sessionType={{this.sessionType}} />`);
 
     assert.dom('svg').exists({ count: 1 });
     await waitFor('.loaded');

--- a/tests/integration/components/yes-no-test.js
+++ b/tests/integration/components/yes-no-test.js
@@ -10,16 +10,14 @@ module('Integration | Component | yes-no', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   test('it renders yes', async function (assert) {
-    await render(hbs`<YesNo @value={{true}} />
-`);
+    await render(hbs`<YesNo @value={{true}} />`);
     assert.strictEqual(component.text, 'Yes');
     assert.ok(component.yes);
     assert.notOk(component.no);
   });
 
   test('it renders no', async function (assert) {
-    await render(hbs`<YesNo @value={{false}} />
-`);
+    await render(hbs`<YesNo @value={{false}} />`);
     assert.strictEqual(component.text, 'No');
     assert.notOk(component.yes);
     assert.ok(component.no);

--- a/tests/integration/helpers/pcrs-uri-to-number-test.js
+++ b/tests/integration/helpers/pcrs-uri-to-number-test.js
@@ -10,8 +10,7 @@ module('Integration | Helper | pcrs-uri-to-number', function (hooks) {
 
   test('it renders', async function (assert) {
     this.set('inputValue', 'aamc-pcrs-comp-c0103');
-    await render(hbs`{{pcrs-uri-to-number this.inputValue}}
-`);
+    await render(hbs`{{pcrs-uri-to-number this.inputValue}}`);
     assert.strictEqual(this.element.textContent.trim(), '1.3');
   });
 });


### PR DESCRIPTION
For both helpers and components doing linting results in less readable code. Additionally we sometimes have to jump through hoops to make a test pretty like production code and most of our template linting just doesn't apply to tests. Let's disable template linting in test files and make tests pretty again.