### PR TITLE
Add course years to Instructor/LearnerGroup displays

### DIFF
--- a/packages/frontend/app/components/instructor-group/courses.hbs
+++ b/packages/frontend/app/components/instructor-group/courses.hbs
@@ -11,7 +11,7 @@
           <li data-test-course>
             <LinkTo @route="course" @model={{course}}>
               <FaIcon @icon="square-up-right" />
-              {{course.title}}
+              {{course.title}} ({{course.year}} - {{year-next course.year}})
             </LinkTo>
           </li>
         {{/each}}

--- a/packages/frontend/app/components/instructor-group/courses.hbs
+++ b/packages/frontend/app/components/instructor-group/courses.hbs
@@ -10,11 +10,11 @@
         {{#each (sort-by "title" @instructorGroup.courses) as |course|}}
           <li data-test-course>
             <LinkTo @route="course" @model={{course}}>
-              <FaIcon @icon="square-up-right" />
+              <FaIcon @icon="square-up-right" /> {{course.title}}
               {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                {{course.title}} ({{course.year}} - {{year-next course.year}})
+                ({{course.year}} - {{add course.year 1}})
               {{else}}
-                {{course.title}} ({{course.year}})
+                ({{course.year}})
               {{/if}}
             </LinkTo>
           </li>

--- a/packages/frontend/app/components/instructor-group/courses.hbs
+++ b/packages/frontend/app/components/instructor-group/courses.hbs
@@ -11,7 +11,11 @@
           <li data-test-course>
             <LinkTo @route="course" @model={{course}}>
               <FaIcon @icon="square-up-right" />
-              {{course.title}} ({{course.year}} - {{year-next course.year}})
+              {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                {{course.title}} ({{course.year}} - {{year-next course.year}})
+              {{else}}
+                {{course.title}} ({{course.year}})
+              {{/if}}
             </LinkTo>
           </li>
         {{/each}}

--- a/packages/frontend/app/components/instructor-group/courses.js
+++ b/packages/frontend/app/components/instructor-group/courses.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import { TrackedAsyncData } from 'ember-async-data';
+import { cached } from '@glimmer/tracking';
+import { service } from '@ember/service';
+
+export default class InstructorGroupCoursesComponent extends Component {
+  @service iliosConfig;
+
+  crossesBoundaryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
+  }
+}

--- a/packages/frontend/app/components/learner-group/root.hbs
+++ b/packages/frontend/app/components/learner-group/root.hbs
@@ -106,7 +106,7 @@
             {{#each (sort-by "courseTitle" this.courses) as |obj|}}
               <li>
                 <LinkTo @route="course" @model={{obj.course}}>
-                  {{obj.courseTitle}}
+                  {{obj.courseTitle}} ({{obj.course.year}} - {{year-next obj.course.year}})
                 </LinkTo>
               </li>
             {{/each}}

--- a/packages/frontend/app/components/learner-group/root.hbs
+++ b/packages/frontend/app/components/learner-group/root.hbs
@@ -106,10 +106,11 @@
             {{#each (sort-by "courseTitle" this.courses) as |obj|}}
               <li>
                 <LinkTo @route="course" @model={{obj.course}}>
+                  {{obj.courseTitle}}
                   {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                    {{obj.courseTitle}} ({{obj.course.year}} - {{year-next obj.course.year}})
+                    ({{obj.course.year}} - {{add obj.course.year 1}})
                   {{else}}
-                    {{obj.courseTitle}} ({{obj.course.year}})
+                    ({{obj.course.year}})
                   {{/if}}
                 </LinkTo>
               </li>

--- a/packages/frontend/app/components/learner-group/root.hbs
+++ b/packages/frontend/app/components/learner-group/root.hbs
@@ -106,7 +106,11 @@
             {{#each (sort-by "courseTitle" this.courses) as |obj|}}
               <li>
                 <LinkTo @route="course" @model={{obj.course}}>
-                  {{obj.courseTitle}} ({{obj.course.year}} - {{year-next obj.course.year}})
+                  {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                    {{obj.courseTitle}} ({{obj.course.year}} - {{year-next obj.course.year}})
+                  {{else}}
+                    {{obj.courseTitle}} ({{obj.course.year}})
+                  {{/if}}
                 </LinkTo>
               </li>
             {{/each}}

--- a/packages/frontend/app/components/learner-group/root.js
+++ b/packages/frontend/app/components/learner-group/root.js
@@ -38,6 +38,7 @@ export default class LearnerGroupRootComponent extends Component {
   @tracked showNewLearnerGroupForm = false;
   @tracked currentGroupsSaved = 0;
   @tracked totalGroupsToSave = 0;
+  @service iliosConfig;
 
   @cached
   get subGroupsData() {
@@ -336,5 +337,14 @@ export default class LearnerGroupRootComponent extends Component {
       uniqueValues(courseObj.groups);
       return arr;
     }, []);
+  }
+
+  crossesBoundaryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
   }
 }

--- a/packages/frontend/app/helpers/year-next.js
+++ b/packages/frontend/app/helpers/year-next.js
@@ -1,7 +1,0 @@
-import ENV from 'frontend/config/environment';
-
-export default function yearNext(year) {
-  const yearNext = (parseInt(year) + 1).toString();
-
-  return ENV.environment != 'production' ? yearNext.substring(2) : yearNext;
-}

--- a/packages/frontend/app/helpers/year-next.js
+++ b/packages/frontend/app/helpers/year-next.js
@@ -1,0 +1,7 @@
+import ENV from 'frontend/config/environment';
+
+export default function yearNext(year) {
+  const yearNext = (parseInt(year) + 1).toString();
+
+  return ENV.environment != 'production' ? yearNext.substring(-2) : yearNext;
+}

--- a/packages/frontend/app/helpers/year-next.js
+++ b/packages/frontend/app/helpers/year-next.js
@@ -3,5 +3,5 @@ import ENV from 'frontend/config/environment';
 export default function yearNext(year) {
   const yearNext = (parseInt(year) + 1).toString();
 
-  return ENV.environment != 'production' ? yearNext.substring(-2) : yearNext;
+  return ENV.environment != 'production' ? yearNext.substring(2) : yearNext;
 }

--- a/packages/frontend/tests/acceptance/instructorgroup-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroup-test.js
@@ -69,8 +69,8 @@ module('Acceptance | Instructor Group', function (hooks) {
     assert.strictEqual(page.root.users.users[0].userNameInfo.fullName, '1 guy M. Mc1son');
     assert.strictEqual(page.root.users.users[1].userNameInfo.fullName, '2 guy M. Mc2son');
     assert.strictEqual(page.root.courses.courses.length, 2);
-    assert.strictEqual(page.root.courses.courses[0].text, 'course 0 (2013 - 14)');
-    assert.strictEqual(page.root.courses.courses[1].text, 'course 1 (2013 - 14)');
+    assert.strictEqual(page.root.courses.courses[0].text, 'course 0 (2013)');
+    assert.strictEqual(page.root.courses.courses[1].text, 'course 1 (2013)');
     await a11yAudit();
     assert.ok(true, 'no a11y errors found!');
   });

--- a/packages/frontend/tests/acceptance/instructorgroup-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroup-test.js
@@ -69,8 +69,8 @@ module('Acceptance | Instructor Group', function (hooks) {
     assert.strictEqual(page.root.users.users[0].userNameInfo.fullName, '1 guy M. Mc1son');
     assert.strictEqual(page.root.users.users[1].userNameInfo.fullName, '2 guy M. Mc2son');
     assert.strictEqual(page.root.courses.courses.length, 2);
-    assert.strictEqual(page.root.courses.courses[0].text, 'course 0');
-    assert.strictEqual(page.root.courses.courses[1].text, 'course 1');
+    assert.strictEqual(page.root.courses.courses[0].text, 'course 0 (2013 - 2014)');
+    assert.strictEqual(page.root.courses.courses[1].text, 'course 1 (2013 - 2014)');
     await a11yAudit();
     assert.ok(true, 'no a11y errors found!');
   });

--- a/packages/frontend/tests/acceptance/instructorgroup-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroup-test.js
@@ -54,7 +54,7 @@ module('Acceptance | Instructor Group', function (hooks) {
   });
 
   test('it renders', async function (assert) {
-    assert.expect(15);
+    assert.expect(13);
     await visit(url);
     await percySnapshot(assert);
     assert.strictEqual(currentRouteName(), 'instructor-group');
@@ -69,10 +69,40 @@ module('Acceptance | Instructor Group', function (hooks) {
     assert.strictEqual(page.root.users.users[0].userNameInfo.fullName, '1 guy M. Mc1son');
     assert.strictEqual(page.root.users.users[1].userNameInfo.fullName, '2 guy M. Mc2son');
     assert.strictEqual(page.root.courses.courses.length, 2);
-    assert.strictEqual(page.root.courses.courses[0].text, 'course 0 (2013)');
-    assert.strictEqual(page.root.courses.courses[1].text, 'course 1 (2013)');
     await a11yAudit();
     assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('course year shows as single year if calendar year boundary IS NOT crossed', async function (assert) {
+    await setupAuthentication({ school: this.school });
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          academicYearCrossesCalendarYearBoundaries: false,
+          apiVersion,
+        },
+      };
+    });
+    await visit(url);
+    assert.strictEqual(page.root.courses.courses[0].text, 'course 0 (2013)');
+    assert.strictEqual(page.root.courses.courses[1].text, 'course 1 (2013)');
+  });
+
+  test('course year shows as range if calendar year boundary IS crossed', async function (assert) {
+    await setupAuthentication({ school: this.school });
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          academicYearCrossesCalendarYearBoundaries: true,
+          apiVersion,
+        },
+      };
+    });
+    await visit(url);
+    assert.strictEqual(page.root.courses.courses[0].text, 'course 0 (2013 - 2014)');
+    assert.strictEqual(page.root.courses.courses[1].text, 'course 1 (2013 - 2014)');
   });
 
   test('change title', async function (assert) {

--- a/packages/frontend/tests/acceptance/instructorgroup-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroup-test.js
@@ -69,8 +69,8 @@ module('Acceptance | Instructor Group', function (hooks) {
     assert.strictEqual(page.root.users.users[0].userNameInfo.fullName, '1 guy M. Mc1son');
     assert.strictEqual(page.root.users.users[1].userNameInfo.fullName, '2 guy M. Mc2son');
     assert.strictEqual(page.root.courses.courses.length, 2);
-    assert.strictEqual(page.root.courses.courses[0].text, 'course 0 (2013 - 2014)');
-    assert.strictEqual(page.root.courses.courses[1].text, 'course 1 (2013 - 2014)');
+    assert.strictEqual(page.root.courses.courses[0].text, 'course 0 (2013 - 14)');
+    assert.strictEqual(page.root.courses.courses[1].text, 'course 1 (2013 - 14)');
     await a11yAudit();
     assert.ok(true, 'no a11y errors found!');
   });

--- a/packages/frontend/tests/integration/components/instructor-group/courses-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/courses-test.js
@@ -43,11 +43,11 @@ module('Integration | Component | instructor-group/courses', function (hooks) {
     await render(hbs`<InstructorGroup::Courses @instructorGroup={{this.instructorGroup}} />`);
     assert.strictEqual(component.title, 'Associated Courses (3)');
     assert.strictEqual(component.courses.length, 3);
-    assert.strictEqual(component.courses[0].text, 'course 0 (2013 - 14)');
+    assert.strictEqual(component.courses[0].text, 'course 0 (2013)');
     assert.strictEqual(component.courses[0].url, '/courses/1');
-    assert.strictEqual(component.courses[1].text, 'course 1 (2013 - 14)');
+    assert.strictEqual(component.courses[1].text, 'course 1 (2013)');
     assert.strictEqual(component.courses[1].url, '/courses/2');
-    assert.strictEqual(component.courses[2].text, 'course 2 (2013 - 14)');
+    assert.strictEqual(component.courses[2].text, 'course 2 (2013)');
     assert.strictEqual(component.courses[2].url, '/courses/3');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');

--- a/packages/frontend/tests/integration/components/instructor-group/courses-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/courses-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | instructor-group/courses', function (hooks) {
   setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
-  test('it renders', async function (assert) {
+  test('it renders with single course year if calendar year boundary IS NOT crossed', async function (assert) {
     const courses = this.server.createList('course', 3);
     const session1 = this.server.create('session', {
       course: courses[0],
@@ -40,6 +40,15 @@ module('Integration | Component | instructor-group/courses', function (hooks) {
       .lookup('service:store')
       .findRecord('instructor-group', instructorGroup.id);
     this.set('instructorGroup', instructorGroupModel);
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          academicYearCrossesCalendarYearBoundaries: false,
+          apiVersion,
+        },
+      };
+    });
     await render(hbs`<InstructorGroup::Courses @instructorGroup={{this.instructorGroup}} />`);
     assert.strictEqual(component.title, 'Associated Courses (3)');
     assert.strictEqual(component.courses.length, 3);
@@ -48,6 +57,56 @@ module('Integration | Component | instructor-group/courses', function (hooks) {
     assert.strictEqual(component.courses[1].text, 'course 1 (2013)');
     assert.strictEqual(component.courses[1].url, '/courses/2');
     assert.strictEqual(component.courses[2].text, 'course 2 (2013)');
+    assert.strictEqual(component.courses[2].url, '/courses/3');
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders with course year range if calendar year boundary IS crossed', async function (assert) {
+    const courses = this.server.createList('course', 3);
+    const session1 = this.server.create('session', {
+      course: courses[0],
+    });
+    const session2 = this.server.create('session', {
+      course: courses[1],
+    });
+    const session3 = this.server.create('session', {
+      course: courses[2],
+    });
+    const offering1 = this.server.create('offering', {
+      session: session1,
+    });
+    const offering2 = this.server.create('offering', {
+      session: session2,
+    });
+    const ilmSession = this.server.create('ilm-session', {
+      session: session3,
+    });
+    const instructorGroup = this.server.create('instructor-group', {
+      offerings: [offering1, offering2],
+      ilmSessions: [ilmSession],
+    });
+    const instructorGroupModel = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', instructorGroup.id);
+    this.set('instructorGroup', instructorGroupModel);
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          academicYearCrossesCalendarYearBoundaries: true,
+          apiVersion,
+        },
+      };
+    });
+    await render(hbs`<InstructorGroup::Courses @instructorGroup={{this.instructorGroup}} />`);
+    assert.strictEqual(component.title, 'Associated Courses (3)');
+    assert.strictEqual(component.courses.length, 3);
+    assert.strictEqual(component.courses[0].text, 'course 0 (2013 - 2014)');
+    assert.strictEqual(component.courses[0].url, '/courses/1');
+    assert.strictEqual(component.courses[1].text, 'course 1 (2013 - 2014)');
+    assert.strictEqual(component.courses[1].url, '/courses/2');
+    assert.strictEqual(component.courses[2].text, 'course 2 (2013 - 2014)');
     assert.strictEqual(component.courses[2].url, '/courses/3');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');

--- a/packages/frontend/tests/integration/components/instructor-group/courses-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/courses-test.js
@@ -43,11 +43,11 @@ module('Integration | Component | instructor-group/courses', function (hooks) {
     await render(hbs`<InstructorGroup::Courses @instructorGroup={{this.instructorGroup}} />`);
     assert.strictEqual(component.title, 'Associated Courses (3)');
     assert.strictEqual(component.courses.length, 3);
-    assert.strictEqual(component.courses[0].text, 'course 0 (2013 - 2014)');
+    assert.strictEqual(component.courses[0].text, 'course 0 (2013 - 14)');
     assert.strictEqual(component.courses[0].url, '/courses/1');
-    assert.strictEqual(component.courses[1].text, 'course 1 (2013 - 2014)');
+    assert.strictEqual(component.courses[1].text, 'course 1 (2013 - 14)');
     assert.strictEqual(component.courses[1].url, '/courses/2');
-    assert.strictEqual(component.courses[2].text, 'course 2 (2013 - 2014)');
+    assert.strictEqual(component.courses[2].text, 'course 2 (2013 - 14)');
     assert.strictEqual(component.courses[2].url, '/courses/3');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');

--- a/packages/frontend/tests/integration/components/instructor-group/courses-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/courses-test.js
@@ -43,11 +43,11 @@ module('Integration | Component | instructor-group/courses', function (hooks) {
     await render(hbs`<InstructorGroup::Courses @instructorGroup={{this.instructorGroup}} />`);
     assert.strictEqual(component.title, 'Associated Courses (3)');
     assert.strictEqual(component.courses.length, 3);
-    assert.strictEqual(component.courses[0].text, 'course 0');
+    assert.strictEqual(component.courses[0].text, 'course 0 (2013 - 2014)');
     assert.strictEqual(component.courses[0].url, '/courses/1');
-    assert.strictEqual(component.courses[1].text, 'course 1');
+    assert.strictEqual(component.courses[1].text, 'course 1 (2013 - 2014)');
     assert.strictEqual(component.courses[1].url, '/courses/2');
-    assert.strictEqual(component.courses[2].text, 'course 2');
+    assert.strictEqual(component.courses[2].text, 'course 2 (2013 - 2014)');
     assert.strictEqual(component.courses[2].url, '/courses/3');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');

--- a/packages/frontend/tests/integration/components/instructor-group/root-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/root-test.js
@@ -54,10 +54,6 @@ module('Integration | Component | instructor-group/root', function (hooks) {
     assert.ok(component.users.users[0].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.users.users[1].userNameInfo.fullName, 'Anton M. Alpha');
     assert.notOk(component.users.users[1].userNameInfo.hasAdditionalInfo);
-    assert.strictEqual(component.courses.title, 'Associated Courses (2)');
-    assert.strictEqual(component.courses.courses.length, 2);
-    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013)');
-    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013)');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -80,10 +76,32 @@ module('Integration | Component | instructor-group/root', function (hooks) {
     assert.ok(component.users.users[0].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.users.users[1].userNameInfo.fullName, 'Anton M. Alpha');
     assert.notOk(component.users.users[1].userNameInfo.hasAdditionalInfo);
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it displays single course year if calendar year boundary IS NOT crossed', async function (assert) {
+    this.set('group', this.instructorGroup);
+    await render(
+      hbs`<InstructorGroup::Root @instructorGroup={{this.group}} @canUpdate={{true}} />`,
+    );
     assert.strictEqual(component.courses.title, 'Associated Courses (2)');
     assert.strictEqual(component.courses.courses.length, 2);
     assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013)');
     assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013)');
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it displays single course year if calendar year boundary IS crossed', async function (assert) {
+    this.set('group', this.instructorGroup);
+    await render(
+      hbs`<InstructorGroup::Root @instructorGroup={{this.group}} @canUpdate={{true}} />`,
+    );
+    assert.strictEqual(component.courses.title, 'Associated Courses (2)');
+    assert.strictEqual(component.courses.courses.length, 2);
+    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013 - 2014)');
+    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013 - 2014)');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });

--- a/packages/frontend/tests/integration/components/instructor-group/root-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/root-test.js
@@ -56,8 +56,8 @@ module('Integration | Component | instructor-group/root', function (hooks) {
     assert.notOk(component.users.users[1].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.courses.title, 'Associated Courses (2)');
     assert.strictEqual(component.courses.courses.length, 2);
-    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013 - 2014)');
-    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013 - 2014)');
+    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013 - 14)');
+    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013 - 14)');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -82,8 +82,8 @@ module('Integration | Component | instructor-group/root', function (hooks) {
     assert.notOk(component.users.users[1].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.courses.title, 'Associated Courses (2)');
     assert.strictEqual(component.courses.courses.length, 2);
-    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013 - 2014)');
-    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013 - 2014)');
+    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013 - 14)');
+    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013 - 14)');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });

--- a/packages/frontend/tests/integration/components/instructor-group/root-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/root-test.js
@@ -56,8 +56,8 @@ module('Integration | Component | instructor-group/root', function (hooks) {
     assert.notOk(component.users.users[1].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.courses.title, 'Associated Courses (2)');
     assert.strictEqual(component.courses.courses.length, 2);
-    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013 - 14)');
-    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013 - 14)');
+    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013)');
+    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013)');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -82,8 +82,8 @@ module('Integration | Component | instructor-group/root', function (hooks) {
     assert.notOk(component.users.users[1].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.courses.title, 'Associated Courses (2)');
     assert.strictEqual(component.courses.courses.length, 2);
-    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013 - 14)');
-    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013 - 14)');
+    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013)');
+    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013)');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });

