### PR TITLE
update ember-concurrency task implementations

### DIFF
--- a/packages/frontend/app/components/bulk-new-users.js
+++ b/packages/frontend/app/components/bulk-new-users.js
@@ -74,13 +74,12 @@ export default class BulkNewUsersComponent extends Component {
     return this.cohorts.slice().reverse()[0];
   }
 
-  @restartableTask
-  *load() {
-    const user = yield this.currentUser.getModel();
-    this.primarySchool = yield user.school;
-    this.schools = yield this.loadSchools.perform();
-    this.cohorts = yield this.loadCohorts.perform(this.bestSelectedSchool);
-  }
+  load = restartableTask(async () => {
+    const user = await this.currentUser.getModel();
+    this.primarySchool = await user.school;
+    this.schools = await this.loadSchools.perform();
+    this.cohorts = await this.loadCohorts.perform(this.bestSelectedSchool);
+  });
 
   @action
   toggleUserSelection(obj) {
@@ -144,53 +143,49 @@ export default class BulkNewUsersComponent extends Component {
     });
   }
 
-  @restartableTask
-  *updateSelectedFile(files) {
+  updateSelectedFile = restartableTask(async files => {
     // Check for the various File API support.
     if (window.File && window.FileReader && window.FileList && window.Blob) {
       if (files.length > 0) {
-        yield this.parseFile.perform(files[0]);
+        await this.parseFile.perform(files[0]);
       }
     } else {
       throw new Error(this.intl.t('general.unsupportedBrowserFailure'));
     }
-  }
+  });
 
-  @restartableTask
-  *setSchool(id) {
+  setSchool = restartableTask(async id => {
     this.schoolId = id;
-    this.cohorts = yield this.loadCohorts.perform(this.bestSelectedSchool);
-  }
+    this.cohorts = await this.loadCohorts.perform(this.bestSelectedSchool);
+  });
 
