### PR TITLE
Replace resolve async value resource

### DIFF
--- a/app/components/curriculum-inventory/report-list-item.js
+++ b/app/components/curriculum-inventory/report-list-item.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import PermissionChecker from 'ilios/classes/permission-checker';
 import { use } from 'ember-could-get-used-to-this';
 import { inject as service } from '@ember/service';
@@ -10,14 +11,19 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
   @service permissionChecker;
   @tracked showConfirmRemoval;
   isFinalized = this.args.report.belongsTo('export').id();
+  academicYearConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
 
   @use canDelete = new PermissionChecker(() => [
     'canDeleteCurriculumInventoryReport',
     this.args.report,
   ]);
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-  ]);
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.academicYearConfig.isResolved ? this.academicYearConfig.value : null;
+  }
 
   get yearLabel() {
     if (this.academicYearCrossesCalendarYearBoundaries) {

--- a/app/components/curriculum-inventory/report-overview.js
+++ b/app/components/curriculum-inventory/report-overview.js
@@ -4,8 +4,8 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import scrollTo from 'ilios-common/utils/scroll-to';
 import { dropTask, restartableTask } from 'ember-concurrency';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import {
   validatable,
   AfterDate,
@@ -29,14 +29,22 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
   @tracked academicYearCrossesCalendarYearBoundaries = false;
   @tracked canRollover = false;
 
-  @use linkedCourses = new ResolveAsyncValue(() => [this.args.report.getLinkedCourses()]);
-
-  get linkedCoursesLoaded() {
-    return !!this.linkedCourses;
+  @cached
+  get courseData() {
+    return new TrackedAsyncData(this.args.report.getLinkedCourses());
   }
 
+  get linkedCourses() {
+    return this.courseData.isResolved ? this.courseData.value : null;
+  }
+
+  get linkedCoursesLoaded() {
+    return this.courseData.isResolved;
+  }
+
+  @cached
   get hasLinkedCourses() {
-    return !!this.linkedCourses?.length;
+    return Boolean(this.linkedCourses?.length);
   }
 
   get showRollover() {

--- a/app/components/curriculum-inventory/reports.js
+++ b/app/components/curriculum-inventory/reports.js
@@ -2,10 +2,10 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { use } from 'ember-could-get-used-to-this';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import { findById, sortBy } from 'ilios-common/utils/array-helpers';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class CurriculumInventoryReportsComponent extends Component {
   @service currentUser;
@@ -20,7 +20,14 @@ export default class CurriculumInventoryReportsComponent extends Component {
   @tracked selectedProgram = null;
   @tracked canCreate = false;
 
-  @use reports = new ResolveAsyncValue(() => [this.selectedProgram?.curriculumInventoryReports]);
+  @cached
+  get reportsData() {
+    return new TrackedAsyncData(this.selectedProgram?.curriculumInventoryReports);
+  }
+
+  get reports() {
+    return this.reportsData.isResolved ? this.reportsData.value : null;
+  }
 
   get curriculumInventoryReports() {
     return this.reports ? this.reports.slice() : [];

--- a/app/components/curriculum-inventory/sequence-block-list-item.js
+++ b/app/components/curriculum-inventory/sequence-block-list-item.js
@@ -1,14 +1,21 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class CurriculumInventorySequenceBlockListItemComponent extends Component {
   @service intl;
   @tracked showConfirmRemoval;
 
-  @use course = new ResolveAsyncValue(() => [this.args.sequenceBlock.course]);
+  @cached
+  get courseData() {
+    return new TrackedAsyncData(this.args.sequenceBlock.course);
+  }
+
+  get course() {
+    return this.courseData.isResolved ? this.courseData.value : null;
+  }
 
   get courseTitle() {
     if (this.course) {

--- a/app/components/curriculum-inventory/sequence-block-session-list.js
+++ b/app/components/curriculum-inventory/sequence-block-session-list.js
@@ -1,14 +1,26 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class SequenceBlockSessionListComponent extends Component {
-  @use sessions = new ResolveAsyncValue(() => [this.args.sequenceBlock.sessions, []]);
-  @use excludedSessions = new ResolveAsyncValue(() => [
-    this.args.sequenceBlock.excludedSessions,
-    [],
-  ]);
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.sequenceBlock.sessions);
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : [];
+  }
+
+  @cached
+  get excludedSessionsData() {
+    return new TrackedAsyncData(this.args.sequenceBlock.excludedSessions);
+  }
+
+  get excludedSessions() {
+    return this.excludedSessionsData.isResolved ? this.excludedSessionsData.value : [];
+  }
 
   get sortedAscending() {
     const sortBy = this.args.sortBy;

--- a/app/components/global-search.js
+++ b/app/components/global-search.js
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { findBy, findById, mapBy, sortBy, uniqueValues } from 'ilios-common/utils/array-helpers';
-import { use } from 'ember-could-get-used-to-this';
 import { action } from '@ember/object';
 
 const MIN_INPUT = 3;
@@ -18,13 +18,17 @@ export default class GlobalSearchComponent extends Component {
   size = 10;
   @tracked results = [];
 
+  @cached
+  get allSchools() {
+    return new TrackedAsyncData(this.store.findAll('school'));
+  }
+
   get hasResults() {
     return Boolean(this.results.length);
   }
 
-  @use allSchools = new ResolveAsyncValue(() => [this.store.findAll('school')]);
   get schools() {
-    return this.allSchools ?? [];
+    return this.allSchools.isResolved ? this.allSchools.value : [];
   }
 
   get ignoredSchoolTitles() {

--- a/app/components/ilios-header.js
+++ b/app/components/ilios-header.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { defaultValidator } from 'ember-a11y-refocus';
 
@@ -11,8 +11,12 @@ export default class IliosHeaderComponent extends Component {
   @service router;
   @service iliosConfig;
   @service pageTitle;
+  searchConfig = new TrackedAsyncData(this.iliosConfig.getSearchEnabled());
 
-  @use searchEnabled = new ResolveAsyncValue(() => [this.iliosConfig.getSearchEnabled()]);
+  @cached
+  get searchEnabled() {
+    return this.searchConfig.isResolved ? this.searchConfig.value : false;
+  }
 
   get showSearch() {
     return (

--- a/app/components/ilios-users.js
+++ b/app/components/ilios-users.js
@@ -2,8 +2,8 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { cleanQuery } from 'ilios-common/utils/query-utils';
 import { restartableTask, timeout } from 'ember-concurrency';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { ensureSafeComponent } from '@embroider/util';
 import NewDirectoryUser from './new-directory-user';
 import NewUser from './new-user';
@@ -13,10 +13,12 @@ const DEBOUNCE_TIMEOUT = 250;
 export default class IliosUsersComponent extends Component {
   @service iliosConfig;
   @service store;
+  searchTypeConfig = new TrackedAsyncData(this.iliosConfig.itemFromConfig('userSearchType'));
 
-  @use userSearchType = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('userSearchType'),
-  ]);
+  @cached
+  get userSearchType() {
+    return this.searchTypeConfig.isResolved ? this.searchTypeConfig.value : null;
+  }
 
   get newUserComponent() {
     const component = this.userSearchType === 'ldap' ? NewDirectoryUser : NewUser;

--- a/app/components/instructor-group/users.js
+++ b/app/components/instructor-group/users.js
@@ -2,14 +2,21 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dropTask, timeout } from 'ember-concurrency';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class InstructorGroupUsersComponent extends Component {
   @tracked usersBuffer = [];
   @tracked isManaging = false;
 
-  @use users = new ResolveAsyncValue(() => [this.args.instructorGroup.users, []]);
+  @cached
+  get usersData() {
+    return new TrackedAsyncData(this.args.instructorGroup.users);
+  }
+
+  get users() {
+    return this.usersData.isResolved ? this.usersData.value : [];
+  }
 
   @action
   addUser(user) {

--- a/app/components/instructor-groups/list-item.js
+++ b/app/components/instructor-groups/list-item.js
@@ -3,7 +3,8 @@ import { tracked } from '@glimmer/tracking';
 import PermissionChecker from 'ilios/classes/permission-checker';
 import { use } from 'ember-could-get-used-to-this';
 import { dropTask } from 'ember-concurrency';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class InstructorGroupsListItemComponent extends Component {
   @tracked showRemoveConfirmation = false;
@@ -13,7 +14,14 @@ export default class InstructorGroupsListItemComponent extends Component {
     this.args.instructorGroup,
   ]);
 
-  @use courses = new ResolveAsyncValue(() => [this.args.instructorGroup.courses]);
+  @cached
+  get coursesData() {
+    return new TrackedAsyncData(this.args.instructorGroup.courses);
+  }
+
+  get courses() {
+    return this.coursesData.isResolved ? this.coursesData.value : null;
+  }
 
   get canDelete() {
     return this.canDeletePermission && this.courses && this.courses.length === 0;

--- a/app/components/instructor-groups/root.js
+++ b/app/components/instructor-groups/root.js
@@ -2,7 +2,8 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { findById } from 'ilios-common/utils/array-helpers';
 import PermissionChecker from 'ilios/classes/permission-checker';
 import { dropTask } from 'ember-concurrency';
@@ -14,19 +15,35 @@ export default class InstructorGroupsRootComponent extends Component {
   @tracked showNewInstructorGroupForm = false;
   @tracked newInstructorGroup;
   @tracked instructorGroupPromises = new Map();
+  userModel = new TrackedAsyncData(this.currentUser.getModel());
 
-  @use user = new ResolveAsyncValue(() => [this.currentUser.getModel()]);
+  @cached
+  get user() {
+    return this.userModel.isResolved ? this.userModel.value : null;
+  }
+
   @use canCreate = new PermissionChecker(() => [
     'canCreateInstructorGroup',
     this.bestSelectedSchool,
   ]);
-  @use loadedSchool = new ResolveAsyncValue(() => [
-    this.getSchoolPromise(this.bestSelectedSchool.id),
-  ]);
-  @use instructorGroups = new ResolveAsyncValue(() => [
-    this.bestSelectedSchool.instructorGroups,
-    [],
-  ]);
+
+  @cached
+  get loadedSchoolData() {
+    return new TrackedAsyncData(this.getSchoolPromise(this.bestSelectedSchool.id));
+  }
+
+  get loadedSchool() {
+    return this.loadedSchoolData.isResolved ? this.loadedSchoolData.value : null;
+  }
+
+  @cached
+  get instructorGroupsData() {
+    return new TrackedAsyncData(this.bestSelectedSchool.instructorGroups);
+  }
+
+  get instructorGroups() {
+    return this.instructorGroupsData.isResolved ? this.instructorGroupsData.value : [];
+  }
 
   get isLoaded() {
     return Boolean(this.loadedSchool);

--- a/app/components/learner-group/instructor-group-members-list.js
+++ b/app/components/learner-group/instructor-group-members-list.js
@@ -1,7 +1,14 @@
 import Component from '@glimmer/component';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class LearnerGroupInstructorGroupMembersListComponent extends Component {
-  @use members = new ResolveAsyncValue(() => [this.args.instructorGroup.users, []]);
+  @cached
+  get membersData() {
+    return new TrackedAsyncData(this.args.instructorGroup.users);
+  }
+
+  get members() {
+    return this.membersData.isResolved ? this.membersData.value : [];
+  }
 }

--- a/app/components/learner-group/instructor-manager.hbs
+++ b/app/components/learner-group/instructor-manager.hbs
@@ -86,9 +86,9 @@
           @currentlyActiveInstructorGroups={{this.instructorGroups}}
         />
       {{else}}
-        {{#if this.allInstructors.length}}
+        {{#if @learnerGroup.allInstructors.length}}
           <ul class="assigned-instructors">
-            {{#each (sort-by "fullName" this.allInstructors) as |instructor|}}
+            {{#each (sort-by "fullName" @learnerGroup.allInstructors) as |instructor|}}
               <li data-test-assigned-instructor>
                 <UserNameInfo @user={{instructor}} />
               </li>

--- a/app/components/learner-group/instructor-manager.js
+++ b/app/components/learner-group/instructor-manager.js
@@ -3,16 +3,12 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import { dropTask, restartableTask } from 'ember-concurrency';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
 
 export default class LearnerGroupInstructorManagerComponent extends Component {
   @tracked availableInstructorGroups = [];
   @tracked instructors = [];
   @tracked instructorGroups = [];
   @tracked isManaging = false;
-
-  @use allInstructors = new ResolveAsyncValue(() => [this.args.learnerGroup.allInstructors, []]);
 
   @restartableTask
   *load(element, [learnerGroup]) {

--- a/app/components/learner-group/list-item.js
+++ b/app/components/learner-group/list-item.js
@@ -1,35 +1,45 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { isNone } from '@ember/utils';
 import { use } from 'ember-could-get-used-to-this';
 import { dropTask } from 'ember-concurrency';
 import { all, filter } from 'rsvp';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import PermissionChecker from 'ilios/classes/permission-checker';
 
 export default class LearnerGroupListItemComponent extends Component {
   @tracked showRemoveConfirmation = false;
   @tracked showCopyConfirmation = false;
 
-  @use school = new ResolveAsyncValue(() => [
-    this.args.learnerGroup.get('cohort.programYear.program.school'),
-  ]);
+  @cached
+  get schoolData() {
+    return new TrackedAsyncData(this.getSchool(this.args.learnerGroup));
+  }
+
+  @cached
+  get isLinkedData() {
+    return new TrackedAsyncData(this.isLinkedToOfferingsOrIlms(this.args.learnerGroup));
+  }
+
+  get school() {
+    return this.schoolData.isResolved ? this.schoolData.value : null;
+  }
+
   @use canDeletePermission = new PermissionChecker(() => [
     'canDeleteLearnerGroup',
     this.args.learnerGroup,
   ]);
-  @use hasLearnersInGroupOrSubgroups = new ResolveAsyncValue(() => [
-    this.args.learnerGroup.hasLearnersInGroupOrSubgroups,
-    true,
-  ]);
+
   @use canCreatePermission = new PermissionChecker(() => ['canCreateLearnerGroup', this.school]);
-  @use isLinked = new ResolveAsyncValue(() => [
-    this.isLinkedToOfferingsOrIlms(this.args.learnerGroup),
-  ]);
+
+  @cached
+  get isLinked() {
+    return this.isLinkedData.isResolved ? this.isLinkedData.value : null;
+  }
 
   get canDelete() {
-    if (isNone(this.isLinked)) {
+    if (this.isLinked) {
       return false;
     }
     return this.canDeletePermission && !this.isLinked;
@@ -37,6 +47,13 @@ export default class LearnerGroupListItemComponent extends Component {
 
   get canCreate() {
     return this.school && this.canCreatePermission;
+  }
+
+  async getSchool(learnerGroup) {
+    const cohort = await learnerGroup.cohort;
+    const programYear = await cohort.programYear;
+    const program = await programYear.program;
+    return program.school;
   }
 
   async isLinkedToOfferingsOrIlms(learnerGroup) {

--- a/app/components/learner-group/root.js
+++ b/app/components/learner-group/root.js
@@ -6,9 +6,9 @@ import { inject as service } from '@ember/service';
 import { isPresent } from '@ember/utils';
 import { all, map } from 'rsvp';
 import { dropTask, enqueueTask, restartableTask, task } from 'ember-concurrency';
-import { use } from 'ember-could-get-used-to-this';
 import pad from 'pad';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { Length, IsURL, validatable } from 'ilios-common/decorators/validation';
 import { findById, mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
 import cloneLearnerGroup from '../../utils/clone-learner-group';
@@ -39,7 +39,14 @@ export default class LearnerGroupRootComponent extends Component {
   @tracked currentGroupsSaved = 0;
   @tracked totalGroupsToSave = 0;
 
-  @use subGroups = new ResolveAsyncValue(() => [this.args.learnerGroup.children]);
+  @cached
+  get subGroupsData() {
+    return new TrackedAsyncData(this.args.learnerGroup.children);
+  }
+
+  get subGroups() {
+    return this.subGroupsData.isResolved ? this.subGroupsData.value : null;
+  }
 
   get learnerGroups() {
     if (!this.subGroups) {

--- a/app/components/manage-users-summary.js
+++ b/app/components/manage-users-summary.js
@@ -4,8 +4,8 @@ import { inject as service } from '@ember/service';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { cleanQuery } from 'ilios-common/utils/query-utils';
 import { tracked } from '@glimmer/tracking';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 const DEBOUNCE_MS = 250;
 const MIN_INPUT = 3;
@@ -20,7 +20,12 @@ export default class ManageUsersSummaryComponent extends Component {
 
   @tracked searchValue;
 
-  @use userSearchType = new ResolveAsyncValue(() => [this.iliosConfig.getUserSearchType()]);
+  userSearchTypeData = new TrackedAsyncData(this.iliosConfig.getUserSearchType());
+
+  @cached
+  get userSearchType() {
+    return this.userSearchTypeData.isResolved ? this.userSearchTypeData.value : null;
+  }
 
   /**
    * Find users using the user API

--- a/app/components/pending-single-user-update.js
+++ b/app/components/pending-single-user-update.js
@@ -2,12 +2,20 @@ import Component from '@glimmer/component';
 import { all } from 'rsvp';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class PendingSingleUserUpdateComponent extends Component {
   @service flashMessages;
-  @use updates = new ResolveAsyncValue(() => [this.args.user.pendingUserUpdates, []]);
+
+  @cached
+  get updatesData() {
+    return new TrackedAsyncData(this.args.user.pendingUserUpdates);
+  }
+
+  get updates() {
+    return this.updatesData.isResolved ? this.updatesData.value : [];
+  }
 
   get isSaving() {
     return (

--- a/app/components/program-year/header.js
+++ b/app/components/program-year/header.js
@@ -1,11 +1,17 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class ProgramYearHeaderComponent extends Component {
   @service iliosConfig;
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-  ]);
+
+  crossesBoundryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+  }
 }

--- a/app/components/program-year/header.js
+++ b/app/components/program-year/header.js
@@ -6,12 +6,12 @@ import { cached } from '@glimmer/tracking';
 export default class ProgramYearHeaderComponent extends Component {
   @service iliosConfig;
 
-  crossesBoundryConfig = new TrackedAsyncData(
+  crossesBoundaryConfig = new TrackedAsyncData(
     this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
   );
 
   @cached
   get academicYearCrossesCalendarYearBoundaries() {
-    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
   }
 }

--- a/app/components/program-year/leadership-expanded.js
+++ b/app/components/program-year/leadership-expanded.js
@@ -1,17 +1,24 @@
 import Component from '@glimmer/component';
 import { dropTask } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class ProgramYearLeadershipExpandedComponent extends Component {
   @tracked directorsToAdd = [];
   @tracked directorsToRemove = [];
-  @use programYearDirectors = new ResolveAsyncValue(() => [this.args.programYear.directors]);
 
+  @cached
+  get programYearDirectors() {
+    return new TrackedAsyncData(this.args.programYear.directors);
+  }
+
+  @cached
   get directors() {
-    const directors = this.programYearDirectors?.slice() || [];
+    const directors = this.programYearDirectors.isResolved
+      ? this.programYearDirectors.value.slice()
+      : [];
     return [...directors, ...this.directorsToAdd].filter(
       (user) => !this.directorsToRemove.includes(user)
     );

--- a/app/components/program-year/list-item.js
+++ b/app/components/program-year/list-item.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import PermissionChecker from 'ilios/classes/permission-checker';
 import { use } from 'ember-could-get-used-to-this';
 import { inject as service } from '@ember/service';
@@ -12,8 +13,24 @@ export default class ProgramYearListItemComponent extends Component {
 
   @tracked showRemoveConfirmation = false;
 
-  @use program = new ResolveAsyncValue(() => [this.args.programYear.program]);
-  @use cohort = new ResolveAsyncValue(() => [this.args.programYear.cohort]);
+  @cached
+  get programData() {
+    return new TrackedAsyncData(this.args.programYear.program);
+  }
+
+  get program() {
+    return this.programData.isResolved ? this.programData.value : null;
+  }
+
+  @cached
+  get cohortData() {
+    return new TrackedAsyncData(this.args.programYear.cohort);
+  }
+
+  get cohort() {
+    return this.cohortData.isResolved ? this.cohortData.value : null;
+  }
+
   @use canDeletePermission = new PermissionChecker(() => [
     'canDeleteProgramYear',
     this.args.programYear,

--- a/app/components/program-year/list.js
+++ b/app/components/program-year/list.js
@@ -13,7 +13,7 @@ export default class ProgramYearListComponent extends Component {
   @tracked savedProgramYear;
   @service fetch;
 
-  crossesBoundryConfig = new TrackedAsyncData(
+  crossesBoundaryConfig = new TrackedAsyncData(
     this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
   );
 
@@ -32,7 +32,7 @@ export default class ProgramYearListComponent extends Component {
 
   @cached
   get academicYearCrossesCalendarYearBoundaries() {
-    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
   }
 
   @dropTask

--- a/app/components/program-year/list.js
+++ b/app/components/program-year/list.js
@@ -1,8 +1,8 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { sortBy } from 'ilios-common/utils/array-helpers';
-import { use } from 'ember-could-get-used-to-this';
 import { dropTask } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 
@@ -13,13 +13,27 @@ export default class ProgramYearListComponent extends Component {
   @tracked savedProgramYear;
   @service fetch;
 
-  @use programYears = new ResolveAsyncValue(() => [this.args.program.programYears, []]);
+  crossesBoundryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
+
+  @cached
+  get programYearsData() {
+    return new TrackedAsyncData(this.args.program.programYears);
+  }
+
+  get programYears() {
+    return this.programYearsData.isResolved ? this.programYearsData.value : [];
+  }
+
   get sortedProgramYears() {
     return sortBy(this.programYears.slice(), 'startYear');
   }
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-  ]);
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+  }
 
   @dropTask
   *saveNew(startYear) {

--- a/app/components/program-year/objective-list.js
+++ b/app/components/program-year/objective-list.js
@@ -4,7 +4,8 @@ import { dropTask } from 'ember-concurrency';
 import { map } from 'rsvp';
 import { inject as service } from '@ember/service';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
 
@@ -14,7 +15,17 @@ export default class ProgramYearObjectiveListComponent extends Component {
 
   @tracked isSorting = false;
 
-  @use programYearCompetencies = new ResolveAsyncValue(() => [this.args.programYear.competencies]);
+  @cached
+  get programYearCompetenciesData() {
+    return new TrackedAsyncData(this.args.programYear.competencies);
+  }
+
+  @cached
+  get programYearCompetencies() {
+    return this.programYearCompetenciesData.isResolved
+      ? this.programYearCompetenciesData.value
+      : null;
+  }
 
   @use domainTrees = new AsyncProcess(() => [
     this.getDomainTrees.bind(this),

--- a/app/components/program/leadership-expanded.js
+++ b/app/components/program/leadership-expanded.js
@@ -1,17 +1,22 @@
 import Component from '@glimmer/component';
 import { dropTask } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class ProgramLeadershipExpandedComponent extends Component {
   @tracked directorsToAdd = [];
   @tracked directorsToRemove = [];
-  @use programDirectors = new ResolveAsyncValue(() => [this.args.program.directors]);
 
+  @cached
+  get programDirectors() {
+    return new TrackedAsyncData(this.args.program.directors);
+  }
+
+  @cached
   get directors() {
-    const directors = this.programDirectors?.slice() || [];
+    const directors = this.programDirectors.isResolved ? this.programDirectors.value.slice() : [];
     return [...directors, ...this.directorsToAdd].filter(
       (user) => !this.directorsToRemove.includes(user)
     );

--- a/app/components/reports/new-subject.js
+++ b/app/components/reports/new-subject.js
@@ -4,7 +4,8 @@ import { map } from 'rsvp';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import { dasherize } from '@ember/string';
 import { validatable, Length, Custom } from 'ilios-common/decorators/validation';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { findById } from 'ilios-common/utils/array-helpers';
 import { use } from 'ember-could-get-used-to-this';
@@ -41,10 +42,40 @@ export default class ReportsNewSubjectComponent extends Component {
 
   loadedPrepositionalObjects = new Map();
 
-  @use userModel = new ResolveAsyncValue(() => [this.currentUser.getModel()]);
-  @use usersPrimarySchool = new ResolveAsyncValue(() => [this.userModel?.school]);
-  @use allSchools = new ResolveAsyncValue(() => [this.store.findAll('school'), []]);
-  @use allAcademicYears = new ResolveAsyncValue(() => [this.store.findAll('academic-year'), []]);
+  userModelData = new TrackedAsyncData(this.currentUser.getModel());
+
+  @cached
+  get userModel() {
+    return this.userModelData.isResolved ? this.userModelData.value : null;
+  }
+
+  @cached
+  get usersPrimarySchoolData() {
+    return new TrackedAsyncData(this.userModel?.school);
+  }
+
+  get usersPrimarySchool() {
+    return this.usersPrimarySchoolData.isResolved ? this.usersPrimarySchoolData.value : null;
+  }
+
+  @cached
+  get allSchoolsData() {
+    return new TrackedAsyncData(this.store.findAll('school'));
+  }
+
+  get allSchools() {
+    return this.allSchoolsData.isResolved ? this.allSchoolsData.value : [];
+  }
+
+  @cached
+  get allAcademicYearsData() {
+    return new TrackedAsyncData(this.store.findAll('academic-year'));
+  }
+
+  get allAcademicYears() {
+    return this.allAcademicYearsData.isResolved ? this.allAcademicYearsData.value : [];
+  }
+
   @use prepositionalObjectIdList = new AsyncProcess(() => [
     this.getPrepositionalObjectIdList.bind(this),
     this.currentPrepositionalObject,

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -8,7 +8,8 @@ import PapaParse from 'papaparse';
 import { dropTask, timeout } from 'ember-concurrency';
 import { use } from 'ember-could-get-used-to-this';
 import createDownloadFile from 'ilios/utils/create-download-file';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import { validatable, Length } from 'ilios-common/decorators/validation';
 import CourseComponent from './subject/course';
@@ -33,7 +34,15 @@ export default class ReportsSubjectComponent extends Component {
   @tracked myReportEditorOn = false;
   @tracked @Length(1, 240) title = '';
 
-  @use allAcademicYears = new ResolveAsyncValue(() => [this.store.findAll('academic-year')]);
+  @cached
+  get allAcademicYearsData() {
+    return new TrackedAsyncData(this.store.findAll('academic-year'));
+  }
+
+  get allAcademicYears() {
+    return this.allAcademicYearsData.isResolved ? this.allAcademicYearsData.value : null;
+  }
+
   @use constructedReportTitle = new AsyncProcess(() => [
     this.constructReportTitle.bind(this),
     this.args.selectedReport,

--- a/app/components/reports/subject/course.js
+++ b/app/components/reports/subject/course.js
@@ -14,7 +14,7 @@ export default class ReportsSubjectCourseComponent extends Component {
   @service iliosConfig;
   @service currentUser;
 
-  crossesBoundryConfig = new TrackedAsyncData(
+  crossesBoundaryConfig = new TrackedAsyncData(
     this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
   );
 
@@ -22,7 +22,7 @@ export default class ReportsSubjectCourseComponent extends Component {
 
   @cached
   get academicYearCrossesCalendarYearBoundaries() {
-    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
   }
 
   get canViewCourse() {

--- a/app/components/reports/subject/course.js
+++ b/app/components/reports/subject/course.js
@@ -3,7 +3,8 @@ import { filterBy } from 'ilios-common/utils/array-helpers';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { pluralize } from 'ember-inflector';
 import { camelize } from '@ember/string';
@@ -13,12 +14,16 @@ export default class ReportsSubjectCourseComponent extends Component {
   @service iliosConfig;
   @service currentUser;
 
+  crossesBoundryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
+
   @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
 
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-    false,
-  ]);
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+  }
 
   get canViewCourse() {
     return this.currentUser.performsNonLearnerFunction;

--- a/app/components/reports/subject/session.js
+++ b/app/components/reports/subject/session.js
@@ -3,7 +3,8 @@ import { filterBy } from 'ilios-common/utils/array-helpers';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { pluralize } from 'ember-inflector';
 import { camelize } from '@ember/string';
@@ -13,12 +14,16 @@ export default class ReportsSubjectSessionComponent extends Component {
   @service iliosConfig;
   @service currentUser;
 
+  crossesBoundryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
+
   @use data = new AsyncProcess(() => [this.getReportResults.bind(this), this.args.report]);
 
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-    false,
-  ]);
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+  }
 
   get canViewCourse() {
     return this.currentUser.performsNonLearnerFunction;

--- a/app/components/reports/subject/session.js
+++ b/app/components/reports/subject/session.js
@@ -14,7 +14,7 @@ export default class ReportsSubjectSessionComponent extends Component {
   @service iliosConfig;
   @service currentUser;
 
-  crossesBoundryConfig = new TrackedAsyncData(
+  crossesBoundaryConfig = new TrackedAsyncData(
     this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
   );
 
@@ -22,7 +22,7 @@ export default class ReportsSubjectSessionComponent extends Component {
 
   @cached
   get academicYearCrossesCalendarYearBoundaries() {
-    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
   }
 
   get canViewCourse() {

--- a/app/components/school-competencies-list-item.js
+++ b/app/components/school-competencies-list-item.js
@@ -2,8 +2,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { uniqueValues } from 'ilios-common/utils/array-helpers';
 
 export default class SchoolCompetenciesListItemComponent extends Component {
@@ -12,8 +12,24 @@ export default class SchoolCompetenciesListItemComponent extends Component {
   @tracked isManaging = false;
   @tracked pcrsToRemove = [];
   @tracked pcrsToAdd = [];
-  @use competencyPcrses = new ResolveAsyncValue(() => [this.args.competency?.aamcPcrses, []]);
-  @use allPcrses = new ResolveAsyncValue(() => [this.store.findAll('aamcPcrs'), []]);
+
+  @cached
+  get competencyPcrsesData() {
+    return new TrackedAsyncData(this.args.competency?.aamcPcrses);
+  }
+
+  get competencyPcrses() {
+    return this.competencyPcrsesData.isResolved ? this.competencyPcrsesData.value : [];
+  }
+
+  @cached
+  get allPcrsesData() {
+    return new TrackedAsyncData(this.store.findAll('aamcPcrs'));
+  }
+
+  get allPcrses() {
+    return this.allPcrsesData.isResolved ? this.allPcrsesData.value : [];
+  }
 
   get selectedPcrses() {
     const filteredCurrent = this.competencyPcrses.filter((p) => {

--- a/app/components/school-vocabularies-list.js
+++ b/app/components/school-vocabularies-list.js
@@ -3,15 +3,23 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { dropTask } from 'ember-concurrency';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { filterBy, sortBy } from 'ilios-common/utils/array-helpers';
 
 export default class SchoolVocabulariesListComponent extends Component {
   @service store;
   @tracked newVocabulary;
   @tracked showRemovalConfirmationFor;
-  @use vocabularies = new ResolveAsyncValue(() => [this.args.school.vocabularies]);
+
+  @cached
+  get vocabulariesData() {
+    return new TrackedAsyncData(this.args.school.vocabularies);
+  }
+
+  get vocabularies() {
+    return this.vocabulariesData.isResolved ? this.vocabulariesData.value : null;
+  }
 
   get sortedVocabularies() {
     if (!this.vocabularies) {

--- a/app/components/school-vocabulary-manager.js
+++ b/app/components/school-vocabulary-manager.js
@@ -5,8 +5,8 @@ import { inject as service } from '@ember/service';
 import { validatable, Custom, Length, NotBlank } from 'ilios-common/decorators/validation';
 import { filterBy, mapBy, sortBy } from 'ilios-common/utils/array-helpers';
 import { dropTask } from 'ember-concurrency';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 @validatable
 export default class SchoolVocabularyManagerComponent extends Component {
@@ -19,7 +19,15 @@ export default class SchoolVocabularyManagerComponent extends Component {
   title;
   @tracked isActive = false;
   @tracked newTerm;
-  @use terms = new ResolveAsyncValue(() => [this.args.vocabulary.terms]);
+
+  @cached
+  get termsData() {
+    return new TrackedAsyncData(this.args.vocabulary.terms);
+  }
+
+  get terms() {
+    return this.termsData.isResolved ? this.termsData.value : null;
+  }
 
   get sortedTerms() {
     if (!this.terms) {

--- a/app/components/school-vocabulary-term-manager.js
+++ b/app/components/school-vocabulary-term-manager.js
@@ -4,10 +4,10 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import { validatable, Custom, Length, NotBlank } from 'ilios-common/decorators/validation';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { mapBy } from 'ilios-common/utils/array-helpers';
 import { dropTask } from 'ember-concurrency';
-import { use } from 'ember-could-get-used-to-this';
 
 @validatable
 export default class SchoolVocabularyTermManagerComponent extends Component {
@@ -25,8 +25,24 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
   @tracked description = this.args.term.description;
   @tracked newTerm;
 
-  @use children = new ResolveAsyncValue(() => [this.args.term.children]);
-  @use allParents = new ResolveAsyncValue(() => [this.args.term.getAllParents()]);
+  @cached
+  get childrenData() {
+    return new TrackedAsyncData(this.args.term.children);
+  }
+
+  @cached
+  get allParentsData() {
+    return new TrackedAsyncData(this.args.term.getAllParents());
+  }
+
+  get children() {
+    return this.childrenData.isResolved ? this.childrenData.value : null;
+  }
+
+  @cached
+  get allParents() {
+    return this.allParentsData.isResolved ? this.allParentsData.value : null;
+  }
 
   get isLoading() {
     return !this.children || !this.allParents;

--- a/app/components/school/visualizer-session-type-vocabularies.js
+++ b/app/components/school/visualizer-session-type-vocabularies.js
@@ -7,7 +7,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class SchoolVisualizerSessionTypeVocabulariesComponent extends Component {
   @service router;
@@ -15,7 +16,15 @@ export default class SchoolVisualizerSessionTypeVocabulariesComponent extends Co
   @tracked tooltipContent = null;
   @tracked tooltipTitle = null;
 
-  @use sessions = new ResolveAsyncValue(() => [this.args.sessionType.sessions, null]);
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.sessionType.sessions);
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : null;
+  }
+
   @use loadedData = new AsyncProcess(() => [this.loadData.bind(this), this.sessions]);
 
   get isLoaded() {

--- a/app/components/school/visualizer-session-type-vocabulary.js
+++ b/app/components/school/visualizer-session-type-vocabulary.js
@@ -6,7 +6,8 @@ import { restartableTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class SchoolVisualizerSessionTypeVocabularyComponent extends Component {
   @service router;
@@ -14,7 +15,14 @@ export default class SchoolVisualizerSessionTypeVocabularyComponent extends Comp
   @tracked tooltipContent = null;
   @tracked tooltipTitle = null;
 
-  @use sessions = new ResolveAsyncValue(() => [this.args.sessionType.sessions, null]);
+  @cached
+  get sessionsData() {
+    return new TrackedAsyncData(this.args.sessionType.sessions);
+  }
+
+  get sessions() {
+    return this.sessionsData.isResolved ? this.sessionsData.value : null;
+  }
 
   @use loadedData = new AsyncProcess(() => [
     this.loadData.bind(this),

--- a/app/components/user-menu.js
+++ b/app/components/user-menu.js
@@ -3,15 +3,21 @@ import { schedule } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class UserMenuComponent extends Component {
   @service intl;
   @service currentUser;
   @tracked isOpen = false;
   @tracked element;
-  @use model = new ResolveAsyncValue(() => [this.currentUser.getModel()]);
+
+  userModel = new TrackedAsyncData(this.currentUser.getModel());
+
+  @cached
+  get model() {
+    return this.userModel.isResolved ? this.userModel.value : null;
+  }
 
   @action
   toggleMenu() {

--- a/app/components/user-profile-bio.js
+++ b/app/components/user-profile-bio.js
@@ -5,8 +5,8 @@ import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import { all } from 'rsvp';
 import { dropTask, restartableTask } from 'ember-concurrency';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { ValidateIf } from 'class-validator';
 import { validatable, IsEmail, NotBlank, Length } from 'ilios-common/decorators/validation';
 
@@ -38,7 +38,12 @@ export default class UserProfileBioComponent extends Component {
   @tracked updatedFieldsFromSync = [];
   @tracked passwordStrengthScore = 0;
 
-  @use userSearchType = new ResolveAsyncValue(() => [this.iliosConfig.getUserSearchType()]);
+  userSearchTypeConfig = new TrackedAsyncData(this.iliosConfig.getUserSearchType());
+
+  @cached
+  get userSearchType() {
+    return this.userSearchTypeConfig.isResolved ? this.userSearchTypeConfig.value : null;
+  }
 
   get canEditUsernameAndPassword() {
     if (!this.userSearchType) {

--- a/app/components/user-profile-permissions.js
+++ b/app/components/user-profile-permissions.js
@@ -4,38 +4,75 @@ import moment from 'moment';
 import { filter } from 'rsvp';
 import { use } from 'ember-could-get-used-to-this';
 import AsyncProcess from 'ilios-common/classes/async-process';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { findById, sortBy, uniqueValues } from 'ilios-common/utils/array-helpers';
 
 export default class UserProfilePermissionsComponent extends Component {
   @service store;
   @service iliosConfig;
 
-  schoolPromise = this.store.findAll('school');
-  academicYearPromise = this.store.findAll('academic-year');
+  @cached
+  get schoolData() {
+    return new TrackedAsyncData(this.store.findAll('school'));
+  }
 
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-    false,
-  ]);
-  @use _schools = new ResolveAsyncValue(() => [this.schoolPromise]);
+  @cached
+  get academicYearData() {
+    return new TrackedAsyncData(this.store.findAll('academic-year'));
+  }
+
+  @cached
+  get defaultSchoolData() {
+    return new TrackedAsyncData(this.args.user.school);
+  }
+
+  @cached
+  get directedSchoolsData() {
+    return new TrackedAsyncData(this.args.user.directedSchools);
+  }
+
+  @cached
+  get administeredSchoolsData() {
+    return new TrackedAsyncData(this.args.user.administeredSchools);
+  }
+
+  crossesBoundryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+  }
+
   get schools() {
-    return this._schools?.slice() ?? [];
+    return this.schoolData.isResolved ? this.schoolData.value.slice() : [];
   }
-  @use _academicYears = new ResolveAsyncValue(() => [this.academicYearPromise]);
+
   get academicYears() {
-    return this._academicYears?.slice() ?? [];
+    return this.academicYearData.isResolved ? this.academicYearData.value.slice() : [];
   }
-  @use defaultSchool = new ResolveAsyncValue(() => [this.args.user.school]);
 
-  @use _directedSchools = new ResolveAsyncValue(() => [this.args.user.directedSchools]);
+  @cached
+  get defaultSchool() {
+    return this.defaultSchoolData.isResolved ? this.defaultSchoolData.value : null;
+  }
+
+  @cached
   get isDirectingSchool() {
-    return this._directedSchools?.includes(this.bestSelectedSchool);
+    if (!this.directedSchoolsData.isResolved) {
+      return false;
+    }
+    return this.directedSchoolsData.value.includes(this.bestSelectedSchool);
   }
 
-  @use _administeredSchools = new ResolveAsyncValue(() => [this.args.user.administeredSchools]);
+  @cached
   get isAdministeringSchool() {
-    return this._administeredSchools?.includes(this.bestSelectedSchool);
+    if (!this.administeredSchoolsData.isResolved) {
+      return false;
+    }
+    return this.administeredSchoolsData.value.includes(this.bestSelectedSchool);
   }
 
   get isLoaded() {
@@ -74,26 +111,63 @@ export default class UserProfilePermissionsComponent extends Component {
     return this.bestSelectedYear?.id;
   }
 
-  @use _userDirectedPrograms = new ResolveAsyncValue(() => [this.args.user.directedPrograms]);
+  @cached
+  get _userDirectedProgramsData() {
+    return new TrackedAsyncData(this.args.user.directedPrograms);
+  }
+
+  get _userDirectedPrograms() {
+    return this._userDirectedProgramsData.isResolved ? this._userDirectedProgramsData.value : null;
+  }
+
   @use directedPrograms = new AsyncProcess(() => [
     this.getDirectedPrograms.bind(this),
     this.bestSelectedSchool,
     this._userDirectedPrograms?.slice() ?? [],
   ]);
-  @use _userProgramYears = new ResolveAsyncValue(() => [this.args.user.programYears]);
+
+  @cached
+  get _userProgramYearsData() {
+    return new TrackedAsyncData(this.args.user.programYears);
+  }
+
+  get _userProgramYears() {
+    return this._userProgramYearsData.isResolved ? this._userProgramYearsData.value : null;
+  }
+
   @use directedProgramYears = new AsyncProcess(() => [
     this.getDirectedProgramYears.bind(this),
     this.bestSelectedSchool,
     this._userProgramYears?.slice() ?? [],
   ]);
-  @use _userDirectedCourses = new ResolveAsyncValue(() => [this.args.user.directedCourses]);
+
+  @cached
+  get _userDirectedCoursesData() {
+    return new TrackedAsyncData(this.args.user.directedCourses);
+  }
+
+  get _userDirectedCourses() {
+    return this._userDirectedCoursesData.isResolved ? this._userDirectedCoursesData.value : null;
+  }
+
   @use directedCourses = new AsyncProcess(() => [
     this.getDirectedCourses.bind(this),
     this.bestSelectedSchool,
     this.selectedYearId,
     this._userDirectedCourses?.slice() ?? [],
   ]);
-  @use _userAdministeredCourses = new ResolveAsyncValue(() => [this.args.user.administeredCourses]);
+
+  @cached
+  get _userAdministeredCoursesData() {
+    return new TrackedAsyncData(this.args.user.administeredCourses);
+  }
+
+  get _userAdministeredCourses() {
+    return this._userAdministeredCoursesData.isResolved
+      ? this._userAdministeredCoursesData.value
+      : null;
+  }
+
   @use administeredCourses = new AsyncProcess(() => [
     this.getAdministeredCourses.bind(this),
     this.bestSelectedSchool,
@@ -106,18 +180,36 @@ export default class UserProfilePermissionsComponent extends Component {
     this.selectedYearId,
     this.args.user.allInstructedCourses,
   ]);
-  @use _userStudentAdvisedCourses = new ResolveAsyncValue(() => [
-    this.args.user.studentAdvisedCourses,
-  ]);
+
+  @cached
+  get _userStudentAdvisedCoursesData() {
+    return new TrackedAsyncData(this.args.user.studentAdvisedCourses);
+  }
+
+  get _userStudentAdvisedCourses() {
+    return this._userStudentAdvisedCoursesData.isResolved
+      ? this._userStudentAdvisedCoursesData.value
+      : null;
+  }
+
   @use studentAdvisedCourses = new AsyncProcess(() => [
     this.getStudentAdvisedCourses.bind(this),
     this.bestSelectedSchool,
     this.selectedYearId,
     this._userStudentAdvisedCourses?.slice() ?? [],
   ]);
-  @use _userAdministeredSessions = new ResolveAsyncValue(() => [
-    this.args.user.administeredSessions,
-  ]);
+
+  @cached
+  get _userAdministeredSessionsData() {
+    return new TrackedAsyncData(this.args.user.administeredSessions);
+  }
+
+  get _userAdministeredSessions() {
+    return this._userAdministeredSessionsData.isResolved
+      ? this._userAdministeredSessionsData.value
+      : null;
+  }
+
   @use administeredSessions = new AsyncProcess(() => [
     this.getAdministeredSessions.bind(this),
     this.bestSelectedSchool,
@@ -130,9 +222,18 @@ export default class UserProfilePermissionsComponent extends Component {
     this.selectedYearId,
     this.args.user.allInstructedSessions,
   ]);
-  @use _userStudentAdvisedSessions = new ResolveAsyncValue(() => [
-    this.args.user.studentAdvisedSessions,
-  ]);
+
+  @cached
+  get _userStudentAdvisedSessionsData() {
+    return new TrackedAsyncData(this.args.user.studentAdvisedSessions);
+  }
+
+  get _userStudentAdvisedSessions() {
+    return this._userStudentAdvisedSessionsData.isResolved
+      ? this._userStudentAdvisedSessionsData.value
+      : null;
+  }
+
   @use studentAdvisedSessions = new AsyncProcess(() => [
     this.getStudentAdvisedSessions.bind(this),
     this.bestSelectedSchool,

--- a/app/components/user-profile-permissions.js
+++ b/app/components/user-profile-permissions.js
@@ -37,13 +37,13 @@ export default class UserProfilePermissionsComponent extends Component {
     return new TrackedAsyncData(this.args.user.administeredSchools);
   }
 
-  crossesBoundryConfig = new TrackedAsyncData(
+  crossesBoundaryConfig = new TrackedAsyncData(
     this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
   );
 
   @cached
   get academicYearCrossesCalendarYearBoundaries() {
-    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
   }
 
   get schools() {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -2,8 +2,8 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { appVersion } from 'ilios/helpers/app-version';
 
 export default class ApplicationController extends Controller {
@@ -17,11 +17,12 @@ export default class ApplicationController extends Controller {
   @tracked errors = [];
   @tracked showErrorDisplay = false;
 
-  @use appVersion = new ResolveAsyncValue(() => [this.iliosConfig.getAppVersion()]);
+  appVersion = new TrackedAsyncData(this.iliosConfig.getAppVersion());
 
+  @cached
   get iliosVersionTag() {
-    if (this.appVersion) {
-      return `v${this.appVersion}`;
+    if (this.appVersion.isResolved) {
+      return `v${this.appVersion.value}`;
     }
 
     return '';

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -3,7 +3,8 @@ import { inject as service } from '@ember/service';
 import { restartableTask, dropTask, timeout } from 'ember-concurrency';
 import moment from 'moment';
 import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import AsyncProcess from 'ilios-common/classes/async-process';
 import PermissionChecker from 'ilios/classes/permission-checker';
 import { findById } from 'ilios-common/utils/array-helpers';
@@ -41,17 +42,42 @@ export default class CoursesController extends Controller {
     this.selectedSchool,
     this.dataLoader,
   ]);
+  userModelData = new TrackedAsyncData(this.currentUser.getModel());
+  crossesBoundryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
+  );
 
-  @use coursesInSelectedSchool = new ResolveAsyncValue(() => [
-    this.preloadedCoursesInSelectedSchool ? this.selectedSchool?.courses : [],
-  ]);
+  @cached
+  get coursesInSelectedSchoolData() {
+    return new TrackedAsyncData(
+      this.preloadedCoursesInSelectedSchool ? this.selectedSchool?.courses : []
+    );
+  }
 
-  @use academicYearCrossesCalendarYearBoundaries = new ResolveAsyncValue(() => [
-    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
-  ]);
+  get coursesInSelectedSchool() {
+    return this.coursesInSelectedSchoolData.isResolved
+      ? this.coursesInSelectedSchoolData.value
+      : null;
+  }
 
-  @use userModel = new ResolveAsyncValue(() => [this.currentUser.getModel()]);
-  @use allRelatedCourses = new ResolveAsyncValue(() => [this.userModel?.allRelatedCourses]);
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+  }
+
+  get userModel() {
+    return this.userModelData.isResolved ? this.userModelData.value : null;
+  }
+
+  @cached
+  get allRelatedCoursesData() {
+    return new TrackedAsyncData(this.userModel?.allRelatedCourses);
+  }
+
+  get allRelatedCourses() {
+    return this.allRelatedCoursesData.isResolved ? this.allRelatedCoursesData.value : null;
+  }
+
   @use canCreateCourse = new PermissionChecker(() => ['canCreateCourse', this.selectedSchool]);
 
   get hasMoreThanOneSchool() {

--- a/app/controllers/courses.js
+++ b/app/controllers/courses.js
@@ -43,7 +43,7 @@ export default class CoursesController extends Controller {
     this.dataLoader,
   ]);
   userModelData = new TrackedAsyncData(this.currentUser.getModel());
-  crossesBoundryConfig = new TrackedAsyncData(
+  crossesBoundaryConfig = new TrackedAsyncData(
     this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries')
   );
 
@@ -62,7 +62,7 @@ export default class CoursesController extends Controller {
 
   @cached
   get academicYearCrossesCalendarYearBoundaries() {
-    return this.crossesBoundryConfig.isResolved ? this.crossesBoundryConfig.value : false;
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
   }
 
   get userModel() {

--- a/app/controllers/curriculum-inventory-report/index.js
+++ b/app/controllers/curriculum-inventory-report/index.js
@@ -1,8 +1,8 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class CurriculumInventoryReportIndexController extends Controller {
   queryParams = ['leadershipDetails', 'manageLeadership'];
@@ -10,7 +10,15 @@ export default class CurriculumInventoryReportIndexController extends Controller
   @tracked leadershipDetails = false;
   @tracked manageLeadership = false;
   @tracked isFinalized = this.model.belongsTo('export').id();
-  @use _sequenceBlocks = new ResolveAsyncValue(() => [this.model.sequenceBlocks]);
+
+  @cached
+  get _sequenceBlocksData() {
+    return new TrackedAsyncData(this.model.sequenceBlocks);
+  }
+
+  get _sequenceBlocks() {
+    return this._sequenceBlocksData.isResolved ? this._sequenceBlocksData.value : null;
+  }
 
   get canUpdate() {
     return this.hasUpdatePermissions && !this.isFinalized;

--- a/app/controllers/curriculum-inventory-sequence-block.js
+++ b/app/controllers/curriculum-inventory-sequence-block.js
@@ -2,8 +2,8 @@ import { tracked } from '@glimmer/tracking';
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
-import { use } from 'ember-could-get-used-to-this';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class CurriculumInventorySequenceBlockController extends Controller {
   @service store;
@@ -11,8 +11,23 @@ export default class CurriculumInventorySequenceBlockController extends Controll
   @tracked sortSessionsBy = 'title';
   @tracked canUpdate = false;
 
-  @use report = new ResolveAsyncValue(() => [this.model.report]);
-  @use children = new ResolveAsyncValue(() => [this.model.children]);
+  @cached
+  get reportData() {
+    return new TrackedAsyncData(this.model.report);
+  }
+
+  get report() {
+    return this.reportData.isResolved ? this.reportData.value : null;
+  }
+
+  @cached
+  get childrenData() {
+    return new TrackedAsyncData(this.model.children);
+  }
+
+  get children() {
+    return this.childrenData.isResolved ? this.childrenData.value : null;
+  }
 
   @action
   async removeChildSequenceBlock(block) {

--- a/app/controllers/learner-group.js
+++ b/app/controllers/learner-group.js
@@ -2,19 +2,37 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { use } from 'ember-could-get-used-to-this';
 import PermissionChecker from 'ilios/classes/permission-checker';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
 export default class LearnerGroupController extends Controller {
   @service permissionChecker;
 
   queryParams = [{ isEditing: 'edit' }, { isBulkAssigning: 'bulkupload', sortUsersBy: 'usersBy' }];
-  @use school = new ResolveAsyncValue(() => [this.model.school]);
+
+  @cached
+  get schoolData() {
+    return new TrackedAsyncData(this.model.school);
+  }
+
+  get school() {
+    return this.schoolData.isResolved ? this.schoolData.value : null;
+  }
+
   @use canUpdate = new PermissionChecker(() => ['canUpdateLearnerGroup', this.model]);
   @use canDelete = new PermissionChecker(() => ['canDeleteLearnerGroup', this.model]);
-  @use canCreate = new ResolveAsyncValue(() => [
-    this.school ? this.permissionChecker.canCreateLearnerGroup(this.school) : false,
-  ]);
+
+  @cached
+  get canCreateData() {
+    return new TrackedAsyncData(
+      this.school ? this.permissionChecker.canCreateLearnerGroup(this.school) : false
+    );
+  }
+
+  get canCreate() {
+    return this.canCreateData.isResolved ? this.canCreateData.value : null;
+  }
 
   @tracked isEditing = false;
   @tracked isBulkAssigning = false;

--- a/app/controllers/program-year/index.js
+++ b/app/controllers/program-year/index.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { use } from 'ember-could-get-used-to-this';
-import ResolveAsyncValue from 'ilios-common/classes/resolve-async-value';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
 
 export default class ProgramYearIndexController extends Controller {
   queryParams = [
@@ -21,5 +21,13 @@ export default class ProgramYearIndexController extends Controller {
   @tracked managePyCompetencies = false;
   @tracked managePyLeadership = false;
 
-  @use program = new ResolveAsyncValue(() => [this.model.program]);
+  @cached
+  get programData() {
+    return new TrackedAsyncData(this.model?.program);
+  }
+
+  @cached
+  get program() {
+    return this.programData.isResolved ? this.programData.value : null;
+  }
 }


### PR DESCRIPTION
Remove these resources and replace them with the TrackedAsyncData resource from ember-async data. This performs better than our version and is on the paved path for ember. The declarations are move verbose requiring a double getter, but this is an OK compromise for now. With time we may be able to refactor some of these getters out and replace them with the load template helper from this addon.