### PR TITLE
adds sortable headers to school session type table.

### DIFF
--- a/app/components/school-session-types-list-item.hbs
+++ b/app/components/school-session-types-list-item.hbs
@@ -7,11 +7,13 @@
     <button class="link-button" type="button" {{on "click" (fn @manageSessionType @sessionType.id)}}>
       {{@sessionType.title}}
     </button>
-    {{#unless @sessionType.active}}
-      <em data-test-inactive>
-        ({{t "general.inactive"}})
-      </em>
-    {{/unless}}
+  </td>
+  <td data-test-active>
+    {{#if @sessionType.active}}
+      <FaIcon @prefix="fas" @icon="lightbulb-on" @title={{t "general.active"}} />
+    {{else}}
+      <FaIcon @prefix="fal" @icon="lightbulb-slash" @title={{t "general.inactive"}} />
+    {{/if}}
   </td>
   <td class="hide-from-small-screen" data-test-sessions-count>
     {{@sessionType.sessionCount}}
@@ -28,11 +30,6 @@
   </td>
   <td class="hide-from-small-screen" colspan="2" data-test-assessment-method-description>
     {{get (await @sessionType.firstAamcMethod) "description"}}
-    {{#if (not (get (await @sessionType.firstAamcMethod) "active"))}}
-      <em>
-        ({{t "general.inactive"}})
-      </em>
-    {{/if}}
   </td>
   <td class="calendar-color hide-from-small-screen">
     {{! template-lint-disable no-inline-styles style-concatenation no-triple-curlies}}

--- a/app/components/school-session-types-list.hbs
+++ b/app/components/school-session-types-list.hbs
@@ -21,6 +21,7 @@
           @sortedAscending={{this.sortedAscending}}
           @sortedBy={{eq this.sortBy "sessionCount"}}
           @onClick={{fn this.setSortBy "sessionCount"}}
+          @sortType="numeric"
           class="hide-from-small-screen"
         >
           {{t "general.sessions"}}

--- a/app/components/school-session-types-list.hbs
+++ b/app/components/school-session-types-list.hbs
@@ -12,6 +12,13 @@
         </SortableTh>
         <SortableTh
           @sortedAscending={{this.sortedAscending}}
+          @sortedBy={{eq this.sortBy "active"}}
+          @onClick={{fn this.setSortBy "active"}}
+        >
+          {{t "general.active"}}
+        </SortableTh>
+        <SortableTh
+          @sortedAscending={{this.sortedAscending}}
           @sortedBy={{eq this.sortBy "sessionCount"}}
           @onClick={{fn this.setSortBy "sessionCount"}}
           class="hide-from-small-screen"

--- a/app/components/school-session-types-list.hbs
+++ b/app/components/school-session-types-list.hbs
@@ -2,31 +2,60 @@
   <table>
     <thead>
       <tr>
-        <th colspan="3">
+        <SortableTh
+          @colspan={{3}}
+          @sortedAscending={{this.sortedAscending}}
+          @sortedBy={{eq this.sortBy "title"}}
+          @onClick={{fn this.setSortBy "title"}}
+        >
           {{t "general.title"}}
-        </th>
-        <th class="hide-from-small-screen">
+        </SortableTh>
+        <SortableTh
+          @sortedAscending={{this.sortedAscending}}
+          @sortedBy={{eq this.sortBy "sessionCount"}}
+          @onClick={{fn this.setSortBy "sessionCount"}}
+          class="hide-from-small-screen"
+        >
           {{t "general.sessions"}}
-        </th>
-        <th>
+        </SortableTh>
+        <SortableTh
+          @sortedAscending={{this.sortedAscending}}
+          @sortedBy={{eq this.sortBy "assessment"}}
+          @onClick={{fn this.setSortBy "assessment"}}
+          class="hide-from-small-screen"
+        >
           {{t "general.assessment"}}
-        </th>
-        <th class="hide-from-small-screen" colspan="2">
+        </SortableTh>
+        <SortableTh
+          @colspan={{2}}
+          @sortedAscending={{this.sortedAscending}}
+          @sortedBy={{eq this.sortBy "assessmentOption"}}
+          @onClick={{fn this.setSortBy "assessmentOption"}}
+          class="hide-from-small-screen"
+        >
           {{t "general.assessmentOption"}}
-        </th>
-        <th class="hide-from-small-screen" colspan="2">
+        </SortableTh>
+        <th
+          class="hide-from-small-screen"
+          colspan="2"
+        >
           {{t "general.aamcMethod"}}
         </th>
-        <th class="hide-from-small-screen">
+        <SortableTh
+          @sortedAscending={{this.sortedAscending}}
+          @sortedBy={{eq this.sortBy "calendarColor"}}
+          @onClick={{fn this.setSortBy "calendarColor"}}
+          class="hide-from-small-screen"
+        >
           {{t "general.color"}}
-        </th>
+        </SortableTh>
         <th>
           {{t "general.actions"}}
         </th>
       </tr>
     </thead>
     <tbody>
-      {{#each (sort-by "active:desc" "title" @sessionTypes) as |sessionType|}}
+      {{#each this.sortedSessionTypes as |sessionType|}}
         <SchoolSessionTypesListItem
           @sessionType={{sessionType}}
           @canDelete={{@canDelete}}

--- a/app/components/school-session-types-list.hbs
+++ b/app/components/school-session-types-list.hbs
@@ -43,12 +43,15 @@
         >
           {{t "general.assessmentOption"}}
         </SortableTh>
-        <th
+        <SortableTh
+          @colspan={{2}}
+          @sortedAscending={{this.sortedAscending}}
+          @sortedBy={{eq this.sortBy "aamcMethod"}}
+          @onClick={{fn this.setSortBy "aamcMethod"}}
           class="hide-from-small-screen"
-          colspan="2"
         >
           {{t "general.aamcMethod"}}
-        </th>
+        </SortableTh>
         <SortableTh
           @sortedAscending={{this.sortedAscending}}
           @sortedBy={{eq this.sortBy "calendarColor"}}

--- a/app/components/school-session-types-list.hbs
+++ b/app/components/school-session-types-list.hbs
@@ -1,7 +1,7 @@
 <div class="school-session-types-list" data-test-school-session-types-list ...attributes>
   <table>
     <thead>
-      <tr>
+      <tr data-test-headings>
         <SortableTh
           @colspan={{3}}
           @sortedAscending={{this.sortedAscending}}

--- a/app/components/school-session-types-list.js
+++ b/app/components/school-session-types-list.js
@@ -28,23 +28,8 @@ export default class SchoolSessionTypesListComponent extends Component {
 
   async sortSessionTypes(sessionTypes, isSortedAscending, sortBy) {
     let items = sessionTypes.toArray();
-    if (['active', 'assessment', 'calendarColor', 'sessionCount', 'title'].includes(sortBy)) {
-      items = sortArray(sessionTypes, sortBy);
-    }
 
-    if ('assessmentOption' === sortBy) {
-      const sortProxies = await map(items, async (sessionType) => {
-        const assessmentOption = await sessionType.assessmentOption;
-        return {
-          sessionType,
-          assessmentOptionName: assessmentOption?.name,
-        };
-      });
-      items = sortArray(sortProxies, 'assessmentOptionName');
-      items = items.map((item) => item.sessionType);
-    }
-
-    if ('aamcMethod' === sortBy) {
+    const sortByAamcMethod = async function (items) {
       const sortProxies = await map(items, async (sessionType) => {
         const aamcMethods = (await sessionType.aamcMethods).toArray();
         let aamcMethodDescription = '';
@@ -58,7 +43,35 @@ export default class SchoolSessionTypesListComponent extends Component {
         };
       });
       items = sortArray(sortProxies, 'aamcMethodDescription');
-      items = items.map((item) => item.sessionType);
+      return items.map((item) => item.sessionType);
+    };
+
+    const sortByAssessmentOption = async function (items) {
+      const sortProxies = await map(items, async (sessionType) => {
+        const assessmentOption = await sessionType.assessmentOption;
+        return {
+          sessionType,
+          assessmentOptionName: assessmentOption?.name,
+        };
+      });
+      items = sortArray(sortProxies, 'assessmentOptionName');
+      return items.map((item) => item.sessionType);
+    };
+
+    switch (sortBy) {
+      case 'active':
+      case 'assessment':
+      case 'calendarColor':
+      case 'sessionCount':
+      case 'title':
+        items = sortArray(sessionTypes, sortBy);
+        break;
+      case 'assessmentOption':
+        items = await sortByAssessmentOption(items);
+        break;
+      case 'aamcMethod':
+        items = await sortByAamcMethod(items);
+        break;
     }
 
     if (!isSortedAscending) {

--- a/app/components/school-session-types-list.js
+++ b/app/components/school-session-types-list.js
@@ -44,6 +44,23 @@ export default class SchoolSessionTypesListComponent extends Component {
       items = items.map((item) => item.sessionType);
     }
 
+    if ('aamcMethod' === sortBy) {
+      const sortProxies = await map(items, async (sessionType) => {
+        const aamcMethods = (await sessionType.aamcMethods).toArray();
+        let aamcMethodDescription = '';
+
+        if (aamcMethods.length) {
+          aamcMethodDescription = aamcMethods[0].description;
+        }
+        return {
+          sessionType,
+          aamcMethodDescription,
+        };
+      });
+      items = sortArray(sortProxies, 'aamcMethodDescription');
+      items = items.map((item) => item.sessionType);
+    }
+
     if (!isSortedAscending) {
       items.reverse();
     }

--- a/app/components/school-session-types-list.js
+++ b/app/components/school-session-types-list.js
@@ -1,0 +1,52 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { use } from 'ember-could-get-used-to-this';
+import AsyncProcess from 'ilios-common/classes/async-process';
+import { sortBy as sortArray } from 'ilios-common/utils/array-helpers';
+import { map } from 'rsvp';
+
+export default class SchoolSessionTypesListComponent extends Component {
+  @tracked sort = 'title';
+  @tracked sortedAscending = true;
+  @use sortedSessionTypes = new AsyncProcess(() => [
+    this.sortSessionTypes,
+    this.args.sessionTypes,
+    this.sortedAscending,
+    this.sortBy,
+  ]);
+
+  get sortBy() {
+    return this.sort || 'title';
+  }
+
+  @action
+  setSortBy(what) {
+    this.sort = what;
+    this.sortedAscending = !this.sortedAscending;
+  }
+
+  async sortSessionTypes(sessionTypes, isSortedAscending, sortBy) {
+    let items = sessionTypes.toArray();
+    if (['title', 'calendarColor', 'assessment', 'sessionCount'].includes(sortBy)) {
+      items = sortArray(sessionTypes, sortBy);
+    }
+
+    if ('assessmentOption' === sortBy) {
+      const sortProxies = await map(items, async (sessionType) => {
+        const assessmentOption = await sessionType.assessmentOption;
+        return {
+          sessionType,
+          assessmentOptionName: assessmentOption?.name,
+        };
+      });
+      items = sortArray(sortProxies, 'assessmentOptionName');
+      items = items.map((item) => item.sessionType);
+    }
+
+    if (!isSortedAscending) {
+      items.reverse();
+    }
+    return items;
+  }
+}

--- a/app/components/school-session-types-list.js
+++ b/app/components/school-session-types-list.js
@@ -7,8 +7,8 @@ import { sortBy as sortArray } from 'ilios-common/utils/array-helpers';
 import { map } from 'rsvp';
 
 export default class SchoolSessionTypesListComponent extends Component {
-  @tracked sort = 'title';
-  @tracked sortedAscending = true;
+  @tracked sort = 'active';
+  @tracked sortedAscending = false;
   @use sortedSessionTypes = new AsyncProcess(() => [
     this.sortSessionTypes,
     this.args.sessionTypes,
@@ -28,7 +28,7 @@ export default class SchoolSessionTypesListComponent extends Component {
 
   async sortSessionTypes(sessionTypes, isSortedAscending, sortBy) {
     let items = sessionTypes.toArray();
-    if (['title', 'calendarColor', 'assessment', 'sessionCount'].includes(sortBy)) {
+    if (['active', 'assessment', 'calendarColor', 'sessionCount', 'title'].includes(sortBy)) {
       items = sortArray(sessionTypes, sortBy);
     }
 

--- a/app/components/school-session-types-list.js
+++ b/app/components/school-session-types-list.js
@@ -22,8 +22,8 @@ export default class SchoolSessionTypesListComponent extends Component {
 
   @action
   setSortBy(what) {
+    this.sortedAscending = this.sort === what ? !this.sortedAscending : true;
     this.sort = what;
-    this.sortedAscending = !this.sortedAscending;
   }
 
   async sortSessionTypes(sessionTypes, isSortedAscending, sortBy) {

--- a/tests/integration/components/school-session-types-list-item-test.js
+++ b/tests/integration/components/school-session-types-list-item-test.js
@@ -47,6 +47,7 @@ module('Integration | Component | school-session-types-list-item', function (hoo
       @manageSessionType={{(noop)}}
     />`);
     assert.strictEqual(component.title.text, 'salt');
+    assert.ok(component.isActive);
     assert.strictEqual(component.sessionCount, '2');
     assert.ok(component.isAssessment);
     assert.strictEqual(component.aamcMethod, aamcMethod1.description);

--- a/tests/integration/components/school-session-types-list-test.js
+++ b/tests/integration/components/school-session-types-list-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | school session types list', function (hooks) {
   setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
-  test('it renders', async function (assert) {
+  hooks.beforeEach(async function () {
     const school = this.server.create('school');
     const assessmentOption = this.server.create('assessment-option', {
       id: 1,
@@ -56,8 +56,11 @@ module('Integration | Component | school session types list', function (hooks) {
       active: true,
     });
 
-    const sessionTypeModels = await this.owner.lookup('service:store').findAll('session-type');
-    this.set('sessionTypes', sessionTypeModels);
+    this.sessionTypes = await this.owner.lookup('service:store').findAll('session-type');
+  });
+
+  test('it renders', async function (assert) {
+    this.set('sessionTypes', this.sessionTypes);
     await render(
       hbs`<SchoolSessionTypesList @sessionTypes={{this.sessionTypes}} @manageSessionType={{(noop)}} />`
     );
@@ -67,39 +70,30 @@ module('Integration | Component | school session types list', function (hooks) {
     assert.ok(component.sessionTypes[0].isActive);
     assert.strictEqual(component.sessionTypes[0].sessionCount, '2');
     assert.notOk(component.sessionTypes[0].isAssessment);
-    assert.strictEqual(component.sessionTypes[0].aamcMethod, aamcMethod1.description);
+    assert.strictEqual(component.sessionTypes[0].aamcMethod, 'Lorem Ipsum');
     assert.strictEqual(component.sessionTypes[0].assessmentOption, '');
     assert.strictEqual(component.sessionTypes[0].calendarColor, 'background-color: #cccccc');
     assert.strictEqual(component.sessionTypes[1].title.text, 'second');
     assert.ok(component.sessionTypes[1].isActive);
     assert.strictEqual(component.sessionTypes[1].sessionCount, '0');
     assert.ok(component.sessionTypes[1].isAssessment);
-    assert.strictEqual(component.sessionTypes[1].aamcMethod, aamcMethod2.description);
+    assert.strictEqual(component.sessionTypes[1].aamcMethod, 'Dolor Et');
     assert.strictEqual(component.sessionTypes[1].assessmentOption, 'formative');
     assert.strictEqual(component.sessionTypes[1].calendarColor, 'background-color: #123456');
     assert.strictEqual(component.sessionTypes[2].title.text, 'not needed anymore');
     assert.ok(component.sessionTypes[2].isInactive);
     assert.strictEqual(component.sessionTypes[2].sessionCount, '2');
     assert.notOk(component.sessionTypes[2].isAssessment);
-    assert.strictEqual(component.sessionTypes[2].aamcMethod, aamcMethod1.description);
+    assert.strictEqual(component.sessionTypes[2].aamcMethod, 'Lorem Ipsum');
     assert.strictEqual(component.sessionTypes[2].assessmentOption, '');
     assert.strictEqual(component.sessionTypes[2].calendarColor, 'background-color: #ffffff');
   });
 
   test('clicking edit fires action', async function (assert) {
     assert.expect(1);
-    const school = this.server.create('school');
-    this.server.create('session-type', {
-      school,
-      title: 'first',
-      assessment: false,
-      calendarColor: '#fff',
-    });
-    const sessionTypeModels = await this.owner.lookup('service:store').findAll('session-type');
-
-    this.set('sessionTypes', sessionTypeModels);
+    this.set('sessionTypes', this.sessionTypes);
     this.set('manageSessionType', (sessionTypeId) => {
-      assert.strictEqual(parseInt(sessionTypeId, 10), 1);
+      assert.strictEqual(parseInt(sessionTypeId, 10), 3);
     });
     await render(hbs`<SchoolSessionTypesList
       @sessionTypes={{this.sessionTypes}}
@@ -111,18 +105,9 @@ module('Integration | Component | school session types list', function (hooks) {
 
   test('clicking title fires action', async function (assert) {
     assert.expect(1);
-    const school = this.server.create('school');
-    this.server.create('session-type', {
-      school,
-      title: 'first',
-      assessment: false,
-      calendarColor: '#fff',
-    });
-    const sessionTypeModels = await this.owner.lookup('service:store').findAll('session-type');
-
-    this.set('sessionTypes', sessionTypeModels);
+    this.set('sessionTypes', this.sessionTypes);
     this.set('manageSessionType', (sessionTypeId) => {
-      assert.strictEqual(parseInt(sessionTypeId, 10), 1);
+      assert.strictEqual(parseInt(sessionTypeId, 10), 3);
     });
     await render(hbs`<SchoolSessionTypesList
       @sessionTypes={{this.sessionTypes}}
@@ -133,25 +118,7 @@ module('Integration | Component | school session types list', function (hooks) {
   });
 
   test('session types without sessions can be deleted', async function (assert) {
-    const school = this.server.create('school');
-    this.server.create('session-type', {
-      school,
-      title: 'unlinked',
-      assessment: false,
-      active: true,
-      calendarColor: '#fff',
-    });
-    this.server.create('session-type', {
-      school,
-      title: 'linked',
-      active: true,
-      assessment: false,
-      calendarColor: '#fff',
-      sessions: this.server.createList('session', 5),
-    });
-
-    const sessionTypeModels = await this.owner.lookup('service:store').findAll('session-type');
-    this.set('sessionTypes', sessionTypeModels);
+    this.set('sessionTypes', this.sessionTypes);
     await render(hbs`<SchoolSessionTypesList
       @sessionTypes={{this.sessionTypes}}
       @manageSessionType={{(noop)}}
@@ -160,31 +127,24 @@ module('Integration | Component | school session types list', function (hooks) {
 
     assert.notOk(component.sessionTypes[0].isDeletable);
     assert.ok(component.sessionTypes[1].isDeletable);
+    assert.notOk(component.sessionTypes[2].isDeletable);
   });
 
   test('delete session type', async function (assert) {
-    const school = this.server.create('school');
-    this.server.create('session-type', {
-      school,
-    });
-
-    const sessionTypeModels = await this.owner.lookup('service:store').findAll('session-type');
-
-    this.set('sessionTypes', sessionTypeModels);
+    this.set('sessionTypes', this.sessionTypes);
     await render(hbs`<SchoolSessionTypesList
       @sessionTypes={{this.sessionTypes}}
       @manageSessionType={{(noop)}}
       @canDelete={{true}}
     />`);
-
-    assert.strictEqual(this.server.db.sessionTypes.length, 1);
-    assert.notOk(component.sessionTypes[0].confirmRemoval.isVisible);
-    await component.sessionTypes[0].delete();
+    assert.strictEqual(this.server.db.sessionTypes.length, 3);
+    assert.notOk(component.sessionTypes[1].confirmRemoval.isVisible);
+    await component.sessionTypes[1].delete();
     assert.strictEqual(
-      component.sessionTypes[0].confirmRemoval.message,
+      component.sessionTypes[1].confirmRemoval.message,
       'Are you sure you want to delete this session type? This action cannot be undone. Yes Cancel'
     );
-    await component.sessionTypes[0].confirmRemoval.confirm();
-    assert.strictEqual(this.server.db.sessionTypes.length, 0);
+    await component.sessionTypes[1].confirmRemoval.confirm();
+    assert.strictEqual(this.server.db.sessionTypes.length, 2);
   });
 });

--- a/tests/integration/components/school-session-types-list-test.js
+++ b/tests/integration/components/school-session-types-list-test.js
@@ -147,4 +147,85 @@ module('Integration | Component | school session types list', function (hooks) {
     await component.sessionTypes[1].confirmRemoval.confirm();
     assert.strictEqual(this.server.db.sessionTypes.length, 2);
   });
+
+  test('sort', async function (assert) {
+    this.set('sessionTypes', this.sessionTypes);
+    await render(hbs`<SchoolSessionTypesList
+      @sessionTypes={{this.sessionTypes}}
+      @manageSessionType={{(noop)}}
+      @canDelete={{true}}
+    />`);
+
+    // default sort order is sorted by active, descending
+    assert.ok(component.isSortedByActiveStatusDescending);
+    assert.ok(component.sessionTypes[0].isActive);
+    assert.ok(component.sessionTypes[1].isActive);
+    assert.notOk(component.sessionTypes[2].isActive);
+
+    await component.sortByActiveStatus();
+    assert.ok(component.isSortedByActiveStatusAscending);
+    assert.notOk(component.sessionTypes[0].isActive);
+    assert.ok(component.sessionTypes[1].isActive);
+    assert.ok(component.sessionTypes[2].isActive);
+
+    await component.sortByTitle();
+    assert.ok(component.isSortedByTitleAscending);
+    assert.strictEqual(component.sessionTypes[0].title.text, 'first');
+    assert.strictEqual(component.sessionTypes[1].title.text, 'not needed anymore');
+    assert.strictEqual(component.sessionTypes[2].title.text, 'second');
+
+    await component.sortByTitle();
+    assert.ok(component.isSortedByTitleDescending);
+    assert.strictEqual(component.sessionTypes[0].title.text, 'second');
+    assert.strictEqual(component.sessionTypes[1].title.text, 'not needed anymore');
+    assert.strictEqual(component.sessionTypes[2].title.text, 'first');
+
+    await component.sortBySessions();
+    assert.ok(component.isSortedBySessionsAscending);
+    assert.strictEqual(component.sessionTypes[0].sessionCount, '0');
+    assert.strictEqual(component.sessionTypes[1].sessionCount, '2');
+    assert.strictEqual(component.sessionTypes[2].sessionCount, '2');
+
+    await component.sortBySessions();
+    assert.ok(component.isSortedBySessionsDescending);
+    assert.strictEqual(component.sessionTypes[0].sessionCount, '2');
+    assert.strictEqual(component.sessionTypes[1].sessionCount, '2');
+    assert.strictEqual(component.sessionTypes[2].sessionCount, '0');
+
+    await component.sortByAssessment();
+    assert.ok(component.isSortedByAssessmentAscending);
+    assert.notOk(component.sessionTypes[0].isAssessment);
+    assert.notOk(component.sessionTypes[1].isAssessment);
+    assert.ok(component.sessionTypes[2].isAssessment);
+
+    await component.sortByAssessment();
+    assert.ok(component.isSortedByAssessmentDescending);
+    assert.ok(component.sessionTypes[0].isAssessment);
+    assert.notOk(component.sessionTypes[1].isAssessment);
+    assert.notOk(component.sessionTypes[2].isAssessment);
+
+    await component.sortByAssessmentOption();
+    assert.ok(component.isSortedByAssessmentOptionAscending);
+    assert.strictEqual(component.sessionTypes[0].assessmentOption, '');
+    assert.strictEqual(component.sessionTypes[1].assessmentOption, '');
+    assert.strictEqual(component.sessionTypes[2].assessmentOption, 'formative');
+
+    await component.sortByAssessmentOption();
+    assert.ok(component.isSortedByAssessmentOptionDescending);
+    assert.strictEqual(component.sessionTypes[0].assessmentOption, 'formative');
+    assert.strictEqual(component.sessionTypes[1].assessmentOption, '');
+    assert.strictEqual(component.sessionTypes[2].assessmentOption, '');
+
+    await component.sortByColor();
+    assert.ok(component.isSortedByColorAscending);
+    assert.strictEqual(component.sessionTypes[0].calendarColor, 'background-color: #123456');
+    assert.strictEqual(component.sessionTypes[1].calendarColor, 'background-color: #cccccc');
+    assert.strictEqual(component.sessionTypes[2].calendarColor, 'background-color: #ffffff');
+
+    await component.sortByColor();
+    assert.ok(component.isSortedByColorDescending);
+    assert.strictEqual(component.sessionTypes[0].calendarColor, 'background-color: #ffffff');
+    assert.strictEqual(component.sessionTypes[1].calendarColor, 'background-color: #cccccc');
+    assert.strictEqual(component.sessionTypes[2].calendarColor, 'background-color: #123456');
+  });
 });

--- a/tests/integration/components/school-session-types-list-test.js
+++ b/tests/integration/components/school-session-types-list-test.js
@@ -64,21 +64,21 @@ module('Integration | Component | school session types list', function (hooks) {
 
     assert.strictEqual(component.sessionTypes.length, 3);
     assert.strictEqual(component.sessionTypes[0].title.text, 'first');
+    assert.ok(component.sessionTypes[0].isActive);
     assert.strictEqual(component.sessionTypes[0].sessionCount, '2');
     assert.notOk(component.sessionTypes[0].isAssessment);
     assert.strictEqual(component.sessionTypes[0].aamcMethod, aamcMethod1.description);
     assert.strictEqual(component.sessionTypes[0].assessmentOption, '');
     assert.strictEqual(component.sessionTypes[0].calendarColor, 'background-color: #cccccc');
     assert.strictEqual(component.sessionTypes[1].title.text, 'second');
+    assert.ok(component.sessionTypes[1].isActive);
     assert.strictEqual(component.sessionTypes[1].sessionCount, '0');
     assert.ok(component.sessionTypes[1].isAssessment);
-    assert.strictEqual(
-      component.sessionTypes[1].aamcMethod,
-      aamcMethod2.description + ' (inactive)'
-    );
+    assert.strictEqual(component.sessionTypes[1].aamcMethod, aamcMethod2.description);
     assert.strictEqual(component.sessionTypes[1].assessmentOption, 'formative');
     assert.strictEqual(component.sessionTypes[1].calendarColor, 'background-color: #123456');
-    assert.strictEqual(component.sessionTypes[2].title.text, 'not needed anymore (inactive)');
+    assert.strictEqual(component.sessionTypes[2].title.text, 'not needed anymore');
+    assert.ok(component.sessionTypes[2].isInactive);
     assert.strictEqual(component.sessionTypes[2].sessionCount, '2');
     assert.notOk(component.sessionTypes[2].isAssessment);
     assert.strictEqual(component.sessionTypes[2].aamcMethod, aamcMethod1.description);

--- a/tests/integration/components/school-session-types-list-test.js
+++ b/tests/integration/components/school-session-types-list-test.js
@@ -216,6 +216,18 @@ module('Integration | Component | school session types list', function (hooks) {
     assert.strictEqual(component.sessionTypes[1].assessmentOption, '');
     assert.strictEqual(component.sessionTypes[2].assessmentOption, '');
 
+    await component.sortByAamcMethod();
+    assert.ok(component.isSortedByAamcMethodAscending);
+    assert.strictEqual(component.sessionTypes[0].aamcMethod, 'Dolor Et');
+    assert.strictEqual(component.sessionTypes[1].aamcMethod, 'Lorem Ipsum');
+    assert.strictEqual(component.sessionTypes[2].aamcMethod, 'Lorem Ipsum');
+
+    await component.sortByAamcMethod();
+    assert.ok(component.isSortedByAamcMethodDescending);
+    assert.strictEqual(component.sessionTypes[0].aamcMethod, 'Lorem Ipsum');
+    assert.strictEqual(component.sessionTypes[1].aamcMethod, 'Lorem Ipsum');
+    assert.strictEqual(component.sessionTypes[2].aamcMethod, 'Dolor Et');
+
     await component.sortByColor();
     assert.ok(component.isSortedByColorAscending);
     assert.strictEqual(component.sessionTypes[0].calendarColor, 'background-color: #123456');

--- a/tests/pages/components/school-session-types-list-item.js
+++ b/tests/pages/components/school-session-types-list-item.js
@@ -6,6 +6,8 @@ const definition = {
     scope: '[data-test-title]',
     edit: clickable('button'),
   },
+  isActive: isVisible('[data-icon="lightbulb-on"]', { scope: '[data-test-active]' }),
+  isInactive: isVisible('[data-icon="lightbulb-slash"]', { scope: '[data-test-active]' }),
   sessionCount: text('[data-test-sessions-count]'),
   isAssessment: hasClass('yes', '[data-test-is-assessment] svg'),
   assessmentOption: text('[data-test-assessment-option]'),

--- a/tests/pages/components/school-session-types-list.js
+++ b/tests/pages/components/school-session-types-list.js
@@ -14,18 +14,18 @@ const definition = {
   isSortedByTitleAscending: hasClass('fa-arrow-down-a-z', '[data-test-headings] th:eq(0) svg'),
   isSortedByTitleDescending: hasClass('fa-arrow-down-z-a', '[data-test-headings] th:eq(0) svg'),
   isSortedByActiveStatusAscending: hasClass(
-    'fa-arrow-down-1-9',
+    'fa-arrow-down-a-z',
     '[data-test-headings] th:eq(1) svg'
   ),
   isSortedByActiveStatusDescending: hasClass(
-    'fa-arrow-down-9-1',
+    'fa-arrow-down-z-a',
     '[data-test-headings] th:eq(1) svg'
   ),
   isSortedBySessionsAscending: hasClass('fa-arrow-down-1-9', '[data-test-headings] th:eq(2) svg'),
   isSortedBySessionsDescending: hasClass('fa-arrow-down-9-1', '[data-test-headings] th:eq(2) svg'),
-  isSortedByAssessmentAscending: hasClass('fa-arrow-down-1-9', '[data-test-headings] th:eq(3) svg'),
+  isSortedByAssessmentAscending: hasClass('fa-arrow-down-a-z', '[data-test-headings] th:eq(3) svg'),
   isSortedByAssessmentDescending: hasClass(
-    'fa-arrow-down-9-1',
+    'fa-arrow-down-z-a',
     '[data-test-headings] th:eq(3) svg'
   ),
   isSortedByAssessmentOptionAscending: hasClass(
@@ -36,8 +36,8 @@ const definition = {
     'fa-arrow-down-z-a',
     '[data-test-headings] th:eq(4) svg'
   ),
-  isSortedByColorAscending: hasClass('fa-arrow-down-1-9', '[data-test-headings] th:eq(6) svg'),
-  isSortedByColorDescending: hasClass('fa-arrow-down-9-1', '[data-test-headings] th:eq(6) svg'),
+  isSortedByColorAscending: hasClass('fa-arrow-down-a-z', '[data-test-headings] th:eq(6) svg'),
+  isSortedByColorDescending: hasClass('fa-arrow-down-z-a', '[data-test-headings] th:eq(6) svg'),
 };
 
 export default definition;

--- a/tests/pages/components/school-session-types-list.js
+++ b/tests/pages/components/school-session-types-list.js
@@ -10,6 +10,7 @@ const definition = {
   sortBySessions: clickable('button', { scope: '[data-test-headings] th:nth-of-type(3)' }),
   sortByAssessment: clickable('button', { scope: '[data-test-headings] th:nth-of-type(4)' }),
   sortByAssessmentOption: clickable('button', { scope: '[data-test-headings] th:nth-of-type(5)' }),
+  sortByAamcMethod: clickable('button', { scope: '[data-test-headings] th:nth-of-type(6)' }),
   sortByColor: clickable('button', { scope: '[data-test-headings] th:nth-of-type(7)' }),
   isSortedByTitleAscending: hasClass('fa-arrow-down-a-z', '[data-test-headings] th:eq(0) svg'),
   isSortedByTitleDescending: hasClass('fa-arrow-down-z-a', '[data-test-headings] th:eq(0) svg'),
@@ -35,6 +36,11 @@ const definition = {
   isSortedByAssessmentOptionDescending: hasClass(
     'fa-arrow-down-z-a',
     '[data-test-headings] th:eq(4) svg'
+  ),
+  isSortedByAamcMethodAscending: hasClass('fa-arrow-down-a-z', '[data-test-headings] th:eq(5) svg'),
+  isSortedByAamcMethodDescending: hasClass(
+    'fa-arrow-down-z-a',
+    '[data-test-headings] th:eq(5) svg'
   ),
   isSortedByColorAscending: hasClass('fa-arrow-down-a-z', '[data-test-headings] th:eq(6) svg'),
   isSortedByColorDescending: hasClass('fa-arrow-down-z-a', '[data-test-headings] th:eq(6) svg'),

--- a/tests/pages/components/school-session-types-list.js
+++ b/tests/pages/components/school-session-types-list.js
@@ -1,10 +1,43 @@
-import { collection, create } from 'ember-cli-page-object';
+import { clickable, collection, create, hasClass } from 'ember-cli-page-object';
 
 import listItem from './school-session-types-list-item';
 
 const definition = {
   scope: '[data-test-school-session-types-list]',
   sessionTypes: collection('[data-test-school-session-types-list-item]', listItem),
+  sortByTitle: clickable('button', { scope: '[data-test-headings] th:nth-of-type(1)' }),
+  sortByActiveStatus: clickable('button', { scope: '[data-test-headings] th:nth-of-type(2)' }),
+  sortBySessions: clickable('button', { scope: '[data-test-headings] th:nth-of-type(3)' }),
+  sortByAssessment: clickable('button', { scope: '[data-test-headings] th:nth-of-type(4)' }),
+  sortByAssessmentOption: clickable('button', { scope: '[data-test-headings] th:nth-of-type(5)' }),
+  sortByColor: clickable('button', { scope: '[data-test-headings] th:nth-of-type(7)' }),
+  isSortedByTitleAscending: hasClass('fa-arrow-down-a-z', '[data-test-headings] th:eq(0) svg'),
+  isSortedByTitleDescending: hasClass('fa-arrow-down-z-a', '[data-test-headings] th:eq(0) svg'),
+  isSortedByActiveStatusAscending: hasClass(
+    'fa-arrow-down-1-9',
+    '[data-test-headings] th:eq(1) svg'
+  ),
+  isSortedByActiveStatusDescending: hasClass(
+    'fa-arrow-down-9-1',
+    '[data-test-headings] th:eq(1) svg'
+  ),
+  isSortedBySessionsAscending: hasClass('fa-arrow-down-1-9', '[data-test-headings] th:eq(2) svg'),
+  isSortedBySessionsDescending: hasClass('fa-arrow-down-9-1', '[data-test-headings] th:eq(2) svg'),
+  isSortedByAssessmentAscending: hasClass('fa-arrow-down-1-9', '[data-test-headings] th:eq(3) svg'),
+  isSortedByAssessmentDescending: hasClass(
+    'fa-arrow-down-9-1',
+    '[data-test-headings] th:eq(3) svg'
+  ),
+  isSortedByAssessmentOptionAscending: hasClass(
+    'fa-arrow-down-a-z',
+    '[data-test-headings] th:eq(4) svg'
+  ),
+  isSortedByAssessmentOptionDescending: hasClass(
+    'fa-arrow-down-z-a',
+    '[data-test-headings] th:eq(4) svg'
+  ),
+  isSortedByColorAscending: hasClass('fa-arrow-down-1-9', '[data-test-headings] th:eq(6) svg'),
+  isSortedByColorDescending: hasClass('fa-arrow-down-9-1', '[data-test-headings] th:eq(6) svg'),
 };
 
 export default definition;


### PR DESCRIPTION
refs https://github.com/ilios/ilios/issues/4494

![image](https://user-images.githubusercontent.com/1410427/215631883-79dea2d8-4931-49ae-aae6-1eaadef4d3e3.png)


couple of notes:
- the original sort order was by active status, descending - that ensures that inactive session types are pushed to the bottom. in order to maintain this functionality, i added a new "active" column.
- filtering is out of scope. this is an interface that is hardly used as it is, i'm kinda drawing the line here. sorting will have to do, at least for the time being (got more important work to do anyway).
- i threw in sort-by-color as this was trivial to implement