### PR TITLE
Fixes course search when searching for title AND externalId

### DIFF
--- a/packages/frontend/app/components/courses/root.js
+++ b/packages/frontend/app/components/courses/root.js
@@ -110,7 +110,10 @@ export default class CoursesRootComponent extends Component {
     return this.coursesInSelectedYear.filter((course) => {
       return (
         course.title?.trim().toLowerCase().includes(title) ||
-        course.externalId?.trim().toLowerCase().includes(title)
+        course.externalId?.trim().toLowerCase().includes(title) ||
+        `${course.title?.trim().toLowerCase()} (${course.externalId?.trim().toLowerCase()})`.includes(
+          title,
+        )
       );
     });
   }


### PR DESCRIPTION
Fixes ilios/ilios#5435 by adding a computed field that concatenates both title and externalId so that either or both will match.