### PR TITLE
Respect showCampusNameOfRecord setting

### DIFF
--- a/packages/frontend/mirage/config.js
+++ b/packages/frontend/mirage/config.js
@@ -59,6 +59,7 @@ export default function (config) {
             apiVersion,
             appVersion: '1.2.3',
             materialStatusEnabled: true,
+            showCampusNameOfRecord: true,
           },
         };
         // return { config: {

--- a/packages/ilios-common/addon/components/user-name-info.hbs
+++ b/packages/ilios-common/addon/components/user-name-info.hbs
@@ -7,7 +7,7 @@
   {{#if @user.pronouns}}
     <span data-test-pronouns>({{@user.pronouns}})</span>
   {{/if}}
-  {{#if @user.hasDifferentDisplayName}}
+  {{#if (and this.showCampusNameOfRecord @user.hasDifferentDisplayName)}}
     <span
       data-test-info
       {{did-insert (set this.theElement)}}

--- a/packages/ilios-common/addon/components/user-name-info.js
+++ b/packages/ilios-common/addon/components/user-name-info.js
@@ -1,10 +1,22 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { TrackedAsyncData } from 'ember-async-data';
+import { service } from '@ember/service';
 
 export default class UserNameInfoComponent extends Component {
+  @service iliosConfig;
   @tracked isHoveringOverUsernameInfo = false;
   @tracked element;
+
+  showCampusNameOfRecordConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('showCampusNameOfRecord'),
+  );
+  get showCampusNameOfRecord() {
+    return this.showCampusNameOfRecordConfig.isResolved
+      ? this.showCampusNameOfRecordConfig.value
+      : false;
+  }
 
   @action
   toggleUsernameInfoHover(isHovering) {

--- a/packages/ilios-common/config/api-version.js
+++ b/packages/ilios-common/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v3.10';
+module.exports = 'v3.11';

--- a/packages/test-app/mirage/config.js
+++ b/packages/test-app/mirage/config.js
@@ -16,6 +16,7 @@ export default function (config) {
             type: 'form',
             materialStatusEnabled: true,
             apiVersion,
+            showCampusNameOfRecord: true,
           },
         };
       });

--- a/packages/test-app/tests/integration/components/user-name-info-test.js
+++ b/packages/test-app/tests/integration/components/user-name-info-test.js
@@ -22,13 +22,6 @@ module('Integration | Component | user-name-info', function (hooks) {
   });
 
   test('it renders with additional info when configured to do so', async function (assert) {
-    this.server.get('application/config', function () {
-      return {
-        config: {
-          showCampusNameOfRecord: true,
-        },
-      };
-    });
     const user = this.server.create('user', { displayName: 'Clem Chowder' });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);

--- a/packages/test-app/tests/integration/components/user-name-info-test.js
+++ b/packages/test-app/tests/integration/components/user-name-info-test.js
@@ -15,19 +15,24 @@ module('Integration | Component | user-name-info', function (hooks) {
     const user = this.server.create('user');
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
-    await render(hbs`<UserNameInfo @user={{this.user}} />
-`);
+    await render(hbs`<UserNameInfo @user={{this.user}} />`);
     assert.notOk(component.hasAdditionalInfo);
     assert.notOk(component.hasPronouns);
     assert.strictEqual(component.fullName, '0 guy M. Mc0son');
   });
 
-  test('it renders with additional info', async function (assert) {
+  test('it renders with additional info when configured to do so', async function (assert) {
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          showCampusNameOfRecord: true,
+        },
+      };
+    });
     const user = this.server.create('user', { displayName: 'Clem Chowder' });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
-    await render(hbs`<UserNameInfo @user={{this.user}} />
-`);
+    await render(hbs`<UserNameInfo @user={{this.user}} />`);
     assert.ok(component.hasAdditionalInfo);
     assert.strictEqual(component.fullName, 'Clem Chowder');
     assert.strictEqual(component.infoIconLabel, 'Campus name of record');
@@ -39,12 +44,27 @@ module('Integration | Component | user-name-info', function (hooks) {
     assert.notOk(component.isTooltipVisible);
   });
 
+  test('it hides additional info when configured to do so', async function (assert) {
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          showCampusNameOfRecord: false,
+        },
+      };
+    });
+    const user = this.server.create('user', { displayName: 'Clem Chowder' });
+    const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
+    this.set('user', userModel);
+    await render(hbs`<UserNameInfo @user={{this.user}} />`);
+    assert.notOk(component.hasAdditionalInfo);
+    assert.strictEqual(component.fullName, 'Clem Chowder');
+  });
+
   test('passing in id as an attributes', async function (assert) {
     const user = this.server.create('user');
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
-    await render(hbs`<UserNameInfo id="test-id" @user={{this.user}} />
-`);
+    await render(hbs`<UserNameInfo id="test-id" @user={{this.user}} />`);
     assert.strictEqual(component.id, 'test-id');
   });
 
@@ -54,8 +74,7 @@ module('Integration | Component | user-name-info', function (hooks) {
     });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     this.set('user', userModel);
-    await render(hbs`<UserNameInfo @user={{this.user}} />
-`);
+    await render(hbs`<UserNameInfo @user={{this.user}} />`);
     assert.ok(component.hasPronouns);
     assert.strictEqual(component.fullName, '0 guy M. Mc0son');
     assert.strictEqual(component.pronouns, '(they/them/tay)');


### PR DESCRIPTION
When configured to hide this data by configuration we don't show the icon or tooltip. The data is still in the API response, but it is hidden from the UI.