### PR TITLE
Use display name in search results

### DIFF
--- a/packages/frontend/app/components/new-directory-user.hbs
+++ b/packages/frontend/app/components/new-directory-user.hbs
@@ -34,6 +34,14 @@
             {{this.lastName}}
           </span>
         </div>
+        <div class="item" data-test-display-name>
+          <label>
+            {{t "general.displayName"}}:
+          </label>
+          <span>
+            {{this.displayName}}
+          </span>
+        </div>
         <div class="item" data-test-campus-id>
           <label>
             {{t "general.campusId"}}:
@@ -260,11 +268,10 @@
                       <td class="text-left" colspan="3" data-test-name>
                         {{#if user.user}}
                           <LinkTo @route="user" @model={{user.user}}>
-                            {{user.firstName}}
-                            {{user.lastName}}
+                            {{user.fullName}}
                           </LinkTo>
                         {{else}}
-                          {{user.firstName}} {{user.lastName}}
+                          {{user.fullName}}
                         {{/if}}
                       </td>
                       <td class="text-left" colspan="2" data-test-campus-id>

--- a/packages/frontend/app/components/new-directory-user.js
+++ b/packages/frontend/app/components/new-directory-user.js
@@ -30,6 +30,7 @@ export default class NewDirectoryUserComponent extends Component {
   @tracked firstName;
   @tracked middleName;
   @tracked lastName;
+  @tracked displayName;
   @tracked campusId;
   @tracked @Length(0, 16) otherId;
   @tracked email;
@@ -160,6 +161,7 @@ export default class NewDirectoryUserComponent extends Component {
     this.selectedUser = true;
     this.firstName = user.firstName;
     this.lastName = user.lastName;
+    this.displayName = user.displayName;
     this.email = user.email;
     this.campusId = user.campusId;
     this.phone = user.telephoneNumber;
@@ -171,6 +173,7 @@ export default class NewDirectoryUserComponent extends Component {
     this.selectedUser = false;
     this.firstName = null;
     this.lastName = null;
+    this.displayName = null;
     this.email = null;
     this.campusId = null;
     this.phone = null;
@@ -228,6 +231,10 @@ export default class NewDirectoryUserComponent extends Component {
           isPresent(result.lastName) &&
           isPresent(result.email) &&
           isPresent(result.campusId);
+
+        result.fullName = result.displayName.length
+          ? result.displayName
+          : `${result.firstName} ${result.lastName}`;
         return result;
       });
       this.tooManyResults = mappedResults.length > 50;
@@ -241,6 +248,7 @@ export default class NewDirectoryUserComponent extends Component {
       'firstName',
       'middleName',
       'lastName',
+      'displayName',
       'campusId',
       'otherId',
       'email',
@@ -258,6 +266,7 @@ export default class NewDirectoryUserComponent extends Component {
       firstName: this.firstName,
       middleName: this.middleName,
       lastName: this.lastName,
+      displayName: this.displayName,
       campusId: this.campusId,
       otherId: this.otherId,
       email: this.email,

--- a/packages/frontend/tests/integration/components/new-directory-user-test.js
+++ b/packages/frontend/tests/integration/components/new-directory-user-test.js
@@ -79,7 +79,7 @@ module('Integration | Component | new directory user', function (hooks) {
   });
 
   test('create new user', async function (assert) {
-    assert.expect(37);
+    assert.expect(39);
     this.server.create('user-role', {
       id: 4,
       title: 'Student',
@@ -87,6 +87,7 @@ module('Integration | Component | new directory user', function (hooks) {
     const user1 = this.server.create('user', {
       firstName: 'user1-first',
       lastName: 'user1-last',
+      displayName: 'user1-display',
       campusId: 'user1-campus',
       email: 'user1@test.com',
       telephoneNumber: 'user11234',
@@ -94,6 +95,7 @@ module('Integration | Component | new directory user', function (hooks) {
     const user2 = this.server.create('user', {
       firstName: 'user2-first',
       lastName: 'user2-last',
+      displayName: '',
       campusId: 'user2-campus',
       email: 'user2@test.com',
       telephoneNumber: 'user21234',
@@ -105,6 +107,7 @@ module('Integration | Component | new directory user', function (hooks) {
     const user3 = this.server.create('user', {
       firstName: 'user3-first',
       lastName: 'user3-last',
+      displayName: '',
       campusId: null,
       email: null,
       telephoneNumber: 'user31234',
@@ -112,6 +115,7 @@ module('Integration | Component | new directory user', function (hooks) {
     const searchResult1 = {
       firstName: user1.firstName,
       lastName: user1.lastName,
+      displayName: user1.displayName,
       campusId: user1.campusId,
       email: user1.email,
       telephoneNumber: user1.telephoneNumber,
@@ -121,6 +125,7 @@ module('Integration | Component | new directory user', function (hooks) {
     const searchResult2 = {
       firstName: user2.firstName,
       lastName: user2.lastName,
+      displayName: user2.displayName,
       campusId: user2.campusId,
       email: user2.email,
       telephoneNumber: user2.telephoneNumber,
@@ -130,6 +135,7 @@ module('Integration | Component | new directory user', function (hooks) {
     const searchResult3 = {
       firstName: user3.firstName,
       lastName: user3.lastName,
+      displayName: user3.displayName,
       campusId: user3.campusId,
       email: user3.email,
       telephoneNumber: user3.telephoneNumber,
@@ -166,10 +172,7 @@ module('Integration | Component | new directory user', function (hooks) {
 
     assert.strictEqual(component.searchResults.length, 3);
     assert.ok(component.searchResults[0].userCanBeAdded);
-    assert.strictEqual(
-      component.searchResults[0].name,
-      `${searchResult1.firstName} ${searchResult1.lastName}`,
-    );
+    assert.strictEqual(component.searchResults[0].name, `${searchResult1.displayName}`);
     assert.strictEqual(component.searchResults[0].campusId, searchResult1.campusId);
     assert.strictEqual(component.searchResults[0].email, searchResult1.email);
     assert.ok(component.searchResults[1].userAlreadyExists);
@@ -191,6 +194,7 @@ module('Integration | Component | new directory user', function (hooks) {
 
     assert.strictEqual(component.form.firstName, `First Name: ${searchResult1.firstName}`);
     assert.strictEqual(component.form.lastName, `Last Name: ${searchResult1.lastName}`);
+    assert.strictEqual(component.form.displayName, `Display Name: ${searchResult1.displayName}`);
     assert.strictEqual(component.form.campusId, `Campus ID: ${searchResult1.campusId}`);
     assert.strictEqual(component.form.email, `Email: ${searchResult1.email}`);
     assert.strictEqual(component.form.phone, `Phone: ${searchResult1.telephoneNumber}`);
@@ -205,6 +209,7 @@ module('Integration | Component | new directory user', function (hooks) {
     assert.strictEqual(userModel.firstName, searchResult1.firstName);
     assert.strictEqual(userModel.middleName, null);
     assert.strictEqual(userModel.lastName, searchResult1.lastName);
+    assert.strictEqual(userModel.displayName, searchResult1.displayName);
     assert.strictEqual(userModel.campusId, searchResult1.campusId);
     assert.strictEqual(userModel.otherId, null);
     assert.strictEqual(userModel.phone, searchResult1.telephoneNumber);
@@ -224,6 +229,7 @@ module('Integration | Component | new directory user', function (hooks) {
     const searchResult = {
       firstName: 'first',
       lastName: 'last',
+      displayName: '',
       campusId: '123',
       email: 'user1@example.edu',
       telephoneNumber: '805',
@@ -282,6 +288,7 @@ module('Integration | Component | new directory user', function (hooks) {
     const searchResult = {
       firstName: 'first',
       lastName: 'last',
+      displayName: '',
       campusId: '123',
       email: 'user1@example.edu',
       telephoneNumber: '805',

--- a/packages/frontend/tests/pages/components/new-directory-user.js
+++ b/packages/frontend/tests/pages/components/new-directory-user.js
@@ -39,6 +39,7 @@ const definition = {
     firstName: text('[data-test-first-name]'),
     middleName: text('[data-test-middle-name]'),
     lastName: text('[data-test-last-name]'),
+    displayName: text('[data-test-display-name]'),
     campusId: text('[data-test-campus-id]'),
     otherId: text('[data-test-other-id]'),
     email: text('[data-test-email]'),


### PR DESCRIPTION
When searching the directory for users we get display name as part of the results. We should use that whenever we have it, otherwise fallback to the existing first last pattern.

Fixes ilios/ilios#5453