### PR TITLE
Add watchDependencies config for common

### DIFF
--- a/packages/frontend/ember-cli-build.js
+++ b/packages/frontend/ember-cli-build.js
@@ -49,6 +49,7 @@ module.exports = function (defaults) {
     },
     autoImport: {
       insertScriptsAt: 'auto-import-scripts',
+      watchDependencies: ['ilios-common'],
     },
     'ember-fetch': {
       preferNative: true,


### PR DESCRIPTION
This is in the blueprint for new addons. I'm not sure we need it here yet, but it seems like a good idea to add it now instead of spending two days searching for why something isn't working in the future.