### PR TITLE
Clear user search when returning

### DIFF
--- a/packages/frontend/app/components/manage-users-summary.hbs
+++ b/packages/frontend/app/components/manage-users-summary.hbs
@@ -1,10 +1,11 @@
-<section class="manage-users-summary large-component" ...attributes>
+<section class="manage-users-summary large-component" data-test-manage-users-summary ...attributes>
   <div class="header">
     <h2 class="title">
       {{t "general.manageUsersSummaryTitle"}}
       (<LinkTo
          @route="users"
-         @query={{hash showBulkNewUserForm=false showNewUserForm=false}}
+         @query={{hash showBulkNewUserForm=false showNewUserForm=false filter=null}}
+         data-test-users-link
        >
          {{t "general.viewAll"}}
        </LinkTo>)
@@ -13,7 +14,8 @@
       {{#if @canCreate}}
         <LinkTo
           @route="users"
-          @query={{hash showNewUserForm=true showBulkNewUserForm=false}}
+          @query={{hash showNewUserForm=true showBulkNewUserForm=false filter=null}}
+          data-test-create-user-link
         >
           <button type="button">
             {{t "general.create"}}

--- a/packages/frontend/tests/acceptance/users-test.js
+++ b/packages/frontend/tests/acceptance/users-test.js
@@ -5,6 +5,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/users';
 import percySnapshot from '@percy/ember';
+import userPage from 'frontend/tests/pages/user';
 
 module('Acceptance | Users', function (hooks) {
   setupApplicationTest(hooks);
@@ -70,5 +71,51 @@ module('Acceptance | Users', function (hooks) {
     await page.root.newUserForm.password.set('G3heimSach*e');
     await page.root.newUserForm.submit();
     assert.strictEqual(currentURL(), '/users/101');
+  });
+
+  test('clear search when returning from creating a new user #4356', async function (assert) {
+    await page.visit();
+    await page.root.search.set('searchingterm');
+    assert.strictEqual(currentURL(), '/users?filter=searchingterm');
+    await page.root.showNewUserFormButton.click();
+    await page.root.newUserForm.firstName.set('Lorem');
+    await page.root.newUserForm.lastName.set('Ipsum');
+    await page.root.newUserForm.email.set('lorem@ipsum.edu');
+    await page.root.newUserForm.username.set('test123');
+    await page.root.newUserForm.password.set('G3heimSach*e');
+    await page.root.newUserForm.submit();
+    assert.strictEqual(currentURL(), '/users/101');
+    await userPage.manageUsersSummary.visitUsers();
+    assert.strictEqual(page.root.search.value, '');
+    assert.strictEqual(currentURL(), '/users');
+  });
+
+  test('clear search when returning from viewing a user #4356', async function (assert) {
+    await page.visit();
+    await page.root.search.set('Mc4son');
+    assert.strictEqual(currentURL(), '/users?filter=Mc4son');
+    assert.strictEqual(page.root.userList.users[0].userNameInfo.fullName, '4 guy M. Mc4son');
+    await page.root.userList.users[0].viewUserDetails();
+    assert.strictEqual(currentURL(), '/users/5');
+    await userPage.manageUsersSummary.visitUsers();
+    assert.strictEqual(page.root.search.value, '');
+    assert.strictEqual(currentURL(), '/users');
+  });
+
+  test('clear search when returning from creating a new user to creating another new user #4356', async function (assert) {
+    await page.visit();
+    await page.root.search.set('searchingterm');
+    assert.strictEqual(currentURL(), '/users?filter=searchingterm');
+    await page.root.showNewUserFormButton.click();
+    await page.root.newUserForm.firstName.set('Lorem');
+    await page.root.newUserForm.lastName.set('Ipsum');
+    await page.root.newUserForm.email.set('lorem@ipsum.edu');
+    await page.root.newUserForm.username.set('test123');
+    await page.root.newUserForm.password.set('G3heimSach*e');
+    await page.root.newUserForm.submit();
+    assert.strictEqual(currentURL(), '/users/101');
+    await userPage.manageUsersSummary.createNewUser();
+    assert.strictEqual(page.root.search.value, '');
+    assert.strictEqual(currentURL(), '/users?addUser=true');
   });
 });

--- a/packages/frontend/tests/pages/components/manage-users-summary.js
+++ b/packages/frontend/tests/pages/components/manage-users-summary.js
@@ -1,0 +1,10 @@
+import { clickable, create } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-manage-users-summary]',
+  visitUsers: clickable('[data-test-users-link]'),
+  createNewUser: clickable('[data-test-create-user-link]'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/frontend/tests/pages/user.js
+++ b/packages/frontend/tests/pages/user.js
@@ -1,10 +1,12 @@
 import { clickable, create, property, text, visitable } from 'ember-cli-page-object';
 import bio from 'frontend/tests/pages/components/user-profile-bio';
 import cohorts from 'frontend/tests/pages/components/user-profile-cohorts';
+import manageUsersSummary from 'frontend/tests/pages/components/manage-users-summary';
 
 export default create({
   scope: '[data-test-user-profile]',
   visit: visitable('/users/:userId'),
+  manageUsersSummary,
   bio,
   cohorts,
   roles: {


### PR DESCRIPTION
When creating a new user or visiting a user from the list clicking either the create new user or view all links should return you to the list without retaining your previous search. The back button will still take you back and keep the filter in place.

Fixes ilios/ilios#4356