### PR TITLE
cleans up lang strings.

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -40,7 +40,7 @@ general:
   backToProgramYears: "Back to Program Years"
   backToReport: "Back to Report"
   backToReports: "Back to Reports"
-  backToSchools: "Back to Schools List"
+  backToSchools: "Back to Schools"
   backToSubjectReports: "Back to Subject Reports"
   backToTableOfContents: "Back to Table of Contents"
   bad: Bad

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -40,7 +40,7 @@ general:
   backToProgramYears: "Atrás a Años de Programas"
   backToReport: "Atrás a Reporte"
   backToReports: "Atrás a Reportes"
-  backToSchools: "Atrás a la Lista de Escuelas"
+  backToSchools: "Atrás a Escuelas"
   backToSubjectReports: "Atrás a Informes de materias"
   backToTableOfContents: "Atrás a la tabla de contenido"
   bad: Malo

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -40,7 +40,7 @@ general:
   backToProgramYears: "Retour à Années de Diplôme"
   backToReport: "Retour à rapport"
   backToReports: "Retour à rapports"
-  backToSchools: "Retour à liste d'écoles"
+  backToSchools: "Retour aux écoles"
   backToSubjectReports: "Retour aux rapports pédagogiques"
   backToTableOfContents: "Retour à la table des matières"
   bad: Mal


### PR DESCRIPTION
shortens "Back to Schools List" to "Back to Schools". this realigns this verbiage with the other "Back to X" labels.


fixes https://github.com/ilios/ilios/issues/4512