### PR TITLE
Check to make sure service workers is enabled

### DIFF
--- a/packages/frontend/app/utils/launch-worker.js
+++ b/packages/frontend/app/utils/launch-worker.js
@@ -2,7 +2,12 @@ import config from 'frontend/config/environment';
 import { isTesting } from '@embroider/macros';
 
 export async function launchWorker() {
-  if (isTesting() || config.disableServiceWorker || navigator.serviceWorker.controller) {
+  if (
+    isTesting() ||
+    config.disableServiceWorker ||
+    !('serviceWorker' in navigator) ||
+    navigator.serviceWorker.controller
+  ) {
     return true;
   }
 


### PR DESCRIPTION
All of our supported browsers support workers, however in comes cases (like FF private) the worker isn't enabled. This check ensures that the worker exists and is enabled before we try and check it.

Fixes ilios/ilios#4761