### PR TITLE
Apply terser optimizations to embroider build

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,7 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 const broccoliAssetRevDefaults = require('broccoli-asset-rev/lib/default-options');
 const { Webpack } = require('@embroider/webpack');
 const { RetryChunkLoadPlugin } = require('webpack-retry-chunk-load-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 // const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 module.exports = function (defaults) {
@@ -94,6 +95,20 @@ module.exports = function (defaults) {
       packagerOptions: {
         webpackConfig: {
           plugins: [new RetryChunkLoadPlugin() /*, new BundleAnalyzerPlugin()*/],
+          optimization: {
+            minimize: true,
+            minimizer: [
+              new TerserPlugin({
+                terserOptions: {
+                  compress: {
+                    passes: 6, // slow, but worth it
+                    inline: 5,
+                    reduce_funcs: false,
+                  },
+                },
+              }),
+            ],
+          },
         },
       },
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,7 @@
         "stylelint-config-standard": "^32.0.0",
         "stylelint-prettier": "^3.0.0",
         "stylelint-scss": "^5.0.1",
+        "terser-webpack-plugin": "^5.3.9",
         "tracked-built-ins": "^3.1.1",
         "validator": "^13.9.0",
         "webpack": "^5.85.1",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "stylelint-config-standard": "^32.0.0",
     "stylelint-prettier": "^3.0.0",
     "stylelint-scss": "^5.0.1",
+    "terser-webpack-plugin": "^5.3.9",
     "tracked-built-ins": "^3.1.1",
     "validator": "^13.9.0",
     "webpack": "^5.85.1",


### PR DESCRIPTION
These were recommended in discord as important optimizations for user performance.

Recommended by `@runspired` in https://discord.com/channels/480462759797063690/1133807825131405322/1133850150960386099

Probably more to optimize here, but it would be difficult to test this so I've stuck with the minimum override to the defaults.