### PR TITLE
Run Percy Tests More Deliberately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,24 +74,6 @@ jobs:
       - name: test build
         run: npm run build
 
-  percy:
-    name: Percy Visual Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs: [test]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18.7
-          cache: npm
-      - name: install dependencies
-        run: npm ci
-      - name: test
-        run: npm run percy:test
-        env:
-          PERCY_TOKEN: web_1899a9764a4891f3a19b87e52aa1ae038359e28ba550daa6bad00d0e0a230a33
-
   test-with-embroider:
     name: Test With Embroider
     runs-on: ubuntu-latest

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,0 +1,43 @@
+name: Percy Visual Tests
+
+on:
+  push:
+    tags:
+      - '*'
+  pull_request_target:
+    types: [labeled]
+  schedule:
+    - cron: "15 23 * * 2,4" # T,Th in the afternoon (UTC)
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  SW_DISABLED: true
+  COVERAGE: false
+  PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
+
+jobs:
+  percy:
+    name: Test and Capture Screenshots
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'run percy tests' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - name: install dependencies
+        run: npm ci
+      - name: Run Percy Tests
+        run: npm run percy:test
+      - uses: act10ns/slack@v2
+        if: failure()
+        with:
+          status: ${{ job.status }}
+          message: Percy Run Failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}

--- a/.github/workflows/update-transitive-dependencies.yaml
+++ b/.github/workflows/update-transitive-dependencies.yaml
@@ -33,7 +33,7 @@ jobs:
 
             [1]: https://github.com/peter-evans/create-pull-request
           branch: auto-update-dependencies
-          labels: dependencies
+          labels: dependencies,"run percy tests"
     - name: Enable Pull Request Automerge
       if: steps.cpr.outputs.pull-request-operation == 'created'
       run: gh pr merge --merge --auto ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
We're running out of screenshots every month. Instead of running these tests on every single PR they will no run when a new tag is created, every few days on a schedule, when we label a PR, and when we manually run the test. I've setup the transitive dependency update action to add this label so they will run on that PR as well.

Because we're no longer running these on un-trusted forks I've also modified the type of action so it has access to our secrets and we can hide the percy token.