### PR TITLE
Convert automerge to be a pull request action

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,8 +1,5 @@
 name: Dependabot auto-merge
 on: pull_request_target
-permissions:
-  pull-requests: write
-  contents: write
 jobs:
   dependabot:
     runs-on: ubuntu-latest
@@ -42,6 +39,7 @@ jobs:
         uses: dependabot/fetch-metadata@v1.3.6
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/checkout@v3
       - name: Enable auto-merge for Dependabot PRs
         if: ${{contains(steps.metadata.outputs.dependency-names, matrix.safe-dependency)}}
         run: gh pr merge --merge --auto


### PR DESCRIPTION
We were using the special pull_request_target event here to be able to merge, but now that we're using the github CLI we may be able to do this with a normal pull request event and a checkout.

see https://github.com/ilios/common/pull/3314