### PR TITLE
replaces Moment with Luxon in  components in ilios-common - part 2

### DIFF
--- a/packages/frontend/tests/acceptance/course/session/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/session/overview-test.js
@@ -215,7 +215,7 @@ module('Acceptance | Session - Overview', function (hooks) {
     assert.strictEqual(currentRouteName(), 'session.index');
     assert.strictEqual(
       page.details.overview.lastUpdated,
-      'Last Update Last Update: 07/09/2019 5:00 PM',
+      'Last Update Last Update: 7/9/2019 5:00 PM',
     );
   });
 

--- a/packages/ilios-common/addon/components/daily-calendar-event.js
+++ b/packages/ilios-common/addon/components/daily-calendar-event.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import colorChange from 'ilios-common/utils/color-change';
 import { htmlSafe } from '@ember/template';
 import calendarEventTooltip from 'ilios-common/utils/calendar-event-tooltip';
@@ -7,7 +7,6 @@ import { service } from '@ember/service';
 
 export default class DailyCalendarEventComponent extends Component {
   @service intl;
-  @service moment;
 
   constructor() {
     super(...arguments);
@@ -37,45 +36,44 @@ export default class DailyCalendarEventComponent extends Component {
 
   get tooltipContent() {
     //access the locale info here so the getter will recompute when it changes
-    this.moment.locale;
     this.intl.locale;
     return calendarEventTooltip(this.args.event, this.intl, 'h:mma');
   }
 
   get recentlyUpdated() {
-    const lastModifiedDate = moment(this.args.event.lastModified);
-    const today = moment();
-    const daysSinceLastUpdate = today.diff(lastModifiedDate, 'days');
+    const lastModifiedDate = DateTime.fromISO(this.args.event.lastModified);
+    const today = DateTime.now();
+    const daysSinceLastUpdate = today.diff(lastModifiedDate, 'days').days;
 
-    return daysSinceLastUpdate < 6 ? true : false;
+    return daysSinceLastUpdate < 6;
   }
 
-  get startMoment() {
-    return moment(this.args.event.startDate);
+  get startLuxon() {
+    return DateTime.fromISO(this.args.event.startDate);
   }
 
-  get endMoment() {
-    return moment(this.args.event.endDate);
+  get endLuxon() {
+    return DateTime.fromISO(this.args.event.endDate);
   }
 
-  get startOfDay() {
-    return this.startMoment.startOf('day');
+  get startOfDayLuxon() {
+    return this.startLuxon.startOf('day');
   }
 
   get startMinuteRounded() {
-    const minute = this.startMoment.diff(this.startOfDay, 'minutes');
+    const minute = this.startLuxon.diff(this.startOfDayLuxon, 'minutes').minutes;
     return Math.ceil(minute / 5);
   }
 
   get totalMinutesRounded() {
-    const minutes = this.endMoment.diff(this.startMoment, 'minutes');
+    const minutes = this.endLuxon.diff(this.startLuxon, 'minutes').minutes;
     return Math.floor(minutes / 5);
   }
 
   getMinuteInTheDay(date) {
-    const m = moment(date);
-    const midnight = moment(date).startOf('day');
-    return m.diff(midnight, 'minutes');
+    const dt = DateTime.fromISO(date);
+    const midnight = dt.startOf('day');
+    return dt.diff(midnight, 'minutes').minutes;
   }
 
   get span() {

--- a/packages/ilios-common/addon/components/dashboard/week.js
+++ b/packages/ilios-common/addon/components/dashboard/week.js
@@ -1,19 +1,19 @@
 import Component from '@glimmer/component';
-import moment from 'moment';
-
+import { DateTime } from 'luxon';
 export default class DashboardWeekComponent extends Component {
   get expanded() {
-    const lastSunday = moment().day(1).subtract(1, 'week').format('W');
-    const thisSunday = moment().day(1).format('W');
-    const nextSunday = moment().day(1).add(1, 'week').format('W');
+    const now = DateTime.now();
+    const lastSunday = now.set({ weekday: 1 }).minus({ week: 1 }).toFormat('W');
+    const thisSunday = now.set({ weekday: 1 }).toFormat('W');
+    const nextSunday = now.set({ weekday: 1 }).plus({ week: 1 }).toFormat('W');
 
     return `${lastSunday}-${thisSunday}-${nextSunday}`;
   }
   get year() {
-    return moment().year();
+    return DateTime.now().year;
   }
   get week() {
     //set day to Thursday to correctly calculate isoWeek
-    return moment().day(4).isoWeek();
+    return DateTime.now().set({ weekday: 4 }).weekNumber;
   }
 }

--- a/packages/ilios-common/addon/components/session-copy.js
+++ b/packages/ilios-common/addon/components/session-copy.js
@@ -4,7 +4,7 @@ import { hash, all, filter } from 'rsvp';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { findById, sortBy } from 'ilios-common/utils/array-helpers';
 
 export default class SessionCopyComponent extends Component {
@@ -31,8 +31,8 @@ export default class SessionCopyComponent extends Component {
         },
       }),
     });
-    const now = moment();
-    const thisYear = now.year();
+    const now = DateTime.now();
+    const thisYear = now.year;
     this.years = years
       .map((year) => Number(year.id))
       .filter((year) => year >= thisYear - 1)

--- a/packages/ilios-common/addon/components/session-overview-ilm-duedate.js
+++ b/packages/ilios-common/addon/components/session-overview-ilm-duedate.js
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { validatable, NotBlank } from 'ilios-common/decorators/validation';
 import { dropTask } from 'ember-concurrency';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 
 @validatable
 export default class SessionOverviewIlmDuedateComponent extends Component {
@@ -16,22 +16,19 @@ export default class SessionOverviewIlmDuedateComponent extends Component {
 
   @action
   updateDate(date) {
-    const currentDueDate = moment(this.dueDate);
-    this.dueDate = moment(date)
-      .hour(currentDueDate.hour())
-      .minute(currentDueDate.minute())
-      .toDate();
+    const currentDueDate = DateTime.fromJSDate(this.dueDate);
+    this.dueDate = DateTime.fromJSDate(date)
+      .set({
+        hour: currentDueDate.hour,
+        minute: currentDueDate.minute,
+      })
+      .toJSDate();
   }
 
   @action
   updateTime(value, type) {
-    const dueDate = moment(this.dueDate);
-    if (type === 'hour') {
-      dueDate.hour(value);
-    } else {
-      dueDate.minute(value);
-    }
-    this.dueDate = dueDate.toDate();
+    const update = 'hour' === type ? { hour: value } : { minute: value };
+    this.dueDate = DateTime.fromJSDate(this.dueDate).set(update).toJSDate();
   }
 
   save = dropTask(async () => {

--- a/packages/ilios-common/addon/components/session-overview.js
+++ b/packages/ilios-common/addon/components/session-overview.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import { task, restartableTask, dropTask } from 'ember-concurrency';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { validatable, Length, Gte, NotBlank } from 'ilios-common/decorators/validation';
 import { hash } from 'rsvp';
 import { findById, sortBy } from 'ilios-common/utils/array-helpers';
@@ -123,7 +123,7 @@ export default class SessionOverview extends Component {
     } else {
       this.isIndependentLearning = false;
     }
-    this.updatedAt = moment(session.updatedAt).format('L LT');
+    this.updatedAt = DateTime.fromJSDate(session.updatedAt).toFormat('D t');
     this.sessionTypes = sessionTypes || [];
     this.description = session.description;
   });
@@ -172,7 +172,7 @@ export default class SessionOverview extends Component {
       await ilmSession.save();
     } else {
       const hours = 1;
-      const dueDate = moment().add(6, 'weeks').hour('17').minute('00').toDate();
+      const dueDate = DateTime.now().plus({ week: 6 }).set({ hour: 17, minute: 0 }).toJSDate();
       this.hours = hours;
       const ilmSession = this.store.createRecord('ilm-session', {
         session: this.args.session,

--- a/packages/ilios-common/addon/components/weekly-events.js
+++ b/packages/ilios-common/addon/components/weekly-events.js
@@ -1,10 +1,10 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 
 export default class WeeklyEvents extends Component {
   get weeksInYear() {
-    const weeksInTheYear = moment().year(this.args.year).isoWeeksInYear();
+    const weeksInTheYear = DateTime.now().set({ year: this.args.year }).weeksInWeekYear;
     const weeks = [];
     for (let i = 1; i <= weeksInTheYear; i++) {
       weeks.push(`${i}`);

--- a/packages/test-app/tests/integration/components/daily-calendar-event-test.js
+++ b/packages/test-app/tests/integration/components/daily-calendar-event-test.js
@@ -15,10 +15,10 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
   this.createEvent = function (startDate, endDate, lastModified, isScheduled, isPublished) {
     const color = '#00cc65';
     this.server.create('userevent', {
-      startDate: DateTime.fromFormat(startDate, 'yyyy-LL-dd hh:mm:ss').toJSDate(),
-      endDate: DateTime.fromFormat(endDate, 'yyyy-LL-dd hh:mm:ss').toJSDate(),
+      startDate,
+      endDate,
       color,
-      lastModified: DateTime.fromFormat(lastModified, 'yyyy-LL-dd hh:mm:ss').toJSDate(),
+      lastModified,
       isPublished,
       isScheduled,
     });
@@ -38,44 +38,44 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
   module('A complicated event list', function (hooks) {
     hooks.beforeEach(function () {
       this.createEvent(
-        '2019-01-09 08:00:00',
-        '2019-01-09 09:00:00',
-        '2012-01-09 08:00:00',
+        '2019-01-09T08:00:00',
+        '2019-01-09T09:00:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2019-01-09 08:00:00',
-        '2019-01-09 11:30:00',
-        '2012-01-09 08:00:00',
+        '2019-01-09T08:00:00',
+        '2019-01-09T11:30:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2019-01-09 08:10:00',
-        '2019-01-09 10:00:00',
-        '2012-01-09 08:00:00',
+        '2019-01-09T08:10:00',
+        '2019-01-09T10:00:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2019-01-09 10:00:00',
-        '2019-01-09 12:00:00',
-        '2012-01-09 08:00:00',
+        '2019-01-09T10:00:00',
+        '2019-01-09T12:00:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2019-01-09 10:10:00',
-        '2019-01-09 12:00:00',
-        '2012-01-09 08:00:00',
+        '2019-01-09T10:10:00',
+        '2019-01-09T12:00:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2019-01-09 12:00:00',
-        '2019-01-09 13:00:00',
-        '2012-01-09 08:00:00',
+        '2019-01-09T12:00:00',
+        '2019-01-09T13:00:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
@@ -197,79 +197,79 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
   module('Second complicated event list', function (hooks) {
     hooks.beforeEach(function () {
       this.createEvent(
-        '2020-02-10 08:10:00',
-        '2020-02-10 10:00:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T08:10:00',
+        '2020-02-10T10:00:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2020-02-10 08:10:00',
-        '2020-02-10 09:20:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T08:10:00',
+        '2020-02-10T09:20:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2020-02-10 09:40:00',
-        '2020-02-10 10:30:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T09:40:00',
+        '2020-02-10T10:30:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2020-02-10 10:10:00',
-        '2020-02-10 12:00:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T10:10:00',
+        '2020-02-10T12:00:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2020-02-10 10:40:00',
-        '2020-02-10 12:30:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T10:40:00',
+        '2020-02-10T12:30:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2020-02-10 10:40:00',
-        '2020-02-10 12:30:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T10:40:00',
+        '2020-02-10T12:30:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2020-02-10 10:40:00',
-        '2020-02-10 12:30:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T10:40:00',
+        '2020-02-10T12:30:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2020-02-10 10:40:00',
-        '2020-02-10 12:30:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T10:40:00',
+        '2020-02-10T12:30:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2020-02-10 10:40:00',
-        '2020-02-10 12:30:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T10:40:00',
+        '2020-02-10T12:30:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2020-02-10 10:40:00',
-        '2020-02-10 12:30:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T10:40:00',
+        '2020-02-10T12:30:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
       this.createEvent(
-        '2020-02-10 12:00:00',
-        '2020-02-10 13:00:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T12:00:00',
+        '2020-02-10T13:00:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
@@ -456,9 +456,9 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
   module('iconography', function () {
     test('recently updated', async function (assert) {
       this.createEvent(
-        '2020-02-10 10:40:00',
-        '2020-02-10 12:30:00',
-        DateTime.now().toFormat('yyyy-LL-dd hh:mm:ss'),
+        '2020-02-10T10:40:00',
+        '2020-02-10T12:30:00',
+        DateTime.now().toISO(),
         false,
         true,
       );
@@ -475,9 +475,9 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
 
     test('not recently updated', async function (assert) {
       this.createEvent(
-        '2020-02-10 10:40:00',
-        '2020-02-10 12:30:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T10:40:00',
+        '2020-02-10T12:30:00',
+        '2012-01-09T08:00:00',
         false,
         true,
       );
@@ -494,9 +494,9 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
 
     test('scheduled', async function (assert) {
       this.createEvent(
-        '2020-02-10 10:40:00',
-        '2020-02-10 12:30:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T10:40:00',
+        '2020-02-10T12:30:00',
+        '2012-01-09T08:00:00',
         true,
         true,
       );
@@ -513,9 +513,9 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
 
     test('draft', async function (assert) {
       this.createEvent(
-        '2020-02-10 10:40:00',
-        '2020-02-10 12:30:00',
-        '2012-01-09 08:00:00',
+        '2020-02-10T10:40:00',
+        '2020-02-10T12:30:00',
+        '2012-01-09T08:00:00',
         true,
         false,
       );


### PR DESCRIPTION
refs https://github.com/ilios/ilios/issues/5193

contains a minor change in date formatting in the "Session Overview" component - the "last updated" date now displays without padding on day and month info on the given date-time. 
Luxon localizes this date differently from Moment, _for reasons._

The alternative would be to force a specific format, independent of localization, which surmounts to a loss of functionality.

![image](https://github.com/ilios/frontend/assets/1410427/6297b6bf-bd37-45d2-b8f8-4a74c7d21e73)
