### PR TITLE
Add v prefix to sentry errors

### DIFF
--- a/packages/frontend/app/sentry.js
+++ b/packages/frontend/app/sentry.js
@@ -8,7 +8,7 @@ function startSentry(config) {
   Sentry.init({
     dsn: captureErrors ? DSN : null,
     environment: config.environment,
-    release: config.APP.version.match(versionRegExp)[0],
+    release: `v${config.APP.version.match(versionRegExp)[0]}`,
     tracesSampleRate: 0.25,
   });
 }


### PR DESCRIPTION
Our releases are prefixed with this in the tag and in the data we're sending to sentry describing the build. However we pull the info from the package.json in frontend where npm asks for the version without the prefix. We need to add it to the sentry errors to ensure our error reports can line up with released versions and their source maps and commit data.