### PR TITLE
Fix the global search test

### DIFF
--- a/packages/frontend/tests/integration/components/global-search-test.js
+++ b/packages/frontend/tests/integration/components/global-search-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
-import { render } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/global-search';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -30,7 +30,14 @@ module('Integration | Component | global-search', function (hooks) {
       return {
         results: {
           autocomplete: [],
-          courses: [],
+          courses: [
+            {
+              title: 'Course 1',
+              year: 2019,
+              sessions: [],
+              school: 'Medicine',
+            },
+          ],
         },
       };
     });
@@ -38,12 +45,14 @@ module('Integration | Component | global-search', function (hooks) {
     this.set('query', '');
     await render(hbs`<GlobalSearch
       @query={{this.query}}
+      @page="1"
       @onQuery={{(noop)}}
       @onSelectPage={{(noop)}}
       @setSelectedYear={{(noop)}}
     />`);
     assert.ok(component.noResultsIsVisible);
     this.set('query', 'hello world');
+    await settled();
     assert.notOk(component.noResultsIsVisible);
   });
 


### PR DESCRIPTION
This test wasn't actually working, it only appeared to pass because we didn't wait for the re-render.

Found this while working on #7784, but didn't want to mess with the tests and the app code in the same place. 