### PR TITLE
updated program year leadership label

### DIFF
--- a/app/components/program-year/details.hbs
+++ b/app/components/program-year/details.hbs
@@ -10,7 +10,7 @@
     />
   {{else}}
     <LeadershipCollapsed
-      @title={{t "general.programYearLeadership"}}
+      @title={{t "general.leadership"}}
       @showAdministrators={{false}}
       @showDirectors={{true}}
       @directorsCount={{has-many-length @programYear "directors"}}

--- a/app/components/program-year/leadership-expanded.hbs
+++ b/app/components/program-year/leadership-expanded.hbs
@@ -11,7 +11,7 @@
       data-test-title
       {{on "click" @collapse}}
     >
-      {{t "general.programYearLeadership"}}
+      {{t "general.leadership"}}
       <FaIcon @icon="caret-down" />
     </button>
     <div class="actions">
@@ -27,7 +27,7 @@
         </button>
       {{else if @canUpdate}}
         <button type="button" {{on "click" (fn @setIsManaging true)}}>
-          {{t "general.manageLeadership"}}
+          {{t "general.leadership"}}
         </button>
       {{/if}}
     </div>

--- a/app/components/program/leadership-expanded.hbs
+++ b/app/components/program/leadership-expanded.hbs
@@ -7,7 +7,7 @@
       data-test-title
       {{on "click" @collapse}}
     >
-      {{t "general.programLeadership"}}
+      {{t "general.leadership"}}
       <FaIcon @icon="caret-down" />
     </button>
     <div class="actions">

--- a/app/components/program/root.hbs
+++ b/app/components/program/root.hbs
@@ -17,7 +17,7 @@
     />
   {{else}}
     <LeadershipCollapsed
-      @title={{t "general.programLeadership"}}
+      @title={{t "general.leadership"}}
       @showAdministrators={{false}}
       @showDirectors={{true}}
       @directorsCount={{has-many-length @program "directors"}}