--- a/packages/frontend/tests/integration/components/instructor-group/root-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/root-test.js
@@ -56,8 +56,8 @@ module('Integration | Component | instructor-group/root', function (hooks) {
     assert.notOk(component.users.users[1].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.courses.title, 'Associated Courses (2)');
     assert.strictEqual(component.courses.courses.length, 2);
-    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1');
-    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101');
+    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013 - 2014)');
+    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013 - 2014)');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -82,8 +82,8 @@ module('Integration | Component | instructor-group/root', function (hooks) {
     assert.notOk(component.users.users[1].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.courses.title, 'Associated Courses (2)');
     assert.strictEqual(component.courses.courses.length, 2);
-    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1');
-    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101');
+    assert.strictEqual(component.courses.courses[0].text, 'Foundations 1 (2013 - 2014)');
+    assert.strictEqual(component.courses.courses[1].text, 'Introduction 101 (2013 - 2014)');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });

--- a/packages/frontend/tests/integration/components/instructor-group/root-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/root-test.js
@@ -82,6 +82,15 @@ module('Integration | Component | instructor-group/root', function (hooks) {
 
   test('it displays single course year if calendar year boundary IS NOT crossed', async function (assert) {
     this.set('group', this.instructorGroup);
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          academicYearCrossesCalendarYearBoundaries: false,
+          apiVersion,
+        },
+      };
+    });
     await render(
       hbs`<InstructorGroup::Root @instructorGroup={{this.group}} @canUpdate={{true}} />`,
     );
