### PR TITLE
Add PR number to auto merge

### DIFF
--- a/.github/workflows/update-transitive-dependencies.yaml
+++ b/.github/workflows/update-transitive-dependencies.yaml
@@ -36,6 +36,6 @@ jobs:
           labels: dependencies
     - name: Enable Pull Request Automerge
       if: steps.cpr.outputs.pull-request-operation == 'created'
-      run: gh pr merge --merge --auto
+      run: gh pr merge --merge --auto ${{ steps.cpr.outputs.pull-request-number }}
       env:
-        GH_TOKEN: ${{ secrets.ZORGBORT_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Take the output of the PR number from creation and add it to the automerge command.

We can use the Github token here because we're using the CLI and not another action.