### PR TITLE
Use husky to run pre-commit lint

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm lint

--- a/package.json
+++ b/package.json
@@ -17,11 +17,15 @@
     "test:frontend": "pnpm run --filter frontend test",
     "test:lti-course-manager": "pnpm run --filter lti-course-manager test",
     "test:lti-dashboard": "pnpm run --filter lti-dashboard test",
-    "test:test-app": "pnpm run --filter test-app test"
+    "test:test-app": "pnpm run --filter test-app test",
+    "prepare": "husky"
   },
   "engines": {
     "node": ">= 20",
     "yarn": "use pnpm",
     "npm": "use pnpm"
+  },
+  "devDependencies": {
+    "husky": "^9.0.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      husky:
+        specifier: ^9.0.11
+        version: 9.0.11
 
   packages/frontend:
     dependencies:
@@ -13225,6 +13229,12 @@ packages:
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+    dev: true
+
+  /husky@9.0.11:
+    resolution: {integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==}
+    engines: {node: '>=18'}
+    hasBin: true
     dev: true
 
   /iconv-lite@0.4.24:


### PR DESCRIPTION
This automates the linting job so every commit gets a check. This restore the functionality we had with the pre-commit package before moving to a monorepo.