@@ -93,8 +102,17 @@ module('Integration | Component | instructor-group/root', function (hooks) {
     assert.ok(true, 'no a11y errors found!');
   });
 
-  test('it displays single course year if calendar year boundary IS crossed', async function (assert) {
+  test('it displays course year range if calendar year boundary IS crossed', async function (assert) {
     this.set('group', this.instructorGroup);
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          academicYearCrossesCalendarYearBoundaries: true,
+          apiVersion,
+        },
+      };
+    });
     await render(
       hbs`<InstructorGroup::Root @instructorGroup={{this.group}} @canUpdate={{true}} />`,
     );

--- a/packages/frontend/tests/integration/components/learner-group/root-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/root-test.js
@@ -104,8 +104,8 @@ module('Integration | Component | learner-group/root', function (hooks) {
     );
     assert.notOk(component.instructorManager.assignedInstructors[1].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.associatedCourses.courses.length, 2);
-    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 2014)');
-    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1 (2013 - 2014)');
+    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 14)');
+    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1 (2013 - 14)');
     assert.ok(component.actions.buttons.toggle.isVisible);
     assert.ok(component.actions.buttons.bulkAssignment.isVisible);
     assert.ok(component.actions.buttons.manageUsers.isVisible);
@@ -354,7 +354,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
     />`);
 
     assert.strictEqual(component.associatedCourses.courses.length, 1);
-    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 2014)');
+    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 14)');
   });
 
   test('associated courses are linked to course pages', async function (assert) {
@@ -390,9 +390,9 @@ module('Integration | Component | learner-group/root', function (hooks) {
     />`);
 
     assert.strictEqual(component.associatedCourses.courses.length, 2);