-  @restartableTask
-  *parseFile(file) {
-    const proposedUsers = yield this.getFileContents(file);
-    const existingUsernames = yield this.existingUsernames();
+  parseFile = restartableTask(async file => {
+    const proposedUsers = await this.getFileContents(file);
+    const existingUsernames = await this.existingUsernames();
     const filledOutUsers = proposedUsers.map((obj) => {
       obj.existingUsernames = existingUsernames;
 
       return obj;
     });
-    this.validUsers = yield filter(filledOutUsers, async (obj) => {
+    this.validUsers = await filter(filledOutUsers, async (obj) => {
       return await obj.isValid();
     });
 
     this.selectedUsers = this.validUsers;
     this.proposedUsers = filledOutUsers;
-  }
+  });
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.savedUserIds = [];
     const nonStudentMode = this.nonStudentMode;
     const selectedSchool = this.bestSelectedSchool;
     const selectedCohort = this.bestSelectedCohort;
-    const roles = yield this.store.findAll('user-role');
+    const roles = await this.store.findAll('user-role');
     const studentRole = findById(roles.slice(), '4');
 
     const proposedUsers = this.selectedUsers;
 
-    const validUsers = yield filter(proposedUsers, async (obj) => {
+    const validUsers = await filter(proposedUsers, async (obj) => {
       return obj.isValid();
     });
 
@@ -244,9 +239,9 @@ export default class BulkNewUsersComponent extends Component {
       try {
         parts = records.splice(0, 10);
         const users = mapBy(parts, 'user');
-        yield all(users.map((user) => user.save()));
+        await all(users.map((user) => user.save()));
         const authentications = mapBy(parts, 'authentication');
-        yield all(authentications.map((auth) => auth.save()));
+        await all(authentications.map((auth) => auth.save()));
       } catch (e) {
         const userErrors = parts.filter((obj) => obj.user.get('isError'));
         const authenticationErrors = parts.filter(
@@ -274,29 +269,27 @@ export default class BulkNewUsersComponent extends Component {
     this.validUsers = [];
     this.selectedUsers = [];
     this.proposedUsers = [];
-  }
+  });
 
-  @restartableTask
-  *loadSchools() {
-    const schools = yield this.store.findAll('school', { reload: true });
+  loadSchools = restartableTask(async () => {
+    const schools = await this.store.findAll('school', { reload: true });
     return filter(schools.slice(), async (school) => {
       return this.permissionChecker.canCreateUser(school);
     });
-  }
+  });
 
-  @restartableTask
-  *loadCohorts(school) {
-    const cohorts = yield this.store.query('cohort', {
+  loadCohorts = restartableTask(async school => {
+    const cohorts = await this.store.query('cohort', {
       filters: {
         schools: [school.id],
       },
     });
 
     //prefetch programYears and programs so that ember data will coalesce these requests.
-    const programYears = yield all(mapBy(cohorts.slice(), 'programYear'));
-    yield all(mapBy(programYears.slice(), 'program'));
+    const programYears = await all(mapBy(cohorts.slice(), 'programYear'));
+    await all(mapBy(programYears.slice(), 'program'));
 
-    const objects = yield all(
+    const objects = await all(
       cohorts.slice().map(async (cohort) => {
         const obj = {
           id: cohort.get('id'),
@@ -317,7 +310,7 @@ export default class BulkNewUsersComponent extends Component {
       const finalYear = parseInt(obj.startYear, 10) + parseInt(obj.duration, 10);
       return finalYear > lastYear;
     });
-  }
+  });
 }
 
 @validatable

--- a/packages/frontend/app/components/bulk-new-users.js
+++ b/packages/frontend/app/components/bulk-new-users.js
@@ -143,7 +143,7 @@ export default class BulkNewUsersComponent extends Component {
     });
   }
 
-  updateSelectedFile = restartableTask(async files => {
+  updateSelectedFile = restartableTask(async (files) => {
     // Check for the various File API support.
     if (window.File && window.FileReader && window.FileList && window.Blob) {
       if (files.length > 0) {
@@ -154,12 +154,12 @@ export default class BulkNewUsersComponent extends Component {
     }
   });
 
-  setSchool = restartableTask(async id => {
+  setSchool = restartableTask(async (id) => {
     this.schoolId = id;
     this.cohorts = await this.loadCohorts.perform(this.bestSelectedSchool);
   });
 
-  parseFile = restartableTask(async file => {
+  parseFile = restartableTask(async (file) => {
     const proposedUsers = await this.getFileContents(file);
     const existingUsernames = await this.existingUsernames();
     const filledOutUsers = proposedUsers.map((obj) => {
@@ -278,7 +278,7 @@ export default class BulkNewUsersComponent extends Component {
     });
   });
 
-  loadCohorts = restartableTask(async school => {
+  loadCohorts = restartableTask(async (school) => {
     const cohorts = await this.store.query('cohort', {
       filters: {
         schools: [school.id],

--- a/packages/frontend/app/components/competency-title-editor.js
+++ b/packages/frontend/app/components/competency-title-editor.js
@@ -18,14 +18,13 @@ export default class CompetencyTitleEditorComponent extends Component {
     this.title = this.args.competency.title;
   }
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid('title');
+    const isValid = await this.isValid('title');
     if (!isValid) {
       return false;
     }
     this.args.competency.set('title', this.title);
     this.removeErrorDisplayFor('title');
-  }
+  });
 }

--- a/packages/frontend/app/components/connection-status.js
+++ b/packages/frontend/app/components/connection-status.js
@@ -49,7 +49,7 @@ export default class ConnectionStatusComponent extends Component {
     }
   }
 
-  changeConnectionState = restartableTask(async isOnline => {
+  changeConnectionState = restartableTask(async (isOnline) => {
     this.timer = 5;
     this.multiplier = 1;
     this.stopAttemptingToReconnect = false;
@@ -61,7 +61,7 @@ export default class ConnectionStatusComponent extends Component {
     }
   });
 
-  reconnect = restartableTask(async force => {
+  reconnect = restartableTask(async (force) => {
     if (navigator.onLine) {
       this.changeConnectionState.perform(true);
     }

--- a/packages/frontend/app/components/connection-status.js
+++ b/packages/frontend/app/components/connection-status.js
@@ -49,28 +49,26 @@ export default class ConnectionStatusComponent extends Component {
     }
   }
 
-  @restartableTask
-  *changeConnectionState(isOnline) {
+  changeConnectionState = restartableTask(async isOnline => {
     this.timer = 5;
     this.multiplier = 1;
     this.stopAttemptingToReconnect = false;
     this.isOnline = isOnline;
     if (!isOnline) {
-      yield this.reconnect.perform();
+      await this.reconnect.perform();
     } else {
       this.reconnect.cancelAll();
     }
-  }
+  });
 
-  @restartableTask
-  *reconnect(force) {
+  reconnect = restartableTask(async force => {
     if (navigator.onLine) {
       this.changeConnectionState.perform(true);
     }
     if (force) {
       this.unableToReconnect = true;
       this.timer = 5;
-      yield timeout(2000);
+      await timeout(2000);
       this.unableToReconnect = false;
     } else if (this.timer > 1) {
       this.unableToReconnect = false;
@@ -78,14 +76,14 @@ export default class ConnectionStatusComponent extends Component {
     } else {
       if (!this.stopAttemptingToReconnect) {
         this.unableToReconnect = true;
-        yield timeout(2000);
+        await timeout(2000);
       }
       const newMultiplier = this.multiplier < 8 ? this.multiplier * 2 : 10;
       this.multiplier = newMultiplier;
       this.timer = 5 * newMultiplier;
     }
 
-    yield timeout(1000);
+    await timeout(1000);
     this.reconnect.perform();
-  }
+  });
 }

--- a/packages/frontend/app/components/courses/list.js
+++ b/packages/frontend/app/components/courses/list.js
@@ -39,25 +39,23 @@ export default class CoursesListComponent extends Component {
     return this.intl.t(translation);
   }
 
-  @task
-  *unlockCourse(course) {
-    const permission = yield this.permissionChecker.canUnlockCourse(course);
+  unlockCourse = task(async course => {
+    const permission = await this.permissionChecker.canUnlockCourse(course);
     this.startSavingCourse(course.id);
     if (permission) {
-      yield this.args.unlock(course);
+      await this.args.unlock(course);
       this.stopSavingCourse(course.id);
     }
-  }
+  });
 
-  @task
-  *lockCourse(course) {
-    const permission = yield this.permissionChecker.canUpdateCourse(course);
+  lockCourse = task(async course => {
+    const permission = await this.permissionChecker.canUpdateCourse(course);
     this.startSavingCourse(course.id);
     if (permission) {
-      yield this.args.lock(course);
+      await this.args.lock(course);
       this.stopSavingCourse(course.id);
     }
-  }
+  });
 
   @action
   confirmRemoval(course) {

--- a/packages/frontend/app/components/courses/list.js
+++ b/packages/frontend/app/components/courses/list.js
@@ -39,7 +39,7 @@ export default class CoursesListComponent extends Component {
     return this.intl.t(translation);
   }
 
-  unlockCourse = task(async course => {
+  unlockCourse = task(async (course) => {
     const permission = await this.permissionChecker.canUnlockCourse(course);
     this.startSavingCourse(course.id);
     if (permission) {
@@ -48,7 +48,7 @@ export default class CoursesListComponent extends Component {
     }
   });
 
-  lockCourse = task(async course => {
+  lockCourse = task(async (course) => {
     const permission = await this.permissionChecker.canUpdateCourse(course);
     this.startSavingCourse(course.id);
     if (permission) {

--- a/packages/frontend/app/components/courses/new.js
+++ b/packages/frontend/app/components/courses/new.js
@@ -45,20 +45,18 @@ export default class CoursesNewComponent extends Component {
     }
   }
 
-  @restartableTask
-  *load() {
-    this.academicYearCrossesCalendarYearBoundaries = yield this.iliosConfig.itemFromConfig(
+  load = restartableTask(async () => {
+    this.academicYearCrossesCalendarYearBoundaries = await this.iliosConfig.itemFromConfig(
       'academicYearCrossesCalendarYearBoundaries',
     );
     if (this.args.currentYear && this.years.includes(parseInt(this.args.currentYear.id, 10))) {
       this.setYear(this.args.currentYear.id);
     }
-  }
+  });
 
-  @dropTask
-  *saveCourse() {
+  saveCourse = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
@@ -69,6 +67,6 @@ export default class CoursesNewComponent extends Component {
       school: this.args.currentSchool,
       year: this.selectedYear,
     });
-    yield this.args.save(course);
-  }
+    await this.args.save(course);
+  });
 }

--- a/packages/frontend/app/components/courses/root.js
+++ b/packages/frontend/app/components/courses/root.js
@@ -145,24 +145,22 @@ export default class CoursesRootComponent extends Component {
     return defaultYear;
   }
 
-  @dropTask
-  *removeCourse(course) {
-    const courses = (yield this.selectedSchool.courses).slice();
+  removeCourse = dropTask(async course => {
+    const courses = ((await this.selectedSchool.courses)).slice();
     courses.splice(courses.indexOf(course), 1);
     this.selectedSchool.set('courses', courses);
-    yield course.destroyRecord();
+    await course.destroyRecord();
     this.deletedCourse = course;
     if (this.newCourse === course) {
       this.newCourse = null;
     }
-  }
+  });
 
-  @dropTask
-  *saveNewCourse(newCourse) {
+  saveNewCourse = dropTask(async newCourse => {
     newCourse.setDatesBasedOnYear();
-    this.newCourse = yield newCourse.save();
+    this.newCourse = await newCourse.save();
     this.showNewCourseForm = false;
-  }
+  });
 
   @action
   lockCourse(course) {

--- a/packages/frontend/app/components/courses/root.js
+++ b/packages/frontend/app/components/courses/root.js
@@ -145,8 +145,8 @@ export default class CoursesRootComponent extends Component {
     return defaultYear;
   }
 
-  removeCourse = dropTask(async course => {
-    const courses = ((await this.selectedSchool.courses)).slice();
+  removeCourse = dropTask(async (course) => {
+    const courses = (await this.selectedSchool.courses).slice();
     courses.splice(courses.indexOf(course), 1);
     this.selectedSchool.set('courses', courses);
     await course.destroyRecord();
@@ -156,7 +156,7 @@ export default class CoursesRootComponent extends Component {
     }
   });
 
-  saveNewCourse = dropTask(async newCourse => {
+  saveNewCourse = dropTask(async (newCourse) => {
     newCourse.setDatesBasedOnYear();
     this.newCourse = await newCourse.save();
     this.showNewCourseForm = false;

--- a/packages/frontend/app/components/curriculum-inventory/leadership-expanded.js
+++ b/packages/frontend/app/components/curriculum-inventory/leadership-expanded.js
@@ -28,23 +28,20 @@ export default class CurriculumInventoryLeadershipExpandedComponent extends Comp
     this.args.setIsManaging(true);
   }
 
-  @dropTask
-  *load() {
-    yield this.setBuffers();
-  }
+  load = dropTask(async () => {
+    await this.setBuffers();
+  });
 
-  @dropTask
-  *save() {
-    yield timeout(10);
+  save = dropTask(async () => {
+    await timeout(10);
     this.args.report.set('administrators', this.administrators);
     this.args.expand();
-    yield this.args.report.save();
+    await this.args.report.save();
     this.args.setIsManaging(false);
-  }
+  });
 
-  @dropTask
-  *cancel() {
-    yield this.setBuffers();
+  cancel = dropTask(async () => {
+    await this.setBuffers();
     this.args.setIsManaging(false);
-  }
+  });
 }

--- a/packages/frontend/app/components/curriculum-inventory/new-report.js
+++ b/packages/frontend/app/components/curriculum-inventory/new-report.js
@@ -23,11 +23,10 @@ export default class CurriculumInventoryNewReportComponent extends Component {
     this.description = this.intl.t('general.curriculumInventoryReport');
   }
 
-  @restartableTask
-  *load() {
+  load = restartableTask(async () => {
     const years = [];
     const currentYear = new Date().getFullYear();
-    this.academicYearCrossesCalendarYearBoundaries = yield this.iliosConfig.itemFromConfig(
+    this.academicYearCrossesCalendarYearBoundaries = await this.iliosConfig.itemFromConfig(
       'academicYearCrossesCalendarYearBoundaries',
     );
     for (let id = currentYear - 5, n = currentYear + 5; id <= n; id++) {
@@ -40,12 +39,11 @@ export default class CurriculumInventoryNewReportComponent extends Component {
     }
     this.years = years;
     this.selectedYear = findById(years, currentYear);
-  }
+  });
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplaysFor(['name', 'description']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
@@ -64,8 +62,8 @@ export default class CurriculumInventoryNewReportComponent extends Component {
       endDate,
       description: this.description,
     });
-    yield this.args.save(report);
-  }
+    await this.args.save(report);
+  });
 
   @action
   setSelectedYear(year) {
@@ -73,17 +71,16 @@ export default class CurriculumInventoryNewReportComponent extends Component {
     this.selectedYear = findById(this.years, id);
   }
 
-  @dropTask
-  *keyboard(ev) {
+  keyboard = dropTask(async ev => {
     const keyCode = ev.keyCode;
 
     if (13 === keyCode) {
-      yield this.save.perform();
+      await this.save.perform();
       return;
     }
 
     if (27 === keyCode) {
       this.args.cancel();
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/curriculum-inventory/new-report.js
+++ b/packages/frontend/app/components/curriculum-inventory/new-report.js
@@ -71,7 +71,7 @@ export default class CurriculumInventoryNewReportComponent extends Component {
     this.selectedYear = findById(this.years, id);
   }
 
-  keyboard = dropTask(async ev => {
+  keyboard = dropTask(async (ev) => {
     const keyCode = ev.keyCode;
 
     if (13 === keyCode) {

--- a/packages/frontend/app/components/curriculum-inventory/new-sequence-block.js
+++ b/packages/frontend/app/components/curriculum-inventory/new-sequence-block.js
@@ -221,11 +221,10 @@ export default class CurriculumInventoryNewSequenceBlock extends Component {
     });
   }
 
-  @restartableTask
-  *load() {
+  load = restartableTask(async () => {
     this.orderInSequence = 0;
     if (this.isInOrderedSequence) {
-      const siblings = yield this.args.parent.children;
+      const siblings = await this.args.parent.children;
       for (let i = 0, n = siblings.slice().length + 1; i < n; i++) {
         this.orderInSequenceOptions.push(i + 1);
       }
@@ -234,39 +233,37 @@ export default class CurriculumInventoryNewSequenceBlock extends Component {
     this.childSequenceOrder = this.childSequenceOrderOptions[0];
     this.required = this.requiredOptions[0];
     if (this.args.parent) {
-      this.startingAcademicLevel = yield this.args.parent.startingAcademicLevel;
-      this.endingAcademicLevel = yield this.args.parent.endingAcademicLevel;
+      this.startingAcademicLevel = await this.args.parent.startingAcademicLevel;
+      this.endingAcademicLevel = await this.args.parent.endingAcademicLevel;
     }
     if (this.args.report) {
-      this.academicLevels = yield this.args.report.academicLevels;
+      this.academicLevels = await this.args.report.academicLevels;
       if (this.args.parent) {
-        this.startingAcademicLevel = yield this.args.parent.startingAcademicLevel;
-        this.endingAcademicLevel = yield this.args.parent.endingAcademicLevel;
+        this.startingAcademicLevel = await this.args.parent.startingAcademicLevel;
+        this.endingAcademicLevel = await this.args.parent.endingAcademicLevel;
       } else {
         this.startingAcademicLevel = this.academicLevels.slice()[0];
         this.endingAcademicLevel = this.academicLevels.slice()[0];
       }
-      this.linkableCourses = yield this.getLinkableCourses(this.args.report);
+      this.linkableCourses = await this.getLinkableCourses(this.args.report);
     }
-  }
+  });
 
-  @restartableTask
-  *reload() {
+  reload = restartableTask(async () => {
     if (this.args.report) {
-      this.academicLevels = yield this.args.report.academicLevels;
+      this.academicLevels = await this.args.report.academicLevels;
       if (this.args.parent) {
-        this.startingAcademicLevel = yield this.args.parent.startingAcademicLevel;
-        this.endingAcademicLevel = yield this.args.parent.endingAcademicLevel;
+        this.startingAcademicLevel = await this.args.parent.startingAcademicLevel;
+        this.endingAcademicLevel = await this.args.parent.endingAcademicLevel;
       } else {
         this.startingAcademicLevel = this.academicLevels.slice()[0];
         this.endingAcademicLevel = this.academicLevels.slice()[0];
       }
-      this.linkableCourses = yield this.getLinkableCourses(this.args.report);
+      this.linkableCourses = await this.getLinkableCourses(this.args.report);
     }
-  }
+  });
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplaysFor([
       'title',
       'duration',
@@ -276,7 +273,7 @@ export default class CurriculumInventoryNewSequenceBlock extends Component {
       'maximum',
       'endingAcademicLevel',
     ]);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
@@ -298,6 +295,6 @@ export default class CurriculumInventoryNewSequenceBlock extends Component {
       duration: this.duration || 0,
       report: this.args.report,
     });
-    yield this.args.save(block);
-  }
+    await this.args.save(block);
+  });
 }

--- a/packages/frontend/app/components/curriculum-inventory/report-details.js
+++ b/packages/frontend/app/components/curriculum-inventory/report-details.js
@@ -15,14 +15,13 @@ export default class CurriculumInventoryReportDetailsComponent extends Component
     return this.args.canUpdate && !this.isFinalizing;
   }
 
-  @dropTask
-  *finalize() {
+  finalize = dropTask(async () => {
     const newExport = this.store.createRecord('curriculumInventoryExport', {
       report: this.args.report,
     });
     this.showFinalizeConfirmation = false;
-    const savedExport = yield newExport.save();
+    const savedExport = await newExport.save();
     this.args.report.set('export', savedExport);
     this.args.setIsFinalized(true);
-  }
+  });
 }

--- a/packages/frontend/app/components/curriculum-inventory/report-header.js
+++ b/packages/frontend/app/components/curriculum-inventory/report-header.js
@@ -13,18 +13,17 @@ export default class CurriculumInventoryReportHeaderComponent extends Component 
     this.name = report?.name;
   }
 
-  @restartableTask
-  *saveName() {
+  saveName = restartableTask(async () => {
     this.addErrorDisplayFor('name');
-    const isValid = yield this.isValid('name');
+    const isValid = await this.isValid('name');
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('name');
     this.args.report.set('name', this.name);
-    yield this.args.report.save();
+    await this.args.report.save();
     this.name = this.args.report.name;
-  }
+  });
 
   @action
   revertNameChanges() {

--- a/packages/frontend/app/components/curriculum-inventory/report-overview.js
+++ b/packages/frontend/app/components/curriculum-inventory/report-overview.js
@@ -62,15 +62,14 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
     return this.year;
   }
 
-  @restartableTask
-  *load() {
+  load = restartableTask(async () => {
     const currentYear = new Date().getFullYear();
-    const program = yield this.args.report.program;
-    const school = yield program.school;
-    this.academicYearCrossesCalendarYearBoundaries = yield this.iliosConfig.itemFromConfig(
+    const program = await this.args.report.program;
+    const school = await program.school;
+    this.academicYearCrossesCalendarYearBoundaries = await this.iliosConfig.itemFromConfig(
       'academicYearCrossesCalendarYearBoundaries',
     );
-    this.canRollover = yield this.permissionChecker.canCreateCurriculumInventoryReport(school);
+    this.canRollover = await this.permissionChecker.canCreateCurriculumInventoryReport(school);
     const yearOptions = [];
     for (let i = currentYear - 5, n = currentYear + 5; i <= n; i++) {
       yearOptions.push({
@@ -83,19 +82,18 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
     this.year = this.args.report.year;
     this.startDate = this.args.report.startDate;
     this.endDate = this.args.report.endDate;
-  }
+  });
 
-  @dropTask
-  *changeStartDate() {
+  changeStartDate = dropTask(async () => {
     this.addErrorDisplayFor('startDate');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('startDate');
     this.args.report.startDate = this.startDate;
-    yield this.args.report.save();
-  }
+    await this.args.report.save();
+  });
 
   @action
   revertStartDateChanges() {
@@ -103,17 +101,16 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
     this.startDate = this.args.report.get.startDate;
   }
 
-  @dropTask
-  *changeEndDate() {
+  changeEndDate = dropTask(async () => {
     this.addErrorDisplayFor('endDate');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('endDate');
     this.args.report.endDate = this.endDate;
-    yield this.args.report.save();
-  }
+    await this.args.report.save();
+  });
 
   @action
   revertEndDateChanges() {
@@ -121,28 +118,26 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
     this.endDate = this.args.report.endDate;
   }
 
-  @dropTask
-  *changeYear() {
+  changeYear = dropTask(async () => {
     this.args.report.year = this.year;
-    yield this.args.report.save();
-  }
+    await this.args.report.save();
+  });
 
   @action
   revertYearChanges() {
     this.year = this.args.report.year;
   }
 
-  @dropTask
-  *changeDescription() {
+  changeDescription = dropTask(async () => {
     this.addErrorDisplayFor('description');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('description');
     this.args.report.description = this.description;
-    yield this.args.report.save();
-  }
+    await this.args.report.save();
+  });
 
   @action
   revertDescriptionChanges() {

--- a/packages/frontend/app/components/curriculum-inventory/report-rollover.js
+++ b/packages/frontend/app/components/curriculum-inventory/report-rollover.js
@@ -20,9 +20,8 @@ export default class CurriculumInventoryReportRolloverComponent extends Componen
   @tracked selectedProgram;
   @tracked programs = [];
 
-  @restartableTask
-  *load() {
-    const academicYearCrossesCalendarYearBoundaries = yield this.iliosConfig.itemFromConfig(
+  load = restartableTask(async () => {
+    const academicYearCrossesCalendarYearBoundaries = await this.iliosConfig.itemFromConfig(
       'academicYearCrossesCalendarYearBoundaries',
     );
     const thisYear = new Date().getFullYear();
@@ -45,9 +44,9 @@ export default class CurriculumInventoryReportRolloverComponent extends Componen
       selectedYear = findBy(years, 'year', reportYear + 1);
     }
 
-    const program = yield this.args.report.program;
-    const school = yield program.school;
-    const programs = yield school.programs;
+    const program = await this.args.report.program;
+    const school = await program.school;
+    const programs = await school.programs;
 
     this.selectedProgram = program;
     this.programs = programs.slice();
@@ -55,7 +54,7 @@ export default class CurriculumInventoryReportRolloverComponent extends Componen
     this.selectedYear = selectedYear.year;
     this.name = this.args.report.name;
     this.description = this.args.report.description;
-  }
+  });
 
   @action
   changeName(newName) {
@@ -79,10 +78,9 @@ export default class CurriculumInventoryReportRolloverComponent extends Componen
     }
   }
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplaysFor(['name', 'description']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
@@ -93,11 +91,11 @@ export default class CurriculumInventoryReportRolloverComponent extends Componen
       program: this.selectedProgram.id,
     };
     const url = `curriculuminventoryreports/${this.args.report.id}/rollover`;
-    const newReportObj = yield this.fetch.postQueryToApi(url, data);
+    const newReportObj = await this.fetch.postQueryToApi(url, data);
     this.flashMessages.success('general.curriculumInventoryReportRolloverSuccess');
     this.store.pushPayload(newReportObj);
     const newReport = this.store.peekRecord('curriculum-inventory-report', newReportObj.data.id);
     this.clearErrorDisplay();
     return this.args.visit(newReport);
-  }
+  });
 }

--- a/packages/frontend/app/components/curriculum-inventory/reports.js
+++ b/packages/frontend/app/components/curriculum-inventory/reports.js
@@ -65,8 +65,7 @@ export default class CurriculumInventoryReportsComponent extends Component {
     this.showNewCurriculumInventoryReportForm = false;
   }
 
-  @restartableTask
-  *load() {
+  load = restartableTask(async () => {
     if (!this.args.schools) {
       return;
     }
@@ -74,17 +73,17 @@ export default class CurriculumInventoryReportsComponent extends Component {
     this.hasMoreThanOneSchool = this.sortedSchools.length > 1;
 
     if (!this.args.schoolId) {
-      const user = yield this.currentUser.getModel();
-      this.selectedSchool = yield user.school;
+      const user = await this.currentUser.getModel();
+      this.selectedSchool = await user.school;
     } else {
       this.selectedSchool = findById(this.args.schools.slice(), this.args.schoolId);
     }
 
     if (this.selectedSchool) {
-      this.canCreate = yield this.permissionChecker.canCreateCurriculumInventoryReport(
+      this.canCreate = await this.permissionChecker.canCreateCurriculumInventoryReport(
         this.selectedSchool,
       );
-      const programs = yield this.selectedSchool.programs;
+      const programs = await this.selectedSchool.programs;
       this.programs = sortBy(programs.slice(), 'title');
     }
 
@@ -93,13 +92,12 @@ export default class CurriculumInventoryReportsComponent extends Component {
     } else {
       this.selectedProgram = this.programs.length ? this.programs[0] : null;
     }
-  }
+  });
 
-  @dropTask
-  *removeCurriculumInventoryReport(report) {
-    const reports = (yield this.selectedProgram.curriculumInventoryReports).slice();
+  removeCurriculumInventoryReport = dropTask(async report => {
+    const reports = ((await this.selectedProgram.curriculumInventoryReports)).slice();
     reports.splice(reports.indexOf(report), 1);
     this.selectedProgram.set('curriculumInventoryReports', reports);
-    yield report.destroyRecord();
-  }
+    await report.destroyRecord();
+  });
 }

--- a/packages/frontend/app/components/curriculum-inventory/reports.js
+++ b/packages/frontend/app/components/curriculum-inventory/reports.js
@@ -94,8 +94,8 @@ export default class CurriculumInventoryReportsComponent extends Component {
     }
   });
 
-  removeCurriculumInventoryReport = dropTask(async report => {
-    const reports = ((await this.selectedProgram.curriculumInventoryReports)).slice();
+  removeCurriculumInventoryReport = dropTask(async (report) => {
+    const reports = (await this.selectedProgram.curriculumInventoryReports).slice();
     reports.splice(reports.indexOf(report), 1);
     this.selectedProgram.set('curriculumInventoryReports', reports);
     await report.destroyRecord();

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-header.js
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-header.js
@@ -20,15 +20,14 @@ export default class CurriculumInventorySequenceBlockHeaderComponent extends Com
     this.title = this.args.sequenceBlock.title;
   }
 
-  @restartableTask
-  *changeTitle() {
+  changeTitle = restartableTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid('title');
+    const isValid = await this.isValid('title');
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('title');
     this.args.sequenceBlock.title = this.title;
-    yield this.args.sequenceBlock.save();
-  }
+    await this.args.sequenceBlock.save();
+  });
 }

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-list.js
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-list.js
@@ -25,7 +25,7 @@ export default class SequenceBlockListComponent extends Component {
     this.editorOn = false;
   }
 
-  save = dropTask(async block => {
+  save = dropTask(async (block) => {
     this.editorOn = false;
     this.savedBlock = await block.save();
     // adding/updating a sequence block will have side-effects on its siblings if the given block is nested

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-list.js
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-list.js
@@ -25,19 +25,18 @@ export default class SequenceBlockListComponent extends Component {
     this.editorOn = false;
   }
 
-  @dropTask
-  *save(block) {
+  save = dropTask(async block => {
     this.editorOn = false;
-    this.savedBlock = yield block.save();
+    this.savedBlock = await block.save();
     // adding/updating a sequence block will have side-effects on its siblings if the given block is nested
     // inside an "ordered" sequence block. they all get re-sorted server-side.
     // therefore, we must reload them here in order to get those updated sort order values.
     // [ST 2021/03/16]
     if (this.args.parent) {
-      yield this.store.findRecord('curriculum_inventory_sequence_block', this.args.parent.id, {
+      await this.store.findRecord('curriculum_inventory_sequence_block', this.args.parent.id, {
         include: 'children',
         reload: true,
       });
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.js
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.js
@@ -83,7 +83,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
   load = restartableTask(async (element, [sequenceBlock]) => {
     this.report = await sequenceBlock.report;
     this.parent = await sequenceBlock.parent;
-    this.academicLevels = ((await this.report.academicLevels)).slice();
+    this.academicLevels = (await this.report.academicLevels).slice();
     this.isInOrderedSequence = false;
     this.orderInSequenceOptions = [];
     if (isPresent(this.parent) && this.parent.isOrdered) {
@@ -237,7 +237,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     this.course = await this.args.sequenceBlock.get('course');
   }
 
-  changeTrack = dropTask(async value => {
+  changeTrack = dropTask(async (value) => {
     this.args.sequenceBlock.set('track', value);
     await this.args.sequenceBlock.save();
   });

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.js
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.js
@@ -80,24 +80,23 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     return 0 === num;
   }
 
-  @restartableTask
-  *load(element, [sequenceBlock]) {
-    this.report = yield sequenceBlock.report;
-    this.parent = yield sequenceBlock.parent;
-    this.academicLevels = (yield this.report.academicLevels).slice();
+  load = restartableTask(async (element, [sequenceBlock]) => {
+    this.report = await sequenceBlock.report;
+    this.parent = await sequenceBlock.parent;
+    this.academicLevels = ((await this.report.academicLevels)).slice();
     this.isInOrderedSequence = false;
     this.orderInSequenceOptions = [];
     if (isPresent(this.parent) && this.parent.isOrdered) {
       this.isInOrderedSequence = true;
-      const siblings = yield this.parent.children;
+      const siblings = await this.parent.children;
       for (let i = 0, n = siblings.slice().length; i < n; i++) {
         const num = i + 1;
         this.orderInSequenceOptions.push(num);
       }
     }
-    this.linkedSessions = yield sequenceBlock.sessions;
-    this.startingAcademicLevel = yield sequenceBlock.startingAcademicLevel;
-    this.endingAcademicLevel = yield sequenceBlock.endingAcademicLevel;
+    this.linkedSessions = await sequenceBlock.sessions;
+    this.startingAcademicLevel = await sequenceBlock.startingAcademicLevel;
+    this.endingAcademicLevel = await sequenceBlock.endingAcademicLevel;
     this.required = sequenceBlock.required.toString();
     this.duration = sequenceBlock.duration;
     this.startDate = sequenceBlock.startDate;
@@ -105,12 +104,12 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     this.childSequenceOrder = sequenceBlock.childSequenceOrder.toString();
     this.orderInSequence = sequenceBlock.orderInSequence;
     this.description = sequenceBlock.description;
-    this.course = yield sequenceBlock.course;
+    this.course = await sequenceBlock.course;
     this.minimum = sequenceBlock.minimum;
     this.maximum = sequenceBlock.maximum;
-    this.sessions = yield this.getSessions(this.course);
-    this.linkableCourses = yield this.getLinkableCourses(this.report, this.course);
-  }
+    this.sessions = await this.getSessions(this.course);
+    this.linkableCourses = await this.getLinkableCourses(this.report, this.course);
+  });
 
   get requiredLabel() {
     switch (this.required) {
@@ -196,14 +195,13 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     return sessions.slice();
   }
 
-  @dropTask
-  *changeRequired() {
+  changeRequired = dropTask(async () => {
     this.args.sequenceBlock.required = parseInt(this.required, 10);
     if ('2' === this.required) {
       this.args.sequenceBlock.minimum = 0;
     }
-    yield this.args.sequenceBlock.save();
-  }
+    await this.args.sequenceBlock.save();
+  });
 
   @action
   setRequired(required) {
@@ -239,46 +237,42 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     this.course = await this.args.sequenceBlock.get('course');
   }
 
-  @dropTask()
-  *changeTrack(value) {
+  changeTrack = dropTask(async value => {
     this.args.sequenceBlock.set('track', value);
-    yield this.args.sequenceBlock.save();
-  }
+    await this.args.sequenceBlock.save();
+  });
 
-  @dropTask()
-  *saveDescription() {
+  saveDescription = dropTask(async () => {
     this.args.sequenceBlock.set('description', this.description);
-    yield this.args.sequenceBlock.save();
-  }
+    await this.args.sequenceBlock.save();
+  });
 
   @action
   revertDescriptionChanges() {
     this.description = this.args.sequenceBlock.get('description');
   }
 
-  @dropTask
-  *changeChildSequenceOrder() {
+  changeChildSequenceOrder = dropTask(async () => {
     this.args.sequenceBlock.set('childSequenceOrder', parseInt(this.childSequenceOrder, 10));
-    const savedBlock = yield this.args.sequenceBlock.save();
-    const children = yield savedBlock.get('children');
-    yield all(children.map((child) => child.reload()));
-  }
+    const savedBlock = await this.args.sequenceBlock.save();
+    const children = await savedBlock.get('children');
+    await all(children.map((child) => child.reload()));
+  });
 
   @action
   revertChildSequenceOrderChanges() {
     this.childSequenceOrder = this.args.sequenceBlock.get('childSequenceOrder').toString();
   }
 
-  @dropTask
-  *changeStartingAcademicLevel() {
+  changeStartingAcademicLevel = dropTask(async () => {
     this.addErrorDisplaysFor(['startingAcademicLevel']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.args.sequenceBlock.set('startingAcademicLevel', this.startingAcademicLevel);
-    yield this.args.sequenceBlock.save();
-  }
+    await this.args.sequenceBlock.save();
+  });
 
   @action
   setStartingAcademicLevel(event) {
@@ -291,16 +285,15 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     this.startingAcademicLevel = this.args.sequenceBlock.startingAcademicLevel;
   }
 
-  @dropTask
-  *changeEndingAcademicLevel() {
+  changeEndingAcademicLevel = dropTask(async () => {
     this.addErrorDisplaysFor(['endingAcademicLevel']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.args.sequenceBlock.set('endingAcademicLevel', this.endingAcademicLevel);
-    yield this.args.sequenceBlock.save();
-  }
+    await this.args.sequenceBlock.save();
+  });
 
   @action
   setEndingAcademicLevel(event) {
@@ -313,14 +306,13 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     this.endingAcademicLevel = this.args.sequenceBlock.endingAcademicLevel;
   }
 
-  @dropTask
-  *changeOrderInSequence() {
+  changeOrderInSequence = dropTask(async () => {
     this.args.sequenceBlock.set('orderInSequence', this.orderInSequence);
-    const savedBlock = yield this.args.sequenceBlock.save();
-    const parent = yield savedBlock.parent;
-    const children = yield parent.children;
-    yield all(children.map((child) => child.reload()));
-  }
+    const savedBlock = await this.args.sequenceBlock.save();
+    const parent = await savedBlock.parent;
+    const children = await parent.children;
+    await all(children.map((child) => child.reload()));
+  });
 
   @action
   revertOrderInSequenceChanges() {
@@ -349,13 +341,12 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     this.isManagingSessions = false;
   }
 
-  @dropTask
-  *changeSessions(sessions, excludedSessions) {
+  changeSessions = dropTask(async (sessions, excludedSessions) => {
     this.args.sequenceBlock.set('sessions', sessions);
     this.args.sequenceBlock.set('excludedSessions', excludedSessions);
-    yield this.args.sequenceBlock.save();
+    await this.args.sequenceBlock.save();
     this.isManagingSessions = false;
-  }
+  });
 
   @action
   updateCourse(event) {
@@ -440,19 +431,18 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     });
   }
 
-  @dropTask
-  *saveMinMax() {
+  saveMinMax = dropTask(async () => {
     this.addErrorDisplaysFor(['minimum', 'maximum']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.args.sequenceBlock.minimum = this.minimum;
     this.args.sequenceBlock.maximum = this.maximum;
 
-    yield this.args.sequenceBlock.save();
+    await this.args.sequenceBlock.save();
     this.isEditingMinMax = false;
-  }
+  });
 
   @action
   changeStartDate(startDate) {
@@ -464,19 +454,18 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     this.endDate = endDate;
   }
 
-  @dropTask
-  *saveDuration() {
+  saveDuration = dropTask(async () => {
     this.addErrorDisplaysFor(['startDate', 'endDate', 'duration']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.args.sequenceBlock.startDate = this.startDate;
     this.args.sequenceBlock.endDate = this.endDate;
     this.args.sequenceBlock.duration = this.duration;
-    yield this.args.sequenceBlock.save();
+    await this.args.sequenceBlock.save();
     this.isEditingDatesAndDuration = false;
-  }
+  });
 
   @action
   cancelDurationEditing() {

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-session-manager.js
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-session-manager.js
@@ -135,15 +135,13 @@ export default class SequenceBlockSessionManagerComponent extends Component {
     this.args.cancel();
   }
 
-  @restartableTask
-  *load() {
-    this.linkedSessions = (yield this.args.sequenceBlock.sessions).slice();
-    this.excludedSessions = (yield this.args.sequenceBlock.excludedSessions).slice();
-    this.sessions = (yield this.args.sessions).slice();
-  }
+  load = restartableTask(async () => {
+    this.linkedSessions = ((await this.args.sequenceBlock.sessions)).slice();
+    this.excludedSessions = ((await this.args.sequenceBlock.excludedSessions)).slice();
+    this.sessions = ((await this.args.sessions)).slice();
+  });
 
-  @dropTask
-  *saveChanges() {
-    yield this.args.save(this.linkedSessions, this.excludedSessions);
-  }
+  saveChanges = dropTask(async () => {
+    await this.args.save(this.linkedSessions, this.excludedSessions);
+  });
 }

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-session-manager.js
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-session-manager.js
@@ -136,9 +136,9 @@ export default class SequenceBlockSessionManagerComponent extends Component {
   }
 
   load = restartableTask(async () => {
-    this.linkedSessions = ((await this.args.sequenceBlock.sessions)).slice();
-    this.excludedSessions = ((await this.args.sequenceBlock.excludedSessions)).slice();
-    this.sessions = ((await this.args.sessions)).slice();
+    this.linkedSessions = (await this.args.sequenceBlock.sessions).slice();
+    this.excludedSessions = (await this.args.sequenceBlock.excludedSessions).slice();
+    this.sessions = (await this.args.sessions).slice();
   });
 
   saveChanges = dropTask(async () => {

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview.js
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview.js
@@ -11,12 +11,11 @@ export default class CurriculumInventoryVerificationPreviewComponent extends Com
   @tracked tables = null;
   @tracked scrollTargets = {};
 
-  @task
-  *load(element, [report]) {
+  load = task(async (element, [report]) => {
     const url = `${this.iliosConfig.apiNameSpace}/curriculuminventoryreports/${report.id}/verificationpreview`;
-    const data = yield this.fetch.getJsonFromApiHost(url);
+    const data = await this.fetch.getJsonFromApiHost(url);
     this.tables = data.preview;
-  }
+  });
 
   @action
   scrollTo(key) {

--- a/packages/frontend/app/components/global-search-box.js
+++ b/packages/frontend/app/components/global-search-box.js
@@ -196,8 +196,7 @@ export default class GlobalSearchBox extends Component {
     return allMatches.filter((text) => text.indexOf(q) === 0);
   }
 
-  @restartableTask
-  *autocomplete() {
+  autocomplete = restartableTask(async () => {
     const q = cleanQuery(this.internalQuery);
 
     if (isBlank(q)) {
@@ -223,14 +222,14 @@ export default class GlobalSearchBox extends Component {
       return this.results;
     }
 
-    yield timeout(DEBOUNCE_MS);
+    await timeout(DEBOUNCE_MS);
 
-    const { autocomplete } = yield this.iliosSearch.forCurriculum(this.internalQuery, true);
+    const { autocomplete } = await this.iliosSearch.forCurriculum(this.internalQuery, true);
     this.autocompleteCache = [...this.autocompleteCache, { q: this.internalQuery, autocomplete }];
 
     this.results = autocomplete.map((text) => {
       return { text };
     });
     return this.results;
-  }
+  });
 }

--- a/packages/frontend/app/components/global-search.js
+++ b/packages/frontend/app/components/global-search.js
@@ -110,13 +110,12 @@ export default class GlobalSearchComponent extends Component {
     this.args.setIgnoredSchoolIds(ignoredSchoolIds);
   }
 
-  @restartableTask
-  *search(el, [query]) {
+  search = restartableTask(async (el, [query]) => {
     this.results = [];
     if (query?.length > MIN_INPUT) {
-      const { courses } = yield this.iliosSearch.forCurriculum(query);
+      const { courses } = await this.iliosSearch.forCurriculum(query);
 
       this.results = courses;
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/ilios-users.js
+++ b/packages/frontend/app/components/ilios-users.js
@@ -32,15 +32,13 @@ export default class IliosUsersComponent extends Component {
     return ensureSafeComponent(component, this);
   }
 
-  @restartableTask
-  *load() {
-    yield this.searchForUsers.perform();
-  }
+  load = restartableTask(async () => {
+    await this.searchForUsers.perform();
+  });
 
-  @restartableTask
-  *searchForUsers() {
+  searchForUsers = restartableTask(async () => {
     const q = cleanQuery(this.args.query);
-    yield timeout(DEBOUNCE_TIMEOUT);
+    await timeout(DEBOUNCE_TIMEOUT);
     return this.store.query('user', {
       limit: this.args.limit,
       q,
@@ -48,5 +46,5 @@ export default class IliosUsersComponent extends Component {
       'order_by[lastName]': 'ASC',
       'order_by[firstName]': 'ASC',
     });
-  }
+  });
 }

--- a/packages/frontend/app/components/instructor-group/header.js
+++ b/packages/frontend/app/components/instructor-group/header.js
@@ -15,18 +15,17 @@ export default class InstructorGroupHeaderComponent extends Component {
     this.title = this.args.instructorGroup.title;
   }
 
-  @dropTask
-  *changeTitle() {
+  changeTitle = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid('title');
+    const isValid = await this.isValid('title');
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('title');
     this.args.instructorGroup.title = this.title;
-    yield this.args.instructorGroup.save();
+    await this.args.instructorGroup.save();
     this.title = this.args.instructorGroup.title;
-  }
+  });
 
   @action
   revertTitleChanges() {

--- a/packages/frontend/app/components/instructor-group/users.js
+++ b/packages/frontend/app/components/instructor-group/users.js
@@ -27,16 +27,15 @@ export default class InstructorGroupUsersComponent extends Component {
     this.usersBuffer = this.usersBuffer.filter((obj) => obj !== user);
   }
 
-  @dropTask
-  *manage() {
-    this.usersBuffer = (yield this.args.instructorGroup.users).slice();
+  manage = dropTask(async () => {
+    this.usersBuffer = ((await this.args.instructorGroup.users)).slice();
     this.isManaging = true;
-  }
-  @dropTask
-  *save() {
-    yield timeout(10);
+  });
+
+  save = dropTask(async () => {
+    await timeout(10);
     this.args.instructorGroup.set('users', this.usersBuffer);
-    yield this.args.instructorGroup.save();
+    await this.args.instructorGroup.save();
     this.isManaging = false;
-  }
+  });
 }

--- a/packages/frontend/app/components/instructor-group/users.js
+++ b/packages/frontend/app/components/instructor-group/users.js
@@ -28,7 +28,7 @@ export default class InstructorGroupUsersComponent extends Component {
   }
 
   manage = dropTask(async () => {
-    this.usersBuffer = ((await this.args.instructorGroup.users)).slice();
+    this.usersBuffer = (await this.args.instructorGroup.users).slice();
     this.isManaging = true;
   });
 

--- a/packages/frontend/app/components/instructor-groups/list-item.js
+++ b/packages/frontend/app/components/instructor-groups/list-item.js
@@ -27,8 +27,7 @@ export default class InstructorGroupsListItemComponent extends Component {
     return this.canDeletePermission && this.courses && this.courses.length === 0;
   }
 
-  @dropTask
-  *remove() {
-    yield this.args.instructorGroup.destroyRecord();
-  }
+  remove = dropTask(async () => {
+    await this.args.instructorGroup.destroyRecord();
+  });
 }

--- a/packages/frontend/app/components/instructor-groups/new.js
+++ b/packages/frontend/app/components/instructor-groups/new.js
@@ -10,10 +10,9 @@ export default class InstructorGroupsNewComponent extends Component {
   @service store;
   @tracked @Length(3, 60) @NotBlank() title;
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
@@ -21,8 +20,8 @@ export default class InstructorGroupsNewComponent extends Component {
     const instructorGroup = this.store.createRecord('instructor-group', {
       title: this.title,
     });
-    yield this.args.save(instructorGroup);
-  }
+    await this.args.save(instructorGroup);
+  });
 
   @action
   async keyboard({ keyCode }) {

--- a/packages/frontend/app/components/instructor-groups/root.js
+++ b/packages/frontend/app/components/instructor-groups/root.js
@@ -91,7 +91,7 @@ export default class InstructorGroupsRootComponent extends Component {
     });
   }
 
-  saveNewInstructorGroup = dropTask(async newInstructorGroup => {
+  saveNewInstructorGroup = dropTask(async (newInstructorGroup) => {
     newInstructorGroup.set('school', this.bestSelectedSchool);
     this.newInstructorGroup = await newInstructorGroup.save();
     this.showNewInstructorGroupForm = false;

--- a/packages/frontend/app/components/instructor-groups/root.js
+++ b/packages/frontend/app/components/instructor-groups/root.js
@@ -91,10 +91,9 @@ export default class InstructorGroupsRootComponent extends Component {
     });
   }
 
-  @dropTask
-  *saveNewInstructorGroup(newInstructorGroup) {
+  saveNewInstructorGroup = dropTask(async newInstructorGroup => {
     newInstructorGroup.set('school', this.bestSelectedSchool);
-    this.newInstructorGroup = yield newInstructorGroup.save();
+    this.newInstructorGroup = await newInstructorGroup.save();
     this.showNewInstructorGroupForm = false;
-  }
+  });
 }

--- a/packages/frontend/app/components/learner-group/bulk-finalize-users.js
+++ b/packages/frontend/app/components/learner-group/bulk-finalize-users.js
@@ -23,10 +23,9 @@ export default class LearnergroupBulkFinalizeUsersComponent extends Component {
     });
   }
 
-  @dropTask
-  *save() {
-    yield timeout(10);
-    const treeGroups = yield map(this.finalData, async ({ learnerGroup, user }) => {
+  save = dropTask(async () => {
+    await timeout(10);
+    const treeGroups = await map(this.finalData, async ({ learnerGroup, user }) => {
       return learnerGroup.addUserToGroupAndAllParents(user);
     });
 
@@ -34,8 +33,8 @@ export default class LearnergroupBulkFinalizeUsersComponent extends Component {
       return [...flattened, ...arr];
     }, []);
 
-    yield all(uniqueValues(flat).map((o) => o.save()));
+    await all(uniqueValues(flat).map((o) => o.save()));
     this.flashMessages.success('general.savedSuccessfully');
     this.args.done();
-  }
+  });
 }

--- a/packages/frontend/app/components/learner-group/cohort-user-manager.js
+++ b/packages/frontend/app/components/learner-group/cohort-user-manager.js
@@ -60,7 +60,7 @@ export default class LearnerGroupCohortUserManagerComponent extends Component {
     }
   }
 
-  addSingleUser = enqueueTask(async user => {
+  addSingleUser = enqueueTask(async (user) => {
     this.usersBeingMoved = [...this.usersBeingMoved, user];
     //timeout gives the spinner time to render
     await timeout(1);

--- a/packages/frontend/app/components/learner-group/cohort-user-manager.js
+++ b/packages/frontend/app/components/learner-group/cohort-user-manager.js
@@ -60,22 +60,20 @@ export default class LearnerGroupCohortUserManagerComponent extends Component {
     }
   }
 
-  @enqueueTask
-  *addSingleUser(user) {
+  addSingleUser = enqueueTask(async user => {
     this.usersBeingMoved = [...this.usersBeingMoved, user];
     //timeout gives the spinner time to render
-    yield timeout(1);
-    yield this.args.addUserToGroup(user);
+    await timeout(1);
+    await this.args.addUserToGroup(user);
     this.usersBeingMoved = this.usersBeingMoved.filter((movingUser) => movingUser !== user);
-  }
+  });
 
-  @enqueueTask
-  *addSelectedUsers() {
+  addSelectedUsers = enqueueTask(async () => {
     this.usersBeingMoved = [...this.usersBeingMoved, ...this.selectedUsers];
     //timeout gives the spinner time to render
-    yield timeout(1);
-    yield this.args.addUsersToGroup(this.selectedUsers);
+    await timeout(1);
+    await this.args.addUsersToGroup(this.selectedUsers);
     this.usersBeingMoved = this.usersBeingMoved.filter((user) => this.selectedUsers.includes(user));
     this.selectedUsers = [];
-  }
+  });
 }

--- a/packages/frontend/app/components/learner-group/header.js
+++ b/packages/frontend/app/components/learner-group/header.js
@@ -56,15 +56,14 @@ export default class LearnerGroupHeaderComponent extends Component {
     this.title = this.args.learnerGroup.title;
   }
 
-  @dropTask
-  *changeTitle() {
+  changeTitle = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid('title');
+    const isValid = await this.isValid('title');
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('title');
     this.args.learnerGroup.title = this.title;
-    yield this.args.learnerGroup.save();
-  }
+    await this.args.learnerGroup.save();
+  });
 }

--- a/packages/frontend/app/components/learner-group/instructor-manager.js
+++ b/packages/frontend/app/components/learner-group/instructor-manager.js
@@ -10,22 +10,21 @@ export default class LearnerGroupInstructorManagerComponent extends Component {
   @tracked instructorGroups = [];
   @tracked isManaging = false;
 
-  @restartableTask
-  *load(element, [learnerGroup]) {
+  load = restartableTask(async (element, [learnerGroup]) => {
     if (isPresent(learnerGroup)) {
-      const instructors = yield learnerGroup.get('instructors');
-      const instructorGroups = yield learnerGroup.get('instructorGroups');
-      const cohort = yield learnerGroup.get('cohort');
-      const programYear = yield cohort.get('programYear');
-      const program = yield programYear.get('program');
-      const school = yield program.get('school');
-      const availableInstructorGroups = yield school.get('instructorGroups');
+      const instructors = await learnerGroup.get('instructors');
+      const instructorGroups = await learnerGroup.get('instructorGroups');
+      const cohort = await learnerGroup.get('cohort');
+      const programYear = await cohort.get('programYear');
+      const program = await programYear.get('program');
+      const school = await program.get('school');
+      const availableInstructorGroups = await school.get('instructorGroups');
 
       this.instructors = instructors.slice();
       this.instructorGroups = instructorGroups.slice();
       this.availableInstructorGroups = availableInstructorGroups.slice();
     }
-  }
+  });
 
   @action
   addInstructor(user) {
@@ -47,9 +46,8 @@ export default class LearnerGroupInstructorManagerComponent extends Component {
     this.instructorGroups = this.instructorGroups.filter((group) => group !== instructorGroup);
   }
 
-  @dropTask
-  *saveChanges() {
-    yield this.args.save(this.instructors, this.instructorGroups);
+  saveChanges = dropTask(async () => {
+    await this.args.save(this.instructors, this.instructorGroups);
     this.isManaging = false;
-  }
+  });
 }

--- a/packages/frontend/app/components/learner-group/list-item.js
+++ b/packages/frontend/app/components/learner-group/list-item.js
@@ -72,14 +72,13 @@ export default class LearnerGroupListItemComponent extends Component {
     return !!linkedChildren.length;
   }
 
-  @dropTask
-  *remove() {
-    const descendants = yield this.args.learnerGroup.allDescendants;
-    yield all([
+  remove = dropTask(async () => {
+    const descendants = await this.args.learnerGroup.allDescendants;
+    await all([
       ...descendants.map((descendant) => descendant.destroyRecord()),
       this.args.learnerGroup.destroyRecord(),
     ]);
-  }
+  });
 
   @action
   copyWithLearners() {

--- a/packages/frontend/app/components/learner-group/new-multiple.js
+++ b/packages/frontend/app/components/learner-group/new-multiple.js
@@ -9,16 +9,15 @@ export default class LearnerGroupNewMultipleComponent extends Component {
   @tracked @IsInt() @Gt(0) @NotBlank() @Lte(50) numberOfGroups;
   @tracked fillWithCohort = false;
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplayFor('numberOfGroups');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('numberOfGroups');
-    yield this.args.generateNewLearnerGroups(this.numberOfGroups);
-  }
+    await this.args.generateNewLearnerGroups(this.numberOfGroups);
+  });
 
   @action
   async keyboard({ keyCode }) {

--- a/packages/frontend/app/components/learner-group/new-single.js
+++ b/packages/frontend/app/components/learner-group/new-single.js
@@ -9,16 +9,15 @@ export default class LearnerGroupNewSingleComponent extends Component {
   @tracked @Length(3, 60) @NotBlank() title;
   @tracked fillWithCohort = false;
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('title');
     return this.args.save(this.title, this.fillWithCohort);
-  }
+  });
 
   @action
   async keyboard({ keyCode }) {

--- a/packages/frontend/app/components/learner-group/root.js
+++ b/packages/frontend/app/components/learner-group/root.js
@@ -85,7 +85,7 @@ export default class LearnerGroupRootComponent extends Component {
     }
   });
 
-  saveNewLearnerGroup = dropTask(async title => {
+  saveNewLearnerGroup = dropTask(async (title) => {
     const cohort = await this.args.learnerGroup.cohort;
     const newLearnerGroup = this.store.createRecord('learner-group', {
       cohort,
@@ -190,7 +190,7 @@ export default class LearnerGroupRootComponent extends Component {
     return this.args.learnerGroup.save();
   }
 
-  addUserToGroup = enqueueTask(async user => {
+  addUserToGroup = enqueueTask(async (user) => {
     const learnerGroup = this.args.learnerGroup;
     const topLevelGroup = await learnerGroup.topLevelGroup;
     const removeGroups = await topLevelGroup.removeUserFromGroupAndAllDescendants(user);
@@ -201,7 +201,7 @@ export default class LearnerGroupRootComponent extends Component {
     this.usersToPassToCohortManager = await this.createUsersToPassToCohortManager.perform();
   });
 
-  removeUserToCohort = enqueueTask(async user => {
+  removeUserToCohort = enqueueTask(async (user) => {
     const topLevelGroup = await this.args.learnerGroup.topLevelGroup;
     const groups = await topLevelGroup.removeUserFromGroupAndAllDescendants(user);
     await all(groups.map((group) => group.save()));
@@ -209,7 +209,7 @@ export default class LearnerGroupRootComponent extends Component {
     this.usersToPassToCohortManager = await this.createUsersToPassToCohortManager.perform();
   });
 
-  addUsersToGroup = enqueueTask(async users => {
+  addUsersToGroup = enqueueTask(async (users) => {
     const learnerGroup = this.args.learnerGroup;
     const topLevelGroup = await learnerGroup.topLevelGroup;
     let addGroups = [];
@@ -218,9 +218,9 @@ export default class LearnerGroupRootComponent extends Component {
       const user = users[i];
       removeGroups = [
         ...removeGroups,
-        ...((await topLevelGroup.removeUserFromGroupAndAllDescendants(user))),
+        ...(await topLevelGroup.removeUserFromGroupAndAllDescendants(user)),
       ];
-      addGroups = [...addGroups, ...((await learnerGroup.addUserToGroupAndAllParents(user)))];
+      addGroups = [...addGroups, ...(await learnerGroup.addUserToGroupAndAllParents(user))];
     }
 
     await Promise.all(uniqueValues(removeGroups).map((g) => g.save()));
@@ -230,7 +230,7 @@ export default class LearnerGroupRootComponent extends Component {
     this.usersToPassToCohortManager = await this.createUsersToPassToCohortManager.perform();
   });
 
-  removeUsersToCohort = enqueueTask(async users => {
+  removeUsersToCohort = enqueueTask(async (users) => {
     const topLevelGroup = await this.args.learnerGroup.topLevelGroup;
     let groupsToSave = [];
     for (let i = 0; i < users.length; i++) {
@@ -271,7 +271,7 @@ export default class LearnerGroupRootComponent extends Component {
     return users.filter((user) => !currentUsers.includes(user));
   });
 
-  changeNeedsAccommodation = restartableTask(async value => {
+  changeNeedsAccommodation = restartableTask(async (value) => {
     this.args.learnerGroup.set('needsAccommodation', value);
     await this.args.learnerGroup.save();
   });

--- a/packages/frontend/app/components/learner-group/root.js
+++ b/packages/frontend/app/components/learner-group/root.js
@@ -67,49 +67,46 @@ export default class LearnerGroupRootComponent extends Component {
     return this.args.sortUsersBy || 'fullName';
   }
 
-  @restartableTask
-  *load(element, [learnerGroup]) {
+  load = restartableTask(async (element, [learnerGroup]) => {
     if (isPresent(learnerGroup)) {
       this.location = learnerGroup.location;
       this.url = learnerGroup.url;
       this.learnerGroupId = learnerGroup.id;
       this.learnerGroupTitle = learnerGroup.title;
-      const cohort = yield learnerGroup.cohort;
+      const cohort = await learnerGroup.cohort;
       this.cohortTitle = cohort.title;
-      const topLevelGroup = yield learnerGroup.getTopLevelGroup();
+      const topLevelGroup = await learnerGroup.getTopLevelGroup();
       this.topLevelGroupTitle = topLevelGroup.title;
-      const allDescendants = yield topLevelGroup.getAllDescendants();
+      const allDescendants = await topLevelGroup.getAllDescendants();
       this.treeGroups = [topLevelGroup, ...allDescendants];
-      this.usersToPassToManager = yield this.createUsersToPassToManager.perform();
-      this.usersToPassToCohortManager = yield this.createUsersToPassToCohortManager.perform();
-      this.courses = yield this.getCoursesForGroupWithSubgroupName(null, this.args.learnerGroup);
+      this.usersToPassToManager = await this.createUsersToPassToManager.perform();
+      this.usersToPassToCohortManager = await this.createUsersToPassToCohortManager.perform();
+      this.courses = await this.getCoursesForGroupWithSubgroupName(null, this.args.learnerGroup);
     }
-  }
+  });
 
-  @dropTask
-  *saveNewLearnerGroup(title) {
-    const cohort = yield this.args.learnerGroup.cohort;
+  saveNewLearnerGroup = dropTask(async title => {
+    const cohort = await this.args.learnerGroup.cohort;
     const newLearnerGroup = this.store.createRecord('learner-group', {
       cohort,
       parent: this.args.learnerGroup,
       title,
     });
-    this.savedGroup = yield newLearnerGroup.save();
+    this.savedGroup = await newLearnerGroup.save();
     this.showNewLearnerGroupForm = false;
-  }
+  });
 
-  @restartableTask
-  *changeLocation() {
+  changeLocation = restartableTask(async () => {
     this.addErrorDisplayFor('location');
-    const isValid = yield this.isValid('location');
+    const isValid = await this.isValid('location');
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('location');
     this.args.learnerGroup.set('location', this.location);
-    yield this.args.learnerGroup.save();
+    await this.args.learnerGroup.save();
     this.location = this.args.learnerGroup.location;
-  }
+  });
 
   @action
   async generateNewLearnerGroups(num) {
@@ -158,18 +155,17 @@ export default class LearnerGroupRootComponent extends Component {
     }
   }
 
-  @restartableTask
-  *saveUrlChanges() {
+  saveUrlChanges = restartableTask(async () => {
     this.addErrorDisplayFor('url');
-    const isValid = yield this.isValid('url');
+    const isValid = await this.isValid('url');
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('url');
     this.args.learnerGroup.set('url', this.url);
-    yield this.args.learnerGroup.save();
+    await this.args.learnerGroup.save();
     this.url = this.args.learnerGroup.url;
-  }
+  });
 
   @action
   revertUrlChanges() {
@@ -194,73 +190,68 @@ export default class LearnerGroupRootComponent extends Component {
     return this.args.learnerGroup.save();
   }
 
-  @enqueueTask
-  *addUserToGroup(user) {
+  addUserToGroup = enqueueTask(async user => {
     const learnerGroup = this.args.learnerGroup;
-    const topLevelGroup = yield learnerGroup.topLevelGroup;
-    const removeGroups = yield topLevelGroup.removeUserFromGroupAndAllDescendants(user);
-    const addGroups = yield learnerGroup.addUserToGroupAndAllParents(user);
-    yield Promise.all(removeGroups.map((g) => g.save()));
-    yield Promise.all(addGroups.map((g) => g.save()));
-    this.usersToPassToManager = yield this.createUsersToPassToManager.perform();
-    this.usersToPassToCohortManager = yield this.createUsersToPassToCohortManager.perform();
-  }
+    const topLevelGroup = await learnerGroup.topLevelGroup;
+    const removeGroups = await topLevelGroup.removeUserFromGroupAndAllDescendants(user);
+    const addGroups = await learnerGroup.addUserToGroupAndAllParents(user);
+    await Promise.all(removeGroups.map((g) => g.save()));
+    await Promise.all(addGroups.map((g) => g.save()));
+    this.usersToPassToManager = await this.createUsersToPassToManager.perform();
+    this.usersToPassToCohortManager = await this.createUsersToPassToCohortManager.perform();
+  });
 
-  @enqueueTask
-  *removeUserToCohort(user) {
-    const topLevelGroup = yield this.args.learnerGroup.topLevelGroup;
-    const groups = yield topLevelGroup.removeUserFromGroupAndAllDescendants(user);
-    yield all(groups.map((group) => group.save()));
-    this.usersToPassToManager = yield this.createUsersToPassToManager.perform();
-    this.usersToPassToCohortManager = yield this.createUsersToPassToCohortManager.perform();
-  }
+  removeUserToCohort = enqueueTask(async user => {
+    const topLevelGroup = await this.args.learnerGroup.topLevelGroup;
+    const groups = await topLevelGroup.removeUserFromGroupAndAllDescendants(user);
+    await all(groups.map((group) => group.save()));
+    this.usersToPassToManager = await this.createUsersToPassToManager.perform();
+    this.usersToPassToCohortManager = await this.createUsersToPassToCohortManager.perform();
+  });
 
-  @enqueueTask
-  *addUsersToGroup(users) {
+  addUsersToGroup = enqueueTask(async users => {
     const learnerGroup = this.args.learnerGroup;
-    const topLevelGroup = yield learnerGroup.topLevelGroup;
+    const topLevelGroup = await learnerGroup.topLevelGroup;
     let addGroups = [];
     let removeGroups = [];
     for (let i = 0; i < users.length; i++) {
       const user = users[i];
       removeGroups = [
         ...removeGroups,
-        ...(yield topLevelGroup.removeUserFromGroupAndAllDescendants(user)),
+        ...((await topLevelGroup.removeUserFromGroupAndAllDescendants(user))),
       ];
-      addGroups = [...addGroups, ...(yield learnerGroup.addUserToGroupAndAllParents(user))];
+      addGroups = [...addGroups, ...((await learnerGroup.addUserToGroupAndAllParents(user)))];
     }
 
-    yield Promise.all(uniqueValues(removeGroups).map((g) => g.save()));
-    yield Promise.all(uniqueValues(addGroups).map((g) => g.save()));
+    await Promise.all(uniqueValues(removeGroups).map((g) => g.save()));
+    await Promise.all(uniqueValues(addGroups).map((g) => g.save()));
 
-    this.usersToPassToManager = yield this.createUsersToPassToManager.perform();
-    this.usersToPassToCohortManager = yield this.createUsersToPassToCohortManager.perform();
-  }
+    this.usersToPassToManager = await this.createUsersToPassToManager.perform();
+    this.usersToPassToCohortManager = await this.createUsersToPassToCohortManager.perform();
+  });
 
-  @enqueueTask
-  *removeUsersToCohort(users) {
-    const topLevelGroup = yield this.args.learnerGroup.topLevelGroup;
+  removeUsersToCohort = enqueueTask(async users => {
+    const topLevelGroup = await this.args.learnerGroup.topLevelGroup;
     let groupsToSave = [];
     for (let i = 0; i < users.length; i++) {
       const user = users[i];
-      const removeGroups = yield topLevelGroup.removeUserFromGroupAndAllDescendants(user);
+      const removeGroups = await topLevelGroup.removeUserFromGroupAndAllDescendants(user);
       groupsToSave = [...groupsToSave, ...removeGroups];
     }
-    yield all(uniqueValues(groupsToSave).map((group) => group.save()));
-    this.usersToPassToManager = yield this.createUsersToPassToManager.perform();
-    this.usersToPassToCohortManager = yield this.createUsersToPassToCohortManager.perform();
-  }
+    await all(uniqueValues(groupsToSave).map((group) => group.save()));
+    this.usersToPassToManager = await this.createUsersToPassToManager.perform();
+    this.usersToPassToCohortManager = await this.createUsersToPassToCohortManager.perform();
+  });
 
-  @task
-  *createUsersToPassToManager() {
+  createUsersToPassToManager = task(async () => {
     let users;
     if (this.args.isEditing) {
-      const topLevelGroup = yield this.args.learnerGroup.getTopLevelGroup();
-      users = yield topLevelGroup.getAllDescendantUsers();
+      const topLevelGroup = await this.args.learnerGroup.getTopLevelGroup();
+      users = await topLevelGroup.getAllDescendantUsers();
     } else {
-      users = yield this.args.learnerGroup.getUsersOnlyAtThisLevel();
+      users = await this.args.learnerGroup.getUsersOnlyAtThisLevel();
     }
-    return yield map(users.slice(), async (user) => {
+    return await map(users.slice(), async (user) => {
       const lowestGroupInTree = await user.getLowestMemberGroupInALearnerGroupTree(this.treeGroups);
       return ObjectProxy.create({
         content: user,
@@ -269,29 +260,26 @@ export default class LearnerGroupRootComponent extends Component {
         lowestGroupInTreeTitle: lowestGroupInTree.title,
       });
     });
-  }
+  });
 
-  @task
-  *createUsersToPassToCohortManager() {
+  createUsersToPassToCohortManager = task(async () => {
     const learnerGroup = this.args.learnerGroup;
-    const cohort = yield learnerGroup.cohort;
-    const topLevelGroup = yield learnerGroup.getTopLevelGroup();
-    const currentUsers = yield topLevelGroup.getAllDescendantUsers();
-    const users = yield cohort.users;
+    const cohort = await learnerGroup.cohort;
+    const topLevelGroup = await learnerGroup.getTopLevelGroup();
+    const currentUsers = await topLevelGroup.getAllDescendantUsers();
+    const users = await cohort.users;
     return users.filter((user) => !currentUsers.includes(user));
-  }
+  });
 
-  @restartableTask
-  *changeNeedsAccommodation(value) {
+  changeNeedsAccommodation = restartableTask(async value => {
     this.args.learnerGroup.set('needsAccommodation', value);
-    yield this.args.learnerGroup.save();
-  }
+    await this.args.learnerGroup.save();
+  });
 
-  @dropTask
-  *copyGroup(withLearners, learnerGroup) {
-    const cohort = yield learnerGroup.cohort;
-    const parentGroup = yield learnerGroup.parent;
-    const newGroups = yield cloneLearnerGroup(
+  copyGroup = dropTask(async (withLearners, learnerGroup) => {
+    const cohort = await learnerGroup.cohort;
+    const parentGroup = await learnerGroup.parent;
+    const newGroups = await cloneLearnerGroup(
       this.store,
       learnerGroup,
       cohort,
@@ -303,11 +291,11 @@ export default class LearnerGroupRootComponent extends Component {
     this.totalGroupsToSave = newGroups.length;
     // save groups one at a time because we need to save in this order so parents are saved before children
     for (let i = 0; i < newGroups.length; i++) {
-      yield newGroups[i].save();
+      await newGroups[i].save();
       this.currentGroupsSaved = i + 1;
     }
     this.savedGroup = newGroups[0];
-  }
+  });
 
   async getCoursesForGroupWithSubgroupName(prefix, learnerGroup) {
     const offerings = (await learnerGroup.offerings).slice();

--- a/packages/frontend/app/components/learner-group/upload-data.js
+++ b/packages/frontend/app/components/learner-group/upload-data.js
@@ -221,11 +221,10 @@ export default class LearnerGroupUploadDataComponent extends Component {
     });
   }
 
-  @task
-  *continue() {
-    yield timeout(10);
-    const matchedGroups = yield this.getMatchedGroups();
+  continue = task(async () => {
+    await timeout(10);
+    const matchedGroups = await this.getMatchedGroups();
     this.args.sendValidUsers(this.validUsers);
     this.args.sendMatchedGroups(matchedGroups);
-  }
+  });
 }

--- a/packages/frontend/app/components/learner-group/user-manager.js
+++ b/packages/frontend/app/components/learner-group/user-manager.js
@@ -144,54 +144,50 @@ export default class LearnerGroupUserManagerComponent extends Component {
     }
   }
 
-  @enqueueTask
-  *addUserToGroup(user) {
+  addUserToGroup = enqueueTask(async user => {
     this.usersBeingAddedToGroup = [...this.usersBeingAddedToGroup, user];
     //timeout gives the spinner time to render
-    yield timeout(1);
-    yield this.args.addUserToGroup(user);
+    await timeout(1);
+    await this.args.addUserToGroup(user);
     this.usersBeingAddedToGroup = this.usersBeingAddedToGroup.filter(
       (movingUser) => movingUser !== user,
     );
-  }
+  });
 
-  @enqueueTask
-  *removeUserFromGroup(user) {
+  removeUserFromGroup = enqueueTask(async user => {
     this.usersBeingRemovedFromGroup = [...this.usersBeingRemovedFromGroup, user];
     //timeout gives the spinner time to render
-    yield timeout(1);
-    yield this.args.removeUserFromGroup(user);
+    await timeout(1);
+    await this.args.removeUserFromGroup(user);
     this.usersBeingRemovedFromGroup = this.usersBeingRemovedFromGroup.filter(
       (movingUser) => movingUser !== user,
     );
-  }
+  });
 
-  @enqueueTask
-  *addUsersToGroup() {
+  addUsersToGroup = enqueueTask(async () => {
     this.usersBeingAddedToGroup = [...this.usersBeingAddedToGroup, ...this.selectedNonGroupUsers];
     //timeout gives the spinner time to render
-    yield timeout(1);
-    yield this.args.addUsersToGroup(this.selectedNonGroupUsers);
+    await timeout(1);
+    await this.args.addUsersToGroup(this.selectedNonGroupUsers);
     this.usersBeingAddedToGroup = this.usersBeingAddedToGroup.filter((user) =>
       this.selectedNonGroupUsers.includes(user),
     );
     this.selectedNonGroupUsers = [];
-  }
+  });
 
-  @enqueueTask
-  *removeUsersFromGroup() {
+  removeUsersFromGroup = enqueueTask(async () => {
     this.usersBeingRemovedFromGroup = [
       ...this.usersBeingRemovedFromGroup,
       ...this.selectedGroupUsers,
     ];
     //timeout gives the spinner time to render
-    yield timeout(1);
-    yield this.args.removeUsersFromGroup(this.selectedGroupUsers);
+    await timeout(1);
+    await this.args.removeUsersFromGroup(this.selectedGroupUsers);
     this.usersBeingRemovedFromGroup = this.usersBeingRemovedFromGroup.filter((user) =>
       this.selectedGroupUsers.includes(user),
     );
     this.selectedGroupUsers = [];
-  }
+  });
 
   willDestroy() {
     super.willDestroy(...arguments);

--- a/packages/frontend/app/components/learner-group/user-manager.js
+++ b/packages/frontend/app/components/learner-group/user-manager.js
@@ -144,7 +144,7 @@ export default class LearnerGroupUserManagerComponent extends Component {
     }
   }
 
-  addUserToGroup = enqueueTask(async user => {
+  addUserToGroup = enqueueTask(async (user) => {
     this.usersBeingAddedToGroup = [...this.usersBeingAddedToGroup, user];
     //timeout gives the spinner time to render
     await timeout(1);
@@ -154,7 +154,7 @@ export default class LearnerGroupUserManagerComponent extends Component {
     );
   });
 
-  removeUserFromGroup = enqueueTask(async user => {
+  removeUserFromGroup = enqueueTask(async (user) => {
     this.usersBeingRemovedFromGroup = [...this.usersBeingRemovedFromGroup, user];
     //timeout gives the spinner time to render
     await timeout(1);

--- a/packages/frontend/app/components/learner-groups/root.js
+++ b/packages/frontend/app/components/learner-groups/root.js
@@ -145,24 +145,22 @@ export default class LearnerGroupsRootComponent extends Component {
     });
   }
 
-  @dropTask
-  *saveNewLearnerGroup(title, fillWithCohort) {
+  saveNewLearnerGroup = dropTask(async (title, fillWithCohort) => {
     const group = this.store.createRecord('learner-group', {
       title,
       cohort: this.selectedCohort,
     });
     if (fillWithCohort) {
-      const users = (yield this.selectedCohort.users).slice();
+      const users = ((await this.selectedCohort.users)).slice();
       group.set('users', users);
     }
-    this.savedLearnerGroup = yield group.save();
+    this.savedLearnerGroup = await group.save();
     this.showNewLearnerGroupForm = false;
-  }
+  });
 
-  @dropTask
-  *copyGroup(withLearners, groupToCopy) {
-    const cohort = yield groupToCopy.cohort;
-    const newGroups = yield cloneLearnerGroup(this.store, groupToCopy, cohort, withLearners);
+  copyGroup = dropTask(async (withLearners, groupToCopy) => {
+    const cohort = await groupToCopy.cohort;
+    const newGroups = await cloneLearnerGroup(this.store, groupToCopy, cohort, withLearners);
     this.totalGroupsToSave = newGroups.length;
     // indicate that the top group is a copy
     newGroups[0].title += ` (${this.intl.t('general.copy')})`;
@@ -170,11 +168,11 @@ export default class LearnerGroupsRootComponent extends Component {
     this.currentGroupsSaved = 0;
     // save groups one at a time because we need to save in this order so parents are saved before children
     for (let i = 0; i < newGroups.length; i++) {
-      yield newGroups[i].save();
+      await newGroups[i].save();
       this.currentGroupsSaved++;
     }
     this.savedLearnerGroup = newGroups[0];
-  }
+  });
 
   async findBestDefaultProgram(programs) {
     if (!programs) {
@@ -227,22 +225,20 @@ export default class LearnerGroupsRootComponent extends Component {
     this.args.setSchoolId(schoolId);
   }
 
-  @dropTask
-  *setProgramId(programId) {
+  setProgramId = dropTask(async programId => {
     const program = findById(this.programs.slice(), programId);
-    const school = yield program.school;
+    const school = await program.school;
     this.args.setSchoolId(school.id);
     this.args.setProgramId(program.id);
     this.args.setProgramYearId(null);
-  }
+  });
 
-  @dropTask
-  *setProgramYearId(programYearId) {
+  setProgramYearId = dropTask(async programYearId => {
     const programYear = findById(this.programYears.slice(), programYearId);
-    const program = yield programYear.program;
-    const school = yield program.school;
+    const program = await programYear.program;
+    const school = await program.school;
     this.args.setSchoolId(school.id);
     this.args.setProgramId(program.id);
     this.args.setProgramYearId(programYear.id);
-  }
+  });
 }

--- a/packages/frontend/app/components/learner-groups/root.js
+++ b/packages/frontend/app/components/learner-groups/root.js
@@ -151,7 +151,7 @@ export default class LearnerGroupsRootComponent extends Component {
       cohort: this.selectedCohort,
     });
     if (fillWithCohort) {
-      const users = ((await this.selectedCohort.users)).slice();
+      const users = (await this.selectedCohort.users).slice();
       group.set('users', users);
     }
     this.savedLearnerGroup = await group.save();
@@ -225,7 +225,7 @@ export default class LearnerGroupsRootComponent extends Component {
     this.args.setSchoolId(schoolId);
   }
 
-  setProgramId = dropTask(async programId => {
+  setProgramId = dropTask(async (programId) => {
     const program = findById(this.programs.slice(), programId);
     const school = await program.school;
     this.args.setSchoolId(school.id);
@@ -233,7 +233,7 @@ export default class LearnerGroupsRootComponent extends Component {
     this.args.setProgramYearId(null);
   });
 
-  setProgramYearId = dropTask(async programYearId => {
+  setProgramYearId = dropTask(async (programYearId) => {
     const programYear = findById(this.programYears.slice(), programYearId);
     const program = await programYear.program;
     const school = await program.school;

--- a/packages/frontend/app/components/login-form.js
+++ b/packages/frontend/app/components/login-form.js
@@ -12,10 +12,9 @@ export default class LoginFormComponent extends Component {
   @tracked @NotBlank() username;
   @tracked @NotBlank() password;
 
-  @task
-  *authenticate() {
+  authenticate = task(async () => {
     this.addErrorDisplaysFor(['username', 'password']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
@@ -23,7 +22,7 @@ export default class LoginFormComponent extends Component {
       this.error = null;
       const session = this.session;
       const authenticator = 'authenticator:ilios-jwt';
-      yield session.authenticate(authenticator, {
+      await session.authenticate(authenticator, {
         username: this.username,
         password: this.password,
       });
@@ -35,7 +34,7 @@ export default class LoginFormComponent extends Component {
     } finally {
       this.clearErrorDisplay();
     }
-  }
+  });
 
   @action
   async submitOnEnter(event) {

--- a/packages/frontend/app/components/manage-users-summary.js
+++ b/packages/frontend/app/components/manage-users-summary.js
@@ -52,14 +52,13 @@ export default class ManageUsersSummaryComponent extends Component {
     return users;
   }
 
-  @restartableTask
-  *searchForUsers() {
+  searchForUsers = restartableTask(async () => {
     const q = cleanQuery(this.searchValue);
     if (!q) {
-      yield timeout(1);
+      await timeout(1);
       return [];
     }
-    yield timeout(DEBOUNCE_MS);
+    await timeout(DEBOUNCE_MS);
 
     if (q.length < MIN_INPUT) {
       return [
@@ -69,8 +68,8 @@ export default class ManageUsersSummaryComponent extends Component {
         },
       ];
     }
-    const searchEnabled = yield this.iliosConfig.getSearchEnabled();
-    const searchResults = searchEnabled ? yield this.indexSearch(q) : yield this.apiSearch(q);
+    const searchEnabled = await this.iliosConfig.getSearchEnabled();
+    const searchResults = searchEnabled ? await this.indexSearch(q) : await this.apiSearch(q);
 
     if (searchResults.length === 0) {
       return [
@@ -94,11 +93,10 @@ export default class ManageUsersSummaryComponent extends Component {
       },
       ...mappedResults,
     ];
-  }
+  });
 
-  @dropTask
-  *clickUser({ id }) {
-    yield this.router.transitionTo('user', id, {
+  clickUser = dropTask(async ({ id }) => {
+    await this.router.transitionTo('user', id, {
       queryParams: {
         isManagingBio: Ember.DEFAULT_VALUE,
         isManagingRoles: Ember.DEFAULT_VALUE,
@@ -108,6 +106,6 @@ export default class ManageUsersSummaryComponent extends Component {
       },
     });
     this.searchValue = null;
-    yield this.searchForUsers.perform();
-  }
+    await this.searchForUsers.perform();
+  });
 }

--- a/packages/frontend/app/components/my-profile.js
+++ b/packages/frontend/app/components/my-profile.js
@@ -53,9 +53,8 @@ export default class MyProfileComponent extends Component {
     this.generatedJwt = null;
   }
 
-  @task
-  *createNewToken() {
-    yield timeout(10); //small delay to allow rendering the spinner
+  createNewToken = task(async () => {
+    await timeout(10); //small delay to allow rendering the spinner
     const selection = this.expiresAt;
     const expiresAt = moment(selection).hour(23).minute(59).second(59);
     const now = moment();
@@ -68,15 +67,14 @@ export default class MyProfileComponent extends Component {
     const interval = `P${days}DT${hours}H${minutes}M${seconds}S`;
 
     const url = '/auth/token?ttl=' + interval;
-    const data = yield this.fetch.getJsonFromApiHost(url);
+    const data = await this.fetch.getJsonFromApiHost(url);
     this.generatedJwt = data.jwt;
-  }
+  });
 
-  @task
-  *invalidateTokens() {
-    yield timeout(10); //small delay to allow rendering the spinner
+  invalidateTokens = task(async () => {
+    await timeout(10); //small delay to allow rendering the spinner
     const url = '/auth/invalidatetokens';
-    const data = yield this.fetch.getJsonFromApiHost(url);
+    const data = await this.fetch.getJsonFromApiHost(url);
 
     if (isPresent(data.jwt)) {
       const flashMessages = this.flashMessages;
@@ -86,5 +84,5 @@ export default class MyProfileComponent extends Component {
       flashMessages.success('general.successfullyInvalidatedTokens');
       this.args.toggleShowInvalidateTokens();
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/new-competency.js
+++ b/packages/frontend/app/components/new-competency.js
@@ -7,12 +7,11 @@ import { validatable, Length, NotBlank } from 'ilios-common/decorators/validatio
 export default class NewCompetencyComponent extends Component {
   @tracked @NotBlank() @Length(1, 200) title;
 
-  @dropTask
-  *cancelOrSave(event) {
+  cancelOrSave = dropTask(async event => {
     const keyCode = event.keyCode;
 
     if (13 === keyCode) {
-      yield this.save.perform();
+      await this.save.perform();
       return;
     }
 
@@ -20,18 +19,17 @@ export default class NewCompetencyComponent extends Component {
       this.removeErrorDisplayFor('title');
       this.title = null;
     }
-  }
+  });
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     const title = this.title;
-    yield this.args.add(title);
+    await this.args.add(title);
     this.removeErrorDisplayFor('title');
     this.title = null;
-  }
+  });
 }

--- a/packages/frontend/app/components/new-competency.js
+++ b/packages/frontend/app/components/new-competency.js
@@ -7,7 +7,7 @@ import { validatable, Length, NotBlank } from 'ilios-common/decorators/validatio
 export default class NewCompetencyComponent extends Component {
   @tracked @NotBlank() @Length(1, 200) title;
 
-  cancelOrSave = dropTask(async event => {
+  cancelOrSave = dropTask(async (event) => {
     const keyCode = event.keyCode;
 
     if (13 === keyCode) {

--- a/packages/frontend/app/components/new-directory-user.js
+++ b/packages/frontend/app/components/new-directory-user.js
@@ -216,7 +216,7 @@ export default class NewDirectoryUserComponent extends Component {
     }
   }
 
-  findUsersInDirectory = restartableTask(async searchTerms => {
+  findUsersInDirectory = restartableTask(async (searchTerms) => {
     this.searchResultsReturned = false;
     this.tooManyResults = false;
     if (!isEmpty(searchTerms)) {

--- a/packages/frontend/app/components/new-user.js
+++ b/packages/frontend/app/components/new-user.js
@@ -138,8 +138,7 @@ export default class NewUserComponent extends Component {
     return !!auths.length;
   }
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplaysFor([
       'firstName',
       'middleName',
@@ -151,17 +150,17 @@ export default class NewUserComponent extends Component {
       'username',
       'password',
     ]);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
-    const isUsernameTaken = yield this.isUsernameTaken(this.username);
+    const isUsernameTaken = await this.isUsernameTaken(this.username);
     if (isUsernameTaken) {
       this.clearErrorDisplay();
       this.showUsernameTakenErrorMessage = true;
       return false;
     }
-    const roles = yield this.store.findAll('user-role');
+    const roles = await this.store.findAll('user-role');
     const primaryCohort = this.bestSelectedCohort;
     let user = this.store.createRecord('user', {
       firstName: this.firstName,
@@ -180,25 +179,24 @@ export default class NewUserComponent extends Component {
       const studentRole = findBy(roles.slice(), 'title', 'Student');
       user.set('roles', [studentRole]);
     }
-    user = yield user.save();
+    user = await user.save();
     const authentication = this.store.createRecord('authentication', {
       user,
       username: this.username,
       password: this.password,
     });
-    yield authentication.save();
+    await authentication.save();
     this.clearErrorDisplay();
     this.flashMessages.success('general.saved');
     this.args.transitionToUser(user.get('id'));
-  }
+  });
 
-  @dropTask
-  *saveOrCancel(event) {
+  saveOrCancel = dropTask(async event => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
-      yield this.save.perform();
+      await this.save.perform();
     } else if (27 === keyCode) {
       this.args.close();
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/new-user.js
+++ b/packages/frontend/app/components/new-user.js
@@ -191,7 +191,7 @@ export default class NewUserComponent extends Component {
     this.args.transitionToUser(user.get('id'));
   });
 
-  saveOrCancel = dropTask(async event => {
+  saveOrCancel = dropTask(async (event) => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
       await this.save.perform();

--- a/packages/frontend/app/components/pending-single-user-update.js
+++ b/packages/frontend/app/components/pending-single-user-update.js
@@ -25,29 +25,26 @@ export default class PendingSingleUserUpdateComponent extends Component {
     );
   }
 
-  @dropTask
-  *updateEmailAddress(update) {
+  updateEmailAddress = dropTask(async update => {
     this.args.user.set('email', update.value);
-    yield this.args.user.save();
-    yield update.destroyRecord();
+    await this.args.user.save();
+    await update.destroyRecord();
     this.flashMessages.success('general.savedSuccessfully');
-  }
+  });
 
-  @dropTask
-  *disableUser() {
-    const updates = yield this.args.user.pendingUserUpdates;
+  disableUser = dropTask(async () => {
+    const updates = await this.args.user.pendingUserUpdates;
     this.args.user.set('enabled', false);
-    yield this.args.user.save();
-    yield all(updates.map((update) => update.destroyRecord()));
+    await this.args.user.save();
+    await all(updates.map((update) => update.destroyRecord()));
     this.flashMessages.success('general.savedSuccessfully');
-  }
+  });
 
-  @dropTask
-  *excludeFromSync() {
-    const updates = yield this.args.user.pendingUserUpdates;
+  excludeFromSync = dropTask(async () => {
+    const updates = await this.args.user.pendingUserUpdates;
     this.args.user.set('userSyncIgnore', true);
-    yield this.args.user.save();
-    yield all(updates.map((update) => update.destroyRecord()));
+    await this.args.user.save();
+    await all(updates.map((update) => update.destroyRecord()));
     this.flashMessages.success('general.savedSuccessfully');
-  }
+  });
 }

--- a/packages/frontend/app/components/pending-single-user-update.js
+++ b/packages/frontend/app/components/pending-single-user-update.js
@@ -25,7 +25,7 @@ export default class PendingSingleUserUpdateComponent extends Component {
     );
   }
 
-  updateEmailAddress = dropTask(async update => {
+  updateEmailAddress = dropTask(async (update) => {
     this.args.user.set('email', update.value);
     await this.args.user.save();
     await update.destroyRecord();

--- a/packages/frontend/app/components/program-year/collapsed-objectives.js
+++ b/packages/frontend/app/components/program-year/collapsed-objectives.js
@@ -8,12 +8,11 @@ export default class ProgramYearCollapsedObjectivesComponent extends Component {
   @tracked objectivesWithMesh;
   @tracked objectivesWithTerms;
 
-  @restartableTask
-  *load(element, [objectivePromise]) {
+  load = restartableTask(async (element, [objectivePromise]) => {
     if (!objectivePromise) {
       return false;
     }
-    this.objectives = yield objectivePromise;
+    this.objectives = await objectivePromise;
 
     this.objectivesWithCompetency = this.objectives.filter((objective) => {
       return !!objective.belongsTo('competency').id();
@@ -28,5 +27,5 @@ export default class ProgramYearCollapsedObjectivesComponent extends Component {
     });
 
     return true;
-  }
+  });
 }

--- a/packages/frontend/app/components/program-year/competencies.js
+++ b/packages/frontend/app/components/program-year/competencies.js
@@ -108,16 +108,15 @@ export default class ProgramYearCompetenciesComponent extends Component {
     }
   }
 
-  @task
-  *save() {
-    yield timeout(10);
+  save = task(async () => {
+    await timeout(10);
     this.args.programYear.set('competencies', this.selectedCompetencies);
     try {
-      yield this.args.programYear.save();
+      await this.args.programYear.save();
     } finally {
       this.flashMessages.success('general.savedSuccessfully');
       this.args.setIsManaging(false);
       this.args.expand();
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/program-year/leadership-expanded.js
+++ b/packages/frontend/app/components/program-year/leadership-expanded.js
@@ -47,11 +47,11 @@ export default class ProgramYearLeadershipExpandedComponent extends Component {
     this.directorsToRemove = [];
     this.args.setIsManaging(false);
   }
-  @dropTask
-  *save() {
+
+  save = dropTask(async () => {
     this.args.programYear.set('directors', this.directors);
     this.args.expand();
-    yield this.args.programYear.save();
+    await this.args.programYear.save();
     this.close();
-  }
+  });
 }

--- a/packages/frontend/app/components/program-year/list-item.js
+++ b/packages/frontend/app/components/program-year/list-item.js
@@ -81,20 +81,17 @@ export default class ProgramYearListItemComponent extends Component {
     return { canDelete, canLock, canUnlock };
   }
 
-  @dropTask
-  *lock() {
+  lock = dropTask(async () => {
     this.args.programYear.set('locked', true);
-    yield this.args.programYear.save();
-  }
+    await this.args.programYear.save();
+  });
 
-  @dropTask
-  *unlock() {
+  unlock = dropTask(async () => {
     this.args.programYear.set('locked', false);
-    yield this.args.programYear.save();
-  }
+    await this.args.programYear.save();
+  });
 
-  @dropTask
-  *remove() {
-    yield this.args.programYear.destroyRecord();
-  }
+  remove = dropTask(async () => {
+    await this.args.programYear.destroyRecord();
+  });
 }

--- a/packages/frontend/app/components/program-year/list.js
+++ b/packages/frontend/app/components/program-year/list.js
@@ -35,8 +35,7 @@ export default class ProgramYearListComponent extends Component {
     return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
   }
 
-  @dropTask
-  *saveNew(startYear) {
+  saveNew = dropTask(async startYear => {
     const latestProgramYear = this.sortedProgramYears.reverse()[0];
     const newProgramYear = this.store.createRecord('program-year', {
       program: this.args.program,
@@ -44,16 +43,16 @@ export default class ProgramYearListComponent extends Component {
     });
 
     if (latestProgramYear) {
-      const directors = (yield latestProgramYear.directors).slice();
-      const competencies = (yield latestProgramYear.competencies).slice();
-      const terms = (yield latestProgramYear.terms).slice();
+      const directors = ((await latestProgramYear.directors)).slice();
+      const competencies = ((await latestProgramYear.competencies)).slice();
+      const terms = ((await latestProgramYear.terms)).slice();
       newProgramYear.set('directors', directors);
       newProgramYear.set('competencies', competencies);
       newProgramYear.set('terms', terms);
     }
-    const savedProgramYear = yield newProgramYear.save();
+    const savedProgramYear = await newProgramYear.save();
     if (latestProgramYear) {
-      const relatedObjectives = yield latestProgramYear.programYearObjectives;
+      const relatedObjectives = await latestProgramYear.programYearObjectives;
       const programYearObjectives = sortBy(relatedObjectives.slice(), 'id');
 
       const newObjectiveObjects = programYearObjectives.map((pyoToCopy) => {
@@ -114,7 +113,7 @@ export default class ProgramYearListComponent extends Component {
 
         return rhett;
       });
-      const newProgramYearObjectives = yield this.fetch.postManyToApi(
+      const newProgramYearObjectives = await this.fetch.postManyToApi(
         `programyearobjectives`,
         newObjectiveObjects,
       );
@@ -122,5 +121,5 @@ export default class ProgramYearListComponent extends Component {
     }
     this.savedProgramYear = newProgramYear;
     this.editorOn = false;
-  }
+  });
 }

--- a/packages/frontend/app/components/program-year/list.js
+++ b/packages/frontend/app/components/program-year/list.js
@@ -35,7 +35,7 @@ export default class ProgramYearListComponent extends Component {
     return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
   }
 
-  saveNew = dropTask(async startYear => {
+  saveNew = dropTask(async (startYear) => {
     const latestProgramYear = this.sortedProgramYears.reverse()[0];
     const newProgramYear = this.store.createRecord('program-year', {
       program: this.args.program,
@@ -43,9 +43,9 @@ export default class ProgramYearListComponent extends Component {
     });
 
     if (latestProgramYear) {
-      const directors = ((await latestProgramYear.directors)).slice();
-      const competencies = ((await latestProgramYear.competencies)).slice();
-      const terms = ((await latestProgramYear.terms)).slice();
+      const directors = (await latestProgramYear.directors).slice();
+      const competencies = (await latestProgramYear.competencies).slice();
+      const terms = (await latestProgramYear.terms).slice();
       newProgramYear.set('directors', directors);
       newProgramYear.set('competencies', competencies);
       newProgramYear.set('terms', terms);

--- a/packages/frontend/app/components/program-year/managed-competency-list-item.js
+++ b/packages/frontend/app/components/program-year/managed-competency-list-item.js
@@ -13,13 +13,13 @@ export default class ProgramYearManagedCompetencyListItemComponent extends Compo
     return this.childrenData.isResolved ? this.childrenData.value : [];
   }
 
-  addCompetencyToBuffer = task(async competency => {
-    const children = ((await competency.children)).slice();
+  addCompetencyToBuffer = task(async (competency) => {
+    const children = (await competency.children).slice();
     this.args.addCompetencyToBuffer(competency, children);
   });
 
-  removeCompetencyFromBuffer = task(async competency => {
-    const children = ((await competency.children)).slice();
+  removeCompetencyFromBuffer = task(async (competency) => {
+    const children = (await competency.children).slice();
     this.args.removeCompetencyFromBuffer(competency, children);
   });
 }

--- a/packages/frontend/app/components/program-year/managed-competency-list-item.js
+++ b/packages/frontend/app/components/program-year/managed-competency-list-item.js
@@ -13,15 +13,13 @@ export default class ProgramYearManagedCompetencyListItemComponent extends Compo
     return this.childrenData.isResolved ? this.childrenData.value : [];
   }
 
-  @task
-  *addCompetencyToBuffer(competency) {
-    const children = (yield competency.children).slice();
+  addCompetencyToBuffer = task(async competency => {
+    const children = ((await competency.children)).slice();
     this.args.addCompetencyToBuffer(competency, children);
-  }
+  });
 
-  @task
-  *removeCompetencyFromBuffer(competency) {
-    const children = (yield competency.children).slice();
+  removeCompetencyFromBuffer = task(async competency => {
+    const children = ((await competency.children)).slice();
     this.args.removeCompetencyFromBuffer(competency, children);
-  }
+  });
 }

--- a/packages/frontend/app/components/program-year/new.js
+++ b/packages/frontend/app/components/program-year/new.js
@@ -39,8 +39,7 @@ export default class NewProgramYearComponent extends Component {
     }
   }
 
-  @dropTask
-  *saveNewYear() {
-    yield this.args.save(this.selectedYear.value);
-  }
+  saveNewYear = dropTask(async () => {
+    await this.args.save(this.selectedYear.value);
+  });
 }

--- a/packages/frontend/app/components/program-year/objective-list-item-expanded.js
+++ b/packages/frontend/app/components/program-year/objective-list-item-expanded.js
@@ -8,13 +8,12 @@ import { findById } from 'ilios-common/utils/array-helpers';
 export default class ProgramYearObjectiveListItemExpandedComponent extends Component {
   @tracked courseObjects;
 
-  @restartableTask
-  *load(element, [programYearObjective]) {
+  load = restartableTask(async (element, [programYearObjective]) => {
     if (!programYearObjective) {
       return;
     }
-    const courseObjectives = (yield programYearObjective.courseObjectives).slice();
-    const objectiveObjects = yield map(courseObjectives, async (courseObjective) => {
+    const courseObjectives = ((await programYearObjective.courseObjectives)).slice();
+    const objectiveObjects = await map(courseObjectives, async (courseObjective) => {
       const course = await courseObjective.course;
       return {
         title: courseObjective.title,
@@ -42,5 +41,5 @@ export default class ProgramYearObjectiveListItemExpandedComponent extends Compo
       });
       return set;
     }, []);
-  }
+  });
 }

--- a/packages/frontend/app/components/program-year/objective-list-item-expanded.js
+++ b/packages/frontend/app/components/program-year/objective-list-item-expanded.js
@@ -12,7 +12,7 @@ export default class ProgramYearObjectiveListItemExpandedComponent extends Compo
     if (!programYearObjective) {
       return;
     }
-    const courseObjectives = ((await programYearObjective.courseObjectives)).slice();
+    const courseObjectives = (await programYearObjective.courseObjectives).slice();
     const objectiveObjects = await map(courseObjectives, async (courseObjective) => {
       const course = await courseObjective.course;
       return {

--- a/packages/frontend/app/components/program-year/objective-list-item.js
+++ b/packages/frontend/app/components/program-year/objective-list-item.js
@@ -95,7 +95,7 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
     this.highlightSave.perform();
   });
 
-  saveIsActive = dropTask(async active => {
+  saveIsActive = dropTask(async (active) => {
     this.args.programYearObjective.set('active', active);
     await this.args.programYearObjective.save();
     this.highlightSave.perform();
@@ -112,7 +112,7 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
     this.isManagingDescriptors = true;
   });
 
-  manageTerms = dropTask(async vocabulary => {
+  manageTerms = dropTask(async (vocabulary) => {
     this.selectedVocabulary = vocabulary;
     const terms = await this.args.programYearObjective.terms;
     this.termsBuffer = terms.slice();

--- a/packages/frontend/app/components/program-year/objective-list-item.js
+++ b/packages/frontend/app/components/program-year/objective-list-item.js
@@ -83,77 +83,69 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
     return { meshDescriptors, programYear, program, school, vocabularies };
   }
 
-  @dropTask
-  *saveTitleChanges() {
+  saveTitleChanges = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid('title');
+    const isValid = await this.isValid('title');
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('title');
     this.args.programYearObjective.set('title', this.title);
-    yield this.args.programYearObjective.save();
+    await this.args.programYearObjective.save();
     this.highlightSave.perform();
-  }
+  });
 
-  @dropTask
-  *saveIsActive(active) {
+  saveIsActive = dropTask(async active => {
     this.args.programYearObjective.set('active', active);
-    yield this.args.programYearObjective.save();
+    await this.args.programYearObjective.save();
     this.highlightSave.perform();
-  }
+  });
 
-  @dropTask
-  *manageCompetency() {
-    this.competencyBuffer = yield this.args.programYearObjective.competency;
+  manageCompetency = dropTask(async () => {
+    this.competencyBuffer = await this.args.programYearObjective.competency;
     this.isManagingCompetency = true;
-  }
-  @dropTask
-  *manageDescriptors() {
-    const meshDescriptors = yield this.args.programYearObjective.meshDescriptors;
+  });
+
+  manageDescriptors = dropTask(async () => {
+    const meshDescriptors = await this.args.programYearObjective.meshDescriptors;
     this.descriptorsBuffer = meshDescriptors.slice();
     this.isManagingDescriptors = true;
-  }
+  });
 
-  @dropTask
-  *manageTerms(vocabulary) {
+  manageTerms = dropTask(async vocabulary => {
     this.selectedVocabulary = vocabulary;
-    const terms = yield this.args.programYearObjective.terms;
+    const terms = await this.args.programYearObjective.terms;
     this.termsBuffer = terms.slice();
     this.isManagingTerms = true;
-  }
+  });
 
-  @restartableTask
-  *highlightSave() {
-    yield timeout(1000);
-  }
+  highlightSave = restartableTask(async () => {
+    await timeout(1000);
+  });
 
-  @dropTask
-  *saveCompetency() {
+  saveCompetency = dropTask(async () => {
     this.args.programYearObjective.set('competency', this.competencyBuffer);
-    yield this.args.programYearObjective.save();
+    await this.args.programYearObjective.save();
     this.competencyBuffer = null;
     this.isManagingCompetency = false;
     this.highlightSave.perform();
-  }
+  });
 
-  @dropTask
-  *saveDescriptors() {
+  saveDescriptors = dropTask(async () => {
     this.args.programYearObjective.set('meshDescriptors', this.descriptorsBuffer);
-    yield this.args.programYearObjective.save();
+    await this.args.programYearObjective.save();
     this.descriptorsBuffer = [];
     this.isManagingDescriptors = false;
     this.highlightSave.perform();
-  }
+  });
 
-  @dropTask
-  *saveTerms() {
+  saveTerms = dropTask(async () => {
     this.args.programYearObjective.set('terms', this.termsBuffer);
-    yield this.args.programYearObjective.save();
+    await this.args.programYearObjective.save();
     this.termsBuffer = [];
     this.isManagingTerms = false;
     this.highlightSave.perform();
-  }
+  });
 
   @action
   revertTitleChanges() {
@@ -195,8 +187,8 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
     this.isManagingTerms = false;
     this.selectedVocabulary = null;
   }
-  @dropTask
-  *deleteObjective() {
-    yield this.args.programYearObjective.destroyRecord();
-  }
+
+  deleteObjective = dropTask(async () => {
+    await this.args.programYearObjective.destroyRecord();
+  });
 }

--- a/packages/frontend/app/components/program-year/objective-list.js
+++ b/packages/frontend/app/components/program-year/objective-list.js
@@ -69,17 +69,16 @@ export default class ProgramYearObjectiveListComponent extends Component {
     return new Headers(headers);
   }
 
-  @dropTask
-  *downloadReport() {
+  downloadReport = dropTask(async () => {
     const apiPath = '/' + this.iliosConfig.apiNameSpace;
     const resourcePath = `/programyears/${this.args.programYear.id}/downloadobjectivesmapping`;
     const host = this.iliosConfig.apiHost ?? `${window.location.protocol}//${window.location.host}`;
     const url = host + apiPath + resourcePath;
-    const { default: saveAs } = yield import('file-saver');
-    const response = yield fetch(url, {
+    const { default: saveAs } = await import('file-saver');
+    const response = await fetch(url, {
       headers: this.authHeaders,
     });
-    const blob = yield response.blob();
+    const blob = await response.blob();
     saveAs(blob, 'report.csv');
-  }
+  });
 }

--- a/packages/frontend/app/components/program-year/objectives.js
+++ b/packages/frontend/app/components/program-year/objectives.js
@@ -26,7 +26,7 @@ export default class ProgramYearObjectivesComponent extends Component {
     this.objectiveCount = programYear.hasMany('programYearObjectives').ids().length;
   }
 
-  saveNewObjective = dropTask(async title => {
+  saveNewObjective = dropTask(async (title) => {
     const programYearObjectives = await this.args.programYear.programYearObjectives;
     const position = programYearObjectives.length
       ? sortBy(programYearObjectives.slice(), 'position').reverse()[0].position + 1

--- a/packages/frontend/app/components/program-year/objectives.js
+++ b/packages/frontend/app/components/program-year/objectives.js
@@ -26,9 +26,8 @@ export default class ProgramYearObjectivesComponent extends Component {
     this.objectiveCount = programYear.hasMany('programYearObjectives').ids().length;
   }
 
-  @dropTask
-  *saveNewObjective(title) {
-    const programYearObjectives = yield this.args.programYear.programYearObjectives;
+  saveNewObjective = dropTask(async title => {
+    const programYearObjectives = await this.args.programYear.programYearObjectives;
     const position = programYearObjectives.length
       ? sortBy(programYearObjectives.slice(), 'position').reverse()[0].position + 1
       : 0;
@@ -38,11 +37,11 @@ export default class ProgramYearObjectivesComponent extends Component {
     newProgramYearObjective.set('position', position);
     newProgramYearObjective.set('programYear', this.args.programYear);
 
-    yield newProgramYearObjective.save();
+    await newProgramYearObjective.save();
 
     this.newObjectiveEditorOn = false;
     this.flashMessages.success('general.newObjectiveSaved');
-  }
+  });
 
   @action
   toggleNewObjectiveEditor() {

--- a/packages/frontend/app/components/program/header.js
+++ b/packages/frontend/app/components/program/header.js
@@ -13,18 +13,17 @@ export default class ProgramHeaderComponent extends Component {
     this.title = this.args.program.title;
   }
 
-  @dropTask
-  *changeTitle() {
+  changeTitle = dropTask(async () => {
     if (this.title !== this.args.program.title) {
       this.addErrorDisplayFor('title');
-      const isValid = yield this.isValid('title');
+      const isValid = await this.isValid('title');
       if (!isValid) {
         return false;
       }
       this.args.program.set('title', this.title);
-      yield this.args.program.save();
+      await this.args.program.save();
       this.title = this.args.program.title;
       this.removeErrorDisplayFor('title');
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/program/leadership-expanded.js
+++ b/packages/frontend/app/components/program/leadership-expanded.js
@@ -45,11 +45,11 @@ export default class ProgramLeadershipExpandedComponent extends Component {
     this.directorsToRemove = [];
     this.args.setIsManaging(false);
   }
-  @dropTask
-  *save() {
+
+  save = dropTask(async () => {
     this.args.program.set('directors', this.directors);
     this.args.expand();
-    yield this.args.program.save();
+    await this.args.program.save();
     this.close();
-  }
+  });
 }

--- a/packages/frontend/app/components/program/new.js
+++ b/packages/frontend/app/components/program/new.js
@@ -11,10 +11,9 @@ export default class NewProgramComponent extends Component {
 
   @tracked @Length(3, 200) @NotBlank() title;
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
@@ -22,8 +21,8 @@ export default class NewProgramComponent extends Component {
     const program = this.store.createRecord('program', {
       title: this.title,
     });
-    yield this.args.save(program);
-  }
+    await this.args.save(program);
+  });
 
   @action
   async keyboard({ keyCode }) {

--- a/packages/frontend/app/components/program/overview.js
+++ b/packages/frontend/app/components/program/overview.js
@@ -17,29 +17,27 @@ export default class ProgramOverviewComponent extends Component {
     this.shortTitle = this.args.program.shortTitle;
   }
 
-  @dropTask
-  *changeShortTitle() {
+  changeShortTitle = dropTask(async () => {
     if (this.shortTitle !== this.args.program.shortTitle) {
       this.addErrorDisplayFor('shortTitle');
-      const isValid = yield this.isValid('shortTitle');
+      const isValid = await this.isValid('shortTitle');
       if (!isValid) {
         return false;
       }
       this.args.program.set('shortTitle', this.shortTitle);
-      yield this.args.program.save();
+      await this.args.program.save();
       this.shortTitle = this.args.program.shortTitle;
       this.removeErrorDisplayFor('shortTitle');
     }
-  }
+  });
 
-  @dropTask
-  *changeDuration() {
+  changeDuration = dropTask(async () => {
     if (this.duration !== this.args.program.duration) {
       this.args.program.set('duration', this.duration);
-      yield this.args.program.save();
+      await this.args.program.save();
       this.duration = this.args.program.duration;
     }
-  }
+  });
 
   @action
   setDuration(ev) {

--- a/packages/frontend/app/components/programs/list-item.js
+++ b/packages/frontend/app/components/programs/list-item.js
@@ -16,8 +16,7 @@ export default class ProgramListItemComponent extends Component {
     return this.canDeletePermission && !hasCiReports && !hasProgramYears;
   }
 
-  @dropTask
-  *remove() {
-    yield this.args.program.destroyRecord();
-  }
+  remove = dropTask(async () => {
+    await this.args.program.destroyRecord();
+  });
 }

--- a/packages/frontend/app/components/programs/root.js
+++ b/packages/frontend/app/components/programs/root.js
@@ -40,11 +40,10 @@ export default class ProgramRootComponent extends Component {
     return schoolId ? findById(this.args.schools.slice(), schoolId) : this.args.schools.slice()[0];
   }
 
-  @dropTask
-  *saveNewProgram(newProgram) {
+  saveNewProgram = dropTask(async newProgram => {
     newProgram.set('school', this.bestSelectedSchool);
     newProgram.set('duration', 4);
-    this.newProgram = yield newProgram.save();
+    this.newProgram = await newProgram.save();
     this.showNewProgramForm = false;
-  }
+  });
 }

--- a/packages/frontend/app/components/programs/root.js
+++ b/packages/frontend/app/components/programs/root.js
@@ -40,7 +40,7 @@ export default class ProgramRootComponent extends Component {
     return schoolId ? findById(this.args.schools.slice(), schoolId) : this.args.schools.slice()[0];
   }
 
-  saveNewProgram = dropTask(async newProgram => {
+  saveNewProgram = dropTask(async (newProgram) => {
     newProgram.set('school', this.bestSelectedSchool);
     newProgram.set('duration', 4);
     this.newProgram = await newProgram.save();

--- a/packages/frontend/app/components/reports/list.js
+++ b/packages/frontend/app/components/reports/list.js
@@ -115,34 +115,33 @@ export default class ReportsListComponent extends Component {
     return this.subjectReportsFilteredByTitle;
   }
 
-  @dropTask
-  *saveNewSubjectReport(report) {
+  saveNewSubjectReport = dropTask(async report => {
     this.runningSubjectReport = null;
-    this.newSubjectReport = yield report.save();
+    this.newSubjectReport = await report.save();
     this.showNewReportForm = false;
-  }
+  });
 
-  @dropTask
-  *removeReport(report) {
-    yield report.destroyRecord();
+  removeReport = dropTask(async report => {
+    await report.destroyRecord();
     this.newSubjectReport = null;
-  }
+  });
 
-  @restartableTask
-  *runSubjectReport(subject, prepositionalObject, prepositionalObjectTableRowId, school) {
-    this.runningSubjectReport = {
-      subject,
-      prepositionalObject,
-      prepositionalObjectTableRowId,
-      school,
-      description: yield this.reporting.buildReportDescription(
+  runSubjectReport = restartableTask(
+    async (subject, prepositionalObject, prepositionalObjectTableRowId, school) => {
+      this.runningSubjectReport = {
         subject,
         prepositionalObject,
         prepositionalObjectTableRowId,
         school,
-      ),
-    };
-  }
+        description: await this.reporting.buildReportDescription(
+          subject,
+          prepositionalObject,
+          prepositionalObjectTableRowId,
+          school,
+        ),
+      };
+    }
+  );
 
   @action
   toggleNewReportForm() {

--- a/packages/frontend/app/components/reports/list.js
+++ b/packages/frontend/app/components/reports/list.js
@@ -115,13 +115,13 @@ export default class ReportsListComponent extends Component {
     return this.subjectReportsFilteredByTitle;
   }
 
-  saveNewSubjectReport = dropTask(async report => {
+  saveNewSubjectReport = dropTask(async (report) => {
     this.runningSubjectReport = null;
     this.newSubjectReport = await report.save();
     this.showNewReportForm = false;
   });
 
-  removeReport = dropTask(async report => {
+  removeReport = dropTask(async (report) => {
     await report.destroyRecord();
     this.newSubjectReport = null;
   });
@@ -140,7 +140,7 @@ export default class ReportsListComponent extends Component {
           school,
         ),
       };
-    }
+    },
   );
 
   @action

--- a/packages/frontend/app/components/reports/new-subject.js
+++ b/packages/frontend/app/components/reports/new-subject.js
@@ -282,10 +282,9 @@ export default class ReportsNewSubjectComponent extends Component {
     }
   }
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplaysFor(['title', 'prepositionalObject', 'prepositionalObjectId']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
@@ -299,13 +298,12 @@ export default class ReportsNewSubjectComponent extends Component {
       prepositionalObjectTableRowId: this.prepositionalObjectId,
       school: this.currentSchool,
     });
-    yield this.args.save(report);
-  }
+    await this.args.save(report);
+  });
 
-  @dropTask
-  *run() {
+  run = dropTask(async () => {
     this.addErrorDisplaysFor(['title', 'prepositionalObject', 'prepositionalObjectId']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
@@ -317,7 +315,7 @@ export default class ReportsNewSubjectComponent extends Component {
       this.prepositionalObjectId,
       this.currentSchool,
     );
-  }
+  });
 
   @action
   changeSchool(schoolId) {

--- a/packages/frontend/app/components/reports/subject.js
+++ b/packages/frontend/app/components/reports/subject.js
@@ -76,33 +76,31 @@ export default class ReportsSubjectComponent extends Component {
     return null;
   }
 
-  @dropTask
-  *changeTitle() {
+  changeTitle = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid('title');
+    const isValid = await this.isValid('title');
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('title');
     this.args.report.title = this.title;
-    yield this.args.report.save();
-  }
+    await this.args.report.save();
+  });
 
   @action
   revertTitleChanges() {
     this.title = this.reportTitle;
   }
 
-  @dropTask
-  *downloadReport() {
+  downloadReport = dropTask(async () => {
     const report = this.args.report;
     const title = this.reportTitle;
     const year = this.args.selectedYear;
-    const data = yield this.reporting.getArrayResults(report, year);
+    const data = await this.reporting.getArrayResults(report, year);
     this.finishedBuildingReport = true;
     const csv = PapaParse.unparse(data);
     createDownloadFile(`${title}.csv`, csv, 'text/csv');
-    yield timeout(2000);
+    await timeout(2000);
     this.finishedBuildingReport = false;
-  }
+  });
 }

--- a/packages/frontend/app/components/reports/subject/new/competency.js
+++ b/packages/frontend/app/components/reports/subject/new/competency.js
@@ -31,9 +31,8 @@ export default class ReportsSubjectNewCompetencyComponent extends Component {
     return sortBy(this.filteredCompetencies, 'title');
   }
 
-  @task
-  *setInitialValue() {
-    yield timeout(1); //wait a moment so we can render before setting
+  setInitialValue = task(async () => {
+    await timeout(1); //wait a moment so we can render before setting
     const ids = this.sortedCompetencies.map(({ id }) => id);
     if (ids.includes(this.args.currentId)) {
       return;
@@ -43,5 +42,5 @@ export default class ReportsSubjectNewCompetencyComponent extends Component {
     } else {
       this.args.changeId(this.sortedCompetencies[0].id);
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/reports/subject/new/course.js
+++ b/packages/frontend/app/components/reports/subject/new/course.js
@@ -41,17 +41,16 @@ export default class ReportsSubjectNewCourseComponent extends Component {
     });
   }
 
-  @restartableTask
-  *search(q) {
+  search = restartableTask(async (q) => {
     if (!q.length) {
       this.courses = false;
       return;
     }
 
-    this.courses = yield this.store.query('course', {
+    this.courses = await this.store.query('course', {
       q,
     });
-  }
+  });
 
   @action
   clear() {

--- a/packages/frontend/app/components/reports/subject/new/instructor-group.js
+++ b/packages/frontend/app/components/reports/subject/new/instructor-group.js
@@ -31,9 +31,8 @@ export default class ReportsSubjectNewInstructorGroupComponent extends Component
     return sortBy(this.filteredInstructorGroups, 'title');
   }
 
-  @task
-  *setInitialValue() {
-    yield timeout(1); //wait a moment so we can render before setting
+  setInitialValue = task(async () => {
+    await timeout(1); //wait a moment so we can render before setting
     const ids = this.sortedInstructorGroups.map(({ id }) => id);
     if (ids.includes(this.args.currentId)) {
       return;
@@ -43,5 +42,5 @@ export default class ReportsSubjectNewInstructorGroupComponent extends Component
     } else {
       this.args.changeId(this.sortedInstructorGroups[0].id);
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/reports/subject/new/learning-material.js
+++ b/packages/frontend/app/components/reports/subject/new/learning-material.js
@@ -25,17 +25,16 @@ export default class ReportsSubjectNewLearningMaterialComponent extends Componen
     return sortBy(this.materials, 'title');
   }
 
-  @restartableTask
-  *search(q) {
+  search = restartableTask(async (q) => {
     if (!q.length) {
       this.materials = false;
       return;
     }
 
-    this.materials = yield this.store.query('learning-material', {
+    this.materials = await this.store.query('learning-material', {
       q,
     });
-  }
+  });
 
   @action
   clear() {

--- a/packages/frontend/app/components/reports/subject/new/program-year.js
+++ b/packages/frontend/app/components/reports/subject/new/program-year.js
@@ -56,9 +56,8 @@ export default class ReportsSubjectNewProgramYearComponent extends Component {
     return this.sortedProgramYears.map(({ programYear }) => programYear);
   }
 
-  @task
-  *setInitialValue() {
-    yield timeout(1); //wait a moment so we can render before setting
+  setInitialValue = task(async () => {
+    await timeout(1); //wait a moment so we can render before setting
     const ids = this.programYears.map(({ id }) => id);
     if (ids.includes(this.args.currentId)) {
       return;
@@ -68,5 +67,5 @@ export default class ReportsSubjectNewProgramYearComponent extends Component {
     } else {
       this.args.changeId(this.programYears[0].id);
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/reports/subject/new/program.js
+++ b/packages/frontend/app/components/reports/subject/new/program.js
@@ -31,9 +31,8 @@ export default class ReportsSubjectNewProgramComponent extends Component {
     return sortBy(this.filteredPrograms, 'title');
   }
 
-  @task
-  *setInitialValue() {
-    yield timeout(1); //wait a moment so we can render before setting
+  setInitialValue = task(async () => {
+    await timeout(1); //wait a moment so we can render before setting
     const ids = this.sortedPrograms.map(({ id }) => id);
     if (ids.includes(this.args.currentId)) {
       return;
@@ -43,5 +42,5 @@ export default class ReportsSubjectNewProgramComponent extends Component {
     } else {
       this.args.changeId(this.sortedPrograms[0].id);
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/reports/subject/new/session-type.js
+++ b/packages/frontend/app/components/reports/subject/new/session-type.js
@@ -31,9 +31,8 @@ export default class ReportsSubjectNewSessionTypeComponent extends Component {
     return sortBy(this.filteredSessionTypes, 'title');
   }
 
-  @task
-  *setInitialValue() {
-    yield timeout(1); //wait a moment so we can render before setting
+  setInitialValue = task(async () => {
+    await timeout(1); //wait a moment so we can render before setting
     const ids = this.sortedSessionTypes.map(({ id }) => id);
     if (ids.includes(this.args.currentId)) {
       return;
@@ -43,5 +42,5 @@ export default class ReportsSubjectNewSessionTypeComponent extends Component {
     } else {
       this.args.changeId(this.sortedSessionTypes[0].id);
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/reports/subject/new/session.js
+++ b/packages/frontend/app/components/reports/subject/new/session.js
@@ -52,18 +52,17 @@ export default class ReportsSubjectNewSessionComponent extends Component {
     });
   }
 
-  @restartableTask
-  *search(q) {
+  search = restartableTask(async (q) => {
     if (!q.length) {
       this.sessions = false;
       return;
     }
 
-    this.sessions = yield this.store.query('session', {
+    this.sessions = await this.store.query('session', {
       q: q,
       include: 'course',
     });
-  }
+  });
 
   @action
   clear() {

--- a/packages/frontend/app/components/reports/subject/new/term.js
+++ b/packages/frontend/app/components/reports/subject/new/term.js
@@ -64,9 +64,8 @@ export default class ReportsSubjectNewProgramYearComponent extends Component {
     return sortBy(this.filteredTerms, ['vocabulary.title', 'title']);
   }
 
-  @task
-  *setInitialValue() {
-    yield timeout(1); //wait a moment so we can render before setting
+  setInitialValue = task(async () => {
+    await timeout(1); //wait a moment so we can render before setting
     const ids = this.sortedTerms.map(({ term }) => term.id);
     if (ids.includes(this.args.currentId)) {
       return;
@@ -76,5 +75,5 @@ export default class ReportsSubjectNewProgramYearComponent extends Component {
     } else {
       this.args.changeId(this.sortedTerms[0].term.id);
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/school-competencies-collapsed.js
+++ b/packages/frontend/app/components/school-competencies-collapsed.js
@@ -21,8 +21,7 @@ export default class SchoolCompetenciesCollapsedComponent extends Component {
     });
   }
 
-  @restartableTask
-  *load() {
-    this.competenciesRelationship = yield this.args.school.competencies;
-  }
+  load = restartableTask(async () => {
+    this.competenciesRelationship = await this.args.school.competencies;
+  });
 }

--- a/packages/frontend/app/components/school-competencies-expanded.js
+++ b/packages/frontend/app/components/school-competencies-expanded.js
@@ -12,11 +12,10 @@ export default class SchoolCompetenciesExpandedComponent extends Component {
   @tracked competenciesToRemove = [];
   @tracked schoolCompetencies;
 
-  @restartableTask
-  *load() {
+  load = restartableTask(async () => {
     this.cleanup();
-    this.schoolCompetencies = yield this.args.school.competencies;
-  }
+    this.schoolCompetencies = await this.args.school.competencies;
+  });
 
   get competencies() {
     if (!this.schoolCompetencies) {
@@ -80,8 +79,7 @@ export default class SchoolCompetenciesExpandedComponent extends Component {
     this.competenciesToRemove = [...this.competenciesToRemove, competency];
   }
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     const domainsToRemove = this.schoolCompetencies.filter((competency) => {
       return !competency.belongsTo('parent').id() && !this.competencies.includes(competency);
     });
@@ -90,8 +88,8 @@ export default class SchoolCompetenciesExpandedComponent extends Component {
     });
 
     // delete all removed competencies first, then all removed domains
-    yield all(competenciesToRemove.map((competency) => competency.destroyRecord()));
-    yield all(domainsToRemove.map((domain) => domain.destroyRecord()));
+    await all(competenciesToRemove.map((competency) => competency.destroyRecord()));
+    await all(domainsToRemove.map((domain) => domain.destroyRecord()));
 
     // set the school on new competencies
     filterBy(this.competencies, 'isNew').forEach((competency) => {
@@ -99,13 +97,13 @@ export default class SchoolCompetenciesExpandedComponent extends Component {
     });
 
     // update all modified competencies (this will include new ones).
-    yield all(
+    await all(
       filterBy(this.competencies, 'hasDirtyAttributes').map((competency) => competency.save()),
     );
 
     // cleanup
     this.cleanup();
     this.args.setSchoolManageCompetencies(false);
-    this.schoolCompetencies = yield this.args.school.competencies;
-  }
+    this.schoolCompetencies = await this.args.school.competencies;
+  });
 }

--- a/packages/frontend/app/components/school-competencies-list-item-pcrs.js
+++ b/packages/frontend/app/components/school-competencies-list-item-pcrs.js
@@ -4,10 +4,9 @@ import { dropTask } from 'ember-concurrency';
 import { TrackedAsyncData } from 'ember-async-data';
 
 export default class SchoolCompetenciesListItemPcrsComponent extends Component {
-  @dropTask
-  *save() {
-    yield this.args.save();
-  }
+  save = dropTask(async () => {
+    await this.args.save();
+  });
 
   @cached
   get aamcPcrsesData() {

--- a/packages/frontend/app/components/school-curriculum-inventory-institution-manager.js
+++ b/packages/frontend/app/components/school-curriculum-inventory-institution-manager.js
@@ -68,7 +68,7 @@ export default class SchoolCurriculumInventoryInstitutionManagerComponent extend
     this.args.manage(false);
   });
 
-  saveOrCancel = dropTask(async event => {
+  saveOrCancel = dropTask(async (event) => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
       await this.save.perform();

--- a/packages/frontend/app/components/school-curriculum-inventory-institution-manager.js
+++ b/packages/frontend/app/components/school-curriculum-inventory-institution-manager.js
@@ -37,8 +37,7 @@ export default class SchoolCurriculumInventoryInstitutionManagerComponent extend
     }
   }
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplaysFor([
       'name',
       'aamcCode',
@@ -48,7 +47,7 @@ export default class SchoolCurriculumInventoryInstitutionManagerComponent extend
       'addressZipCode',
       'addressCountryCode',
     ]);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
@@ -64,18 +63,17 @@ export default class SchoolCurriculumInventoryInstitutionManagerComponent extend
     institution.set('addressStateOrProvince', this.addressStateOrProvince);
     institution.set('addressZipCode', this.addressZipCode);
     institution.set('addressCountryCode', this.addressCountryCode);
-    yield this.args.save(institution);
+    await this.args.save(institution);
     this.clearErrorDisplay();
     this.args.manage(false);
-  }
+  });
 
-  @dropTask
-  *saveOrCancel(event) {
+  saveOrCancel = dropTask(async event => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
-      yield this.save.perform();
+      await this.save.perform();
     } else if (27 === keyCode) {
       this.args.manage(false);
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/school-leadership-expanded.js
+++ b/packages/frontend/app/components/school-leadership-expanded.js
@@ -23,11 +23,10 @@ export default class SchoolLeadershipExpandedComponent extends Component {
     return this.administrators.length + this.directors.length;
   }
 
-  @restartableTask
-  *load() {
-    this.schoolDirectors = yield this.args.school.directors;
-    this.schoolAdministrators = yield this.args.school.administrators;
-  }
+  load = restartableTask(async () => {
+    this.schoolDirectors = await this.args.school.directors;
+    this.schoolAdministrators = await this.args.school.administrators;
+  });
 
   get directors() {
     const arr = [...this.schoolDirectors.slice(), ...this.directorsToAdd];
@@ -59,15 +58,14 @@ export default class SchoolLeadershipExpandedComponent extends Component {
     this.administratorsToRemove = [...this.administratorsToRemove, user];
   }
 
-  @dropTask
-  *save() {
-    yield timeout(10);
+  save = dropTask(async () => {
+    await timeout(10);
     this.args.school.setProperties({
       directors: this.directors,
       administrators: this.administrators,
     });
     this.args.expand();
-    yield this.args.school.save();
+    await this.args.school.save();
     this.args.setIsManaging(false);
-  }
+  });
 }

--- a/packages/frontend/app/components/school-list.js
+++ b/packages/frontend/app/components/school-list.js
@@ -31,10 +31,9 @@ export default class SchoolListComponent extends Component {
     this.iliosAdministratorEmail = null;
   }
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplaysFor(['title', 'iliosAdministratorEmail']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
@@ -42,15 +41,14 @@ export default class SchoolListComponent extends Component {
       title: this.title,
       iliosAdministratorEmail: this.iliosAdministratorEmail,
     });
-    this.newSchool = yield newSchool.save();
+    this.newSchool = await newSchool.save();
     this.clearErrorDisplay();
     this.title = null;
     this.iliosAdministratorEmail = null;
     this.showNewSchoolForm = false;
-  }
+  });
 
-  @dropTask
-  *saveOrCancel(event) {
+  saveOrCancel = dropTask(async event => {
     const keyCode = event.keyCode;
     const target = event.target;
 
@@ -59,9 +57,9 @@ export default class SchoolListComponent extends Component {
     }
 
     if (13 === keyCode) {
-      yield this.save.perform();
+      await this.save.perform();
     } else if (27 === keyCode) {
       this.closeNewSchoolForm();
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/school-list.js
+++ b/packages/frontend/app/components/school-list.js
@@ -48,7 +48,7 @@ export default class SchoolListComponent extends Component {
     this.showNewSchoolForm = false;
   });
 
-  saveOrCancel = dropTask(async event => {
+  saveOrCancel = dropTask(async (event) => {
     const keyCode = event.keyCode;
     const target = event.target;
 

--- a/packages/frontend/app/components/school-manager.js
+++ b/packages/frontend/app/components/school-manager.js
@@ -42,19 +42,18 @@ export default class SchoolManagerComponent extends Component {
     return this.sessionTypesData.isResolved ? !!this.sessionTypesData.value.length : false;
   }
 
-  @dropTask
-  *changeTitle() {
+  changeTitle = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('title');
 
     this.args.school.title = this.title;
-    this.newSchool = yield this.args.school.save();
+    this.newSchool = await this.args.school.save();
     this.flashMessages.success('general.savedSuccessfully');
-  }
+  });
 
   @action
   revertTitleChanges() {

--- a/packages/frontend/app/components/school-new-vocabulary-form.js
+++ b/packages/frontend/app/components/school-new-vocabulary-form.js
@@ -25,7 +25,7 @@ export default class SchoolNewVocabularyFormComponent extends Component {
     this.clearErrorDisplay();
   });
 
-  saveOrCancel = dropTask(async event => {
+  saveOrCancel = dropTask(async (event) => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
       await this.saveNew.perform();

--- a/packages/frontend/app/components/school-new-vocabulary-form.js
+++ b/packages/frontend/app/components/school-new-vocabulary-form.js
@@ -15,28 +15,26 @@ export default class SchoolNewVocabularyFormComponent extends Component {
   @Custom('validateTitleCallback', 'validateTitleMessageCallback')
   title;
 
-  @dropTask
-  *saveNew() {
+  saveNew = dropTask(async () => {
     this.addErrorDisplaysFor(['title']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
-    yield this.args.save.linked().perform(this.title, this.args.school, true);
+    await this.args.save.linked().perform(this.title, this.args.school, true);
     this.clearErrorDisplay();
-  }
+  });
 
-  @dropTask
-  *saveOrCancel(event) {
+  saveOrCancel = dropTask(async event => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
-      yield this.saveNew.perform();
+      await this.saveNew.perform();
       return;
     }
     if (27 === keyCode) {
       this.args.close();
     }
-  }
+  });
 
   async validateTitleCallback() {
     const allVocabsInSchool = await this.args.school.vocabularies;

--- a/packages/frontend/app/components/school-session-attributes-expanded.js
+++ b/packages/frontend/app/components/school-session-attributes-expanded.js
@@ -63,14 +63,13 @@ export default class SchoolSessionAttributesExpandedComponent extends Component 
     this[bufferName] = this.args[name];
   }
 
-  @dropTask
-  *save() {
-    yield this.args.saveAll({
+  save = dropTask(async () => {
+    await this.args.saveAll({
       showSessionAttendanceRequired: this.showSessionAttendanceRequired,
       showSessionSupplemental: this.showSessionSupplemental,
       showSessionSpecialAttireRequired: this.showSessionSpecialAttireRequired,
       showSessionSpecialEquipmentRequired: this.showSessionSpecialEquipmentRequired,
     });
     this.resetFlipped();
-  }
+  });
 }

--- a/packages/frontend/app/components/school-session-attributes.js
+++ b/packages/frontend/app/components/school-session-attributes.js
@@ -12,9 +12,8 @@ export default class SchoolSessionAttributesComponent extends Component {
   @tracked showSessionSpecialAttireRequiredConfig;
   @tracked showSessionSpecialEquipmentRequiredConfig;
 
-  @restartableTask
-  *load(element, [school]) {
-    const schoolConfigs = (yield school.configurations).slice();
+  load = restartableTask(async (element, [school]) => {
+    const schoolConfigs = ((await school.configurations)).slice();
     this.showSessionAttendanceRequiredConfig = findBy(
       schoolConfigs,
       'name',
@@ -31,7 +30,7 @@ export default class SchoolSessionAttributesComponent extends Component {
       'name',
       'showSessionSpecialEquipmentRequired',
     );
-  }
+  });
 
   get showSessionAttendanceRequired() {
     return JSON.parse(this.showSessionAttendanceRequiredConfig?.value ?? null);
@@ -46,8 +45,7 @@ export default class SchoolSessionAttributesComponent extends Component {
     return JSON.parse(this.showSessionSpecialEquipmentRequiredConfig?.value ?? null);
   }
 
-  @dropTask
-  *save(newValues) {
+  save = dropTask(async newValues => {
     const names = [
       'showSessionAttendanceRequired',
       'showSessionSupplemental',
@@ -57,15 +55,15 @@ export default class SchoolSessionAttributesComponent extends Component {
     const toSave = [];
     for (let i = 0; i < names.length; i++) {
       const name = names[i];
-      const config = yield this.args.school.setConfigValue(name, newValues[name]);
+      const config = await this.args.school.setConfigValue(name, newValues[name]);
       if (config) {
         toSave.push(config);
       }
     }
     try {
-      yield all(toSave.map((o) => o.save()));
+      await all(toSave.map((o) => o.save()));
     } finally {
       this.args.manage(false);
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/school-session-attributes.js
+++ b/packages/frontend/app/components/school-session-attributes.js
@@ -13,7 +13,7 @@ export default class SchoolSessionAttributesComponent extends Component {
   @tracked showSessionSpecialEquipmentRequiredConfig;
 
   load = restartableTask(async (element, [school]) => {
-    const schoolConfigs = ((await school.configurations)).slice();
+    const schoolConfigs = (await school.configurations).slice();
     this.showSessionAttendanceRequiredConfig = findBy(
       schoolConfigs,
       'name',
@@ -45,7 +45,7 @@ export default class SchoolSessionAttributesComponent extends Component {
     return JSON.parse(this.showSessionSpecialEquipmentRequiredConfig?.value ?? null);
   }
 
-  save = dropTask(async newValues => {
+  save = dropTask(async (newValues) => {
     const names = [
       'showSessionAttendanceRequired',
       'showSessionSupplemental',

--- a/packages/frontend/app/components/school-session-type-form.js
+++ b/packages/frontend/app/components/school-session-type-form.js
@@ -57,8 +57,8 @@ export default class SchoolSessionTypeFormComponent extends Component {
     this.title = this.args.title;
     this.selectedAssessmentOptionId = this.args.selectedAssessmentOptionId;
     this.selectedAamcMethodId = this.args.selectedAamcMethodId;
-    this.assessmentOptions = ((await this.store.findAll('assessment-option'))).slice();
-    this.aamcMethods = ((await this.store.findAll('aamc-method'))).slice();
+    this.assessmentOptions = (await this.store.findAll('assessment-option')).slice();
+    this.aamcMethods = (await this.store.findAll('aamc-method')).slice();
   });
 
   @action
@@ -84,7 +84,7 @@ export default class SchoolSessionTypeFormComponent extends Component {
     );
   });
 
-  saveOrCancel = dropTask(async event => {
+  saveOrCancel = dropTask(async (event) => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
       await this.saveSessionType.perform();

--- a/packages/frontend/app/components/school-session-type-form.js
+++ b/packages/frontend/app/components/school-session-type-form.js
@@ -50,17 +50,16 @@ export default class SchoolSessionTypeFormComponent extends Component {
     return null;
   }
 
-  @restartableTask
-  *load() {
+  load = restartableTask(async () => {
     this.assessment = this.args.assessment;
     this.calendarColor = this.args.calendarColor;
     this.isActive = this.args.isActive;
     this.title = this.args.title;
     this.selectedAssessmentOptionId = this.args.selectedAssessmentOptionId;
     this.selectedAamcMethodId = this.args.selectedAamcMethodId;
-    this.assessmentOptions = (yield this.store.findAll('assessment-option')).slice();
-    this.aamcMethods = (yield this.store.findAll('aamc-method')).slice();
-  }
+    this.assessmentOptions = ((await this.store.findAll('assessment-option'))).slice();
+    this.aamcMethods = ((await this.store.findAll('aamc-method'))).slice();
+  });
 
   @action
   updateAssessment(assessment) {
@@ -68,15 +67,14 @@ export default class SchoolSessionTypeFormComponent extends Component {
     this.assessment = assessment;
   }
 
-  @dropTask
-  *saveSessionType() {
+  saveSessionType = dropTask(async () => {
     this.addErrorDisplaysFor(['title', 'calendarColor']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.clearErrorDisplay();
-    yield this.args.save(
+    await this.args.save(
       this.title,
       this.calendarColor,
       this.assessment,
@@ -84,17 +82,16 @@ export default class SchoolSessionTypeFormComponent extends Component {
       this.selectedAamcMethod,
       this.isActive,
     );
-  }
+  });
 
-  @dropTask
-  *saveOrCancel(event) {
+  saveOrCancel = dropTask(async event => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
-      yield this.saveSessionType.perform();
+      await this.saveSessionType.perform();
       return;
     }
     if (27 === keyCode) {
       this.args.close();
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/school-session-type-manager.js
+++ b/packages/frontend/app/components/school-session-type-manager.js
@@ -7,12 +7,11 @@ export default class SchoolSessionTypeManagerComponent extends Component {
   @service store;
   @tracked readonlySessionType;
 
-  @restartableTask
-  *load() {
+  load = restartableTask(async () => {
     const { title, calendarColor, assessment, active: isActive } = this.args.sessionType;
-    const assessmentOption = yield this.args.sessionType.assessmentOption;
+    const assessmentOption = await this.args.sessionType.assessmentOption;
     const selectedAssessmentOptionId = assessmentOption?.id;
-    const firstAamcMethod = yield this.args.sessionType.firstAamcMethod;
+    const firstAamcMethod = await this.args.sessionType.firstAamcMethod;
     const selectedAamcMethodId = firstAamcMethod?.id;
     this.readonlySessionType = {
       title,
@@ -22,21 +21,22 @@ export default class SchoolSessionTypeManagerComponent extends Component {
       selectedAamcMethodId,
       isActive,
     };
-  }
+  });
 
-  @dropTask
-  *save(title, calendarColor, assessment, assessmentOption, aamcMethod, isActive) {
-    const aamcMethods = aamcMethod ? [aamcMethod] : [];
-    this.args.sessionType.setProperties({
-      title,
-      calendarColor,
-      assessment,
-      assessmentOption,
-      aamcMethods,
-      active: isActive,
-    });
+  save = dropTask(
+    async (title, calendarColor, assessment, assessmentOption, aamcMethod, isActive) => {
+      const aamcMethods = aamcMethod ? [aamcMethod] : [];
+      this.args.sessionType.setProperties({
+        title,
+        calendarColor,
+        assessment,
+        assessmentOption,
+        aamcMethods,
+        active: isActive,
+      });
 
-    yield this.args.sessionType.save();
-    this.args.close();
-  }
+      await this.args.sessionType.save();
+      this.args.close();
+    }
+  );
 }

--- a/packages/frontend/app/components/school-session-type-manager.js
+++ b/packages/frontend/app/components/school-session-type-manager.js
@@ -37,6 +37,6 @@ export default class SchoolSessionTypeManagerComponent extends Component {
 
       await this.args.sessionType.save();
       this.args.close();
-    }
+    },
   );
 }

--- a/packages/frontend/app/components/school-session-types-collapsed.js
+++ b/packages/frontend/app/components/school-session-types-collapsed.js
@@ -6,10 +6,9 @@ import { filterBy } from 'ilios-common/utils/array-helpers';
 export default class SchoolSessionTypesCollapseComponent extends Component {
   @tracked sessionTypes = [];
 
-  @restartableTask
-  *load(element, [school]) {
-    this.sessionTypes = yield school.sessionTypes;
-  }
+  load = restartableTask(async (element, [school]) => {
+    this.sessionTypes = await school.sessionTypes;
+  });
 
   get instructionalMethods() {
     return filterBy(this.sessionTypes, 'assessment', false);

--- a/packages/frontend/app/components/school-session-types-expanded.js
+++ b/packages/frontend/app/components/school-session-types-expanded.js
@@ -14,11 +14,10 @@ export default class SchoolSessionTypesExpandedComponent extends Component {
     return !!this.args.managedSessionTypeId;
   }
 
-  @restartableTask
-  *load(element, [school]) {
-    this.sessionTypes = yield school.sessionTypes;
+  load = restartableTask(async (element, [school]) => {
+    this.sessionTypes = await school.sessionTypes;
     this.isCollapsible = !this.isManaging && this.sessionTypes.length;
-  }
+  });
 
   get managedSessionType() {
     if (!this.sessionTypes) {
@@ -35,38 +34,40 @@ export default class SchoolSessionTypesExpandedComponent extends Component {
     }
   }
 
-  @dropTask
-  *save(title, calendarColor, assessment, assessmentOption, aamcMethod, isActive) {
-    this.args.setSchoolNewSessionType(null);
-    const sessionType = this.store.createRecord('sessionType');
-    const aamcMethods = aamcMethod ? [aamcMethod] : [];
-    sessionType.setProperties({
-      school: this.args.school,
-      title,
-      calendarColor,
-      assessment,
-      assessmentOption,
-      aamcMethods,
-      active: isActive,
-    });
+  save = dropTask(
+    async (title, calendarColor, assessment, assessmentOption, aamcMethod, isActive) => {
+      this.args.setSchoolNewSessionType(null);
+      const sessionType = this.store.createRecord('sessionType');
+      const aamcMethods = aamcMethod ? [aamcMethod] : [];
+      sessionType.setProperties({
+        school: this.args.school,
+        title,
+        calendarColor,
+        assessment,
+        assessmentOption,
+        aamcMethods,
+        active: isActive,
+      });
 
-    yield sessionType.save();
-  }
+      await sessionType.save();
+    }
+  );
 
-  @dropTask
-  *update(title, calendarColor, assessment, assessmentOption, aamcMethod, isActive) {
-    const aamcMethods = aamcMethod ? [aamcMethod] : [];
-    const sessionType = this.managedSessionType;
-    this.args.setSchoolManagedSessionType(null);
-    sessionType.setProperties({
-      title,
-      calendarColor,
-      assessment,
-      assessmentOption,
-      aamcMethods,
-      active: isActive,
-    });
+  update = dropTask(
+    async (title, calendarColor, assessment, assessmentOption, aamcMethod, isActive) => {
+      const aamcMethods = aamcMethod ? [aamcMethod] : [];
+      const sessionType = this.managedSessionType;
+      this.args.setSchoolManagedSessionType(null);
+      sessionType.setProperties({
+        title,
+        calendarColor,
+        assessment,
+        assessmentOption,
+        aamcMethods,
+        active: isActive,
+      });
 
-    yield sessionType.save();
-  }
+      await sessionType.save();
+    }
+  );
 }

--- a/packages/frontend/app/components/school-session-types-expanded.js
+++ b/packages/frontend/app/components/school-session-types-expanded.js
@@ -50,7 +50,7 @@ export default class SchoolSessionTypesExpandedComponent extends Component {
       });
 
       await sessionType.save();
-    }
+    },
   );
 
   update = dropTask(
@@ -68,6 +68,6 @@ export default class SchoolSessionTypesExpandedComponent extends Component {
       });
 
       await sessionType.save();
-    }
+    },
   );
 }

--- a/packages/frontend/app/components/school-session-types-list-item.js
+++ b/packages/frontend/app/components/school-session-types-list-item.js
@@ -5,8 +5,7 @@ import { dropTask } from 'ember-concurrency';
 export default class SchoolSessionTypesListItemComponent extends Component {
   @tracked showRemoveConfirmation = false;
 
-  @dropTask
-  *remove() {
-    yield this.args.sessionType.destroyRecord();
-  }
+  remove = dropTask(async () => {
+    await this.args.sessionType.destroyRecord();
+  });
 }

--- a/packages/frontend/app/components/school-vocabularies-expanded.js
+++ b/packages/frontend/app/components/school-vocabularies-expanded.js
@@ -33,7 +33,7 @@ export default class SchoolVocabulariesExpandedComponent extends Component {
 
   load = restartableTask(async () => {
     await this.loadSchool(this.args.school.id);
-    const vocabularies = ((await this.args.school.vocabularies)).slice();
+    const vocabularies = (await this.args.school.vocabularies).slice();
     this.schoolVocabularies = await map(vocabularies, async (vocabulary) => {
       const terms = await vocabulary.terms;
       return {

--- a/packages/frontend/app/components/school-vocabularies-expanded.js
+++ b/packages/frontend/app/components/school-vocabularies-expanded.js
@@ -31,18 +31,17 @@ export default class SchoolVocabulariesExpandedComponent extends Component {
     return this.#loadedSchools[schoolId];
   }
 
-  @restartableTask
-  *load() {
-    yield this.loadSchool(this.args.school.id);
-    const vocabularies = (yield this.args.school.vocabularies).slice();
-    this.schoolVocabularies = yield map(vocabularies, async (vocabulary) => {
+  load = restartableTask(async () => {
+    await this.loadSchool(this.args.school.id);
+    const vocabularies = ((await this.args.school.vocabularies)).slice();
+    this.schoolVocabularies = await map(vocabularies, async (vocabulary) => {
       const terms = await vocabulary.terms;
       return {
         vocabulary,
         terms,
       };
     });
-  }
+  });
 
   get managedVocabulary() {
     if (!this.args.managedVocabularyId || !this.schoolVocabularies.length) {
@@ -81,14 +80,13 @@ export default class SchoolVocabulariesExpandedComponent extends Component {
     }
   }
 
-  @dropTask
-  *saveNewVocabulary(title, school, active) {
+  saveNewVocabulary = dropTask(async (title, school, active) => {
     const vocabulary = this.store.createRecord('vocabulary', {
       title,
       school,
       active,
     });
     this.args.setSchoolNewVocabulary(null);
-    yield vocabulary.save();
-  }
+    await vocabulary.save();
+  });
 }

--- a/packages/frontend/app/components/school-vocabularies-list.js
+++ b/packages/frontend/app/components/school-vocabularies-list.js
@@ -38,7 +38,7 @@ export default class SchoolVocabulariesListComponent extends Component {
     this.showRemovalConfirmationFor = null;
   }
 
-  remove = dropTask(async vocabulary => {
+  remove = dropTask(async (vocabulary) => {
     await vocabulary.destroyRecord();
     if (this.newVocabulary === vocabulary) {
       this.newVocabulary = null;

--- a/packages/frontend/app/components/school-vocabularies-list.js
+++ b/packages/frontend/app/components/school-vocabularies-list.js
@@ -38,11 +38,10 @@ export default class SchoolVocabulariesListComponent extends Component {
     this.showRemovalConfirmationFor = null;
   }
 
-  @dropTask
-  *remove(vocabulary) {
-    yield vocabulary.destroyRecord();
+  remove = dropTask(async vocabulary => {
+    await vocabulary.destroyRecord();
     if (this.newVocabulary === vocabulary) {
       this.newVocabulary = null;
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/school-vocabulary-manager.js
+++ b/packages/frontend/app/components/school-vocabulary-manager.js
@@ -49,17 +49,16 @@ export default class SchoolVocabularyManagerComponent extends Component {
     this.isActive = this.args.vocabulary.active;
   }
 
-  @dropTask
-  *changeTitle() {
+  changeTitle = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('title');
     this.args.vocabulary.title = this.title;
-    yield this.args.vocabulary.save();
-  }
+    await this.args.vocabulary.save();
+  });
 
   @action
   revertTitleChanges() {

--- a/packages/frontend/app/components/school-vocabulary-new-term.js
+++ b/packages/frontend/app/components/school-vocabulary-new-term.js
@@ -15,25 +15,23 @@ export default class SchoolVocabularyNewTermComponent extends Component {
   @Custom('validateTitleCallback', 'validateTitleMessageCallback')
   title;
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('title');
-    yield this.args.createTerm(this.title);
+    await this.args.createTerm(this.title);
     this.title = null;
-  }
+  });
 
-  @dropTask
-  *saveOnEnter(event) {
+  saveOnEnter = dropTask(async event => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
-      yield this.save.perform();
+      await this.save.perform();
     }
-  }
+  });
 
   async validateTitleCallback() {
     const terms = this.args.term

--- a/packages/frontend/app/components/school-vocabulary-new-term.js
+++ b/packages/frontend/app/components/school-vocabulary-new-term.js
@@ -26,7 +26,7 @@ export default class SchoolVocabularyNewTermComponent extends Component {
     this.title = null;
   });
 
-  saveOnEnter = dropTask(async event => {
+  saveOnEnter = dropTask(async (event) => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
       await this.save.perform();

--- a/packages/frontend/app/components/school-vocabulary-term-manager.js
+++ b/packages/frontend/app/components/school-vocabulary-term-manager.js
@@ -98,7 +98,7 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
     const goTo = isEmpty(parent) ? null : parent.id;
     this.args.term.deleteRecord();
     if (parent) {
-      const siblings = ((await parent.children)).slice();
+      const siblings = (await parent.children).slice();
       siblings.splice(siblings.indexOf(this.args.term), 1);
       parent.set('children', siblings);
     }
@@ -113,7 +113,7 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
     this.args.manageTerm(null);
   }
 
-  changeIsActive = dropTask(async isActive => {
+  changeIsActive = dropTask(async (isActive) => {
     this.args.term.active = isActive;
     await this.args.term.save();
     this.isActive = this.args.term.active;

--- a/packages/frontend/app/components/school-vocabulary-term-manager.js
+++ b/packages/frontend/app/components/school-vocabulary-term-manager.js
@@ -55,17 +55,16 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
     return !this.children || !this.allParents;
   }
 
-  @dropTask
-  *changeTitle() {
+  changeTitle = dropTask(async () => {
     this.addErrorDisplayFor('title');
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
     this.removeErrorDisplayFor('title');
     this.args.term.title = this.title;
     return this.args.term.save();
-  }
+  });
 
   @action
   revertTitleChanges() {
@@ -73,11 +72,10 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
     this.title = this.args.term.title;
   }
 
-  @dropTask
-  *changeDescription() {
+  changeDescription = dropTask(async () => {
     this.args.term.set('description', this.description);
-    yield this.args.term.save();
-  }
+    await this.args.term.save();
+  });
 
   @action
   revertDescriptionChanges() {
@@ -95,20 +93,19 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
     this.newTerm = await term.save();
   }
 
-  @dropTask
-  *deleteTerm() {
-    const parent = yield this.args.term.parent;
+  deleteTerm = dropTask(async () => {
+    const parent = await this.args.term.parent;
     const goTo = isEmpty(parent) ? null : parent.id;
     this.args.term.deleteRecord();
     if (parent) {
-      const siblings = (yield parent.children).slice();
+      const siblings = ((await parent.children)).slice();
       siblings.splice(siblings.indexOf(this.args.term), 1);
       parent.set('children', siblings);
     }
-    yield this.args.term.save();
+    await this.args.term.save();
     this.args.manageTerm(goTo);
     this.flashMessages.success('general.successfullyRemovedTerm');
-  }
+  });
 
   @action
   clearVocabAndTerm() {
@@ -116,12 +113,11 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
     this.args.manageTerm(null);
   }
 
-  @dropTask
-  *changeIsActive(isActive) {
+  changeIsActive = dropTask(async isActive => {
     this.args.term.active = isActive;
-    yield this.args.term.save();
+    await this.args.term.save();
     this.isActive = this.args.term.active;
-  }
+  });
 
   async validateTitleCallback() {
     const terms = await this.args.term.children;

--- a/packages/frontend/app/components/school/emails-editor.js
+++ b/packages/frontend/app/components/school/emails-editor.js
@@ -50,26 +50,24 @@ export default class SchoolEmailsEditorComponent extends Component {
     return this.intl.t('errors.invalidChangeAlertRecipients');
   }
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.addErrorDisplaysFor(['administratorEmail', 'changeAlertRecipients']);
-    const isValid = yield this.isValid();
+    const isValid = await this.isValid();
     if (!isValid) {
       return false;
     }
 
-    yield this.args.save(this.administratorEmail, this.changeAlertRecipientsFormatted);
+    await this.args.save(this.administratorEmail, this.changeAlertRecipientsFormatted);
     this.clearErrorDisplay();
     this.args.cancel();
-  }
+  });
 
-  @dropTask
-  *saveOrCancel(event) {
+  saveOrCancel = dropTask(async event => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
-      yield this.save.perform();
+      await this.save.perform();
     } else if (27 === keyCode) {
       this.args.cancel();
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/school/emails-editor.js
+++ b/packages/frontend/app/components/school/emails-editor.js
@@ -62,7 +62,7 @@ export default class SchoolEmailsEditorComponent extends Component {
     this.args.cancel();
   });
 
-  saveOrCancel = dropTask(async event => {
+  saveOrCancel = dropTask(async (event) => {
     const keyCode = event.keyCode;
     if (13 === keyCode) {
       await this.save.perform();

--- a/packages/frontend/app/components/school/visualizer-session-type-vocabularies.js
+++ b/packages/frontend/app/components/school/visualizer-session-type-vocabularies.js
@@ -109,7 +109,7 @@ export default class SchoolVisualizerSessionTypeVocabulariesComponent extends Co
       });
   }
 
-  donutHover = restartableTask(async obj => {
+  donutHover = restartableTask(async (obj) => {
     await timeout(100);
     if (this.args.isIcon || !obj || obj.empty) {
       this.tooltipTitle = null;

--- a/packages/frontend/app/components/school/visualizer-session-type-vocabularies.js
+++ b/packages/frontend/app/components/school/visualizer-session-type-vocabularies.js
@@ -109,9 +109,8 @@ export default class SchoolVisualizerSessionTypeVocabulariesComponent extends Co
       });
   }
 
-  @restartableTask
-  *donutHover(obj) {
-    yield timeout(100);
+  donutHover = restartableTask(async obj => {
+    await timeout(100);
     if (this.args.isIcon || !obj || obj.empty) {
       this.tooltipTitle = null;
       this.tooltipContent = null;
@@ -120,7 +119,7 @@ export default class SchoolVisualizerSessionTypeVocabulariesComponent extends Co
 
     this.tooltipTitle = htmlSafe(obj.label);
     this.tooltipContent = obj.description;
-  }
+  });
 
   @action
   donutClick(obj) {

--- a/packages/frontend/app/components/school/visualizer-session-type-vocabulary.js
+++ b/packages/frontend/app/components/school/visualizer-session-type-vocabulary.js
@@ -103,9 +103,8 @@ export default class SchoolVisualizerSessionTypeVocabularyComponent extends Comp
       });
   }
 
-  @restartableTask
-  *donutHover(obj) {
-    yield timeout(100);
+  donutHover = restartableTask(async obj => {
+    await timeout(100);
     if (this.args.isIcon || !obj || obj.empty) {
       this.tooltipTitle = null;
       this.tooltipContent = null;
@@ -114,5 +113,5 @@ export default class SchoolVisualizerSessionTypeVocabularyComponent extends Comp
 
     this.tooltipTitle = htmlSafe(obj.label);
     this.tooltipContent = obj.description;
-  }
+  });
 }

--- a/packages/frontend/app/components/school/visualizer-session-type-vocabulary.js
+++ b/packages/frontend/app/components/school/visualizer-session-type-vocabulary.js
@@ -103,7 +103,7 @@ export default class SchoolVisualizerSessionTypeVocabularyComponent extends Comp
       });
   }
 
-  donutHover = restartableTask(async obj => {
+  donutHover = restartableTask(async (obj) => {
     await timeout(100);
     if (this.args.isIcon || !obj || obj.empty) {
       this.tooltipTitle = null;

--- a/packages/frontend/app/components/unassigned-students-summary.js
+++ b/packages/frontend/app/components/unassigned-students-summary.js
@@ -16,15 +16,14 @@ export default class UnassignedStudentsSummaryComponent extends Component {
     return this.unassignedStudents?.length > 0;
   }
 
-  @restartableTask
-  *load(element, [schoolId]) {
+  load = restartableTask(async (element, [schoolId]) => {
     if (schoolId) {
       this.selectedSchool = findById(this.args.schools.slice(), schoolId);
     } else {
-      const user = yield this.currentUser.getModel();
-      this.selectedSchool = yield user.school;
+      const user = await this.currentUser.getModel();
+      this.selectedSchool = await user.school;
     }
-    this.unassignedStudents = yield this.store.query('user', {
+    this.unassignedStudents = await this.store.query('user', {
       filters: {
         cohorts: null,
         enabled: true,
@@ -32,5 +31,5 @@ export default class UnassignedStudentsSummaryComponent extends Component {
         school: this.selectedSchool.id,
       },
     });
-  }
+  });
 }

--- a/packages/frontend/app/components/update-notification.js
+++ b/packages/frontend/app/components/update-notification.js
@@ -6,10 +6,9 @@ export default class UpdateNotificationComponent extends Component {
    * send a message to update every tab attached to this worker
    * this message is caught by our sw-skip-wait in-repo addon
    */
-  @restartableTask
-  *click() {
+  click = restartableTask(async () => {
     if ('serviceWorker' in navigator) {
-      const reg = yield navigator.serviceWorker.getRegistration();
+      const reg = await navigator.serviceWorker.getRegistration();
       if (reg && reg.waiting) {
         reg.waiting.postMessage('skipWaiting');
       }
@@ -17,5 +16,5 @@ export default class UpdateNotificationComponent extends Component {
     if (this.args.reload) {
       this.args.reload();
     }
-  }
+  });
 }

--- a/packages/frontend/app/components/user-profile-calendar.js
+++ b/packages/frontend/app/components/user-profile-calendar.js
@@ -18,8 +18,7 @@ export default class UserProfileCalendar extends Component {
     this.date = new Date();
   }
 
-  @dropTask
-  *load() {
+  load = dropTask(async () => {
     const from = moment(this.date).day(0).hour(0).minute(0).second(0).format('X');
     const to = moment(this.date).day(6).hour(23).minute(59).second(59).format('X');
 
@@ -28,12 +27,13 @@ export default class UserProfileCalendar extends Component {
       url += '/' + this.iliosConfig.apiNameSpace;
     }
     url += '/userevents/' + this.args.user.get('id') + '?from=' + from + '&to=' + to;
-    const data = yield this.fetch.getJsonFromApiHost(url);
+    const data = await this.fetch.getJsonFromApiHost(url);
     this.calendarEvents = sortBy(
       data.userEvents.map((obj) => this.userEvents.createEventFromData(obj, true)),
       ['startDate', 'name'],
     );
-  }
+  });
+
   @action
   goForward() {
     const newDate = moment(this.date).add(1, 'week').toDate();

--- a/packages/frontend/app/components/user-profile-cohorts.js
+++ b/packages/frontend/app/components/user-profile-cohorts.js
@@ -61,7 +61,7 @@ export default class UserProfileCohortsComponent extends Component {
 
   load = restartableTask(async () => {
     const primaryCohort = await this.args.user.primaryCohort;
-    const cohorts = ((await this.args.user.cohorts)).slice();
+    const cohorts = (await this.args.user.cohorts).slice();
     this.primaryCohortBuffer = primaryCohort;
     this.secondaryCohortsBuffer = cohorts;
     this.primaryCohortBuffer = primaryCohort;
@@ -69,7 +69,7 @@ export default class UserProfileCohortsComponent extends Component {
 
   cancel = restartableTask(async () => {
     const primaryCohort = await this.args.user.primaryCohort;
-    const cohorts = ((await this.args.user.cohorts)).slice();
+    const cohorts = (await this.args.user.cohorts).slice();
     this.primaryCohortBuffer = primaryCohort;
     this.secondaryCohortsBuffer = cohorts;
     this.args.setIsManaging(false);

--- a/packages/frontend/app/components/user-profile-cohorts.js
+++ b/packages/frontend/app/components/user-profile-cohorts.js
@@ -59,32 +59,29 @@ export default class UserProfileCohortsComponent extends Component {
     this.primaryCohortBuffer = cohort;
   }
 
-  @restartableTask
-  *load() {
-    const primaryCohort = yield this.args.user.primaryCohort;
-    const cohorts = (yield this.args.user.cohorts).slice();
+  load = restartableTask(async () => {
+    const primaryCohort = await this.args.user.primaryCohort;
+    const cohorts = ((await this.args.user.cohorts)).slice();
     this.primaryCohortBuffer = primaryCohort;
     this.secondaryCohortsBuffer = cohorts;
     this.primaryCohortBuffer = primaryCohort;
-  }
+  });
 
-  @restartableTask
-  *cancel() {
-    const primaryCohort = yield this.args.user.primaryCohort;
-    const cohorts = (yield this.args.user.cohorts).slice();
+  cancel = restartableTask(async () => {
+    const primaryCohort = await this.args.user.primaryCohort;
+    const cohorts = ((await this.args.user.cohorts)).slice();
     this.primaryCohortBuffer = primaryCohort;
     this.secondaryCohortsBuffer = cohorts;
     this.args.setIsManaging(false);
-  }
+  });
 
-  @dropTask
-  *save() {
+  save = dropTask(async () => {
     this.args.user.primaryCohort = this.primaryCohortBuffer;
     this.args.user.cohorts = this.secondaryCohortsBuffer;
-    yield this.args.user.save();
+    await this.args.user.save();
     this.args.setIsManaging(false);
     this.hasSavedRecently = true;
-    yield timeout(500);
+    await timeout(500);
     this.hasSavedRecently = false;
-  }
+  });
 }

--- a/packages/frontend/app/components/user-profile-ics.js
+++ b/packages/frontend/app/components/user-profile-ics.js
@@ -65,21 +65,19 @@ export default class UserProfileIcsComponent extends Component {
     return rhett;
   }
 
-  @dropTask
-  *refreshKey() {
-    const token = yield this.randomToken(this.args.user.id);
+  refreshKey = dropTask(async () => {
+    const token = await this.randomToken(this.args.user.id);
     this.args.user.set('icsFeedKey', token);
-    yield this.args.user.save();
+    await this.args.user.save();
     this.args.setIsManaging(false);
     this.hasSavedRecently = true;
-    yield timeout(500);
+    await timeout(500);
     this.hasSavedRecently = false;
-  }
+  });
 
-  @restartableTask
-  *textCopied() {
+  textCopied = restartableTask(async () => {
     this.showCopySuccessMessage = true;
-    yield timeout(3000);
+    await timeout(3000);
     this.showCopySuccessMessage = false;
-  }
+  });
 }

--- a/packages/frontend/app/components/user-profile-roles.js
+++ b/packages/frontend/app/components/user-profile-roles.js
@@ -15,11 +15,10 @@ export default class UserProfileRolesComponent extends Component {
   @tracked isUserSyncIgnoredFlipped = false;
   @tracked roleTitles = [];
 
-  @restartableTask
-  *load() {
-    const roles = yield this.args.user.roles;
+  load = restartableTask(async () => {
+    const roles = await this.args.user.roles;
     this.roleTitles = roles.map((role) => role.title.toLowerCase());
-  }
+  });
 
   get isStudent() {
     const originallyYes = this.roleTitles.includes('student');
@@ -61,9 +60,8 @@ export default class UserProfileRolesComponent extends Component {
     this.isUserSyncIgnoredFlipped = false;
   }
 
-  @dropTask
-  *save() {
-    const roles = (yield this.store.findAll('user-role')).slice();
+  save = dropTask(async () => {
+    const roles = ((await this.store.findAll('user-role'))).slice();
     const studentRole = findBy(roles, 'title', 'Student');
     const formerStudentRole = findBy(roles, 'title', 'Former Student');
     this.args.user.set('enabled', this.isEnabled);
@@ -77,12 +75,12 @@ export default class UserProfileRolesComponent extends Component {
     }
     this.args.user.set('roles', userRoles);
     this.resetFlipped();
-    yield this.args.user.save();
+    await this.args.user.save();
     if (this.args.setIsManaging) {
       this.args.setIsManaging(false);
     }
     this.hasSavedRecently = true;
-    yield timeout(500);
+    await timeout(500);
     this.hasSavedRecently = false;
-  }
+  });
 }

--- a/packages/frontend/app/components/user-profile-roles.js
+++ b/packages/frontend/app/components/user-profile-roles.js
@@ -61,7 +61,7 @@ export default class UserProfileRolesComponent extends Component {
   }
 
   save = dropTask(async () => {
-    const roles = ((await this.store.findAll('user-role'))).slice();
+    const roles = (await this.store.findAll('user-role')).slice();
     const studentRole = findBy(roles, 'title', 'Student');
     const formerStudentRole = findBy(roles, 'title', 'Former Student');
     this.args.user.set('enabled', this.isEnabled);

--- a/packages/frontend/app/components/visualizer-program-year-objectives.js
+++ b/packages/frontend/app/components/visualizer-program-year-objectives.js
@@ -117,7 +117,7 @@ export default class VisualizerProgramYearObjectivesComponent extends Component 
     };
   }
 
-  nodeHover = restartableTask(async obj => {
+  nodeHover = restartableTask(async (obj) => {
     await timeout(100);
     const isIcon = this.isIcon;
     if (isIcon || !obj || obj.empty) {

--- a/packages/frontend/app/components/visualizer-program-year-objectives.js
+++ b/packages/frontend/app/components/visualizer-program-year-objectives.js
@@ -16,15 +16,14 @@ export default class VisualizerProgramYearObjectivesComponent extends Component 
   @tracked programYearName;
   @tracked data;
 
-  @restartableTask
-  *load(element, [programYear]) {
-    const cohort = yield programYear.cohort;
-    const year = yield programYear.getClassOfYear();
+  load = restartableTask(async (element, [programYear]) => {
+    const cohort = await programYear.cohort;
+    const year = await programYear.getClassOfYear();
     const classOfYear = this.intl.t('general.classOf', { year });
     this.programYearName = cohort.title ?? classOfYear;
 
-    this.data = yield this.getData(programYear);
-  }
+    this.data = await this.getData(programYear);
+  });
 
   async getObjectiveObjects(programYear) {
     const buildTreeLevel = async function (parent, childrenTree, sessionTitle, courseTitle) {
@@ -118,9 +117,8 @@ export default class VisualizerProgramYearObjectivesComponent extends Component 
     };
   }
 
-  @restartableTask
-  *nodeHover(obj) {
-    yield timeout(100);
+  nodeHover = restartableTask(async obj => {
+    await timeout(100);
     const isIcon = this.isIcon;
     if (isIcon || !obj || obj.empty) {
       this.tooltipTitle = null;
@@ -148,5 +146,5 @@ export default class VisualizerProgramYearObjectivesComponent extends Component 
     this.tooltipTitle = htmlSafe(name);
     this.tooltipCourses = uniqueValues(allCourseTitles);
     this.tooltipSessions = uniqueValues(allSessionTitles);
-  }
+  });
 }

--- a/packages/frontend/app/controllers/assign-students.js
+++ b/packages/frontend/app/controllers/assign-students.js
@@ -40,7 +40,7 @@ export default class AssignStudentsController extends Controller {
     return this.query ? this.filterStudents(this.sortedStudents, this.query) : this.sortedStudents;
   }
 
-  setQuery = restartableTask(async q => {
+  setQuery = restartableTask(async (q) => {
     await timeout(DEBOUNCE_DELAY);
     this.query = q;
   });

--- a/packages/frontend/app/controllers/assign-students.js
+++ b/packages/frontend/app/controllers/assign-students.js
@@ -40,11 +40,10 @@ export default class AssignStudentsController extends Controller {
     return this.query ? this.filterStudents(this.sortedStudents, this.query) : this.sortedStudents;
   }
 
-  @restartableTask
-  *setQuery(q) {
-    yield timeout(DEBOUNCE_DELAY);
+  setQuery = restartableTask(async q => {
+    await timeout(DEBOUNCE_DELAY);
     this.query = q;
-  }
+  });
 
   filterStudents(students, query) {
     return students.filter((student) => {

--- a/packages/frontend/app/controllers/courses.js
+++ b/packages/frontend/app/controllers/courses.js
@@ -33,7 +33,7 @@ export default class CoursesController extends Controller {
     this.userCoursesOnly = !this.userCoursesOnly;
   }
 
-  changeTitleFilter = restartableTask(async value => {
+  changeTitleFilter = restartableTask(async (value) => {
     this.titleFilter = value;
     await timeout(250);
     return value;

--- a/packages/frontend/app/controllers/courses.js
+++ b/packages/frontend/app/controllers/courses.js
@@ -33,10 +33,9 @@ export default class CoursesController extends Controller {
     this.userCoursesOnly = !this.userCoursesOnly;
   }
 
-  @restartableTask
-  *changeTitleFilter(value) {
+  changeTitleFilter = restartableTask(async value => {
     this.titleFilter = value;
-    yield timeout(250);
+    await timeout(250);
     return value;
-  }
+  });
 }

--- a/packages/frontend/app/controllers/instructor-groups.js
+++ b/packages/frontend/app/controllers/instructor-groups.js
@@ -8,10 +8,9 @@ export default class InstructorGroupsController extends Controller {
   @tracked titleFilter;
   @tracked sortBy = 'title';
 
-  @restartableTask
-  *changeTitleFilter(value) {
+  changeTitleFilter = restartableTask(async value => {
     this.titleFilter = value;
-    yield timeout(250);
+    await timeout(250);
     return value;
-  }
+  });
 }

--- a/packages/frontend/app/controllers/instructor-groups.js
+++ b/packages/frontend/app/controllers/instructor-groups.js
@@ -8,7 +8,7 @@ export default class InstructorGroupsController extends Controller {
   @tracked titleFilter;
   @tracked sortBy = 'title';
 
-  changeTitleFilter = restartableTask(async value => {
+  changeTitleFilter = restartableTask(async (value) => {
     this.titleFilter = value;
     await timeout(250);
     return value;

--- a/packages/frontend/app/controllers/learner-groups.js
+++ b/packages/frontend/app/controllers/learner-groups.js
@@ -11,7 +11,7 @@ export default class LearnerGroupsController extends Controller {
   @tracked filter;
   @tracked sortBy = 'title';
 
-  setTitleFilter = restartableTask(async value => {
+  setTitleFilter = restartableTask(async (value) => {
     //if we already have a value or if resetting filter then add a keyboard delay
     if (this.filter && value) {
       await timeout(250);

--- a/packages/frontend/app/controllers/learner-groups.js
+++ b/packages/frontend/app/controllers/learner-groups.js
@@ -11,12 +11,11 @@ export default class LearnerGroupsController extends Controller {
   @tracked filter;
   @tracked sortBy = 'title';
 
-  @restartableTask
-  *setTitleFilter(value) {
+  setTitleFilter = restartableTask(async value => {
     //if we already have a value or if resetting filter then add a keyboard delay
     if (this.filter && value) {
-      yield timeout(250);
+      await timeout(250);
     }
     this.filter = value;
-  }
+  });
 }

--- a/packages/frontend/app/controllers/pending-user-updates.js
+++ b/packages/frontend/app/controllers/pending-user-updates.js
@@ -52,46 +52,43 @@ export default class PendingUserUpdatesController extends Controller {
     });
   }
 
-  @task
-  *updateEmailAddress(update) {
+  updateEmailAddress = task(async update => {
     this.updatesBeingSaved = [...this.updatesBeingSaved, update];
-    const user = yield update.user;
+    const user = await update.user;
     user.email = update.value;
-    yield user.save();
+    await user.save();
 
-    yield update.destroyRecord();
+    await update.destroyRecord();
     this.deletedUpdates = [...this.deletedUpdates, update];
     this.updatesBeingSaved = this.updatesBeingSaved.filter((u) => u !== update);
     this.flashMessages.success('general.savedSuccessfully');
-  }
+  });
 
-  @task
-  *disableUser(update) {
+  disableUser = task(async update => {
     this.updatesBeingSaved = [...this.updatesBeingSaved, update];
-    const user = yield update.user;
+    const user = await update.user;
     user.enabled = false;
-    yield user.save();
+    await user.save();
 
-    const updates = yield user.pendingUserUpdates;
-    yield Promise.all(updates.map((update) => update.destroyRecord()));
+    const updates = await user.pendingUserUpdates;
+    await Promise.all(updates.map((update) => update.destroyRecord()));
 
     this.deletedUpdates = [...this.deletedUpdates, ...updates.slice()];
     this.updatesBeingSaved = this.updatesBeingSaved.filter((u) => u !== update);
     this.flashMessages.success('general.savedSuccessfully');
-  }
+  });
 
-  @task
-  *excludeFromSync(update) {
+  excludeFromSync = task(async update => {
     this.updatesBeingSaved = [...this.updatesBeingSaved, update];
-    const user = yield update.user;
+    const user = await update.user;
     user.userSyncIgnore = true;
-    yield user.save();
+    await user.save();
 
-    const updates = yield user.pendingUserUpdates;
-    yield Promise.all(updates.map((update) => update.destroyRecord()));
+    const updates = await user.pendingUserUpdates;
+    await Promise.all(updates.map((update) => update.destroyRecord()));
 
     this.deletedUpdates = [...this.deletedUpdates, ...updates.slice()];
     this.updatesBeingSaved = this.updatesBeingSaved.filter((u) => u !== update);
     this.flashMessages.success('general.savedSuccessfully');
-  }
+  });
 }

--- a/packages/frontend/app/controllers/pending-user-updates.js
+++ b/packages/frontend/app/controllers/pending-user-updates.js
@@ -52,7 +52,7 @@ export default class PendingUserUpdatesController extends Controller {
     });
   }
 
-  updateEmailAddress = task(async update => {
+  updateEmailAddress = task(async (update) => {
     this.updatesBeingSaved = [...this.updatesBeingSaved, update];
     const user = await update.user;
     user.email = update.value;
@@ -64,7 +64,7 @@ export default class PendingUserUpdatesController extends Controller {
     this.flashMessages.success('general.savedSuccessfully');
   });
 
-  disableUser = task(async update => {
+  disableUser = task(async (update) => {
     this.updatesBeingSaved = [...this.updatesBeingSaved, update];
     const user = await update.user;
     user.enabled = false;
@@ -78,7 +78,7 @@ export default class PendingUserUpdatesController extends Controller {
     this.flashMessages.success('general.savedSuccessfully');
   });
 
-  excludeFromSync = task(async update => {
+  excludeFromSync = task(async (update) => {
     this.updatesBeingSaved = [...this.updatesBeingSaved, update];
     const user = await update.user;
     user.userSyncIgnore = true;

--- a/packages/frontend/app/controllers/reports.js
+++ b/packages/frontend/app/controllers/reports.js
@@ -8,10 +8,9 @@ export default class ReportsController extends Controller {
   @tracked sortReportsBy = 'title';
   @tracked titleFilter = null;
 
-  @restartableTask
-  *changeTitleFilter(value) {
+  changeTitleFilter = restartableTask(async value => {
     this.titleFilter = value;
-    yield timeout(250);
+    await timeout(250);
     return value;
-  }
+  });
 }

--- a/packages/frontend/app/controllers/reports.js
+++ b/packages/frontend/app/controllers/reports.js
@@ -8,7 +8,7 @@ export default class ReportsController extends Controller {
   @tracked sortReportsBy = 'title';
   @tracked titleFilter = null;
 
-  changeTitleFilter = restartableTask(async value => {
+  changeTitleFilter = restartableTask(async (value) => {
     this.titleFilter = value;
     await timeout(250);
     return value;

--- a/packages/frontend/ember-cli-build.js
+++ b/packages/frontend/ember-cli-build.js
@@ -27,6 +27,7 @@ module.exports = function (defaults) {
     babel: {
       plugins: [
         require.resolve('ember-auto-import/babel-plugin'),
+        // eslint-disable-next-line
         require.resolve('ember-concurrency/async-arrow-task-transform'),
       ],
     },

--- a/packages/frontend/ember-cli-build.js
+++ b/packages/frontend/ember-cli-build.js
@@ -25,7 +25,10 @@ module.exports = function (defaults) {
 
     hinting: isTestBuild,
     babel: {
-      plugins: [require.resolve('ember-auto-import/babel-plugin')],
+      plugins: [
+        require.resolve('ember-auto-import/babel-plugin'),
+        require.resolve('ember-concurrency/async-arrow-task-transform'),
+      ],
     },
     'ember-cli-image-transformer': {
       images: [


### PR DESCRIPTION
- [x] convert tasks from modifier, `yield` syntax to fat-arrow, `async/await` equivalent
- [ ] ~~in templates, replace `perform` helper with calls to the `perform()` method directly on the givens Tasks~~ 

 on second thought - pass on the `perform` helper replacement for now.
 
from the [v4.0.0 release notes](https://github.com/machty/ember-concurrency/releases/tag/4.0.0):

> (Not really an enhancement, but) users are encouraged to directly use a task's bound .perform method (and curry with fn helper if needed) rather than to use the classic perform helper, which doesn't really add much value anymore

looking at how pervasive our use of the `perform` helper throughout common/frontend is, this seems like a pretty big lift without much to gain from at this point. 
suggesting we wait until that helper gets deprecated in future versions (having proper deprecation output will make it easier to find and replace anyway).