### PR TITLE
Remove error from route splitting againg

### DIFF
--- a/packages/frontend/ember-cli-build.js
+++ b/packages/frontend/ember-cli-build.js
@@ -76,7 +76,7 @@ module.exports = function (defaults) {
         'dashboard.activities',
         'dashboard.calendar',
         'dashboard.materials',
-        'error',
+        // 'error', don't ever split the error route, it will break error handling
         'events',
         'four-oh-four',
         /instructor[a-z-]*/,


### PR DESCRIPTION
If we split this route then ember's default error substate system doesn't work anymore.

This is re-adding [1d2bfe0] which got lost when I disable embroider.