### PR TITLE
Remove unsupported toSorted method

### DIFF
--- a/app/components/reports/subject/new/course.js
+++ b/app/components/reports/subject/new/course.js
@@ -32,7 +32,7 @@ export default class ReportsSubjectNewCourseComponent extends Component {
   }
 
   get sortedCourses() {
-    return this.filteredCourses.toSorted((a, b) => {
+    return this.filteredCourses.slice().sort((a, b) => {
       if (a.year !== b.year) {
         return b.year - a.year;
       }

--- a/app/components/reports/subject/new/session.js
+++ b/app/components/reports/subject/new/session.js
@@ -35,7 +35,7 @@ export default class ReportsSubjectNewSessionComponent extends Component {
   }
 
   get sortedSessions() {
-    return this.filteredSessions.toSorted((a, b) => {
+    return this.filteredSessions.slice().sort((a, b) => {
       const courseA = this.store.peekRecord('course', a.belongsTo('course').id());
       const courseB = this.store.peekRecord('course', b.belongsTo('course').id());
 


### PR DESCRIPTION
This was only added recently and several of our browsers don't support it yet. It copies the array before sorting it, I'm not sure if we need that functionality here, but I duplicated it by calling slice first.