### PR TITLE
Rename app to frontend

### DIFF
--- a/app/components/learner-groups/root.js
+++ b/app/components/learner-groups/root.js
@@ -6,7 +6,7 @@ import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 import { findById, sortBy } from 'ilios-common/utils/array-helpers';
 import PermissionChecker from 'ilios-common/classes/permission-checker';
-import cloneLearnerGroup from 'ilios/utils/clone-learner-group';
+import cloneLearnerGroup from 'frontend/utils/clone-learner-group';
 import { dropTask } from 'ember-concurrency';
 import { map } from 'rsvp';
 import { action } from '@ember/object';

--- a/app/components/reports/subject.js
+++ b/app/components/reports/subject.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import PapaParse from 'papaparse';
 import { dropTask, timeout } from 'ember-concurrency';
-import createDownloadFile from 'ilios/utils/create-download-file';
+import createDownloadFile from 'frontend/utils/create-download-file';
 import { validatable, Length } from 'ilios-common/decorators/validation';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';

--- a/app/components/user-profile-cohorts-details.js
+++ b/app/components/user-profile-cohorts-details.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
 import { TrackedAsyncData } from 'ember-async-data';
-import sortCohorts from 'ilios/utils/sort-cohorts';
+import sortCohorts from 'frontend/utils/sort-cohorts';
 
 export default class UserProfileCohortsDetailsComponent extends Component {
   @cached

--- a/app/components/user-profile-cohorts-manager.js
+++ b/app/components/user-profile-cohorts-manager.js
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import { filter } from 'rsvp';
 import { findById } from 'ilios-common/utils/array-helpers';
-import sortCohorts from 'ilios/utils/sort-cohorts';
+import sortCohorts from 'frontend/utils/sort-cohorts';
 
 export default class UserProfileCohortsManagerComponent extends Component {
   @service currentUser;

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
-import { appVersion } from 'ilios/helpers/app-version';
+import { appVersion } from 'frontend/helpers/app-version';
 
 export default class ApplicationController extends Controller {
   @service apiVersion;

--- a/app/index.html
+++ b/app/index.html
@@ -20,10 +20,10 @@
     {{content-for "body"}}
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/ilios.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/frontend.css">
     <script defer src="{{rootURL}}assets/vendor.js"></script>
     <auto-import-scripts defer entrypoint="app"> </auto-import-scripts>
-    <script defer src="{{rootURL}}assets/ilios.js"></script>
+    <script defer src="{{rootURL}}assets/frontend.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/app/router.js
+++ b/app/router.js
@@ -1,6 +1,6 @@
 import { service } from '@ember/service';
 import EmberRouter from '@embroider/router';
-import config from 'ilios/config/environment';
+import config from 'frontend/config/environment';
 import { courseRoutes, dashboardRoutes } from 'ilios-common/common-routes';
 
 export default class Router extends EmberRouter {

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import { isPresent } from '@ember/utils';
 import { Promise } from 'rsvp';
-import EmberConfig from 'ilios/config/environment';
+import EmberConfig from 'frontend/config/environment';
 
 export default class LoginRoute extends Route {
   @service currentUser;

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,5 +1,5 @@
 import ESASessionService from 'ember-simple-auth/services/session';
-import config from 'ilios/config/environment';
+import config from 'frontend/config/environment';
 import * as Sentry from '@sentry/ember';
 import { service } from '@ember/service';
 

--- a/app/utils/launch-worker.js
+++ b/app/utils/launch-worker.js
@@ -1,4 +1,4 @@
-import config from 'ilios/config/environment';
+import config from 'frontend/config/environment';
 import { isTesting } from '@embroider/macros';
 
 export async function launchWorker() {

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,7 +2,7 @@
 
 module.exports = function (environment) {
   const ENV = {
-    modulePrefix: 'ilios',
+    modulePrefix: 'frontend',
     environment,
     rootURL: '/',
     locationType: 'history',

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,5 +1,5 @@
 import commonRoutes from './routes';
-import ENV from 'ilios/config/environment';
+import ENV from 'frontend/config/environment';
 import { createServer, Response } from 'miragejs';
 import { DateTime } from 'luxon';
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ilios",
+  "name": "frontend",
   "version": "38.0.0",
   "description": "Curriculum Management System for the Health Professions",
   "repository": "https://github.com/ilios/frontend",

--- a/tests/acceptance/courses-test.js
+++ b/tests/acceptance/courses-test.js
@@ -2,7 +2,7 @@ import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
 import { DateTime } from 'luxon';
-import page from 'ilios/tests/pages/courses';
+import page from 'frontend/tests/pages/courses';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import percySnapshot from '@percy/ember';

--- a/tests/acceptance/curriculum-inventory/leadership-test.js
+++ b/tests/acceptance/curriculum-inventory/leadership-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupAuthentication } from 'ilios-common';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/curriculum-inventory-report';
+import page from 'frontend/tests/pages/curriculum-inventory-report';
 
 module('Acceptance | curriculum inventory leadership', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/curriculum-inventory/nested-sequence-blocks-test.js
+++ b/tests/acceptance/curriculum-inventory/nested-sequence-blocks-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupAuthentication } from 'ilios-common';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/curriculum-inventory-sequence-block';
+import page from 'frontend/tests/pages/curriculum-inventory-sequence-block';
 
 module('Acceptance | curriculum inventory nested sequence blocks', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/curriculum-inventory/report-test.js
+++ b/tests/acceptance/curriculum-inventory/report-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/curriculum-inventory-report';
+import page from 'frontend/tests/pages/curriculum-inventory-report';
 
 module('Acceptance | curriculum inventory report', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/curriculum-inventory/reports-test.js
+++ b/tests/acceptance/curriculum-inventory/reports-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/curriculum-inventory-reports';
+import page from 'frontend/tests/pages/curriculum-inventory-reports';
 
 const url = '/curriculum-inventory-reports/?program=1&school=1';
 

--- a/tests/acceptance/curriculum-inventory/rollover-test.js
+++ b/tests/acceptance/curriculum-inventory/rollover-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/curriculum-inventory-report-rollover';
+import page from 'frontend/tests/pages/curriculum-inventory-report-rollover';
 import queryString from 'query-string';
 import { DateTime } from 'luxon';
 

--- a/tests/acceptance/curriculum-inventory/sequence-blocks-test.js
+++ b/tests/acceptance/curriculum-inventory/sequence-blocks-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupAuthentication } from 'ilios-common';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/curriculum-inventory-report';
+import page from 'frontend/tests/pages/curriculum-inventory-report';
 
 module('Acceptance | curriculum inventory sequence blocks', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/footer-test.js
+++ b/tests/acceptance/footer-test.js
@@ -3,7 +3,7 @@ import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupAuthentication } from 'ilios-common';
-import ENV from 'ilios/config/environment';
+import ENV from 'frontend/config/environment';
 import { versionRegExp } from 'ember-cli-app-version/utils/regexp';
 const { version } = ENV.APP;
 

--- a/tests/acceptance/instructorgroups-test.js
+++ b/tests/acceptance/instructorgroups-test.js
@@ -1,7 +1,7 @@
 import { currentURL, currentRouteName } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
-import page from 'ilios/tests/pages/instructor-groups';
+import page from 'frontend/tests/pages/instructor-groups';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';

--- a/tests/acceptance/learnergroups-test.js
+++ b/tests/acceptance/learnergroups-test.js
@@ -3,8 +3,8 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/learner-groups';
-import learnerGroupPage from 'ilios/tests/pages/learner-group';
+import page from 'frontend/tests/pages/learner-groups';
+import learnerGroupPage from 'frontend/tests/pages/learner-group';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Learner Groups', function (hooks) {

--- a/tests/acceptance/pending-user-updates-test.js
+++ b/tests/acceptance/pending-user-updates-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/pending-user-updates';
+import page from 'frontend/tests/pages/pending-user-updates';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | pending user updates', function (hooks) {

--- a/tests/acceptance/program-year/competencies-test.js
+++ b/tests/acceptance/program-year/competencies-test.js
@@ -3,7 +3,7 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/program-year';
+import page from 'frontend/tests/pages/program-year';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Program Year - Competencies', function (hooks) {

--- a/tests/acceptance/program-year/leadership-test.js
+++ b/tests/acceptance/program-year/leadership-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupAuthentication } from 'ilios-common';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/program-year';
+import page from 'frontend/tests/pages/program-year';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Program Year - Leadership', function (hooks) {

--- a/tests/acceptance/program-year/objectives-test.js
+++ b/tests/acceptance/program-year/objectives-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/program-year';
+import page from 'frontend/tests/pages/program-year';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Program Year - Objectives', function (hooks) {

--- a/tests/acceptance/program-year/objectiveterms-test.js
+++ b/tests/acceptance/program-year/objectiveterms-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import page from 'ilios/tests/pages/program-year';
+import page from 'frontend/tests/pages/program-year';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Program Year - Objective Vocabulary Terms', function (hooks) {

--- a/tests/acceptance/program-year/terms-test.js
+++ b/tests/acceptance/program-year/terms-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/program-year';
+import page from 'frontend/tests/pages/program-year';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Program Year - Terms', function (hooks) {

--- a/tests/acceptance/program/leadership-test.js
+++ b/tests/acceptance/program/leadership-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupAuthentication } from 'ilios-common';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/program';
+import page from 'frontend/tests/pages/program';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Program - Leadership', function (hooks) {

--- a/tests/acceptance/program/overview-test.js
+++ b/tests/acceptance/program/overview-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/program';
+import page from 'frontend/tests/pages/program';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Program - Overview', function (hooks) {

--- a/tests/acceptance/program/programyear-list-test.js
+++ b/tests/acceptance/program/programyear-list-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/program';
+import page from 'frontend/tests/pages/program';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Program - ProgramYear List', function (hooks) {

--- a/tests/acceptance/programs-test.js
+++ b/tests/acceptance/programs-test.js
@@ -4,7 +4,7 @@ import { setupAuthentication } from 'ilios-common';
 
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/programs';
+import page from 'frontend/tests/pages/programs';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Programs', function (hooks) {

--- a/tests/acceptance/reports/subject-test.js
+++ b/tests/acceptance/reports/subject-test.js
@@ -1,7 +1,7 @@
 import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import page from 'ilios/tests/pages/reports-subject';
+import page from 'frontend/tests/pages/reports-subject';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import percySnapshot from '@percy/ember';

--- a/tests/acceptance/reports/subjects-test.js
+++ b/tests/acceptance/reports/subjects-test.js
@@ -1,8 +1,8 @@
 import { currentRouteName, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import page from 'ilios/tests/pages/reports';
-import subjectReportPage from 'ilios/tests/pages/reports-subject';
+import page from 'frontend/tests/pages/reports';
+import subjectReportPage from 'frontend/tests/pages/reports-subject';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import percySnapshot from '@percy/ember';

--- a/tests/acceptance/school/session-attributes-test.js
+++ b/tests/acceptance/school/session-attributes-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/school';
+import page from 'frontend/tests/pages/school';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | School - Session Attributes', function (hooks) {

--- a/tests/acceptance/school/session-types-test.js
+++ b/tests/acceptance/school/session-types-test.js
@@ -3,7 +3,7 @@ import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentURL } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/school';
+import page from 'frontend/tests/pages/school';
 
 // @todo flesh out test coverage - the full CRUD, read-only mode, etc [ST 2023/09/18]
 module('Acceptance | School - Session Types', function (hooks) {

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -3,8 +3,8 @@ import { currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupAuthentication } from 'ilios-common';
-import page from 'ilios/tests/pages/search';
-import dashboardPage from 'ilios/tests/pages/dashboard';
+import page from 'frontend/tests/pages/search';
+import dashboardPage from 'frontend/tests/pages/dashboard';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | search', function (hooks) {

--- a/tests/acceptance/user-test.js
+++ b/tests/acceptance/user-test.js
@@ -4,7 +4,7 @@ import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
 
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/user';
+import page from 'frontend/tests/pages/user';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | User', function (hooks) {

--- a/tests/acceptance/users-test.js
+++ b/tests/acceptance/users-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import page from 'ilios/tests/pages/users';
+import page from 'frontend/tests/pages/users';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Users', function (hooks) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,7 +10,7 @@
     {{content-for "test-head"}}
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/ilios.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/frontend.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     <!-- Ilios variables set  by the web server -->
@@ -35,7 +35,7 @@
     <auto-import-scripts entrypoint="app"> </auto-import-scripts>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <auto-import-scripts entrypoint="tests"> </auto-import-scripts>
-    <script src="{{rootURL}}assets/ilios.js"></script>
+    <script src="{{rootURL}}assets/frontend.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}

--- a/tests/integration/components/assign-students-test.js
+++ b/tests/integration/components/assign-students-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/assign-students';
+import { component } from 'frontend/tests/pages/components/assign-students';
 
 module('Integration | Component | assign students', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/back-to-admin-dashboard-test.js
+++ b/tests/integration/components/back-to-admin-dashboard-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/back-to-admin-dashboard';
+import { component } from 'frontend/tests/pages/components/back-to-admin-dashboard';
 
 module('Integration | Component | back-to-admin-dashboard', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/competency-title-editor-test.js
+++ b/tests/integration/components/competency-title-editor-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/competency-title-editor';
+import { component } from 'frontend/tests/pages/components/competency-title-editor';
 
 module('Integration | Component | competency title editor', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/course-search-result-test.js
+++ b/tests/integration/components/course-search-result-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/course-search-result';
+import { component } from 'frontend/tests/pages/components/course-search-result';
 
 module('Integration | Component | course-search-result', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/courses/list-item-test.js
+++ b/tests/integration/components/courses/list-item-test.js
@@ -5,7 +5,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/courses/list-item';
+import { component } from 'frontend/tests/pages/components/courses/list-item';
 
 module('Integration | Component | courses/list-item', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/courses/list-test.js
+++ b/tests/integration/components/courses/list-test.js
@@ -5,7 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
-import { component } from 'ilios/tests/pages/components/courses/list';
+import { component } from 'frontend/tests/pages/components/courses/list';
 
 module('Integration | Component | courses/list', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/courses/new-test.js
+++ b/tests/integration/components/courses/new-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/courses/new';
+import { component } from 'frontend/tests/pages/components/courses/new';
 
 module('Integration | Component | courses/new', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/courses/root-test.js
+++ b/tests/integration/components/courses/root-test.js
@@ -5,7 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
-import { component } from 'ilios/tests/pages/components/courses/root';
+import { component } from 'frontend/tests/pages/components/courses/root';
 
 module('Integration | Component | courses/root', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/leadership-expanded-test.js
+++ b/tests/integration/components/curriculum-inventory/leadership-expanded-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/leadership-expanded';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/leadership-expanded';
 
 module('Integration | Component | curriculum-inventory/leadership-expanded', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/new-report-test.js
+++ b/tests/integration/components/curriculum-inventory/new-report-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/new-report';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/new-report';
 
 module('Integration | Component | curriculum-inventory/new-report', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/new-sequence-block-test.js
+++ b/tests/integration/components/curriculum-inventory/new-sequence-block-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/new-sequence-block';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/new-sequence-block';
 
 module('Integration | Component | curriculum-inventory/new-sequence-block', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/report-details-test.js
+++ b/tests/integration/components/curriculum-inventory/report-details-test.js
@@ -6,7 +6,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import Service from '@ember/service';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/report-details';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/report-details';
 
 module('Integration | Component | curriculum-inventory/report-details', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/report-header-test.js
+++ b/tests/integration/components/curriculum-inventory/report-header-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/report-header';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/report-header';
 
 module('Integration | Component | curriculum-inventory/report-header', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/report-list-item-test.js
+++ b/tests/integration/components/curriculum-inventory/report-list-item-test.js
@@ -5,7 +5,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/report-list-item';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/report-list-item';
 
 module('Integration | Component | curriculum-inventory/report-list-item', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/report-list-test.js
+++ b/tests/integration/components/curriculum-inventory/report-list-test.js
@@ -6,7 +6,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/report-list';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/report-list';
 
 module('Integration | Component | curriculum-inventory/report-list', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/report-overview-test.js
+++ b/tests/integration/components/curriculum-inventory/report-overview-test.js
@@ -6,7 +6,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/report-overview';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/report-overview';
 
 module('Integration | Component | curriculum-inventory/report-overview', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/report-rollover-test.js
+++ b/tests/integration/components/curriculum-inventory/report-rollover-test.js
@@ -6,7 +6,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import queryString from 'query-string';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/report-rollover';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/report-rollover';
 
 module('Integration | Component | curriculum-inventory/report-rollover', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/reports-test.js
+++ b/tests/integration/components/curriculum-inventory/reports-test.js
@@ -5,7 +5,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/reports';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/reports';
 module('Integration | Component | curriculum-inventory/reports', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en-us');

--- a/tests/integration/components/curriculum-inventory/sequence-block-details-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-details-test.js
@@ -5,7 +5,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-details';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-details';
 
 module('Integration | Component | curriculum-inventory/sequence-block-details', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/sequence-block-header-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-header-test.js
@@ -3,7 +3,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-header';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-header';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | curriculum-inventory/sequence-block-header', function (hooks) {

--- a/tests/integration/components/curriculum-inventory/sequence-block-list-item-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-list-item-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-list-item';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-list-item';
 
 module('Integration | Component | curriculum-inventory/sequence-block-list-item', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/sequence-block-list-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-list-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-list';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-list';
 
 module('Integration | Component | curriculum-inventory/sequence-block-list', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/sequence-block-overview-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-overview-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-overview';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-overview';
 
 module('Integration | Component | curriculum-inventory/sequence-block-overview', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/curriculum-inventory/sequence-block-session-list-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-session-list-test.js
@@ -5,7 +5,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { DateTime } from 'luxon';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-session-list';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-session-list';
 
 module(
   'Integration | Component | curriculum-inventory/sequence-block-session-list',

--- a/tests/integration/components/curriculum-inventory/sequence-block-session-manager-test.js
+++ b/tests/integration/components/curriculum-inventory/sequence-block-session-manager-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { DateTime } from 'luxon';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-session-manager';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-session-manager';
 
 module(
   'Integration | Component | curriculum-inventory/sequence-block-session-manager',

--- a/tests/integration/components/curriculum-inventory/verification-preview-header-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-header-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-header';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-header';
 
 module(
   'Integration | Component | curriculum-inventory/verification-preview-header',

--- a/tests/integration/components/curriculum-inventory/verification-preview-table1-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table1-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table1';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table1';
 
 module(
   'Integration | Component | curriculum-inventory/verification-preview-table1',

--- a/tests/integration/components/curriculum-inventory/verification-preview-table2-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table2-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table2';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table2';
 
 module(
   'Integration | Component | curriculum-inventory/verification-preview-table2',

--- a/tests/integration/components/curriculum-inventory/verification-preview-table3a-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table3a-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table3a';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table3a';
 
 module(
   'Integration | Component | curriculum-inventory/verification-preview-table3a',

--- a/tests/integration/components/curriculum-inventory/verification-preview-table3b-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table3b-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table3b';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table3b';
 
 module(
   'Integration | Component | curriculum-inventory/verification-preview-table3b',

--- a/tests/integration/components/curriculum-inventory/verification-preview-table4-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table4-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table4';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table4';
 
 module(
   'Integration | Component | curriculum-inventory/verification-preview-table4',

--- a/tests/integration/components/curriculum-inventory/verification-preview-table5-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table5-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table5';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table5';
 
 module(
   'Integration | Component | curriculum-inventory/verification-preview-table5',

--- a/tests/integration/components/curriculum-inventory/verification-preview-table6-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table6-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table6';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table6';
 
 module(
   'Integration | Component | curriculum-inventory/verification-preview-table6',

--- a/tests/integration/components/curriculum-inventory/verification-preview-table7-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table7-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table7';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table7';
 
 module(
   'Integration | Component | curriculum-inventory/verification-preview-table7',

--- a/tests/integration/components/curriculum-inventory/verification-preview-table8-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-table8-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table8';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table8';
 
 module(
   'Integration | Component | curriculum-inventory/verification-preview-table8',

--- a/tests/integration/components/curriculum-inventory/verification-preview-test.js
+++ b/tests/integration/components/curriculum-inventory/verification-preview-test.js
@@ -5,7 +5,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/curriculum-inventory/verification-preview';
+import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview';
 
 module('Integration | Component | curriculum-inventory/verification-preview', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/flash-messages-test.js
+++ b/tests/integration/components/flash-messages-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/flash-messages';
+import { component } from 'frontend/tests/pages/components/flash-messages';
 
 module('Integration | Component | flash-messages', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/global-search-box-test.js
+++ b/tests/integration/components/global-search-box-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/global-search-box';
+import { component } from 'frontend/tests/pages/components/global-search-box';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 

--- a/tests/integration/components/global-search-tags-test.js
+++ b/tests/integration/components/global-search-tags-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/global-search-tags';
+import { component } from 'frontend/tests/pages/components/global-search-tags';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | global-search-tags', function (hooks) {

--- a/tests/integration/components/global-search-test.js
+++ b/tests/integration/components/global-search-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/global-search';
+import { component } from 'frontend/tests/pages/components/global-search';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | global-search', function (hooks) {

--- a/tests/integration/components/ilios-header-test.js
+++ b/tests/integration/components/ilios-header-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/ilios-header';
+import { component } from 'frontend/tests/pages/components/ilios-header';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | ilios-header', function (hooks) {

--- a/tests/integration/components/ilios-navigation-test.js
+++ b/tests/integration/components/ilios-navigation-test.js
@@ -5,7 +5,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/ilios-navigation';
+import { component } from 'frontend/tests/pages/components/ilios-navigation';
 
 module('Integration | Component | ilios-navigation', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/ilios-users-test.js
+++ b/tests/integration/components/ilios-users-test.js
@@ -5,7 +5,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/ilios-users';
+import { component } from 'frontend/tests/pages/components/ilios-users';
 
 module('Integration | Component | ilios users', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/instructor-group/courses-test.js
+++ b/tests/integration/components/instructor-group/courses-test.js
@@ -5,7 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/instructor-group/courses';
+import { component } from 'frontend/tests/pages/components/instructor-group/courses';
 
 module('Integration | Component | instructor-group/courses', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/instructor-group/header-test.js
+++ b/tests/integration/components/instructor-group/header-test.js
@@ -5,7 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/instructor-group/header';
+import { component } from 'frontend/tests/pages/components/instructor-group/header';
 
 module('Integration | Component | instructor-group/header', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/instructor-group/instructor-manager-test.js
+++ b/tests/integration/components/instructor-group/instructor-manager-test.js
@@ -5,7 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/instructor-group/instructor-manager';
+import { component } from 'frontend/tests/pages/components/instructor-group/instructor-manager';
 
 module('Integration | Component | instructor-group/instructor-manager', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/instructor-group/root-test.js
+++ b/tests/integration/components/instructor-group/root-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/instructor-group/root';
+import { component } from 'frontend/tests/pages/components/instructor-group/root';
 
 module('Integration | Component | instructor-group/root', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/instructor-group/users-test.js
+++ b/tests/integration/components/instructor-group/users-test.js
@@ -5,7 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/instructor-group/users';
+import { component } from 'frontend/tests/pages/components/instructor-group/users';
 
 module('Integration | Component | instructor-group/users', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/instructor-groups/list-item-test.js
+++ b/tests/integration/components/instructor-groups/list-item-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import Service from '@ember/service';
-import { component } from 'ilios/tests/pages/components/instructor-groups/list-item';
+import { component } from 'frontend/tests/pages/components/instructor-groups/list-item';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | instructor-groups/list-item', function (hooks) {

--- a/tests/integration/components/instructor-groups/list-test.js
+++ b/tests/integration/components/instructor-groups/list-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/instructor-groups/list';
+import { component } from 'frontend/tests/pages/components/instructor-groups/list';
 import Service from '@ember/service';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 

--- a/tests/integration/components/instructor-groups/new-test.js
+++ b/tests/integration/components/instructor-groups/new-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/instructor-groups/new';
+import { component } from 'frontend/tests/pages/components/instructor-groups/new';
 
 module('Integration | Component | instructor-groups/new', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/instructor-groups/root-test.js
+++ b/tests/integration/components/instructor-groups/root-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import Service from '@ember/service';
-import { component } from 'ilios/tests/pages/components/instructor-groups/root';
+import { component } from 'frontend/tests/pages/components/instructor-groups/root';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | instructor-groups/root', function (hooks) {

--- a/tests/integration/components/learner-group/calendar-test.js
+++ b/tests/integration/components/learner-group/calendar-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/learner-group/calendar';
+import { component } from 'frontend/tests/pages/components/learner-group/calendar';
 import { DateTime } from 'luxon';
 
 module('Integration | Component | learner-group/calendar', function (hooks) {

--- a/tests/integration/components/learner-group/cohort-user-manager-test.js
+++ b/tests/integration/components/learner-group/cohort-user-manager-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/learner-group/cohort-user-manager';
+import { component } from 'frontend/tests/pages/components/learner-group/cohort-user-manager';
 
 module('Integration | Component | learner-group/cohort-user-manager', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/learner-group/header-test.js
+++ b/tests/integration/components/learner-group/header-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/learner-group/header';
+import { component } from 'frontend/tests/pages/components/learner-group/header';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | learner-group/header', function (hooks) {

--- a/tests/integration/components/learner-group/instructor-group-members-list-test.js
+++ b/tests/integration/components/learner-group/instructor-group-members-list-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/learner-group/instructor-group-members-list';
+import { component } from 'frontend/tests/pages/components/learner-group/instructor-group-members-list';
 
 module('Integration | Component | learner-group/instructor-group-members-list', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/learner-group/instructor-manager-test.js
+++ b/tests/integration/components/learner-group/instructor-manager-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/learner-group/instructor-manager';
+import { component } from 'frontend/tests/pages/components/learner-group/instructor-manager';
 
 module('Integration | Component | learner-group/instructor-manager', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/learner-group/list-item-test.js
+++ b/tests/integration/components/learner-group/list-item-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import Service from '@ember/service';
-import { component } from 'ilios/tests/pages/components/learner-group/list-item';
+import { component } from 'frontend/tests/pages/components/learner-group/list-item';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | learner-group/list-item', function (hooks) {

--- a/tests/integration/components/learner-group/list-test.js
+++ b/tests/integration/components/learner-group/list-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/learner-group/list';
+import { component } from 'frontend/tests/pages/components/learner-group/list';
 import Service from '@ember/service';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 

--- a/tests/integration/components/learner-group/members-test.js
+++ b/tests/integration/components/learner-group/members-test.js
@@ -5,7 +5,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/learner-group/members';
+import { component } from 'frontend/tests/pages/components/learner-group/members';
 
 module('Integration | Component | learner-group/members', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/learner-group/new-multiple-test.js
+++ b/tests/integration/components/learner-group/new-multiple-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/learner-group/new-multiple';
+import { component } from 'frontend/tests/pages/components/learner-group/new-multiple';
 
 module('Integration | Component | learner-group/new-multiple', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/learner-group/new-single-test.js
+++ b/tests/integration/components/learner-group/new-single-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/learner-group/new-single';
+import { component } from 'frontend/tests/pages/components/learner-group/new-single';
 
 module('Integration | Component | learner-group/new-single', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/learner-group/new-test.js
+++ b/tests/integration/components/learner-group/new-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/learner-group/new';
+import { component } from 'frontend/tests/pages/components/learner-group/new';
 
 module('Integration | Component | learner-group/new', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/learner-group/root-test.js
+++ b/tests/integration/components/learner-group/root-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/learner-group/root';
+import { component } from 'frontend/tests/pages/components/learner-group/root';
 
 module('Integration | Component | learner-group/root', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/learner-group/user-manager-test.js
+++ b/tests/integration/components/learner-group/user-manager-test.js
@@ -5,7 +5,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/learner-group/user-manager';
+import { component } from 'frontend/tests/pages/components/learner-group/user-manager';
 
 module('Integration | Component | learner-group/user-manager', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/learner-groups/root-test.js
+++ b/tests/integration/components/learner-groups/root-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import Service from '@ember/service';
-import { component } from 'ilios/tests/pages/components/learner-groups/root';
+import { component } from 'frontend/tests/pages/components/learner-groups/root';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | learner-groups/root', function (hooks) {

--- a/tests/integration/components/locale-chooser-test.js
+++ b/tests/integration/components/locale-chooser-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import component from 'ilios/tests/pages/components/locale-chooser';
+import component from 'frontend/tests/pages/components/locale-chooser';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | locale-chooser', function (hooks) {

--- a/tests/integration/components/login-form-test.js
+++ b/tests/integration/components/login-form-test.js
@@ -5,7 +5,7 @@ import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/login-form';
+import { component } from 'frontend/tests/pages/components/login-form';
 
 module('Integration | Component | login-form', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/my-profile-test.js
+++ b/tests/integration/components/my-profile-test.js
@@ -6,7 +6,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime, Duration } from 'luxon';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/my-profile';
+import { component } from 'frontend/tests/pages/components/my-profile';
 
 module('Integration | Component | my profile', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/new-competency-test.js
+++ b/tests/integration/components/new-competency-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/new-competency';
+import { component } from 'frontend/tests/pages/components/new-competency';
 
 module('Integration | Component | new competency', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/new-directory-user-test.js
+++ b/tests/integration/components/new-directory-user-test.js
@@ -6,7 +6,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/new-directory-user';
+import { component } from 'frontend/tests/pages/components/new-directory-user';
 
 module('Integration | Component | new directory user', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/new-user-test.js
+++ b/tests/integration/components/new-user-test.js
@@ -7,7 +7,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { mapBy } from 'ilios-common/utils/array-helpers';
-import { component } from 'ilios/tests/pages/components/new-user';
+import { component } from 'frontend/tests/pages/components/new-user';
 
 module('Integration | Component | new user', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/pagination-links-test.js
+++ b/tests/integration/components/pagination-links-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/pagination-links';
+import { component } from 'frontend/tests/pages/components/pagination-links';
 
 module('Integration | Component | pagination-links', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/pending-single-user-update-test.js
+++ b/tests/integration/components/pending-single-user-update-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/pending-single-user-update';
+import { component } from 'frontend/tests/pages/components/pending-single-user-update';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | pending single user update', function (hooks) {

--- a/tests/integration/components/pending-updates-summary-test.js
+++ b/tests/integration/components/pending-updates-summary-test.js
@@ -5,7 +5,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/pending-updates-summary';
+import { component } from 'frontend/tests/pages/components/pending-updates-summary';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | pending updates summary', function (hooks) {

--- a/tests/integration/components/program-year/collapsed-objectives-test.js
+++ b/tests/integration/components/program-year/collapsed-objectives-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/program-year/collapsed-objectives';
+import { component } from 'frontend/tests/pages/components/program-year/collapsed-objectives';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | program-year/collapsed-objectives', function (hooks) {

--- a/tests/integration/components/program-year/competencies-test.js
+++ b/tests/integration/components/program-year/competencies-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/program-year/competencies';
+import { component } from 'frontend/tests/pages/components/program-year/competencies';
 
 module('Integration | Component | program-year/competencies', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program-year/competency-list-item-test.js
+++ b/tests/integration/components/program-year/competency-list-item-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/program-year/competency-list-item';
+import { component } from 'frontend/tests/pages/components/program-year/competency-list-item';
 
 module('Integration | Component | program-year/competency-list-item', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program-year/courses-test.js
+++ b/tests/integration/components/program-year/courses-test.js
@@ -5,7 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/program-year/courses';
+import { component } from 'frontend/tests/pages/components/program-year/courses';
 
 module('Integration | Component | program-year/courses', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program-year/header-test.js
+++ b/tests/integration/components/program-year/header-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/program-year/header';
+import { component } from 'frontend/tests/pages/components/program-year/header';
 
 module('Integration | Component | program-year/header', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program-year/leadership-expanded-test.js
+++ b/tests/integration/components/program-year/leadership-expanded-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/program-year/leadership-expanded';
+import { component } from 'frontend/tests/pages/components/program-year/leadership-expanded';
 
 module('Integration | Component | program-year/leadership-expanded', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program-year/list-item-test.js
+++ b/tests/integration/components/program-year/list-item-test.js
@@ -5,7 +5,7 @@ import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/program-year/list-item';
+import { component } from 'frontend/tests/pages/components/program-year/list-item';
 
 module('Integration | Component | program-year/list-item', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program-year/list-test.js
+++ b/tests/integration/components/program-year/list-test.js
@@ -6,7 +6,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { sortBy } from 'ilios-common/utils/array-helpers';
-import { component } from 'ilios/tests/pages/components/program-year/list';
+import { component } from 'frontend/tests/pages/components/program-year/list';
 
 module('Integration | Component | program-year/list', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program-year/manage-objective-competency-test.js
+++ b/tests/integration/components/program-year/manage-objective-competency-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/program-year/manage-objective-competency';
+import { component } from 'frontend/tests/pages/components/program-year/manage-objective-competency';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 

--- a/tests/integration/components/program-year/manage-objective-descriptors-test.js
+++ b/tests/integration/components/program-year/manage-objective-descriptors-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/program-year/manage-objective-descriptors';
+import { component } from 'frontend/tests/pages/components/program-year/manage-objective-descriptors';
 
 module('Integration | Component | program-year/manage-objective-descriptors', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program-year/managed-competency-list-item-test.js
+++ b/tests/integration/components/program-year/managed-competency-list-item-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/program-year/managed-competency-list-item';
+import { component } from 'frontend/tests/pages/components/program-year/managed-competency-list-item';
 
 module('Integration | Component | program-year/managed-competency-list-item', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program-year/new-test.js
+++ b/tests/integration/components/program-year/new-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
-import { component } from 'ilios/tests/pages/components/program-year/new';
+import { component } from 'frontend/tests/pages/components/program-year/new';
 
 module('Integration | Component | program-year/new', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program-year/objective-list-item-competency-test.js
+++ b/tests/integration/components/program-year/objective-list-item-competency-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/program-year/objective-list-item-competency';
+import { component } from 'frontend/tests/pages/components/program-year/objective-list-item-competency';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | program-year/objective-list-item-competency', function (hooks) {

--- a/tests/integration/components/program-year/objective-list-item-descriptors-test.js
+++ b/tests/integration/components/program-year/objective-list-item-descriptors-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/program-year/objective-list-item-descriptors';
+import { component } from 'frontend/tests/pages/components/program-year/objective-list-item-descriptors';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | program-year/objective-list-item-descriptors', function (hooks) {

--- a/tests/integration/components/program-year/objective-list-item-expanded-test.js
+++ b/tests/integration/components/program-year/objective-list-item-expanded-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/program-year/objective-list-item-expanded';
+import { component } from 'frontend/tests/pages/components/program-year/objective-list-item-expanded';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 

--- a/tests/integration/components/program-year/objective-list-item-test.js
+++ b/tests/integration/components/program-year/objective-list-item-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/program-year/objective-list-item';
+import { component } from 'frontend/tests/pages/components/program-year/objective-list-item';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 

--- a/tests/integration/components/program-year/objective-list-test.js
+++ b/tests/integration/components/program-year/objective-list-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/program-year/objective-list';
+import { component } from 'frontend/tests/pages/components/program-year/objective-list';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 

--- a/tests/integration/components/program-year/objectives-test.js
+++ b/tests/integration/components/program-year/objectives-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/program-year/objectives';
+import { component } from 'frontend/tests/pages/components/program-year/objectives';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 

--- a/tests/integration/components/program-year/overview-test.js
+++ b/tests/integration/components/program-year/overview-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/program-year/overview';
+import { component } from 'frontend/tests/pages/components/program-year/overview';
 import { enableFeature } from 'ember-feature-flags/test-support';
 
 module('Integration | Component | program-year/overview', function (hooks) {

--- a/tests/integration/components/program-year/visualize-objectives-test.js
+++ b/tests/integration/components/program-year/visualize-objectives-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/program-year/visualize-objectives';
+import { component } from 'frontend/tests/pages/components/program-year/visualize-objectives';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | program-year/visualize-objectives', function (hooks) {

--- a/tests/integration/components/program/header-test.js
+++ b/tests/integration/components/program/header-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/program/header';
+import { component } from 'frontend/tests/pages/components/program/header';
 
 module('Integration | Component | program/header', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program/leadership-expanded-test.js
+++ b/tests/integration/components/program/leadership-expanded-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/program/leadership-expanded';
+import { component } from 'frontend/tests/pages/components/program/leadership-expanded';
 
 module('Integration | Component | program/leadership expanded', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/program/new-test.js
+++ b/tests/integration/components/program/new-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/program/new';
+import { component } from 'frontend/tests/pages/components/program/new';
 
 module('Integration | Component | program/new', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/programs/list-item-test.js
+++ b/tests/integration/components/programs/list-item-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import Service from '@ember/service';
-import { component } from 'ilios/tests/pages/components/programs/list-item';
+import { component } from 'frontend/tests/pages/components/programs/list-item';
 
 module('Integration | Component | programs/list-item', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/programs/list-test.js
+++ b/tests/integration/components/programs/list-test.js
@@ -5,7 +5,7 @@ import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/programs/list';
+import { component } from 'frontend/tests/pages/components/programs/list';
 
 module('Integration | Component | programs/list', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/programs/root-test.js
+++ b/tests/integration/components/programs/root-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import Service from '@ember/service';
-import { component } from 'ilios/tests/pages/components/programs/root';
+import { component } from 'frontend/tests/pages/components/programs/root';
 
 module('Integration | Component | programs/root', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/reports/list-loading-test.js
+++ b/tests/integration/components/reports/list-loading-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';

--- a/tests/integration/components/reports/list-test.js
+++ b/tests/integration/components/reports/list-test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupAuthentication } from 'ilios-common';
-import { component } from 'ilios/tests/pages/components/reports/list';
+import { component } from 'frontend/tests/pages/components/reports/list';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | reports/list', function (hooks) {

--- a/tests/integration/components/reports/new-subject-test.js
+++ b/tests/integration/components/reports/new-subject-test.js
@@ -5,7 +5,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/new-subject';
+import { component } from 'frontend/tests/pages/components/reports/new-subject';
 
 module('Integration | Component | reports/new-subject', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/reports/root-test.js
+++ b/tests/integration/components/reports/root-test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupAuthentication } from 'ilios-common';
-import { component } from 'ilios/tests/pages/components/reports/root';
+import { component } from 'frontend/tests/pages/components/reports/root';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | reports/root', function (hooks) {

--- a/tests/integration/components/reports/subject-results-test.js
+++ b/tests/integration/components/reports/subject-results-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/reports/results';
+import { component } from 'frontend/tests/pages/components/reports/results';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | reports/subject-results', function (hooks) {

--- a/tests/integration/components/reports/subject-test.js
+++ b/tests/integration/components/reports/subject-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupAuthentication } from 'ilios-common';
-import { component } from 'ilios/tests/pages/components/reports/subject';
+import { component } from 'frontend/tests/pages/components/reports/subject';
 
 module('Integration | Component | reports/subject', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/reports/subject/competency-test.js
+++ b/tests/integration/components/reports/subject/competency-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/competency';
+import { component } from 'frontend/tests/pages/components/reports/subject/competency';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/competency', function (hooks) {

--- a/tests/integration/components/reports/subject/course-test.js
+++ b/tests/integration/components/reports/subject/course-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/course';
+import { component } from 'frontend/tests/pages/components/reports/subject/course';
 import { setupAuthentication } from 'ilios-common';
 
 module('Integration | Component | reports/subject/course', function (hooks) {

--- a/tests/integration/components/reports/subject/instructor-group-test.js
+++ b/tests/integration/components/reports/subject/instructor-group-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/instructor-group';
+import { component } from 'frontend/tests/pages/components/reports/subject/instructor-group';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/instructor-group', function (hooks) {

--- a/tests/integration/components/reports/subject/instructor-test.js
+++ b/tests/integration/components/reports/subject/instructor-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/instructor';
+import { component } from 'frontend/tests/pages/components/reports/subject/instructor';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/instructor', function (hooks) {

--- a/tests/integration/components/reports/subject/learning-material-test.js
+++ b/tests/integration/components/reports/subject/learning-material-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/learning-material';
+import { component } from 'frontend/tests/pages/components/reports/subject/learning-material';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/learning-material', function (hooks) {

--- a/tests/integration/components/reports/subject/mesh-term-test.js
+++ b/tests/integration/components/reports/subject/mesh-term-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/mesh-term';
+import { component } from 'frontend/tests/pages/components/reports/subject/mesh-term';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/mesh-term', function (hooks) {

--- a/tests/integration/components/reports/subject/new/competency-test.js
+++ b/tests/integration/components/reports/subject/new/competency-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/competency';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/competency';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/competency', function (hooks) {

--- a/tests/integration/components/reports/subject/new/course-test.js
+++ b/tests/integration/components/reports/subject/new/course-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/course';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/course';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/course', function (hooks) {

--- a/tests/integration/components/reports/subject/new/instructor-group-test.js
+++ b/tests/integration/components/reports/subject/new/instructor-group-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/instructor-group';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/instructor-group';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/instructor-group', function (hooks) {

--- a/tests/integration/components/reports/subject/new/instructor-test.js
+++ b/tests/integration/components/reports/subject/new/instructor-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/instructor';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/instructor';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/instructor', function (hooks) {

--- a/tests/integration/components/reports/subject/new/learning-material-test.js
+++ b/tests/integration/components/reports/subject/new/learning-material-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/learning-material';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/learning-material';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/learning-material', function (hooks) {

--- a/tests/integration/components/reports/subject/new/mesh-term-test.js
+++ b/tests/integration/components/reports/subject/new/mesh-term-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/mesh-term';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/mesh-term';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/mesh-term', function (hooks) {

--- a/tests/integration/components/reports/subject/new/program-test.js
+++ b/tests/integration/components/reports/subject/new/program-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/program';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/program';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/program', function (hooks) {

--- a/tests/integration/components/reports/subject/new/program-year-test.js
+++ b/tests/integration/components/reports/subject/new/program-year-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/program-year';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/program-year';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/program-year', function (hooks) {

--- a/tests/integration/components/reports/subject/new/search/input-test.js
+++ b/tests/integration/components/reports/subject/new/search/input-test.js
@@ -1,8 +1,8 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/search/input';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/search/input';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { setupIntl } from 'ember-intl/test-support';
 

--- a/tests/integration/components/reports/subject/new/session-test.js
+++ b/tests/integration/components/reports/subject/new/session-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/session';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/session';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/session', function (hooks) {

--- a/tests/integration/components/reports/subject/new/session-type-test.js
+++ b/tests/integration/components/reports/subject/new/session-type-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/session-type';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/session-type';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/session-type', function (hooks) {

--- a/tests/integration/components/reports/subject/new/term-test.js
+++ b/tests/integration/components/reports/subject/new/term-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/new/term';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/term';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/term', function (hooks) {

--- a/tests/integration/components/reports/subject/program-test.js
+++ b/tests/integration/components/reports/subject/program-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/program';
+import { component } from 'frontend/tests/pages/components/reports/subject/program';
 import { setupAuthentication } from 'ilios-common';
 
 module('Integration | Component | reports/subject/program', function (hooks) {

--- a/tests/integration/components/reports/subject/program-year-test.js
+++ b/tests/integration/components/reports/subject/program-year-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/program-year';
+import { component } from 'frontend/tests/pages/components/reports/subject/program-year';
 import { setupAuthentication } from 'ilios-common';
 
 module('Integration | Component | reports/subject/program-year', function (hooks) {

--- a/tests/integration/components/reports/subject/session-test.js
+++ b/tests/integration/components/reports/subject/session-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/session';
+import { component } from 'frontend/tests/pages/components/reports/subject/session';
 import { setupAuthentication } from 'ilios-common';
 
 module('Integration | Component | reports/subject/session', function (hooks) {

--- a/tests/integration/components/reports/subject/session-type-test.js
+++ b/tests/integration/components/reports/subject/session-type-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/session-type';
+import { component } from 'frontend/tests/pages/components/reports/subject/session-type';
 import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/session-type', function (hooks) {

--- a/tests/integration/components/reports/subject/term-test.js
+++ b/tests/integration/components/reports/subject/term-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/reports/subject/term';
+import { component } from 'frontend/tests/pages/components/reports/subject/term';
 
 module('Integration | Component | reports/subject/term', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/reports/table-row-test.js
+++ b/tests/integration/components/reports/table-row-test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupAuthentication } from 'ilios-common';
-import { component } from 'ilios/tests/pages/components/reports/table-row';
+import { component } from 'frontend/tests/pages/components/reports/table-row';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | reports/table-row', function (hooks) {

--- a/tests/integration/components/reports/table-test.js
+++ b/tests/integration/components/reports/table-test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupAuthentication } from 'ilios-common';
-import { component } from 'ilios/tests/pages/components/reports/table';
+import { component } from 'frontend/tests/pages/components/reports/table';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | reports/table', function (hooks) {

--- a/tests/integration/components/school-competencies-collapsed-test.js
+++ b/tests/integration/components/school-competencies-collapsed-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/school-competencies-collapsed';
+import { component } from 'frontend/tests/pages/components/school-competencies-collapsed';
 
 module('Integration | Component | school competencies collapsed', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-competencies-expanded-test.js
+++ b/tests/integration/components/school-competencies-expanded-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/school-competencies-expanded';
+import { component } from 'frontend/tests/pages/components/school-competencies-expanded';
 
 module('Integration | Component | school competencies expanded', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-competencies-list-item-pcrs-test.js
+++ b/tests/integration/components/school-competencies-list-item-pcrs-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/school-competencies-list-item-pcrs';
+import { component } from 'frontend/tests/pages/components/school-competencies-list-item-pcrs';
 
 module('Integration | Component | school-competencies-list-item-pcrs', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-competencies-list-item-test.js
+++ b/tests/integration/components/school-competencies-list-item-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/school-competencies-list-item';
+import { component } from 'frontend/tests/pages/components/school-competencies-list-item';
 
 module('Integration | Component | school-competencies-list-item', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-competencies-list-test.js
+++ b/tests/integration/components/school-competencies-list-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/school-competencies-list';
+import { component } from 'frontend/tests/pages/components/school-competencies-list';
 
 module('Integration | Component | school competencies list', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-competencies-manager-test.js
+++ b/tests/integration/components/school-competencies-manager-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school-competencies-manager';
+import { component } from 'frontend/tests/pages/components/school-competencies-manager';
 
 module('Integration | Component | school competencies manager', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-competencies-pcrs-mapper-test.js
+++ b/tests/integration/components/school-competencies-pcrs-mapper-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/school-competencies-pcrs-mapper';
+import { component } from 'frontend/tests/pages/components/school-competencies-pcrs-mapper';
 
 module('Integration | Component | school-competencies-pcrs-mapper', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-curriculum-inventory-institution-details-test.js
+++ b/tests/integration/components/school-curriculum-inventory-institution-details-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school-curriculum-inventory-institution-details';
+import { component } from 'frontend/tests/pages/components/school-curriculum-inventory-institution-details';
 
 module(
   'Integration | Component | school-curriculum-inventory-institution-details',

--- a/tests/integration/components/school-curriculum-inventory-institution-manager-test.js
+++ b/tests/integration/components/school-curriculum-inventory-institution-manager-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school-curriculum-inventory-institution-manager';
+import { component } from 'frontend/tests/pages/components/school-curriculum-inventory-institution-manager';
 
 module(
   'Integration | Component | school-curriculum-inventory-institution-manager',

--- a/tests/integration/components/school-leadership-expanded-test.js
+++ b/tests/integration/components/school-leadership-expanded-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school-leadership-expanded';
+import { component } from 'frontend/tests/pages/components/school-leadership-expanded';
 
 module('Integration | Component | school leadership expanded', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-list-test.js
+++ b/tests/integration/components/school-list-test.js
@@ -5,7 +5,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school-list';
+import { component } from 'frontend/tests/pages/components/school-list';
 
 module('Integration | Component | school list', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-manager-test.js
+++ b/tests/integration/components/school-manager-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school-manager';
+import { component } from 'frontend/tests/pages/components/school-manager';
 
 module('Integration | Component | school manager', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-new-vocabulary-form-test.js
+++ b/tests/integration/components/school-new-vocabulary-form-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/school-new-vocabulary-form';
+import { component } from 'frontend/tests/pages/components/school-new-vocabulary-form';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 

--- a/tests/integration/components/school-session-attributes-collapsed-test.js
+++ b/tests/integration/components/school-session-attributes-collapsed-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/school-session-attributes-collapsed';
+import { component } from 'frontend/tests/pages/components/school-session-attributes-collapsed';
 
 module('Integration | Component | school session attributes collapsed', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-session-attributes-expanded-test.js
+++ b/tests/integration/components/school-session-attributes-expanded-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/school-session-attributes-expanded';
+import { component } from 'frontend/tests/pages/components/school-session-attributes-expanded';
 
 module('Integration | Component | school session attributes expanded', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-session-attributes-manager-test.js
+++ b/tests/integration/components/school-session-attributes-manager-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/school-session-attributes-manager';
+import { component } from 'frontend/tests/pages/components/school-session-attributes-manager';
 
 module('Integration | Component | school session attributes manager', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-session-attributes-test.js
+++ b/tests/integration/components/school-session-attributes-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/school-session-attributes';
+import { component } from 'frontend/tests/pages/components/school-session-attributes';
 
 module('Integration | Component | school session attributes', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-session-type-form-test.js
+++ b/tests/integration/components/school-session-type-form-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school-session-type-form';
+import { component } from 'frontend/tests/pages/components/school-session-type-form';
 
 module('Integration | Component | school session type form', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-session-type-manager-test.js
+++ b/tests/integration/components/school-session-type-manager-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school-session-type-manager';
+import { component } from 'frontend/tests/pages/components/school-session-type-manager';
 
 module('Integration | Component | school session type manager', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-session-types-collapsed-test.js
+++ b/tests/integration/components/school-session-types-collapsed-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/school-session-types-collapsed';
+import { component } from 'frontend/tests/pages/components/school-session-types-collapsed';
 
 module('Integration | Component | school session types collapsed', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-session-types-expanded-test.js
+++ b/tests/integration/components/school-session-types-expanded-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school-session-types-expanded';
+import { component } from 'frontend/tests/pages/components/school-session-types-expanded';
 
 module('Integration | Component | school session types expanded', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-session-types-list-item-test.js
+++ b/tests/integration/components/school-session-types-list-item-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/school-session-types-list-item';
+import { component } from 'frontend/tests/pages/components/school-session-types-list-item';
 
 module('Integration | Component | school-session-types-list-item', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-session-types-list-test.js
+++ b/tests/integration/components/school-session-types-list-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/school-session-types-list';
+import { component } from 'frontend/tests/pages/components/school-session-types-list';
 
 module('Integration | Component | school session types list', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-vocabularies-collapsed-test.js
+++ b/tests/integration/components/school-vocabularies-collapsed-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/school-vocabularies-collapsed';
+import { component } from 'frontend/tests/pages/components/school-vocabularies-collapsed';
 
 module('Integration | Component | school vocabularies collapsed', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-vocabularies-expanded-test.js
+++ b/tests/integration/components/school-vocabularies-expanded-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { component } from 'ilios/tests/pages/components/school-vocabularies-expanded';
+import { component } from 'frontend/tests/pages/components/school-vocabularies-expanded';
 
 module('Integration | Component | school vocabularies expanded', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-vocabularies-list-test.js
+++ b/tests/integration/components/school-vocabularies-list-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school-vocabularies-list';
+import { component } from 'frontend/tests/pages/components/school-vocabularies-list';
 
 module('Integration | Component | school vocabularies list', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school-vocabulary-manager-test.js
+++ b/tests/integration/components/school-vocabulary-manager-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/school-vocabulary-manager';
+import { component } from 'frontend/tests/pages/components/school-vocabulary-manager';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | school vocabulary manager', function (hooks) {

--- a/tests/integration/components/school-vocabulary-new-term-test.js
+++ b/tests/integration/components/school-vocabulary-new-term-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/school-vocabulary-new-term';
+import { component } from 'frontend/tests/pages/components/school-vocabulary-new-term';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | school vocabulary new term', function (hooks) {

--- a/tests/integration/components/school-vocabulary-term-manager-test.js
+++ b/tests/integration/components/school-vocabulary-term-manager-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school-vocabulary-term-manager';
+import { component } from 'frontend/tests/pages/components/school-vocabulary-term-manager';
 
 module('Integration | Component | school vocabulary term manager', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school/session-type-visualize-vocabularies-test.js
+++ b/tests/integration/components/school/session-type-visualize-vocabularies-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school/session-type-visualize-vocabularies';
+import { component } from 'frontend/tests/pages/components/school/session-type-visualize-vocabularies';
 
 module('Integration | Component | school/session-type-visualize-vocabularies', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school/session-type-visualize-vocabulary-test.js
+++ b/tests/integration/components/school/session-type-visualize-vocabulary-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school/session-type-visualize-vocabulary';
+import { component } from 'frontend/tests/pages/components/school/session-type-visualize-vocabulary';
 
 module('Integration | Component | school/session-type-visualize-vocabulary', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school/visualizer-session-type-vocabularies-test.js
+++ b/tests/integration/components/school/visualizer-session-type-vocabularies-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school/visualizer-session-type-vocabularies';
+import { component } from 'frontend/tests/pages/components/school/visualizer-session-type-vocabularies';
 
 module('Integration | Component | school/visualizer-session-type-vocabularies', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/school/visualizer-session-type-vocabulary-test.js
+++ b/tests/integration/components/school/visualizer-session-type-vocabulary-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/school/visualizer-session-type-vocabulary';
+import { component } from 'frontend/tests/pages/components/school/visualizer-session-type-vocabulary';
 
 module('Integration | Component | school/visualizer-session-type-vocabulary', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/unassigned-students-summary-test.js
+++ b/tests/integration/components/unassigned-students-summary-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupAuthentication } from 'ilios-common';
-import { component } from 'ilios/tests/pages/components/unassigned-students-summary';
+import { component } from 'frontend/tests/pages/components/unassigned-students-summary';
 
 module('Integration | Component | unassigned students summary', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/user-list-test.js
+++ b/tests/integration/components/user-list-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/user-list';
+import { component } from 'frontend/tests/pages/components/user-list';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | user list', function (hooks) {

--- a/tests/integration/components/user-menu-test.js
+++ b/tests/integration/components/user-menu-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import component from 'ilios/tests/pages/components/user-menu';
+import component from 'frontend/tests/pages/components/user-menu';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { setupAuthentication } from 'ilios-common';
 import { setupMirage } from 'ember-cli-mirage/test-support';

--- a/tests/integration/components/user-profile-bio-test.js
+++ b/tests/integration/components/user-profile-bio-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { component } from 'ilios/tests/pages/components/user-profile-bio';
+import { component } from 'frontend/tests/pages/components/user-profile-bio';
 
 module('Integration | Component | user profile bio', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/user-profile-cohorts-details-test.js
+++ b/tests/integration/components/user-profile-cohorts-details-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/user-profile-cohorts-details';
+import { component } from 'frontend/tests/pages/components/user-profile-cohorts-details';
 
 module('Integration | Component | user-profile-cohorts-details', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/user-profile-cohorts-manager-test.js
+++ b/tests/integration/components/user-profile-cohorts-manager-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupAuthentication } from 'ilios-common';
-import { component } from 'ilios/tests/pages/components/user-profile-cohorts-manager';
+import { component } from 'frontend/tests/pages/components/user-profile-cohorts-manager';
 
 module('Integration | Component | user-profile-cohorts-manager', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/user-profile-cohorts-test.js
+++ b/tests/integration/components/user-profile-cohorts-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupAuthentication } from 'ilios-common';
-import { component } from 'ilios/tests/pages/components/user-profile-cohorts';
+import { component } from 'frontend/tests/pages/components/user-profile-cohorts';
 
 module('Integration | Component | user profile cohorts', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/user-profile-ics-test.js
+++ b/tests/integration/components/user-profile-ics-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render, waitUntil } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/user-profile-ics';
+import { component } from 'frontend/tests/pages/components/user-profile-ics';
 
 module('Integration | Component | user profile ics', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/user-profile-permissions-test.js
+++ b/tests/integration/components/user-profile-permissions-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { DateTime } from 'luxon';
-import { component } from 'ilios/tests/pages/components/user-profile-permissions';
+import { component } from 'frontend/tests/pages/components/user-profile-permissions';
 import { freezeDateAt, unfreezeDate } from 'ilios-common';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 

--- a/tests/integration/components/user-profile-roles-test.js
+++ b/tests/integration/components/user-profile-roles-test.js
@@ -4,7 +4,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/user-profile-roles';
+import { component } from 'frontend/tests/pages/components/user-profile-roles';
 
 module('Integration | Component | user profile roles', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/user-profile-test.js
+++ b/tests/integration/components/user-profile-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/user-profile';
+import { component } from 'frontend/tests/pages/components/user-profile';
 
 module('Integration | Component | user-profile', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/user-profile/learner-group-test.js
+++ b/tests/integration/components/user-profile/learner-group-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';

--- a/tests/integration/components/user-profile/learner-groups-test.js
+++ b/tests/integration/components/user-profile/learner-groups-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ilios/tests/helpers';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { component } from 'ilios/tests/pages/components/user-profile/learner-groups';
+import { component } from 'frontend/tests/pages/components/user-profile/learner-groups';
 
 module('Integration | Component | user-profile/learner-groups', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/yes-no-test.js
+++ b/tests/integration/components/yes-no-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { component } from 'ilios/tests/pages/components/yes-no';
+import { component } from 'frontend/tests/pages/components/yes-no';
 
 module('Integration | Component | yes-no', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/pages/components/curriculum-inventory/verification-preview.js
+++ b/tests/pages/components/curriculum-inventory/verification-preview.js
@@ -1,13 +1,13 @@
 import { create, collection, text } from 'ember-cli-page-object';
-import table1 from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table1';
-import table2 from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table2';
-import table3a from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table3a';
-import table3b from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table3b';
-import table4 from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table4';
-import table5 from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table5';
-import table6 from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table6';
-import table7 from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table7';
-import table8 from 'ilios/tests/pages/components/curriculum-inventory/verification-preview-table8';
+import table1 from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table1';
+import table2 from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table2';
+import table3a from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table3a';
+import table3b from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table3b';
+import table4 from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table4';
+import table5 from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table5';
+import table6 from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table6';
+import table7 from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table7';
+import table8 from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table8';
 
 const definition = {
   scope: '[data-test-curriculum-inventory-verification-preview]',

--- a/tests/pages/components/ilios-header.js
+++ b/tests/pages/components/ilios-header.js
@@ -1,5 +1,5 @@
 import { create, text } from 'ember-cli-page-object';
-import searchBox from 'ilios/tests/pages/components/global-search-box';
+import searchBox from 'frontend/tests/pages/components/global-search-box';
 
 const definition = {
   scope: '[data-test-ilios-header]',

--- a/tests/pages/components/ilios-users.js
+++ b/tests/pages/components/ilios-users.js
@@ -1,6 +1,6 @@
 import { clickable, create, fillable, value } from 'ember-cli-page-object';
-import newUserForm from 'ilios/tests/pages/components/new-user';
-import userList from 'ilios/tests/pages/components/user-list';
+import newUserForm from 'frontend/tests/pages/components/new-user';
+import userList from 'frontend/tests/pages/components/user-list';
 import pagedlistControls from 'ilios-common/page-objects/components/pagedlist-controls';
 
 const definition = {

--- a/tests/pages/components/school-session-type-manager.js
+++ b/tests/pages/components/school-session-type-manager.js
@@ -1,6 +1,6 @@
 import { create, text } from 'ember-cli-page-object';
 
-import form from 'ilios/tests/pages/components/school-session-type-form';
+import form from 'frontend/tests/pages/components/school-session-type-form';
 
 const definition = {
   scope: '[data-test-school-session-type-manager]',

--- a/tests/pages/components/user-profile.js
+++ b/tests/pages/components/user-profile.js
@@ -1,12 +1,12 @@
 import { create } from 'ember-cli-page-object';
 
-import bio from 'ilios/tests/pages/components/user-profile-bio';
-import calendar from 'ilios/tests/pages/components/user-profile-calendar';
-import cohorts from 'ilios/tests/pages/components/user-profile-cohorts';
-import ics from 'ilios/tests/pages/components/user-profile-ics';
-import learnerGroups from 'ilios/tests/pages/components/user-profile/learner-groups';
-import permissions from 'ilios/tests/pages/components/user-profile-permissions';
-import roles from 'ilios/tests/pages/components/user-profile-roles';
+import bio from 'frontend/tests/pages/components/user-profile-bio';
+import calendar from 'frontend/tests/pages/components/user-profile-calendar';
+import cohorts from 'frontend/tests/pages/components/user-profile-cohorts';
+import ics from 'frontend/tests/pages/components/user-profile-ics';
+import learnerGroups from 'frontend/tests/pages/components/user-profile/learner-groups';
+import permissions from 'frontend/tests/pages/components/user-profile-permissions';
+import roles from 'frontend/tests/pages/components/user-profile-roles';
 import toggleButtons from 'ilios-common/page-objects/components/toggle-buttons';
 
 // @todo flesh this out. [ST 2023/09/08]

--- a/tests/pages/curriculum-inventory-report-rollover.js
+++ b/tests/pages/curriculum-inventory-report-rollover.js
@@ -1,6 +1,6 @@
 import { create, visitable } from 'ember-cli-page-object';
-import details from 'ilios/tests/pages/components/curriculum-inventory/report-details';
-import rollover from 'ilios/tests/pages/components/curriculum-inventory/report-rollover';
+import details from 'frontend/tests/pages/components/curriculum-inventory/report-details';
+import rollover from 'frontend/tests/pages/components/curriculum-inventory/report-rollover';
 
 export default create({
   visit: visitable('/curriculum-inventory-reports/:reportId/rollover'),

--- a/tests/pages/curriculum-inventory-report.js
+++ b/tests/pages/curriculum-inventory-report.js
@@ -1,6 +1,6 @@
 import { create, visitable } from 'ember-cli-page-object';
-import details from 'ilios/tests/pages/components/curriculum-inventory/report-details';
-import blocks from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-list';
+import details from 'frontend/tests/pages/components/curriculum-inventory/report-details';
+import blocks from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-list';
 
 export default create({
   visit: visitable('/curriculum-inventory-reports/:reportId'),

--- a/tests/pages/curriculum-inventory-reports.js
+++ b/tests/pages/curriculum-inventory-reports.js
@@ -1,5 +1,5 @@
 import { create, visitable } from 'ember-cli-page-object';
-import reports from 'ilios/tests/pages/components/curriculum-inventory/reports';
+import reports from 'frontend/tests/pages/components/curriculum-inventory/reports';
 
 export default create({
   visit: visitable('/curriculum-inventory-reports'),

--- a/tests/pages/curriculum-inventory-sequence-block.js
+++ b/tests/pages/curriculum-inventory-sequence-block.js
@@ -1,7 +1,7 @@
 import { create, visitable } from 'ember-cli-page-object';
 
-import blocks from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-list';
-import overview from 'ilios/tests/pages/components/curriculum-inventory/sequence-block-overview';
+import blocks from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-list';
+import overview from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-overview';
 
 export default create({
   visit: visitable('/curriculum-inventory-sequence-block/:blockId'),

--- a/tests/pages/dashboard.js
+++ b/tests/pages/dashboard.js
@@ -1,5 +1,5 @@
 import { create, visitable } from 'ember-cli-page-object';
-import iliosHeader from 'ilios/tests/pages/components/ilios-header';
+import iliosHeader from 'frontend/tests/pages/components/ilios-header';
 
 export default create({
   visit: visitable('/dashboard/week'),

--- a/tests/pages/search.js
+++ b/tests/pages/search.js
@@ -1,7 +1,7 @@
 import { create, visitable } from 'ember-cli-page-object';
 
-import globalSearch from 'ilios/tests/pages/components/global-search';
-import paginationLinks from 'ilios/tests/pages/components/pagination-links';
+import globalSearch from 'frontend/tests/pages/components/global-search';
+import paginationLinks from 'frontend/tests/pages/components/pagination-links';
 
 export default create({
   visit: visitable('/search'),

--- a/tests/pages/user.js
+++ b/tests/pages/user.js
@@ -1,6 +1,6 @@
 import { clickable, create, property, text, visitable } from 'ember-cli-page-object';
-import bio from 'ilios/tests/pages/components/user-profile-bio';
-import cohorts from 'ilios/tests/pages/components/user-profile-cohorts';
+import bio from 'frontend/tests/pages/components/user-profile-bio';
+import cohorts from 'frontend/tests/pages/components/user-profile-cohorts';
 
 export default create({
   scope: '[data-test-user-profile]',

--- a/tests/pages/users.js
+++ b/tests/pages/users.js
@@ -1,6 +1,6 @@
 import { create, visitable } from 'ember-cli-page-object';
-import root from 'ilios/tests/pages/components/ilios-users';
-import backToAdminDashboard from 'ilios/tests/pages/components/back-to-admin-dashboard';
+import root from 'frontend/tests/pages/components/ilios-users';
+import backToAdminDashboard from 'frontend/tests/pages/components/back-to-admin-dashboard';
 
 export default create({
   visit: visitable('/users'),

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,5 +1,5 @@
-import Application from 'ilios/app';
-import config from 'ilios/config/environment';
+import Application from 'frontend/app';
+import config from 'frontend/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';

--- a/tests/unit/controllers/reports-test.js
+++ b/tests/unit/controllers/reports-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ilios/tests/helpers';
+import { setupTest } from 'frontend/tests/helpers';
 
 module('Unit | Controller | reports', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/initializers/inflector-test.js
+++ b/tests/unit/initializers/inflector-test.js
@@ -1,6 +1,6 @@
 import Application from '@ember/application';
-import config from 'ilios/config/environment';
-import { initialize } from 'ilios/initializers/inflector';
+import config from 'frontend/config/environment';
+import { initialize } from 'frontend/initializers/inflector';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
 import { pluralize } from 'ember-inflector';

--- a/tests/unit/initializers/metrics-imports-test.js
+++ b/tests/unit/initializers/metrics-imports-test.js
@@ -1,6 +1,6 @@
 import Application from '@ember/application';
-import config from 'ilios/config/environment';
-import { initialize } from 'ilios/initializers/metrics-imports';
+import config from 'frontend/config/environment';
+import { initialize } from 'frontend/initializers/metrics-imports';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
 import { run } from '@ember/runloop';

--- a/tests/unit/mixins/live-search-item-test.js
+++ b/tests/unit/mixins/live-search-item-test.js
@@ -1,5 +1,5 @@
 import EmberObject from '@ember/object';
-import LiveSearchItemMixin from 'ilios/mixins/live-search-item';
+import LiveSearchItemMixin from 'frontend/mixins/live-search-item';
 import { module, test } from 'qunit';
 
 module('LiveSearchItemMixin', function () {

--- a/tests/unit/services/graphql-test.js
+++ b/tests/unit/services/graphql-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ilios/tests/helpers';
+import { setupTest } from 'frontend/tests/helpers';
 
 module('Unit | Service | graphql', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/utils/clone-learner-group-test.js
+++ b/tests/unit/utils/clone-learner-group-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import RSVP from 'rsvp';
-import cloneLearnerGroup from 'ilios/utils/clone-learner-group';
+import cloneLearnerGroup from 'frontend/utils/clone-learner-group';
 import { module, test } from 'qunit';
 
 const { resolve } = RSVP;

--- a/tests/unit/utils/launch-worker-test.js
+++ b/tests/unit/utils/launch-worker-test.js
@@ -1,4 +1,4 @@
-import { launchWorker } from 'ilios/utils/launch-worker';
+import { launchWorker } from 'frontend/utils/launch-worker';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | launch-worker', function () {

--- a/tests/unit/utils/readable-file-size-test.js
+++ b/tests/unit/utils/readable-file-size-test.js
@@ -1,4 +1,4 @@
-import readableFileSize from 'ilios/utils/readable-file-size';
+import readableFileSize from 'frontend/utils/readable-file-size';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | readable file size', function () {

--- a/tests/unit/utils/sort-cohorts-test.js
+++ b/tests/unit/utils/sort-cohorts-test.js
@@ -1,4 +1,4 @@
-import sortCohorts from 'ilios/utils/sort-cohorts';
+import sortCohorts from 'frontend/utils/sort-cohorts';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 


### PR DESCRIPTION
We called this package ilios, which is nice, but it's going to be annoying when dealing with it in a monorepo. I've changed the name everywhere (except the <title> tag) to be frontend.

Requires ilios/common#3680