### PR TITLE
Fix dashboard LTI deployment

### DIFF
--- a/packages/lti-dashboard/config/deploy.js
+++ b/packages/lti-dashboard/config/deploy.js
@@ -21,13 +21,13 @@ module.exports = function (deployTarget) {
 
   if (deployTarget === 'staging') {
     ENV.build.environment = 'production';
-    ENV.s3.bucket = 'ilios-lti-dashboard-staging';
+    ENV.s3.bucket = 'ilios-lti-app-staging';
     ENV.cloudfront.distribution = 'E8JZZJVG36758';
   }
 
   if (deployTarget === 'production') {
     ENV.build.environment = 'production';
-    ENV.s3.bucket = 'ilios-lti-dashboard-production';
+    ENV.s3.bucket = 'ilios-lti-app-production';
     ENV.cloudfront.distribution = 'E33FMSW7332DVL';
   }
 


### PR DESCRIPTION
I munged the name of the S3 bucket when moving into the monorepo, fixing it back to the original will fix the deploy process.