### PR TITLE
Fix test-support.css bug

### DIFF
--- a/packages/frontend/public/assets/test-support.css
+++ b/packages/frontend/public/assets/test-support.css
@@ -1,0 +1,1 @@
+/* add styles here specifically for testing */

--- a/packages/frontend/public/assets/test-support.css
+++ b/packages/frontend/public/assets/test-support.css
@@ -1,1 +1,0 @@
-/* add styles here specifically for testing */

--- a/packages/frontend/tests/index.html
+++ b/packages/frontend/tests/index.html
@@ -1,22 +1,26 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Ilios Tests</title>
-    <meta name="description" content="" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    {{content-for "head"}} {{content-for "test-head"}}
+    {{content-for "head"}}
+    {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
-    <link rel="stylesheet" href="{{rootURL}}assets/frontend.css" />
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/frontend.css">
 
     <!-- Ilios variables set  by the web server -->
-    {{content-for 'server-variables'}} {{content-for "head-footer"}}
+    {{content-for 'server-variables'}}
+
+    {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>
   <body>
-    {{content-for "body"}} {{content-for "test-body"}}
+    {{content-for "body"}}
+    {{content-for "test-body"}}
 
     <div id="qunit"></div>
     <div id="qunit-fixture">
@@ -33,6 +37,7 @@
     <script src="{{rootURL}}assets/frontend.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
-    {{content-for "body-footer"}} {{content-for "test-body-footer"}}
+    {{content-for "body-footer"}}
+    {{content-for "test-body-footer"}}
   </body>
 </html>

--- a/packages/frontend/tests/index.html
+++ b/packages/frontend/tests/index.html
@@ -1,27 +1,22 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Ilios Tests</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    {{content-for "head"}}
-    {{content-for "test-head"}}
+    {{content-for "head"}} {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/frontend.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link rel="stylesheet" href="{{rootURL}}assets/frontend.css" />
 
     <!-- Ilios variables set  by the web server -->
-    {{content-for 'server-variables'}}
-
-    {{content-for "head-footer"}}
+    {{content-for 'server-variables'}} {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>
   <body>
-    {{content-for "body"}}
-    {{content-for "test-body"}}
+    {{content-for "body"}} {{content-for "test-body"}}
 
     <div id="qunit"></div>
     <div id="qunit-fixture">
@@ -38,7 +33,6 @@
     <script src="{{rootURL}}assets/frontend.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
-    {{content-for "body-footer"}}
-    {{content-for "test-body-footer"}}
+    {{content-for "body-footer"}} {{content-for "test-body-footer"}}
   </body>
 </html>

--- a/packages/lti-course-manager/tests/index.html
+++ b/packages/lti-course-manager/tests/index.html
@@ -9,8 +9,8 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
-    <link rel="stylesheet" href="{{rootURL}}assets/lti-course-manager.css" />
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/lti-course-manager.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}

--- a/packages/lti-course-manager/tests/index.html
+++ b/packages/lti-course-manager/tests/index.html
@@ -1,20 +1,23 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Ilios LTI Course Manager Tests</title>
-    <meta name="description" content="" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    {{content-for "head"}} {{content-for "test-head"}}
+    {{content-for "head"}}
+    {{content-for "test-head"}}
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
     <link rel="stylesheet" href="{{rootURL}}assets/lti-course-manager.css" />
 
-    {{content-for "head-footer"}} {{content-for "test-head-footer"}}
+    {{content-for "head-footer"}}
+    {{content-for "test-head-footer"}}
   </head>
   <body>
-    {{content-for "body"}} {{content-for "test-body"}}
+    {{content-for "body"}}
+    {{content-for "test-body"}}
 
     <div id="qunit"></div>
     <div id="qunit-fixture">
@@ -29,6 +32,7 @@
     <script src="{{rootURL}}assets/lti-course-manager.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
-    {{content-for "body-footer"}} {{content-for "test-body-footer"}}
+    {{content-for "body-footer"}}
+    {{content-for "test-body-footer"}}
   </body>
 </html>

--- a/packages/lti-course-manager/tests/index.html
+++ b/packages/lti-course-manager/tests/index.html
@@ -1,24 +1,20 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Ilios LTI Course Manager Tests</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    {{content-for "head"}}
-    {{content-for "test-head"}}
+    {{content-for "head"}} {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/lti-course-manager.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link rel="stylesheet" href="{{rootURL}}assets/lti-course-manager.css" />
 
-    {{content-for "head-footer"}}
-    {{content-for "test-head-footer"}}
+    {{content-for "head-footer"}} {{content-for "test-head-footer"}}
   </head>
   <body>
-    {{content-for "body"}}
-    {{content-for "test-body"}}
+    {{content-for "body"}} {{content-for "test-body"}}
 
     <div id="qunit"></div>
     <div id="qunit-fixture">
@@ -33,7 +29,6 @@
     <script src="{{rootURL}}assets/lti-course-manager.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
-    {{content-for "body-footer"}}
-    {{content-for "test-body-footer"}}
+    {{content-for "body-footer"}} {{content-for "test-body-footer"}}
   </body>
 </html>

--- a/packages/lti-dashboard/tests/index.html
+++ b/packages/lti-dashboard/tests/index.html
@@ -1,24 +1,20 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Ilios LTI App Tests</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    {{content-for "head"}}
-    {{content-for "test-head"}}
+    {{content-for "head"}} {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/lti-dashboard.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link rel="stylesheet" href="{{rootURL}}assets/lti-dashboard.css" />
 
-    {{content-for "head-footer"}}
-    {{content-for "test-head-footer"}}
+    {{content-for "head-footer"}} {{content-for "test-head-footer"}}
   </head>
   <body>
-    {{content-for "body"}}
-    {{content-for "test-body"}}
+    {{content-for "body"}} {{content-for "test-body"}}
 
     <div id="qunit"></div>
     <div id="qunit-fixture">
@@ -33,7 +29,6 @@
     <script src="{{rootURL}}assets/lti-dashboard.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
-    {{content-for "body-footer"}}
-    {{content-for "test-body-footer"}}
+    {{content-for "body-footer"}} {{content-for "test-body-footer"}}
   </body>
 </html>

--- a/packages/lti-dashboard/tests/index.html
+++ b/packages/lti-dashboard/tests/index.html
@@ -1,20 +1,23 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Ilios LTI App Tests</title>
-    <meta name="description" content="" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    {{content-for "head"}} {{content-for "test-head"}}
+    {{content-for "head"}}
+    {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
-    <link rel="stylesheet" href="{{rootURL}}assets/lti-dashboard.css" />
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/lti-dashboard.css">
 
-    {{content-for "head-footer"}} {{content-for "test-head-footer"}}
+    {{content-for "head-footer"}}
+    {{content-for "test-head-footer"}}
   </head>
   <body>
-    {{content-for "body"}} {{content-for "test-body"}}
+    {{content-for "body"}}
+    {{content-for "test-body"}}
 
     <div id="qunit"></div>
     <div id="qunit-fixture">
@@ -29,6 +32,7 @@
     <script src="{{rootURL}}assets/lti-dashboard.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
-    {{content-for "body-footer"}} {{content-for "test-body-footer"}}
+    {{content-for "body-footer"}}
+    {{content-for "test-body-footer"}}
   </body>
 </html>

--- a/packages/test-app/tests/index.html
+++ b/packages/test-app/tests/index.html
@@ -1,22 +1,26 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>TestApp Tests</title>
-    <meta name="description" content="" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    {{content-for "head"}} {{content-for "test-head"}}
+    {{content-for "head"}}
+    {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
-    <link rel="stylesheet" href="{{rootURL}}assets/test-app.css" />
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-app.css">
 
     <!-- Ilios variables set  by the web server -->
-    {{content-for 'server-variables'}} {{content-for "head-footer"}}
+    {{content-for 'server-variables'}}
+
+    {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>
   <body>
-    {{content-for "body"}} {{content-for "test-body"}}
+    {{content-for "body"}}
+    {{content-for "test-body"}}
 
     <div id="qunit"></div>
     <div id="qunit-fixture">
@@ -31,6 +35,7 @@
     <script src="{{rootURL}}assets/test-app.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
-    {{content-for "body-footer"}} {{content-for "test-body-footer"}}
+    {{content-for "body-footer"}}
+    {{content-for "test-body-footer"}}
   </body>
 </html>

--- a/packages/test-app/tests/index.html
+++ b/packages/test-app/tests/index.html
@@ -1,27 +1,22 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>TestApp Tests</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    {{content-for "head"}}
-    {{content-for "test-head"}}
+    {{content-for "head"}} {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-app.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link rel="stylesheet" href="{{rootURL}}assets/test-app.css" />
 
     <!-- Ilios variables set  by the web server -->
-    {{content-for 'server-variables'}}
-
-    {{content-for "head-footer"}}
+    {{content-for 'server-variables'}} {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>
   <body>
-    {{content-for "body"}}
-    {{content-for "test-body"}}
+    {{content-for "body"}} {{content-for "test-body"}}
 
     <div id="qunit"></div>
     <div id="qunit-fixture">
@@ -36,7 +31,6 @@
     <script src="{{rootURL}}assets/test-app.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
-    {{content-for "body-footer"}}
-    {{content-for "test-body-footer"}}
+    {{content-for "body-footer"}} {{content-for "test-body-footer"}}
   </body>
 </html>


### PR DESCRIPTION
Undoes what https://github.com/ilios/frontend/pull/7838 was planning, and instead removes the reference to `test-support.css` in our testing `index.html` files.