### PR TITLE
Add icon to header to link to User Guide

### DIFF
--- a/packages/frontend/app/components/ilios-header.hbs
+++ b/packages/frontend/app/components/ilios-header.hbs
@@ -15,5 +15,6 @@
     {{#if this.session.isAuthenticated}}
       <UserMenu />
     {{/if}}
+    <UserGuideLink />
   </div>
 </header>

--- a/packages/frontend/app/components/user-guide-link.hbs
+++ b/packages/frontend/app/components/user-guide-link.hbs
@@ -1,5 +1,5 @@
 <div class="user-guide-link" data-test-user-guide-link>
   <a href="https://iliosproject.gitbook.io/ilios-user-guide" target="_blank" rel="noopener noreferrer">
-    <FaIcon @icon="circle-question"></FaIcon>
+    <FaIcon @icon="circle-question" @title={{t "general.iliosUserGuide"}}></FaIcon>
   </a>
 </div>

--- a/packages/frontend/app/components/user-guide-link.hbs
+++ b/packages/frontend/app/components/user-guide-link.hbs
@@ -1,0 +1,5 @@
+<div class="user-guide-link" data-test-user-guide-link>
+  <a href="https://iliosproject.gitbook.io/ilios-user-guide" target="_blank" rel="noopener noreferrer">
+    <FaIcon @icon="circle-question"></FaIcon>
+  </a>
+</div>

--- a/packages/frontend/app/components/user-guide-link.hbs
+++ b/packages/frontend/app/components/user-guide-link.hbs
@@ -1,5 +1,13 @@
 <div class="user-guide-link" data-test-user-guide-link>
-  <a href="https://iliosproject.gitbook.io/ilios-user-guide" target="_blank" rel="noopener noreferrer">
-    <FaIcon @icon="circle-question" @title={{t "general.iliosUserGuide"}}></FaIcon>
+  <a
+    href="https://iliosproject.gitbook.io/ilios-user-guide"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <FaIcon
+      @icon="circle-question"
+      @title={{t "general.iliosUserGuide"}}
+      data-test-user-guide-link-icon
+    />
   </a>
 </div>

--- a/packages/frontend/app/components/user-menu.hbs
+++ b/packages/frontend/app/components/user-menu.hbs
@@ -1,6 +1,6 @@
 {{#let (unique-id) as |templateId|}}
   <nav
-    class="{{if this.isOpen "is-open"}} user-menu"
+    class="user-menu{{if this.isOpen " is-open"}}"
     aria-label={{t "general.userMenu"}}
     {{did-insert (set this.element)}}
     {{! template-lint-disable no-invalid-interactive }}

--- a/packages/frontend/app/styles/components.scss
+++ b/packages/frontend/app/styles/components.scss
@@ -57,6 +57,7 @@
 @import "components/pending-user-updates";
 @import "components/unassigned-students-summary";
 @import "components/update-notification";
+@import "components/user-guide-link";
 @import "components/user-menu";
 @import "components/user-profile-calendar";
 @import "components/user-profile";

--- a/packages/frontend/app/styles/components/ilios-header.scss
+++ b/packages/frontend/app/styles/components/ilios-header.scss
@@ -22,8 +22,8 @@
     display: grid;
     justify-content: end;
     grid-template-areas:
-      ". locale user"
-      "search search search";
+      ". locale user guide"
+      "search search search search";
     row-gap: 0.25rem;
 
     @include m.for-tablet-and-up {

--- a/packages/frontend/app/styles/components/ilios-header.scss
+++ b/packages/frontend/app/styles/components/ilios-header.scss
@@ -38,6 +38,7 @@
     }
     .user-guide-link {
       grid-area: guide;
+      height: 100%;
     }
 
     .global-search-box {

--- a/packages/frontend/app/styles/components/ilios-header.scss
+++ b/packages/frontend/app/styles/components/ilios-header.scss
@@ -27,7 +27,7 @@
     row-gap: 0.25rem;
 
     @include m.for-tablet-and-up {
-      grid-template-areas: "search locale user";
+      grid-template-areas: "search locale user guide";
     }
 
     .locale-chooser {
@@ -35,6 +35,9 @@
     }
     .user-menu {
       grid-area: user;
+    }
+    .user-guide-link {
+      grid-area: guide;
     }
 
     .global-search-box {

--- a/packages/frontend/app/styles/components/user-guide-link.scss
+++ b/packages/frontend/app/styles/components/user-guide-link.scss
@@ -1,7 +1,10 @@
 @use "../ilios-common/mixins" as cm;
 @use "../ilios-common/colors" as c;
+@use "../mixins" as m;
 
 .user-guide-link {
+  @include m.header-menu;
+  margin-left: 0;
   @include cm.for-tablet-and-up {
     margin-right: 0.5rem;
   }
@@ -9,6 +12,8 @@
   a {
     svg {
       color: c.$white;
+      height: 1.5em;
+      width: 1.5em;
     }
   }
 }

--- a/packages/frontend/app/styles/components/user-guide-link.scss
+++ b/packages/frontend/app/styles/components/user-guide-link.scss
@@ -1,18 +1,12 @@
 @use "../ilios-common/mixins" as cm;
 @use "../ilios-common/colors" as c;
-@use "../mixins" as m;
 
 .user-guide-link {
-  @include m.header-menu;
+  margin-left: 0.5rem;
 
   @include cm.for-tablet-and-up {
     margin-left: 0.25rem;
     margin-right: 0.5rem;
-  }
-
-  @include cm.for-phone-only {
-    /* stylelint-disable property-disallowed-list */
-    font-size: 3.5vw;
   }
 
   a {
@@ -20,8 +14,17 @@
       align-items: center;
       color: c.$white;
       display: flex;
-      height: 1.85em;
-      width: 1.85em;
+      height: 30px;
+      width: 30px;
+    }
+  }
+
+  @include cm.for-phone-only {
+    a {
+      svg {
+        height: 24px;
+        width: 24px;
+      }
     }
   }
 }

--- a/packages/frontend/app/styles/components/user-guide-link.scss
+++ b/packages/frontend/app/styles/components/user-guide-link.scss
@@ -6,7 +6,7 @@
   @include m.header-menu;
 
   @include cm.for-tablet-and-up {
-    margin-left: 0;
+    margin-left: 0.25rem;
     margin-right: 0.5rem;
   }
 

--- a/packages/frontend/app/styles/components/user-guide-link.scss
+++ b/packages/frontend/app/styles/components/user-guide-link.scss
@@ -1,0 +1,14 @@
+@use "../ilios-common/mixins" as cm;
+@use "../ilios-common/colors" as c;
+
+.user-guide-link {
+  @include cm.for-tablet-and-up {
+    margin-right: 0.5rem;
+  }
+
+  a {
+    svg {
+      color: c.$white;
+    }
+  }
+}

--- a/packages/frontend/app/styles/components/user-guide-link.scss
+++ b/packages/frontend/app/styles/components/user-guide-link.scss
@@ -4,16 +4,24 @@
 
 .user-guide-link {
   @include m.header-menu;
-  margin-left: 0;
+
   @include cm.for-tablet-and-up {
+    margin-left: 0;
     margin-right: 0.5rem;
+  }
+
+  @include cm.for-phone-only {
+    /* stylelint-disable property-disallowed-list */
+    font-size: 3.5vw;
   }
 
   a {
     svg {
+      align-items: center;
       color: c.$white;
-      height: 1.5em;
-      width: 1.5em;
+      display: flex;
+      height: 1.85em;
+      width: 1.85em;
     }
   }
 }

--- a/packages/frontend/tests/integration/components/user-guide-link-test.js
+++ b/packages/frontend/tests/integration/components/user-guide-link-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | user-guide-link', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<UserGuideLink />`);
+
+    assert.dom('.user-guide-link').exists();
+    assert.dom('.user-guide-link svg.awesome-icon.fa-circle-question').exists();
+  });
+});

--- a/packages/frontend/tests/integration/components/user-guide-link-test.js
+++ b/packages/frontend/tests/integration/components/user-guide-link-test.js
@@ -1,15 +1,30 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | user-guide-link', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<UserGuideLink />`);
 
     assert.dom('.user-guide-link').exists();
-    assert.dom('.user-guide-link svg.awesome-icon.fa-circle-question').exists();
+    assert.dom('.user-guide-link svg.fa-circle-question').exists();
+    assert.dom('.user-guide-link svg.fa-circle-question title').hasText('Ilios User Guide');
+
+    this.owner.lookup('service:intl').setLocale('es');
+    await settled();
+
+    assert.dom('.user-guide-link svg.fa-circle-question title').hasText('Ilios Guía de usuario');
+
+    this.owner.lookup('service:intl').setLocale('fr');
+    await settled();
+
+    assert
+      .dom('.user-guide-link svg.fa-circle-question title')
+      .hasText("Ilios Guide d'utilisation");
   });
 });