-    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 2014)');
+    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 14)');
     assert.strictEqual(component.associatedCourses.courses[0].linksTo, '/courses/1');
-    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1 (2013 - 2014)');
+    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1 (2013 - 14)');
     assert.strictEqual(component.associatedCourses.courses[1].linksTo, '/courses/2');
   });
 

--- a/packages/frontend/tests/integration/components/learner-group/root-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/root-test.js
@@ -104,8 +104,8 @@ module('Integration | Component | learner-group/root', function (hooks) {
     );
     assert.notOk(component.instructorManager.assignedInstructors[1].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.associatedCourses.courses.length, 2);
-    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 14)');
-    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1 (2013 - 14)');
+    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013)');
+    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1 (2013)');
     assert.ok(component.actions.buttons.toggle.isVisible);
     assert.ok(component.actions.buttons.bulkAssignment.isVisible);
     assert.ok(component.actions.buttons.manageUsers.isVisible);
@@ -354,7 +354,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
     />`);
 
     assert.strictEqual(component.associatedCourses.courses.length, 1);
-    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 14)');
+    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013)');
   });
 
   test('associated courses are linked to course pages', async function (assert) {
@@ -390,9 +390,9 @@ module('Integration | Component | learner-group/root', function (hooks) {
     />`);
 
     assert.strictEqual(component.associatedCourses.courses.length, 2);
