### PR TITLE
Temporarily add school config serializer

### DIFF
--- a/app/serializers/school-config.js
+++ b/app/serializers/school-config.js
@@ -1,0 +1,14 @@
+import IliosSerializer from 'ilios-common/serializers/ilios';
+
+export default class SchoolConfigSerializer extends IliosSerializer {
+  serialize(snapshot, options) {
+    const originalValue = snapshot.attr('value');
+    let json = super.serialize(snapshot, options);
+
+    if (originalValue === false) {
+      json.data.attributes.value = 'false';
+    }
+
+    return json;
+  }
+}


### PR DESCRIPTION
This [belongs in common](https://github.com/ilios/common/pull/3545), however I'm adding it here temporarily while we work on a release plan. This file should be removed with the next common update. This was we can do a release to fix ilios/ilios#4953 without needing to do any gymnastics to avoid the API bump in common.