### PR TITLE
Fix update tracking of user profile cohorts

### DIFF
--- a/app/components/user-profile-cohorts.hbs
+++ b/app/components/user-profile-cohorts.hbs
@@ -1,7 +1,7 @@
 <div
   class="user-profile-cohorts small-component {{if this.hasSavedRecently "has-saved" "has-not-saved"}}"
   {{did-insert (perform this.load) @user}}
-  {{did-update (perform this.load) @user.cohorts @user.primaryCohort}}
+  {{did-update (perform this.load) @user @user.cohorts @user.primaryCohort}}
   ...attributes
   data-test-user-profile-cohorts
 >

--- a/tests/pages/user.js
+++ b/tests/pages/user.js
@@ -1,8 +1,12 @@
 import { clickable, create, property, text, visitable } from 'ember-cli-page-object';
+import bio from 'ilios/tests/pages/components/user-profile-bio';
+import cohorts from 'ilios/tests/pages/components/user-profile-cohorts';
 
 export default create({
   scope: '[data-test-user-profile]',
   visit: visitable('/users/:userId'),
+  bio,
+  cohorts,
   roles: {
     scope: '[data-test-user-profile-roles]',
     manage: clickable('[data-test-manage]'),


### PR DESCRIPTION
The user wasn't getting correctly passed into the update task which prevented re-loading the cohorts when the user changed.

Fixes ilios/ilios#4809