### PR TITLE
Add Some Reporting by Academic Year

### DIFF
--- a/packages/frontend/app/components/reports/new-subject.hbs
+++ b/packages/frontend/app/components/reports/new-subject.hbs
@@ -71,7 +71,7 @@
           <option value="" selected={{eq null this.prepositionalObject}}>
             {{t "general.anything"}}
           </option>
-          {{#each this.prepositionalObjectList as |o|}}
+          {{#each (sort-by "label" this.prepositionalObjectList) as |o|}}
             <option
               value={{o.value}}
               selected={{eq o.value this.prepositionalObject}}

--- a/packages/frontend/app/components/reports/new-subject.js
+++ b/packages/frontend/app/components/reports/new-subject.js
@@ -19,6 +19,7 @@ import NewProgramYearComponent from './subject/new/program-year';
 import NewSessionComponent from './subject/new/session';
 import NewSessionTypeComponent from './subject/new/session-type';
 import NewTermComponent from './subject/new/term';
+import NewAcademicYearComponent from './subject/new/academic-year';
 
 @validatable
 export default class ReportsNewSubjectComponent extends Component {
@@ -173,6 +174,19 @@ export default class ReportsNewSubjectComponent extends Component {
       label: this.intl.t('general.term'),
       subjects: ['course', 'session', 'program', 'program year', 'session type'],
     },
+    {
+      value: 'academic year',
+      label: this.intl.t('general.academicYear'),
+      subjects: [
+        'course',
+        'session',
+        'instructor',
+        'instructor group',
+        'competency',
+        'session type',
+        'term',
+      ],
+    },
   ];
 
   userModelData = new TrackedAsyncData(this.currentUser.getModel());
@@ -224,6 +238,8 @@ export default class ReportsNewSubjectComponent extends Component {
         return ensureSafeComponent(NewSessionTypeComponent, this);
       case 'term':
         return ensureSafeComponent(NewTermComponent, this);
+      case 'academic year':
+        return ensureSafeComponent(NewAcademicYearComponent, this);
     }
 
     return null;

--- a/packages/frontend/app/components/reports/subject-results.js
+++ b/packages/frontend/app/components/reports/subject-results.js
@@ -60,6 +60,7 @@ export default class ReportsSubjectResultsComponent extends Component {
   get showAcademicYearFilter() {
     return (
       this.args.prepositionalObject !== 'course' &&
+      this.args.prepositionalObject !== 'academic year' &&
       ['course', 'session'].includes(this.args.subject)
     );
   }

--- a/packages/frontend/app/components/reports/subject/course.js
+++ b/packages/frontend/app/components/reports/subject/course.js
@@ -36,7 +36,7 @@ export default class ReportsSubjectCourseComponent extends Component {
   }
 
   get showYear() {
-    return !this.args.year;
+    return !this.args.year && this.args.prepositionalObject !== 'academic year';
   }
 
   get filteredCourses() {

--- a/packages/frontend/app/components/reports/subject/instructor.js
+++ b/packages/frontend/app/components/reports/subject/instructor.js
@@ -50,7 +50,13 @@ export default class ReportsSubjectInstructorComponent extends Component {
     }
     if (prepositionalObject && prepositionalObjectTableRowId) {
       let what = pluralize(camelize(prepositionalObject));
-      const specialInstructed = ['learningMaterials', 'sessionTypes', 'courses', 'sessions'];
+      const specialInstructed = [
+        'learningMaterials',
+        'sessionTypes',
+        'courses',
+        'sessions',
+        'academicYears',
+      ];
       if (specialInstructed.includes(what)) {
         what = 'instructed' + capitalize(what);
       }

--- a/packages/frontend/app/components/reports/subject/new/academic-year.hbs
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.hbs
@@ -1,0 +1,29 @@
+<p data-test-reports-subject-new-academic-year>
+  <label for="new-term">
+    {{t "general.whichIs"}}
+  </label>
+  {{#if this.isLoaded}}
+    <select
+      id="new-academic-year"
+      data-test-prepositional-objects
+      {{on "change" (pick "target.value" @changeId)}}
+      {{did-insert (perform this.setInitialValue)}}
+      {{did-update (perform this.setInitialValue) @school}}
+    >
+      {{#each (sort-by "title" this.academicYears) as |year|}}
+        <option
+          selected={{eq year.id @currentId}}
+          value={{year.id}}
+        >
+        {{#if this.academicYearCrossesCalendarYearBoundaries}}
+          {{year.id}} - {{add year.id 1}}
+        {{else}}
+          {{year.id}}
+        {{/if}}
+        </option>
+      {{/each}}
+    </select>
+  {{else}}
+    <LoadingSpinner />
+  {{/if}}
+</p>

--- a/packages/frontend/app/components/reports/subject/new/academic-year.js
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.js
@@ -1,0 +1,46 @@
+import Component from '@glimmer/component';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
+import { service } from '@ember/service';
+import { task, timeout } from 'ember-concurrency';
+
+export default class ReportsSubjectNewAcademicYearComponent extends Component {
+  @service store;
+  @service iliosConfig;
+
+  @cached
+  get data() {
+    return new TrackedAsyncData(this.store.findAll('academic-year'));
+  }
+
+  crossesBoundaryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
+  }
+
+  get academicYears() {
+    return this.data.value;
+  }
+
+  get isLoaded() {
+    return this.data.isResolved;
+  }
+
+  @task
+  *setInitialValue() {
+    yield timeout(1); //wait a moment so we can render before setting
+    const ids = this.academicYears.map(({ id }) => id);
+    if (ids.includes(this.args.currentId)) {
+      return;
+    }
+    if (!this.academicYears.length) {
+      this.args.changeId(null);
+    } else {
+      this.args.changeId(this.academicYears[0].id);
+    }
+  }
+}

--- a/packages/frontend/app/services/reporting.js
+++ b/packages/frontend/app/services/reporting.js
@@ -32,6 +32,7 @@ const objectTranslations = {
   session: 'general.session',
   school: 'general.school',
   term: 'general.term',
+  'academic year': 'general.academicYear',
 };
 
 export default class ReportingService extends Service {

--- a/packages/frontend/tests/acceptance/reports/subjects-test.js
+++ b/packages/frontend/tests/acceptance/reports/subjects-test.js
@@ -201,7 +201,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('get all courses associated with mesh term #3419', async function (assert) {
-    assert.expect(14);
+    assert.expect(15);
     await page.visit();
     assert.strictEqual(page.root.list.table.reports.length, 2);
     assert.strictEqual(
@@ -248,6 +248,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
       subjectReportPage.report.title.text,
       'All Courses for descriptor 0 in school 0',
     );
+    assert.ok(subjectReportPage.report.academicYears.isVisible);
     assert.strictEqual(subjectReportPage.report.results.length, 2);
     assert.strictEqual(
       subjectReportPage.report.results[0].text,
@@ -410,5 +411,83 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
       page.root.list.table.reports[1].title,
       'All Sessions for term 0 in school 0',
     );
+  });
+
+  test('create new report for instructors by academic year #3594', async function (assert) {
+    assert.expect(14);
+    this.server.createList('user', 3);
+    await page.visit();
+    assert.strictEqual(page.root.list.table.reports.length, 2);
+    assert.ok(page.root.list.newReportLinkIsHidden);
+    await page.root.list.toggleNewSubjectReportForm();
+    await page.root.list.newSubject.schools.choose('1');
+    await page.root.list.newSubject.subjects.choose('instructor');
+    await page.root.list.newSubject.objects.choose('academic year');
+    await page.root.list.newSubject.save();
+    assert.notOk(page.root.list.newReportLinkIsHidden);
+    assert.strictEqual(page.root.list.table.reports.length, 3);
+    assert.strictEqual(
+      page.root.list.table.reports[0].title,
+      'All Instructors for 2015 - 2016 in school 0',
+    );
+    assert.strictEqual(page.root.list.newReportLink, 'All Instructors for 2015 - 2016 in school 0');
+
+    this.server.post('api/graphql', ({ db }, { requestBody }) => {
+      const { query } = JSON.parse(requestBody);
+
+      assert.strictEqual(
+        query,
+        'query { users(schools: [1], instructedAcademicYears: [2015]) { firstName,middleName,lastName,displayName } }',
+      );
+      return {
+        data: {
+          users: db.users.map(({ firstName, middleName, lastName, displayName }) => {
+            return { firstName, middleName, lastName, displayName };
+          }),
+        },
+      };
+    });
+    await page.root.list.table.reports[0].select();
+    assert.strictEqual(currentURL(), '/reports/subjects/3');
+    assert.strictEqual(
+      subjectReportPage.report.title.text,
+      'All Instructors for 2015 - 2016 in school 0',
+    );
+    assert.strictEqual(subjectReportPage.report.results.length, 4);
+    assert.strictEqual(subjectReportPage.report.results[0].text, '0 guy M. Mc0son');
+    assert.strictEqual(subjectReportPage.report.results[1].text, '1 guy M. Mc1son');
+    assert.strictEqual(subjectReportPage.report.results[2].text, '2 guy M. Mc2son');
+    assert.strictEqual(subjectReportPage.report.results[3].text, '3 guy M. Mc3son');
+  });
+
+  test('courses by academic year hides year', async function (assert) {
+    assert.expect(5);
+    await page.visit();
+    await page.root.list.toggleNewSubjectReportForm();
+    await page.root.list.newSubject.schools.choose('');
+    await page.root.list.newSubject.subjects.choose('course');
+    await page.root.list.newSubject.objects.choose('academic year');
+    await page.root.list.newSubject.prepositionalObjects.choose('2015');
+    await page.root.list.newSubject.save();
+    this.server.post('api/graphql', ({ db }, { requestBody }) => {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { courses(academicYears: [2015]) { id, title, year, externalId } }',
+      );
+      const coursesIn2015 = db.courses.filter(({ year }) => year === 2015);
+      return {
+        data: {
+          courses: coursesIn2015.map(({ id, title, year, externalId }) => {
+            return { id, title, year, externalId };
+          }),
+        },
+      };
+    });
+    await page.root.list.table.reports[0].select();
+    assert.strictEqual(currentURL(), '/reports/subjects/3');
+    assert.notOk(subjectReportPage.report.academicYears.isVisible);
+    assert.strictEqual(subjectReportPage.report.results.length, 1);
+    assert.strictEqual(subjectReportPage.report.results[0].text, 'course 0 (Theoretical Phys Ed)');
   });
 });

--- a/packages/frontend/tests/integration/components/reports/new-subject-test.js
+++ b/packages/frontend/tests/integration/components/reports/new-subject-test.js
@@ -128,27 +128,29 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing course selects correct objects', function (assert) {
-    assert.expect(8);
+    assert.expect(9);
     return checkObjects(this, assert, 0, 'course', [
-      'program',
+      'academic year',
+      'competency',
       'instructor',
       'instructor group',
       'learning material',
-      'competency',
       'mesh term',
+      'program',
     ]);
   });
 
   test('choosing session selects correct objects', function (assert) {
-    assert.expect(10);
+    assert.expect(11);
     return checkObjects(this, assert, 1, 'session', [
+      'academic year',
+      'competency',
       'course',
-      'program',
       'instructor',
       'instructor group',
       'learning material',
-      'competency',
       'mesh term',
+      'program',
       'session type',
     ]);
   });
@@ -164,23 +166,25 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing instructor selects correct objects', function (assert) {
-    assert.expect(7);
+    assert.expect(8);
     return checkObjects(this, assert, 4, 'instructor', [
+      'academic year',
       'course',
-      'session',
       'instructor group',
       'learning material',
+      'session',
       'session type',
     ]);
   });
 
   test('choosing instructor group selects correct objects', function (assert) {
-    assert.expect(7);
+    assert.expect(8);
     return checkObjects(this, assert, 5, 'instructor group', [
+      'academic year',
       'course',
-      'session',
       'instructor',
       'learning material',
+      'session',
       'session type',
     ]);
   });
@@ -189,53 +193,60 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     assert.expect(8);
     return checkObjects(this, assert, 6, 'learning material', [
       'course',
-      'session',
       'instructor',
       'instructor group',
       'mesh term',
+      'session',
       'session type',
     ]);
   });
 
   test('choosing competency selects correct objects', function (assert) {
-    assert.expect(5);
-    return checkObjects(this, assert, 7, 'competency', ['course', 'session', 'session type']);
+    assert.expect(6);
+    return checkObjects(this, assert, 7, 'competency', [
+      'academic year',
+      'course',
+      'session',
+      'session type',
+    ]);
   });
 
   test('choosing mesh term selects correct objects', function (assert) {
     assert.expect(6);
     return checkObjects(this, assert, 8, 'mesh term', [
       'course',
-      'session',
       'learning material',
+      'session',
       'session type',
     ]);
   });
 
   test('choosing term selects correct objects', function (assert) {
-    assert.expect(10);
+    assert.expect(11);
     return checkObjects(this, assert, 9, 'term', [
+      'academic year',
+      'competency',
       'course',
-      'session',
-      'program year',
-      'program',
       'instructor',
       'learning material',
-      'competency',
       'mesh term',
+      'program',
+      'program year',
+      'session',
     ]);
   });
 
   test('choosing session type selects correct objects', function (assert) {
-    assert.expect(10);
+    assert.expect(11);
     return checkObjects(this, assert, 10, 'session type', [
+      'academic year',
+      'competency',
       'course',
-      'program',
       'instructor',
       'instructor group',
       'learning material',
-      'competency',
       'mesh term',
+      'program',
       'term',
     ]);
   });

--- a/packages/frontend/tests/integration/components/reports/subject/course-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/course-test.js
@@ -221,4 +221,31 @@ module('Integration | Component | reports/subject/course', function (hooks) {
       @prepositionalObjectTableRowId={{this.report.prepositionalObjectTableRowId}}
     />`);
   });
+
+  test('filter by academic year', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { courses(academicYears: [2015]) { id, title, year, externalId } }',
+      );
+      return {
+        data: {
+          courses: [{ id: 1, title: 'First Course', year: 2015 }],
+        },
+      };
+    });
+    const { id } = this.server.create('report', {
+      subject: 'course',
+      prepositionalObject: 'academic year',
+      prepositionalObjectTableRowId: '2015',
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Course
+      @subject={{this.report.subject}}
+      @prepositionalObject={{this.report.prepositionalObject}}
+      @prepositionalObjectTableRowId={{this.report.prepositionalObjectTableRowId}}
+    />`);
+  });
 });

--- a/packages/frontend/tests/integration/components/reports/subject/instructor-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/instructor-test.js
@@ -114,4 +114,27 @@ module('Integration | Component | reports/subject/instructor', function (hooks) 
       @school={{this.school}}
     />`);
   });
+
+  test('filter by academic year', async function (assert) {
+    assert.expect(1);
+    this.server.post('api/graphql', function (schema, { requestBody }) {
+      const { query } = JSON.parse(requestBody);
+      assert.strictEqual(
+        query,
+        'query { users(instructedAcademicYears: [2005]) { firstName,middleName,lastName,displayName } }',
+      );
+      return responseData;
+    });
+    const { id } = this.server.create('report', {
+      subject: 'instructor',
+      prepositionalObject: 'academic year',
+      prepositionalObjectTableRowId: 2005,
+    });
+    this.set('report', await this.owner.lookup('service:store').findRecord('report', id));
+    await render(hbs`<Reports::Subject::Instructor
+      @subject={{this.report.subject}}
+      @prepositionalObject={{this.report.prepositionalObject}}
+      @prepositionalObjectTableRowId={{this.report.prepositionalObjectTableRowId}}
+    />`);
+  });
 });

--- a/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
@@ -1,0 +1,74 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { component } from 'frontend/tests/pages/components/reports/subject/new/academic-year';
+import { setupIntl } from 'ember-intl/test-support';
+
+module('Integration | Component | reports/subject/new/academic-year', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks, 'en-us');
+
+  hooks.beforeEach(function () {
+    this.server.create('academicYear', {
+      id: 2015,
+      title: 2015,
+    });
+    this.server.create('academicYear', {
+      id: 2031,
+      title: 2031,
+    });
+    this.server.create('academicYear', {
+      id: 2060,
+      title: 2060,
+    });
+  });
+
+  test('it renders', async function (assert) {
+    assert.expect(10);
+    this.set('currentId', null);
+    this.set('changeId', (id) => {
+      assert.strictEqual(id, '2015');
+      this.set('currentId', id);
+    });
+    await render(hbs`<Reports::Subject::New::AcademicYear
+      @currentId={{this.currentId}}
+      @changeId={{this.changeId}}
+      @school={{null}}
+     />`);
+
+    assert.strictEqual(component.options.length, 3);
+    assert.strictEqual(component.options[0].text, '2015');
+    assert.ok(component.options[0].isSelected);
+    assert.strictEqual(component.value, '2015');
+
+    assert.strictEqual(component.options[1].text, '2031');
+    assert.notOk(component.options[1].isSelected);
+
+    this.set('currentId', '2031');
+    assert.notOk(component.options[0].isSelected);
+    assert.ok(component.options[1].isSelected);
+    assert.strictEqual(component.value, '2031');
+  });
+
+  test('it works', async function (assert) {
+    assert.expect(5);
+    this.set('currentId', '2031');
+    await render(hbs`<Reports::Subject::New::AcademicYear
+      @currentId={{this.currentId}}
+      @changeId={{this.changeId}}
+      @school={{null}}
+     />`);
+    this.set('changeId', (id) => {
+      assert.strictEqual(id, '2015');
+      this.set('currentId', id);
+    });
+    assert.ok(component.options[1].isSelected);
+    await component.set('2015');
+    assert.notOk(component.options[1].isSelected);
+    assert.ok(component.options[0].isSelected);
+    assert.strictEqual(component.value, '2015');
+  });
+});

--- a/packages/frontend/tests/pages/components/reports/subject/new/academic-year.js
+++ b/packages/frontend/tests/pages/components/reports/subject/new/academic-year.js
@@ -1,0 +1,13 @@
+import { create, collection, fillable, property } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-reports-subject-new-academic-year]',
+  set: fillable('select'),
+  options: collection('option', {
+    isSelected: property('selected'),
+  }),
+  value: property('value', 'select'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/ilios-common/config/api-version.js
+++ b/packages/ilios-common/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v3.9';
+module.exports = 'v3.10';


### PR DESCRIPTION
Now reports on some things can be run based on the academic year allowing easier access to some complicated things like instructors in a year or terms.

This required an API bump to add the filters we need (which will be in ilios/ilios#5264) so it isn't easily testable outside of a local build with that PR in it as well.

Fixes ilios/ilios#3594