### PR TITLE
We're seeing errors from JS hitting this line

### DIFF
--- a/packages/frontend/app/controllers/error.js
+++ b/packages/frontend/app/controllers/error.js
@@ -8,7 +8,7 @@ export default class ErrorController extends Controller {
   }
 
   get isA404() {
-    if (this.model?.errors.length > 0) {
+    if (this.model?.errors?.length > 0) {
       return Number(this.model.errors[0].status) === 404;
     }
 


### PR DESCRIPTION
For some reason not all the content here has an error object. No idea why that would be true, but it's easy to protect against.

Fixes ilios/ilios#5348