### PR TITLE
Temporarily pin node to v18.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.7
           cache: npm
       - name: Install Dependencies
         run: npm ci
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.7
           cache: npm
       - name: install dependencies
         run: npm ci
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.7
           cache: npm
       - run: npm ci
       - run: npm test
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.7
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 18.7
         cache: 'npm'
     - name: install dependencies
       run: npm ci

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -18,7 +18,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 18.7
         cache: 'npm'
     - name: install dependencies
       run: npm ci

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 18.7
         cache: 'npm'
     - name: install dependencies
       run: npm ci

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 18.7
         cache: 'npm'
     - name: install dependencies
       run: npm ci

--- a/.github/workflows/update-transitive-dependencies.yaml
+++ b/.github/workflows/update-transitive-dependencies.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 18.7
     - name: remove and re-create lock file
       run: |
         rm package-lock.json


### PR DESCRIPTION
This is a workaround for a linux-only issue with node 18.8 that breaks webpack and prevents our app from building at all. While we await a backport and fix we can pin this version.