### PR TITLE
Ignore updates to webpack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,7 @@ updates:
   - dependency-name: prettier
   - dependency-name: qunit
   - dependency-name: qunit-dom
+  - dependency-name: webpack
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
This is provided by EmberCLI blueprints, let's not update it ourselves.