### PR TITLE
Fix school selection in new user creation

### DIFF
--- a/app/components/new-directory-user.js
+++ b/app/components/new-directory-user.js
@@ -79,7 +79,7 @@ export default class NewDirectoryUserComponent extends Component {
   }
 
   get primarySchool() {
-    return findBy(this.allSchools, this.user.belongsTo('school').id());
+    return findById(this.allSchools, this.user.belongsTo('school').id());
   }
 
   @cached
@@ -129,7 +129,12 @@ export default class NewDirectoryUserComponent extends Component {
         return currentSchool;
       }
     }
-    return this.primarySchool;
+
+    if (this.schools.includes(this.primarySchool)) {
+      return this.primarySchool;
+    }
+
+    return this.schools[0];
   }
 
   get bestSelectedCohort() {

--- a/app/components/new-user.js
+++ b/app/components/new-user.js
@@ -62,7 +62,7 @@ export default class NewUserComponent extends Component {
   }
 
   get primarySchool() {
-    return findBy(this.allSchools, this.user.belongsTo('school').id());
+    return findById(this.allSchools, this.user.belongsTo('school').id());
   }
 
   @cached
@@ -112,7 +112,11 @@ export default class NewUserComponent extends Component {
         return currentSchool;
       }
     }
-    return this.primarySchool;
+    if (this.schools.includes(this.primarySchool)) {
+      return this.primarySchool;
+    }
+
+    return this.schools[0];
   }
 
   get bestSelectedCohort() {


### PR DESCRIPTION
We were doing a bad job choosing the users primary school and a worse job ensuring that school was available to pick from to create a new user. This was resulting in users in some schools being unable to add new users because the wrong ID was being sent for each new user.

Fixes ilios/ilios#4830