### PR TITLE
applies vertical margins to expanded program-year objective component.

### DIFF
--- a/packages/frontend/app/styles/components/program-year/objective-list-item-expanded.scss
+++ b/packages/frontend/app/styles/components/program-year/objective-list-item-expanded.scss
@@ -3,7 +3,7 @@
 
 .program-year-objective-list-item-expanded {
   @include m.ilios-table-structure;
-  margin: 1em 0;
+  margin: 1em 2em;
   grid-column: 1 / -1;
 
   thead {


### PR DESCRIPTION
this visually aligns it better with its sibling components in py objective management.

fixes https://github.com/ilios/ilios/issues/5277