### PR TITLE
Fix common specifier in LTIs

### DIFF
--- a/packages/lti-course-manager/package.json
+++ b/packages/lti-course-manager/package.json
@@ -51,7 +51,7 @@
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.6.0",
     "ember-web-app": "^5.0.0",
-    "ilios-common": "^87.0.1",
+    "ilios-common": "workspace:*",
     "loader.js": "^4.7.0",
     "prettier": "^3.2.4",
     "qunit": "^2.20.0",

--- a/packages/lti-dashboard/package.json
+++ b/packages/lti-dashboard/package.json
@@ -52,7 +52,7 @@
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.6.0",
     "ember-web-app": "^5.0.0",
-    "ilios-common": "^87.0.1",
+    "ilios-common": "workspace:*",
     "loader.js": "^4.7.0",
     "postcss-scss": "^4.0.9",
     "prettier": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,7 +692,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.1
       ilios-common:
-        specifier: ^87.0.1
+        specifier: workspace:*
         version: link:../ilios-common
       loader.js:
         specifier: ^4.7.0
@@ -827,7 +827,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.1
       ilios-common:
-        specifier: ^87.0.1
+        specifier: workspace:*
         version: link:../ilios-common
       loader.js:
         specifier: ^4.7.0


### PR DESCRIPTION
No longer using the published version, now we use what is in the workspace.