--- a/packages/frontend/tests/integration/components/user-guide-link-test.js
+++ b/packages/frontend/tests/integration/components/user-guide-link-test.js
@@ -1,8 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
-import { render, settled } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | user-guide-link', function (hooks) {
   setupRenderingTest(hooks);
@@ -11,20 +11,16 @@ module('Integration | Component | user-guide-link', function (hooks) {
   test('it renders', async function (assert) {
     await render(hbs`<UserGuideLink />`);
 
-    assert.dom('.user-guide-link').exists();
-    assert.dom('.user-guide-link svg.fa-circle-question').exists();
-    assert.dom('.user-guide-link svg.fa-circle-question title').hasText('Ilios User Guide');
+    assert.dom('[data-test-user-guide-link]').exists();
+    assert.dom('[data-test-user-guide-link-icon]').exists();
+    assert.dom('[data-test-user-guide-link-icon]').hasText('Ilios User Guide');
 
-    this.owner.lookup('service:intl').setLocale('es');
-    await settled();
+    await setLocale('es');
 
-    assert.dom('.user-guide-link svg.fa-circle-question title').hasText('Ilios Guía de usuario');
+    assert.dom('[data-test-user-guide-link-icon]').hasText('Ilios Guía de usuario');
 
-    this.owner.lookup('service:intl').setLocale('fr');
-    await settled();
+    await setLocale('fr');
 
-    assert
-      .dom('.user-guide-link svg.fa-circle-question title')
-      .hasText("Ilios Guide d'utilisation");
+    assert.dom('[data-test-user-guide-link-icon]').hasText("Ilios Guide d'utilisation");
   });
 });

