### PR TITLE
Dasherize route names

### DIFF
--- a/packages/frontend/app/components/ilios-navigation.hbs
+++ b/packages/frontend/app/components/ilios-navigation.hbs
@@ -71,7 +71,7 @@
                 "course-visualize-vocabularies"
                 "course-visualize-vocabulary"
                 "courses"
-                "print_course"
+                "print-course"
               )
             }}
           >

--- a/packages/frontend/tests/acceptance/course/publicationcheck-test.js
+++ b/packages/frontend/tests/acceptance/course/publicationcheck-test.js
@@ -43,7 +43,7 @@ module('Acceptance | Course - Publication Check', function (hooks) {
     assert.expect(7);
     await page.visit({ courseId: this.fullCourse.id });
     assert.strictEqual(page.publicationcheck.backToCourse.url, '/courses/1');
-    assert.strictEqual(currentRouteName(), 'course.publication_check');
+    assert.strictEqual(currentRouteName(), 'course.publication-check');
     assert.strictEqual(page.publicationcheck.courseTitle, 'course 0');
     assert.strictEqual(page.publicationcheck.cohorts, 'Yes (1)');
     assert.strictEqual(page.publicationcheck.terms, 'Yes (1)');
@@ -53,7 +53,7 @@ module('Acceptance | Course - Publication Check', function (hooks) {
 
   test('empty course count', async function (assert) {
     await page.visit({ courseId: this.emptyCourse.id });
-    assert.strictEqual(currentRouteName(), 'course.publication_check');
+    assert.strictEqual(currentRouteName(), 'course.publication-check');
     assert.strictEqual(page.publicationcheck.courseTitle, 'course 1');
     assert.strictEqual(page.publicationcheck.cohorts, 'No');
     assert.strictEqual(page.publicationcheck.terms, 'No');

--- a/packages/frontend/tests/acceptance/course/session/publicationcheck-test.js
+++ b/packages/frontend/tests/acceptance/course/session/publicationcheck-test.js
@@ -33,7 +33,7 @@ module('Acceptance | Session - Publication Check', function (hooks) {
     this.server.create('offering', { session });
     await page.visit({ courseId: this.course.id, sessionId: session.id });
     await percySnapshot(assert);
-    assert.strictEqual(currentRouteName(), 'session.publication_check');
+    assert.strictEqual(currentRouteName(), 'session.publication-check');
     assert.strictEqual(page.sessionTitle, 'session 0');
     assert.strictEqual(page.offerings, 'Yes (1)');
     assert.strictEqual(page.terms, 'Yes (1)');

--- a/packages/ilios-common/addon/common-routes.js
+++ b/packages/ilios-common/addon/common-routes.js
@@ -24,7 +24,7 @@ export function courseRoutes(router) {
       resetNamespace: true,
     },
     function () {
-      this.route('publication_check', { path: '/publicationcheck' });
+      this.route('publication-check', { path: '/publicationcheck' });
       this.route('publishall');
       this.route('rollover');
       this.route(
@@ -34,14 +34,14 @@ export function courseRoutes(router) {
           resetNamespace: true,
         },
         function () {
-          this.route('publication_check', { path: '/publicationcheck' });
+          this.route('publication-check', { path: '/publicationcheck' });
           this.route('copy');
         },
       );
     },
   );
   router.route('course-materials', { path: 'courses/:course_id/materials' });
-  router.route('print_course', { path: 'course/:course_id/print' });
+  router.route('print-course', { path: 'course/:course_id/print' });
   router.route('course-visualizations', {
     path: 'data/courses/:course_id',
   });

--- a/packages/ilios-common/addon/components/course-overview.hbs
+++ b/packages/ilios-common/addon/components/course-overview.hbs
@@ -18,7 +18,7 @@
           />
         </LinkTo>
         <LinkTo
-          @route="print_course"
+          @route="print-course"
           @model={{@course}}
           @query={{hash unpublished=true}}
           class="print"

--- a/packages/ilios-common/addon/components/course-summary-header.hbs
+++ b/packages/ilios-common/addon/components/course-summary-header.hbs
@@ -18,7 +18,7 @@
         </LinkTo>
       {{/if}}
       <LinkTo
-        @route="print_course"
+        @route="print-course"
         @model={{@course}}
         @query={{hash unpublished=true}}
         class="print"

--- a/packages/ilios-common/addon/components/course/publication-menu.js
+++ b/packages/ilios-common/addon/components/course/publication-menu.js
@@ -39,7 +39,7 @@ export default class CoursePublicationMenuComponent extends Component {
     );
   }
   get showReview() {
-    if (this.router.currentRouteName === 'course.publication_check') {
+    if (this.router.currentRouteName === 'course.publication-check') {
       return false;
     }
     return this.args.course.allPublicationIssuesLength > 0;
@@ -115,7 +115,7 @@ export default class CoursePublicationMenuComponent extends Component {
   @action
   scrollToCoursePublication() {
     this.isOpen = false;
-    this.router.transitionTo('course.publication_check', this.args.course);
+    this.router.transitionTo('course.publication-check', this.args.course);
   }
   @action
   async publish() {

--- a/packages/ilios-common/addon/components/session/publication-menu.js
+++ b/packages/ilios-common/addon/components/session/publication-menu.js
@@ -43,7 +43,7 @@ export default class SessionPublicationMenuComponent extends Component {
     );
   }
   get showReview() {
-    if (this.router.currentRouteName === 'session.publication_check') {
+    if (this.router.currentRouteName === 'session.publication-check') {
       return false;
     }
     return !this.hideCheckLink && this.args.session.allPublicationIssuesLength > 0;
@@ -119,7 +119,7 @@ export default class SessionPublicationMenuComponent extends Component {
   @action
   scrollToSessionPublication() {
     this.isOpen = false;
-    this.router.transitionTo('session.publication_check', this.args.session);
+    this.router.transitionTo('session.publication-check', this.args.session);
   }
   @action
   async publish() {


### PR DESCRIPTION
Both the print_course and publication_check routes did not match all of our other routes with a dasherized name. This caused our embroider route splitting to fail for these locations.

Fixes ilios/ilios#5213