### PR TITLE
Ignore tmp directory from deploys

### DIFF
--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -1,6 +1,7 @@
 # compiled output
 /dist/
 /declarations/
+/tmp/
 
 # dependencies
 /node_modules/

--- a/packages/lti-course-manager/.gitignore
+++ b/packages/lti-course-manager/.gitignore
@@ -1,6 +1,7 @@
 # compiled output
 /dist/
 /declarations/
+/tmp/
 
 # dependencies
 /node_modules/

--- a/packages/lti-dashboard/.gitignore
+++ b/packages/lti-dashboard/.gitignore
@@ -1,6 +1,7 @@
 # compiled output
 /dist/
 /declarations/
+/tmp/
 
 # dependencies
 /node_modules/


### PR DESCRIPTION
These get created when deploying, we should ignore them to ensure they never get pushed accidentally into our commits.