### PR TITLE
applies focus/hover specific styles to terms in taxonomy manager.

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/selectable-terms-list-item.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/selectable-terms-list-item.scss
@@ -12,6 +12,12 @@
   vertical-align: middle;
   width: 100%;
 
+  &:focus,
+  &:hover {
+    background-color: c.$culturedGrey;
+    border: 1px c.$black solid;
+  }
+
   &.selected {
     background-color: c.$culturedGrey;
   }


### PR DESCRIPTION

![image](https://github.com/ilios/frontend/assets/1410427/5fbf3bc6-8968-4c6f-809f-5ccf2644af17)

refs https://github.com/ilios/ilios/issues/4782

fixes  https://github.com/ilios/ilios/issues/5362