### PR TITLE
Display Errors Messages in Output

### DIFF
--- a/lib/ilios-error/index.js
+++ b/lib/ilios-error/index.js
@@ -24,7 +24,7 @@ module.exports = {
     const supportedBrowsers = this.getSupportedBrowsers().join('');
     return `
       // if there is an uncaught runtime error show the error message
-      window.addEventListener('error', function () {
+      window.addEventListener('error', function (event) {
         var loadingIndicator = document.getElementById('ilios-loading-indicator');
         if (loadingIndicator) {
           loadingIndicator.parentNode.removeChild(loadingIndicator);
@@ -49,7 +49,14 @@ module.exports = {
             '<div class="supported-browsers">' +
               '<h2 id="ilios-loading-error-browsers">Minimum Supported Browsers</h2>' +
               '<ul aria-labelledby="ilios-loading-error-browsers">${supportedBrowsers}</ul>' +
-            '</div>';
+            '</div>' +
+            '<fieldset>' +
+              '<legend>Error Message</legend>' +
+              '<pre>' + event.message + '</pre>' +
+              '<pre>' + event.filename + '</pre>' +
+              '<pre>' + event.lineno + '</pre>' +
+            '</fieldset>'
+          ;
           document.body.appendChild(errorContainer);
         }
       });

--- a/lib/ilios-error/public/style.css
+++ b/lib/ilios-error/public/style.css
@@ -7,7 +7,7 @@
 }
 #ilios-loading-error .supported-browsers {
   border: 1px solid blue;
-  margin-top: 1rem;
+  margin: 1rem 0;
   padding: 1rem 2rem;
 }
 #ilios-loading-error ul {


### PR DESCRIPTION
This error display page is usually shown when a browser error prevents the application from booting, it's super helpful to display the actual error in the output because we often get a screen shot of it. Having the message itself displayed ensures we don't need console logs to see what went wrong.

From:
<img width="1631" alt="before" src="https://user-images.githubusercontent.com/349624/216529449-525c4bc4-82cf-49ce-94ee-35fb7de7a53f.png">

To:
<img width="1635" alt="after" src="https://user-images.githubusercontent.com/349624/216529485-10830ef1-fe8e-401f-abb7-3a81ccc1cc7e.png">
