### PR TITLE
Specify PR number to automerge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -39,9 +39,8 @@ jobs:
         uses: dependabot/fetch-metadata@v1.3.6
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: actions/checkout@v3
       - name: Enable auto-merge for Dependabot PRs
         if: ${{contains(steps.metadata.outputs.dependency-names, matrix.safe-dependency)}}
-        run: gh pr merge --merge --auto
+        run: gh pr merge --merge --auto ${{ github.event.number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Doesn't seem to work to checkout the branch with the PR, instead we can get the PR number from the github context and use it.