### PR TITLE
revamps user profile permissions toggles for a11y

### DIFF
--- a/app/components/my-profile.hbs
+++ b/app/components/my-profile.hbs
@@ -15,7 +15,7 @@
         @user={{@user}}
         @isManageable={{false}}
       />
-      <div class="small-component" data-test-info>
+      <div class="small-component my-profile-schools" data-test-info>
         <div >
           <label>
             {{t "general.primarySchool"}}:

--- a/app/components/user-profile-permissions.hbs
+++ b/app/components/user-profile-permissions.hbs
@@ -15,7 +15,7 @@
         <FaIcon @icon="building-columns" @fixedWidth={{true}} />
         <select
           aria-label={{t "general.schools"}}
-          {{on "change" (pick "target.value" @setSchool)}}
+          {{on "change" (pick "target.value" this.changeSchool)}}
           data-test-select-school
         >
           {{#each (sort-by "title" this.schools) as |school|}}
@@ -32,7 +32,7 @@
         <FaIcon @icon="calendar" @fixedWidth={{true}} />
         <select
           aria-label={{t "general.academicYears"}}
-          {{on "change" (pick "target.value" @setYear)}}
+          {{on "change" (pick "target.value" this.changeYear)}}
           data-test-select-year
         >
           {{#each (reverse (sort-by "title" this.academicYears)) as |year|}}
@@ -68,19 +68,21 @@
         <h5 data-test-title>
           <label for="expand-collapse-program-permissions-{{templateId}}">
             {{t "general.programs"}}
-            ({{get this.directedPrograms "length"}})
+            ({{this.directedPrograms.length}})
           </label>
-          <button
-            aria-expanded={{if this.programCollapsed "false" "true"}}
-            class="toggle-button {{if this.programCollapsed "collapsed" "expanded"}}"
-            id="expand-collapse-program-permissions-{{templateId}}"
-            type="button"
-            {{on "click" (toggle "programCollapsed" this)}}
-          >
-             <FaIcon @icon={{if this.programCollapsed "caret-right" "caret-down"}} class="disabled" />
-          </button>
+          {{#if this.directedPrograms.length}}
+            <button
+              aria-expanded={{if this.programCollapsed "false" "true"}}
+              class="toggle-button {{if this.programCollapsed "collapsed" "expanded"}}"
+              id="expand-collapse-program-permissions-{{templateId}}"
+              type="button"
+              {{on "click" (set this.programCollapsed (not this.programCollapsed))}}
+            >
+              <FaIcon @icon={{if this.programCollapsed "caret-right" "caret-down"}} class="disabled" />
+            </button>
+          {{/if}}
         </h5>
-        {{#unless this.programCollapsed}}
+        {{#if (and this.directedPrograms.length this.programExpanded)}}
           <h6>
             {{t "general.director"}}
           </h6>
@@ -95,7 +97,7 @@
               </li>
             {{/each}}
           </ul>
-        {{/unless}}
+        {{/if}}
       </p>
       <p data-test-program-year-permissions>
         <h5 data-test-title>
@@ -103,17 +105,19 @@
             {{t "general.programYears"}}
             ({{this.directedProgramYears.length}})
           </label>
-          <button
-            aria-expanded={{if this.programYearCollapsed "false" "true"}}
-            class="toggle-button {{if this.programYearCollapsed "collapsed" "expanded"}}"
-            id="expand-collapse-program-years-permissions-{{templateId}}"
-            type="button"
-            {{on "click" (toggle "programYearCollapsed" this)}}
-          >
-            <FaIcon @icon={{if this.programYearCollapsed "caret-right" "caret-down"}} class="disabled" />
-          </button>
+          {{#if this.directedProgramYears.length}}
+            <button
+              aria-expanded={{if this.programYearCollapsed "false" "true"}}
+              class="toggle-button {{if this.programYearCollapsed "collapsed" "expanded"}}"
+              id="expand-collapse-program-years-permissions-{{templateId}}"
+              type="button"
+              {{on "click" (set this.programYearCollapsed (not this.programYearCollapsed))}}
+            >
+              <FaIcon @icon={{if this.programYearCollapsed "caret-right" "caret-down"}} class="disabled" />
+            </button>
+          {{/if}}
         </h5>
-        {{#unless this.programYearCollapsed}}
+        {{#if (and this.directedProgramYears.length this.programYearExpanded)}}
           <h6>
             {{t "general.director"}}
           </h6>
@@ -135,7 +139,7 @@
               </li>
             {{/each}}
           </ul>
-        {{/unless}}
+        {{/if}}
       </p>
       <p data-test-course-permissions>
         <h5 data-test-title>
@@ -143,17 +147,19 @@
             {{t "general.courses"}}
             ({{this.courseCount}})
           </label>
-          <button
-            aria-expanded={{if this.courseCollapsed "false" "true"}}
-            class="toggle-button {{if this.courseCollapsed "collapsed" "expanded"}}"
-            id="expand-collapse-courses-permissions-{{templateId}}"
-            type="button"
-            {{on "click" (toggle "courseCollapsed" this)}}
-          >
-            <FaIcon @icon={{if this.courseCollapsed "caret-right" "caret-down"}} class="disabled" />
-          </button>
+          {{#if this.courseCount}}
+            <button
+              aria-expanded={{if this.courseCollapsed "false" "true"}}
+              class="toggle-button {{if this.courseCollapsed "collapsed" "expanded"}}"
+              id="expand-collapse-courses-permissions-{{templateId}}"
+              type="button"
+              {{on "click" (set this.courseCollapsed (not this.courseCollapsed))}}
+            >
+              <FaIcon @icon={{if this.courseCollapsed "caret-right" "caret-down"}} class="disabled" />
+            </button>
+          {{/if}}
         </h5>
-        {{#unless this.courseCollapsed}}
+        {{#if (and this.courseCount this.courseExpanded)}}
           <h6>
             {{t "general.director"}}
           </h6>
@@ -237,25 +243,32 @@
               </li>
             {{/each}}
           </ul>
-        {{/unless}}
+        {{/if}}
       </p>
       <p data-test-session-permissions>
         <h5 data-test-title>
-          <label for="expand-collapse-sessions-permissions-{{templateId}}">
+          {{#if this.sessionCount}}
+            <label for="expand-collapse-sessions-permissions-{{templateId}}">
+              {{t "general.sessions"}}
+              ({{this.sessionCount}})
+            </label>
+            {{#if this.sessionCount}}
+              <button
+                aria-expanded={{if this.sessionCollapsed "false" "true"}}
+                class="toggle-button {{if this.sessionCollapsed "collapsed" "expanded"}}"
+                id="expand-collapse-sessions-permissions-{{templateId}}"
+                type="button"
+                {{on "click" (set this.sessionCollapsed (not this.sessionCollapsed))}}
+              >
+                <FaIcon @icon={{if this.sessionCollapsed "caret-right" "caret-down"}} class="disabled" />
+              </button>
+            {{/if}}
+          {{else}}
             {{t "general.sessions"}}
             ({{this.sessionCount}})
-          </label>
-          <button
-            aria-expanded={{if this.sessionCollapsed "false" "true"}}
-            class="toggle-button {{if this.sessionCollapsed "collapsed" "expanded"}}"
-            id="expand-collapse-sessions-permissions-{{templateId}}"
-            type="button"
-            {{on "click" (toggle "sessionCollapsed" this)}}
-          >
-            <FaIcon @icon={{if this.sessionCollapsed "caret-right" "caret-down"}} class="disabled" />
-          </button>
+          {{/if}}
         </h5>
-        {{#unless this.sessionCollapsed}}
+        {{#if (and this.sessionCount this.sessionExpanded)}}
           <h6>
             {{t "general.administrator"}}
           </h6>
@@ -330,7 +343,7 @@
               </li>
             {{/each}}
           </ul>
-        {{/unless}}
+        {{/if}}
       </p>
     {{/if}}
   </div>

--- a/app/components/user-profile-permissions.hbs
+++ b/app/components/user-profile-permissions.hbs
@@ -91,10 +91,6 @@
               <li data-test-program>
                 {{program.title}}
               </li>
-            {{else}}
-              <li data-test-none>
-                {{t "general.none"}}
-              </li>
             {{/each}}
           </ul>
         {{/if}}
@@ -132,10 +128,6 @@
                 <strong>
                   {{programYear.cohort.title}}
                 </strong>
-              </li>
-            {{else}}
-              <li data-test-none>
-                {{t "general.none"}}
               </li>
             {{/each}}
           </ul>

--- a/app/components/user-profile-permissions.hbs
+++ b/app/components/user-profile-permissions.hbs
@@ -1,283 +1,337 @@
-<div
-  class="user-profile-permissions large-component"
-  data-test-user-profile-permissions
-  ...attributes
->
-  <h3 class="title" data-test-title>
-    {{t "general.permissions"}}
-    {{#unless this.isLoaded}}
-      <LoadingSpinner />
-    {{/unless}}
-  </h3>
-  {{#if this.isLoaded}}
-    <span>
-      <FaIcon @icon="building-columns" @fixedWidth={{true}} />
-      <select
-        aria-label={{t "general.schools"}}
-        {{on "change" (pick "target.value" @setSchool)}}
-        data-test-select-school
-      >
-        {{#each (sort-by "title" this.schools) as |school|}}
-          <option
-            value={{school.id}}
-            selected={{eq school.id this.bestSelectedSchool.id}}
-          >
-            {{school.title}}
-          </option>
-        {{/each}}
-      </select>
-    </span>
-    <span>
-      <FaIcon @icon="calendar" @fixedWidth={{true}} />
-      <select
-        aria-label={{t "general.academicYears"}}
-        {{on "change" (pick "target.value" @setYear)}}
-        data-test-select-year
-      >
-        {{#each (reverse (sort-by "title" this.academicYears)) as |year|}}
-          <option value={{year.id}} selected={{eq year.id this.selectedYearId}}>
-            {{year.title}}
-          </option>
-        {{/each}}
-      </select>
-    </span>
+{{#let (unique-id) as |templateId|}}
+  <div
+    class="user-profile-permissions large-component"
+    data-test-user-profile-permissions
+    ...attributes
+  >
+    <h3 class="title" data-test-title>
+      {{t "general.permissions"}}
+      {{#unless this.isLoaded}}
+        <LoadingSpinner />
+      {{/unless}}
+    </h3>
+    {{#if this.isLoaded}}
+      <span>
+        <FaIcon @icon="building-columns" @fixedWidth={{true}} />
+        <select
+          aria-label={{t "general.schools"}}
+          {{on "change" (pick "target.value" @setSchool)}}
+          data-test-select-school
+        >
+          {{#each (sort-by "title" this.schools) as |school|}}
+            <option
+              value={{school.id}}
+              selected={{eq school.id this.bestSelectedSchool.id}}
+            >
+              {{school.title}}
+            </option>
+          {{/each}}
+        </select>
+      </span>
+      <span>
+        <FaIcon @icon="calendar" @fixedWidth={{true}} />
+        <select
+          aria-label={{t "general.academicYears"}}
+          {{on "change" (pick "target.value" @setYear)}}
+          data-test-select-year
+        >
+          {{#each (reverse (sort-by "title" this.academicYears)) as |year|}}
+            <option value={{year.id}} selected={{eq year.id this.selectedYearId}}>
+              {{year.title}}
+            </option>
+          {{/each}}
+        </select>
+      </span>
 
-    <p data-test-school-permissions>
-    <h5 data-test-title>
-      {{t "general.school"}}
-      ({{this.bestSelectedSchool.title}})
-    </h5>
-    <span class="hide-on-collapse" data-test-director>
-        <strong>
-          {{t "general.director"}}:
-        </strong>
-        <YesNo @value={{this.isDirectingSchool}} />
-        <br>
-      </span>
-    <span class="hide-on-collapse" data-test-administrator>
-        <strong>
-          {{t "general.administrator"}}:
-        </strong>
-        <YesNo @value={{this.isAdministeringSchool}} />
-        <br>
-      </span>
-    </p>
-    <p class={{if this.programCollapsed "collapsed" "expanded"}} data-test-program-permissions>
-    <h5 {{on "click" (toggle "programCollapsed" this)}} role="button" data-test-title>
-      {{t "general.programs"}}
-      ({{get this.directedPrograms "length"}})
-    </h5>
-    <h6>
-      {{t "general.director"}}
-    </h6>
-    <ul data-test-directors>
-      {{#each (sort-by "title" this.directedPrograms) as |program|}}
-        <li data-test-program>
-          {{program.title}}
-        </li>
-      {{else}}
-        <li data-test-none>
-          {{t "general.none"}}
-        </li>
-      {{/each}}
-    </ul>
-    </p>
-    <p class={{if this.programYearCollapsed "collapsed" "expanded"}} data-test-program-year-permissions>
-    <h5 {{on "click" (toggle "programYearCollapsed" this)}} role="button" data-test-title>
-      {{t "general.programYears"}}
-      ({{this.directedProgramYears.length}})
-    </h5>
-    <h6>
-      {{t "general.director"}}
-    </h6>
-    <ul data-test-directors>
-      {{#each
-        (sort-by
-          "program.title" "title" this.directedProgramYears
-        ) as |programYear|
-      }}
-        <li data-test-program>
-          {{programYear.program.title}}
+      <p data-test-school-permissions>
+        <h5 data-test-title>
+          {{t "general.school"}}
+          ({{this.bestSelectedSchool.title}})
+        </h5>
+        <span class="hide-on-collapse" data-test-director>
           <strong>
-            {{programYear.cohort.title}}
+            {{t "general.director"}}:
           </strong>
-        </li>
-      {{else}}
-        <li data-test-none>
-          {{t "general.none"}}
-        </li>
-      {{/each}}
-    </ul>
-    </p>
-    <p class={{if this.courseCollapsed "collapsed" "expanded"}} data-test-course-permissions>
-    <h5 {{on "click" (toggle "courseCollapsed" this)}} role="button" data-test-title>
-      {{t "general.courses"}}
-      ({{this.courseCount}})
-    </h5>
-    <h6>
-      {{t "general.director"}}
-    </h6>
-    <ul data-test-directors>
-      {{#each (sort-by "title" this.directedCourses) as |course|}}
-        <li data-test-course>
-          {{#if this.academicYearCrossesCalendarYearBoundaries}}
-            {{course.year}} - {{add course.year 1}}
-          {{else}}
-            {{course.year}}
-          {{/if}}            <LinkTo @route="course" @model={{course}}>
-          {{course.title}}
-        </LinkTo>
-        </li>
-      {{else}}
-        <li data-test-none>
-          {{t "general.none"}}
-        </li>
-      {{/each}}
-    </ul>
-    <h6>
-      {{t "general.administrator"}}
-    </h6>
-    <ul data-test-administrators>
-      {{#each (sort-by "title" this.administeredCourses) as |course|}}
-        <li data-test-course>
-          {{#if this.academicYearCrossesCalendarYearBoundaries}}
-            {{course.year}} - {{add course.year 1}}
-          {{else}}
-            {{course.year}}
-          {{/if}}
-          <LinkTo @route="course" @model={{course}}>
-            {{course.title}}
-          </LinkTo>
-        </li>
-      {{else}}
-        <li data-test-none>
-          {{t "general.none"}}
-        </li>
-      {{/each}}
-    </ul>
-    <h6>
-      {{t "general.instructor"}}
-    </h6>
-    <ul data-test-instructors>
-      {{#each (sort-by "title" this.instructedCourses) as |course|}}
-        <li data-test-course>
-          {{#if this.academicYearCrossesCalendarYearBoundaries}}
-            {{course.year}} - {{add course.year 1}}
-          {{else}}
-            {{course.year}}
-          {{/if}}
-          <LinkTo @route="course" @model={{course}}>
-            {{course.title}}
-          </LinkTo>
-        </li>
-      {{else}}
-        <li data-test-none>
-          {{t "general.none"}}
-        </li>
-      {{/each}}
-    </ul>
-    <h6>
-      {{t "general.studentAdvisors"}}
-    </h6>
-    <ul data-test-student-advisors>
-      {{#each this.studentAdvisedCourses as |course|}}
-        <li data-test-course>
-          {{#if this.academicYearCrossesCalendarYearBoundaries}}
-            {{course.year}} - {{add course.year 1}}
-          {{else}}
-            {{course.year}}
-          {{/if}}
-          <LinkTo @route="course" @model={{course}}>
-            {{course.title}}
-          </LinkTo>
-        </li>
-      {{else}}
-        <li data-test-none>
-          {{t "general.none"}}
-        </li>
-      {{/each}}
-    </ul>
-    </p>
-    <p class={{if this.sessionCollapsed "collapsed" "expanded"}} data-test-session-permissions>
-    <h5 {{on "click" (toggle "sessionCollapsed" this)}} role="button" data-test-title>
-      {{t "general.sessions"}}
-      ({{this.sessionCount}})
-    </h5>
-    <h6>
-      {{t "general.administrator"}}
-    </h6>
-    <ul data-test-administrators="">
-      {{#each this.administeredSessions as |session|}}
-      {{! template-lint-disable no-bare-strings }}
-        <li data-test-course>
-          {{#if this.academicYearCrossesCalendarYearBoundaries}}
-            {{session.course.year}} - {{add (await session.course.year) 1}}
-          {{else}}
-            {{session.course.year}}
-          {{/if}}
-          {{session.course.title}}
-          &raquo;
-          <LinkTo @route="session" @models={{array session.course session}}>
-            {{session.title}}
-          </LinkTo>
-        </li>
-      {{else}}
-        <li data-test-none>
-          {{t "general.none"}}
-        </li>
-      {{/each}}
-    </ul>
-    <h6>
-      {{t "general.instructor"}}
-    </h6>
-    <ul data-test-instructors>
-      {{#each
-        (sort-by
-          "course.year:desc" "course.title" "title" this.instructedSessions
-        ) as |session|
-      }}
-        <li data-test-course>
-          {{#if this.academicYearCrossesCalendarYearBoundaries}}
-            {{session.course.year}} - {{add (await session.course.year) 1}}
-          {{else}}
-            {{session.course.year}}
-          {{/if}}
-          {{session.course.title}}
-          &raquo;
-          <LinkTo @route="session" @models={{array session.course session}}>
-            {{session.title}}
-          </LinkTo>
-        </li>
-      {{else}}
-        <li data-test-none>
-          {{t "general.none"}}
-        </li>
-      {{/each}}
-    </ul>
-    <h6>
-      {{t "general.studentAdvisors"}}
-    </h6>
-    <ul data-test-student-advisors>
-      {{#each this.studentAdvisedSessions as |session|}}
-        <li data-test-course>
-          {{#if this.academicYearCrossesCalendarYearBoundaries}}
-            {{session.course.year}} - {{add (await session.course.year) 1}}
-          {{else}}
-            {{session.course.year}}
-          {{/if}}
-          {{session.course.title}}
-          &raquo;
-          <LinkTo @route="session" @models={{array session.course session}}>
-            {{session.title}}
-          </LinkTo>
-        </li>
-      {{else}}
-        <li data-test-none>
-          {{t "general.none"}}
-        </li>
-      {{/each}}
-    </ul>
-    </p>
-  {{/if}}
+          <YesNo @value={{this.isDirectingSchool}} />
+          <br>
+        </span>
+        <span class="hide-on-collapse" data-test-administrator>
+          <strong>
+            {{t "general.administrator"}}:
+          </strong>
+          <YesNo @value={{this.isAdministeringSchool}} />
+          <br>
+        </span>
+      </p>
 
-</div>
+      <p data-test-program-permissions>
+        <h5 data-test-title>
+          <label for="expand-collapse-program-permissions-{{templateId}}">
+            {{t "general.programs"}}
+            ({{get this.directedPrograms "length"}})
+          </label>
+          <button
+            aria-expanded={{if this.programCollapsed "false" "true"}}
+            class="toggle-button {{if this.programCollapsed "collapsed" "expanded"}}"
+            id="expand-collapse-program-permissions-{{templateId}}"
+            type="button"
+            {{on "click" (toggle "programCollapsed" this)}}
+          >
+             <FaIcon @icon={{if this.programCollapsed "caret-right" "caret-down"}} class="disabled" />
+          </button>
+        </h5>
+        {{#unless this.programCollapsed}}
+          <h6>
+            {{t "general.director"}}
+          </h6>
+          <ul data-test-directors>
+            {{#each (sort-by "title" this.directedPrograms) as |program|}}
+              <li data-test-program>
+                {{program.title}}
+              </li>
+            {{else}}
+              <li data-test-none>
+                {{t "general.none"}}
+              </li>
+            {{/each}}
+          </ul>
+        {{/unless}}
+      </p>
+      <p data-test-program-year-permissions>
+        <h5 data-test-title>
+          <label for="expand-collapse-program-years-permissions-{{templateId}}">
+            {{t "general.programYears"}}
+            ({{this.directedProgramYears.length}})
+          </label>
+          <button
+            aria-expanded={{if this.programYearCollapsed "false" "true"}}
+            class="toggle-button {{if this.programYearCollapsed "collapsed" "expanded"}}"
+            id="expand-collapse-program-years-permissions-{{templateId}}"
+            type="button"
+            {{on "click" (toggle "programYearCollapsed" this)}}
+          >
+            <FaIcon @icon={{if this.programYearCollapsed "caret-right" "caret-down"}} class="disabled" />
+          </button>
+        </h5>
+        {{#unless this.programYearCollapsed}}
+          <h6>
+            {{t "general.director"}}
+          </h6>
+          <ul data-test-directors>
+            {{#each
+              (sort-by
+                "program.title" "title" this.directedProgramYears
+              ) as |programYear|
+            }}
+              <li data-test-program>
+                {{programYear.program.title}}
+                <strong>
+                  {{programYear.cohort.title}}
+                </strong>
+              </li>
+            {{else}}
+              <li data-test-none>
+                {{t "general.none"}}
+              </li>
+            {{/each}}
+          </ul>
+        {{/unless}}
+      </p>
+      <p data-test-course-permissions>
+        <h5 data-test-title>
+          <label for="expand-collapse-courses-permissions-{{templateId}}">
+            {{t "general.courses"}}
+            ({{this.courseCount}})
+          </label>
+          <button
+            aria-expanded={{if this.courseCollapsed "false" "true"}}
+            class="toggle-button {{if this.courseCollapsed "collapsed" "expanded"}}"
+            id="expand-collapse-courses-permissions-{{templateId}}"
+            type="button"
+            {{on "click" (toggle "courseCollapsed" this)}}
+          >
+            <FaIcon @icon={{if this.courseCollapsed "caret-right" "caret-down"}} class="disabled" />
+          </button>
+        </h5>
+        {{#unless this.courseCollapsed}}
+          <h6>
+            {{t "general.director"}}
+          </h6>
+          <ul data-test-directors>
+            {{#each (sort-by "title" this.directedCourses) as |course|}}
+              <li data-test-course>
+                {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                  {{course.year}} - {{add course.year 1}}
+                {{else}}
+                  {{course.year}}
+                {{/if}}            <LinkTo @route="course" @model={{course}}>
+                {{course.title}}
+              </LinkTo>
+              </li>
+            {{else}}
+              <li data-test-none>
+                {{t "general.none"}}
+              </li>
+            {{/each}}
+          </ul>
+          <h6>
+            {{t "general.administrator"}}
+          </h6>
+          <ul data-test-administrators>
+            {{#each (sort-by "title" this.administeredCourses) as |course|}}
+              <li data-test-course>
+                {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                  {{course.year}} - {{add course.year 1}}
+                {{else}}
+                  {{course.year}}
+                {{/if}}
+                <LinkTo @route="course" @model={{course}}>
+                  {{course.title}}
+                </LinkTo>
+              </li>
+            {{else}}
+              <li data-test-none>
+                {{t "general.none"}}
+              </li>
+            {{/each}}
+          </ul>
+          <h6>
+            {{t "general.instructor"}}
+          </h6>
+          <ul data-test-instructors>
+            {{#each (sort-by "title" this.instructedCourses) as |course|}}
+              <li data-test-course>
+                {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                  {{course.year}} - {{add course.year 1}}
+                {{else}}
+                  {{course.year}}
+                {{/if}}
+                <LinkTo @route="course" @model={{course}}>
+                  {{course.title}}
+                </LinkTo>
+              </li>
+            {{else}}
+              <li data-test-none>
+                {{t "general.none"}}
+              </li>
+            {{/each}}
+          </ul>
+          <h6>
+            {{t "general.studentAdvisors"}}
+          </h6>
+          <ul data-test-student-advisors>
+            {{#each this.studentAdvisedCourses as |course|}}
+              <li data-test-course>
+                {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                  {{course.year}} - {{add course.year 1}}
+                {{else}}
+                  {{course.year}}
+                {{/if}}
+                <LinkTo @route="course" @model={{course}}>
+                  {{course.title}}
+                </LinkTo>
+              </li>
+            {{else}}
+              <li data-test-none>
+                {{t "general.none"}}
+              </li>
+            {{/each}}
+          </ul>
+        {{/unless}}
+      </p>
+      <p data-test-session-permissions>
+        <h5 data-test-title>
+          <label for="expand-collapse-sessions-permissions-{{templateId}}">
+            {{t "general.sessions"}}
+            ({{this.sessionCount}})
+          </label>
+          <button
+            aria-expanded={{if this.sessionCollapsed "false" "true"}}
+            class="toggle-button {{if this.sessionCollapsed "collapsed" "expanded"}}"
+            id="expand-collapse-sessions-permissions-{{templateId}}"
+            type="button"
+            {{on "click" (toggle "sessionCollapsed" this)}}
+          >
+            <FaIcon @icon={{if this.sessionCollapsed "caret-right" "caret-down"}} class="disabled" />
+          </button>
+        </h5>
+        {{#unless this.sessionCollapsed}}
+          <h6>
+            {{t "general.administrator"}}
+          </h6>
+          <ul data-test-administrators="">
+            {{#each this.administeredSessions as |session|}}
+            {{! template-lint-disable no-bare-strings }}
+              <li data-test-course>
+                {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                  {{session.course.year}} - {{add (await session.course.year) 1}}
+                {{else}}
+                  {{session.course.year}}
+                {{/if}}
+                {{session.course.title}}
+                &raquo;
+                <LinkTo @route="session" @models={{array session.course session}}>
+                  {{session.title}}
+                </LinkTo>
+              </li>
+            {{else}}
+              <li data-test-none>
+                {{t "general.none"}}
+              </li>
+            {{/each}}
+          </ul>
+          <h6>
+            {{t "general.instructor"}}
+          </h6>
+          <ul data-test-instructors>
+            {{#each
+              (sort-by
+                "course.year:desc" "course.title" "title" this.instructedSessions
+              ) as |session|
+            }}
+              <li data-test-course>
+                {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                  {{session.course.year}} - {{add (await session.course.year) 1}}
+                {{else}}
+                  {{session.course.year}}
+                {{/if}}
+                {{session.course.title}}
+                &raquo;
+                <LinkTo @route="session" @models={{array session.course session}}>
+                  {{session.title}}
+                </LinkTo>
+              </li>
+            {{else}}
+              <li data-test-none>
+                {{t "general.none"}}
+              </li>
+            {{/each}}
+          </ul>
+          <h6>
+            {{t "general.studentAdvisors"}}
+          </h6>
+          <ul data-test-student-advisors>
+            {{#each this.studentAdvisedSessions as |session|}}
+              <li data-test-course>
+                {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                  {{session.course.year}} - {{add (await session.course.year) 1}}
+                {{else}}
+                  {{session.course.year}}
+                {{/if}}
+                {{session.course.title}}
+                &raquo;
+                <LinkTo @route="session" @models={{array session.course session}}>
+                  {{session.title}}
+                </LinkTo>
+              </li>
+            {{else}}
+              <li data-test-none>
+                {{t "general.none"}}
+              </li>
+            {{/each}}
+          </ul>
+        {{/unless}}
+      </p>
+    {{/if}}
+  </div>
+{{/let}}

--- a/app/components/user-profile-permissions.js
+++ b/app/components/user-profile-permissions.js
@@ -1,4 +1,6 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import moment from 'moment';
 import { filter } from 'rsvp';
@@ -11,6 +13,27 @@ import { findById, sortBy, uniqueValues } from 'ilios-common/utils/array-helpers
 export default class UserProfilePermissionsComponent extends Component {
   @service store;
   @service iliosConfig;
+
+  @tracked programCollapsed = false;
+  @tracked programYearCollapsed = false;
+  @tracked courseCollapsed = false;
+  @tracked sessionCollapsed = false;
+
+  get programExpanded() {
+    return !this.programCollapsed;
+  }
+
+  get programYearExpanded() {
+    return !this.programYearCollapsed;
+  }
+
+  get courseExpanded() {
+    return !this.courseCollapsed;
+  }
+
+  get sessionExpanded() {
+    return !this.sessionCollapsed;
+  }
 
   @cached
   get schoolData() {
@@ -336,5 +359,24 @@ export default class UserProfilePermissionsComponent extends Component {
       return sortBy(this.schools, 'title')[0];
     }
     return null;
+  }
+
+  @action
+  changeSchool(schoolId) {
+    this.resetCollapsers();
+    this.args.setSchool(schoolId);
+  }
+
+  @action
+  changeYear(year) {
+    this.resetCollapsers();
+    this.args.setYear(year);
+  }
+
+  resetCollapsers() {
+    this.programCollapsed = false;
+    this.programYearCollapsed = false;
+    this.courseCollapsed = false;
+    this.sessionCollapsed = false;
   }
 }

--- a/app/styles/components/my-profile.scss
+++ b/app/styles/components/my-profile.scss
@@ -4,7 +4,7 @@
 
 .my-profile {
   @include cm.main-section;
-  
+
   .name {
     margin: .25rem 0 0;
     text-align: center;
@@ -26,13 +26,15 @@
     @include m.admin-blocks;
     margin-top: 1rem;
 
-    label {
-      @include cm.ilios-label;
-    }
-
     ul {
       @include cm.ilios-list-reset;
       margin-left: 1rem;
+    }
+  }
+
+  .my-profile-schools {
+    label {
+      @include cm.ilios-label;
     }
   }
 
@@ -58,6 +60,7 @@
         width: 7rem;
       }
     }
+
 
     .new-token-result {
       label {

--- a/app/styles/components/user-profile-bio.scss
+++ b/app/styles/components/user-profile-bio.scss
@@ -4,6 +4,11 @@
 @use "sass:color";
 
 .user-profile-bio {
+
+  label {
+    @include m.ilios-label;
+  }
+
   .actions {
     @include m.detail-container-actions;
   }

--- a/app/styles/components/user-profile-cohorts.scss
+++ b/app/styles/components/user-profile-cohorts.scss
@@ -23,6 +23,10 @@
     margin-bottom: 2rem;
   }
 
+  label {
+    @include m.ilios-label;
+  }
+
   h4 {
     @include m.ilios-heading-h5;
   }

--- a/app/styles/components/user-profile-permissions.scss
+++ b/app/styles/components/user-profile-permissions.scss
@@ -1,4 +1,5 @@
 @use "../ilios-common/colors" as c;
+@use "../ilios-common/mixins" as m;
 
 .user-profile-permissions {
   span {
@@ -7,40 +8,20 @@
 
   p {
     padding: .25rem;
-    h5 {
-      cursor: pointer;
+
+    button {
+      @include m.ilios-button-reset;
     }
+
     h6 {
       margin: .5rem 0 0 .5rem;
     }
+
     ul {
       margin: 0 0 .5rem 1rem;
       list-style-position: inside;
       list-style-type: circle;
       padding: 0;
-    }
-
-    &.collapsed {
-      h5 {
-        &::after {
-          content: '\25BA';
-        }
-      }
-      h6,
-      ul,
-      .hide-on-collapse {
-        display: none;
-      }
-    }
-
-    &.expanded {
-      border-bottom: 1px solid c.$black;
-      h5 {
-        &::after {
-          content: '\25BC';
-        }
-      }
-
     }
   }
 }

--- a/app/styles/components/user-profile-roles.scss
+++ b/app/styles/components/user-profile-roles.scss
@@ -3,6 +3,10 @@
 
 .user-profile-roles {
 
+  label {
+    @include m.ilios-label;
+  }
+
   hr {
     border-top: .5px solid c.$raisinBlack;
   }

--- a/app/styles/components/user-profile-schools.scss
+++ b/app/styles/components/user-profile-schools.scss
@@ -3,6 +3,10 @@
 
 .user-profile-schools {
 
+  label {
+    @include m.ilios-label;
+  }
+
   .user-profile-schools-header {
     @include m.detail-container-header;
 

--- a/app/styles/components/user-profile.scss
+++ b/app/styles/components/user-profile.scss
@@ -4,7 +4,7 @@
 
 .user-profile {
   @include cm.main-section;
-  
+
   h1 {
     margin-bottom: 1rem;
     text-align: center;
@@ -20,10 +20,6 @@
     .user-is-student {
       color: c.$fernGreen;
     }
-  }
-
-  label {
-    @include cm.ilios-label;
   }
 }
 

--- a/tests/integration/components/user-profile-permissions-test.js
+++ b/tests/integration/components/user-profile-permissions-test.js
@@ -51,21 +51,25 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
     assert.strictEqual(component.school.administrator, 'No');
 
     assert.strictEqual(component.programs.title, 'Programs (0)');
-    assert.ok(component.programs.notDirecting);
+    assert.strictEqual(component.programs.directors.length, 0);
+    assert.notOk(component.programs.canBeToggled);
 
     assert.strictEqual(component.programYears.title, 'Program Years (0)');
-    assert.ok(component.programYears.notDirecting);
+    assert.strictEqual(component.programYears.directors.length, 0);
+    assert.notOk(component.programYears.canBeToggled);
 
     assert.strictEqual(component.courses.title, 'Courses (0)');
-    assert.ok(component.courses.notDirecting);
-    assert.ok(component.courses.notAdministrating);
-    assert.ok(component.courses.notInstructing);
-    assert.ok(component.courses.notStudentAdvising);
+    assert.notOk(component.courses.canBeToggled);
+    assert.strictEqual(component.courses.directors.length, 0);
+    assert.strictEqual(component.courses.administrators.length, 0);
+    assert.strictEqual(component.courses.instructors.length, 0);
+    assert.strictEqual(component.courses.studentAdvisors.length, 0);
 
     assert.strictEqual(component.sessions.title, 'Sessions (0)');
-    assert.ok(component.sessions.notAdministrating);
-    assert.ok(component.sessions.notInstructing);
-    assert.ok(component.sessions.notStudentAdvising);
+    assert.notOk(component.sessions.canBeToggled);
+    assert.strictEqual(component.sessions.administrators.length, 0);
+    assert.strictEqual(component.sessions.instructors.length, 0);
+    assert.strictEqual(component.sessions.studentAdvisors.length, 0);
   });
 
   test('change school', async function (assert) {
@@ -117,7 +121,6 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @setYear={{this.setYear}}
     />`);
     assert.strictEqual(parseInt(component.selectedYear, 10), this.currentAcademicYear);
-    await component.courses.toggle();
     assert.strictEqual(component.courses.directors.length, 1);
     assert.ok(component.courses.notAdministrating);
     await component.changeYear(this.currentAcademicYear + 1);
@@ -140,13 +143,6 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
 
     assert.strictEqual(component.school.director, 'Yes');
     assert.strictEqual(component.school.administrator, 'Yes');
-    assert.ok(component.programs.notDirecting);
-    assert.ok(component.programYears.notDirecting);
-    assert.ok(component.courses.notDirecting);
-    assert.ok(component.courses.notAdministrating);
-    assert.ok(component.courses.notInstructing);
-    assert.ok(component.sessions.notAdministrating);
-    assert.ok(component.sessions.notInstructing);
   });
 
   test('it renders with program data', async function (assert) {
@@ -166,17 +162,16 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @setYear={{(noop)}}
     />`);
 
-    assert.strictEqual(component.school.director, 'No');
-    assert.strictEqual(component.school.administrator, 'No');
     assert.strictEqual(component.programs.title, 'Programs (1)');
+    assert.ok(component.programs.isExpanded);
     assert.strictEqual(component.programs.directors.length, 1);
     assert.strictEqual(component.programs.directors[0].text, 'program 0');
-
-    assert.ok(component.courses.notDirecting);
-    assert.ok(component.courses.notAdministrating);
-    assert.ok(component.courses.notInstructing);
-    assert.ok(component.sessions.notAdministrating);
-    assert.ok(component.sessions.notInstructing);
+    await component.programs.toggle();
+    assert.notOk(component.programs.isExpanded);
+    assert.strictEqual(component.programs.directors.length, 0);
+    await component.programs.toggle();
+    assert.ok(component.programs.isExpanded);
+    assert.strictEqual(component.programs.directors.length, 1);
   });
 
   test('it renders with program year data', async function (assert) {
@@ -200,18 +195,16 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @setYear={{(noop)}}
     />`);
 
-    assert.strictEqual(component.school.director, 'No');
-    assert.strictEqual(component.school.administrator, 'No');
-    assert.ok(component.programs.notDirecting);
     assert.strictEqual(component.programYears.title, 'Program Years (1)');
+    assert.ok(component.programYears.isExpanded);
     assert.strictEqual(component.programYears.directors.length, 1);
     assert.strictEqual(component.programYears.directors[0].text, 'program 0 cohort 0');
-
-    assert.ok(component.courses.notDirecting);
-    assert.ok(component.courses.notAdministrating);
-    assert.ok(component.courses.notInstructing);
-    assert.ok(component.sessions.notAdministrating);
-    assert.ok(component.sessions.notInstructing);
+    await component.programYears.toggle();
+    assert.notOk(component.programYears.isExpanded);
+    assert.strictEqual(component.programYears.directors.length, 0);
+    await component.programYears.toggle();
+    assert.ok(component.programYears.isExpanded);
+    assert.strictEqual(component.programYears.directors.length, 1);
   });
 
   test('it renders with course data', async function (assert) {
@@ -248,12 +241,8 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       @setYear={{(noop)}}
     />`);
 
-    assert.strictEqual(component.school.director, 'No');
-    assert.strictEqual(component.school.administrator, 'No');
-    assert.ok(component.programs.notDirecting);
-    assert.ok(component.programYears.notDirecting);
-
     assert.strictEqual(component.courses.title, 'Courses (4)');
+    assert.ok(component.courses.isExpanded);
     assert.strictEqual(component.courses.directors.length, 1);
     assert.strictEqual(component.courses.directors[0].text, `${this.currentAcademicYear} course 0`);
     assert.strictEqual(component.courses.administrators.length, 1);
@@ -283,6 +272,18 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       `${this.currentAcademicYear} course 0 » session 1`
     );
     assert.ok(component.sessions.notStudentAdvising);
+    await component.courses.toggle();
+    assert.notOk(component.courses.isExpanded);
+    assert.strictEqual(component.courses.administrators.length, 0);
+    assert.strictEqual(component.courses.directors.length, 0);
+    assert.strictEqual(component.courses.instructors.length, 0);
+    assert.strictEqual(component.courses.studentAdvisors.length, 0);
+    await component.courses.toggle();
+    assert.ok(component.courses.isExpanded);
+    assert.strictEqual(component.courses.administrators.length, 1);
+    assert.strictEqual(component.courses.directors.length, 1);
+    assert.strictEqual(component.courses.instructors.length, 1);
+    assert.strictEqual(component.courses.studentAdvisors.length, 1);
   });
 
   test('it renders with session data', async function (assert) {
@@ -313,9 +314,6 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
 
     assert.strictEqual(component.school.director, 'No');
     assert.strictEqual(component.school.administrator, 'No');
-    assert.ok(component.programs.notDirecting);
-    assert.ok(component.programYears.notDirecting);
-
     assert.strictEqual(component.courses.title, 'Courses (1)');
     assert.ok(component.courses.notDirecting);
     assert.ok(component.courses.notAdministrating);
@@ -327,6 +325,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
     assert.ok(component.courses.notStudentAdvising);
     assert.strictEqual(component.sessions.title, 'Sessions (3)');
     assert.strictEqual(component.sessions.administrators.length, 1);
+    assert.ok(component.sessions.isExpanded);
     assert.strictEqual(
       component.sessions.administrators[0].text,
       `${this.currentAcademicYear} course 0 » session 0`
@@ -341,6 +340,16 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       component.sessions.studentAdvisors[0].text,
       `${this.currentAcademicYear} course 0 » session 0`
     );
+    await component.sessions.toggle();
+    assert.notOk(component.sessions.isExpanded);
+    assert.strictEqual(component.sessions.administrators.length, 0);
+    assert.strictEqual(component.sessions.instructors.length, 0);
+    assert.strictEqual(component.sessions.studentAdvisors.length, 0);
+    await component.sessions.toggle();
+    assert.ok(component.sessions.isExpanded);
+    assert.strictEqual(component.sessions.administrators.length, 1);
+    assert.strictEqual(component.sessions.instructors.length, 1);
+    assert.strictEqual(component.sessions.studentAdvisors.length, 1);
   });
 
   test('if academic year does not cross year boundaries, and its the first half of the year then last year is selected', async function (assert) {

--- a/tests/pages/components/user-profile-permissions.js
+++ b/tests/pages/components/user-profile-permissions.js
@@ -4,6 +4,7 @@ import {
   collection,
   isPresent,
   fillable,
+  hasClass,
   value,
   text,
 } from 'ember-cli-page-object';
@@ -22,21 +23,22 @@ const definition = {
     title: text('[data-test-title]'),
     director: text('[data-test-director] [data-test-yes-no]'),
     administrator: text('[data-test-administrator] [data-test-yes-no]'),
-    toggle: clickable(),
   },
   programs: {
     scope: '[data-test-program-permissions]',
     title: text('[data-test-title]'),
     directors: collection('[data-test-directors] [data-test-program]'),
-    notDirecting: isPresent('[data-test-directors] [data-test-none]'),
-    toggle: clickable(),
+    toggle: clickable('button'),
+    isExpanded: hasClass('expanded', 'button'),
+    canBeToggled: isPresent('button'),
   },
   programYears: {
     scope: '[data-test-program-year-permissions]',
     title: text('[data-test-title]'),
     directors: collection('[data-test-directors] [data-test-program]'),
-    notDirecting: isPresent('[data-test-directors] [data-test-none]'),
-    toggle: clickable(),
+    toggle: clickable('button'),
+    isExpanded: hasClass('expanded', 'button'),
+    canBeToggled: isPresent('button'),
   },
   courses: {
     scope: '[data-test-course-permissions]',
@@ -49,7 +51,9 @@ const definition = {
     notInstructing: isPresent('[data-test-instructors] [data-test-none]'),
     studentAdvisors: collection('[data-test-student-advisors] [data-test-course]'),
     notStudentAdvising: isPresent('[data-test-student-advisors] [data-test-none]'),
-    toggle: clickable(),
+    toggle: clickable('button'),
+    isExpanded: hasClass('expanded', 'button'),
+    canBeToggled: isPresent('button'),
   },
   sessions: {
     scope: '[data-test-session-permissions]',
@@ -60,7 +64,9 @@ const definition = {
     notInstructing: isPresent('[data-test-instructors] [data-test-none]'),
     studentAdvisors: collection('[data-test-student-advisors] [data-test-course]'),
     notStudentAdvising: isPresent('[data-test-student-advisors] [data-test-none]'),
-    toggle: clickable(),
+    toggle: clickable('button'),
+    isExpanded: hasClass('expanded', 'button'),
+    canBeToggled: isPresent('button'),
   },
 };
 


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/4783
fixes https://github.com/ilios/ilios/issues/4784

- toggles are now actual buttons, with aria- attributes etc.
- sub-sections (programs, courses, etc) without any relevant roles are collapsed by default and won't be expandable.