--- a/tests/acceptance/program-year/leadership-test.js
+++ b/tests/acceptance/program-year/leadership-test.js
@@ -29,7 +29,7 @@ module('Acceptance | Program Year - Leadership', function (hooks) {
     assert.expect(6);
     await page.visit({ programId: 1, programYearId: 1 });
     await percySnapshot(assert);
-    assert.strictEqual(page.details.collapsedLeadership.title, 'Program Year Leadership');
+    assert.strictEqual(page.details.collapsedLeadership.title, 'Leadership');
     assert.strictEqual(page.details.collapsedLeadership.headers.length, 1);
     assert.strictEqual(page.details.collapsedLeadership.headers[0].title, 'Summary');
     assert.strictEqual(page.details.collapsedLeadership.summary.length, 1);

--- a/tests/acceptance/program-year/leadership-test.js
+++ b/tests/acceptance/program-year/leadership-test.js
@@ -41,7 +41,7 @@ module('Acceptance | Program Year - Leadership', function (hooks) {
     assert.expect(4);
     await page.visit({ programId: 1, programYearId: 1, pyLeadershipDetails: true });
     await percySnapshot(assert);
-    assert.strictEqual(page.details.expandedLeadership.title, 'Program Year Leadership');
+    assert.strictEqual(page.details.expandedLeadership.title, 'Leadership');
     const { directors } = page.details.expandedLeadership.leadershipList;
     assert.strictEqual(directors.length, 2);
     assert.strictEqual(directors[0].text, '3 guy M. Mc3son');

--- a/tests/acceptance/program/leadership-test.js
+++ b/tests/acceptance/program/leadership-test.js
@@ -25,7 +25,7 @@ module('Acceptance | Program - Leadership', function (hooks) {
     assert.expect(6);
     await page.visit({ programId: 1 });
     await percySnapshot(assert);
-    assert.strictEqual(page.root.leadershipCollapsed.title, 'Program Leadership');
+    assert.strictEqual(page.root.leadershipCollapsed.title, 'Leadership');
     assert.strictEqual(page.root.leadershipCollapsed.headers.length, 1);
     assert.strictEqual(page.root.leadershipCollapsed.headers[0].title, 'Summary');
     assert.strictEqual(page.root.leadershipCollapsed.summary.length, 1);
@@ -37,7 +37,7 @@ module('Acceptance | Program - Leadership', function (hooks) {
     assert.expect(4);
     await page.visit({ programId: 1, leadershipDetails: true });
     await percySnapshot(assert);
-    assert.strictEqual(page.root.leadershipExpanded.title, 'Program Leadership');
+    assert.strictEqual(page.root.leadershipExpanded.title, 'Leadership');
     const { directors } = page.root.leadershipExpanded.leadershipList;
     assert.strictEqual(directors.length, 2);
     assert.strictEqual(directors[0].text, '3 guy M. Mc3son');

--- a/tests/acceptance/program/overview-test.js
+++ b/tests/acceptance/program/overview-test.js
@@ -22,7 +22,7 @@ module('Acceptance | Program - Overview', function (hooks) {
     await page.visit({ programId: 1 });
     await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'program.index');
-    assert.strictEqual(page.root.overview.shortTitle.text, 'Program Title (short): short_0');
+    assert.strictEqual(page.root.overview.shortTitle.text, 'Title (short): short_0');
     assert.strictEqual(page.root.overview.duration.text, 'Duration (in Years): 4');
   });
 
@@ -35,7 +35,7 @@ module('Acceptance | Program - Overview', function (hooks) {
     await page.visit({ programId: 1 });
     await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'program.index');
-    assert.strictEqual(page.root.overview.shortTitle.text, 'Program Title (short): short_0');
+    assert.strictEqual(page.root.overview.shortTitle.text, 'Title (short): short_0');
     assert.strictEqual(page.root.overview.duration.text, 'Duration (in Years): 4');
   });
 
@@ -60,11 +60,11 @@ module('Acceptance | Program - Overview', function (hooks) {
     });
     await page.visit({ programId: 1 });
 
-    assert.strictEqual(page.root.overview.shortTitle.text, 'Program Title (short): short_0');
+    assert.strictEqual(page.root.overview.shortTitle.text, 'Title (short): short_0');
     await page.root.overview.shortTitle.edit();
     await page.root.overview.shortTitle.set('newshort');
     await page.root.overview.shortTitle.save();
-    assert.strictEqual(page.root.overview.shortTitle.text, 'Program Title (short): newshort');
+    assert.strictEqual(page.root.overview.shortTitle.text, 'Title (short): newshort');
   });
 
   test('change duration', async function (assert) {

--- a/tests/integration/components/program-year/leadership-expanded-test.js
+++ b/tests/integration/components/program-year/leadership-expanded-test.js
@@ -39,7 +39,7 @@ module('Integration | Component | program-year/leadership-expanded', function (h
       @isManaging={{false}}
       @setIsManaging={{(noop)}}
     />`);
-    assert.strictEqual(component.title, 'Program Year Leadership');
+    assert.strictEqual(component.title, 'Leadership');
     assert.strictEqual(component.leadershipList.directors.length, 2);
     assert.strictEqual(component.leadershipList.directors[0].text, 'a M. person');
     assert.strictEqual(component.leadershipList.directors[1].text, 'b M. person');

--- a/tests/integration/components/program/leadership-expanded-test.js
+++ b/tests/integration/components/program/leadership-expanded-test.js
@@ -36,7 +36,7 @@ module('Integration | Component | program/leadership expanded', function (hooks)
       @isManaging={{false}}
       @setIsManaging={{(noop)}}
     />`);
-    assert.strictEqual(component.title, 'Program Leadership');
+    assert.strictEqual(component.title, 'Leadership');
     assert.strictEqual(component.leadershipList.directors.length, 2);
     assert.strictEqual(component.leadershipList.directors[0].text, 'a M. person');
     assert.strictEqual(component.leadershipList.directors[1].text, 'b M. person');

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -179,6 +179,7 @@ general:
     es: "Español (es)"
     fr: "Français (fr)"
   lastName: "Last Name"
+  leadership: "Leadership"
   learner: Learner
   learnerAssignments: "{groupTitle} Learner Assignments"
   learnerGroupTitle: "Learner Group Title"

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -315,7 +315,7 @@ general:
   programTitle: "Program Title"
   programTitleFilterPlaceholder: "Filter by Program Title"
   programTitlePlaceholder: "Enter a title for this program"
-  programTitleShort: "Program Title (short)"
+  programTitleShort: "Title (short)"
   programYear: "Program Year"
   programYears: "Program Years"
   programYearLeadership: "Program Year Leadership"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -179,6 +179,7 @@ general:
     es: "Español (es)"
     fr: "Français (fr)"
   lastName: Apellido
+  leadership: "Liderazgo"
   learner: Aprendedor
   learnerAssignments: "{groupTitle} Asignaciónes de Aprendedores"
   learnerGroupTitle: "Título de Grupo de Instructores"

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -315,7 +315,7 @@ general:
   programTitle: "Titulo de Programa"
   programTitleFilterPlaceholder: "Filtrar por Titulo de Programa"
   programTitlePlaceholder: "Meter un titulo para este programa"
-  programTitleShort: "Titulo de Programa (corto)"
+  programTitleShort: "Titulo (corto)"
   programYear: "Año de Programa"
   programYears: "Años de Programa"
   programYearLeadership: "Liderazgo de Año de Programa"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -179,6 +179,7 @@ general:
     es: "Español (es)"
     fr: "Français (fr)"
   lastName: "Nom de famille"
+  leadership: "Direction"
   learner: Apprenant
   learnerAssignments: "{groupTitle} affectations d'étudiant"
   learnerGroupTitle: "Titre de groupe d'apprenants"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -316,7 +316,7 @@ general:
   programTitle: "Titre de Diplôme"
   programTitleFilterPlaceholder: "Filtre par Titre de Diplôme"
   programTitlePlaceholder: "Ajoutez un titre pour ce Diplôme"
-  programTitleShort: "Titre de Diplôme (bref)"
+  programTitleShort: "Titre (bref)"
   programYear: "Année de Diplôme"
   programYears: "Années des Diplôme"
   programYearLeadership: "Direction de l'Année de Diplôme"


### PR DESCRIPTION
```
On branch update_program_year_translation_label
Changes to be committed:
        modified:   app/components/program-year/details.hbs
        modified:   tests/acceptance/program-year/leadership-test.js
        modified:   translations/en-us.yaml
        modified:   translations/es.yaml
        modified:   translations/fr.yaml
```

* modified `details.hbs` to point to the newly added `leadership` translation - using this instead of `programYearLeadership`. 
* updated all three translation files by adding this new value
* updated test coverage to look for this new value 

There is certainly no hurry on this - feel free to discuss if even necessary however I propose that it makes the screen look cleaner since we don't pre-pend "Program Year" on the other values below. 

This would close https://github.com/ilios/ilios/issues/5062 if approved and merged.

Related to https://github.com/ilios/ilios/issues/5063 in the sense that it is dealing with the same caption on program year detail. 

Here is what the change looks like in English - Spanish and French also updated.

![image](https://github.com/ilios/frontend/assets/7493331/2292415d-bf3e-4002-89c8-0d2e61368a2e)





