### PR TITLE
aligns left-hand padding of components on curr inv preview reports page.

### DIFF
--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-header.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-header.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 0.8rem;
+  padding: 0.8rem 0 0.8rem 1rem;
 
   @include m.for-tablet-and-up {
     flex-direction: row;

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table1.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table1.scss
@@ -2,7 +2,7 @@
 @use "../../mixins" as m;
 
 .curriculum-inventory-verification-preview-table1 {
-  padding: 0 0.8rem;
+  padding: 0 0.8rem 0 1rem;
   table {
     @include cm.ilios-table-structure;
     @include cm.ilios-table-colors;

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table2.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table2.scss
@@ -2,7 +2,7 @@
 @use "../../mixins" as m;
 
 .curriculum-inventory-verification-preview-table2 {
-  padding: 0 0.8rem;
+  padding: 0 0.8rem 0 1rem;
   table {
     @include cm.ilios-table-structure;
     @include cm.ilios-table-colors;

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table3a.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table3a.scss
@@ -2,7 +2,7 @@
 @use "../../mixins" as m;
 
 .curriculum-inventory-verification-preview-table3a {
-  padding: 0 0.8rem;
+  padding: 0 0.8rem 0 1rem;
   table {
     @include cm.ilios-table-structure;
     @include cm.ilios-table-colors;

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table3b.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table3b.scss
@@ -2,7 +2,7 @@
 @use "../../mixins" as m;
 
 .curriculum-inventory-verification-preview-table3b {
-  padding: 0 0.8rem;
+  padding: 0 0.8rem 0 1rem;
   table {
     @include cm.ilios-table-structure;
     @include cm.ilios-table-colors;

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table4.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table4.scss
@@ -2,7 +2,7 @@
 @use "../../mixins" as m;
 
 .curriculum-inventory-verification-preview-table4 {
-  padding: 0 0.8rem;
+  padding: 0 0.8rem 0 1rem;
   table {
     @include cm.ilios-table-structure;
     @include cm.ilios-table-colors;

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table5.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table5.scss
@@ -2,7 +2,7 @@
 @use "../../mixins" as m;
 
 .curriculum-inventory-verification-preview-table5 {
-  padding: 0 0.8rem;
+  padding: 0 0.8rem 0 1rem;
   table {
     @include cm.ilios-table-structure;
     @include cm.ilios-table-colors;

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table6.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table6.scss
@@ -2,7 +2,7 @@
 @use "../../mixins" as m;
 
 .curriculum-inventory-verification-preview-table6 {
-  padding: 0 0.8rem;
+  padding: 0 0.8rem 0 1rem;
   table {
     @include cm.ilios-table-structure;
     @include cm.ilios-table-colors;

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table7.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table7.scss
@@ -2,7 +2,7 @@
 @use "../../mixins" as m;
 
 .curriculum-inventory-verification-preview-table7 {
-  padding: 0 0.8rem;
+  padding: 0 0.8rem 0 1rem;
   table {
     @include cm.ilios-table-structure;
     @include cm.ilios-table-colors;

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table8.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table8.scss
@@ -2,7 +2,7 @@
 @use "../../mixins" as m;
 
 .curriculum-inventory-verification-preview-table8 {
-  padding: 0 0.8rem;
+  padding: 0 0.8rem 0 1rem;
   table {
     @include cm.ilios-table-structure;
     @include cm.ilios-table-colors;

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview.scss
@@ -1,9 +1,12 @@
 .curriculum-inventory-verification-preview {
   .back-to-toc {
     display: block;
-    padding: 1em 0;
+    padding: 1rem 0 1rem 1rem;
   }
+
   .table-of-contents {
     list-style-type: none;
+    margin-left: 0;
+    padding-left: 1rem;
   }
 }


### PR DESCRIPTION
fixes ilios/ilios#5278

realigns all the components on that page on the left-hand.

top of the page:

![image](https://github.com/ilios/frontend/assets/1410427/426430a1-cdef-4baa-9ff2-79fabbf15901)

links back to the top:

![image](https://github.com/ilios/frontend/assets/1410427/ff5ddc52-cd01-4994-82c2-51963bcf881f)
