### PR TITLE
Align our dependabot ignore with blueprint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,9 +23,11 @@ updates:
       - dependency-name: "@ember/optional-features"
       - dependency-name: "@ember/string"
       - dependency-name: "@ember/test-helpers"
+      - dependency-name: "@embroider/test-setup"
       - dependency-name: "@glimmer/component"
       - dependency-name: "@glimmer/tracking"
       - dependency-name: broccoli-asset-rev
+      - dependency-name: concurrently
       - dependency-name: ember-auto-import
       - dependency-name: ember-cli
       - dependency-name: ember-cli-app-version
@@ -44,8 +46,22 @@ updates:
       - dependency-name: ember-qunit
       - dependency-name: ember-resolver
       - dependency-name: ember-source
+      - dependency-name: ember-source-channel-url
+      - dependency-name: ember-template-lint
+      - dependency-name: ember-try
       - dependency-name: ember-welcome-page
+      - dependency-name: eslint
+      - dependency-name: eslint-config-prettier
+      - dependency-name: eslint-plugin-ember
+      - dependency-name: eslint-plugin-n
+      - dependency-name: eslint-plugin-prettier
+      - dependency-name: eslint-plugin-qunit
+      - dependency-name: loader.js
+      - dependency-name: prettier
       - dependency-name: qunit
       - dependency-name: qunit-dom
+      - dependency-name: stylelint
+      - dependency-name: stylelint-config-standard
+      - dependency-name: stylelint-prettier
       - dependency-name: tracked-built-ins
       - dependency-name: webpack


### PR DESCRIPTION
Ignore everything in the ember-cli blueprints. This got out of sync in the monorepo consolidation, but I've added all the packages from the app and addon blueprints back in.

Refs #7617 #7623

Sourced these packages from:
https://github.com/ember-cli/ember-new-output/blob/v5.7.0/package.json
https://github.com/ember-cli/ember-addon-output/blob/v5.7.0/package.json