### PR TITLE
Use Zorgbort to Create Dependency Update Pull Requests

### DIFF
--- a/.github/workflows/update-transitive-dependencies.yaml
+++ b/.github/workflows/update-transitive-dependencies.yaml
@@ -26,7 +26,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ZORGBORT_TOKEN }}
           commit-message: Update Transitive Dependencies
           title: Update Transitive Dependencies
           body: |


### PR DESCRIPTION
Using the github token prevents other actions from running so we don't get CI. I whimsically swapped these in #7802 and I shouldn't have. 😊 