### PR TITLE
fixes user filtering on pending-updates page.

### DIFF
--- a/app/controllers/pending-user-updates.js
+++ b/app/controllers/pending-user-updates.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { findById } from 'ilios-common/utils/array-helpers';
+import { isEmpty } from '@ember/utils';
 
 export default class PendingUserUpdatesController extends Controller {
   @service flashMessages;
@@ -41,7 +42,7 @@ export default class PendingUserUpdatesController extends Controller {
     return this.updatesInCurrentSchool.filter((update) => {
       const user = this.store.peekRecord('user', update.belongsTo('user').id());
       const isNotDeleted = !this.deletedUpdates.includes(update);
-      const noUpdateName = !!user.fullName;
+      const noUpdateName = isEmpty(user.fullName);
       const filterMatch = update
         .get('user.fullName')
         .trim()

--- a/tests/pages/pending-user-updates.js
+++ b/tests/pages/pending-user-updates.js
@@ -22,6 +22,7 @@ export default create({
   },
   titleFilter: {
     scope: '[data-test-title-filter]',
+    set: fillable('input'),
   },
   updates: collection('[data-test-pending-update]', {
     userNameInfo,


### PR DESCRIPTION
this corrects a regression introduced when this controller was octanified. see commit 4a7a56e07c39801d9e561af29052e125ba84030c

fixes https://github.com/ilios/ilios/issues/4873