### PR TITLE
Replaces ember-cli-new-version dependency with home-grown equivalent

### DIFF
--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -21,6 +21,12 @@ module.exports = {
     'ember/no-classic-classes': 0,
     'ember/no-mixins': 0,
     'ember/no-new-mixins': 0,
+    'n/no-extraneous-require': [
+      'error',
+      {
+        allowModules: ['broccoli-file-creator'],
+      },
+    ],
   },
   overrides: [
     // node files

--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -21,12 +21,6 @@ module.exports = {
     'ember/no-classic-classes': 0,
     'ember/no-mixins': 0,
     'ember/no-new-mixins': 0,
-    'n/no-extraneous-require': [
-      'error',
-      {
-        allowModules: ['broccoli-file-creator'],
-      },
-    ],
   },
   overrides: [
     // node files

--- a/packages/frontend/app/components/update-notification.hbs
+++ b/packages/frontend/app/components/update-notification.hbs
@@ -1,8 +1,10 @@
-<button
-  type="button"
-  class="ilios-update-notification"
-  {{on "click" (perform this.click)}}
-  ...attributes
->
-  {{t "general.iliosUpdatePending"}}
-</button>
+{{#if this.newVersion.isNewVersionAvailable}}
+  <div class="update-notification" data-test-update-notification>
+    <button
+      type="button"
+      {{on "click" (perform this.click)}}
+    >
+      {{t "general.iliosUpdatePending"}}
+    </button>
+  </div>
+{{/if}}

--- a/packages/frontend/app/components/update-notification.js
+++ b/packages/frontend/app/components/update-notification.js
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
+import { service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 
 export default class UpdateNotificationComponent extends Component {
+  @service newVersion;
+
   /**
    * send a message to update every tab attached to this worker
    * this message is caught by our sw-skip-wait in-repo addon
@@ -13,8 +16,8 @@ export default class UpdateNotificationComponent extends Component {
         reg.waiting.postMessage('skipWaiting');
       }
     }
-    if (this.args.reload) {
-      this.args.reload();
+    if (typeof window !== 'undefined' && window.location) {
+      window.location.reload(true);
     }
   });
 }

--- a/packages/frontend/app/services/graphql.js
+++ b/packages/frontend/app/services/graphql.js
@@ -1,5 +1,4 @@
 import Service from '@ember/service';
-import fetch from 'fetch';
 import { service } from '@ember/service';
 
 export default class GraphqlService extends Service {

--- a/packages/frontend/app/services/new-version.js
+++ b/packages/frontend/app/services/new-version.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import Ember from 'ember';
+import { isTesting } from '@embroider/macros';
 import { task, timeout } from 'ember-concurrency';
 import config from 'frontend/config/environment';
 
@@ -25,7 +25,7 @@ export default class NewVersionService extends Service {
   constructor() {
     super(...arguments);
     // don't autostart this task in a test environment.
-    if (!Ember.testing) {
+    if (!isTesting()) {
       this.updateVersion.perform();
     }
   }
@@ -42,7 +42,7 @@ export default class NewVersionService extends Service {
       this.onError(e);
     } finally {
       // @todo figure out a way to test the recursion. For now, don't run it in test mode [ST 2024/04/09]
-      if (!Ember.testing) {
+      if (!isTesting()) {
         await timeout(ONE_MINUTE);
         this.updateVersion.perform();
       }
@@ -50,7 +50,7 @@ export default class NewVersionService extends Service {
   });
 
   onError(error) {
-    if (!Ember.testing) {
+    if (!isTesting()) {
       console.log(error);
     }
   }

--- a/packages/frontend/app/services/new-version.js
+++ b/packages/frontend/app/services/new-version.js
@@ -18,8 +18,7 @@ export default class NewVersionService extends Service {
   }
 
   get url() {
-    const baseUrl = config.prepend || config.rootURL || config.baseURL;
-    return baseUrl + config.newVersion.versionFile;
+    return config.rootURL + config.newVersion.versionFile;
   }
 
   constructor() {

--- a/packages/frontend/app/services/new-version.js
+++ b/packages/frontend/app/services/new-version.js
@@ -1,0 +1,53 @@
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import Ember from 'ember';
+import { task, timeout } from 'ember-concurrency';
+import config from 'frontend/config/environment';
+
+const ONE_MINUTE = 60000;
+
+export default class NewVersionService extends Service {
+  @tracked latestVersion = undefined;
+
+  get currentVersion() {
+    return config.newVersion.currentVersion;
+  }
+
+  get isNewVersionAvailable() {
+    return this.latestVersion && this.currentVersion !== this.latestVersion;
+  }
+
+  get url() {
+    const baseUrl = config.prepend || config.rootURL || config.baseURL;
+    return baseUrl + config.newVersion.versionFile;
+  }
+
+  constructor() {
+    super(...arguments);
+    if (!Ember.testing) {
+      this.updateVersion.perform();
+    }
+  }
+
+  updateVersion = task(async () => {
+    try {
+      const response = fetch(this.url + '?_=' + Date.now());
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+      const payload = await response.text();
+      this.latestVersion = payload ? payload.trim() : undefined;
+    } catch (e) {
+      this.onError(e);
+    } finally {
+      await timeout(ONE_MINUTE);
+      this.updateVersion.perform();
+    }
+  });
+
+  onError(error) {
+    if (!Ember.testing) {
+      console.log(error);
+    }
+  }
+}

--- a/packages/frontend/app/services/new-version.js
+++ b/packages/frontend/app/services/new-version.js
@@ -24,6 +24,7 @@ export default class NewVersionService extends Service {
 
   constructor() {
     super(...arguments);
+    // don't autostart this task in a test environment.
     if (!Ember.testing) {
       this.updateVersion.perform();
     }
@@ -31,7 +32,7 @@ export default class NewVersionService extends Service {
 
   updateVersion = task(async () => {
     try {
-      const response = fetch(this.url + '?_=' + Date.now());
+      const response = await fetch(this.url + '?_=' + Date.now());
       if (!response.ok) {
         throw new Error(response.statusText);
       }
@@ -40,8 +41,11 @@ export default class NewVersionService extends Service {
     } catch (e) {
       this.onError(e);
     } finally {
-      await timeout(ONE_MINUTE);
-      this.updateVersion.perform();
+      // @todo figure out a way to test the recursion. For now, don't run it in test mode [ST 2024/04/09]
+      if (!Ember.testing) {
+        await timeout(ONE_MINUTE);
+        this.updateVersion.perform();
+      }
     }
   });
 

--- a/packages/frontend/app/styles/components/update-notification.scss
+++ b/packages/frontend/app/styles/components/update-notification.scss
@@ -2,10 +2,8 @@
 @use "../ilios-common/mixins" as m;
 
 .update-notification {
-  background-color: #fcf8e3;
-  border-color: #faebcc;
-  border: 1px solid transparent;
-  color: #8a6d3b;
+  background-color: c.$pearl;
+  border: 1px solid c.$slightWhite;
   left: 0;
   padding: 15px;
   position: fixed;

--- a/packages/frontend/app/styles/components/update-notification.scss
+++ b/packages/frontend/app/styles/components/update-notification.scss
@@ -1,9 +1,22 @@
 @use "../ilios-common/colors" as c;
 @use "../ilios-common/mixins" as m;
 
-// class name prefixed with ilios to avoid conflicts with addon provided css
-.ilios-update-notification {
-  @include m.ilios-button-reset;
-  $height: 2.5rem;
-  @include m.critical-notice(c.$blueMunsell, c.$culturedGrey, $height);
+.update-notification {
+  background-color: #fcf8e3;
+  border-color: #faebcc;
+  border: 1px solid transparent;
+  color: #8a6d3b;
+  left: 0;
+  padding: 15px;
+  position: fixed;
+  right: 0;
+  text-align: center;
+  top: 0;
+  z-index: 9999;
+
+  button {
+    @include m.ilios-button-reset;
+    $height: 2.5rem;
+    @include m.critical-notice(c.$blueMunsell, c.$culturedGrey, $height);
+  }
 }

--- a/packages/frontend/app/templates/application.hbs
+++ b/packages/frontend/app/templates/application.hbs
@@ -1,9 +1,6 @@
 {{page-title (t "general.ilios") separator=" " front=true}}
 <ConnectionStatus />
 <ApiVersionNotice />
-<NewVersionNotifier as |version lastVersion reload|>
-  <UpdateNotification @reload={{reload}} />
-</NewVersionNotifier>
 <div
   class="application-wrapper
     {{if this.currentUser.performsNonLearnerFunction "show-navigation"}}"

--- a/packages/frontend/app/templates/application.hbs
+++ b/packages/frontend/app/templates/application.hbs
@@ -1,6 +1,7 @@
 {{page-title (t "general.ilios") separator=" " front=true}}
 <ConnectionStatus />
 <ApiVersionNotice />
+<UpdateNotification />
 <div
   class="application-wrapper
     {{if this.currentUser.performsNonLearnerFunction "show-navigation"}}"

--- a/packages/frontend/config/dependency-lint.js
+++ b/packages/frontend/config/dependency-lint.js
@@ -6,6 +6,5 @@ module.exports = {
     generateTests: false,
     'ember-get-config': '^1.0.0 || ^2.0.0',
     'ember-modifier': '^3.0.0 || ^4.0.0',
-    'ember-concurrency': '^2.0.0 || ^4.0.0', //ember-cli-new-version on v2
   },
 };

--- a/packages/frontend/lib/new-version/index.js
+++ b/packages/frontend/lib/new-version/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const writeFile = require('broccoli-file-creator');
+
+const versionFileName = 'VERSION.txt';
+
+module.exports = {
+  name: require('./package').name,
+
+  treeForPublic() {
+    const currentVersion = this.parent.pkg.version;
+    return writeFile(versionFileName, currentVersion);
+  },
+};

--- a/packages/frontend/lib/new-version/index.js
+++ b/packages/frontend/lib/new-version/index.js
@@ -2,13 +2,23 @@
 
 const writeFile = require('broccoli-file-creator');
 
-const versionFileName = 'VERSION.txt';
+const VERSION_FILE = 'VERSION.txt';
 
 module.exports = {
   name: require('./package').name,
 
+  _config: {
+    currentVersion: null,
+    versionFile: VERSION_FILE,
+  },
+
+  config(env, baseConfig) {
+    this._config.currentVersion = this.parent.pkg.version;
+    baseConfig.newVersion = this._config;
+    return baseConfig;
+  },
+
   treeForPublic() {
-    const currentVersion = this.parent.pkg.version;
-    return writeFile(versionFileName, currentVersion);
+    return writeFile(this._config.versionFile, this._config.currentVersion);
   },
 };

--- a/packages/frontend/lib/new-version/package.json
+++ b/packages/frontend/lib/new-version/package.json
@@ -2,5 +2,8 @@
   "name": "new-version",
   "keywords": [
     "ember-addon"
-  ]
+  ],
+  "dependencies": {
+    "broccoli-file-creator": "^2.1.1"
+  }
 }

--- a/packages/frontend/lib/new-version/package.json
+++ b/packages/frontend/lib/new-version/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "new-version",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -140,7 +140,8 @@
   "ember-addon": {
     "paths": [
       "lib/ilios-error",
-      "lib/ilios-loading"
+      "lib/ilios-loading",
+      "lib/new-version"
     ]
   },
   "private": true,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -74,7 +74,6 @@
     "ember-cli-image-transformer": "^7.0.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-mirage": "^3.0.3",
-    "ember-cli-new-version": "^4.1.0",
     "ember-cli-page-object": "^2.3.0",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-server-variables": "3.0.0",

--- a/packages/frontend/tests/integration/components/update-notification-test.js
+++ b/packages/frontend/tests/integration/components/update-notification-test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+import Service from '@ember/service';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
@@ -8,12 +9,29 @@ module('Integration | Component | update notification', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks, 'en-us');
 
-  test('it renders', async function (assert) {
+  test('it renders when new version is available', async function (assert) {
+    class NewVersionServiceMock extends Service {
+      get isNewVersionAvailable() {
+        return true;
+      }
+    }
+    this.owner.register('service:newVersion', NewVersionServiceMock);
     await render(hbs`<UpdateNotification />`);
     assert
       .dom(this.element)
       .hasText(
         "Huzzah! We've made Ilios better. You will get the new stuff on your next login, or click to update now.",
       );
+  });
+
+  test('it renders empty when no new version is available', async function (assert) {
+    class NewVersionServiceMock extends Service {
+      get isNewVersionAvailable() {
+        return false;
+      }
+    }
+    this.owner.register('service:newVersion', NewVersionServiceMock);
+    await render(hbs`<UpdateNotification />`);
+    assert.dom(this.element).hasNoText();
   });
 });

--- a/packages/frontend/tests/unit/services/new-version-test.js
+++ b/packages/frontend/tests/unit/services/new-version-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend/tests/helpers';
+
+module('Unit | Service | new-version', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:new-version');
+    assert.ok(service);
+  });
+});

--- a/packages/frontend/tests/unit/services/new-version-test.js
+++ b/packages/frontend/tests/unit/services/new-version-test.js
@@ -1,12 +1,52 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'frontend/tests/helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { Response } from 'miragejs';
+import config from 'frontend/config/environment';
 
 module('Unit | Service | new-version', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  // TODO: Replace this with your real tests.
-  test('it exists', function (assert) {
-    let service = this.owner.lookup('service:new-version');
-    assert.ok(service);
+  test('new version available', async function (assert) {
+    const service = this.owner.lookup('service:new-version');
+    assert.strictEqual(service.latestVersion, undefined);
+    assert.notOk(service.isNewVersionAvailable);
+
+    this.server.get('/VERSION.txt', function () {
+      return 'some-version';
+    });
+    await service.updateVersion.perform();
+    assert.strictEqual(service.latestVersion, 'some-version');
+    assert.notEqual(service.latestVersion, service.currentVersion);
+    assert.ok(service.isNewVersionAvailable);
+  });
+
+  test('no new version available', async function (assert) {
+    const service = this.owner.lookup('service:new-version');
+    assert.strictEqual(service.latestVersion, undefined);
+    assert.notOk(service.isNewVersionAvailable);
+
+    this.server.get('/VERSION.txt', function () {
+      return config.newVersion.currentVersion;
+    });
+    await service.updateVersion.perform();
+    assert.strictEqual(service.latestVersion, config.newVersion.currentVersion);
+    assert.strictEqual(service.latestVersion, service.currentVersion);
+    assert.notOk(service.isNewVersionAvailable);
+  });
+
+  test('fetching new version fails', async function (assert) {
+    const service = this.owner.lookup('service:new-version');
+    assert.strictEqual(service.latestVersion, undefined);
+    assert.notOk(service.isNewVersionAvailable);
+
+    this.server.get('/VERSION.txt', function () {
+      return new Response(500);
+    });
+    await service.updateVersion.perform();
+    assert.strictEqual(service.latestVersion, undefined);
+    assert.notEqual(service.latestVersion, service.currentVersion);
+    assert.notOk(service.isNewVersionAvailable);
   });
 });

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -20,3 +20,5 @@ $culturedGrey: hsl(200, 15%, 92%);
 $crimson: hsl(346, 82%, 48%);
 $lavenderBlush: hsl(346, 80%, 96%);
 $rosewood: hsl(346, 80%, 20%);
+
+$pearl: hsl(50.4, 80.65%, 93.92%);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,9 +165,6 @@ importers:
       ember-cli-mirage:
         specifier: ^3.0.3
         version: 3.0.3(@ember/test-helpers@3.3.0)(ember-qunit@8.0.2)(ember-source@5.6.0)(miragejs@0.1.48)(webpack@5.91.0)
-      ember-cli-new-version:
-        specifier: ^4.1.0
-        version: 4.1.0(@babel/core@7.24.4)
       ember-cli-page-object:
         specifier: ^2.3.0
         version: 2.3.0(@ember/test-helpers@3.3.0)
@@ -9988,23 +9985,6 @@ packages:
       - webpack
     dev: true
 
-  /ember-cli-new-version@4.1.0(@babel/core@7.24.4):
-    resolution: {integrity: sha512-nhIFfrLs+JqyordanQ1KnSGm168LIc4gCAW93OHArhfmQppD5xb2aWVOmVDvU2AZkbagkr5IXBskUCBAm8pYEg==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      '@glimmer/component': 1.1.2(@babel/core@7.24.4)
-      '@glimmer/tracking': 1.1.2
-      broccoli-file-creator: 2.1.1
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 5.7.2
-      ember-concurrency: 2.3.7(@babel/core@7.24.4)
-      ember-fetch: 8.1.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - encoding
-      - supports-color
-    dev: true
-
   /ember-cli-normalize-entity-name@1.0.0:
     resolution: {integrity: sha512-rF4P1rW2P1gVX1ynZYPmuIf7TnAFDiJmIUFI1Xz16VYykUAyiOCme0Y22LeZq8rTzwBMiwBwoE3RO4GYWehXZA==}
     dependencies:
@@ -10400,23 +10380,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-
-  /ember-concurrency@2.3.7(@babel/core@7.24.4):
-    resolution: {integrity: sha512-sz6sTIXN/CuLb5wdpauFa+rWXuvXXSnSHS4kuNzU5GSMDX1pLBWSuovoUk61FUe6CYRqBmT1/UushObwBGickQ==}
-    engines: {node: 10.* || 12.* || 14.* || >= 16}
-    dependencies:
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/types': 7.24.0
-      '@glimmer/tracking': 1.1.2
-      ember-cli-babel: 7.26.11
-      ember-cli-babel-plugin-helpers: 1.1.1
-      ember-cli-htmlbars: 5.7.2
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.24.4)
-      ember-destroyable-polyfill: 2.0.3(@babel/core@7.24.4)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-    dev: true
 
   /ember-concurrency@4.0.2(@babel/core@7.24.4)(@glimmer/tracking@1.1.2)(ember-source@5.6.0):
     resolution: {integrity: sha512-enmStRE8bHIeF/kPZoDZlzP9YINN7H8l3Myk1sVkqo235ph0Vjee37AGCw44eRq6cBRvcdQmb5K3pkzVY7A6WA==}


### PR DESCRIPTION
fixes ilios/ilios#5285

i stripped this down to what i think is the absolute minimum necessary.

the in-place-plugin was necessary to add the version file creation and to add some info to the application config. i couldn't suss how how to do the former without a plugin, so here it is `¯\_(ツ)_/¯`

todo: 

- [x] add/update test coverage
- [x] dial in styles
