### PR TITLE
align the years filter in the subject reports left instead of right.

### DIFF
--- a/app/styles/components/reports/subject.scss
+++ b/app/styles/components/reports/subject.scss
@@ -45,7 +45,7 @@
     .years-filter {
       margin: 0.5rem 0 1rem;
       padding-right: 0.5rem;
-      text-align: right;
+      text-align: left;
       width: 100%;
     }
 


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/4835

![image](https://github.com/ilios/frontend/assets/1410427/f7e76ac8-b099-45ce-aa49-3dad8326126b)
