### PR TITLE
adds babel transforms to build config.

### DIFF
--- a/packages/test-app/ember-cli-build.js
+++ b/packages/test-app/ember-cli-build.js
@@ -20,6 +20,13 @@ module.exports = function (defaults) {
     autoImport: {
       watchDependencies: ['ilios-common'],
     },
+    babel: {
+      plugins: [
+        require.resolve('ember-auto-import/babel-plugin'),
+        // eslint-disable-next-line
+        require.resolve('ember-concurrency/async-arrow-task-transform'),
+      ],
+    },
   });
 
   const { maybeEmbroider } = require('@embroider/test-setup');


### PR DESCRIPTION
noticed that the login form on the test app was broken with an ember-concurrency related error. 

this fixes it.

i threw the ember-auto-import transform into the mix, might not be necessary but doesn't seem to hurt.