### PR TITLE
Handle invalid calendar date gracefully

### DIFF
--- a/packages/frontend/tests/acceptance/dashboard/calendar-test.js
+++ b/packages/frontend/tests/acceptance/dashboard/calendar-test.js
@@ -301,6 +301,20 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
     assert.strictEqual(page.calendar.dailyCalendar.events[0].name, 'today');
   });
 
+  test('invalid date loads today #5342', async function (assert) {
+    assert.expect(2);
+    freezeDateAt(
+      DateTime.fromObject({
+        year: 2005,
+        month: 6,
+        day: 24,
+      }).toJSDate(),
+    );
+    await visit('/dashboard/calendar?view=day&date=somethinginvalid');
+    assert.strictEqual(currentRouteName(), 'dashboard.calendar');
+    assert.strictEqual(page.calendar.dailyCalendar.title.longDayOfWeek, 'Friday, June 24, 2005');
+  });
+
   test('click month day number and go to day', async function (assert) {
     const aDayInTheMonth = DateTime.fromObject({ hour: 8 }).startOf('month').plus({ days: 12 });
     this.server.create('userevent', {

--- a/packages/ilios-common/addon/controllers/dashboard/calendar.js
+++ b/packages/ilios-common/addon/controllers/dashboard/calendar.js
@@ -43,7 +43,13 @@ export default class DashboardCalendarController extends Controller {
 
   get selectedDate() {
     if (this.date) {
-      return DateTime.fromFormat(this.date, 'yyyy-MM-dd').toJSDate();
+      const dt = DateTime.fromFormat(this.date, 'yyyy-MM-dd');
+
+      if (dt.isValid) {
+        return dt.toJSDate();
+      } else {
+        console.error(`date in URL is invalid: ${dt.invalidExplanation}`);
+      }
     }
 
     return DateTime.now().toJSDate();


### PR DESCRIPTION
If an invalid date is specified as a query param in the URL we fall through to today instead of dying horribly.

I elected, after some experimentation, to not show this error to the user. It's in the console for power users and troubleshooting, however I don't think this case is common enough to warrant more explicit error handling.

Fixes ilios/ilios#5342