### PR TITLE
Fixes flash-of-content during saving of program- and program-year-leadership.

### DIFF
--- a/packages/frontend/app/components/program-year/details.hbs
+++ b/packages/frontend/app/components/program-year/details.hbs
@@ -2,7 +2,7 @@
   {{#if @programYearLeadershipDetails}}
     <ProgramYear::LeadershipExpanded
       @programYear={{@programYear}}
-      @canUpdate={{@canUpdate}}
+      @editable={{@canUpdate}}
       @collapse={{fn @setProgramYearLeadershipDetails false}}
       @expand={{fn @setProgramYearLeadershipDetails true}}
       @isManaging={{@manageProgramYearLeadership}}

--- a/packages/frontend/app/components/program-year/leadership-expanded.hbs
+++ b/packages/frontend/app/components/program-year/leadership-expanded.hbs
@@ -1,33 +1,42 @@
 <div
   class="program-year-leadership-expanded"
   data-test-program-year-leadership-expanded
-  ...attributes
+  {{did-insert (perform this.load) @programYear}}
 >
+{{#if this.load.isRunning}}
+    <LoadingSpinner />
+{{else}}
   <div class="program-year-leadership-expanded-header">
-    <button
-      class="title link-button"
-      type="button"
-      aria-expanded="true"
-      data-test-title
-      {{on "click" @collapse}}
-    >
-      {{t "general.leadership"}} ({{this.count}})
-      <FaIcon @icon="caret-down" />
-    </button>
+    {{#if @isManaging}}
+      <h3 class="title" data-test-title>
+        {{t "general.leadership"}} ({{this.count}})
+      </h3>
+    {{else}}
+      <button
+        class="title link-button"
+        type="button"
+        aria-expanded="true"
+        data-test-title
+        {{on "click" @collapse}}
+      >
+        {{t "general.leadership"}} ({{this.count}})
+        <FaIcon @icon="caret-down" />
+      </button>
+    {{/if}}
     <div class="actions">
       {{#if @isManaging}}
-        <button type="button" class="bigadd" {{on "click" (perform this.save)}}>
+        <button type="button" class="bigadd" {{on "click" (perform this.save)}} data-test-save>
           <FaIcon
             @icon={{if this.save.isRunning "spinner" "check"}}
             @spin={{this.save.isRunning}}
           />
         </button>
-        <button type="button" class="bigcancel" {{on "click" this.close}}>
+        <button type="button" class="bigcancel" {{on "click" (perform this.cancel)}} data-test-cancel>
           <FaIcon @icon="arrow-rotate-left" />
         </button>
-      {{else if @canUpdate}}
-        <button type="button" {{on "click" (fn @setIsManaging true)}}>
-          {{t "general.leadership"}}
+      {{else if @editable}}
+        <button type="button" {{on "click" this.manage}} data-test-manage>
+          {{t "general.manageLeadership"}}
         </button>
       {{/if}}
     </div>
@@ -49,4 +58,5 @@
       />
     {{/if}}
   </div>
+{{/if}}
 </div>

--- a/packages/frontend/app/components/program-year/leadership-expanded.js
+++ b/packages/frontend/app/components/program-year/leadership-expanded.js
@@ -1,57 +1,48 @@
 import Component from '@glimmer/component';
-import { dropTask } from 'ember-concurrency';
+import { dropTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import { TrackedAsyncData } from 'ember-async-data';
-import { cached } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class ProgramYearLeadershipExpandedComponent extends Component {
-  @tracked directorsToAdd = [];
-  @tracked directorsToRemove = [];
+  @tracked directors = [];
 
-  @cached
   get count() {
     return this.directors.length;
   }
 
-  @cached
-  get programYearDirectors() {
-    return new TrackedAsyncData(this.args.programYear.directors);
-  }
-
-  @cached
-  get directors() {
-    const directors = this.programYearDirectors.isResolved
-      ? this.programYearDirectors.value.slice()
-      : [];
-    return [...directors, ...this.directorsToAdd].filter(
-      (user) => !this.directorsToRemove.includes(user),
-    );
-  }
-
   @action
   addDirector(user) {
-    this.directorsToAdd = [...this.directorsToAdd, user];
-    this.directorsToRemove = this.directorsToRemove.filter((d) => d !== user);
+    this.directors = [...this.directors, user];
   }
 
   @action
   removeDirector(user) {
-    this.directorsToRemove = [...this.directorsToRemove, user];
-    this.directorsToAdd = this.directorsToAdd.filter((d) => d !== user);
+    this.directors = this.directors.filter((obj) => obj !== user);
   }
 
   @action
-  close() {
-    this.directorsToAdd = [];
-    this.directorsToRemove = [];
-    this.args.setIsManaging(false);
+  manage() {
+    this.args.setIsManaging(true);
   }
 
+  async setBuffers() {
+    this.directors = (await this.args.programYear.directors).slice();
+  }
+
+  load = dropTask(async () => {
+    await this.setBuffers();
+  });
+
   save = dropTask(async () => {
+    await timeout(10);
     this.args.programYear.set('directors', this.directors);
     this.args.expand();
     await this.args.programYear.save();
-    this.close();
+    this.args.setIsManaging(false);
+  });
+
+  cancel = dropTask(async () => {
+    await this.setBuffers();
+    this.args.setIsManaging(false);
   });
 }

--- a/packages/frontend/app/components/program/leadership-expanded.hbs
+++ b/packages/frontend/app/components/program/leadership-expanded.hbs
@@ -1,48 +1,62 @@
-<div class="program-leadership-expanded" data-test-program-leadership-expanded ...attributes>
-  <div class="program-leadership-expanded-header">
-    <button
-      class="title link-button"
-      type="button"
-      aria-expanded="true"
-      data-test-title
-      {{on "click" @collapse}}
-    >
-      {{t "general.leadership"}} ({{this.count}})
-      <FaIcon @icon="caret-down" />
-    </button>
-    <div class="actions">
+<div
+  class="program-leadership-expanded"
+  data-test-program-leadership-expanded
+  {{did-insert (perform this.load) @program}}
+>
+  {{#if this.load.isRunning}}
+      <LoadingSpinner />
+  {{else}}
+    <div class="program-leadership-expanded-header">
       {{#if @isManaging}}
-        <button type="button" class="bigadd" {{on "click" (perform this.save)}}>
-          <FaIcon
-            @icon={{if this.save.isRunning "spinner" "check"}}
-            @spin={{this.save.isRunning}}
-          />
-        </button>
-        <button type="button" class="bigcancel" {{on "click" this.close}}>
-          <FaIcon @icon="arrow-rotate-left" />
-        </button>
-      {{else if @canUpdate}}
-        <button type="button" {{on "click" (fn @setIsManaging true)}}>
-          {{t "general.manageLeadership"}}
-        </button>
+        <h3 class="title" data-test-title>
+          {{t "general.leadership"}} ({{this.count}})
+        </h3>
+      {{else}}
+        <button
+          class="title link-button"
+          type="button"
+          aria-expanded="true"
+          data-test-title
+          {{on "click" @collapse}}
+        >
+          {{t "general.leadership"}} ({{this.count}})
+          <FaIcon @icon="caret-down" />
+      </button>
+      {{/if}}
+      <div class="actions">
+        {{#if @isManaging}}
+          <button type="button" class="bigadd" {{on "click" (perform this.save)}} data-test-save>
+            <FaIcon
+              @icon={{if this.save.isRunning "spinner" "check"}}
+              @spin={{this.save.isRunning}}
+            />
+          </button>
+          <button type="button" class="bigcancel" {{on "click" (perform this.cancel)}} data-test-cancel>
+            <FaIcon @icon="arrow-rotate-left" />
+          </button>
+        {{else if @editable}}
+          <button type="button" {{on "click" this.manage}} data-test-manage>
+            {{t "general.manageLeadership"}}
+          </button>
+        {{/if}}
+      </div>
+    </div>
+    <div class="program-leadership-expanded-content">
+      {{#if @isManaging}}
+        <LeadershipManager
+          @directors={{this.directors}}
+          @showAdministrators={{false}}
+          @showDirectors={{true}}
+          @addDirector={{this.addDirector}}
+          @removeDirector={{this.removeDirector}}
+        />
+      {{else}}
+        <LeadershipList
+          @directors={{this.directors}}
+          @showAdministrators={{false}}
+          @showDirectors={{true}}
+        />
       {{/if}}
     </div>
-  </div>
-  <div class="program-leadership-expanded-content">
-    {{#if @isManaging}}
-      <LeadershipManager
-        @directors={{this.directors}}
-        @showAdministrators={{false}}
-        @showDirectors={{true}}
-        @addDirector={{this.addDirector}}
-        @removeDirector={{this.removeDirector}}
-      />
-    {{else}}
-      <LeadershipList
-        @directors={{this.directors}}
-        @showAdministrators={{false}}
-        @showDirectors={{true}}
-      />
-    {{/if}}
-  </div>
+  {{/if}}
 </div>

--- a/packages/frontend/app/components/program/leadership-expanded.js
+++ b/packages/frontend/app/components/program/leadership-expanded.js
@@ -1,55 +1,48 @@
 import Component from '@glimmer/component';
-import { dropTask } from 'ember-concurrency';
+import { dropTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import { TrackedAsyncData } from 'ember-async-data';
-import { cached } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class ProgramLeadershipExpandedComponent extends Component {
-  @tracked directorsToAdd = [];
-  @tracked directorsToRemove = [];
+  @tracked directors = [];
 
-  @cached
   get count() {
     return this.directors.length;
   }
 
-  @cached
-  get programDirectors() {
-    return new TrackedAsyncData(this.args.program.directors);
-  }
-
-  @cached
-  get directors() {
-    const directors = this.programDirectors.isResolved ? this.programDirectors.value.slice() : [];
-    return [...directors, ...this.directorsToAdd].filter(
-      (user) => !this.directorsToRemove.includes(user),
-    );
-  }
-
   @action
   addDirector(user) {
-    this.directorsToAdd = [...this.directorsToAdd, user];
-    this.directorsToRemove = this.directorsToRemove.filter((d) => d !== user);
+    this.directors = [...this.directors, user];
   }
 
   @action
   removeDirector(user) {
-    this.directorsToRemove = [...this.directorsToRemove, user];
-    this.directorsToAdd = this.directorsToAdd.filter((d) => d !== user);
+    this.directors = this.directors.filter((obj) => obj !== user);
   }
 
   @action
-  close() {
-    this.directorsToAdd = [];
-    this.directorsToRemove = [];
-    this.args.setIsManaging(false);
+  manage() {
+    this.args.setIsManaging(true);
   }
 
+  async setBuffers() {
+    this.directors = (await this.args.program.directors).slice();
+  }
+
+  load = dropTask(async () => {
+    await this.setBuffers();
+  });
+
   save = dropTask(async () => {
+    await timeout(10);
     this.args.program.set('directors', this.directors);
     this.args.expand();
     await this.args.program.save();
-    this.close();
+    this.args.setIsManaging(false);
+  });
+
+  cancel = dropTask(async () => {
+    await this.setBuffers();
+    this.args.setIsManaging(false);
   });
 }

--- a/packages/frontend/app/components/program/root.hbs
+++ b/packages/frontend/app/components/program/root.hbs
@@ -9,7 +9,7 @@
   {{#if @leadershipDetails}}
     <Program::LeadershipExpanded
       @program={{@program}}
-      @canUpdate={{@canUpdate}}
+      @editable={{@canUpdate}}
       @collapse={{fn @setLeadershipDetails false}}
       @expand={{fn @setLeadershipDetails true}}
       @isManaging={{@manageLeadership}}

--- a/packages/frontend/tests/integration/components/program-year/leadership-expanded-test.js
+++ b/packages/frontend/tests/integration/components/program-year/leadership-expanded-test.js
@@ -33,7 +33,7 @@ module('Integration | Component | program-year/leadership-expanded', function (h
     this.set('programYear', programYearModel);
     await render(hbs`<ProgramYear::LeadershipExpanded
       @programYear={{this.programYear}}
-      @canUpdate={{true}}
+      @editable={{true}}
       @collapse={{(noop)}}
       @expand={{(noop)}}
       @isManaging={{false}}
@@ -60,7 +60,7 @@ module('Integration | Component | program-year/leadership-expanded', function (h
     });
     await render(hbs`<ProgramYear::LeadershipExpanded
       @programYear={{this.programYear}}
-      @canUpdate={{true}}
+      @editable={{true}}
       @collapse={{this.click}}
       @expand={{(noop)}}
       @isManaging={{false}}
@@ -84,7 +84,7 @@ module('Integration | Component | program-year/leadership-expanded', function (h
     });
     await render(hbs`<ProgramYear::LeadershipExpanded
       @programYear={{this.programYear}}
-      @canUpdate={{true}}
+      @editable={{true}}
       @collapse={{(noop)}}
       @expand={{(noop)}}
       @isManaging={{false}}

--- a/packages/frontend/tests/integration/components/program/leadership-expanded-test.js
+++ b/packages/frontend/tests/integration/components/program/leadership-expanded-test.js
@@ -30,7 +30,7 @@ module('Integration | Component | program/leadership expanded', function (hooks)
     this.set('program', programModel);
     await render(hbs`<Program::LeadershipExpanded
       @program={{this.program}}
-      @canUpdate={{true}}
+      @editable={{true}}
       @collapse={{(noop)}}
       @expand={{(noop)}}
       @isManaging={{false}}
@@ -53,7 +53,7 @@ module('Integration | Component | program/leadership expanded', function (hooks)
     });
     await render(hbs`<Program::LeadershipExpanded
       @program={{this.program}}
-      @canUpdate={{true}}
+      @editable={{true}}
       @collapse={{this.click}}
       @expand={{(noop)}}
       @isManaging={{false}}
@@ -73,7 +73,7 @@ module('Integration | Component | program/leadership expanded', function (hooks)
     });
     await render(hbs`<Program::LeadershipExpanded
       @program={{this.program}}
-      @canUpdate={{true}}
+      @editable={{true}}
       @collapse={{(noop)}}
       @expand={{(noop)}}
       @isManaging={{false}}

--- a/packages/frontend/tests/pages/components/program-year/leadership-expanded.js
+++ b/packages/frontend/tests/pages/components/program-year/leadership-expanded.js
@@ -6,9 +6,9 @@ const definition = {
   scope: '[data-test-program-year-leadership-expanded]',
   title: text('[data-test-title]'),
   collapse: clickable('[data-test-title]'),
-  manage: clickable('.actions button'),
-  save: clickable('.actions button.bigadd'),
-  cancel: clickable('.actions button.bigcancel'),
+  manage: clickable('[data-test-manage]'),
+  save: clickable('[data-test-save]'),
+  cancel: clickable('[data-test-cancel]'),
   leadershipList,
   leadershipManager,
 };

--- a/packages/frontend/tests/pages/components/program/leadership-expanded.js
+++ b/packages/frontend/tests/pages/components/program/leadership-expanded.js
@@ -6,9 +6,9 @@ const definition = {
   scope: '[data-test-program-leadership-expanded]',
   title: text('[data-test-title]'),
   collapse: clickable('[data-test-title]'),
-  manage: clickable('.actions button'),
-  save: clickable('.actions button.bigadd'),
-  cancel: clickable('.actions button.bigcancel'),
+  manage: clickable('[data-test-manage]'),
+  save: clickable('[data-test-save]'),
+  cancel: clickable('[data-test-cancel]'),
   leadershipList,
   leadershipManager,
 };


### PR DESCRIPTION
Going back to the modifier-based approach to loading/unloading component state is the solution here.
This realigns this leadership management component with the one used for course management.

fixes https://github.com/ilios/ilios/issues/5139

also fixes https://github.com/ilios/ilios/issues/5324