### PR TITLE
Add missing test-support.css

### DIFF
--- a/packages/frontend/public/assets/test-support.css
+++ b/packages/frontend/public/assets/test-support.css
@@ -1,0 +1,1 @@
+/* add styles here specifically for testing */


### PR DESCRIPTION
Running tests at `/tests` always throws a 404 error for `test-support.css`, which is annoying as it pollutes the dev console. This file seems to be missing even from a new EmberJS application, but the `tests/index.html` file links to it.

It _could_ be useful as a last-resort place to override things, but at the very least it kills the dumb error.