### PR TITLE
lint against untranslated strings in templates.

### DIFF
--- a/packages/frontend/.template-lintrc.js
+++ b/packages/frontend/.template-lintrc.js
@@ -7,5 +7,6 @@ module.exports = {
       //our helpers which do not take arguments have to be listed here
       allow: ['browser-timezone', 'noop'],
     },
+    'no-bare-strings': true,
   },
 };

--- a/packages/ilios-common/.template-lintrc.js
+++ b/packages/ilios-common/.template-lintrc.js
@@ -7,5 +7,6 @@ module.exports = {
       //our helpers which do not take arguments have to be listed here
       allow: ['browser-timezone', 'noop'],
     },
+    'no-bare-strings': true,
   },
 };

--- a/packages/lti-course-manager/.template-lintrc.js
+++ b/packages/lti-course-manager/.template-lintrc.js
@@ -7,5 +7,6 @@ module.exports = {
       //our helpers which do not take arguments have to be listed here
       allow: ['browser-timezone', 'noop'],
     },
+    'no-bare-strings': true,
   },
 };

--- a/packages/lti-dashboard/.template-lintrc.js
+++ b/packages/lti-dashboard/.template-lintrc.js
@@ -7,5 +7,6 @@ module.exports = {
       //our helpers which do not take arguments have to be listed here
       allow: ['browser-timezone', 'noop'],
     },
+    'no-bare-strings': true,
   },
 };

--- a/packages/test-app/.template-lintrc.js
+++ b/packages/test-app/.template-lintrc.js
@@ -7,5 +7,6 @@ module.exports = {
       //our helpers which do not take arguments have to be listed here
       allow: ['browser-timezone', 'noop'],
     },
+    'no-bare-strings': true,
   },
 };


### PR DESCRIPTION
we used to have this in place before, but somehow this got lost in the churn (perhaps during the monorepo transition).