### PR TITLE
Send environment with Sentry data

### DIFF
--- a/packages/frontend/config/environment.js
+++ b/packages/frontend/config/environment.js
@@ -30,6 +30,8 @@ module.exports = function (environment) {
         'api-host': process.env.ILIOS_FRONTEND_API_HOST || null,
         'error-capture-enabled':
           process.env.ILIOS_FRONTEND_ERROR_CAPTURE_ENABLED || environment === 'production',
+        'error-capture-environment':
+          process.env.ILIOS_FRONTEND_ERROR_CAPTURE_ENVIRONMENT || environment,
       },
     },
     'ember-metrics': {


### PR DESCRIPTION
Will consume the environment from the API server or can be overridden with a configuration value locally. This will make it easier to differentiate data in our error logs.