### PR TITLE
Replace dotenv in startup directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,9 @@ You will need the following things properly installed on your computer.
 
 This Frontend will need to know where your backend API server is located.
 You can set this information in a system wide environment variable name ILIOS_FRONTEND_API_HOST
-or can just add the setting to a file named .env file
-within the same directory as your Ilios Frontend code:
+or you can add it to the CLI when you start the server.
 
-* `echo "ILIOS_FRONTEND_API_HOST=https://ilios3-demo.ucsf.edu" > .env`
-
-Then you can start a local development server:
-
-* `pnpm start`
+* `ILIOS_FRONTEND_API_HOST=https://demo.iliosproject.org pnpm start`
 * Visit your app at [http://localhost:4200](http://localhost:4200).
 * Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
 


### PR DESCRIPTION
We've replaced this with the monorepo conversion and need to update the docs.