### PR TITLE
GraphQL Subject Reports

### DIFF
--- a/app/components/reports/subject.hbs
+++ b/app/components/reports/subject.hbs
@@ -56,35 +56,9 @@
         </select>
       </div>
     {{/if}}
-    {{#if (is-array this.reportResultsList)}}
-      <ul class="report-results" data-test-results>
-        {{#each this.reportResultsList as |item|}}
-          {{#if item.model2}}
-            <li>
-              <LinkTo
-                @route={{item.route}}
-                @models={{array item.model item.model2}}
-              >
-                {{item.value}}
-              </LinkTo>
-            </li>
-          {{else if item.model}}
-            <li>
-              <LinkTo @route={{item.route}} @model={{item.model}}>
-                {{item.value}}
-              </LinkTo>
-            </li>
-          {{else}}
-            <li>
-              {{item.value}}
-            </li>
-          {{/if}}
-        {{else}}
-            <li>{{t "general.none"}}</li>
-        {{/each}}
-      </ul>
-    {{else}}
-      <LoadingSpinner />
-    {{/if}}
+    <this.subjectComponent
+      @report={{@selectedReport}}
+      @year={{@selectedYear}}
+    />
   </div>
 </section>

--- a/app/components/reports/subject.hbs
+++ b/app/components/reports/subject.hbs
@@ -8,7 +8,7 @@
       {{t "general.backToSubjectReports"}}
     </LinkTo>
   </div>
-  <div class="header">
+  <div class="header" data-test-report-header>
     <h2 id="title" class="title" data-test-title>
       {{this.selectedReportTitle}}
     </h2>

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -19,6 +19,7 @@ import LearningMaterialComponent from './subject/learning-material';
 import CompetencyComponent from './subject/competency';
 import MeshTermComponent from './subject/mesh-term';
 import TermComponent from './subject/term';
+import SessionTypeComponent from './subject/session-type';
 
 export default class ReportsSubjectComponent extends Component {
   @service currentUser;
@@ -59,6 +60,8 @@ export default class ReportsSubjectComponent extends Component {
         return ensureSafeComponent(MeshTermComponent, this);
       case 'term':
         return ensureSafeComponent(TermComponent, this);
+      case 'session type':
+        return ensureSafeComponent(SessionTypeComponent, this);
     }
 
     return null;

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -13,6 +13,7 @@ import CourseComponent from './subject/course';
 import SessionComponent from './subject/session';
 import ProgramComponent from './subject/program';
 import ProgramYearComponent from './subject/program-year';
+import InstructorComponent from './subject/instructor';
 
 export default class ReportsSubjectComponent extends Component {
   @service currentUser;
@@ -41,6 +42,8 @@ export default class ReportsSubjectComponent extends Component {
         return ensureSafeComponent(ProgramComponent, this);
       case 'program year':
         return ensureSafeComponent(ProgramYearComponent, this);
+      case 'instructor':
+        return ensureSafeComponent(InstructorComponent, this);
     }
 
     return null;

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -18,6 +18,7 @@ import InstructorGroupComponent from './subject/instructor-group';
 import LearningMaterialComponent from './subject/learning-material';
 import CompetencyComponent from './subject/competency';
 import MeshTermComponent from './subject/mesh-term';
+import TermComponent from './subject/term';
 
 export default class ReportsSubjectComponent extends Component {
   @service currentUser;
@@ -56,6 +57,8 @@ export default class ReportsSubjectComponent extends Component {
         return ensureSafeComponent(CompetencyComponent, this);
       case 'mesh term':
         return ensureSafeComponent(MeshTermComponent, this);
+      case 'term':
+        return ensureSafeComponent(TermComponent, this);
     }
 
     return null;

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -16,6 +16,7 @@ import ProgramYearComponent from './subject/program-year';
 import InstructorComponent from './subject/instructor';
 import InstructorGroupComponent from './subject/instructor-group';
 import LearningMaterialComponent from './subject/learning-material';
+import CompetencyComponent from './subject/competency';
 
 export default class ReportsSubjectComponent extends Component {
   @service currentUser;
@@ -50,6 +51,8 @@ export default class ReportsSubjectComponent extends Component {
         return ensureSafeComponent(InstructorGroupComponent, this);
       case 'learning material':
         return ensureSafeComponent(LearningMaterialComponent, this);
+      case 'competency':
+        return ensureSafeComponent(CompetencyComponent, this);
     }
 
     return null;

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -11,6 +11,7 @@ import AsyncProcess from 'ilios-common/classes/async-process';
 import { ensureSafeComponent } from '@embroider/util';
 import CourseComponent from './subject/course';
 import SessionComponent from './subject/session';
+import ProgramComponent from './subject/program';
 
 export default class ReportsSubjectComponent extends Component {
   @service currentUser;
@@ -35,6 +36,8 @@ export default class ReportsSubjectComponent extends Component {
         return ensureSafeComponent(CourseComponent, this);
       case 'session':
         return ensureSafeComponent(SessionComponent, this);
+      case 'program':
+        return ensureSafeComponent(ProgramComponent, this);
     }
 
     return null;

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -17,6 +17,7 @@ import InstructorComponent from './subject/instructor';
 import InstructorGroupComponent from './subject/instructor-group';
 import LearningMaterialComponent from './subject/learning-material';
 import CompetencyComponent from './subject/competency';
+import MeshTermComponent from './subject/mesh-term';
 
 export default class ReportsSubjectComponent extends Component {
   @service currentUser;
@@ -53,6 +54,8 @@ export default class ReportsSubjectComponent extends Component {
         return ensureSafeComponent(LearningMaterialComponent, this);
       case 'competency':
         return ensureSafeComponent(CompetencyComponent, this);
+      case 'mesh term':
+        return ensureSafeComponent(MeshTermComponent, this);
     }
 
     return null;

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -15,6 +15,7 @@ import ProgramComponent from './subject/program';
 import ProgramYearComponent from './subject/program-year';
 import InstructorComponent from './subject/instructor';
 import InstructorGroupComponent from './subject/instructor-group';
+import LearningMaterialComponent from './subject/learning-material';
 
 export default class ReportsSubjectComponent extends Component {
   @service currentUser;
@@ -47,6 +48,8 @@ export default class ReportsSubjectComponent extends Component {
         return ensureSafeComponent(InstructorComponent, this);
       case 'instructor group':
         return ensureSafeComponent(InstructorGroupComponent, this);
+      case 'learning material':
+        return ensureSafeComponent(LearningMaterialComponent, this);
     }
 
     return null;

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -12,6 +12,7 @@ import { ensureSafeComponent } from '@embroider/util';
 import CourseComponent from './subject/course';
 import SessionComponent from './subject/session';
 import ProgramComponent from './subject/program';
+import ProgramYearComponent from './subject/program-year';
 
 export default class ReportsSubjectComponent extends Component {
   @service currentUser;
@@ -38,6 +39,8 @@ export default class ReportsSubjectComponent extends Component {
         return ensureSafeComponent(SessionComponent, this);
       case 'program':
         return ensureSafeComponent(ProgramComponent, this);
+      case 'program year':
+        return ensureSafeComponent(ProgramYearComponent, this);
     }
 
     return null;

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -8,6 +8,8 @@ import buildReportTitle from 'ilios/utils/build-report-title';
 import createDownloadFile from 'ilios/utils/create-download-file';
 import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
+import { ensureSafeComponent } from '@embroider/util';
+import CourseComponent from './subject/course';
 
 export default class ReportsSubjectComponent extends Component {
   @service currentUser;
@@ -26,24 +28,20 @@ export default class ReportsSubjectComponent extends Component {
     this.args.selectedReport,
   ]);
 
-  @use reportResultsList = new AsyncProcess(() => [
-    this.getReportResults.bind(this),
-    this.args.selectedReport,
-    this.args.selectedYear,
-  ]);
+  get subjectComponent() {
+    switch (this.args.selectedReport.subject) {
+      case 'course':
+        return ensureSafeComponent(CourseComponent, this);
+    }
+
+    return null;
+  }
 
   async getSelectedReportTitle(selectedReport) {
     if (!selectedReport) {
       return '';
     }
     return buildReportTitle(selectedReport, this.store, this.intl);
-  }
-
-  async getReportResults(selectedReport, selectedYear) {
-    if (!selectedReport) {
-      return [];
-    }
-    return this.reporting.getResults(selectedReport, selectedYear);
   }
 
   get showAcademicYearFilter() {

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -10,6 +10,7 @@ import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { ensureSafeComponent } from '@embroider/util';
 import CourseComponent from './subject/course';
+import SessionComponent from './subject/session';
 
 export default class ReportsSubjectComponent extends Component {
   @service currentUser;
@@ -32,6 +33,8 @@ export default class ReportsSubjectComponent extends Component {
     switch (this.args.selectedReport.subject) {
       case 'course':
         return ensureSafeComponent(CourseComponent, this);
+      case 'session':
+        return ensureSafeComponent(SessionComponent, this);
     }
 
     return null;

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -14,6 +14,7 @@ import SessionComponent from './subject/session';
 import ProgramComponent from './subject/program';
 import ProgramYearComponent from './subject/program-year';
 import InstructorComponent from './subject/instructor';
+import InstructorGroupComponent from './subject/instructor-group';
 
 export default class ReportsSubjectComponent extends Component {
   @service currentUser;
@@ -44,6 +45,8 @@ export default class ReportsSubjectComponent extends Component {
         return ensureSafeComponent(ProgramYearComponent, this);
       case 'instructor':
         return ensureSafeComponent(InstructorComponent, this);
+      case 'instructor group':
+        return ensureSafeComponent(InstructorGroupComponent, this);
     }
 
     return null;

--- a/app/components/reports/subject/competency.hbs
+++ b/app/components/reports/subject/competency.hbs
@@ -1,0 +1,15 @@
+<div data-test-reports-subject-competency>
+  {{#if this.finishedLoading}}
+    <ul class="report-results" data-test-results>
+      {{#each this.data as |title|}}
+        <li>
+          {{title}}
+        </li>
+      {{else}}
+        <li>{{t "general.none"}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</div>

--- a/app/components/reports/subject/competency.hbs
+++ b/app/components/reports/subject/competency.hbs
@@ -1,7 +1,7 @@
 <div data-test-reports-subject-competency>
   {{#if this.finishedLoading}}
     <ul class="report-results" data-test-results>
-      {{#each this.data as |title|}}
+      {{#each this.sortedData as |title|}}
         <li>
           {{title}}
         </li>

--- a/app/components/reports/subject/competency.js
+++ b/app/components/reports/subject/competency.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { camelize } from '@ember/string';
+
+export default class ReportsSubjectCompetencyComponent extends Component {
+  @service graphql;
+
+  @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
+
+  get finishedLoading() {
+    return Array.isArray(this.data);
+  }
+
+  async getReportResults(report) {
+    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
+
+    if (subject !== 'competency') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectCompetencyComponent`);
+    }
+
+    const school = await report.school;
+
+    let filters = [];
+    if (school) {
+      filters.push(`schools: [${school.id}]`);
+    }
+    if (prepositionalObject && prepositionalObjectTableRowId) {
+      const what = pluralize(camelize(prepositionalObject));
+      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+    }
+    const result = await this.graphql.find('competencies', filters, 'id, title');
+    return result.data.competencies.map(({ title }) => title).sort();
+  }
+}

--- a/app/components/reports/subject/competency.js
+++ b/app/components/reports/subject/competency.js
@@ -7,11 +7,18 @@ import { camelize } from '@ember/string';
 
 export default class ReportsSubjectCompetencyComponent extends Component {
   @service graphql;
+  @service intl;
 
   @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
 
   get finishedLoading() {
     return Array.isArray(this.data);
+  }
+
+  get sortedData() {
+    return this.data?.sort((a, b) => {
+      return a.localeCompare(b, this.intl.primaryLocale);
+    });
   }
 
   async getReportResults(report) {
@@ -32,6 +39,6 @@ export default class ReportsSubjectCompetencyComponent extends Component {
       filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }
     const result = await this.graphql.find('competencies', filters, 'id, title');
-    return result.data.competencies.map(({ title }) => title).sort();
+    return result.data.competencies.map(({ title }) => title);
   }
 }

--- a/app/components/reports/subject/course.hbs
+++ b/app/components/reports/subject/course.hbs
@@ -16,9 +16,15 @@
             {{#if this.canViewCourse}}
               <LinkTo @route="course" @model={{course.id}}>
                 {{course.title}}
+                {{#if course.externalId}}
+                  ({{course.externalId}})
+                {{/if}}
               </LinkTo>
             {{else}}
               {{course.title}}
+              {{#if course.externalId}}
+                ({{course.externalId}})
+              {{/if}}
             {{/if}}
           </span>
         </li>

--- a/app/components/reports/subject/course.hbs
+++ b/app/components/reports/subject/course.hbs
@@ -6,7 +6,7 @@
           {{#if this.showYear}}
             <span data-test-year>
               {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                {{course.year}}-{{add course.year 1}}
+                {{course.year}} - {{add course.year 1}}
               {{else}}
                 {{course.year}}
               {{/if}}

--- a/app/components/reports/subject/course.hbs
+++ b/app/components/reports/subject/course.hbs
@@ -1,0 +1,32 @@
+<div data-test-reports-subject-course>
+  {{#if this.finishedLoading}}
+    <ul class="report-results" data-test-results>
+      {{#each this.sortedCourses as |course|}}
+        <li>
+          {{#if this.showYear}}
+            <span data-test-year>
+              {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                {{course.year}}-{{add course.year 1}}
+              {{else}}
+                {{course.year}}
+              {{/if}}
+            </span>
+          {{/if}}
+          <span data-test-title>
+            {{#if this.canViewCourse}}
+              <LinkTo @route="course" @model={{course.id}}>
+                {{course.title}}
+              </LinkTo>
+            {{else}}
+              {{course.title}}
+            {{/if}}
+          </span>
+        </li>
+      {{else}}
+        <li>{{t "general.none"}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</div>

--- a/app/components/reports/subject/course.js
+++ b/app/components/reports/subject/course.js
@@ -45,7 +45,7 @@ export default class ReportsSubjectCourseComponent extends Component {
   }
 
   async getGraphQLFilters(report) {
-    const { prepositionalObject, prepositionalObjectTableRowId } = report;
+    let { prepositionalObject, prepositionalObjectTableRowId } = report;
     const school = await report.school;
     let rhett = [];
     if (school) {
@@ -55,6 +55,7 @@ export default class ReportsSubjectCourseComponent extends Component {
       let what = pluralize(camelize(prepositionalObject));
       if (prepositionalObject === 'mesh term') {
         what = 'meshDescriptors';
+        prepositionalObjectTableRowId = `"${prepositionalObjectTableRowId}"`;
       }
       rhett.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }

--- a/app/components/reports/subject/course.js
+++ b/app/components/reports/subject/course.js
@@ -44,25 +44,30 @@ export default class ReportsSubjectCourseComponent extends Component {
     return Array.isArray(this.data);
   }
 
-  async getReportResults(report) {
-    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
-
-    if (subject !== 'course') {
-      throw new Error(`Report for ${subject} sent to ReportsSubjectCourseComponent`);
-    }
-
+  async getGraphQLFilters(report) {
+    const { prepositionalObject, prepositionalObjectTableRowId } = report;
     const school = await report.school;
-
-    let filters = [];
+    let rhett = [];
     if (school) {
-      filters.push(`schools: [${school.id}]`);
+      rhett.push(`schools: [${school.id}]`);
     }
     if (prepositionalObject && prepositionalObjectTableRowId) {
       let what = pluralize(camelize(prepositionalObject));
       if (prepositionalObject === 'mesh term') {
         what = 'meshDescriptors';
       }
-      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+      rhett.push(`${what}: [${prepositionalObjectTableRowId}]`);
+    }
+
+    return rhett;
+  }
+
+  async getReportResults(report) {
+    const { subject } = report;
+
+    const filters = await this.getGraphQLFilters(report);
+    if (subject !== 'course') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectCourseComponent`);
     }
     const result = await this.graphql.find('courses', filters, 'id, title, year, externalId');
 

--- a/app/components/reports/subject/course.js
+++ b/app/components/reports/subject/course.js
@@ -1,0 +1,74 @@
+import Component from '@glimmer/component';
+import { filterBy } from 'ilios-common/utils/array-helpers';
+import { sortBy } from 'ilios-common/utils/array-helpers';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { camelize } from '@ember/string';
+
+export default class ReportsSubjectCourseComponent extends Component {
+  @service graphql;
+  @service iliosConfig;
+  @service currentUser;
+
+  @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
+
+  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
+    false,
+  ]);
+
+  get canViewCourse() {
+    return this.currentUser.performsNonLearnerFunction;
+  }
+
+  get showYear() {
+    return !this.args.year;
+  }
+
+  get filteredCourses() {
+    if (this.args.year) {
+      return filterBy(this.data, 'year', Number(this.args.year));
+    }
+
+    return this.data;
+  }
+
+  get sortedCourses() {
+    return sortBy(this.filteredCourses, ['year', 'title']);
+  }
+
+  get finishedLoading() {
+    return Array.isArray(this.data);
+  }
+
+  async getReportResults(report) {
+    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
+
+    if (subject !== 'course') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectCourseComponent`);
+    }
+
+    const school = await report.school;
+
+    let filters = [];
+    if (school) {
+      filters.push(`schools: [${school.id}]`);
+    }
+    if (prepositionalObject && prepositionalObjectTableRowId) {
+      let what = pluralize(camelize(prepositionalObject));
+      if (prepositionalObject === 'mesh term') {
+        what = 'meshDescriptors';
+      }
+      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+    }
+    const filterString = filters.length ? '(' + filters.join(', ') + ')' : '';
+    const result = await this.graphql.query(`
+      query { courses${filterString} { id, title, year } }
+    `);
+
+    return result.data.courses;
+  }
+}

--- a/app/components/reports/subject/course.js
+++ b/app/components/reports/subject/course.js
@@ -64,7 +64,7 @@ export default class ReportsSubjectCourseComponent extends Component {
       }
       filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }
-    const result = await this.graphql.find('courses', filters, 'id, title, year');
+    const result = await this.graphql.find('courses', filters, 'id, title, year, externalId');
 
     return result.data.courses;
   }

--- a/app/components/reports/subject/course.js
+++ b/app/components/reports/subject/course.js
@@ -64,10 +64,7 @@ export default class ReportsSubjectCourseComponent extends Component {
       }
       filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }
-    const filterString = filters.length ? '(' + filters.join(', ') + ')' : '';
-    const result = await this.graphql.query(`
-      query { courses${filterString} { id, title, year } }
-    `);
+    const result = await this.graphql.find('courses', filters, 'id, title, year');
 
     return result.data.courses;
   }

--- a/app/components/reports/subject/instructor-group.hbs
+++ b/app/components/reports/subject/instructor-group.hbs
@@ -1,0 +1,15 @@
+<div data-test-reports-subject-instructor-group>
+  {{#if this.finishedLoading}}
+    <ul class="report-results" data-test-results>
+      {{#each this.data as |title|}}
+        <li>
+          {{title}}
+        </li>
+      {{else}}
+        <li>{{t "general.none"}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</div>

--- a/app/components/reports/subject/instructor-group.hbs
+++ b/app/components/reports/subject/instructor-group.hbs
@@ -1,7 +1,7 @@
 <div data-test-reports-subject-instructor-group>
   {{#if this.finishedLoading}}
     <ul class="report-results" data-test-results>
-      {{#each this.data as |title|}}
+      {{#each this.sortedData as |title|}}
         <li>
           {{title}}
         </li>

--- a/app/components/reports/subject/instructor-group.js
+++ b/app/components/reports/subject/instructor-group.js
@@ -7,11 +7,18 @@ import { camelize } from '@ember/string';
 
 export default class ReportsSubjectInstructorGroupComponent extends Component {
   @service graphql;
+  @service intl;
 
   @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
 
   get finishedLoading() {
     return Array.isArray(this.data);
+  }
+
+  get sortedData() {
+    return this.data?.sort((a, b) => {
+      return a.localeCompare(b, this.intl.primaryLocale);
+    });
   }
 
   async getReportResults(report) {
@@ -32,6 +39,6 @@ export default class ReportsSubjectInstructorGroupComponent extends Component {
       filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }
     const result = await this.graphql.find('instructorGroups', filters, 'title');
-    return result.data.instructorGroups.map(({ title }) => title).sort();
+    return result.data.instructorGroups.map(({ title }) => title);
   }
 }

--- a/app/components/reports/subject/instructor-group.js
+++ b/app/components/reports/subject/instructor-group.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { camelize } from '@ember/string';
+
+export default class ReportsSubjectInstructorGroupComponent extends Component {
+  @service graphql;
+
+  @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
+
+  get finishedLoading() {
+    return Array.isArray(this.data);
+  }
+
+  async getReportResults(report) {
+    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
+
+    if (subject !== 'instructor group') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectInstructorGroupComponent`);
+    }
+
+    const school = await report.school;
+
+    let filters = [];
+    if (school) {
+      filters.push(`schools: [${school.id}]`);
+    }
+    if (prepositionalObject && prepositionalObjectTableRowId) {
+      const what = pluralize(camelize(prepositionalObject));
+      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+    }
+    const result = await this.graphql.find('instructorGroups', filters, 'title');
+    return result.data.instructorGroups.map(({ title }) => title).sort();
+  }
+}

--- a/app/components/reports/subject/instructor.hbs
+++ b/app/components/reports/subject/instructor.hbs
@@ -1,7 +1,7 @@
 <div data-test-reports-subject-instructor>
   {{#if this.finishedLoading}}
     <ul class="report-results" data-test-results>
-      {{#each this.data as |name|}}
+      {{#each this.sortedResults as |name|}}
         <li>
           {{name}}
         </li>

--- a/app/components/reports/subject/instructor.hbs
+++ b/app/components/reports/subject/instructor.hbs
@@ -1,0 +1,15 @@
+<div data-test-reports-subject-instructor>
+  {{#if this.finishedLoading}}
+    <ul class="report-results" data-test-results>
+      {{#each this.data as |name|}}
+        <li>
+          {{name}}
+        </li>
+      {{else}}
+        <li>{{t "general.none"}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</div>

--- a/app/components/reports/subject/instructor.js
+++ b/app/components/reports/subject/instructor.js
@@ -1,0 +1,56 @@
+import Component from '@glimmer/component';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { camelize, capitalize } from '@ember/string';
+
+export default class ReportsSubjectInstructorComponent extends Component {
+  @service graphql;
+
+  @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
+
+  get finishedLoading() {
+    return Array.isArray(this.data);
+  }
+
+  async getReportResults(report) {
+    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
+
+    if (subject !== 'instructor') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectInstructorComponent`);
+    }
+
+    const school = await report.school;
+
+    let filters = [];
+    if (school) {
+      filters.push(`schools: [${school.id}]`);
+    }
+    if (prepositionalObject && prepositionalObjectTableRowId) {
+      let what = pluralize(camelize(prepositionalObject));
+      const specialInstructed = ['learningMaterials', 'sessionTypes', 'courses', 'sessions'];
+      if (specialInstructed.includes(what)) {
+        what = 'instructed' + capitalize(what);
+      }
+      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+    }
+    const attributes = ['firstName', 'middleName', 'lastName', 'displayName'];
+    const result = await this.graphql.find('users', filters, attributes.join(','));
+    return result.data.users
+      .map(({ firstName, middleName, lastName, displayName }) => {
+        if (displayName) {
+          return displayName;
+        }
+
+        const middleInitial = middleName ? middleName.charAt(0) : false;
+
+        if (middleInitial) {
+          return `${firstName} ${middleInitial}. ${lastName}`;
+        } else {
+          return `${firstName} ${lastName}`;
+        }
+      })
+      .sort();
+  }
+}

--- a/app/components/reports/subject/instructor.js
+++ b/app/components/reports/subject/instructor.js
@@ -7,6 +7,7 @@ import { camelize, capitalize } from '@ember/string';
 
 export default class ReportsSubjectInstructorComponent extends Component {
   @service graphql;
+  @service intl;
 
   @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
 
@@ -15,7 +16,9 @@ export default class ReportsSubjectInstructorComponent extends Component {
   }
 
   get sortedResults() {
-    return this.mappedResults?.sort();
+    return this.mappedResults?.sort((a, b) => {
+      return a.localeCompare(b, this.intl.primaryLocale);
+    });
   }
 
   get mappedResults() {

--- a/app/components/reports/subject/learning-material.hbs
+++ b/app/components/reports/subject/learning-material.hbs
@@ -1,7 +1,7 @@
 <div data-test-reports-subject-learning-material>
   {{#if this.finishedLoading}}
     <ul class="report-results" data-test-results>
-      {{#each this.data as |title|}}
+      {{#each this.sortedData as |title|}}
         <li>
           {{title}}
         </li>

--- a/app/components/reports/subject/learning-material.hbs
+++ b/app/components/reports/subject/learning-material.hbs
@@ -1,0 +1,15 @@
+<div data-test-reports-subject-learning-material>
+  {{#if this.finishedLoading}}
+    <ul class="report-results" data-test-results>
+      {{#each this.data as |title|}}
+        <li>
+          {{title}}
+        </li>
+      {{else}}
+        <li>{{t "general.none"}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</div>

--- a/app/components/reports/subject/learning-material.js
+++ b/app/components/reports/subject/learning-material.js
@@ -28,6 +28,9 @@ export default class ReportsSubjectLearningMaterialComponent extends Component {
       if (what === 'course') {
         what = 'fullCourses';
       }
+      if (prepositionalObject === 'mesh term') {
+        what = 'meshDescriptors';
+      }
       rhett.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }
 

--- a/app/components/reports/subject/learning-material.js
+++ b/app/components/reports/subject/learning-material.js
@@ -22,7 +22,7 @@ export default class ReportsSubjectLearningMaterialComponent extends Component {
   }
 
   async getGraphQLFilters(report) {
-    const { prepositionalObject, prepositionalObjectTableRowId } = report;
+    let { prepositionalObject, prepositionalObjectTableRowId } = report;
 
     const school = await report.school;
 
@@ -37,6 +37,7 @@ export default class ReportsSubjectLearningMaterialComponent extends Component {
       }
       if (prepositionalObject === 'mesh term') {
         what = 'meshDescriptors';
+        prepositionalObjectTableRowId = `"${prepositionalObjectTableRowId}"`;
       }
       rhett.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }

--- a/app/components/reports/subject/learning-material.js
+++ b/app/components/reports/subject/learning-material.js
@@ -1,0 +1,40 @@
+import Component from '@glimmer/component';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { camelize } from '@ember/string';
+
+export default class ReportsSubjectLearningMaterialComponent extends Component {
+  @service graphql;
+
+  @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
+
+  get finishedLoading() {
+    return Array.isArray(this.data);
+  }
+
+  async getReportResults(report) {
+    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
+
+    if (subject !== 'learning material') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectLearningMaterialComponent`);
+    }
+
+    const school = await report.school;
+
+    let filters = [];
+    if (school) {
+      filters.push(`schools: [${school.id}]`);
+    }
+    if (prepositionalObject && prepositionalObjectTableRowId) {
+      let what = pluralize(camelize(prepositionalObject));
+      if (what === 'course') {
+        what = 'fullCourses';
+      }
+      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+    }
+    const result = await this.graphql.find('learningMaterials', filters, 'id, title');
+    return result.data.learningMaterials.map(({ title }) => title).sort();
+  }
+}

--- a/app/components/reports/subject/learning-material.js
+++ b/app/components/reports/subject/learning-material.js
@@ -7,11 +7,18 @@ import { camelize } from '@ember/string';
 
 export default class ReportsSubjectLearningMaterialComponent extends Component {
   @service graphql;
+  @service intl;
 
   @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
 
   get finishedLoading() {
     return Array.isArray(this.data);
+  }
+
+  get sortedData() {
+    return this.data?.sort((a, b) => {
+      return a.localeCompare(b, this.intl.primaryLocale);
+    });
   }
 
   async getGraphQLFilters(report) {
@@ -46,6 +53,6 @@ export default class ReportsSubjectLearningMaterialComponent extends Component {
 
     const filters = await this.getGraphQLFilters(report);
     const result = await this.graphql.find('learningMaterials', filters, 'id, title');
-    return result.data.learningMaterials.map(({ title }) => title).sort();
+    return result.data.learningMaterials.map(({ title }) => title);
   }
 }

--- a/app/components/reports/subject/learning-material.js
+++ b/app/components/reports/subject/learning-material.js
@@ -14,26 +14,34 @@ export default class ReportsSubjectLearningMaterialComponent extends Component {
     return Array.isArray(this.data);
   }
 
-  async getReportResults(report) {
-    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
-
-    if (subject !== 'learning material') {
-      throw new Error(`Report for ${subject} sent to ReportsSubjectLearningMaterialComponent`);
-    }
+  async getGraphQLFilters(report) {
+    const { prepositionalObject, prepositionalObjectTableRowId } = report;
 
     const school = await report.school;
 
-    let filters = [];
+    let rhett = [];
     if (school) {
-      filters.push(`schools: [${school.id}]`);
+      rhett.push(`schools: [${school.id}]`);
     }
     if (prepositionalObject && prepositionalObjectTableRowId) {
       let what = pluralize(camelize(prepositionalObject));
       if (what === 'course') {
         what = 'fullCourses';
       }
-      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+      rhett.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }
+
+    return rhett;
+  }
+
+  async getReportResults(report) {
+    const { subject } = report;
+
+    if (subject !== 'learning material') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectLearningMaterialComponent`);
+    }
+
+    const filters = await this.getGraphQLFilters(report);
     const result = await this.graphql.find('learningMaterials', filters, 'id, title');
     return result.data.learningMaterials.map(({ title }) => title).sort();
   }

--- a/app/components/reports/subject/mesh-term.hbs
+++ b/app/components/reports/subject/mesh-term.hbs
@@ -1,0 +1,15 @@
+<div data-test-reports-subject-mesh-term>
+  {{#if this.finishedLoading}}
+    <ul class="report-results" data-test-results>
+      {{#each this.data as |name|}}
+        <li>
+          {{name}}
+        </li>
+      {{else}}
+        <li>{{t "general.none"}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</div>

--- a/app/components/reports/subject/mesh-term.hbs
+++ b/app/components/reports/subject/mesh-term.hbs
@@ -1,7 +1,7 @@
 <div data-test-reports-subject-mesh-term>
   {{#if this.finishedLoading}}
     <ul class="report-results" data-test-results>
-      {{#each this.data as |name|}}
+      {{#each this.sortedData as |name|}}
         <li>
           {{name}}
         </li>

--- a/app/components/reports/subject/mesh-term.js
+++ b/app/components/reports/subject/mesh-term.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { camelize } from '@ember/string';
+
+export default class ReportsSubjectMeshTermComponent extends Component {
+  @service graphql;
+
+  @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
+
+  get finishedLoading() {
+    return Array.isArray(this.data);
+  }
+
+  async getReportResults(report) {
+    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
+
+    if (subject !== 'mesh term') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectMeshTermComponent`);
+    }
+
+    const school = await report.school;
+
+    let filters = [];
+    if (school) {
+      filters.push(`schools: [${school.id}]`);
+    }
+    if (prepositionalObject && prepositionalObjectTableRowId) {
+      const what = pluralize(camelize(prepositionalObject));
+      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+    }
+    const result = await this.graphql.find('meshDescriptors', filters, 'id, name');
+    return result.data.meshDescriptors.map(({ name }) => name).sort();
+  }
+}

--- a/app/components/reports/subject/mesh-term.js
+++ b/app/components/reports/subject/mesh-term.js
@@ -7,11 +7,18 @@ import { camelize } from '@ember/string';
 
 export default class ReportsSubjectMeshTermComponent extends Component {
   @service graphql;
+  @service intl;
 
   @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
 
   get finishedLoading() {
     return Array.isArray(this.data);
+  }
+
+  get sortedData() {
+    return this.data?.sort((a, b) => {
+      return a.localeCompare(b, this.intl.primaryLocale);
+    });
   }
 
   async getReportResults(report) {
@@ -32,6 +39,6 @@ export default class ReportsSubjectMeshTermComponent extends Component {
       filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }
     const result = await this.graphql.find('meshDescriptors', filters, 'id, name');
-    return result.data.meshDescriptors.map(({ name }) => name).sort();
+    return result.data.meshDescriptors.map(({ name }) => name);
   }
 }

--- a/app/components/reports/subject/program-year.hbs
+++ b/app/components/reports/subject/program-year.hbs
@@ -1,0 +1,31 @@
+<div data-test-reports-subject-program-year>
+  {{#if this.finishedLoading}}
+    <ul class="report-results" data-test-results>
+      {{#each this.sortedProgramYears as |obj|}}
+        <li>
+          {{#if this.showSchool}}
+            <span data-test-school>
+              {{obj.program.school.title}} -
+            </span>
+          {{/if}}
+          <span data-test-program>
+            {{obj.program.title}}:
+          </span>
+          <span data-test-title>
+            {{#if this.canView}}
+              <LinkTo @route="program-year" @models={{array obj.program.id obj.id}}>
+                {{obj.classOfYear}}
+              </LinkTo>
+            {{else}}
+              {{obj.classOfYear}}
+            {{/if}}
+          </span>
+        </li>
+      {{else}}
+        <li>{{t "general.none"}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</div>

--- a/app/components/reports/subject/program-year.js
+++ b/app/components/reports/subject/program-year.js
@@ -1,0 +1,61 @@
+import Component from '@glimmer/component';
+import { sortBy } from 'ilios-common/utils/array-helpers';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { camelize } from '@ember/string';
+
+export default class ReportsSubjectProgramYearComponent extends Component {
+  @service graphql;
+  @service currentUser;
+
+  @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
+
+  get canView() {
+    return this.currentUser.performsNonLearnerFunction;
+  }
+
+  get showSchool() {
+    return !this.args.report.belongsTo('school').id();
+  }
+
+  get sortedProgramYears() {
+    return sortBy(this.data, ['program.school.title', 'program.title', 'classOfYear']);
+  }
+
+  get finishedLoading() {
+    return Array.isArray(this.data);
+  }
+
+  async getReportResults(report) {
+    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
+
+    if (subject !== 'program year') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectProgramYearComponent`);
+    }
+
+    const school = await report.school;
+
+    let filters = [];
+    if (school) {
+      filters.push(`schools: [${school.id}]`);
+    }
+    if (prepositionalObject && prepositionalObjectTableRowId) {
+      const what = pluralize(camelize(prepositionalObject));
+      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+    }
+    const result = await this.graphql.find(
+      'programYears',
+      filters,
+      'id, startYear, program { id, title, duration, school { title } }'
+    );
+
+    return result.data.programYears.map((obj) => {
+      const classOfYear = Number(obj.startYear) + Number(obj.program.duration);
+      obj.classOfYear = String(classOfYear);
+
+      return obj;
+    });
+  }
+}

--- a/app/components/reports/subject/program.hbs
+++ b/app/components/reports/subject/program.hbs
@@ -1,0 +1,28 @@
+<div data-test-reports-subject-program>
+  {{#if this.finishedLoading}}
+    <ul class="report-results" data-test-results>
+      {{#each this.sortedPrograms as |program|}}
+        <li>
+          {{#if this.showSchool}}
+            <span data-test-school>
+              {{program.school.title}}
+            </span>
+          {{/if}}
+          <span data-test-title>
+            {{#if this.canView}}
+              <LinkTo @route="program" @model={{program.id}}>
+                {{program.title}}
+              </LinkTo>
+            {{else}}
+              {{program.title}}
+            {{/if}}
+          </span>
+        </li>
+      {{else}}
+        <li>{{t "general.none"}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</div>

--- a/app/components/reports/subject/program.js
+++ b/app/components/reports/subject/program.js
@@ -1,0 +1,52 @@
+import Component from '@glimmer/component';
+import { sortBy } from 'ilios-common/utils/array-helpers';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { camelize } from '@ember/string';
+
+export default class ReportsSubjectProgramComponent extends Component {
+  @service graphql;
+  @service currentUser;
+
+  @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
+
+  get canView() {
+    return this.currentUser.performsNonLearnerFunction;
+  }
+
+  get showSchool() {
+    return !this.args.report.belongsTo('school').id();
+  }
+
+  get sortedPrograms() {
+    return sortBy(this.data, ['school.title', 'title']);
+  }
+
+  get finishedLoading() {
+    return Array.isArray(this.data);
+  }
+
+  async getReportResults(report) {
+    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
+
+    if (subject !== 'program') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectProgramComponent`);
+    }
+
+    const school = await report.school;
+
+    let filters = [];
+    if (school) {
+      filters.push(`schools: [${school.id}]`);
+    }
+    if (prepositionalObject && prepositionalObjectTableRowId) {
+      const what = pluralize(camelize(prepositionalObject));
+      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+    }
+    const result = await this.graphql.find('programs', filters, 'id, title, school { title }');
+
+    return result.data.programs;
+  }
+}

--- a/app/components/reports/subject/session-type.hbs
+++ b/app/components/reports/subject/session-type.hbs
@@ -1,7 +1,7 @@
 <div data-test-reports-subject-session-type>
   {{#if this.finishedLoading}}
     <ul class="report-results" data-test-results>
-      {{#each this.data as |title|}}
+      {{#each this.sortedData as |title|}}
         <li>
           {{title}}
         </li>

--- a/app/components/reports/subject/session-type.hbs
+++ b/app/components/reports/subject/session-type.hbs
@@ -1,0 +1,15 @@
+<div data-test-reports-subject-session-type>
+  {{#if this.finishedLoading}}
+    <ul class="report-results" data-test-results>
+      {{#each this.data as |title|}}
+        <li>
+          {{title}}
+        </li>
+      {{else}}
+        <li>{{t "general.none"}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</div>

--- a/app/components/reports/subject/session-type.js
+++ b/app/components/reports/subject/session-type.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { camelize } from '@ember/string';
+
+export default class ReportsSubjectSessionTypeComponent extends Component {
+  @service graphql;
+
+  @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
+
+  get finishedLoading() {
+    return Array.isArray(this.data);
+  }
+
+  async getReportResults(report) {
+    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
+
+    if (subject !== 'session type') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectSessionTypeComponent`);
+    }
+
+    const school = await report.school;
+
+    let filters = [];
+    if (school) {
+      filters.push(`schools: [${school.id}]`);
+    }
+    if (prepositionalObject && prepositionalObjectTableRowId) {
+      const what = pluralize(camelize(prepositionalObject));
+      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+    }
+    const result = await this.graphql.find('sessionTypes', filters, 'title');
+    return result.data.sessionTypes.map(({ title }) => title).sort();
+  }
+}

--- a/app/components/reports/subject/session-type.js
+++ b/app/components/reports/subject/session-type.js
@@ -7,11 +7,18 @@ import { camelize } from '@ember/string';
 
 export default class ReportsSubjectSessionTypeComponent extends Component {
   @service graphql;
+  @service intl;
 
   @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
 
   get finishedLoading() {
     return Array.isArray(this.data);
+  }
+
+  get sortedData() {
+    return this.data?.sort((a, b) => {
+      return a.localeCompare(b, this.intl.primaryLocale);
+    });
   }
 
   async getGraphQLFilters(report) {
@@ -43,6 +50,6 @@ export default class ReportsSubjectSessionTypeComponent extends Component {
 
     const filters = await this.getGraphQLFilters(report);
     const result = await this.graphql.find('sessionTypes', filters, 'title');
-    return result.data.sessionTypes.map(({ title }) => title).sort();
+    return result.data.sessionTypes.map(({ title }) => title);
   }
 }

--- a/app/components/reports/subject/session-type.js
+++ b/app/components/reports/subject/session-type.js
@@ -22,7 +22,7 @@ export default class ReportsSubjectSessionTypeComponent extends Component {
   }
 
   async getGraphQLFilters(report) {
-    const { prepositionalObject, prepositionalObjectTableRowId } = report;
+    let { prepositionalObject, prepositionalObjectTableRowId } = report;
 
     const school = await report.school;
 
@@ -34,6 +34,7 @@ export default class ReportsSubjectSessionTypeComponent extends Component {
       let what = pluralize(camelize(prepositionalObject));
       if (prepositionalObject === 'mesh term') {
         what = 'meshDescriptors';
+        prepositionalObjectTableRowId = `"${prepositionalObjectTableRowId}"`;
       }
       rhett.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }

--- a/app/components/reports/subject/session.hbs
+++ b/app/components/reports/subject/session.hbs
@@ -6,7 +6,7 @@
           {{#if this.showYear}}
             <span data-test-year>
               {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                {{obj.year}}-{{add obj.year 1}}
+                {{obj.year}} - {{add obj.year 1}}
               {{else}}
                 {{obj.year}}
               {{/if}}

--- a/app/components/reports/subject/session.hbs
+++ b/app/components/reports/subject/session.hbs
@@ -1,0 +1,42 @@
+<div data-test-reports-subject-session>
+  {{#if this.finishedLoading}}
+    <ul class="report-results" data-test-results>
+      {{#each this.sortedSessions as |obj|}}
+        <li>
+          {{#if this.showYear}}
+            <span data-test-year>
+              {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                {{obj.year}}-{{add obj.year 1}}
+              {{else}}
+                {{obj.year}}
+              {{/if}}
+            </span>
+          {{/if}}
+          <span data-test-course-title>
+            {{#if this.canViewCourse}}
+              <LinkTo @route="course" @model={{obj.courseId}}>
+                {{obj.courseTitle}}:
+              </LinkTo>
+            {{else}}
+              {{obj.courseTitle}}:
+            {{/if}}
+          </span>
+
+          <span data-test-session-title>
+            {{#if this.canViewCourse}}
+              <LinkTo @route="session" @models={{array obj.courseId obj.id}}>
+                {{obj.title}}
+              </LinkTo>
+            {{else}}
+              {{obj.title}}
+            {{/if}}
+          </span>
+        </li>
+      {{else}}
+        <li>{{t "general.none"}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</div>

--- a/app/components/reports/subject/session.js
+++ b/app/components/reports/subject/session.js
@@ -59,19 +59,10 @@ export default class ReportsSubjectSessionComponent extends Component {
     }
     if (prepositionalObject && prepositionalObjectTableRowId) {
       let what = pluralize(camelize(prepositionalObject));
-      switch (what) {
-        case 'mesh term':
-          filters.push(`meshDescriptors: [${prepositionalObjectTableRowId}]`);
-          break;
-        case 'sessionTypes':
-          filters.push(`sessionType: ${prepositionalObjectTableRowId}`);
-          break;
-        case 'courses':
-          filters.push(`course: ${prepositionalObjectTableRowId}`);
-          break;
-        default:
-          filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+      if (prepositionalObject === 'mesh term') {
+        what = 'meshDescriptors';
       }
+      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }
     const result = await this.graphql.find(
       'sessions',

--- a/app/components/reports/subject/session.js
+++ b/app/components/reports/subject/session.js
@@ -45,7 +45,7 @@ export default class ReportsSubjectSessionComponent extends Component {
   }
 
   async getGraphQLFilters(report) {
-    const { prepositionalObject, prepositionalObjectTableRowId } = report;
+    let { prepositionalObject, prepositionalObjectTableRowId } = report;
     const school = await report.school;
     const rhett = [];
     if (school) {
@@ -55,6 +55,7 @@ export default class ReportsSubjectSessionComponent extends Component {
       let what = pluralize(camelize(prepositionalObject));
       if (prepositionalObject === 'mesh term') {
         what = 'meshDescriptors';
+        prepositionalObjectTableRowId = `"${prepositionalObjectTableRowId}"`;
       }
       rhett.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }

--- a/app/components/reports/subject/session.js
+++ b/app/components/reports/subject/session.js
@@ -44,26 +44,32 @@ export default class ReportsSubjectSessionComponent extends Component {
     return Array.isArray(this.data);
   }
 
-  async getReportResults(report) {
-    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
-
-    if (subject !== 'session') {
-      throw new Error(`Report for ${subject} sent to ReportsSubjectSessionComponent`);
-    }
-
+  async getGraphQLFilters(report) {
+    const { prepositionalObject, prepositionalObjectTableRowId } = report;
     const school = await report.school;
-
-    let filters = [];
+    const rhett = [];
     if (school) {
-      filters.push(`schools: [${school.id}]`);
+      rhett.push(`schools: [${school.id}]`);
     }
     if (prepositionalObject && prepositionalObjectTableRowId) {
       let what = pluralize(camelize(prepositionalObject));
       if (prepositionalObject === 'mesh term') {
         what = 'meshDescriptors';
       }
-      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+      rhett.push(`${what}: [${prepositionalObjectTableRowId}]`);
     }
+
+    return rhett;
+  }
+
+  async getReportResults(report) {
+    const { subject } = report;
+
+    if (subject !== 'session') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectSessionComponent`);
+    }
+
+    const filters = await this.getGraphQLFilters(report);
     const result = await this.graphql.find(
       'sessions',
       filters,

--- a/app/components/reports/subject/session.js
+++ b/app/components/reports/subject/session.js
@@ -73,10 +73,11 @@ export default class ReportsSubjectSessionComponent extends Component {
           filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
       }
     }
-    const filterString = filters.length ? '(' + filters.join(', ') + ')' : '';
-    const result = await this.graphql.query(`
-      query { sessions${filterString} { id, title, course { id, year, title } } }
-    `);
+    const result = await this.graphql.find(
+      'sessions',
+      filters,
+      'id, title, course { id, year, title }'
+    );
 
     return result.data.sessions.map(({ id, title, course }) => {
       return { id, title, year: course.year, courseId: course.id, courseTitle: course.title };

--- a/app/components/reports/subject/session.js
+++ b/app/components/reports/subject/session.js
@@ -1,0 +1,85 @@
+import Component from '@glimmer/component';
+import { filterBy } from 'ilios-common/utils/array-helpers';
+import { sortBy } from 'ilios-common/utils/array-helpers';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { camelize } from '@ember/string';
+
+export default class ReportsSubjectSessionComponent extends Component {
+  @service graphql;
+  @service iliosConfig;
+  @service currentUser;
+
+  @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
+
+  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
+    false,
+  ]);
+
+  get canViewCourse() {
+    return this.currentUser.performsNonLearnerFunction;
+  }
+
+  get showYear() {
+    return !this.args.year && this.args.report.prepositionalObject !== 'course';
+  }
+
+  get filteredSessions() {
+    if (this.args.year) {
+      return filterBy(this.data, 'year', Number(this.args.year));
+    }
+
+    return this.data;
+  }
+
+  get sortedSessions() {
+    return sortBy(this.filteredSessions, ['year', 'courseTitle', 'title']);
+  }
+
+  get finishedLoading() {
+    return Array.isArray(this.data);
+  }
+
+  async getReportResults(report) {
+    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
+
+    if (subject !== 'session') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectSessionComponent`);
+    }
+
+    const school = await report.school;
+
+    let filters = [];
+    if (school) {
+      filters.push(`schools: [${school.id}]`);
+    }
+    if (prepositionalObject && prepositionalObjectTableRowId) {
+      let what = pluralize(camelize(prepositionalObject));
+      switch (what) {
+        case 'mesh term':
+          filters.push(`meshDescriptors: [${prepositionalObjectTableRowId}]`);
+          break;
+        case 'sessionTypes':
+          filters.push(`sessionType: ${prepositionalObjectTableRowId}`);
+          break;
+        case 'courses':
+          filters.push(`course: ${prepositionalObjectTableRowId}`);
+          break;
+        default:
+          filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+      }
+    }
+    const filterString = filters.length ? '(' + filters.join(', ') + ')' : '';
+    const result = await this.graphql.query(`
+      query { sessions${filterString} { id, title, course { id, year, title } } }
+    `);
+
+    return result.data.sessions.map(({ id, title, course }) => {
+      return { id, title, year: course.year, courseId: course.id, courseTitle: course.title };
+    });
+  }
+}

--- a/app/components/reports/subject/term.hbs
+++ b/app/components/reports/subject/term.hbs
@@ -1,0 +1,15 @@
+<div data-test-reports-subject-term>
+  {{#if this.finishedLoading}}
+    <ul class="report-results" data-test-results>
+      {{#each this.sortedData as |obj|}}
+        <li>
+          {{obj.vocabulary.title}} &gt; {{obj.title}}
+        </li>
+      {{else}}
+        <li>{{t "general.none"}}</li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</div>

--- a/app/components/reports/subject/term.js
+++ b/app/components/reports/subject/term.js
@@ -1,0 +1,42 @@
+import Component from '@glimmer/component';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { camelize } from '@ember/string';
+import { sortBy } from 'ilios-common/utils/array-helpers';
+
+export default class ReportsSubjectTermComponent extends Component {
+  @service graphql;
+
+  @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
+
+  get finishedLoading() {
+    return Array.isArray(this.data);
+  }
+
+  get sortedData() {
+    return sortBy(this.data, ['vocabulary.title', 'title']);
+  }
+
+  async getReportResults(report) {
+    const { subject, prepositionalObject, prepositionalObjectTableRowId } = report;
+
+    if (subject !== 'term') {
+      throw new Error(`Report for ${subject} sent to ReportsSubjectTermComponent`);
+    }
+
+    const school = await report.school;
+
+    let filters = [];
+    if (school) {
+      filters.push(`schools: [${school.id}]`);
+    }
+    if (prepositionalObject && prepositionalObjectTableRowId) {
+      const what = pluralize(camelize(prepositionalObject));
+      filters.push(`${what}: [${prepositionalObjectTableRowId}]`);
+    }
+    const result = await this.graphql.find('terms', filters, 'id, title, vocabulary { id, title }');
+    return result.data.terms;
+  }
+}

--- a/app/services/graphql.js
+++ b/app/services/graphql.js
@@ -24,7 +24,7 @@ export default class GraphqlService extends Service {
       : window.location.protocol + '//' + window.location.host;
   }
 
-  async query(q) {
+  async #query(q) {
     const url = `${this.host}/api/graphql`;
     const headers = this.authHeaders;
     headers['Content-Type'] = 'application/json';
@@ -35,5 +35,10 @@ export default class GraphqlService extends Service {
       body: JSON.stringify({ query: q }),
     });
     return response.json();
+  }
+
+  async find(endpoint, filters, attributes) {
+    const filterString = filters.length ? '(' + filters.join(', ') + ')' : '';
+    return this.#query(`query { ${endpoint}${filterString} { ${attributes} } }`);
   }
 }

--- a/app/services/graphql.js
+++ b/app/services/graphql.js
@@ -1,0 +1,39 @@
+import Service from '@ember/service';
+import fetch from 'fetch';
+import { inject as service } from '@ember/service';
+
+export default class GraphqlService extends Service {
+  @service session;
+  @service iliosConfig;
+
+  get authHeaders() {
+    const headers = {};
+    if (this.session && this.session.isAuthenticated) {
+      const { jwt } = this.session.data.authenticated;
+      if (jwt) {
+        headers['X-JWT-Authorization'] = `Token ${jwt}`;
+      }
+    }
+
+    return headers;
+  }
+
+  get host() {
+    return this.iliosConfig.apiHost
+      ? this.iliosConfig.apiHost
+      : window.location.protocol + '//' + window.location.host;
+  }
+
+  async query(q) {
+    const url = `${this.host}/api/graphql`;
+    const headers = this.authHeaders;
+    headers['Content-Type'] = 'application/json';
+    headers['Accept'] = 'application/json';
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query: q }),
+    });
+    return response.json();
+  }
+}

--- a/tests/acceptance/reports/subject-test.js
+++ b/tests/acceptance/reports/subject-test.js
@@ -55,18 +55,40 @@ module('Acceptance | Reports - Subject Report', function (hooks) {
       user,
       school,
     });
-    this.courseReport = await this.owner
-      .lookup('service:store')
-      .findRecord('report', courseReport.id);
+    const store = this.owner.lookup('service:store');
+    this.courseReport = await store.findRecord('report', courseReport.id);
     this.termReport = await this.owner.lookup('service:store').findRecord('report', termReport.id);
+
+    this.getReportData = async (sessionIds) => {
+      const sessions = await store.findAll('session');
+      const courses = await store.findAll('course');
+      const reportData = sessions
+        .filter(({ id }) => sessionIds.includes(id))
+        .map((m) => {
+          const course = courses.find(({ id }) => id == m.belongsTo('course').id());
+          return {
+            id: m.id,
+            title: m.title,
+            course: {
+              id: course.id,
+              title: course.title,
+              year: course.year,
+            },
+          };
+        });
+
+      return { data: { sessions: reportData } };
+    };
+    this.server.post('api/graphql', async () => this.getReportData(['1', '2']));
   });
 
   test('course report works', async function (assert) {
+    this.server.post('api/graphql', async () => this.getReportData(['1']));
     await page.visit({ reportId: this.courseReport.id });
     assert.strictEqual(currentURL(), '/reports/subjects/1');
     assert.strictEqual(page.report.title, 'my report 0');
     assert.strictEqual(page.report.results.length, 1);
-    assert.strictEqual(page.report.results[0].text, '2015 course 0 session 0');
+    assert.strictEqual(page.report.results[0].text, 'course 0: session 0');
   });
 
   test('term report works', async function (assert) {
@@ -74,8 +96,8 @@ module('Acceptance | Reports - Subject Report', function (hooks) {
     assert.strictEqual(currentURL(), '/reports/subjects/2');
     assert.strictEqual(page.report.title, 'All Sessions for term 0 in school 0');
     assert.strictEqual(page.report.results.length, 2);
-    assert.strictEqual(page.report.results[0].text, '2015 course 0 session 0');
-    assert.strictEqual(page.report.results[1].text, '2016 course 1 session 1');
+    assert.strictEqual(page.report.results[0].text, '2015 course 0: session 0');
+    assert.strictEqual(page.report.results[1].text, '2016 course 1: session 1');
   });
 
   test('academic years is shown as range as applicable by configuration', async function (assert) {
@@ -88,8 +110,9 @@ module('Acceptance | Reports - Subject Report', function (hooks) {
         },
       };
     });
-    await page.visit({ reportId: this.courseReport.id });
-    assert.strictEqual(page.report.results[0].text, '2015 - 2016 course 0 session 0');
+    await page.visit({ reportId: this.termReport.id });
+    assert.strictEqual(page.report.results[0].text, '2015 - 2016 course 0: session 0');
+    assert.strictEqual(page.report.results[1].text, '2016 - 2017 course 1: session 1');
   });
 
   test('no academic years filter on reports with a course prepositional object', async function (assert) {
@@ -98,14 +121,15 @@ module('Acceptance | Reports - Subject Report', function (hooks) {
   });
 
   test('academic year filter works', async function (assert) {
+    this.server.post('api/graphql', async () => this.getReportData(['1', '2']));
     await page.visit({ reportId: this.termReport.id });
     assert.strictEqual(currentURL(), '/reports/subjects/2');
     assert.strictEqual(page.report.results.length, 2);
-    assert.strictEqual(page.report.results[0].text, '2015 course 0 session 0');
-    assert.strictEqual(page.report.results[1].text, '2016 course 1 session 1');
+    assert.strictEqual(page.report.results[0].text, '2015 course 0: session 0');
+    assert.strictEqual(page.report.results[1].text, '2016 course 1: session 1');
     await page.report.academicYears.choose('2016');
     assert.strictEqual(page.report.results.length, 1);
-    assert.strictEqual(page.report.results[0].text, '2016 course 1 session 1');
+    assert.strictEqual(page.report.results[0].text, 'course 1: session 1');
     assert.strictEqual(currentURL(), '/reports/subjects/2?reportYear=2016');
   });
 });

--- a/tests/acceptance/reports/subjects-test.js
+++ b/tests/acceptance/reports/subjects-test.js
@@ -75,6 +75,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('create new report', async function (assert) {
+    assert.expect(12);
     await page.visit();
     assert.strictEqual(page.reports.reports.length, 2);
     assert.strictEqual(page.reports.reports[0].title, 'All Sessions for term 0 in school 0');
@@ -90,14 +91,32 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
     assert.strictEqual(page.reports.reports[0].title, 'aardvark');
     assert.strictEqual(page.reports.reports[1].title, 'All Sessions for term 0 in school 0');
     assert.strictEqual(page.reports.reports[2].title, 'my report 0');
+    this.server.post('api/graphql', ({ db }, { requestBody }) => {
+      const { query } = JSON.parse(requestBody);
+      const course = db.courses[0];
+      const { id, title } = db.sessions[0];
+
+      assert.strictEqual(
+        query,
+        'query { sessions(schools: [1], courses: [1]) { id, title, course { id, year, title } } }'
+      );
+      return {
+        data: {
+          sessions: [
+            { id, title, course: { id: course.id, title: course.title, year: course.year } },
+          ],
+        },
+      };
+    });
     await page.reports.reports[0].select();
     assert.strictEqual(currentURL(), '/reports/subjects/3');
     assert.strictEqual(reportPage.report.title, 'aardvark');
     assert.strictEqual(reportPage.report.results.length, 1);
-    assert.strictEqual(reportPage.report.results[0].text, '2015 course 0 session 0');
+    assert.strictEqual(reportPage.report.results[0].text, 'course 0: session 0');
   });
 
   test('filter courses by year in new report form', async function (assert) {
+    assert.expect(14);
     await page.visit();
     assert.strictEqual(page.reports.reports.length, 2);
     assert.strictEqual(page.reports.reports[0].title, 'All Sessions for term 0 in school 0');
@@ -115,14 +134,32 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
     assert.strictEqual(page.reports.reports[0].title, 'All Sessions for course 1 in school 0');
     assert.strictEqual(page.reports.reports[1].title, 'All Sessions for term 0 in school 0');
     assert.strictEqual(page.reports.reports[2].title, 'my report 0');
+    this.server.post('api/graphql', ({ db }, { requestBody }) => {
+      const { query } = JSON.parse(requestBody);
+      const course = db.courses[1];
+      const { id, title } = db.sessions[1];
+
+      assert.strictEqual(
+        query,
+        'query { sessions(schools: [1], courses: [2]) { id, title, course { id, year, title } } }'
+      );
+      return {
+        data: {
+          sessions: [
+            { id, title, course: { id: course.id, title: course.title, year: course.year } },
+          ],
+        },
+      };
+    });
     await page.reports.reports[0].select();
     assert.strictEqual(currentURL(), '/reports/subjects/3');
     assert.strictEqual(reportPage.report.title, 'All Sessions for course 1 in school 0');
     assert.strictEqual(reportPage.report.results.length, 1);
-    assert.strictEqual(reportPage.report.results[0].text, '2016 course 1 session 1');
+    assert.strictEqual(reportPage.report.results[0].text, 'course 1: session 1');
   });
 
   test('filter session by year in new report form', async function (assert) {
+    assert.expect(14);
     await page.visit();
     assert.strictEqual(page.reports.reports.length, 2);
     assert.strictEqual(page.reports.reports[0].title, 'All Sessions for term 0 in school 0');
@@ -140,6 +177,21 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
     assert.strictEqual(page.reports.reports[0].title, 'All Sessions for term 0 in school 0');
     assert.strictEqual(page.reports.reports[1].title, 'All Terms for session 1 in school 0');
     assert.strictEqual(page.reports.reports[2].title, 'my report 0');
+    this.server.post('api/graphql', ({ db }, { requestBody }) => {
+      const { query } = JSON.parse(requestBody);
+      const { id, title } = db.terms[0];
+      const vocab = db.vocabularies[0];
+
+      assert.strictEqual(
+        query,
+        'query { terms(schools: [1], sessions: [2]) { id, title, vocabulary { id, title } } }'
+      );
+      return {
+        data: {
+          terms: [{ id, title, vocabulary: { id: vocab.id, title: vocab.title } }],
+        },
+      };
+    });
     await page.reports.reports[1].select();
     assert.strictEqual(currentURL(), '/reports/subjects/3');
     assert.strictEqual(reportPage.report.title, 'All Terms for session 1 in school 0');
@@ -148,6 +200,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('get all courses associated with mesh term #3419', async function (assert) {
+    assert.expect(14);
     await page.visit();
     assert.strictEqual(page.reports.reports.length, 2);
     assert.strictEqual(page.reports.reports[0].title, 'All Sessions for term 0 in school 0');
@@ -164,6 +217,21 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
     assert.strictEqual(page.reports.reports[0].title, 'All Courses for descriptor 0 in school 0');
     assert.strictEqual(page.reports.reports[1].title, 'All Sessions for term 0 in school 0');
     assert.strictEqual(page.reports.reports[2].title, 'my report 0');
+    this.server.post('api/graphql', ({ db }, { requestBody }) => {
+      const { query } = JSON.parse(requestBody);
+
+      assert.strictEqual(
+        query,
+        'query { courses(schools: [1], meshDescriptors: [D1234]) { id, title, year, externalId } }'
+      );
+      return {
+        data: {
+          courses: db.courses.map(({ id, title, year, externalId }) => {
+            return { id, title, year, externalId };
+          }),
+        },
+      };
+    });
     await page.reports.reports[0].select();
     assert.strictEqual(currentURL(), '/reports/subjects/3');
     assert.strictEqual(reportPage.report.title, 'All Courses for descriptor 0 in school 0');
@@ -208,6 +276,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('course external Id in report', async function (assert) {
+    assert.expect(13);
     await page.visit();
     assert.strictEqual(page.reports.reports.length, 2);
     assert.strictEqual(page.reports.reports[0].title, 'All Sessions for term 0 in school 0');
@@ -220,6 +289,18 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
     assert.strictEqual(page.reports.reports[0].title, 'All Courses in All Schools');
     assert.strictEqual(page.reports.reports[1].title, 'All Sessions for term 0 in school 0');
     assert.strictEqual(page.reports.reports[2].title, 'my report 0');
+    this.server.post('api/graphql', ({ db }, { requestBody }) => {
+      const { query } = JSON.parse(requestBody);
+
+      assert.strictEqual(query, 'query { courses { id, title, year, externalId } }');
+      return {
+        data: {
+          courses: db.courses.map(({ id, title, year, externalId }) => {
+            return { id, title, year, externalId };
+          }),
+        },
+      };
+    });
     await page.reports.reports[0].select();
     assert.strictEqual(currentURL(), '/reports/subjects/3');
     assert.strictEqual(reportPage.report.title, 'All Courses in All Schools');

--- a/tests/acceptance/reports/subjects-test.js
+++ b/tests/acceptance/reports/subjects-test.js
@@ -222,7 +222,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
 
       assert.strictEqual(
         query,
-        'query { courses(schools: [1], meshDescriptors: [D1234]) { id, title, year, externalId } }'
+        'query { courses(schools: [1], meshDescriptors: ["D1234"]) { id, title, year, externalId } }'
       );
       return {
         data: {

--- a/tests/integration/components/reports/subject/competency-test.js
+++ b/tests/integration/components/reports/subject/competency-test.js
@@ -1,0 +1,89 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/reports/subject/competency';
+
+module('Integration | Component | reports/subject/competency', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  const responseData = {
+    data: {
+      competencies: [
+        { id: 1, title: 'First' },
+        { id: 2, title: 'Second' },
+      ],
+    },
+  };
+
+  test('it renders', async function (assert) {
+    assert.expect(4);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { competencies { id, title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'competency',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Competency @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.strictEqual(component.results[0].title, 'First');
+    assert.strictEqual(component.results[1].title, 'Second');
+  });
+
+  test('filter by school', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { competencies(schools: [33]) { id, title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'competency',
+      school: this.server.create('school', { id: 33 }),
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Competency @report={{this.report}} />`);
+  });
+
+  test('filter by course', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { competencies(courses: [13]) { id, title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'competency',
+      prepositionalObject: 'course',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Competency @report={{this.report}} />`);
+  });
+
+  test('filter by school and session', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { competencies(schools: [24], sessions: [13]) { id, title } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'competency',
+      school: this.server.create('school', { id: 24 }),
+      prepositionalObject: 'session',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Competency @report={{this.report}} />`);
+  });
+});

--- a/tests/integration/components/reports/subject/competency-test.js
+++ b/tests/integration/components/reports/subject/competency-test.js
@@ -4,15 +4,17 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/reports/subject/competency';
+import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/competency', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {
       competencies: [
-        { id: 1, title: 'First' },
+        { id: 1, title: 'first' },
         { id: 2, title: 'Second' },
       ],
     },
@@ -32,7 +34,7 @@ module('Integration | Component | reports/subject/competency', function (hooks) 
     await render(hbs`<Reports::Subject::Competency @report={{this.report}} />`);
 
     assert.strictEqual(component.results.length, 2);
-    assert.strictEqual(component.results[0].title, 'First');
+    assert.strictEqual(component.results[0].title, 'first');
     assert.strictEqual(component.results[1].title, 'Second');
   });
 

--- a/tests/integration/components/reports/subject/course-test.js
+++ b/tests/integration/components/reports/subject/course-test.js
@@ -1,0 +1,166 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/reports/subject/course';
+import { setupAuthentication } from 'ilios-common';
+
+module('Integration | Component | reports/subject/course', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  let validateFilterString;
+
+  hooks.beforeEach(async function () {
+    validateFilterString = () => {};
+    class GraphQlMock extends Service {
+      async query(filterString) {
+        validateFilterString(filterString);
+        return {
+          data: {
+            courses: [
+              { id: 1, title: 'First Course', year: 2023 },
+              { id: 2, title: 'Second Course', year: 2020 },
+            ],
+          },
+        };
+      }
+    }
+
+    this.owner.register('service:graphql', GraphQlMock);
+  });
+
+  test('it renders for user with permissions', async function (assert) {
+    await setupAuthentication({}, true);
+    assert.expect(10);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(filterString.trim(), 'query { courses { id, title, year } }');
+    };
+    const { id } = this.server.create('report', {
+      subject: 'course',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Course @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.ok(component.results[0].hasLink);
+    assert.ok(component.results[1].hasLink);
+    assert.strictEqual(component.results[0].year, '2020');
+    assert.strictEqual(component.results[1].year, '2023');
+    assert.strictEqual(component.results[0].courseTitle, 'Second Course');
+    assert.strictEqual(component.results[1].courseTitle, 'First Course');
+    assert.strictEqual(component.results[0].link, '/courses/2');
+    assert.strictEqual(component.results[1].link, '/courses/1');
+  });
+
+  test('it renders for user with no permissions', async function (assert) {
+    await setupAuthentication();
+    assert.expect(8);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(filterString.trim(), 'query { courses { id, title, year } }');
+    };
+    const { id } = this.server.create('report', {
+      subject: 'course',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Course @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.notOk(component.results[0].hasLink);
+    assert.notOk(component.results[1].hasLink);
+    assert.strictEqual(component.results[0].year, '2020');
+    assert.strictEqual(component.results[1].year, '2023');
+    assert.strictEqual(component.results[0].courseTitle, 'Second Course');
+    assert.strictEqual(component.results[1].courseTitle, 'First Course');
+  });
+
+  test('it reads academic year config', async function (assert) {
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          academicYearCrossesCalendarYearBoundaries: true,
+        },
+      };
+    });
+    const { id } = this.server.create('report', {
+      subject: 'course',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Course @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.strictEqual(component.results[0].year, '2020-2021');
+    assert.strictEqual(component.results[1].year, '2023-2024');
+    assert.strictEqual(component.results[0].courseTitle, 'Second Course');
+    assert.strictEqual(component.results[1].courseTitle, 'First Course');
+  });
+
+  test('year filter works', async function (assert) {
+    assert.expect(4);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(filterString.trim(), 'query { courses { id, title, year } }');
+    };
+    const { id } = this.server.create('report', {
+      subject: 'course',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Course @report={{this.report}} @year={{2023}} />`);
+
+    assert.strictEqual(component.results.length, 1);
+    assert.notOk(component.results[0].hasYear);
+    assert.strictEqual(component.results[0].courseTitle, 'First Course');
+  });
+
+  test('filter by school', async function (assert) {
+    assert.expect(1);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(
+        filterString.trim(),
+        'query { courses(schools: [33]) { id, title, year } }'
+      );
+    };
+    const { id } = this.server.create('report', {
+      subject: 'course',
+      school: this.server.create('school', { id: 33 }),
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Course @report={{this.report}} />`);
+  });
+
+  test('filter by program', async function (assert) {
+    assert.expect(1);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(
+        filterString.trim(),
+        'query { courses(programs: [13]) { id, title, year } }'
+      );
+    };
+    const { id } = this.server.create('report', {
+      subject: 'course',
+      prepositionalObject: 'program',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Course @report={{this.report}} />`);
+  });
+
+  test('filter by school and program', async function (assert) {
+    assert.expect(1);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(
+        filterString.trim(),
+        'query { courses(schools: [24], programs: [13]) { id, title, year } }'
+      );
+    };
+    const { id } = this.server.create('report', {
+      subject: 'course',
+      school: this.server.create('school', { id: 24 }),
+      prepositionalObject: 'program',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Course @report={{this.report}} />`);
+  });
+});

--- a/tests/integration/components/reports/subject/course-test.js
+++ b/tests/integration/components/reports/subject/course-test.js
@@ -88,8 +88,8 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     await render(hbs`<Reports::Subject::Course @report={{this.report}} />`);
 
     assert.strictEqual(component.results.length, 2);
-    assert.strictEqual(component.results[0].year, '2020-2021');
-    assert.strictEqual(component.results[1].year, '2023-2024');
+    assert.strictEqual(component.results[0].year, '2020 - 2021');
+    assert.strictEqual(component.results[1].year, '2023 - 2024');
     assert.strictEqual(component.results[0].courseTitle, 'Second Course (ext ID 1)');
     assert.strictEqual(component.results[1].courseTitle, 'First Course');
   });

--- a/tests/integration/components/reports/subject/course-test.js
+++ b/tests/integration/components/reports/subject/course-test.js
@@ -165,4 +165,23 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
     await render(hbs`<Reports::Subject::Course @report={{this.report}} />`);
   });
+
+  test('filter by mesh', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { courses(meshDescriptors: [ABC]) { id, title, year, externalId } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'course',
+      prepositionalObject: 'mesh term',
+      prepositionalObjectTableRowId: 'ABC',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Course @report={{this.report}} />`);
+  });
 });

--- a/tests/integration/components/reports/subject/course-test.js
+++ b/tests/integration/components/reports/subject/course-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     data: {
       courses: [
         { id: 1, title: 'First Course', year: 2023 },
-        { id: 2, title: 'Second Course', year: 2020 },
+        { id: 2, title: 'Second Course', year: 2020, externalId: 'ext ID 1' },
       ],
     },
   };
@@ -24,7 +24,7 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     assert.expect(10);
     this.server.post('api/graphql', function (schema, { requestBody }) {
       const { query } = JSON.parse(requestBody);
-      assert.strictEqual(query, 'query { courses { id, title, year } }');
+      assert.strictEqual(query, 'query { courses { id, title, year, externalId } }');
       return responseData;
     });
     const { id } = this.server.create('report', {
@@ -38,7 +38,7 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     assert.ok(component.results[1].hasLink);
     assert.strictEqual(component.results[0].year, '2020');
     assert.strictEqual(component.results[1].year, '2023');
-    assert.strictEqual(component.results[0].courseTitle, 'Second Course');
+    assert.strictEqual(component.results[0].courseTitle, 'Second Course (ext ID 1)');
     assert.strictEqual(component.results[1].courseTitle, 'First Course');
     assert.strictEqual(component.results[0].link, '/courses/2');
     assert.strictEqual(component.results[1].link, '/courses/1');
@@ -49,7 +49,7 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     assert.expect(8);
     this.server.post('api/graphql', function (schema, { requestBody }) {
       const { query } = JSON.parse(requestBody);
-      assert.strictEqual(query, 'query { courses { id, title, year } }');
+      assert.strictEqual(query, 'query { courses { id, title, year, externalId } }');
       return responseData;
     });
     const { id } = this.server.create('report', {
@@ -63,7 +63,7 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     assert.notOk(component.results[1].hasLink);
     assert.strictEqual(component.results[0].year, '2020');
     assert.strictEqual(component.results[1].year, '2023');
-    assert.strictEqual(component.results[0].courseTitle, 'Second Course');
+    assert.strictEqual(component.results[0].courseTitle, 'Second Course (ext ID 1)');
     assert.strictEqual(component.results[1].courseTitle, 'First Course');
   });
 
@@ -78,7 +78,7 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     });
     this.server.post('api/graphql', function (schema, { requestBody }) {
       const { query } = JSON.parse(requestBody);
-      assert.strictEqual(query, 'query { courses { id, title, year } }');
+      assert.strictEqual(query, 'query { courses { id, title, year, externalId } }');
       return responseData;
     });
     const { id } = this.server.create('report', {
@@ -90,7 +90,7 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     assert.strictEqual(component.results.length, 2);
     assert.strictEqual(component.results[0].year, '2020-2021');
     assert.strictEqual(component.results[1].year, '2023-2024');
-    assert.strictEqual(component.results[0].courseTitle, 'Second Course');
+    assert.strictEqual(component.results[0].courseTitle, 'Second Course (ext ID 1)');
     assert.strictEqual(component.results[1].courseTitle, 'First Course');
   });
 
@@ -98,7 +98,7 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     assert.expect(4);
     this.server.post('api/graphql', function (schema, { requestBody }) {
       const { query } = JSON.parse(requestBody);
-      assert.strictEqual(query, 'query { courses { id, title, year } }');
+      assert.strictEqual(query, 'query { courses { id, title, year, externalId } }');
       return responseData;
     });
     const { id } = this.server.create('report', {
@@ -116,7 +116,7 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     assert.expect(1);
     this.server.post('api/graphql', function (schema, { requestBody }) {
       const { query } = JSON.parse(requestBody);
-      assert.strictEqual(query, 'query { courses(schools: [33]) { id, title, year } }');
+      assert.strictEqual(query, 'query { courses(schools: [33]) { id, title, year, externalId } }');
       return responseData;
     });
     const { id } = this.server.create('report', {
@@ -131,7 +131,10 @@ module('Integration | Component | reports/subject/course', function (hooks) {
     assert.expect(1);
     this.server.post('api/graphql', function (schema, { requestBody }) {
       const { query } = JSON.parse(requestBody);
-      assert.strictEqual(query, 'query { courses(programs: [13]) { id, title, year } }');
+      assert.strictEqual(
+        query,
+        'query { courses(programs: [13]) { id, title, year, externalId } }'
+      );
       return responseData;
     });
     const { id } = this.server.create('report', {
@@ -149,7 +152,7 @@ module('Integration | Component | reports/subject/course', function (hooks) {
       const { query } = JSON.parse(requestBody);
       assert.strictEqual(
         query,
-        'query { courses(schools: [24], programs: [13]) { id, title, year } }'
+        'query { courses(schools: [24], programs: [13]) { id, title, year, externalId } }'
       );
       return responseData;
     });

--- a/tests/integration/components/reports/subject/course-test.js
+++ b/tests/integration/components/reports/subject/course-test.js
@@ -172,7 +172,7 @@ module('Integration | Component | reports/subject/course', function (hooks) {
       const { query } = JSON.parse(requestBody);
       assert.strictEqual(
         query,
-        'query { courses(meshDescriptors: [ABC]) { id, title, year, externalId } }'
+        'query { courses(meshDescriptors: ["ABC"]) { id, title, year, externalId } }'
       );
       return responseData;
     });

--- a/tests/integration/components/reports/subject/instructor-group-test.js
+++ b/tests/integration/components/reports/subject/instructor-group-test.js
@@ -1,0 +1,86 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/reports/subject/instructor-group';
+
+module('Integration | Component | reports/subject/instructor-group', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  const responseData = {
+    data: {
+      instructorGroups: [{ title: 'First Group' }, { title: 'Second Group' }],
+    },
+  };
+
+  test('it renders', async function (assert) {
+    assert.expect(4);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { instructorGroups { title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'instructor group',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::InstructorGroup @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.strictEqual(component.results[0].title, 'First Group');
+    assert.strictEqual(component.results[1].title, 'Second Group');
+  });
+
+  test('filter by school', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { instructorGroups(schools: [33]) { title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'instructor group',
+      school: this.server.create('school', { id: 33 }),
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::InstructorGroup @report={{this.report}} />`);
+  });
+
+  test('filter by course', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { instructorGroups(courses: [13]) { title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'instructor group',
+      prepositionalObject: 'course',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::InstructorGroup @report={{this.report}} />`);
+  });
+
+  test('filter by school and session', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { instructorGroups(schools: [24], sessions: [13]) { title } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'instructor group',
+      school: this.server.create('school', { id: 24 }),
+      prepositionalObject: 'session',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::InstructorGroup @report={{this.report}} />`);
+  });
+});

--- a/tests/integration/components/reports/subject/instructor-group-test.js
+++ b/tests/integration/components/reports/subject/instructor-group-test.js
@@ -4,14 +4,16 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/reports/subject/instructor-group';
+import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/instructor-group', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {
-      instructorGroups: [{ title: 'First Group' }, { title: 'Second Group' }],
+      instructorGroups: [{ title: 'first Group' }, { title: 'Second Group' }],
     },
   };
 
@@ -29,7 +31,7 @@ module('Integration | Component | reports/subject/instructor-group', function (h
     await render(hbs`<Reports::Subject::InstructorGroup @report={{this.report}} />`);
 
     assert.strictEqual(component.results.length, 2);
-    assert.strictEqual(component.results[0].title, 'First Group');
+    assert.strictEqual(component.results[0].title, 'first Group');
     assert.strictEqual(component.results[1].title, 'Second Group');
   });
 

--- a/tests/integration/components/reports/subject/instructor-test.js
+++ b/tests/integration/components/reports/subject/instructor-test.js
@@ -1,0 +1,95 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/reports/subject/instructor';
+
+module('Integration | Component | reports/subject/instructor', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  const responseData = {
+    data: {
+      users: [
+        { firstName: 'First', middleName: 'Middle', lastName: 'Last', displayName: '' },
+        { firstName: 'Second', middleName: 'Middle', lastName: 'Last', displayName: 'ABC' },
+      ],
+    },
+  };
+
+  test('it renders', async function (assert) {
+    assert.expect(4);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { users { firstName,middleName,lastName,displayName } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'instructor',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Instructor @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.strictEqual(component.results[0].name, 'ABC');
+    assert.strictEqual(component.results[1].name, 'First M. Last');
+  });
+
+  test('filter by school', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { users(schools: [33]) { firstName,middleName,lastName,displayName } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'instructor',
+      school: this.server.create('school', { id: 33 }),
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Instructor @report={{this.report}} />`);
+  });
+
+  test('filter by course', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { users(instructedCourses: [13]) { firstName,middleName,lastName,displayName } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'instructor',
+      prepositionalObject: 'course',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Instructor @report={{this.report}} />`);
+  });
+
+  test('filter by school and session', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { users(schools: [24], instructedSessions: [13]) { firstName,middleName,lastName,displayName } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'instructor',
+      school: this.server.create('school', { id: 24 }),
+      prepositionalObject: 'session',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Instructor @report={{this.report}} />`);
+  });
+});

--- a/tests/integration/components/reports/subject/instructor-test.js
+++ b/tests/integration/components/reports/subject/instructor-test.js
@@ -4,16 +4,18 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/reports/subject/instructor';
+import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/instructor', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {
       users: [
         { firstName: 'First', middleName: 'Middle', lastName: 'Last', displayName: '' },
-        { firstName: 'Second', middleName: 'Middle', lastName: 'Last', displayName: 'ABC' },
+        { firstName: 'Second', middleName: 'Middle', lastName: 'Last', displayName: 'abc' },
       ],
     },
   };
@@ -32,7 +34,7 @@ module('Integration | Component | reports/subject/instructor', function (hooks) 
     await render(hbs`<Reports::Subject::Instructor @report={{this.report}} />`);
 
     assert.strictEqual(component.results.length, 2);
-    assert.strictEqual(component.results[0].name, 'ABC');
+    assert.strictEqual(component.results[0].name, 'abc');
     assert.strictEqual(component.results[1].name, 'First M. Last');
   });
 

--- a/tests/integration/components/reports/subject/learning-material-test.js
+++ b/tests/integration/components/reports/subject/learning-material-test.js
@@ -95,7 +95,7 @@ module('Integration | Component | reports/subject/learning-material', function (
       const { query } = JSON.parse(requestBody);
       assert.strictEqual(
         query,
-        'query { learningMaterials(meshDescriptors: [ABC]) { id, title } }'
+        'query { learningMaterials(meshDescriptors: ["ABC"]) { id, title } }'
       );
       return responseData;
     });

--- a/tests/integration/components/reports/subject/learning-material-test.js
+++ b/tests/integration/components/reports/subject/learning-material-test.js
@@ -4,15 +4,17 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/reports/subject/learning-material';
+import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/learning-material', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {
       learningMaterials: [
-        { id: 1, title: 'First' },
+        { id: 1, title: 'first' },
         { id: 2, title: 'Second' },
       ],
     },
@@ -32,7 +34,7 @@ module('Integration | Component | reports/subject/learning-material', function (
     await render(hbs`<Reports::Subject::LearningMaterial @report={{this.report}} />`);
 
     assert.strictEqual(component.results.length, 2);
-    assert.strictEqual(component.results[0].title, 'First');
+    assert.strictEqual(component.results[0].title, 'first');
     assert.strictEqual(component.results[1].title, 'Second');
   });
 

--- a/tests/integration/components/reports/subject/learning-material-test.js
+++ b/tests/integration/components/reports/subject/learning-material-test.js
@@ -86,4 +86,23 @@ module('Integration | Component | reports/subject/learning-material', function (
     this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
     await render(hbs`<Reports::Subject::LearningMaterial @report={{this.report}} />`);
   });
+
+  test('filter by mesh', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { learningMaterials(meshDescriptors: [ABC]) { id, title } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'learning material',
+      prepositionalObject: 'mesh term',
+      prepositionalObjectTableRowId: 'ABC',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::LearningMaterial @report={{this.report}} />`);
+  });
 });

--- a/tests/integration/components/reports/subject/learning-material-test.js
+++ b/tests/integration/components/reports/subject/learning-material-test.js
@@ -1,0 +1,89 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/reports/subject/learning-material';
+
+module('Integration | Component | reports/subject/learning-material', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  const responseData = {
+    data: {
+      learningMaterials: [
+        { id: 1, title: 'First' },
+        { id: 2, title: 'Second' },
+      ],
+    },
+  };
+
+  test('it renders', async function (assert) {
+    assert.expect(4);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { learningMaterials { id, title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'learning material',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::LearningMaterial @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.strictEqual(component.results[0].title, 'First');
+    assert.strictEqual(component.results[1].title, 'Second');
+  });
+
+  test('filter by school', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { learningMaterials(schools: [33]) { id, title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'learning material',
+      school: this.server.create('school', { id: 33 }),
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::LearningMaterial @report={{this.report}} />`);
+  });
+
+  test('filter by course', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { learningMaterials(courses: [13]) { id, title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'learning material',
+      prepositionalObject: 'course',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::LearningMaterial @report={{this.report}} />`);
+  });
+
+  test('filter by school and session', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { learningMaterials(schools: [24], sessions: [13]) { id, title } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'learning material',
+      school: this.server.create('school', { id: 24 }),
+      prepositionalObject: 'session',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::LearningMaterial @report={{this.report}} />`);
+  });
+});

--- a/tests/integration/components/reports/subject/mesh-term-test.js
+++ b/tests/integration/components/reports/subject/mesh-term-test.js
@@ -4,16 +4,18 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/reports/subject/mesh-term';
+import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/mesh-term', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {
       meshDescriptors: [
         { id: 2, name: 'Second Term' },
-        { id: 1, name: 'First Term' },
+        { id: 1, name: 'first Term' },
       ],
     },
   };
@@ -32,7 +34,7 @@ module('Integration | Component | reports/subject/mesh-term', function (hooks) {
     await render(hbs`<Reports::Subject::MeshTerm @report={{this.report}} />`);
 
     assert.strictEqual(component.results.length, 2);
-    assert.strictEqual(component.results[0].name, 'First Term');
+    assert.strictEqual(component.results[0].name, 'first Term');
     assert.strictEqual(component.results[1].name, 'Second Term');
   });
 

--- a/tests/integration/components/reports/subject/mesh-term-test.js
+++ b/tests/integration/components/reports/subject/mesh-term-test.js
@@ -1,0 +1,89 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/reports/subject/mesh-term';
+
+module('Integration | Component | reports/subject/mesh-term', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  const responseData = {
+    data: {
+      meshDescriptors: [
+        { id: 2, name: 'Second Term' },
+        { id: 1, name: 'First Term' },
+      ],
+    },
+  };
+
+  test('it renders', async function (assert) {
+    assert.expect(4);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { meshDescriptors { id, name } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'mesh term',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::MeshTerm @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.strictEqual(component.results[0].name, 'First Term');
+    assert.strictEqual(component.results[1].name, 'Second Term');
+  });
+
+  test('filter by school', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { meshDescriptors(schools: [33]) { id, name } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'mesh term',
+      school: this.server.create('school', { id: 33 }),
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::MeshTerm @report={{this.report}} />`);
+  });
+
+  test('filter by session', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { meshDescriptors(sessions: [13]) { id, name } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'mesh term',
+      prepositionalObject: 'session',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::MeshTerm @report={{this.report}} />`);
+  });
+
+  test('filter by school and session', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { meshDescriptors(schools: [24], sessions: [13]) { id, name } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'mesh term',
+      school: this.server.create('school', { id: 24 }),
+      prepositionalObject: 'session',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::MeshTerm @report={{this.report}} />`);
+  });
+});

--- a/tests/integration/components/reports/subject/program-test.js
+++ b/tests/integration/components/reports/subject/program-test.js
@@ -1,0 +1,126 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/reports/subject/program';
+import { setupAuthentication } from 'ilios-common';
+
+module('Integration | Component | reports/subject/program', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  const responseData = {
+    data: {
+      programs: [
+        { id: 1, title: 'First Program', school: { title: 'School B' } },
+        { id: 2, title: 'Second Program', school: { title: 'School A' } },
+      ],
+    },
+  };
+
+  test('it renders for user with permissions', async function (assert) {
+    await setupAuthentication({}, true);
+    assert.expect(10);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { programs { id, title, school { title } } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'program',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Program @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.ok(component.results[0].hasLink);
+    assert.ok(component.results[1].hasLink);
+    assert.strictEqual(component.results[0].school, 'School A');
+    assert.strictEqual(component.results[1].school, 'School B');
+    assert.strictEqual(component.results[0].title, 'Second Program');
+    assert.strictEqual(component.results[1].title, 'First Program');
+    assert.strictEqual(component.results[0].link, '/programs/2');
+    assert.strictEqual(component.results[1].link, '/programs/1');
+  });
+
+  test('it renders for user with no permissions', async function (assert) {
+    await setupAuthentication();
+    assert.expect(8);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { programs { id, title, school { title } } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'program',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Program @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.notOk(component.results[0].hasLink);
+    assert.notOk(component.results[1].hasLink);
+    assert.strictEqual(component.results[0].school, 'School A');
+    assert.strictEqual(component.results[1].school, 'School B');
+    assert.strictEqual(component.results[0].title, 'Second Program');
+    assert.strictEqual(component.results[1].title, 'First Program');
+  });
+
+  test('filter by school', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { programs(schools: [33]) { id, title, school { title } } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'program',
+      school: this.server.create('school', { id: 33 }),
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Program @report={{this.report}} />`);
+  });
+
+  test('filter by session', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { programs(sessions: [13]) { id, title, school { title } } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'program',
+      prepositionalObject: 'session',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Program @report={{this.report}} />`);
+  });
+
+  test('filter by school and session', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { programs(schools: [24], sessions: [13]) { id, title, school { title } } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'program',
+      school: this.server.create('school', { id: 24 }),
+      prepositionalObject: 'session',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Program @report={{this.report}} />`);
+  });
+});

--- a/tests/integration/components/reports/subject/program-year-test.js
+++ b/tests/integration/components/reports/subject/program-year-test.js
@@ -1,0 +1,132 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/reports/subject/program-year';
+import { setupAuthentication } from 'ilios-common';
+
+module('Integration | Component | reports/subject/program-year', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+  const responseData = {
+    data: {
+      programYears: [
+        {
+          id: 1,
+          startYear: 2020,
+          program: { id: 1, title: 'Program 1', duration: 2, school: { title: 'School B' } },
+        },
+        {
+          id: 2,
+          startYear: 2019,
+          program: { id: 1, title: 'Program 1', duration: 2, school: { title: 'School B' } },
+        },
+        {
+          id: 3,
+          startYear: 2023,
+          program: { id: 2, title: 'Program 2', duration: 5, school: { title: 'School A' } },
+        },
+      ],
+    },
+  };
+
+  test('it renders for user with permissions', async function (assert) {
+    await setupAuthentication({}, true);
+    assert.expect(20);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { programYears { id, startYear, program { id, title, duration, school { title } } } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'program year',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::ProgramYear @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 3);
+    assert.ok(component.results[0].hasLink);
+    assert.ok(component.results[1].hasLink);
+    assert.ok(component.results[2].hasLink);
+    assert.ok(component.results[0].hasSchool);
+    assert.ok(component.results[1].hasSchool);
+    assert.ok(component.results[2].hasSchool);
+    assert.strictEqual(component.results[0].school, 'School A -');
+    assert.strictEqual(component.results[1].school, 'School B -');
+    assert.strictEqual(component.results[2].school, 'School B -');
+    assert.strictEqual(component.results[0].program, 'Program 2:');
+    assert.strictEqual(component.results[1].program, 'Program 1:');
+    assert.strictEqual(component.results[2].program, 'Program 1:');
+    assert.strictEqual(component.results[0].title, '2028');
+    assert.strictEqual(component.results[1].title, '2021');
+    assert.strictEqual(component.results[2].title, '2022');
+    assert.strictEqual(component.results[0].link, '/programs/2/programyears/3');
+    assert.strictEqual(component.results[1].link, '/programs/1/programyears/2');
+    assert.strictEqual(component.results[2].link, '/programs/1/programyears/1');
+  });
+
+  test('it renders for user with no permissions', async function (assert) {
+    await setupAuthentication();
+    assert.expect(17);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { programYears { id, startYear, program { id, title, duration, school { title } } } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'program year',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::ProgramYear @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 3);
+    assert.notOk(component.results[0].hasLink);
+    assert.notOk(component.results[1].hasLink);
+    assert.notOk(component.results[2].hasLink);
+    assert.ok(component.results[0].hasSchool);
+    assert.ok(component.results[1].hasSchool);
+    assert.ok(component.results[2].hasSchool);
+    assert.strictEqual(component.results[0].school, 'School A -');
+    assert.strictEqual(component.results[1].school, 'School B -');
+    assert.strictEqual(component.results[2].school, 'School B -');
+    assert.strictEqual(component.results[0].program, 'Program 2:');
+    assert.strictEqual(component.results[1].program, 'Program 1:');
+    assert.strictEqual(component.results[2].program, 'Program 1:');
+    assert.strictEqual(component.results[0].title, '2028');
+    assert.strictEqual(component.results[1].title, '2021');
+    assert.strictEqual(component.results[2].title, '2022');
+  });
+
+  test('filter by school', async function (assert) {
+    assert.expect(8);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { programYears(schools: [33]) { id, startYear, program { id, title, duration, school { title } } } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'program year',
+      school: this.server.create('school', { id: 33 }),
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::ProgramYear @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 3);
+    assert.notOk(component.results[0].hasSchool);
+    assert.notOk(component.results[1].hasSchool);
+    assert.notOk(component.results[2].hasSchool);
+    assert.strictEqual(component.results[0].title, '2028');
+    assert.strictEqual(component.results[1].title, '2021');
+    assert.strictEqual(component.results[2].title, '2022');
+  });
+});

--- a/tests/integration/components/reports/subject/session-test.js
+++ b/tests/integration/components/reports/subject/session-test.js
@@ -251,7 +251,7 @@ module('Integration | Component | reports/subject/session', function (hooks) {
       const { query } = JSON.parse(requestBody);
       assert.strictEqual(
         query,
-        'query { sessions(meshDescriptors: [ABC]) { id, title, course { id, year, title } } }'
+        'query { sessions(meshDescriptors: ["ABC"]) { id, title, course { id, year, title } } }'
       );
       return responseData;
     });

--- a/tests/integration/components/reports/subject/session-test.js
+++ b/tests/integration/components/reports/subject/session-test.js
@@ -1,0 +1,247 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/reports/subject/session';
+import { setupAuthentication } from 'ilios-common';
+
+module('Integration | Component | reports/subject/session', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  let validateFilterString;
+
+  hooks.beforeEach(async function () {
+    validateFilterString = () => {};
+    class GraphQlMock extends Service {
+      async query(filterString) {
+        validateFilterString(filterString);
+        return {
+          data: {
+            sessions: [
+              { id: 1, title: 'First Session', course: { id: 1, year: 2023, title: 'Course' } },
+              {
+                id: 2,
+                title: 'Second Session',
+                course: { id: 1, year: 2023, title: 'Course' },
+              },
+              {
+                id: 3,
+                title: 'Third Session',
+                course: { id: 2, year: 2020, title: 'Course 2' },
+              },
+            ],
+          },
+        };
+      }
+    }
+
+    this.owner.register('service:graphql', GraphQlMock);
+  });
+
+  test('it renders for user with permissions', async function (assert) {
+    await setupAuthentication({}, true);
+    assert.expect(23);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(
+        filterString.trim(),
+        'query { sessions { id, title, course { id, year, title } } }'
+      );
+    };
+    const { id } = this.server.create('report', {
+      subject: 'session',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Session @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 3);
+    assert.ok(component.results[0].hasCourseLink);
+    assert.ok(component.results[1].hasCourseLink);
+    assert.ok(component.results[2].hasCourseLink);
+    assert.ok(component.results[0].hasSessionLink);
+    assert.ok(component.results[1].hasSessionLink);
+    assert.ok(component.results[2].hasSessionLink);
+    assert.strictEqual(component.results[0].year, '2020');
+    assert.strictEqual(component.results[1].year, '2023');
+    assert.strictEqual(component.results[2].year, '2023');
+    assert.strictEqual(component.results[0].courseTitle, 'Course 2:');
+    assert.strictEqual(component.results[1].courseTitle, 'Course:');
+    assert.strictEqual(component.results[2].courseTitle, 'Course:');
+    assert.strictEqual(component.results[0].sessionTitle, 'Third Session');
+    assert.strictEqual(component.results[1].sessionTitle, 'First Session');
+    assert.strictEqual(component.results[2].sessionTitle, 'Second Session');
+    assert.strictEqual(component.results[0].courseLink, '/courses/2');
+    assert.strictEqual(component.results[1].courseLink, '/courses/1');
+    assert.strictEqual(component.results[2].courseLink, '/courses/1');
+    assert.strictEqual(component.results[0].sessionLink, '/courses/2/sessions/3');
+    assert.strictEqual(component.results[1].sessionLink, '/courses/1/sessions/1');
+    assert.strictEqual(component.results[2].sessionLink, '/courses/1/sessions/2');
+  });
+
+  test('it renders for user with no permissions', async function (assert) {
+    await setupAuthentication();
+    assert.expect(17);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(
+        filterString.trim(),
+        'query { sessions { id, title, course { id, year, title } } }'
+      );
+    };
+    const { id } = this.server.create('report', {
+      subject: 'session',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Session @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 3);
+    assert.notOk(component.results[0].hasCourseLink);
+    assert.notOk(component.results[1].hasCourseLink);
+    assert.notOk(component.results[2].hasCourseLink);
+    assert.notOk(component.results[0].hasSessionLink);
+    assert.notOk(component.results[1].hasSessionLink);
+    assert.notOk(component.results[2].hasSessionLink);
+    assert.strictEqual(component.results[0].year, '2020');
+    assert.strictEqual(component.results[1].year, '2023');
+    assert.strictEqual(component.results[2].year, '2023');
+    assert.strictEqual(component.results[0].courseTitle, 'Course 2:');
+    assert.strictEqual(component.results[1].courseTitle, 'Course:');
+    assert.strictEqual(component.results[2].courseTitle, 'Course:');
+    assert.strictEqual(component.results[0].sessionTitle, 'Third Session');
+    assert.strictEqual(component.results[1].sessionTitle, 'First Session');
+    assert.strictEqual(component.results[2].sessionTitle, 'Second Session');
+  });
+
+  test('it reads academic year config', async function (assert) {
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          academicYearCrossesCalendarYearBoundaries: true,
+        },
+      };
+    });
+    const { id } = this.server.create('report', {
+      subject: 'session',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Session @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 3);
+    assert.strictEqual(component.results[0].year, '2020-2021');
+    assert.strictEqual(component.results[1].year, '2023-2024');
+    assert.strictEqual(component.results[2].year, '2023-2024');
+    assert.strictEqual(component.results[0].courseTitle, 'Course 2:');
+    assert.strictEqual(component.results[1].courseTitle, 'Course:');
+    assert.strictEqual(component.results[1].courseTitle, 'Course:');
+    assert.strictEqual(component.results[0].sessionTitle, 'Third Session');
+    assert.strictEqual(component.results[1].sessionTitle, 'First Session');
+    assert.strictEqual(component.results[2].sessionTitle, 'Second Session');
+  });
+
+  test('year filter works', async function (assert) {
+    assert.expect(6);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(
+        filterString.trim(),
+        'query { sessions { id, title, course { id, year, title } } }'
+      );
+    };
+    const { id } = this.server.create('report', {
+      subject: 'session',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Session @report={{this.report}} @year={{2023}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.notOk(component.results[0].hasYear);
+    assert.notOk(component.results[1].hasYear);
+    assert.strictEqual(component.results[0].sessionTitle, 'First Session');
+    assert.strictEqual(component.results[1].sessionTitle, 'Second Session');
+  });
+
+  test('filter by school', async function (assert) {
+    assert.expect(1);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(
+        filterString.trim(),
+        'query { sessions(schools: [33]) { id, title, course { id, year, title } } }'
+      );
+    };
+    const { id } = this.server.create('report', {
+      subject: 'session',
+      school: this.server.create('school', { id: 33 }),
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Session @report={{this.report}} />`);
+  });
+
+  test('filter by program', async function (assert) {
+    assert.expect(1);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(
+        filterString.trim(),
+        'query { sessions(programs: [13]) { id, title, course { id, year, title } } }'
+      );
+    };
+    const { id } = this.server.create('report', {
+      subject: 'session',
+      prepositionalObject: 'program',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Session @report={{this.report}} />`);
+  });
+
+  test('filter by school and program', async function (assert) {
+    assert.expect(1);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(
+        filterString.trim(),
+        'query { sessions(schools: [24], programs: [13]) { id, title, course { id, year, title } } }'
+      );
+    };
+    const { id } = this.server.create('report', {
+      subject: 'session',
+      school: this.server.create('school', { id: 24 }),
+      prepositionalObject: 'program',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Session @report={{this.report}} />`);
+  });
+
+  test('filter by course', async function (assert) {
+    assert.expect(1);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(
+        filterString.trim(),
+        'query { sessions(course: 13) { id, title, course { id, year, title } } }'
+      );
+    };
+    const { id } = this.server.create('report', {
+      subject: 'session',
+      prepositionalObject: 'course',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Session @report={{this.report}} />`);
+  });
+
+  test('filter by session type', async function (assert) {
+    assert.expect(1);
+    validateFilterString = function (filterString) {
+      assert.strictEqual(
+        filterString.trim(),
+        'query { sessions(sessionType: 13) { id, title, course { id, year, title } } }'
+      );
+    };
+    const { id } = this.server.create('report', {
+      subject: 'session',
+      prepositionalObject: 'sessionType',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Session @report={{this.report}} />`);
+  });
+});

--- a/tests/integration/components/reports/subject/session-test.js
+++ b/tests/integration/components/reports/subject/session-test.js
@@ -244,4 +244,23 @@ module('Integration | Component | reports/subject/session', function (hooks) {
     this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
     await render(hbs`<Reports::Subject::Session @report={{this.report}} />`);
   });
+
+  test('filter by mesh', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { sessions(meshDescriptors: [ABC]) { id, title, course { id, year, title } } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'session',
+      prepositionalObject: 'mesh term',
+      prepositionalObjectTableRowId: 'ABC',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Session @report={{this.report}} />`);
+  });
 });

--- a/tests/integration/components/reports/subject/session-test.js
+++ b/tests/integration/components/reports/subject/session-test.js
@@ -119,9 +119,9 @@ module('Integration | Component | reports/subject/session', function (hooks) {
     await render(hbs`<Reports::Subject::Session @report={{this.report}} />`);
 
     assert.strictEqual(component.results.length, 3);
-    assert.strictEqual(component.results[0].year, '2020-2021');
-    assert.strictEqual(component.results[1].year, '2023-2024');
-    assert.strictEqual(component.results[2].year, '2023-2024');
+    assert.strictEqual(component.results[0].year, '2020 - 2021');
+    assert.strictEqual(component.results[1].year, '2023 - 2024');
+    assert.strictEqual(component.results[2].year, '2023 - 2024');
     assert.strictEqual(component.results[0].courseTitle, 'Course 2:');
     assert.strictEqual(component.results[1].courseTitle, 'Course:');
     assert.strictEqual(component.results[1].courseTitle, 'Course:');

--- a/tests/integration/components/reports/subject/session-test.js
+++ b/tests/integration/components/reports/subject/session-test.js
@@ -213,7 +213,7 @@ module('Integration | Component | reports/subject/session', function (hooks) {
       const { query } = JSON.parse(requestBody);
       assert.strictEqual(
         query,
-        'query { sessions(course: 13) { id, title, course { id, year, title } } }'
+        'query { sessions(courses: [13]) { id, title, course { id, year, title } } }'
       );
       return responseData;
     });
@@ -232,7 +232,7 @@ module('Integration | Component | reports/subject/session', function (hooks) {
       const { query } = JSON.parse(requestBody);
       assert.strictEqual(
         query,
-        'query { sessions(sessionType: 13) { id, title, course { id, year, title } } }'
+        'query { sessions(sessionTypes: [13]) { id, title, course { id, year, title } } }'
       );
       return responseData;
     });

--- a/tests/integration/components/reports/subject/session-type-test.js
+++ b/tests/integration/components/reports/subject/session-type-test.js
@@ -87,7 +87,7 @@ module('Integration | Component | reports/subject/session-type', function (hooks
     assert.expect(1);
     this.server.post('api/graphql', function (schema, { requestBody }) {
       const { query } = JSON.parse(requestBody);
-      assert.strictEqual(query, 'query { sessionTypes(meshDescriptors: [ABC]) { title } }');
+      assert.strictEqual(query, 'query { sessionTypes(meshDescriptors: ["ABC"]) { title } }');
       return responseData;
     });
     const { id } = this.server.create('report', {

--- a/tests/integration/components/reports/subject/session-type-test.js
+++ b/tests/integration/components/reports/subject/session-type-test.js
@@ -4,14 +4,16 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios/tests/pages/components/reports/subject/session-type';
+import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/session-type', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {
-      sessionTypes: [{ title: 'First Type' }, { title: 'Second Type' }],
+      sessionTypes: [{ title: 'first Type' }, { title: 'Second Type' }],
     },
   };
 
@@ -29,7 +31,7 @@ module('Integration | Component | reports/subject/session-type', function (hooks
     await render(hbs`<Reports::Subject::SessionType @report={{this.report}} />`);
 
     assert.strictEqual(component.results.length, 2);
-    assert.strictEqual(component.results[0].title, 'First Type');
+    assert.strictEqual(component.results[0].title, 'first Type');
     assert.strictEqual(component.results[1].title, 'Second Type');
   });
 

--- a/tests/integration/components/reports/subject/session-type-test.js
+++ b/tests/integration/components/reports/subject/session-type-test.js
@@ -80,4 +80,20 @@ module('Integration | Component | reports/subject/session-type', function (hooks
     this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
     await render(hbs`<Reports::Subject::SessionType @report={{this.report}} />`);
   });
+
+  test('filter by mesh', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { sessionTypes(meshDescriptors: [ABC]) { title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'session type',
+      prepositionalObject: 'mesh term',
+      prepositionalObjectTableRowId: 'ABC',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::SessionType @report={{this.report}} />`);
+  });
 });

--- a/tests/integration/components/reports/subject/session-type-test.js
+++ b/tests/integration/components/reports/subject/session-type-test.js
@@ -1,0 +1,83 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/reports/subject/session-type';
+
+module('Integration | Component | reports/subject/session-type', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  const responseData = {
+    data: {
+      sessionTypes: [{ title: 'First Type' }, { title: 'Second Type' }],
+    },
+  };
+
+  test('it renders', async function (assert) {
+    assert.expect(4);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { sessionTypes { title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'session type',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::SessionType @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 2);
+    assert.strictEqual(component.results[0].title, 'First Type');
+    assert.strictEqual(component.results[1].title, 'Second Type');
+  });
+
+  test('filter by school', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { sessionTypes(schools: [33]) { title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'session type',
+      school: this.server.create('school', { id: 33 }),
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::SessionType @report={{this.report}} />`);
+  });
+
+  test('filter by course', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { sessionTypes(courses: [13]) { title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'session type',
+      prepositionalObject: 'course',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::SessionType @report={{this.report}} />`);
+  });
+
+  test('filter by school and session', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { sessionTypes(schools: [24], sessions: [13]) { title } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'session type',
+      school: this.server.create('school', { id: 24 }),
+      prepositionalObject: 'session',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::SessionType @report={{this.report}} />`);
+  });
+});

--- a/tests/integration/components/reports/subject/term-test.js
+++ b/tests/integration/components/reports/subject/term-test.js
@@ -1,0 +1,97 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/reports/subject/term';
+
+module('Integration | Component | reports/subject/term', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  const responseData = {
+    data: {
+      terms: [
+        { id: 1, title: 'First', vocabulary: { id: 1, title: 'Vocab A' } },
+        { id: 2, title: 'Second', vocabulary: { id: 2, title: 'Vocab B' } },
+        { id: 3, title: 'Third', vocabulary: { id: 1, title: 'Vocab A' } },
+      ],
+    },
+  };
+
+  test('it renders', async function (assert) {
+    assert.expect(5);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(query, 'query { terms { id, title, vocabulary { id, title } } }');
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'term',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Term @report={{this.report}} />`);
+
+    assert.strictEqual(component.results.length, 3);
+    assert.strictEqual(component.results[0].title, 'Vocab A > First');
+    assert.strictEqual(component.results[1].title, 'Vocab A > Third');
+    assert.strictEqual(component.results[2].title, 'Vocab B > Second');
+  });
+
+  test('filter by school', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { terms(schools: [33]) { id, title, vocabulary { id, title } } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'term',
+      school: this.server.create('school', { id: 33 }),
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Term @report={{this.report}} />`);
+  });
+
+  test('filter by course', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { terms(courses: [13]) { id, title, vocabulary { id, title } } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'term',
+      prepositionalObject: 'course',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Term @report={{this.report}} />`);
+  });
+
+  test('filter by school and session', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { terms(schools: [24], sessions: [13]) { id, title, vocabulary { id, title } } }'
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'term',
+      school: this.server.create('school', { id: 24 }),
+      prepositionalObject: 'session',
+      prepositionalObjectTableRowId: 13,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Term @report={{this.report}} />`);
+  });
+});

--- a/tests/pages/components/reports/subject.js
+++ b/tests/pages/components/reports/subject.js
@@ -14,7 +14,7 @@ const definition = {
   backToReports: {
     scope: '[data-test-back-to-reports]',
   },
-  title: text('[data-test-title]'),
+  title: text('[data-test-report-header] [data-test-title]'),
   download: clickable('[data-test-download]'),
   academicYears: {
     scope: '[data-test-year-filter]',

--- a/tests/pages/components/reports/subject/competency.js
+++ b/tests/pages/components/reports/subject/competency.js
@@ -1,0 +1,11 @@
+import { create, collection, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-competency]',
+  results: collection('[data-test-results] li', {
+    title: text(),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/reports/subject/course.js
+++ b/tests/pages/components/reports/subject/course.js
@@ -1,0 +1,16 @@
+import { attribute, clickable, create, collection, isPresent, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-course]',
+  download: clickable('[data-test-download]'),
+  results: collection('[data-test-results] li', {
+    courseTitle: text('[data-test-title]'),
+    link: attribute('href', 'a'),
+    hasLink: isPresent('a'),
+    hasYear: isPresent('[data-test-year]'),
+    year: text('[data-test-year]'),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/reports/subject/course.js
+++ b/tests/pages/components/reports/subject/course.js
@@ -1,8 +1,7 @@
-import { attribute, clickable, create, collection, isPresent, text } from 'ember-cli-page-object';
+import { attribute, create, collection, isPresent, text } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-reports-subject-course]',
-  download: clickable('[data-test-download]'),
   results: collection('[data-test-results] li', {
     courseTitle: text('[data-test-title]'),
     link: attribute('href', 'a'),

--- a/tests/pages/components/reports/subject/instructor-group.js
+++ b/tests/pages/components/reports/subject/instructor-group.js
@@ -1,0 +1,11 @@
+import { create, collection, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-instructor-group]',
+  results: collection('[data-test-results] li', {
+    title: text(),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/reports/subject/instructor.js
+++ b/tests/pages/components/reports/subject/instructor.js
@@ -1,0 +1,11 @@
+import { create, collection, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-instructor]',
+  results: collection('[data-test-results] li', {
+    name: text(),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/reports/subject/learning-material.js
+++ b/tests/pages/components/reports/subject/learning-material.js
@@ -1,0 +1,11 @@
+import { create, collection, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-learning-material]',
+  results: collection('[data-test-results] li', {
+    title: text(),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/reports/subject/mesh-term.js
+++ b/tests/pages/components/reports/subject/mesh-term.js
@@ -1,0 +1,11 @@
+import { create, collection, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-mesh-term]',
+  results: collection('[data-test-results] li', {
+    name: text(),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/reports/subject/program-year.js
+++ b/tests/pages/components/reports/subject/program-year.js
@@ -1,0 +1,16 @@
+import { attribute, create, collection, isPresent, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-program-year]',
+  results: collection('[data-test-results] li', {
+    title: text('[data-test-title]'),
+    link: attribute('href', 'a'),
+    hasLink: isPresent('a'),
+    program: text('[data-test-program]'),
+    hasSchool: isPresent('[data-test-school]'),
+    school: text('[data-test-school]'),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/reports/subject/program.js
+++ b/tests/pages/components/reports/subject/program.js
@@ -1,0 +1,16 @@
+import { attribute, clickable, create, collection, isPresent, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-program]',
+  download: clickable('[data-test-download]'),
+  results: collection('[data-test-results] li', {
+    title: text('[data-test-title]'),
+    link: attribute('href', 'a'),
+    hasLink: isPresent('a'),
+    hasSchool: isPresent('[data-test-school]'),
+    school: text('[data-test-school]'),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/reports/subject/program.js
+++ b/tests/pages/components/reports/subject/program.js
@@ -1,8 +1,7 @@
-import { attribute, clickable, create, collection, isPresent, text } from 'ember-cli-page-object';
+import { attribute, create, collection, isPresent, text } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-reports-subject-program]',
-  download: clickable('[data-test-download]'),
   results: collection('[data-test-results] li', {
     title: text('[data-test-title]'),
     link: attribute('href', 'a'),

--- a/tests/pages/components/reports/subject/session-type.js
+++ b/tests/pages/components/reports/subject/session-type.js
@@ -1,0 +1,11 @@
+import { create, collection, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-session-type]',
+  results: collection('[data-test-results] li', {
+    title: text(),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/reports/subject/session.js
+++ b/tests/pages/components/reports/subject/session.js
@@ -1,0 +1,19 @@
+import { attribute, clickable, create, collection, isPresent, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-session]',
+  download: clickable('[data-test-download]'),
+  results: collection('[data-test-results] li', {
+    courseTitle: text('[data-test-course-title]'),
+    sessionTitle: text('[data-test-session-title]'),
+    courseLink: attribute('href', '[data-test-course-title] a'),
+    sessionLink: attribute('href', '[data-test-session-title] a'),
+    hasCourseLink: isPresent('[data-test-course-title] a'),
+    hasSessionLink: isPresent('[data-test-session-title] a'),
+    hasYear: isPresent('[data-test-year]'),
+    year: text('[data-test-year]'),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/reports/subject/term.js
+++ b/tests/pages/components/reports/subject/term.js
@@ -1,0 +1,11 @@
+import { create, collection, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-term]',
+  results: collection('[data-test-results] li', {
+    title: text(),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/unit/services/graphql-test.js
+++ b/tests/unit/services/graphql-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ilios/tests/helpers';
+
+module('Unit | Service | graphql', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:graphql');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
Taking advantage of our GraphQL endpoints for our existing subject reports speeds up query and rendering for these reports.

Because we no longer need so much boilerplate for loading the report results I've been able to split each report into its own component and handler rendering in templates which should make it much easier to augment reports with more data or formatting in the future.

WIP:
- [ ] needs to be tested with lots of real reports