--- a/packages/ilios-common/addon/components/fa-icon.hbs
+++ b/packages/ilios-common/addon/components/fa-icon.hbs
@@ -15,6 +15,8 @@
 
   {{#if (eq @prefix "brands")}}
     <use xlink:href="/fontawesome/brands.svg#{{@icon}}"></use>
+  {{else if (eq @prefix "regular")}}
+    <use xlink:href="/fontawesome/regular.svg#{{@icon}}"></use>
   {{else}}
     <use xlink:href="/fontawesome/solid.svg#{{@icon}}"></use>
   {{/if}}

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -148,6 +148,7 @@ general:
   hours: Hours
   icsInstructions: "To add your Ilios calendar to another application or service, use this URL.  This URL is like a password. Anyone who knows it can view your calendar!"
   ilios: Ilios
+  iliosUserGuide: Ilios User Guide
   ilm: ILM
   ilmDue: ILM - Due
   inactive: inactive

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -148,6 +148,7 @@ general:
   hours: Horas
   icsInstructions: "Para agregar tu calendario a otra aplicación o servicio, utiliza esta URL.  Esta URL es como una contraseña.  ¡Cualquiera persona que la sepa puede ver tu calendario!"
   ilios: Ilios
+  iliosUserGuide: Ilios Guía de usuario
   ilm: ILM
   ilmDue: AI - Debido Por
   inactive: inactivo

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -148,6 +148,7 @@ general:
   hours: Heures
   icsInstructions: "Pour ajouter votre calendrier à des services ou applications autre, utilisez cette URL. Cette URL comme un mot de passe. Toutes les personnes qui le connaissent pouvez voir votre calendrier!"
   ilios: Ilios
+  iliosUserGuide: Ilios Guide d'utilisation
   ilm: ILM
   ilmDue: ILM - Échéance
   inactive: inactif


### PR DESCRIPTION
Fixes ilios/ilios#3759.

Created new `UserGuideLink` component that displays an icon to click that opens the Ilios User Guide in a new window. It has translations for the `<svg><title>` element, and a simple component test.