### PR TITLE
Skip linting again during tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Run Tests
-        run: npm test
+        run: npm run test:ember
 
   build:
     name: Build
@@ -105,7 +105,7 @@ jobs:
           node-version: 18.7
           cache: npm
       - run: npm ci
-      - run: npm test
+      - run: npm run test:ember
 
   build-with-embroider:
     name: Build With Embroider


### PR DESCRIPTION
This adds time and, since we lint in a separate step is a waste.