### PR TITLE
Refactor UserProfileCalendar component

### DIFF
--- a/packages/frontend/app/components/user-profile-calendar.hbs
+++ b/packages/frontend/app/components/user-profile-calendar.hbs
@@ -1,7 +1,5 @@
 <div
   class="user-profile-calendar"
-  {{did-insert (perform this.load) @user this.date}}
-  {{did-update (perform this.load) @user this.date}}
   data-test-user-profile-calendar
 >
   <h2 class="title">
@@ -47,11 +45,7 @@
       @date={{this.date}}
       @areEventsSelectable={{false}}
       @areDaysSelectable={{false}}
+      @isLoadingEvents={{this.eventsData.isPending}}
     />
   </div>
-  <span class="loading-indicator {{if (is-array this.calendarEvents) "loaded"}}">
-    <LoadingSpinner />
-    {{t "general.loadingEvents"}}
-    ...
-  </span>
 </div>

--- a/packages/frontend/app/styles/components/user-profile-calendar.scss
+++ b/packages/frontend/app/styles/components/user-profile-calendar.scss
@@ -26,17 +26,4 @@
       margin-right: 2em;
     }
   }
-
-  .loading-indicator {
-    @include m.ilios-heading-h1;
-    left: 4rem;
-    opacity: 75;
-    position: absolute;
-    top: 5rem;
-    transition: all 0.5s ease-in-out;
-
-    &.loaded {
-      opacity: 0;
-    }
-  }
 }


### PR DESCRIPTION
The impetus of this was to fix the component's data loading on Sunday night in en-us where the data from the previous week would get loaded instead. I replaced the loading modifier with a tracked async getter and linked this up to the localeDays service.

I also replaced the loader with the built in one that is now in the weekly calendar.