### PR TITLE
correctly parse given target date input when transitioning from week/…

### DIFF
--- a/packages/ilios-common/addon/components/monthly-calendar.hbs
+++ b/packages/ilios-common/addon/components/monthly-calendar.hbs
@@ -20,7 +20,7 @@
           <button
             type="button"
             aria-label={{concat (t "general.view") " " day.name}}
-            {{on "click" (fn @changeToDayView day.date)}}
+            {{on "click" (fn this.changeToDayView day.date)}}
             data-test-day-button={{day.dayOfMonth}}
           >
             {{day.dayOfMonth}}
@@ -46,7 +46,7 @@
             type="button"
             class="month-more-events"
             aria-label={{t "general.showMore"}}
-            {{on "click" (fn @changeToDayView day.date)}}
+            {{on "click" (fn this.changeToDayView day.date)}}
             data-test-show-more-button
           >
             <FaIcon @icon="ellipsis" />

--- a/packages/ilios-common/addon/components/monthly-calendar.js
+++ b/packages/ilios-common/addon/components/monthly-calendar.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 import { DateTime } from 'luxon';
@@ -102,5 +103,10 @@ export default class MonthlyCalendarComponent extends Component {
         shortName: this.intl.formatDate(date, { weekday: 'short' }),
       };
     });
+  }
+
+  @action
+  changeToDayView(date) {
+    this.args.changeToDayView(DateTime.fromJSDate(date).toFormat('yyyy-MM-dd'));
   }
 }

--- a/packages/ilios-common/addon/components/weekly-calendar.hbs
+++ b/packages/ilios-common/addon/components/weekly-calendar.hbs
@@ -37,7 +37,7 @@
         <h3 class="day-name" data-test-day-name>
           <button
             type="button"
-            {{on "click" (fn @changeToDayView day.date)}}
+            {{on "click" (fn this.changeToDayView day.date)}}
           >
             {{format-date day.date weekday="long"}}
           </button>
@@ -64,7 +64,7 @@
       <div class="day-heading day-{{day.dayOfWeek}}">
         <button
           type="button"
-          {{on "click" (fn @changeToDayView day.date)}}
+          {{on "click" (fn this.changeToDayView day.date)}}
           tabindex="-1"
           data-test-day
           aria-label={{day.longName}}

--- a/packages/ilios-common/addon/components/weekly-calendar.js
+++ b/packages/ilios-common/addon/components/weekly-calendar.js
@@ -136,4 +136,9 @@ export default class WeeklyCalendarComponent extends Component {
       this.args.selectEvent(event);
     }
   }
+
+  @action
+  changeToDayView(date) {
+    this.args.changeToDayView(DateTime.fromJSDate(date).toFormat('yyyy-MM-dd'));
+  }
 }

--- a/packages/ilios-common/addon/controllers/dashboard/calendar.js
+++ b/packages/ilios-common/addon/controllers/dashboard/calendar.js
@@ -59,7 +59,7 @@ export default class DashboardCalendarController extends Controller {
 
   @action
   changeDate(newDate) {
-    this.date = DateTime.fromJSDate(newDate).toFormat('yyyy-MM-dd');
+    this.date = DateTime.fromISO(newDate).toFormat('yyyy-MM-dd');
   }
 
   @action

--- a/packages/test-app/tests/integration/components/ilios-calendar-month-test.js
+++ b/packages/test-app/tests/integration/components/ilios-calendar-month-test.js
@@ -61,12 +61,11 @@ module('Integration | Component | ilios calendar month', function (hooks) {
   });
 
   test('clicking on a day fires the correct event', async function (assert) {
-    assert.expect(3);
+    assert.expect(2);
     const date = DateTime.fromISO('2015-09-30T12:00:00');
     this.set('date', date.toJSDate());
     this.set('changeDate', (newDate) => {
-      assert.ok(newDate instanceof Date);
-      assert.ok(newDate.toString().includes('Tue Sep 01'));
+      assert.strictEqual(newDate, '2015-09-01');
     });
     this.set('changeView', (newView) => {
       assert.strictEqual(newView, 'day');

--- a/packages/test-app/tests/integration/components/ilios-calendar-week-test.js
+++ b/packages/test-app/tests/integration/components/ilios-calendar-week-test.js
@@ -27,7 +27,7 @@ module('Integration | Component | ilios calendar week', function (hooks) {
   });
 
   test('clicking on a day header fires the correct events', async function (assert) {
-    assert.expect(3);
+    assert.expect(2);
     const date = DateTime.fromObject({
       year: 2015,
       month: 9,
@@ -38,8 +38,7 @@ module('Integration | Component | ilios calendar week', function (hooks) {
     });
     this.set('date', date.toJSDate());
     this.set('changeDate', (newDate) => {
-      assert.ok(newDate instanceof Date);
-      assert.strictEqual(newDate.toString().search(/Sun Sep 27/), 0);
+      assert.strictEqual(newDate, '2015-09-27');
     });
     this.set('changeView', (newView) => {
       assert.strictEqual(newView, 'day');
@@ -53,7 +52,7 @@ module('Integration | Component | ilios calendar week', function (hooks) {
       @changeView={{this.changeView}}
     />
 `);
-    component.calendar.dayHeadings[0].selectDay();
+    await component.calendar.dayHeadings[0].selectDay();
   });
 
   test('clicking on a day header does nothing when areDaysSelectable is false', async function (assert) {


### PR DESCRIPTION
…month view to day view for multi-instance events.

we're getting an ISO formatted string, not a YYYY-MM-DD formatted day string. this fixes it.