-    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 14)');
+    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013)');
     assert.strictEqual(component.associatedCourses.courses[0].linksTo, '/courses/1');
-    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1 (2013 - 14)');
+    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1 (2013)');
     assert.strictEqual(component.associatedCourses.courses[1].linksTo, '/courses/2');
   });
 

--- a/packages/frontend/tests/integration/components/learner-group/root-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/root-test.js
@@ -104,8 +104,8 @@ module('Integration | Component | learner-group/root', function (hooks) {
     );
     assert.notOk(component.instructorManager.assignedInstructors[1].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.associatedCourses.courses.length, 2);
-    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0');
-    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1');
+    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 2014)');
+    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1 (2013 - 2014)');
     assert.ok(component.actions.buttons.toggle.isVisible);
     assert.ok(component.actions.buttons.bulkAssignment.isVisible);
     assert.ok(component.actions.buttons.manageUsers.isVisible);
@@ -354,7 +354,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
     />`);
 
     assert.strictEqual(component.associatedCourses.courses.length, 1);
-    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0');
+    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 2014)');
   });
 
   test('associated courses are linked to course pages', async function (assert) {
@@ -390,9 +390,9 @@ module('Integration | Component | learner-group/root', function (hooks) {
     />`);
 
     assert.strictEqual(component.associatedCourses.courses.length, 2);
-    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0');
+    assert.strictEqual(component.associatedCourses.courses[0].text, 'course 0 (2013 - 2014)');
     assert.strictEqual(component.associatedCourses.courses[0].linksTo, '/courses/1');
-    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1');
+    assert.strictEqual(component.associatedCourses.courses[1].text, 'course 1 (2013 - 2014)');
     assert.strictEqual(component.associatedCourses.courses[1].linksTo, '/courses/2');
   });
 


### PR DESCRIPTION
InstructorGroups and LearnerGroups both show Associated Courses, but only the title. To fix ilios/3422, this adds the display of the course year range, starting with `course.year` and appending ` - course.year+1` if it crosses a year boundary.