### PR TITLE
Learner Groups now use same loading style as Instructor Groups

### DIFF
--- a/packages/frontend/app/components/learner-groups/loading.hbs
+++ b/packages/frontend/app/components/learner-groups/loading.hbs
@@ -1,0 +1,32 @@
+<table class="learner-groups-loading" ...attributes>
+  <thead>
+    <tr>
+      <th class="text-left" colspan="2">
+        {{t "general.learnerGroupTitle"}}
+      </th>
+      <th class="text-center hide-from-small-screen">
+        {{t "general.members"}}
+      </th>
+      <th class="text-center hide-from-small-screen">
+        {{t "general.subgroups"}}
+      </th>
+      <th class="text-right">
+        {{t "general.actions"}}
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {{! template-lint-disable no-unused-block-params }}
+    {{#each (repeat @count) as |empty|}}
+      <tr class="is-loading">
+        <td class="text-left" colspan="2">{{truncate
+            (repeat (random 3 10) "ilios rocks")
+            100
+          }}</td>
+        <td class="text-center hide-from-small-screen">{{random 1 9}}</td>
+        <td class="text-center hide-from-small-screen">{{random 1 9}}</td>
+        <td class="text-right"></td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>

--- a/packages/frontend/app/components/learner-groups/root.hbs
+++ b/packages/frontend/app/components/learner-groups/root.hbs
@@ -122,7 +122,7 @@
           @setSortBy={{@setSortBy}}
         />
       {{else}}
-        <LearnerGroups::Loading />
+        <LearnerGroups::Loading @count={{this.countForSelectedCohort}} />
       {{/if}}
     </div>
   </div>

--- a/packages/frontend/app/components/learner-groups/root.hbs
+++ b/packages/frontend/app/components/learner-groups/root.hbs
@@ -122,7 +122,7 @@
           @setSortBy={{@setSortBy}}
         />
       {{else}}
-        <LearnerGroups::Loading @count={{this.countForSelectedCohort}} />
+        <LearnerGroups::Loading @count="2" />
       {{/if}}
     </div>
   </div>

--- a/packages/frontend/app/components/learner-groups/root.hbs
+++ b/packages/frontend/app/components/learner-groups/root.hbs
@@ -122,7 +122,7 @@
           @setSortBy={{@setSortBy}}
         />
       {{else}}
-        <LearnerGroups::Loading @count="2" />
+        <LearnerGroups::Loading @count={{2}} />
       {{/if}}
     </div>
   </div>

--- a/packages/frontend/app/components/learner-groups/root.hbs
+++ b/packages/frontend/app/components/learner-groups/root.hbs
@@ -122,7 +122,7 @@
           @setSortBy={{@setSortBy}}
         />
       {{else}}
-        <PulseLoader />
+        <LearnerGroups::Loading />
       {{/if}}
     </div>
   </div>

--- a/packages/frontend/app/components/learner-groups/root.js
+++ b/packages/frontend/app/components/learner-groups/root.js
@@ -155,6 +155,10 @@ export default class LearnerGroupsRootComponent extends Component {
     });
   }
 
