### PR TITLE
Fix staging deploy runs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -48,4 +48,4 @@ jobs:
         if: ${{contains(steps.metadata.outputs.dependency-names, matrix.safe-dependency) && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') }}
         run: gh pr merge --merge --auto ${{ github.event.number }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ZORGBORT_TOKEN }}

--- a/.github/workflows/update-transitive-dependencies.yaml
+++ b/.github/workflows/update-transitive-dependencies.yaml
@@ -26,7 +26,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.ZORGBORT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update Transitive Dependencies
           title: Update Transitive Dependencies
           body: |
@@ -41,4 +41,4 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         run: gh pr merge --merge --auto ${{ steps.cpr.outputs.pull-request-number }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ZORGBORT_TOKEN }}


### PR DESCRIPTION
Using the GITHUB_TOKEN to create an automerge will not trigger other github actions so our staging deploys aren't running when these get merged. Github recommends we use a PAT, and we've got one ready made from Zorgbort. This was Zorgbort is responsible for the merge and github is happy to go forth and trigger more actions.