### PR TITLE
corrects various learnergroup user manager bugs

### DIFF
--- a/app/components/learner-group/members.hbs
+++ b/app/components/learner-group/members.hbs
@@ -1,0 +1,65 @@
+{{#let (unique-id) as |templateId|}}
+  <div class="learner-group-user-manager" ...attributes data-test-learner-group-user-manager>
+    {{#if this.usersInGroup.length}}
+      <div class="actions">
+        <Input
+          @value={{this.filter}}
+          placeholder={{t "general.filterByNameOrEmail"}}
+          aria-label={{t "general.filterByNameOrEmail"}}
+          data-test-filter
+        />
+      </div>
+      <div class="learner-group-user-manager-content">
+        <div class="list">
+          <table data-test-assigned-users>
+            <thead>
+            <tr>
+              <th class="text-left" colspan="1">
+              </th>
+              <SortableTh
+                @colspan={{4}}
+                @onClick={{fn this.setSortBy "fullName"}}
+                @sortedBy={{or (eq @sortBy "fullName") (eq @sortBy "fullName:desc")}}
+                @sortedAscending={{this.sortedAscending}}
+              >
+                {{t "general.name"}}
+              </SortableTh>
+              <th class="text-left" colspan="2">
+                {{t "general.campusId"}}
+              </th>
+              <th class="text-left hide-from-small-screen" colspan="5">
+                {{t "general.email"}}
+              </th>
+            </tr>
+            </thead>
+            <tbody data-test-users-in-current-group>
+            {{#each (sort-by @sortBy this.filteredUsers) as |user index|}}
+              <tr class={{unless user.enabled "disabled-user-account" ""}}>
+                <td class="text-left" colspan="1">
+                  {{#unless user.enabled}}
+                    <FaIcon
+                      @icon="user-xmark"
+                      @title={{t "general.disabled"}}
+                      class="error"
+                      data-test-is-disabled
+                    />
+                  {{/unless}}
+                </td>
+                <td class="text-left" colspan="4">
+                  <UserNameInfo id="selected-username-{{index}}-{{templateId}}" @user={{user}} />
+                </td>
+                <td class="text-left" colspan="2">
+                  {{user.campusId}}
+                </td>
+                <td class="text-left hide-from-small-screen" colspan="5">
+                  {{user.email}}
+                </td>
+              </tr>
+            {{/each}}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    {{/if}}
+  </div>
+{{/let}}

--- a/app/components/learner-group/members.hbs
+++ b/app/components/learner-group/members.hbs
@@ -1,5 +1,8 @@
 {{#let (unique-id) as |templateId|}}
-  <div class="learner-group-user-manager" ...attributes data-test-learner-group-user-manager>
+  <div
+    class="learner-group-members"
+    data-test-learner-group-members
+  >
     {{#if this.usersInGroup.length}}
       <div class="actions">
         <Input
@@ -9,9 +12,9 @@
           data-test-filter
         />
       </div>
-      <div class="learner-group-user-manager-content">
+      <div class="learner-group-members-content">
         <div class="list">
-          <table data-test-assigned-users>
+          <table>
             <thead>
             <tr>
               <th class="text-left" colspan="1">
@@ -32,7 +35,7 @@
               </th>
             </tr>
             </thead>
-            <tbody data-test-users-in-current-group>
+            <tbody>
             {{#each (sort-by @sortBy this.filteredUsers) as |user index|}}
               <tr class={{unless user.enabled "disabled-user-account" ""}}>
                 <td class="text-left" colspan="1">

--- a/app/components/learner-group/members.js
+++ b/app/components/learner-group/members.js
@@ -1,0 +1,47 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class LearnerGroupUserMembersComponent extends Component {
+  @service currentUser;
+  @tracked filter = '';
+
+  get sortedAscending() {
+    return this.args.sortBy.search(/desc/) === -1;
+  }
+
+  get usersInGroup() {
+    return this.args.users.filter(
+      (user) => user.get('lowestGroupInTree').id === this.args.learnerGroupId
+    );
+  }
+
+  get filteredUsers() {
+    const users = this.usersInGroup;
+    if (!users) {
+      return [];
+    }
+
+    const filter = this.filter.trim().toLowerCase();
+    if (!filter) {
+      return users;
+    }
+
+    return users.filter((user) => {
+      return (
+        user.get('fullNameFromFirstLastName').trim().toLowerCase().includes(filter) ||
+        user.get('fullName').trim().toLowerCase().includes(filter) ||
+        user.get('email').trim().toLowerCase().includes(filter)
+      );
+    });
+  }
+
+  @action
+  setSortBy(what) {
+    if (this.args.sortBy === what) {
+      what += ':desc';
+    }
+    this.args.setSortBy(what);
+  }
+}

--- a/app/components/learner-group/root.hbs
+++ b/app/components/learner-group/root.hbs
@@ -170,7 +170,7 @@
             @learnerGroup={{@learnerGroup}}
             @done={{fn @setIsBulkAssigning false}}
           />
-        {{else}}
+        {{else if @isEditing}}
           <div class="learner-group-overview-content">
             <LearnerGroup::UserManager
               @learnerGroupId={{this.learnerGroupId}}
@@ -185,6 +185,15 @@
               @removeUserFromGroup={{perform this.removeUserToCohort}}
               @addUsersToGroup={{perform this.addUsersToGroup}}
               @removeUsersFromGroup={{perform this.removeUsersToCohort}}
+            />
+          </div>
+        {{else}}
+          <div class="learner-group-overview-content">
+            <LearnerGroup::Members
+              @learnerGroupId={{this.learnerGroupId}}
+              @setSortBy={{@setSortUsersBy}}
+              @sortBy={{this.sortUsersBy}}
+              @users={{this.usersToPassToManager}}
             />
           </div>
         {{/if}}

--- a/app/components/learner-group/root.hbs
+++ b/app/components/learner-group/root.hbs
@@ -180,7 +180,6 @@
               @users={{this.usersToPassToManager}}
               @sortBy={{this.sortUsersBy}}
               @setSortBy={{@setSortUsersBy}}
-              @isEditing={{@isEditing}}
               @addUserToGroup={{perform this.addUserToGroup}}
               @removeUserFromGroup={{perform this.removeUserToCohort}}
               @addUsersToGroup={{perform this.addUsersToGroup}}

--- a/app/components/learner-group/user-manager.hbs
+++ b/app/components/learner-group/user-manager.hbs
@@ -25,6 +25,7 @@
                     indeterminate={{this.hasSomeSelectedGroupUsers}}
                     aria-label={{t "general.selectAllOrNone"}}
                     {{on "click" this.toggleAllGroupUsersSelection}}
+                    data-test-toggle-all
                   >
                 </th>
                 <SortableTh
@@ -54,7 +55,7 @@
                 </th>
               </tr>
             </thead>
-            <tbody data-test-users-in-current-group>
+            <tbody>
               {{#each (sort-by @sortBy this.groupUsers) as |user index|}}
                 <tr class={{unless user.enabled "disabled-user-account" ""}}>
                   <td class="text-left" colspan="1">
@@ -165,6 +166,7 @@
                   indeterminate={{this.hasSomeSelectedNonGroupUsers}}
                   aria-label={{t "general.selectAllOrNone"}}
                   {{on "click" this.toggleAllNonGroupUsersSelection}}
+                  data-test-toggle-all
                 >
               </th>
               <SortableTh
@@ -194,7 +196,7 @@
               </th>
             </tr>
             </thead>
-            <tbody data-test-users-not-in-current-group>
+            <tbody>
               {{#each (sort-by @sortBy this.nonGroupUsers) as |user index|}}
                 <tr class={{unless user.enabled "disabled-user-account" ""}}>
                   <td class="text-left" colspan="1">

--- a/app/components/learner-group/user-manager.hbs
+++ b/app/components/learner-group/user-manager.hbs
@@ -1,5 +1,5 @@
 {{#let (unique-id) as |templateId|}}
-  <div class="learner-group-user-manager" ...attributes data-test-learner-group-user-manager>
+  <div class="learner-group-user-manager" data-test-learner-group-user-manager ...attributes>
     {{#if @users.length}}
       <div class="actions">
         <Input
@@ -10,171 +10,21 @@
         />
       </div>
       <div class="learner-group-user-manager-content">
-
         <div class="list">
-          {{#if @isEditing}}
-            <div class="title" data-test-group-members>
-              {{t "general.groupMembers"}}
-              ({{this.groupUsers.length}})
-            </div>
-          {{/if}}
+          <div class="title" data-test-group-members>
+            {{t "general.groupMembers"}}
+            ({{this.groupUsers.length}})
+          </div>
           <table data-test-assigned-users>
             <thead>
               <tr>
                 <th class="text-left" colspan="1">
-                  {{#if @isEditing}}
-                    <input
-                      type="checkbox"
-                      checked={{this.hasAllSelectedGroupUsers}}
-                      indeterminate={{this.hasSomeSelectedGroupUsers}}
-                      aria-label={{t "general.selectAllOrNone"}}
-                      {{on "click" this.toggleAllGroupUsersSelection}}
-                    >
-                  {{/if}}
-                </th>
-                <SortableTh
-                  @colspan={{4}}
-                  @onClick={{fn this.setSortBy "fullName"}}
-                  @sortedBy={{or (eq @sortBy "fullName") (eq @sortBy "fullName:desc")}}
-                  @sortedAscending={{this.sortedAscending}}
-                >
-                  {{t "general.name"}}
-                </SortableTh>
-                <th class="text-left" colspan="2">
-                  {{t "general.campusId"}}
-                </th>
-                <th class="text-left hide-from-small-screen" colspan="5">
-                  {{t "general.email"}}
-                </th>
-                {{#if @isEditing}}
-                  <SortableTh
-                    @colspan={{2}}
-                    @onClick={{fn this.setSortBy "lowestGroupInTreeTitle"}}
-                    @sortedBy={{or (eq @sortBy "lowestGroupInTreeTitle") (eq @sortBy "lowestGroupInTreeTitle:desc")}}
-                    @sortedAscending={{this.sortedAscending}}
-                  >
-                    {{t "general.groupName"}}
-                  </SortableTh>
-                  <th class="text-left" colspan="1">
-                    {{t "general.actions"}}
-                  </th>
-                {{/if}}
-              </tr>
-            </thead>
-            <tbody data-test-users-in-current-group>
-              {{#each (sort-by @sortBy this.groupUsers) as |user index|}}
-                <tr class={{unless user.enabled "disabled-user-account" ""}}>
-                  <td class="text-left" colspan="1">
-                    {{#if (and @isEditing (or user.enabled this.currentUser.isRoot))}}
-                      <input
-                        aria-labelledby="selected-username-{{index}}-{{templateId}}"
-                        type="checkbox"
-                        checked={{includes user.content this.selectedGroupUsers}}
-                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
-                      >
-                    {{/if}}
-                    {{#unless user.enabled}}
-                      <FaIcon
-                        @icon="user-xmark"
-                        @title={{t "general.disabled"}}
-                        class="error"
-                        data-test-is-disabled
-                      />
-                    {{/unless}}
-                  </td>
-                  <td class="text-left" colspan="4">
-                    {{#if (and @isEditing (or user.enabled this.currentUser.isRoot))}}
-                      <button
-                        class="inline-button"
-                        type="button"
-                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
-                      >
-                        <UserNameInfo id="selected-username-{{index}}-{{templateId}}" @user={{user}} />
-                      </button>
-                    {{else}}
-                      <UserNameInfo id="selected-username-{{index}}-{{templateId}}" @user={{user}} />
-                    {{/if}}
-                  </td>
-                  <td class="text-left" colspan="2">
-                    {{#if (and @isEditing (or user.enabled this.currentUser.isRoot))}}
-                      <button
-                        class="inline-button"
-                        type="button"
-                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
-                      >
-                        {{user.campusId}}
-                      </button>
-                    {{else}}
-                      {{user.campusId}}
-                    {{/if}}
-                  </td>
-                  <td class="text-left hide-from-small-screen" colspan="5">
-                    {{#if (and @isEditing (or user.enabled this.currentUser.isRoot))}}
-                      <button
-                        class="inline-button"
-                        type="button"
-                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
-                      >
-                        {{user.email}}
-                      </button>
-                    {{else}}
-                      {{user.email}}
-                    {{/if}}
-                  </td>
-                  {{#if @isEditing}}
-                    <td class="text-left" colspan="2">
-                      <LinkTo
-                        @route="learner-group"
-                        @model={{user.lowestGroupInTree}}
-                        @query={{hash isEditing=@isEditing sortUsersBy=@sortBy}}
-                      >
-                        {{user.lowestGroupInTree.title}}
-                      </LinkTo>
-                    </td>
-                    <td>
-                      {{#if (includes user.content this.usersBeingRemovedFromGroup)}}
-                        <LoadingSpinner />
-                      {{else if user.enabled}}
-                        {{#if (eq this.selectedGroupUsers.length 0)}}
-                          <button
-                            type="button"
-                            class="link-button"
-                            {{on "click" (perform this.removeUserFromGroup user.content)}}
-                            data-test-remove-user
-                          >
-                            <FaIcon
-                              @icon="minus"
-                              class="no"
-                              @title={{t
-                                "general.removeLearnerToCohort"
-                                cohort=@cohortTitle
-                                count=1
-                              }}
-                            />
-                          </button>
-                        {{/if}}
-                      {{/if}}
-                    </td>
-                  {{/if}}
-                </tr>
-              {{/each}}
-            </tbody>
-          </table>
-          {{#if @isEditing}}
-            <div class="title" data-test-all-other-members>
-              {{t "general.allOtherMembers" topLevelGroupTitle=@topLevelGroupTitle}}
-              ({{this.nonGroupUsers.length}})
-            </div>
-            <table data-test-assignable-users>
-              <thead>
-              <tr>
-                <th class="text-left" colspan="1">
                   <input
                     type="checkbox"
-                    checked={{this.hasAllSelectedNonGroupUsers}}
-                    indeterminate={{this.hasSomeSelectedNonGroupUsers}}
+                    checked={{this.hasAllSelectedGroupUsers}}
+                    indeterminate={{this.hasSomeSelectedGroupUsers}}
                     aria-label={{t "general.selectAllOrNone"}}
-                    {{on "click" this.toggleAllNonGroupUsersSelection}}
+                    {{on "click" this.toggleAllGroupUsersSelection}}
                   >
                 </th>
                 <SortableTh
@@ -203,109 +53,247 @@
                   {{t "general.actions"}}
                 </th>
               </tr>
-              </thead>
-              <tbody data-test-users-not-in-current-group>
-                {{#each (sort-by @sortBy this.nonGroupUsers) as |user index|}}
-                  <tr class={{unless user.enabled "disabled-user-account" ""}}>
-                    <td class="text-left" colspan="1">
-                      {{#if (or user.enabled this.currentUser.isRoot)}}
-                        <input
-                          aria-labelledby="cohort-username-{{index}}-{{templateId}}"
-                          type="checkbox"
-                          checked={{includes user.content this.selectedNonGroupUsers}}
-                          {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
-                        >
-                      {{/if}}
-                      {{#unless user.enabled}}
-                        <FaIcon
-                          @icon="user-xmark"
-                          @title={{t "general.disabled"}}
-                          class="error"
-                          data-test-is-disabled
-                        />
-                      {{/unless}}
-                    </td>
-                    <td class="text-left" colspan="4">
-                      {{#if (or user.enabled this.currentUser.isRoot)}}
-                        <button
-                          class="inline-button"
-                          type="button"
-                          {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
-                        >
-                          <UserNameInfo id="cohort-username-{{index}}-{{templateId}}" @user={{user}} />
-                        </button>
-                      {{else}}
-                        <UserNameInfo id="cohort-username-{{index}}-{{templateId}}" @user={{user}} />
-                      {{/if}}
-                    </td>
-                    <td class="text-left" colspan="2">
-                      {{#if (or user.enabled this.currentUser.isRoot)}}
-                        <button
-                          class="inline-button"
-                          type="button"
-                          {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
-                        >
-                          {{user.campusId}}
-                        </button>
-                      {{else}}
-                        {{user.campusId}}
-                      {{/if}}
-                    </td>
-                    <td class="text-left hide-from-small-screen" colspan="5">
-                      {{#if (or user.enabled this.currentUser.isRoot)}}
-                        <button
-                          class="inline-button"
-                          type="button"
-                          {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
-                        >
-                          {{user.email}}
-                        </button>
-                      {{else}}
-                        {{user.email}}
-                      {{/if}}
-                    </td>
-                    <td class="text-left" colspan="2">
-                      <LinkTo
-                        @route="learner-group"
-                        @model={{user.lowestGroupInTree}}
-                        @query={{hash isEditing=true sortUsersBy=@sortBy}}
+            </thead>
+            <tbody data-test-users-in-current-group>
+              {{#each (sort-by @sortBy this.groupUsers) as |user index|}}
+                <tr class={{unless user.enabled "disabled-user-account" ""}}>
+                  <td class="text-left" colspan="1">
+                    {{#if (or user.enabled this.currentUser.isRoot)}}
+                      <input
+                        aria-labelledby="selected-username-{{index}}-{{templateId}}"
+                        type="checkbox"
+                        checked={{includes user.content this.selectedGroupUsers}}
+                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
                       >
-                        {{user.lowestGroupInTree.title}}
-                      </LinkTo>
-                    </td>
-                    <td>
-                      {{#if (includes user.content this.usersBeingAddedToGroup)}}
-                        <LoadingSpinner />
-                      {{else if user.enabled}}
-                        {{#if (eq this.selectedNonGroupUsers.length 0)}}
-                          <button
-                            type="button"
-                            class="link-button"
-                            {{on "click" (perform this.addUserToGroup user.content)}}
-                            data-test-add-user
-                          >
-                            <FaIcon
-                              @icon="plus"
-                              class="yes"
-                              @title={{t
-                                "general.moveToGroup"
-                                groupTitle=@learnerGroupTitle
-                                count=1
-                              }}
-                            />
-                          </button>
-                        {{/if}}
+                    {{/if}}
+                    {{#unless user.enabled}}
+                      <FaIcon
+                        @icon="user-xmark"
+                        @title={{t "general.disabled"}}
+                        class="error"
+                        data-test-is-disabled
+                      />
+                    {{/unless}}
+                  </td>
+                  <td class="text-left" colspan="4">
+                    {{#if (or user.enabled this.currentUser.isRoot)}}
+                      <button
+                        class="inline-button"
+                        type="button"
+                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
+                      >
+                        <UserNameInfo id="selected-username-{{index}}-{{templateId}}" @user={{user}} />
+                      </button>
+                    {{else}}
+                      <UserNameInfo id="selected-username-{{index}}-{{templateId}}" @user={{user}} />
+                    {{/if}}
+                  </td>
+                  <td class="text-left" colspan="2">
+                    {{#if (or user.enabled this.currentUser.isRoot)}}
+                      <button
+                        class="inline-button"
+                        type="button"
+                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
+                      >
+                        {{user.campusId}}
+                      </button>
+                    {{else}}
+                      {{user.campusId}}
+                    {{/if}}
+                  </td>
+                  <td class="text-left hide-from-small-screen" colspan="5">
+                    {{#if (or user.enabled this.currentUser.isRoot)}}
+                      <button
+                        class="inline-button"
+                        type="button"
+                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
+                      >
+                        {{user.email}}
+                      </button>
+                    {{else}}
+                      {{user.email}}
+                    {{/if}}
+                  </td>
+                  <td class="text-left" colspan="2">
+                    <LinkTo
+                      @route="learner-group"
+                      @model={{user.lowestGroupInTree}}
+                      @query={{hash isEditing=true sortUsersBy=@sortBy}}
+                    >
+                      {{user.lowestGroupInTree.title}}
+                    </LinkTo>
+                  </td>
+                  <td>
+                    {{#if (includes user.content this.usersBeingRemovedFromGroup)}}
+                      <LoadingSpinner />
+                    {{else if user.enabled}}
+                      {{#if (eq this.selectedGroupUsers.length 0)}}
+                        <button
+                          type="button"
+                          class="link-button"
+                          {{on "click" (perform this.removeUserFromGroup user.content)}}
+                          data-test-remove-user
+                        >
+                          <FaIcon
+                            @icon="minus"
+                            class="no"
+                            @title={{t
+                              "general.removeLearnerToCohort"
+                              cohort=@cohortTitle
+                              count=1
+                            }}
+                          />
+                        </button>
                       {{/if}}
-                    </td>
-                  </tr>
-                {{/each}}
-              </tbody>
-            </table>
-          {{/if}}
+                    {{/if}}
+                  </td>
+                </tr>
+              {{/each}}
+            </tbody>
+          </table>
+          <div class="title" data-test-all-other-members>
+            {{t "general.allOtherMembers" topLevelGroupTitle=@topLevelGroupTitle}}
+            ({{this.nonGroupUsers.length}})
+          </div>
+          <table data-test-assignable-users>
+            <thead>
+            <tr>
+              <th class="text-left" colspan="1">
+                <input
+                  type="checkbox"
+                  checked={{this.hasAllSelectedNonGroupUsers}}
+                  indeterminate={{this.hasSomeSelectedNonGroupUsers}}
+                  aria-label={{t "general.selectAllOrNone"}}
+                  {{on "click" this.toggleAllNonGroupUsersSelection}}
+                >
+              </th>
+              <SortableTh
+                @colspan={{4}}
+                @onClick={{fn this.setSortBy "fullName"}}
+                @sortedBy={{or (eq @sortBy "fullName") (eq @sortBy "fullName:desc")}}
+                @sortedAscending={{this.sortedAscending}}
+              >
+                {{t "general.name"}}
+              </SortableTh>
+              <th class="text-left" colspan="2">
+                {{t "general.campusId"}}
+              </th>
+              <th class="text-left hide-from-small-screen" colspan="5">
+                {{t "general.email"}}
+              </th>
+              <SortableTh
+                @colspan={{2}}
+                @onClick={{fn this.setSortBy "lowestGroupInTreeTitle"}}
+                @sortedBy={{or (eq @sortBy "lowestGroupInTreeTitle") (eq @sortBy "lowestGroupInTreeTitle:desc")}}
+                @sortedAscending={{this.sortedAscending}}
+              >
+                {{t "general.groupName"}}
+              </SortableTh>
+              <th class="text-left" colspan="1">
+                {{t "general.actions"}}
+              </th>
+            </tr>
+            </thead>
+            <tbody data-test-users-not-in-current-group>
+              {{#each (sort-by @sortBy this.nonGroupUsers) as |user index|}}
+                <tr class={{unless user.enabled "disabled-user-account" ""}}>
+                  <td class="text-left" colspan="1">
+                    {{#if (or user.enabled this.currentUser.isRoot)}}
+                      <input
+                        aria-labelledby="cohort-username-{{index}}-{{templateId}}"
+                        type="checkbox"
+                        checked={{includes user.content this.selectedNonGroupUsers}}
+                        {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
+                      >
+                    {{/if}}
+                    {{#unless user.enabled}}
+                      <FaIcon
+                        @icon="user-xmark"
+                        @title={{t "general.disabled"}}
+                        class="error"
+                        data-test-is-disabled
+                      />
+                    {{/unless}}
+                  </td>
+                  <td class="text-left" colspan="4">
+                    {{#if (or user.enabled this.currentUser.isRoot)}}
+                      <button
+                        class="inline-button"
+                        type="button"
+                        {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
+                      >
+                        <UserNameInfo id="cohort-username-{{index}}-{{templateId}}" @user={{user}} />
+                      </button>
+                    {{else}}
+                      <UserNameInfo id="cohort-username-{{index}}-{{templateId}}" @user={{user}} />
+                    {{/if}}
+                  </td>
+                  <td class="text-left" colspan="2">
+                    {{#if (or user.enabled this.currentUser.isRoot)}}
+                      <button
+                        class="inline-button"
+                        type="button"
+                        {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
+                      >
+                        {{user.campusId}}
+                      </button>
+                    {{else}}
+                      {{user.campusId}}
+                    {{/if}}
+                  </td>
+                  <td class="text-left hide-from-small-screen" colspan="5">
+                    {{#if (or user.enabled this.currentUser.isRoot)}}
+                      <button
+                        class="inline-button"
+                        type="button"
+                        {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
+                      >
+                        {{user.email}}
+                      </button>
+                    {{else}}
+                      {{user.email}}
+                    {{/if}}
+                  </td>
+                  <td class="text-left" colspan="2">
+                    <LinkTo
+                      @route="learner-group"
+                      @model={{user.lowestGroupInTree}}
+                      @query={{hash isEditing=true sortUsersBy=@sortBy}}
+                    >
+                      {{user.lowestGroupInTree.title}}
+                    </LinkTo>
+                  </td>
+                  <td>
+                    {{#if (includes user.content this.usersBeingAddedToGroup)}}
+                      <LoadingSpinner />
+                    {{else if user.enabled}}
+                      {{#if (eq this.selectedNonGroupUsers.length 0)}}
+                        <button
+                          type="button"
+                          class="link-button"
+                          {{on "click" (perform this.addUserToGroup user.content)}}
+                          data-test-add-user
+                        >
+                          <FaIcon
+                            @icon="plus"
+                            class="yes"
+                            @title={{t
+                              "general.moveToGroup"
+                              groupTitle=@learnerGroupTitle
+                              count=1
+                            }}
+                          />
+                        </button>
+                      {{/if}}
+                    {{/if}}
+                  </td>
+                </tr>
+              {{/each}}
+            </tbody>
+          </table>
         </div>
       </div>
-      {{#if @isEditing}}
-        <p class="fullwidth">
+      <p class="fullwidth">
           {{#if (gt this.selectedNonGroupUsers.length 0)}}
             <button type="button" class="done text" {{on "click" (perform this.addUsersToGroup)}}>
               {{t
@@ -325,7 +313,6 @@
             </button>
           {{/if}}
         </p>
-      {{/if}}
     {{/if}}
   </div>
 {{/let}}

--- a/app/components/learner-group/user-manager.hbs
+++ b/app/components/learner-group/user-manager.hbs
@@ -10,25 +10,26 @@
         />
       </div>
       <div class="learner-group-user-manager-content">
+
         <div class="list">
-          <table data-test-headers>
+          {{#if @isEditing}}
+            <div class="title" data-test-group-members>
+              {{t "general.groupMembers"}}
+              ({{this.groupUsers.length}})
+            </div>
+          {{/if}}
+          <table data-test-assigned-users>
             <thead>
               <tr>
                 <th class="text-left" colspan="1">
                   {{#if @isEditing}}
-                    <Input
-                      @type="checkbox"
-                      @checked={{and
-                        (includes this.selectableUsers this.selectedUsers)
-                        this.selectedUsers.length
-                      }}
-                      indeterminate={{and
-                        (not (includes this.selectableUsers this.selectedUsers))
-                        this.selectedUsers.length
-                      }}
+                    <input
+                      type="checkbox"
+                      checked={{this.hasAllSelectedGroupUsers}}
+                      indeterminate={{this.hasSomeSelectedGroupUsers}}
                       aria-label={{t "general.selectAllOrNone"}}
-                      {{on "click" this.toggleUserSelectionAllOrNone}}
-                    />
+                      {{on "click" this.toggleAllGroupUsersSelection}}
+                    >
                   {{/if}}
                 </th>
                 <SortableTh
@@ -60,24 +61,16 @@
                 {{/if}}
               </tr>
             </thead>
-          </table>
-          {{#if @isEditing}}
-            <div class="title" data-test-group-members>
-              {{t "general.groupMembers"}}
-              ({{this.usersInCurrentGroup.length}})
-            </div>
-          {{/if}}
-          <table>
             <tbody data-test-users-in-current-group>
-              {{#each (sort-by @sortBy this.usersInCurrentGroup) as |user index|}}
+              {{#each (sort-by @sortBy this.groupUsers) as |user index|}}
                 <tr class={{unless user.enabled "disabled-user-account" ""}}>
                   <td class="text-left" colspan="1">
                     {{#if (and @isEditing (or user.enabled this.currentUser.isRoot))}}
                       <input
                         aria-labelledby="selected-username-{{index}}-{{templateId}}"
                         type="checkbox"
-                        checked={{includes user.content this.selectedUsers}}
-                        {{on "click" (fn this.toggleUserSelection user.content)}}
+                        checked={{includes user.content this.selectedGroupUsers}}
+                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
                       >
                     {{/if}}
                     {{#unless user.enabled}}
@@ -94,7 +87,7 @@
                       <button
                         class="inline-button"
                         type="button"
-                        {{on "click" (fn this.toggleUserSelection user.content)}}
+                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
                       >
                         <UserNameInfo id="selected-username-{{index}}-{{templateId}}" @user={{user}} />
                       </button>
@@ -107,7 +100,7 @@
                       <button
                         class="inline-button"
                         type="button"
-                        {{on "click" (fn this.toggleUserSelection user.content)}}
+                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
                       >
                         {{user.campusId}}
                       </button>
@@ -120,7 +113,7 @@
                       <button
                         class="inline-button"
                         type="button"
-                        {{on "click" (fn this.toggleUserSelection user.content)}}
+                        {{on "click" (fn this.toggleGroupUserSelection user.content)}}
                       >
                         {{user.email}}
                       </button>
@@ -139,14 +132,14 @@
                       </LinkTo>
                     </td>
                     <td>
-                      {{#if (includes user.content this.usersBeingMoved)}}
+                      {{#if (includes user.content this.usersBeingRemovedFromGroup)}}
                         <LoadingSpinner />
                       {{else if user.enabled}}
-                        {{#if (eq this.selectedUsers.length 0)}}
+                        {{#if (eq this.selectedGroupUsers.length 0)}}
                           <button
                             type="button"
                             class="link-button"
-                            {{on "click" (perform this.removeSingleUser user.content)}}
+                            {{on "click" (perform this.removeUserFromGroup user.content)}}
                             data-test-remove-user
                           >
                             <FaIcon
@@ -170,19 +163,57 @@
           {{#if @isEditing}}
             <div class="title" data-test-all-other-members>
               {{t "general.allOtherMembers" topLevelGroupTitle=@topLevelGroupTitle}}
-              ({{this.usersNotInCurrentGroup.length}})
+              ({{this.nonGroupUsers.length}})
             </div>
-            <table>
+            <table data-test-assignable-users>
+              <thead>
+              <tr>
+                <th class="text-left" colspan="1">
+                  <input
+                    type="checkbox"
+                    checked={{this.hasAllSelectedNonGroupUsers}}
+                    indeterminate={{this.hasSomeSelectedNonGroupUsers}}
+                    aria-label={{t "general.selectAllOrNone"}}
+                    {{on "click" this.toggleAllNonGroupUsersSelection}}
+                  >
+                </th>
+                <SortableTh
+                  @colspan={{4}}
+                  @onClick={{fn this.setSortBy "fullName"}}
+                  @sortedBy={{or (eq @sortBy "fullName") (eq @sortBy "fullName:desc")}}
+                  @sortedAscending={{this.sortedAscending}}
+                >
+                  {{t "general.name"}}
+                </SortableTh>
+                <th class="text-left" colspan="2">
+                  {{t "general.campusId"}}
+                </th>
+                <th class="text-left hide-from-small-screen" colspan="5">
+                  {{t "general.email"}}
+                </th>
+                <SortableTh
+                  @colspan={{2}}
+                  @onClick={{fn this.setSortBy "lowestGroupInTreeTitle"}}
+                  @sortedBy={{or (eq @sortBy "lowestGroupInTreeTitle") (eq @sortBy "lowestGroupInTreeTitle:desc")}}
+                  @sortedAscending={{this.sortedAscending}}
+                >
+                  {{t "general.groupName"}}
+                </SortableTh>
+                <th class="text-left" colspan="1">
+                  {{t "general.actions"}}
+                </th>
+              </tr>
+              </thead>
               <tbody data-test-users-not-in-current-group>
-                {{#each (sort-by @sortBy this.usersNotInCurrentGroup) as |user index|}}
+                {{#each (sort-by @sortBy this.nonGroupUsers) as |user index|}}
                   <tr class={{unless user.enabled "disabled-user-account" ""}}>
                     <td class="text-left" colspan="1">
-                      {{#if (and @isEditing (or user.enabled this.currentUser.isRoot))}}
+                      {{#if (or user.enabled this.currentUser.isRoot)}}
                         <input
                           aria-labelledby="cohort-username-{{index}}-{{templateId}}"
                           type="checkbox"
-                          checked={{includes user.content this.selectedUsers}}
-                          {{on "click" (fn this.toggleUserSelection user.content)}}
+                          checked={{includes user.content this.selectedNonGroupUsers}}
+                          {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
                         >
                       {{/if}}
                       {{#unless user.enabled}}
@@ -195,11 +226,11 @@
                       {{/unless}}
                     </td>
                     <td class="text-left" colspan="4">
-                      {{#if (and @isEditing (or user.enabled this.currentUser.isRoot))}}
+                      {{#if (or user.enabled this.currentUser.isRoot)}}
                         <button
                           class="inline-button"
                           type="button"
-                          {{on "click" (fn this.toggleUserSelection user.content)}}
+                          {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
                         >
                           <UserNameInfo id="cohort-username-{{index}}-{{templateId}}" @user={{user}} />
                         </button>
@@ -208,11 +239,11 @@
                       {{/if}}
                     </td>
                     <td class="text-left" colspan="2">
-                      {{#if (and @isEditing (or user.enabled this.currentUser.isRoot))}}
+                      {{#if (or user.enabled this.currentUser.isRoot)}}
                         <button
                           class="inline-button"
                           type="button"
-                          {{on "click" (fn this.toggleUserSelection user.content)}}
+                          {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
                         >
                           {{user.campusId}}
                         </button>
@@ -221,11 +252,11 @@
                       {{/if}}
                     </td>
                     <td class="text-left hide-from-small-screen" colspan="5">
-                      {{#if (and @isEditing (or user.enabled this.currentUser.isRoot))}}
+                      {{#if (or user.enabled this.currentUser.isRoot)}}
                         <button
                           class="inline-button"
                           type="button"
-                          {{on "click" (fn this.toggleUserSelection user.content)}}
+                          {{on "click" (fn this.toggleNonGroupUserSelection user.content)}}
                         >
                           {{user.email}}
                         </button>
@@ -233,41 +264,39 @@
                         {{user.email}}
                       {{/if}}
                     </td>
-                    {{#if @isEditing}}
-                      <td class="text-left" colspan="2">
-                        <LinkTo
-                          @route="learner-group"
-                          @model={{user.lowestGroupInTree}}
-                          @query={{hash isEditing=@isEditing sortUsersBy=@sortBy}}
-                        >
-                          {{user.lowestGroupInTree.title}}
-                        </LinkTo>
-                      </td>
-                      <td>
-                        {{#if (includes user.content this.usersBeingMoved)}}
-                          <LoadingSpinner />
-                        {{else if user.enabled}}
-                          {{#if (eq this.selectedUsers.length 0)}}
-                            <button
-                              type="button"
-                              class="link-button"
-                              {{on "click" (perform this.addSingleUser user.content)}}
-                              data-test-add-user
-                            >
-                              <FaIcon
-                                @icon="plus"
-                                class="yes"
-                                @title={{t
-                                  "general.moveToGroup"
-                                  groupTitle=@learnerGroupTitle
-                                  count=1
-                                }}
-                              />
-                            </button>
-                          {{/if}}
+                    <td class="text-left" colspan="2">
+                      <LinkTo
+                        @route="learner-group"
+                        @model={{user.lowestGroupInTree}}
+                        @query={{hash isEditing=true sortUsersBy=@sortBy}}
+                      >
+                        {{user.lowestGroupInTree.title}}
+                      </LinkTo>
+                    </td>
+                    <td>
+                      {{#if (includes user.content this.usersBeingAddedToGroup)}}
+                        <LoadingSpinner />
+                      {{else if user.enabled}}
+                        {{#if (eq this.selectedNonGroupUsers.length 0)}}
+                          <button
+                            type="button"
+                            class="link-button"
+                            {{on "click" (perform this.addUserToGroup user.content)}}
+                            data-test-add-user
+                          >
+                            <FaIcon
+                              @icon="plus"
+                              class="yes"
+                              @title={{t
+                                "general.moveToGroup"
+                                groupTitle=@learnerGroupTitle
+                                count=1
+                              }}
+                            />
+                          </button>
                         {{/if}}
-                      </td>
-                    {{/if}}
+                      {{/if}}
+                    </td>
                   </tr>
                 {{/each}}
               </tbody>
@@ -275,22 +304,26 @@
           {{/if}}
         </div>
       </div>
-      {{#if (gt this.selectedUsers.length 0)}}
+      {{#if @isEditing}}
         <p class="fullwidth">
-          <button type="button" class="done text" {{on "click" (perform this.addSelectedUsers)}}>
-            {{t
-              "general.moveToGroup"
-              groupTitle=@learnerGroupTitle
-              count=this.selectedUsers.length
-            }}
-          </button>
-          <button type="button" class="cancel text" {{on "click" (perform this.removeSelectedUsers)}}>
-            {{t
-              "general.removeLearnerToCohort"
-              cohort=@cohortTitle
-              count=this.selectedUsers.length
-            }}
-          </button>
+          {{#if (gt this.selectedNonGroupUsers.length 0)}}
+            <button type="button" class="done text" {{on "click" (perform this.addUsersToGroup)}}>
+              {{t
+                "general.moveToGroup"
+                groupTitle=@learnerGroupTitle
+                count=this.selectedNonGroupUsers.length
+              }}
+            </button>
+          {{/if}}
+          {{#if (gt this.selectedGroupUsers.length 0)}}
+            <button type="button" class="cancel text" {{on "click" (perform this.removeUsersFromGroup)}}>
+              {{t
+                "general.removeLearnerToCohort"
+                cohort=@cohortTitle
+                count=this.selectedGroupUsers.length
+              }}
+            </button>
+          {{/if}}
         </p>
       {{/if}}
     {{/if}}

--- a/app/components/learner-group/user-manager.js
+++ b/app/components/learner-group/user-manager.js
@@ -198,4 +198,11 @@ export default class LearnerGroupUserManagerComponent extends Component {
     );
     this.selectedGroupUsers = [];
   }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    //undo selections
+    this.selectedGroupUsers = [];
+    this.selectedNonGroupUsers = [];
+  }
 }

--- a/app/components/learner-group/user-manager.js
+++ b/app/components/learner-group/user-manager.js
@@ -50,9 +50,6 @@ export default class LearnerGroupUserManagerComponent extends Component {
   }
 
   get groupUsers() {
-    if (!this.args.isEditing) {
-      return this.filteredUsers;
-    }
     return this.filteredUsers.filter(
       (user) => user.get('lowestGroupInTree').id === this.args.learnerGroupId
     );

--- a/app/components/learner-group/user-manager.js
+++ b/app/components/learner-group/user-manager.js
@@ -70,24 +70,34 @@ export default class LearnerGroupUserManagerComponent extends Component {
   }
 
   get hasSomeSelectedGroupUsers() {
-    return this.hasSelectedGroupUsers && this.groupUsers.length !== this.selectedGroupUsers.length;
+    return (
+      this.hasSelectedGroupUsers &&
+      !mapBy(this.groupUsers, 'content').every((user) => this.selectedGroupUsers.includes(user))
+    );
   }
 
   get hasSomeSelectedNonGroupUsers() {
     return (
       this.hasSelectedNonGroupUsers &&
-      this.nonGroupUsers.length !== this.selectedNonGroupUsers.length
+      !mapBy(this.nonGroupUsers, 'content').every((user) =>
+        this.selectedNonGroupUsers.includes(user)
+      )
     );
   }
 
   get hasAllSelectedGroupUsers() {
-    return this.hasSelectedGroupUsers && this.groupUsers.length === this.selectedGroupUsers.length;
+    return (
+      this.hasSelectedGroupUsers &&
+      mapBy(this.groupUsers, 'content').every((user) => this.selectedGroupUsers.includes(user))
+    );
   }
 
   get hasAllSelectedNonGroupUsers() {
     return (
       this.hasSelectedNonGroupUsers &&
-      this.nonGroupUsers.length === this.selectedNonGroupUsers.length
+      mapBy(this.nonGroupUsers, 'content').every((user) =>
+        this.selectedNonGroupUsers.includes(user)
+      )
     );
   }
 
@@ -124,27 +134,25 @@ export default class LearnerGroupUserManagerComponent extends Component {
   @action
   toggleAllGroupUsersSelection() {
     if (!this.groupUsers.length) {
-      return false;
+      return;
     }
     if (this.hasAllSelectedGroupUsers) {
       this.selectedGroupUsers = [];
     } else {
       this.selectedGroupUsers = [...mapBy(this.groupUsers, 'content')];
     }
-    return false;
   }
 
   @action
   toggleAllNonGroupUsersSelection() {
     if (!this.nonGroupUsers.length) {
-      return false;
+      return;
     }
     if (this.hasAllSelectedNonGroupUsers) {
       this.selectedNonGroupUsers = [];
     } else {
       this.selectedNonGroupUsers = [...mapBy(this.nonGroupUsers, 'content')];
     }
-    return false;
   }
 
   @enqueueTask

--- a/app/styles/components.scss
+++ b/app/styles/components.scss
@@ -81,6 +81,7 @@
 @import 'components/learner-group/new';
 @import 'components/learner-group/root';
 @import 'components/learner-group/user-manager';
+@import 'components/learner-group/members';
 
 @import 'components/learner-groups/root';
 

--- a/app/styles/components/learner-group/members.scss
+++ b/app/styles/components/learner-group/members.scss
@@ -1,0 +1,40 @@
+@use "../../ilios-common/colors" as c;
+@use "../../ilios-common/mixins" as cm;
+@use "../../mixins" as m;
+
+.learner-group-members {
+  @include cm.detail-container(c.$tealBlue);
+  border-bottom: 0;
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+
+  .title {
+    @include cm.detail-container-title-style;
+  }
+
+  .actions {
+    input {
+      @include cm.ilios-input;
+      width: 15rem;
+    }
+  }
+
+  .learner-group-members-content {
+    @include cm.detail-container-content;
+    grid-column: 1 / -1;
+
+    .list {
+      @include m.main-list-box-table;
+      @include cm.ilios-zebra-table;
+      grid-column: 1 / -1;
+      max-height: 540px;
+      overflow: auto;
+    }
+  }
+
+  .inline-button {
+    @include cm.ilios-button-reset;
+    text-align: left;
+    width: 100%;
+  }
+}

--- a/tests/acceptance/learnergroup-test.js
+++ b/tests/acceptance/learnergroup-test.js
@@ -289,7 +289,7 @@ module('Acceptance | Learner Group', function (hooks) {
     assert.strictEqual(learnerGroupsPage.list.items[0].title, 'learner group 0');
     await learnerGroupsPage.list.items[0].clickTitle();
     assert.strictEqual(currentURL(), '/learnergroups/1');
-    assert.strictEqual(page.root.userManager.usersInCurrentGroup.length, 5);
+    assert.strictEqual(page.root.members.users.length, 5);
     assert.strictEqual(page.root.cohortUserManager.users.length, 5);
   });
 
@@ -379,7 +379,7 @@ module('Acceptance | Learner Group', function (hooks) {
 
     await page.visit({ learnerGroupId: 2 });
     assert.strictEqual(currentURL(), '/learnergroups/2');
-    assert.strictEqual(page.root.userManager.usersInCurrentGroup.length, 1);
+    assert.strictEqual(page.root.members.users.length, 1);
     await page.root.actions.buttons.manageUsers.click();
     assert.strictEqual(page.root.userManager.usersInCurrentGroup.length, 1);
     assert.strictEqual(page.root.userManager.usersNotInCurrentGroup.length, 2);

--- a/tests/integration/components/learner-group/members-test.js
+++ b/tests/integration/components/learner-group/members-test.js
@@ -1,11 +1,88 @@
-import { module, todo } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import ObjectProxy from '@ember/object/proxy';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupIntl } from 'ember-intl/test-support';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'ilios/tests/pages/components/learner-group/members';
 
 module('Integration | Component | learner-group/members', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us');
+  setupMirage(hooks);
 
-  todo('it renders', function () {
-    // @todo implement [ST 2023/05/17]
-    this.ok(false);
+  hooks.beforeEach(async function () {
+    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const user1 = this.server.create('user', {
+      firstName: 'Jasper',
+      lastName: 'Dog',
+      campusId: '1234',
+      email: 'testemail',
+      enabled: true,
+      learnerGroups: [learnerGroup],
+    });
+    const user2 = this.server.create('user', {
+      firstName: 'Jackson',
+      lastName: 'Doggy',
+      campusId: '123',
+      email: 'testemail2',
+      enabled: false,
+      learnerGroups: [learnerGroup],
+    });
+    const userModel1 = await this.owner.lookup('service:store').findRecord('user', user1.id);
+    const userModel2 = await this.owner.lookup('service:store').findRecord('user', user2.id);
+    this.learnerGroup = await this.owner
+      .lookup('service:store')
+      .findRecord('learner-group', learnerGroup.id);
+    this.userProxy1 = ObjectProxy.create({
+      content: userModel1,
+      lowestGroupInTree: this.learnerGroup,
+      lowestGroupInTreeTitle: this.learnerGroup.title,
+    });
+    this.userProxy2 = ObjectProxy.create({
+      content: userModel2,
+      lowestGroupInTree: this.learnerGroup,
+      lowestGroupInTreeTitle: this.learnerGroup.title,
+    });
+  });
+
+  test('it renders', async function (assert) {
+    this.set('users', [this.userProxy1, this.userProxy2]);
+    this.set('learnerGroup', this.learnerGroup);
+    await render(hbs`<LearnerGroup::Members
+      @learnerGroupId={{this.learnerGroup.id}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{(noop)}}
+    />`);
+    assert.strictEqual(component.users.length, 2);
+    assert.strictEqual(component.users[0].name.userNameInfo.fullName, 'Jasper M. Dog');
+    assert.strictEqual(component.users[0].campusId.text, '1234');
+    assert.strictEqual(component.users[0].email.text, 'testemail');
+    assert.strictEqual(component.users[1].name.userNameInfo.fullName, 'Jackson M. Doggy');
+    assert.strictEqual(component.users[1].campusId.text, '123');
+    assert.strictEqual(component.users[1].email.text, 'testemail2');
+  });
+
+  test('filtering', async function (assert) {
+    this.set('users', [this.userProxy1, this.userProxy2]);
+    this.set('learnerGroup', this.learnerGroup);
+    await render(hbs`<LearnerGroup::Members
+      @learnerGroupId={{this.learnerGroup.id}}
+      @users={{this.users}}
+      @sortBy="id"
+      @setSortBy={{(noop)}}
+    />`);
+    assert.strictEqual(component.users.length, 2);
+    assert.strictEqual(component.users[0].name.userNameInfo.fullName, 'Jasper M. Dog');
+    assert.strictEqual(component.users[1].name.userNameInfo.fullName, 'Jackson M. Doggy');
+    await component.filter('Jackson');
+    assert.strictEqual(component.users.length, 1);
+    assert.strictEqual(component.users[0].name.userNameInfo.fullName, 'Jackson M. Doggy');
+    await component.filter('');
+    assert.strictEqual(component.users.length, 2);
+    assert.strictEqual(component.users[0].name.userNameInfo.fullName, 'Jasper M. Dog');
+    assert.strictEqual(component.users[1].name.userNameInfo.fullName, 'Jackson M. Doggy');
   });
 });

--- a/tests/integration/components/learner-group/members-test.js
+++ b/tests/integration/components/learner-group/members-test.js
@@ -1,0 +1,11 @@
+import { module, todo } from 'qunit';
+import { setupRenderingTest } from 'ilios/tests/helpers';
+
+module('Integration | Component | learner-group/members', function (hooks) {
+  setupRenderingTest(hooks);
+
+  todo('it renders', function () {
+    // @todo implement [ST 2023/05/17]
+    this.ok(false);
+  });
+});

--- a/tests/pages/components/learner-group/members.js
+++ b/tests/pages/components/learner-group/members.js
@@ -1,0 +1,38 @@
+import {
+  clickable,
+  collection,
+  create,
+  fillable,
+  isPresent,
+  property,
+} from 'ember-cli-page-object';
+import userNameInfo from 'ilios-common/page-objects/components/user-name-info';
+
+const definition = {
+  scope: '[data-test-learner-group-members]',
+  filter: fillable('[data-test-filter]'),
+  users: collection('table tbody tr', {
+    isSelected: property('checked', 'td:eq(0) input'),
+    canBeSelected: isPresent('td:eq(0) input'),
+    select: clickable('td:eq(0) input'),
+    name: {
+      scope: 'td:eq(1)',
+      isClickable: isPresent('button'),
+      click: clickable('button'),
+      userNameInfo,
+    },
+    campusId: {
+      scope: 'td:eq(2)',
+      isClickable: isPresent('button'),
+      click: clickable('button'),
+    },
+    email: {
+      scope: 'td:eq(3)',
+      isClickable: isPresent('button'),
+      click: clickable('button'),
+    },
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/tests/pages/components/learner-group/root.js
+++ b/tests/pages/components/learner-group/root.js
@@ -14,6 +14,7 @@ import cohortUserManager from './cohort-user-manager';
 import instructorManager from './instructor-manager';
 import bulkAssignment from './bulk-assignment';
 import userManager from './user-manager';
+import members from './members';
 import subgroupList from './list';
 import calendar from './calendar';
 import newLearnerGroupForm from './new';
@@ -78,6 +79,7 @@ const definition = {
   bulkAssignment,
   userManager,
   calendar,
+  members,
   subgroups: {
     scope: '[data-test-subgroups]',
     title: text('h3'),

--- a/tests/pages/components/learner-group/user-manager.js
+++ b/tests/pages/components/learner-group/user-manager.js
@@ -14,13 +14,19 @@ const definition = {
   filter: fillable('[data-test-filter]'),
   groupMembers: text('[data-test-group-members]'),
   allOtherMembers: text('[data-test-all-other-members]'),
-  selectAll: {
-    scope: '[data-test-headers] th:eq(0) input',
+  selectAllUsersInGroup: {
+    scope: '[data-test-assigned-users] th:eq(0) input',
     toggle: clickable(),
     isChecked: property('checked'),
     isIndeterminate: property('indeterminate'),
   },
-  usersInCurrentGroup: collection('[data-test-users-in-current-group] tr', {
+  selectAllUsersNotInGroup: {
+    scope: '[data-test-assignable-users] th:eq(0) input',
+    toggle: clickable(),
+    isChecked: property('checked'),
+    isIndeterminate: property('indeterminate'),
+  },
+  usersInCurrentGroup: collection('[data-test-assigned-users] tbody tr', {
     isSelected: property('checked', 'td:eq(0) input'),
     canBeSelected: isPresent('td:eq(0) input'),
     select: clickable('td:eq(0) input'),
@@ -44,7 +50,7 @@ const definition = {
     remove: clickable('[data-test-remove-user]'),
     canBeRemoved: isPresent('[data-test-remove-user]'),
   }),
-  usersNotInCurrentGroup: collection('[data-test-users-not-in-current-group] tr', {
+  usersNotInCurrentGroup: collection('[data-test-assignable-users] tbody tr', {
     isSelected: property('checked', 'td:eq(0) input'),
     canBeSelected: isPresent('td:eq(0) input'),
     select: clickable('td:eq(0) input'),


### PR DESCRIPTION
- adds capability to select/deselect all users that are _in_ the given group from the users that can be added _to_ the given group
- fix: clear selections when user manager is closed
- fix: corrects visibility and labeling of multi-user selection buttons

this component is still dreadful, but a bit better now.

fixes ilios/ilios#4736