+  get countForSelectedCohort() {
+    return 2;
+  }
+
   saveNewLearnerGroup = dropTask(async (title, fillWithCohort) => {
     const group = this.store.createRecord('learner-group', {
       title,

--- a/packages/frontend/app/components/learner-groups/root.js
+++ b/packages/frontend/app/components/learner-groups/root.js
@@ -155,10 +155,6 @@ export default class LearnerGroupsRootComponent extends Component {
     });
   }
 
-  get countForSelectedCohort() {
-    return 2;
-  }
-
   saveNewLearnerGroup = dropTask(async (title, fillWithCohort) => {
     const group = this.store.createRecord('learner-group', {
       title,

--- a/packages/frontend/app/styles/components.scss
+++ b/packages/frontend/app/styles/components.scss
@@ -81,6 +81,7 @@
 @import "components/learner-group/members";
 
 @import "components/learner-groups/root";
+@import "components/learner-groups/loading";
 
 @import "components/instructor-group/courses";
 @import "components/instructor-group/header";

--- a/packages/frontend/app/styles/components/learner-groups/loading.scss
+++ b/packages/frontend/app/styles/components/learner-groups/loading.scss
@@ -1,5 +1,5 @@
 @use "../../mixins" as m;
 
-.instructor-groups-loading {
+.learner-groups-loading {
   @include m.main-list-loading-table;
 }

--- a/packages/frontend/app/styles/components/learner-groups/loading.scss
+++ b/packages/frontend/app/styles/components/learner-groups/loading.scss
@@ -1,0 +1,5 @@
+@use "../../mixins" as m;
+
+.instructor-groups-loading {
+  @include m.main-list-loading-table;
+}

--- a/packages/frontend/tests/acceptance/learnergroups-test.js
+++ b/packages/frontend/tests/acceptance/learnergroups-test.js
@@ -16,7 +16,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('visiting /learnergroups', async function (assert) {
-    assert.expect(1);
     await page.visit();
     assert.strictEqual(currentRouteName(), 'learner-groups');
   });

--- a/packages/frontend/tests/acceptance/learnergroups-test.js
+++ b/packages/frontend/tests/acceptance/learnergroups-test.js
@@ -21,6 +21,47 @@ module('Acceptance | Learner Groups', function (hooks) {
     assert.strictEqual(currentRouteName(), 'learner-groups');
   });
 
+  test('list groups', async function (assert) {
+    assert.expect(8);
+    this.server.createList('user', 11);
+    const program = this.server.create('program', { school: this.school });
+    const programYear = this.server.create('program-year', { program });
+    const cohort = this.server.create('cohort', { programYear });
+    const firstLearnerGroup = this.server.create('learner-group', {
+      cohort,
+      userIds: [2, 3, 4, 5, 6],
+    });
+    this.server.create('learner-group', {
+      cohort,
+    });
+    const firstChildGroup = this.server.create('learner-group', {
+      parent: firstLearnerGroup,
+      userIds: [7, 8],
+    });
+    this.server.create('learner-group', {
+      parent: firstLearnerGroup,
+      userIds: [9, 10],
+    });
+    this.server.create('learner-group', {
+      parent: firstChildGroup,
+      userIds: [11, 12],
+    });
+    this.server.createList('offering', 2, {
+      learnerGroups: [firstLearnerGroup],
+    });
+
+    await page.visit();
+    await percySnapshot(assert);
+    assert.strictEqual(page.headerTitle, 'Learner Groups (2)');
+    assert.strictEqual(page.list.items.length, 2);
+    assert.strictEqual(page.list.items[0].title, 'learner group 0');
+    assert.strictEqual(page.list.items[0].users, '5');
+    assert.strictEqual(page.list.items[0].children, '2');
+    assert.strictEqual(page.list.items[1].title, 'learner group 1');
+    assert.strictEqual(page.list.items[1].users, '0');
+    assert.strictEqual(page.list.items[1].children, '0');
+  });
+
   test('single option filters', async function (assert) {
     assert.expect(6);
     const program = this.server.create('program', { school: this.school });
@@ -91,47 +132,6 @@ module('Acceptance | Learner Groups', function (hooks) {
     assert.strictEqual(page.headerTitle, 'Learner Groups (1)');
     assert.strictEqual(page.list.items.length, 1);
     assert.strictEqual(page.list.items[0].title, 'learner group 1');
-  });
-
-  test('list groups', async function (assert) {
-    assert.expect(8);
-    this.server.createList('user', 11);
-    const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('program-year', { program });
-    const cohort = this.server.create('cohort', { programYear });
-    const firstLearnerGroup = this.server.create('learner-group', {
-      cohort,
-      userIds: [2, 3, 4, 5, 6],
-    });
-    this.server.create('learner-group', {
-      cohort,
-    });
-    const firstChildGroup = this.server.create('learner-group', {
-      parent: firstLearnerGroup,
-      userIds: [7, 8],
-    });
-    this.server.create('learner-group', {
-      parent: firstLearnerGroup,
-      userIds: [9, 10],
-    });
-    this.server.create('learner-group', {
-      parent: firstChildGroup,
-      userIds: [11, 12],
-    });
-    this.server.createList('offering', 2, {
-      learnerGroups: [firstLearnerGroup],
-    });
-
-    await page.visit();
-    await percySnapshot(assert);
-    assert.strictEqual(page.headerTitle, 'Learner Groups (2)');
-    assert.strictEqual(page.list.items.length, 2);
-    assert.strictEqual(page.list.items[0].title, 'learner group 0');
-    assert.strictEqual(page.list.items[0].users, '5');
-    assert.strictEqual(page.list.items[0].children, '2');
-    assert.strictEqual(page.list.items[1].title, 'learner group 1');
-    assert.strictEqual(page.list.items[1].users, '0');
-    assert.strictEqual(page.list.items[1].children, '0');
   });
 
   test('filters by title', async function (assert) {

--- a/packages/frontend/tests/integration/components/learner-groups/loading-test.js
+++ b/packages/frontend/tests/integration/components/learner-groups/loading-test.js
@@ -10,8 +10,8 @@ module('Integration | Component | learner-groups/loading', function (hooks) {
   setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
-    await render(hbs`<LearnerGroups::Loading />`);
-    assert.dom('tbody tr').exists({ count: 1 });
+    await render(hbs`<LearnerGroups::Loading @count={{2}} />`);
+    assert.dom('tbody tr').exists({ count: 2 });
     await a11yAudit(this.element);
   });
 });

--- a/packages/frontend/tests/integration/components/learner-groups/loading-test.js
+++ b/packages/frontend/tests/integration/components/learner-groups/loading-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupIntl } from 'ember-intl/test-support';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+
+module('Integration | Component | learner-groups/loading', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us');
+
+  test('it renders', async function (assert) {
+    await render(hbs`<LearnerGroups::Loading />`);
+    assert.dom('tbody tr').exists({ count: 1 });
+    await a11yAudit(this.element);
+  });
+});


### PR DESCRIPTION
Fixes ilios/ilios#5426

Learner Groups were using the deprecated(?) `<PulseLoader>` loading component, but now they are using the same style as Instructor Groups (i.e. obfuscated shimmer method).