### PR TITLE
Replace deprecated outputs in release workflow

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,6 +1,6 @@
 name: Release Notes
 
-on: 
+on:
   push:
     tags:
     - '*'
@@ -13,34 +13,31 @@ jobs:
       with:
         fetch-depth: 0
     - name: Get Previous Tag
-      id: previousTag
       run: |
         PREVIOUS_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))
         echo ${PREVIOUS_TAG}
-        echo ::set-output name=tag::${PREVIOUS_TAG}
+        echo "previous_tag=${PREVIOUS_TAG}" >> $GITHUB_ENV
     - name: Get New Tag
-      id: nextTag
       run: |
         NEW_TAG=${GITHUB_REF#refs/tags/}
         echo ${NEW_TAG}
-        echo ::set-output name=tag::${NEW_TAG}
+        echo "new_tag=${NEW_TAG}" >> $GITHUB_ENV
     - uses: actions/setup-node@v3
     - name: Generate Release Notes
-      id: notes
       run: |
-        NOTES=$(npx generate-github-release-notes ilios frontend ${{ steps.previousTag.outputs.tag }} ${{steps.nextTag.outputs.tag}})
-        echo ${NOTES}
-        # remove line breaks from notes so they can be passed around
-        NOTES="${NOTES//$'\n'/'%0A'}"
-        echo "::set-output name=releaseNotes::$NOTES"
+        NOTES=$(npx generate-github-release-notes ilios frontend ${{ env.previous_tag }} ${{env.new_tag}})
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        echo "${NOTES}"
+        echo "RELEASE_NOTES<<$EOF" >> "$GITHUB_ENV"
+        echo "${NOTES}" >> $GITHUB_ENV
+        echo "$EOF" >> "$GITHUB_ENV"
     - name: Generate Release Name
-      id: name
       run: |
         NAME=$(npx dartajax-music random-song)
         echo ${NAME}
-        echo "::set-output name=releaseName::$NAME"
+        echo "RELEASE_NAME=${NAME}" >> $GITHUB_ENV
     - uses: ncipollo/release-action@v1
       with:
-        name: ${{steps.name.outputs.releaseName}}
-        body: ${{steps.notes.outputs.releaseNotes}}
+        name: ${{env.RELEASE_NAME}}
+        body: ${{env.RELEASE_NOTES}}
         token: ${{ secrets.ZORGBORT_TOKEN }}


### PR DESCRIPTION
This set-output way of moving data between steps has been deprecated by github, this replaces it with the recommended environment variable alternative.