### PR TITLE
Use ember test setup to setup intl

### DIFF
--- a/packages/frontend/tests/acceptance/admin-test.js
+++ b/packages/frontend/tests/acceptance/admin-test.js
@@ -4,7 +4,7 @@ import { setupAuthentication } from 'ilios-common';
 
 const url = '/admin';
 
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import percySnapshot from '@percy/ember';
 

--- a/packages/frontend/tests/acceptance/api-version-notice-test.js
+++ b/packages/frontend/tests/acceptance/api-version-notice-test.js
@@ -1,7 +1,7 @@
 import { visit, waitFor } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'ilios-common/page-objects/components/api-version-notice';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/assign-students-test.js
+++ b/packages/frontend/tests/acceptance/assign-students-test.js
@@ -1,7 +1,7 @@
 import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/assign-students';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/course/session/offerings-test.js
+++ b/packages/frontend/tests/acceptance/course/session/offerings-test.js
@@ -5,11 +5,9 @@ import { setupApplicationTest } from 'frontend/tests/helpers';
 import page from 'ilios-common/page-objects/session';
 import percySnapshot from '@percy/ember';
 import { freezeDateAt, unfreezeDate } from 'ilios-common';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Acceptance | Session - Offerings', function (hooks) {
   setupApplicationTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(async function () {
     freezeDateAt(

--- a/packages/frontend/tests/acceptance/courses-test.js
+++ b/packages/frontend/tests/acceptance/courses-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
 import { DateTime } from 'luxon';
 import page from 'frontend/tests/pages/courses';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import percySnapshot from '@percy/ember';
 

--- a/packages/frontend/tests/acceptance/curriculum-inventory/leadership-test.js
+++ b/packages/frontend/tests/acceptance/curriculum-inventory/leadership-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import { setupAuthentication } from 'ilios-common';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/curriculum-inventory-report';

--- a/packages/frontend/tests/acceptance/curriculum-inventory/nested-sequence-blocks-test.js
+++ b/packages/frontend/tests/acceptance/curriculum-inventory/nested-sequence-blocks-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import { setupAuthentication } from 'ilios-common';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/curriculum-inventory-sequence-block';

--- a/packages/frontend/tests/acceptance/curriculum-inventory/report-test.js
+++ b/packages/frontend/tests/acceptance/curriculum-inventory/report-test.js
@@ -1,7 +1,7 @@
 import { currentRouteName } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/curriculum-inventory-report';
 

--- a/packages/frontend/tests/acceptance/curriculum-inventory/reports-test.js
+++ b/packages/frontend/tests/acceptance/curriculum-inventory/reports-test.js
@@ -1,7 +1,7 @@
 import { visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/curriculum-inventory-reports';
 

--- a/packages/frontend/tests/acceptance/curriculum-inventory/rollover-test.js
+++ b/packages/frontend/tests/acceptance/curriculum-inventory/rollover-test.js
@@ -1,7 +1,7 @@
 import { currentRouteName, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/curriculum-inventory-report-rollover';
 import queryString from 'query-string';

--- a/packages/frontend/tests/acceptance/curriculum-inventory/sequence-blocks-test.js
+++ b/packages/frontend/tests/acceptance/curriculum-inventory/sequence-blocks-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import { setupAuthentication } from 'ilios-common';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/curriculum-inventory-report';

--- a/packages/frontend/tests/acceptance/dashboard/accessibility-test.js
+++ b/packages/frontend/tests/acceptance/dashboard/accessibility-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { setupAuthentication } from 'ilios-common';

--- a/packages/frontend/tests/acceptance/events-test.js
+++ b/packages/frontend/tests/acceptance/events-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { currentURL } from '@ember/test-helpers';
 import page from 'ilios-common/page-objects/events';

--- a/packages/frontend/tests/acceptance/footer-test.js
+++ b/packages/frontend/tests/acceptance/footer-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupAuthentication } from 'ilios-common';
 import ENV from 'frontend/config/environment';

--- a/packages/frontend/tests/acceptance/four-oh-four-test.js
+++ b/packages/frontend/tests/acceptance/four-oh-four-test.js
@@ -1,7 +1,7 @@
 import { currentRouteName, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import percySnapshot from '@percy/ember';
 

--- a/packages/frontend/tests/acceptance/header-test.js
+++ b/packages/frontend/tests/acceptance/header-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/instructorgroup-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroup-test.js
@@ -1,7 +1,7 @@
 import { currentRouteName, visit, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import page from '../pages/instructor-group';

--- a/packages/frontend/tests/acceptance/instructorgroups-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroups-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 
 import page from 'frontend/tests/pages/instructor-groups';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import percySnapshot from '@percy/ember';
 

--- a/packages/frontend/tests/acceptance/learner-group/bulk-assignment-test.js
+++ b/packages/frontend/tests/acceptance/learner-group/bulk-assignment-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import { triggerEvent, waitFor } from '@ember/test-helpers';
 import { setupAuthentication } from 'ilios-common';
 import page from '../../pages/learner-group';

--- a/packages/frontend/tests/acceptance/learnergroup-test.js
+++ b/packages/frontend/tests/acceptance/learnergroup-test.js
@@ -2,7 +2,7 @@ import { currentURL } from '@ember/test-helpers';
 import { test, module } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { DateTime } from 'luxon';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from '../pages/learner-group';
 import learnerGroupsPage from '../pages/learner-groups';

--- a/packages/frontend/tests/acceptance/learnergroups-test.js
+++ b/packages/frontend/tests/acceptance/learnergroups-test.js
@@ -1,7 +1,7 @@
 import { currentRouteName, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/learner-groups';
 import learnerGroupPage from 'frontend/tests/pages/learner-group';

--- a/packages/frontend/tests/acceptance/login-test.js
+++ b/packages/frontend/tests/acceptance/login-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/pending-user-updates-test.js
+++ b/packages/frontend/tests/acceptance/pending-user-updates-test.js
@@ -1,7 +1,7 @@
 import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/pending-user-updates';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/program-year/competencies-test.js
+++ b/packages/frontend/tests/acceptance/program-year/competencies-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/program-year';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/program-year/leadership-test.js
+++ b/packages/frontend/tests/acceptance/program-year/leadership-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import { setupAuthentication } from 'ilios-common';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/program-year';

--- a/packages/frontend/tests/acceptance/program-year/objectives-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectives-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/program-year';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/program-year/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectiveterms-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import page from 'frontend/tests/pages/program-year';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/program-year/terms-test.js
+++ b/packages/frontend/tests/acceptance/program-year/terms-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/program-year';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/program/leadership-test.js
+++ b/packages/frontend/tests/acceptance/program/leadership-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import { setupAuthentication } from 'ilios-common';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/program';

--- a/packages/frontend/tests/acceptance/program/overview-test.js
+++ b/packages/frontend/tests/acceptance/program/overview-test.js
@@ -1,7 +1,7 @@
 import { currentRouteName } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/program';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/program/programyear-list-test.js
+++ b/packages/frontend/tests/acceptance/program/programyear-list-test.js
@@ -2,7 +2,7 @@ import { currentRouteName } from '@ember/test-helpers';
 import { DateTime } from 'luxon';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/program';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/program/publicationcheck-test.js
+++ b/packages/frontend/tests/acceptance/program/publicationcheck-test.js
@@ -1,7 +1,7 @@
 import { currentRouteName, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import percySnapshot from '@percy/ember';
 

--- a/packages/frontend/tests/acceptance/programs-test.js
+++ b/packages/frontend/tests/acceptance/programs-test.js
@@ -2,7 +2,7 @@ import { click, fillIn, find, currentURL, currentRouteName, visit } from '@ember
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/programs';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/reports/subject-test.js
+++ b/packages/frontend/tests/acceptance/reports/subject-test.js
@@ -2,7 +2,7 @@ import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import page from 'frontend/tests/pages/reports-subject';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import percySnapshot from '@percy/ember';
 

--- a/packages/frontend/tests/acceptance/reports/subjects-test.js
+++ b/packages/frontend/tests/acceptance/reports/subjects-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import page from 'frontend/tests/pages/reports';
 import subjectReportPage from 'frontend/tests/pages/reports-subject';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import percySnapshot from '@percy/ember';
 

--- a/packages/frontend/tests/acceptance/school/session-attributes-test.js
+++ b/packages/frontend/tests/acceptance/school/session-attributes-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/school';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/school/session-types-test.js
+++ b/packages/frontend/tests/acceptance/school/session-types-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import { currentURL } from '@ember/test-helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/school';

--- a/packages/frontend/tests/acceptance/search-test.js
+++ b/packages/frontend/tests/acceptance/search-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupAuthentication } from 'ilios-common';
 import page from 'frontend/tests/pages/search';

--- a/packages/frontend/tests/acceptance/user-menu-test.js
+++ b/packages/frontend/tests/acceptance/user-menu-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupAuthentication } from 'ilios-common';
 import dashboardPage from 'frontend/tests/pages/dashboard';

--- a/packages/frontend/tests/acceptance/user-test.js
+++ b/packages/frontend/tests/acceptance/user-test.js
@@ -2,7 +2,7 @@ import { click, fillIn, currentURL, triggerEvent, visit } from '@ember/test-help
 import { module, test } from 'qunit';
 import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
 
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/user';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/users-test.js
+++ b/packages/frontend/tests/acceptance/users-test.js
@@ -1,7 +1,7 @@
 import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'frontend/tests/pages/users';
 import percySnapshot from '@percy/ember';

--- a/packages/frontend/tests/acceptance/weeklyevents-test.js
+++ b/packages/frontend/tests/acceptance/weeklyevents-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import page from 'ilios-common/page-objects/weeklyevents';
 

--- a/packages/frontend/tests/helpers/index.js
+++ b/packages/frontend/tests/helpers/index.js
@@ -24,13 +24,14 @@ function setupApplicationTest(hooks, options) {
   //
   // This is also a good place to call test setup functions coming
   // from other addons:
-  //
+
   setupIntl(hooks, 'en-us'); // ember-intl
   setupMirage(hooks); // ember-cli-mirage
 }
 
 function setupRenderingTest(hooks, options) {
   upstreamSetupRenderingTest(hooks, options);
+  setupIntl(hooks, 'en-us'); // ember-intl
 
   // Additional setup for rendering tests can be done here.
 }

--- a/packages/frontend/tests/integration/components/assign-students/manager-test.js
+++ b/packages/frontend/tests/integration/components/assign-students/manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { DateTime } from 'luxon';
 
 module('Integration | Component | assign-students/manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/assign-students/root-test.js
+++ b/packages/frontend/tests/integration/components/assign-students/root-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { DateTime } from 'luxon';
 
 module('Integration | Component | assign-students/root', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/back-to-admin-dashboard-test.js
+++ b/packages/frontend/tests/integration/components/back-to-admin-dashboard-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/back-to-admin-dashboard';
 
 module('Integration | Component | back-to-admin-dashboard', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<BackToAdminDashboard />`);

--- a/packages/frontend/tests/integration/components/bulk-new-users-test.js
+++ b/packages/frontend/tests/integration/components/bulk-new-users-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import {
   render,
   settled,
@@ -19,7 +18,6 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | bulk new users', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/competency-title-editor-test.js
+++ b/packages/frontend/tests/integration/components/competency-title-editor-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/competency-title-edit
 
 module('Integration | Component | competency title editor', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('validation errors do not show up initially', async function (assert) {

--- a/packages/frontend/tests/integration/components/connection-status-test.js
+++ b/packages/frontend/tests/integration/components/connection-status-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | connection status', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders offline and therefor hidden', async function (assert) {
     await render(hbs`<ConnectionStatus />`);

--- a/packages/frontend/tests/integration/components/course-search-result-test.js
+++ b/packages/frontend/tests/integration/components/course-search-result-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/course-search-result';
 
 module('Integration | Component | course-search-result', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it display course and session info properly', async function (assert) {
     assert.expect(9);

--- a/packages/frontend/tests/integration/components/courses/list-item-test.js
+++ b/packages/frontend/tests/integration/components/courses/list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import Service from '@ember/service';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/courses/list-item';
 
 module('Integration | Component | courses/list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/courses/list-test.js
+++ b/packages/frontend/tests/integration/components/courses/list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/courses/list';
 
 module('Integration | Component | courses/list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/courses/new-test.js
+++ b/packages/frontend/tests/integration/components/courses/new-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/courses/new';
 
 module('Integration | Component | courses/new', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/courses/root-test.js
+++ b/packages/frontend/tests/integration/components/courses/root-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/courses/root';
 
 module('Integration | Component | courses/root', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/new-report-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/new-report-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/curriculum-inventory/
 
 module('Integration | Component | curriculum-inventory/new-report', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/new-sequence-block-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/new-sequence-block-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/curriculum-inventory/
 
 module('Integration | Component | curriculum-inventory/new-sequence-block', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-details-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-details-test.js
@@ -1,5 +1,4 @@
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, click, find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
@@ -10,7 +9,6 @@ import { component } from 'frontend/tests/pages/components/curriculum-inventory/
 
 module('Integration | Component | curriculum-inventory/report-details', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-header-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-header-test.js
@@ -1,5 +1,4 @@
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/curriculum-inventory/
 
 module('Integration | Component | curriculum-inventory/report-header', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-list-item-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-list-item-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/curriculum-inventory/
 
 module('Integration | Component | curriculum-inventory/report-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-list-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-list-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -10,7 +9,6 @@ import { component } from 'frontend/tests/pages/components/curriculum-inventory/
 
 module('Integration | Component | curriculum-inventory/report-list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-overview-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-overview-test.js
@@ -1,16 +1,14 @@
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
-import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/report-overview';
 
 module('Integration | Component | curriculum-inventory/report-overview', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-rollover-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-rollover-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -10,7 +9,6 @@ import { component } from 'frontend/tests/pages/components/curriculum-inventory/
 
 module('Integration | Component | curriculum-inventory/report-rollover', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/reports-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/reports-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
@@ -8,7 +7,6 @@ import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/reports';
 module('Integration | Component | curriculum-inventory/reports', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-details-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-details-test.js
@@ -1,15 +1,13 @@
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
-import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-details';
 
 module('Integration | Component | curriculum-inventory/sequence-block-details', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-header-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-header-test.js
@@ -1,5 +1,4 @@
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
@@ -8,7 +7,6 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | curriculum-inventory/sequence-block-header', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-list-item-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/curriculum-inventory/
 
 module('Integration | Component | curriculum-inventory/sequence-block-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-list-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/curriculum-inventory/
 
 module('Integration | Component | curriculum-inventory/sequence-block-list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-overview-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-overview-test.js
@@ -1,5 +1,4 @@
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/curriculum-inventory/
 
 module('Integration | Component | curriculum-inventory/sequence-block-overview', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-session-list-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-session-list-test.js
@@ -1,8 +1,7 @@
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { DateTime } from 'luxon';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/sequence-block-session-list';
@@ -11,7 +10,6 @@ module(
   'Integration | Component | curriculum-inventory/sequence-block-session-list',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks);
     setupMirage(hooks);
 
     test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-session-manager-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-session-manager-test.js
@@ -1,5 +1,4 @@
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
@@ -11,7 +10,6 @@ module(
   'Integration | Component | curriculum-inventory/sequence-block-session-manager',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
     setupMirage(hooks);
 
     test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-header-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-header-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -10,7 +9,6 @@ module(
   'Integration | Component | curriculum-inventory/verification-preview-header',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
     setupMirage(hooks);
 
     test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table1-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table1-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table1';
@@ -9,7 +8,6 @@ module(
   'Integration | Component | curriculum-inventory/verification-preview-table1',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
 
     test('it renders', async function (assert) {
       assert.expect(12);

--- a/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table2-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table2-test.js
@@ -1,7 +1,6 @@
 /*eslint camelcase: 0 */
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table2';
@@ -10,7 +9,6 @@ module(
   'Integration | Component | curriculum-inventory/verification-preview-table2',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
 
     test('it renders', async function (assert) {
       const data = {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table3a-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table3a-test.js
@@ -1,7 +1,6 @@
 /*eslint camelcase: 0 */
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table3a';
@@ -10,7 +9,6 @@ module(
   'Integration | Component | curriculum-inventory/verification-preview-table3a',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
 
     test('it renders', async function (assert) {
       const data = [

--- a/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table3b-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table3b-test.js
@@ -1,7 +1,6 @@
 /*eslint camelcase: 0 */
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table3b';
@@ -10,7 +9,6 @@ module(
   'Integration | Component | curriculum-inventory/verification-preview-table3b',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
 
     test('it renders', async function (assert) {
       const data = [

--- a/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table4-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table4-test.js
@@ -1,7 +1,6 @@
 /*eslint camelcase: 0 */
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table4';
@@ -10,7 +9,6 @@ module(
   'Integration | Component | curriculum-inventory/verification-preview-table4',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
 
     test('it renders', async function (assert) {
       assert.expect(20);

--- a/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table5-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table5-test.js
@@ -1,7 +1,6 @@
 /*eslint camelcase: 0 */
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table5';
@@ -10,7 +9,6 @@ module(
   'Integration | Component | curriculum-inventory/verification-preview-table5',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
 
     test('it renders', async function (assert) {
       const data = {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table6-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table6-test.js
@@ -1,7 +1,6 @@
 /*eslint camelcase: 0 */
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table6';
@@ -10,7 +9,6 @@ module(
   'Integration | Component | curriculum-inventory/verification-preview-table6',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
 
     test('it renders', async function (assert) {
       const data = {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table7-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table7-test.js
@@ -1,7 +1,6 @@
 /*eslint camelcase: 0 */
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table7';
@@ -10,7 +9,6 @@ module(
   'Integration | Component | curriculum-inventory/verification-preview-table7',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
 
     test('it renders', async function (assert) {
       assert.expect(19);

--- a/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table8-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-table8-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/curriculum-inventory/verification-preview-table8';
@@ -9,7 +8,6 @@ module(
   'Integration | Component | curriculum-inventory/verification-preview-table8',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
 
     test('it renders', async function (assert) {
       assert.expect(12);

--- a/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/verification-preview-test.js
@@ -1,7 +1,6 @@
 /*eslint camelcase: 0 */
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/curriculum-inventory/
 
 module('Integration | Component | curriculum-inventory/verification-preview', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/dashboard-loading-test.js
+++ b/packages/frontend/tests/integration/components/dashboard-loading-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | dashboard loading', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<DashboardLoading />`);

--- a/packages/frontend/tests/integration/components/error-display-test.js
+++ b/packages/frontend/tests/integration/components/error-display-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | error display', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('the detail link toggles properly', async function (assert) {
     assert.expect(3);

--- a/packages/frontend/tests/integration/components/flash-messages-test.js
+++ b/packages/frontend/tests/integration/components/flash-messages-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/flash-messages';
 
 module('Integration | Component | flash-messages', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   // @link https://github.com/poteto/ember-cli-flash#acceptance--integration-tests
   hooks.beforeEach(function () {

--- a/packages/frontend/tests/integration/components/global-search-box-test.js
+++ b/packages/frontend/tests/integration/components/global-search-box-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/global-search-box';
@@ -9,7 +8,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | global search box', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/frontend/tests/integration/components/global-search-tags-test.js
+++ b/packages/frontend/tests/integration/components/global-search-tags-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/global-search-tags';
@@ -8,7 +7,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | global-search-tags', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders and is accessible', async function (assert) {
     this.set('tags', ['terms', 'meshdescriptors', 'id', 'learningmaterials']);

--- a/packages/frontend/tests/integration/components/global-search-test.js
+++ b/packages/frontend/tests/integration/components/global-search-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/global-search';
@@ -8,7 +7,6 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | global-search', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/ilios-header-test.js
+++ b/packages/frontend/tests/integration/components/ilios-header-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | ilios-header', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks); //even though we're not using mirage directly we need to ensure that /config API is owned
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/frontend/tests/integration/components/ilios-navigation-test.js
+++ b/packages/frontend/tests/integration/components/ilios-navigation-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/ilios-navigation';
 
 module('Integration | Component | ilios-navigation', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders for privileged user', async function (assert) {
     const currentUserMock = Service.extend({

--- a/packages/frontend/tests/integration/components/ilios-users-test.js
+++ b/packages/frontend/tests/integration/components/ilios-users-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/ilios-users';
 
 module('Integration | Component | ilios users', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/instructor-group/courses-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/courses-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/instructor-group/cour
 
 module('Integration | Component | instructor-group/courses', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders with single course year if calendar year boundary IS NOT crossed', async function (assert) {

--- a/packages/frontend/tests/integration/components/instructor-group/header-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/header-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/instructor-group/head
 
 module('Integration | Component | instructor-group/header', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/instructor-group/instructor-manager-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/instructor-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/instructor-group/inst
 
 module('Integration | Component | instructor-group/instructor-manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/instructor-group/root-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/root-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/instructor-group/root
 
 module('Integration | Component | instructor-group/root', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/instructor-group/users-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/users-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/instructor-group/user
 
 module('Integration | Component | instructor-group/users', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/instructor-groups/list-item-test.js
+++ b/packages/frontend/tests/integration/components/instructor-groups/list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | instructor-groups/list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/instructor-groups/list-test.js
+++ b/packages/frontend/tests/integration/components/instructor-groups/list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | instructor-groups/list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/instructor-groups/loading-test.js
+++ b/packages/frontend/tests/integration/components/instructor-groups/loading-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | instructor-groups/loading', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<InstructorGroups::Loading @count={{4}} />`);

--- a/packages/frontend/tests/integration/components/instructor-groups/new-test.js
+++ b/packages/frontend/tests/integration/components/instructor-groups/new-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/instructor-groups/new
 
 module('Integration | Component | instructor-groups/new', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<InstructorGroups::New

--- a/packages/frontend/tests/integration/components/instructor-groups/root-test.js
+++ b/packages/frontend/tests/integration/components/instructor-groups/root-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | instructor-groups/root', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/learner-group/calendar-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/calendar-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { DateTime } from 'luxon';
 
 module('Integration | Component | learner-group/calendar', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/learner-group/cohort-user-manager-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/cohort-user-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/learner-group/cohort-
 
 module('Integration | Component | learner-group/cohort-user-manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/learner-group/header-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/header-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | learner-group/header', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/learner-group/instructor-group-members-list-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/instructor-group-members-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/learner-group/instruc
 
 module('Integration | Component | learner-group/instructor-group-members-list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/learner-group/instructor-manager-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/instructor-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/learner-group/instruc
 
 module('Integration | Component | learner-group/instructor-manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/learner-group/list-item-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | learner-group/list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/learner-group/list-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | learner-group/list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/learner-group/members-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/members-test.js
@@ -1,7 +1,6 @@
 import ObjectProxy from '@ember/object/proxy';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/learner-group/members
 
 module('Integration | Component | learner-group/members', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/learner-group/new-multiple-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/new-multiple-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/learner-group/new-mul
 
 module('Integration | Component | learner-group/new-multiple', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<LearnerGroup::NewMultiple

--- a/packages/frontend/tests/integration/components/learner-group/new-single-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/new-single-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/learner-group/new-sin
 
 module('Integration | Component | learner-group/new-single', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders without fill mode', async function (assert) {
     await render(hbs`<LearnerGroup::NewSingle

--- a/packages/frontend/tests/integration/components/learner-group/new-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/new-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/learner-group/new';
 
 module('Integration | Component | learner-group/new', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<LearnerGroup::New

--- a/packages/frontend/tests/integration/components/learner-group/root-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/root-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/learner-group/root';
 
 module('Integration | Component | learner-group/root', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/learner-group/user-manager-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/user-manager-test.js
@@ -1,7 +1,6 @@
 import ObjectProxy from '@ember/object/proxy';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/learner-group/user-ma
 
 module('Integration | Component | learner-group/user-manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders when editing', async function (assert) {

--- a/packages/frontend/tests/integration/components/learner-groups/root-test.js
+++ b/packages/frontend/tests/integration/components/learner-groups/root-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | learner-groups/root', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/link-to-with-action-test.js
+++ b/packages/frontend/tests/integration/components/link-to-with-action-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/link-to-with-action';
 
 module('Integration | Component | link-to-with-action', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('content', 'Link Text');

--- a/packages/frontend/tests/integration/components/locale-chooser-test.js
+++ b/packages/frontend/tests/integration/components/locale-chooser-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import component from 'frontend/tests/pages/components/locale-chooser';
@@ -8,7 +7,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | locale-chooser', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders and is accessible', async function (assert) {
     await render(hbs`<LocaleChooser />`);

--- a/packages/frontend/tests/integration/components/login-form-test.js
+++ b/packages/frontend/tests/integration/components/login-form-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/login-form';
 
 module('Integration | Component | login-form', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<LoginForm />`);

--- a/packages/frontend/tests/integration/components/manage-users-summary-test.js
+++ b/packages/frontend/tests/integration/components/manage-users-summary-test.js
@@ -1,13 +1,11 @@
 import { module, skip, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, findAll, find, fillIn, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
 module('Integration | Component | manage users summary', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(async function () {
     const iliosConfig = class extends Service {

--- a/packages/frontend/tests/integration/components/my-profile-test.js
+++ b/packages/frontend/tests/integration/components/my-profile-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime, Duration } from 'luxon';
@@ -10,7 +9,6 @@ import { component } from 'frontend/tests/pages/components/my-profile';
 
 module('Integration | Component | my profile', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/new-competency-test.js
+++ b/packages/frontend/tests/integration/components/new-competency-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/new-competency';
 
 module('Integration | Component | new competency', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('save', async function (assert) {
     assert.expect(1);

--- a/packages/frontend/tests/integration/components/new-directory-user-test.js
+++ b/packages/frontend/tests/integration/components/new-directory-user-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -10,7 +9,6 @@ import { component } from 'frontend/tests/pages/components/new-directory-user';
 
 module('Integration | Component | new directory user', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/new-user-test.js
+++ b/packages/frontend/tests/integration/components/new-user-test.js
@@ -1,8 +1,7 @@
 import Service from '@ember/service';
 import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -11,7 +10,6 @@ import { component } from 'frontend/tests/pages/components/new-user';
 
 module('Integration | Component | new user', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/pagination-links-test.js
+++ b/packages/frontend/tests/integration/components/pagination-links-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/pagination-links';
 
 module('Integration | Component | pagination-links', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it displays pagination links properly', async function (assert) {
     assert.expect(64);

--- a/packages/frontend/tests/integration/components/pending-single-user-update-test.js
+++ b/packages/frontend/tests/integration/components/pending-single-user-update-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | pending single user update', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders missing from directory', async function (assert) {

--- a/packages/frontend/tests/integration/components/pending-updates-summary-test.js
+++ b/packages/frontend/tests/integration/components/pending-updates-summary-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | pending updates summary', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders with updates', async function (assert) {

--- a/packages/frontend/tests/integration/components/program-year/collapsed-objectives-test.js
+++ b/packages/frontend/tests/integration/components/program-year/collapsed-objectives-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/program-year/collapsed-objectives';
@@ -8,7 +7,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | program-year/collapsed-objectives', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/program-year/competencies-test.js
+++ b/packages/frontend/tests/integration/components/program-year/competencies-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/program-year/competen
 
 module('Integration | Component | program-year/competencies', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/program-year/competency-list-item-test.js
+++ b/packages/frontend/tests/integration/components/program-year/competency-list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/program-year/competen
 
 module('Integration | Component | program-year/competency-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/program-year/courses-test.js
+++ b/packages/frontend/tests/integration/components/program-year/courses-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/program-year/courses'
 
 module('Integration | Component | program-year/courses', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/program-year/header-test.js
+++ b/packages/frontend/tests/integration/components/program-year/header-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/program-year/header';
 
 module('Integration | Component | program-year/header', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/program-year/list-item-test.js
+++ b/packages/frontend/tests/integration/components/program-year/list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/program-year/list-ite
 
 module('Integration | Component | program-year/list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/program-year/list-test.js
+++ b/packages/frontend/tests/integration/components/program-year/list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -10,7 +9,6 @@ import { component } from 'frontend/tests/pages/components/program-year/list';
 
 module('Integration | Component | program-year/list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/program-year/manage-objective-competency-test.js
+++ b/packages/frontend/tests/integration/components/program-year/manage-objective-competency-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/program-year/manage-objective-competency';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | program-year/manage-objective-competency', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/program-year/manage-objective-descriptors-test.js
+++ b/packages/frontend/tests/integration/components/program-year/manage-objective-descriptors-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/program-year/manage-o
 
 module('Integration | Component | program-year/manage-objective-descriptors', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/program-year/managed-competency-list-item-test.js
+++ b/packages/frontend/tests/integration/components/program-year/managed-competency-list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/program-year/managed-
 
 module('Integration | Component | program-year/managed-competency-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/program-year/new-test.js
+++ b/packages/frontend/tests/integration/components/program-year/new-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import { component } from 'frontend/tests/pages/components/program-year/new';
 
 module('Integration | Component | program-year/new', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     this.currentYear = new Date().getFullYear();

--- a/packages/frontend/tests/integration/components/program-year/objective-list-item-competency-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-item-competency-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | program-year/objective-list-item-competency', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible when managing', async function (assert) {

--- a/packages/frontend/tests/integration/components/program-year/objective-list-item-descriptors-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-item-descriptors-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | program-year/objective-list-item-descriptors', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible when managing', async function (assert) {

--- a/packages/frontend/tests/integration/components/program-year/objective-list-item-expanded-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-item-expanded-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/program-year/objective-list-item-expanded';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | program-year/objective-list-item-expanded', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/frontend/tests/integration/components/program-year/objective-list-item-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/program-year/objective-list-item';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | program-year/objective-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/program-year/objective-list-loading-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-loading-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | program-year/objective-list-loading', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<ProgramYear::ObjectiveListLoading @count={{9}} />`);

--- a/packages/frontend/tests/integration/components/program-year/objective-list-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/program-year/objective-list';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | program-year/objective-list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/frontend/tests/integration/components/program-year/objectives-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objectives-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/program-year/objectives';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | program-year/objectives', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/frontend/tests/integration/components/program-year/overview-test.js
+++ b/packages/frontend/tests/integration/components/program-year/overview-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -10,7 +9,6 @@ import { enableFeature } from 'ember-feature-flags/test-support';
 
 module('Integration | Component | program-year/overview', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/program-year/visualize-objectives-test.js
+++ b/packages/frontend/tests/integration/components/program-year/visualize-objectives-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | program-year/visualize-objectives', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/program/header-test.js
+++ b/packages/frontend/tests/integration/components/program/header-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/program/header';
 
 module('Integration | Component | program/header', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/program/new-test.js
+++ b/packages/frontend/tests/integration/components/program/new-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/program/new';
 
 module('Integration | Component | program/new', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<Program::New @save={{(noop)}} @cancel={{(noop)}} />`);

--- a/packages/frontend/tests/integration/components/programs/list-item-test.js
+++ b/packages/frontend/tests/integration/components/programs/list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/programs/list-item';
 
 module('Integration | Component | programs/list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/programs/list-test.js
+++ b/packages/frontend/tests/integration/components/programs/list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/programs/list';
 
 module('Integration | Component | programs/list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/programs/root-test.js
+++ b/packages/frontend/tests/integration/components/programs/root-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/programs/root';
 
 module('Integration | Component | programs/root', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/reports/list-loading-test.js
+++ b/packages/frontend/tests/integration/components/reports/list-loading-test.js
@@ -2,11 +2,9 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/list-loading', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<Reports::ListLoading @count={{2}} />`);

--- a/packages/frontend/tests/integration/components/reports/list-test.js
+++ b/packages/frontend/tests/integration/components/reports/list-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupAuthentication } from 'ilios-common';
 import { component } from 'frontend/tests/pages/components/reports/list';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | reports/list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/reports/new-subject-test.js
+++ b/packages/frontend/tests/integration/components/reports/new-subject-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/reports/new-subject';
 
 module('Integration | Component | reports/new-subject', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   const checkObjects = async function (context, assert, subjectNum, subjectVal, expectedObjects) {

--- a/packages/frontend/tests/integration/components/reports/root-test.js
+++ b/packages/frontend/tests/integration/components/reports/root-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupAuthentication } from 'ilios-common';
 import { component } from 'frontend/tests/pages/components/reports/root';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | reports/root', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/reports/subject-results-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject-results-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { component } from 'frontend/tests/pages/components/reports/results';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 module('Integration | Component | reports/subject-results', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(async function () {
     this.server.create('course');

--- a/packages/frontend/tests/integration/components/reports/subject-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/reports/subject';
 
 module('Integration | Component | reports/subject', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/reports/subject/competency-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/competency-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/competency';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/competency', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {

--- a/packages/frontend/tests/integration/components/reports/subject/instructor-group-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/instructor-group-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/instructor-group';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/instructor-group', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {

--- a/packages/frontend/tests/integration/components/reports/subject/instructor-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/instructor-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/instructor';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/instructor', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {

--- a/packages/frontend/tests/integration/components/reports/subject/learning-material-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/learning-material-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/learning-material';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/learning-material', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {

--- a/packages/frontend/tests/integration/components/reports/subject/mesh-term-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/mesh-term-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/mesh-term';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/mesh-term', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {

--- a/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/academic-year';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/academic-year', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     this.server.create('academicYear', {

--- a/packages/frontend/tests/integration/components/reports/subject/new/competency-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/competency-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/competency';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/competency', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     const [school1, school2] = this.server.createList('school', 2);

--- a/packages/frontend/tests/integration/components/reports/subject/new/course-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/course-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/course';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/course', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     this.server.create('academicYear', { id: 2022 });

--- a/packages/frontend/tests/integration/components/reports/subject/new/instructor-group-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/instructor-group-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/instructor-group';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/instructor-group', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     const [school1, school2] = this.server.createList('school', 2);

--- a/packages/frontend/tests/integration/components/reports/subject/new/instructor-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/instructor-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/instructor';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/instructor', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     this.server.createList('user', 5, { school: this.server.create('school') });

--- a/packages/frontend/tests/integration/components/reports/subject/new/learning-material-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/learning-material-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/learning-material';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/learning-material', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     this.server.createList('learning-material', 5);

--- a/packages/frontend/tests/integration/components/reports/subject/new/mesh-term-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/mesh-term-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/mesh-term';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/mesh-term', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     this.server.createList('mesh-descriptor', 5);

--- a/packages/frontend/tests/integration/components/reports/subject/new/program-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/program-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/program';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/program', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     const [school1, school2] = this.server.createList('school', 2);

--- a/packages/frontend/tests/integration/components/reports/subject/new/program-year-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/program-year-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/program-year';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/program-year', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     const [school1, school2] = this.server.createList('school', 2);

--- a/packages/frontend/tests/integration/components/reports/subject/new/search/input-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/search/input-test.js
@@ -4,11 +4,9 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/search/input';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/search/input', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test('it renders and is accessible', async function (assert) {
     await render(hbs`<Reports::Subject::New::Search::Input />`);

--- a/packages/frontend/tests/integration/components/reports/subject/new/session-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/session-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/session';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/session', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     this.server.create('academicYear', { id: 2027 });

--- a/packages/frontend/tests/integration/components/reports/subject/new/session-type-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/session-type-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/session-type';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/session-type', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     const [school1, school2] = this.server.createList('school', 2);

--- a/packages/frontend/tests/integration/components/reports/subject/new/term-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/term-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/new/term';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/new/term', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     const [school1, school2] = this.server.createList('school', 2);

--- a/packages/frontend/tests/integration/components/reports/subject/session-type-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/session-type-test.js
@@ -4,12 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/reports/subject/session-type';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | reports/subject/session-type', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   const responseData = {
     data: {

--- a/packages/frontend/tests/integration/components/reports/table-row-test.js
+++ b/packages/frontend/tests/integration/components/reports/table-row-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupAuthentication } from 'ilios-common';
 import { component } from 'frontend/tests/pages/components/reports/table-row';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | reports/table-row', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/reports/table-test.js
+++ b/packages/frontend/tests/integration/components/reports/table-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupAuthentication } from 'ilios-common';
 import { component } from 'frontend/tests/pages/components/reports/table';
@@ -10,7 +9,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | reports/table', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/school-competencies-collapsed-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-collapsed-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-competencies-c
 
 module('Integration | Component | school competencies collapsed', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-competencies-expanded-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-expanded-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/school-competencies-e
 
 module('Integration | Component | school competencies expanded', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-competencies-list-item-pcrs-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-list-item-pcrs-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/school-competencies-l
 
 module('Integration | Component | school-competencies-list-item-pcrs', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/school-competencies-list-item-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/school-competencies-l
 
 module('Integration | Component | school-competencies-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/school-competencies-list-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/school-competencies-l
 
 module('Integration | Component | school competencies list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-competencies-manager-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-competencies-m
 
 module('Integration | Component | school competencies manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-competencies-pcrs-mapper-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-pcrs-mapper-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/school-competencies-p
 
 module('Integration | Component | school-competencies-pcrs-mapper', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/school-curriculum-inventory-institution-details-test.js
+++ b/packages/frontend/tests/integration/components/school-curriculum-inventory-institution-details-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -10,7 +9,6 @@ module(
   'Integration | Component | school-curriculum-inventory-institution-details',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
     setupMirage(hooks);
 
     test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-curriculum-inventory-institution-manager-test.js
+++ b/packages/frontend/tests/integration/components/school-curriculum-inventory-institution-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -10,7 +9,6 @@ module(
   'Integration | Component | school-curriculum-inventory-institution-manager',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, 'en-us');
     setupMirage(hooks);
 
     test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-list-test.js
+++ b/packages/frontend/tests/integration/components/school-list-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/school-list';
 
 module('Integration | Component | school list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/school-manager-test.js
+++ b/packages/frontend/tests/integration/components/school-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-manager';
 
 module('Integration | Component | school manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/school-new-vocabulary-form-test.js
+++ b/packages/frontend/tests/integration/components/school-new-vocabulary-form-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/school-new-vocabulary-form';
@@ -9,7 +8,6 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | school-new-vocabulary-form', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/school-session-attributes-collapsed-test.js
+++ b/packages/frontend/tests/integration/components/school-session-attributes-collapsed-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/school-session-attributes-collapsed';
 
 module('Integration | Component | school session attributes collapsed', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('showSessionAttendanceRequired', false);

--- a/packages/frontend/tests/integration/components/school-session-attributes-expanded-test.js
+++ b/packages/frontend/tests/integration/components/school-session-attributes-expanded-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/school-session-attributes-expanded';
 
 module('Integration | Component | school session attributes expanded', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('showSessionAttendanceRequired', false);

--- a/packages/frontend/tests/integration/components/school-session-attributes-manager-test.js
+++ b/packages/frontend/tests/integration/components/school-session-attributes-manager-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/school-session-attributes-manager';
 
 module('Integration | Component | school session attributes manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('showSessionAttendanceRequired', false);

--- a/packages/frontend/tests/integration/components/school-session-attributes-test.js
+++ b/packages/frontend/tests/integration/components/school-session-attributes-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-session-attrib
 
 module('Integration | Component | school session attributes', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders collapsed', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-session-type-form-test.js
+++ b/packages/frontend/tests/integration/components/school-session-type-form-test.js
@@ -1,6 +1,5 @@
 import { module, skip, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-session-type-f
 
 module('Integration | Component | school session type form', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-session-type-manager-test.js
+++ b/packages/frontend/tests/integration/components/school-session-type-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-session-type-m
 
 module('Integration | Component | school session type manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/frontend/tests/integration/components/school-session-types-collapsed-test.js
+++ b/packages/frontend/tests/integration/components/school-session-types-collapsed-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-session-types-
 
 module('Integration | Component | school session types collapsed', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-session-types-expanded-test.js
+++ b/packages/frontend/tests/integration/components/school-session-types-expanded-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-session-types-
 
 module('Integration | Component | school session types expanded', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/school-session-types-list-item-test.js
+++ b/packages/frontend/tests/integration/components/school-session-types-list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-session-types-
 
 module('Integration | Component | school-session-types-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-session-types-list-test.js
+++ b/packages/frontend/tests/integration/components/school-session-types-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-session-types-
 
 module('Integration | Component | school session types list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-vocabularies-collapsed-test.js
+++ b/packages/frontend/tests/integration/components/school-vocabularies-collapsed-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-vocabularies-c
 
 module('Integration | Component | school vocabularies collapsed', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-vocabularies-expanded-test.js
+++ b/packages/frontend/tests/integration/components/school-vocabularies-expanded-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-vocabularies-e
 
 module('Integration | Component | school vocabularies expanded', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-vocabularies-list-test.js
+++ b/packages/frontend/tests/integration/components/school-vocabularies-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-vocabularies-l
 
 module('Integration | Component | school vocabularies list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-vocabulary-manager-test.js
+++ b/packages/frontend/tests/integration/components/school-vocabulary-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/school-vocabulary-manager';
@@ -8,7 +7,6 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | school vocabulary manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-vocabulary-new-term-test.js
+++ b/packages/frontend/tests/integration/components/school-vocabulary-new-term-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/school-vocabulary-new-term';
@@ -8,7 +7,6 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | school vocabulary new term', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('add term', async function (assert) {

--- a/packages/frontend/tests/integration/components/school-vocabulary-term-manager-test.js
+++ b/packages/frontend/tests/integration/components/school-vocabulary-term-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school-vocabulary-ter
 
 module('Integration | Component | school vocabulary term manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school/emails-editor-test.js
+++ b/packages/frontend/tests/integration/components/school/emails-editor-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school/emails-editor'
 
 module('Integration | Component | school/emails-editor', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school/emails-test.js
+++ b/packages/frontend/tests/integration/components/school/emails-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school/emails';
 
 module('Integration | Component | school/emails', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school/session-type-visualize-vocabularies-test.js
+++ b/packages/frontend/tests/integration/components/school/session-type-visualize-vocabularies-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school/session-type-v
 
 module('Integration | Component | school/session-type-visualize-vocabularies', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/school/session-type-visualize-vocabulary-test.js
+++ b/packages/frontend/tests/integration/components/school/session-type-visualize-vocabulary-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school/session-type-v
 
 module('Integration | Component | school/session-type-visualize-vocabulary', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/school/visualizer-session-type-vocabularies-test.js
+++ b/packages/frontend/tests/integration/components/school/visualizer-session-type-vocabularies-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school/visualizer-ses
 
 module('Integration | Component | school/visualizer-session-type-vocabularies', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/school/visualizer-session-type-vocabulary-test.js
+++ b/packages/frontend/tests/integration/components/school/visualizer-session-type-vocabulary-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/school/visualizer-ses
 
 module('Integration | Component | school/visualizer-session-type-vocabulary', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/unassigned-students-summary-test.js
+++ b/packages/frontend/tests/integration/components/unassigned-students-summary-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/unassigned-students-s
 
 module('Integration | Component | unassigned students summary', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/update-notification-test.js
+++ b/packages/frontend/tests/integration/components/update-notification-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import Service from '@ember/service';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | update notification', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders when new version is available', async function (assert) {
     class NewVersionServiceMock extends Service {

--- a/packages/frontend/tests/integration/components/user-list-test.js
+++ b/packages/frontend/tests/integration/components/user-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/user-list';
@@ -8,7 +7,6 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | user list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/user-menu-test.js
+++ b/packages/frontend/tests/integration/components/user-menu-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import component from 'frontend/tests/pages/components/user-menu';
@@ -10,7 +9,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | user-menu', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/user-profile-bio-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-bio-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/user-profile-bio';
 
 module('Integration | Component | user profile bio', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   const setupApplicationConfig = function (userSearchType, context) {

--- a/packages/frontend/tests/integration/components/user-profile-calendar-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-calendar-test.js
@@ -1,8 +1,7 @@
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -10,7 +9,6 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | user profile calendar', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/frontend/tests/integration/components/user-profile-cohorts-details-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-cohorts-details-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/user-profile-cohorts-
 
 module('Integration | Component | user-profile-cohorts-details', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/user-profile-cohorts-manager-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-cohorts-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/user-profile-cohorts-
 
 module('Integration | Component | user-profile-cohorts-manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/user-profile-cohorts-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-cohorts-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/user-profile-cohorts'
 
 module('Integration | Component | user profile cohorts', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/user-profile-ics-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-ics-test.js
@@ -1,6 +1,5 @@
 import { module, test, skip } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, waitUntil } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/user-profile-ics';
 
 module('Integration | Component | user profile ics', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/frontend/tests/integration/components/user-profile-permissions-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-permissions-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -11,7 +10,6 @@ import a11yAudit from 'ember-a11y-testing/test-support/audit';
 
 module('Integration | Component | user-profile-permissions', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/user-profile-roles-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-roles-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +7,6 @@ import { component } from 'frontend/tests/pages/components/user-profile-roles';
 
 module('Integration | Component | user profile roles', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/user-profile-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'frontend/tests/pages/components/user-profile';
 
 module('Integration | Component | user-profile', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/frontend/tests/integration/components/user-profile/learner-group-test.js
+++ b/packages/frontend/tests/integration/components/user-profile/learner-group-test.js
@@ -2,12 +2,10 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | user-profile/learner-group', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/user-profile/learner-groups-test.js
+++ b/packages/frontend/tests/integration/components/user-profile/learner-groups-test.js
@@ -2,13 +2,11 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { component } from 'frontend/tests/pages/components/user-profile/learner-groups';
 
 module('Integration | Component | user-profile/learner-groups', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/visualizer-program-year-objectives-test.js
+++ b/packages/frontend/tests/integration/components/visualizer-program-year-objectives-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Integration | Component | visualizer-program-year-objectives', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/yes-no-test.js
+++ b/packages/frontend/tests/integration/components/yes-no-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'frontend/tests/pages/components/yes-no';
 
 module('Integration | Component | yes-no', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders yes', async function (assert) {
     await render(hbs`<YesNo @value={{true}} />`);

--- a/packages/frontend/tests/integration/helpers/pcrs-uri-to-number-test.js
+++ b/packages/frontend/tests/integration/helpers/pcrs-uri-to-number-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { setupIntl } from 'ember-intl/test-support';
+import { setupRenderingTest } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | pcrs-uri-to-number', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('inputValue', 'aamc-pcrs-comp-c0103');

--- a/packages/frontend/tests/unit/services/reporting-test.js
+++ b/packages/frontend/tests/unit/services/reporting-test.js
@@ -5,7 +5,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Unit | Service | reporting', function (hooks) {
   setupTest(hooks);
-  setupIntl(hooks);
+  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/test-app/tests/helpers/index.js
+++ b/packages/test-app/tests/helpers/index.js
@@ -23,13 +23,13 @@ function setupApplicationTest(hooks, options) {
   //
   // This is also a good place to call test setup functions coming
   // from other addons:
-  //
   setupIntl(hooks, 'en-us'); // ember-intl
   setupMirage(hooks); // ember-cli-mirage
 }
 
 function setupRenderingTest(hooks, options) {
-  upstreamSetupRenderingTest(hooks, options);
+  upstreamSetupRenderingTest(hooks, options); // ember-intl
+  setupIntl(hooks, 'en-us'); // ember-intl
 
   // Additional setup for rendering tests can be done here.
 }

--- a/packages/test-app/tests/integration/components/api-version-notice-test.js
+++ b/packages/test-app/tests/integration/components/api-version-notice-test.js
@@ -1,14 +1,12 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/api-version-notice';
 
 module('Integration | Component | api-version-notice', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('hidden when version match', async function (assert) {
     const apiVersionMock = Service.extend({

--- a/packages/test-app/tests/integration/components/back-link-test.js
+++ b/packages/test-app/tests/integration/components/back-link-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/back-link';
 
 module('Integration | Component | back link', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<BackLink />`);

--- a/packages/test-app/tests/integration/components/choose-material-type-test.js
+++ b/packages/test-app/tests/integration/components/choose-material-type-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/choose-material-type';
@@ -8,7 +7,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | choose-material-type', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders and is accessible', async function (assert) {
     this.set('nothing', () => {});

--- a/packages/test-app/tests/integration/components/click-choice-button-test.js
+++ b/packages/test-app/tests/integration/components/click-choice-button-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/click-choice-buttons';
@@ -8,7 +7,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | click choice buttons', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<ClickChoiceButtons

--- a/packages/test-app/tests/integration/components/collapsed-competencies-test.js
+++ b/packages/test-app/tests/integration/components/collapsed-competencies-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/collapsed-compet
 
 module('Integration | Component | collapsed competencies', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/collapsed-taxonomies-test.js
+++ b/packages/test-app/tests/integration/components/collapsed-taxonomies-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/collapsed-taxono
 
 module('Integration | Component | collapsed taxonomies', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/course-header-test.js
+++ b/packages/test-app/tests/integration/components/course-header-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course-header', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/test-app/tests/integration/components/course-materials-test.js
+++ b/packages/test-app/tests/integration/components/course-materials-test.js
@@ -1,14 +1,12 @@
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { component } from 'ilios-common/page-objects/components/course-materials';
 
 module('Integration | Component | course materials', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('course lms render', async function (assert) {

--- a/packages/test-app/tests/integration/components/course-overview-test.js
+++ b/packages/test-app/tests/integration/components/course-overview-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { component } from 'ilios-common/page-objects/components/course-overview'
 
 module('Integration | Component | course overview', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/test-app/tests/integration/components/course-publicationcheck-test.js
+++ b/packages/test-app/tests/integration/components/course-publicationcheck-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/course-publicati
 
 module('Integration | Component | course-publicationcheck', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it shows unlink icon', async function (assert) {

--- a/packages/test-app/tests/integration/components/course-rollover-test.js
+++ b/packages/test-app/tests/integration/components/course-rollover-test.js
@@ -3,7 +3,6 @@ import { resolve } from 'rsvp';
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, click, find, findAll, fillIn, blur as emberBlur } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -12,7 +11,6 @@ import queryString from 'query-string';
 
 module('Integration | Component | course rollover', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/course-sessions-test.js
+++ b/packages/test-app/tests/integration/components/course-sessions-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'ilios-common/page-objects/components/course-sessions'
 
 module('Integration | Component | course sessions', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/course-summary-header-test.js
+++ b/packages/test-app/tests/integration/components/course-summary-header-test.js
@@ -1,14 +1,12 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course summary header', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/test-app/tests/integration/components/course-visualizations-test.js
+++ b/packages/test-app/tests/integration/components/course-visualizations-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/course-visualiza
 
 module('Integration | Component | course-visualizations', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/course-visualize-instructor-test.js
+++ b/packages/test-app/tests/integration/components/course-visualize-instructor-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { component } from 'ilios-common/page-objects/components/course-visualize
 
 module('Integration | Component | course-visualize-instructor', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/course-visualize-instructors-test.js
+++ b/packages/test-app/tests/integration/components/course-visualize-instructors-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/course-visualize
 
 module('Integration | Component | course-visualize-instructors', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/course-visualize-objectives-test.js
+++ b/packages/test-app/tests/integration/components/course-visualize-objectives-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/course-visualize
 
 module('Integration | Component | course-visualize-objectives', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/course-visualize-session-type-test.js
+++ b/packages/test-app/tests/integration/components/course-visualize-session-type-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/course-visualize
 
 module('Integration | Component | course-visualize-session-type', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/course-visualize-session-types-test.js
+++ b/packages/test-app/tests/integration/components/course-visualize-session-types-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/course-visualize
 
 module('Integration | Component | course-visualize-session-types', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/course-visualize-term-test.js
+++ b/packages/test-app/tests/integration/components/course-visualize-term-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/course-visualize
 
 module('Integration | Component | course-visualize-term', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/course-visualize-vocabularies-test.js
+++ b/packages/test-app/tests/integration/components/course-visualize-vocabularies-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/course-visualize
 
 module('Integration | Component | course-visualize-vocabularies', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/course-visualize-vocabulary-test.js
+++ b/packages/test-app/tests/integration/components/course-visualize-vocabulary-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/course-visualize
 
 module('Integration | Component | course-visualize-vocabulary', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/course/collapsed-objectives-test.js
+++ b/packages/test-app/tests/integration/components/course/collapsed-objectives-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/course/collapsed-objectives';
@@ -8,7 +7,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course/collapsed-objectives', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/course/loader-test.js
+++ b/packages/test-app/tests/integration/components/course/loader-test.js
@@ -3,14 +3,12 @@ import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { setupIntl } from 'ember-intl/test-support';
 import Service from '@ember/service';
 import { defer } from 'rsvp';
 
 module('Integration | Component | course/loader', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     assert.expect(3);

--- a/packages/test-app/tests/integration/components/course/loading-test.js
+++ b/packages/test-app/tests/integration/components/course/loading-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course/loading', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/manage-objective-descriptors-test.js
+++ b/packages/test-app/tests/integration/components/course/manage-objective-descriptors-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/course/manage-ob
 
 module('Integration | Component | course/manage-objective-descriptors', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/manage-objective-parents-item-test.js
+++ b/packages/test-app/tests/integration/components/course/manage-objective-parents-item-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | course/manage-objective-parents-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('isSelected', true);

--- a/packages/test-app/tests/integration/components/course/manage-objective-parents-test.js
+++ b/packages/test-app/tests/integration/components/course/manage-objective-parents-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/course/manage-objective-parents';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course/manage-objective-parents', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible with a single cohort', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/objective-list-item-descriptors-test.js
+++ b/packages/test-app/tests/integration/components/course/objective-list-item-descriptors-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course/objective-list-item-descriptors', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/course/objective-list-item-parents-test.js
+++ b/packages/test-app/tests/integration/components/course/objective-list-item-parents-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course/objective-list-item-parents', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/course/objective-list-item-test.js
+++ b/packages/test-app/tests/integration/components/course/objective-list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/course/objective-list-item';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course/objective-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/objective-list-loading-test.js
+++ b/packages/test-app/tests/integration/components/course/objective-list-loading-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | course/objective-list-loading', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<Course::ObjectiveListLoading @count={{9}} />

--- a/packages/test-app/tests/integration/components/course/objective-list-test.js
+++ b/packages/test-app/tests/integration/components/course/objective-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/course/objective-list';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course/objective-list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/objectives-test.js
+++ b/packages/test-app/tests/integration/components/course/objectives-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/course/objectives';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course/objectives', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible with a single cohort', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/publication-menu-test.js
+++ b/packages/test-app/tests/integration/components/course/publication-menu-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/course/publication-menu';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | course/publication-menu', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible for draft course', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/rollover-date-picker-test.js
+++ b/packages/test-app/tests/integration/components/course/rollover-date-picker-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { DateTime } from 'luxon';
 
 module('Integration | Component | course/rollover-date-picker', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/daily-calendar-event-test.js
+++ b/packages/test-app/tests/integration/components/daily-calendar-event-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { component } from 'ilios-common/page-objects/components/daily-calendar-e
 
 module('Integration | Component | daily-calendar-event', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   this.createEvent = function (startDate, endDate, lastModified, isScheduled, isPublished) {

--- a/packages/test-app/tests/integration/components/daily-calendar-test.js
+++ b/packages/test-app/tests/integration/components/daily-calendar-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { settled, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -10,7 +9,6 @@ import { component } from 'ilios-common/page-objects/components/daily-calendar';
 
 module('Integration | Component | daily-calendar', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   //reset locale for other tests

--- a/packages/test-app/tests/integration/components/dashboard/calendar-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/calendar-test.js
@@ -1,10 +1,8 @@
 import { module, skip } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | dashboard/calendar', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   skip('it renders', function () {
     //since the result of this component is to expose the calendar it is hard to test

--- a/packages/test-app/tests/integration/components/dashboard/cohort-calendar-filter-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/cohort-calendar-filter-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/dashboard/cohort-calendar-filter';
@@ -8,7 +7,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | dashboard/cohort-calendar-filter', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders and is accessible', async function (assert) {
     this.set('cohortProxies', [

--- a/packages/test-app/tests/integration/components/dashboard/courses-calendar-filter-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/courses-calendar-filter-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | dashboard/courses-calendar-filter', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/test-app/tests/integration/components/dashboard/filter-checkbox-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/filter-checkbox-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/dashboard/filter-checkbox';
 
 module('Integration | Component | dashboard/filter-checkbox', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders unchecked', async function (assert) {
     const id = '100';

--- a/packages/test-app/tests/integration/components/dashboard/filter-tags-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/filter-tags-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | dashboard/filter-tags', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/dashboard/material-list-item-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/material-list-item-test.js
@@ -1,8 +1,7 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { DateTime } from 'luxon';
 import { component } from 'ilios-common/page-objects/components/dashboard/material-list-item';
@@ -10,7 +9,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | dashboard/material-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders a material with no a11y errors', async function (assert) {

--- a/packages/test-app/tests/integration/components/dashboard/materials-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/materials-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -11,7 +10,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | dashboard/materials', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/test-app/tests/integration/components/dashboard/navigation.js
+++ b/packages/test-app/tests/integration/components/dashboard/navigation.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/dashboard/navigation';
@@ -8,7 +7,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | dashboard/navigation', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders and is accessible', async function (assert) {
     await render(hbs`<Dashboard::Navigation />

--- a/packages/test-app/tests/integration/components/dashboard/selected-term-tree-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/selected-term-tree-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/dashboard/select
 
 module('Integration | Component | dashboard/SelectedTermTree', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/dashboard/selected-vocabulary-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/selected-vocabulary-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/dashboard/select
 
 module('Integration | Component | dashboard/selected-vocabulary', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/dashboard/week-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/week-test.js
@@ -2,7 +2,6 @@ import Service from '@ember/service';
 import { DateTime } from 'luxon';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -11,7 +10,6 @@ import { freezeDateAt, unfreezeDate } from 'ilios-common';
 
 module('Integration | Component | dashboard/week', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   const today = DateTime.fromObject({ hour: 8 });

--- a/packages/test-app/tests/integration/components/date-picker-test.js
+++ b/packages/test-app/tests/integration/components/date-picker-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/date-picker';
@@ -8,7 +7,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | date-picker', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     const date = new Date(2020, 4, 6);

--- a/packages/test-app/tests/integration/components/detail-cohort-list-test.js
+++ b/packages/test-app/tests/integration/components/detail-cohort-list-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | detail cohort list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/detail-learnergroups-list-item-test.js
+++ b/packages/test-app/tests/integration/components/detail-learnergroups-list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/detail-learnergr
 
 module('Integration | Component | detail-learnergroups-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/detail-learnergroups-list-test.js
+++ b/packages/test-app/tests/integration/components/detail-learnergroups-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/detail-learnergr
 
 module('Integration | Component | detail-learnergroups-list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/detail-learners-and-learnergroups-test.js
+++ b/packages/test-app/tests/integration/components/detail-learners-and-learnergroups-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/detail-learners-
 
 module('Integration | Component | detail-learners-and-learner-groups', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/detail-learning-materials-item-test.js
+++ b/packages/test-app/tests/integration/components/detail-learning-materials-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/detail-learning-
 
 module('Integration | Component | detail-learning-materials-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/detail-learning-materials-test.js
+++ b/packages/test-app/tests/integration/components/detail-learning-materials-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/detail-learning-
 
 module('Integration | Component | detail learning materials', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/test-app/tests/integration/components/detail-terms-list-item-test.js
+++ b/packages/test-app/tests/integration/components/detail-terms-list-item-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, click, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | detail terms list item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/test-app/tests/integration/components/detail-terms-list-test.js
+++ b/packages/test-app/tests/integration/components/detail-terms-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/detail-terms-lis
 
 module('Integration | Component | detail terms list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('list with terms', async function (assert) {

--- a/packages/test-app/tests/integration/components/editable-field-test.js
+++ b/packages/test-app/tests/integration/components/editable-field-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, click, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | editable field', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders value', async function (assert) {
     await render(hbs`<EditableField @value="woot!" />

--- a/packages/test-app/tests/integration/components/event-not-found-test.js
+++ b/packages/test-app/tests/integration/components/event-not-found-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/event-not-found';
 
 module('Integration | Component | event-not-found', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<EventNotFound />`);

--- a/packages/test-app/tests/integration/components/expand-collapse-button-test.js
+++ b/packages/test-app/tests/integration/components/expand-collapse-button-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | expand collapse button', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('renders with default value false', async function (assert) {
     this.set('action', () => {});

--- a/packages/test-app/tests/integration/components/html-editor-test.js
+++ b/packages/test-app/tests/integration/components/html-editor-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | html editor', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<HtmlEditor />

--- a/packages/test-app/tests/integration/components/ics-feed-test.js
+++ b/packages/test-app/tests/integration/components/ics-feed-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/ics-feed';
 
 module('Integration | Component | ics feed', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it show instructions', async function (assert) {
     const instructions = 'SOME TEST INS';

--- a/packages/test-app/tests/integration/components/ilios-calendar-day-test.js
+++ b/packages/test-app/tests/integration/components/ilios-calendar-day-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/ilios-calendar-day';
@@ -8,7 +7,6 @@ import { DateTime } from 'luxon';
 
 module('Integration | Component | ilios calendar day', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     const september30th2015 = DateTime.fromObject({

--- a/packages/test-app/tests/integration/components/ilios-calendar-event-month-test.js
+++ b/packages/test-app/tests/integration/components/ilios-calendar-event-month-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -8,7 +7,6 @@ const s = '[data-test-ilios-calendar-event-month]';
 
 module('Integration | Component | ilios calendar event month', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     const november111984 = DateTime.fromObject({ year: 1984, month: 11, day: 11, hour: 8 });

--- a/packages/test-app/tests/integration/components/ilios-calendar-month-test.js
+++ b/packages/test-app/tests/integration/components/ilios-calendar-month-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/ilios-calendar-m
 
 module('Integration | Component | ilios calendar month', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('month displays with three events', async function (assert) {
     const date = DateTime.fromISO('2015-09-30T12:00:00');

--- a/packages/test-app/tests/integration/components/ilios-calendar-multiday-event-test.js
+++ b/packages/test-app/tests/integration/components/ilios-calendar-multiday-event-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { DateTime } from 'luxon';
 import { hbs } from 'ember-cli-htmlbars';
@@ -9,7 +8,6 @@ import { component } from 'ilios-common/page-objects/components/ilios-calendar-m
 
 module('Integration | Component | ilios calendar multiday event', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     this.ev = {

--- a/packages/test-app/tests/integration/components/ilios-calendar-multiday-events-test.js
+++ b/packages/test-app/tests/integration/components/ilios-calendar-multiday-events-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -9,7 +8,6 @@ import { component } from 'ilios-common/page-objects/components/ilios-calendar-m
 
 module('Integration | Component | ilios calendar multiday events', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     this.events = [

--- a/packages/test-app/tests/integration/components/ilios-calendar-test.js
+++ b/packages/test-app/tests/integration/components/ilios-calendar-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/ilios-calendar';
@@ -8,7 +7,6 @@ import { DateTime } from 'luxon';
 
 module('Integration | Component | ilios calendar', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders in day view mode', async function (assert) {
     const date = DateTime.fromObject({

--- a/packages/test-app/tests/integration/components/ilios-calendar-week-test.js
+++ b/packages/test-app/tests/integration/components/ilios-calendar-week-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/ilios-calendar-week';
@@ -8,7 +7,6 @@ import { DateTime } from 'luxon';
 
 module('Integration | Component | ilios calendar week', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     const date = DateTime.fromObject({

--- a/packages/test-app/tests/integration/components/instructor-selection-manager-test.js
+++ b/packages/test-app/tests/integration/components/instructor-selection-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/instructor-selection-manager';
@@ -8,7 +7,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | instructor selection manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/leadership-collapsed-test.js
+++ b/packages/test-app/tests/integration/components/leadership-collapsed-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/leadership-collapsed';
 
 module('Integration | Component | leadership collapsed', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('title', 'Test Title');

--- a/packages/test-app/tests/integration/components/leadership-expanded-test.js
+++ b/packages/test-app/tests/integration/components/leadership-expanded-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/leadership-expanded';
@@ -8,7 +7,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | leadership expanded', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   module('course', function () {

--- a/packages/test-app/tests/integration/components/leadership-list-test.js
+++ b/packages/test-app/tests/integration/components/leadership-list-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, find, findAll, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | leadership list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/leadership-manager-test.js
+++ b/packages/test-app/tests/integration/components/leadership-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/leadership-manag
 
 module('Integration | Component | leadership manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders with data', async function (assert) {

--- a/packages/test-app/tests/integration/components/leadership-search-test.js
+++ b/packages/test-app/tests/integration/components/leadership-search-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, find, click, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | leadership search', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/learner-selection-manager-test.js
+++ b/packages/test-app/tests/integration/components/learner-selection-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/learner-selection-manager';
@@ -8,7 +7,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | learner selection manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/learnergroup-selection-cohort-manager-test.js
+++ b/packages/test-app/tests/integration/components/learnergroup-selection-cohort-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/learnergroup-sel
 
 module('Integration | Component | learnergroup-selection-cohort-manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/learnergroup-selection-manager-test.js
+++ b/packages/test-app/tests/integration/components/learnergroup-selection-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/learnergroup-sel
 
 module('Integration | Component | learnergroup-selection-manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/learnergroup-tree-test.js
+++ b/packages/test-app/tests/integration/components/learnergroup-tree-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/learnergroup-tre
 
 module('Integration | Component | learnergroup-tree', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/learning-material-uploader-test.js
+++ b/packages/test-app/tests/integration/components/learning-material-uploader-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { uploadHandler } from 'ember-file-upload';
@@ -11,7 +10,6 @@ import { Response } from 'miragejs';
 
 module('Integration | Component | learning-material-uploader', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('upload file', async function (assert) {

--- a/packages/test-app/tests/integration/components/learning-materials-sort-manager-test.js
+++ b/packages/test-app/tests/integration/components/learning-materials-sort-manager-test.js
@@ -1,5 +1,4 @@
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, click, find } from '@ember/test-helpers';
 import { module, skip, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
@@ -8,7 +7,6 @@ import { capitalize } from '@ember/string';
 
 module('Integration | Component | learning materials sort manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/learningmaterial-search-test.js
+++ b/packages/test-app/tests/integration/components/learningmaterial-search-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/learningmaterial
 
 module('Integration | Component | learningmaterial search', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('search shows results', async function (assert) {

--- a/packages/test-app/tests/integration/components/lm-icons-test.js
+++ b/packages/test-app/tests/integration/components/lm-icons-test.js
@@ -2,13 +2,11 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import { component } from 'ilios-common/page-objects/components/lm-icons';
 import createTypedLearningMaterialProxy from 'ilios-common/utils/create-typed-learning-material-proxy';
 
 module('Integration | Component | lm-icons', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders optional', async function (assert) {
     this.set('lm', createTypedLearningMaterialProxy({ link: 'https://iliosproject.org' }));

--- a/packages/test-app/tests/integration/components/lm-type-icon-test.js
+++ b/packages/test-app/tests/integration/components/lm-type-icon-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/lm-type-icon';
@@ -8,7 +7,6 @@ import createTypedLearningMaterialProxy from 'ilios-common/utils/create-typed-le
 
 module('Integration | Component | lm type icon', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('link', async function (assert) {
     const lm = createTypedLearningMaterialProxy({ link: 'https://iliosproject.org' });

--- a/packages/test-app/tests/integration/components/loading-spinner-test.js
+++ b/packages/test-app/tests/integration/components/loading-spinner-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | loading-spinner', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<LoadingSpinner />

--- a/packages/test-app/tests/integration/components/mesh-descriptor-last-tree-number-test.js
+++ b/packages/test-app/tests/integration/components/mesh-descriptor-last-tree-number-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/mesh-descriptor-
 
 module('Integration | Component | mesh-descriptor-last-tree-number', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/mesh-manager-test.js
+++ b/packages/test-app/tests/integration/components/mesh-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/mesh-manager';
@@ -8,7 +7,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | mesh-manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/monthly-calendar-test.js
+++ b/packages/test-app/tests/integration/components/monthly-calendar-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -10,7 +9,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | monthly-calendar', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders empty and is accessible', async function (assert) {

--- a/packages/test-app/tests/integration/components/new-learningmaterial-test.js
+++ b/packages/test-app/tests/integration/components/new-learningmaterial-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupAuthentication } from 'ilios-common';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -10,7 +9,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 // @todo flesh this integration test out [ST 2020/09/02]
 module('Integration | Component | new learningmaterial', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/new-objective-test.js
+++ b/packages/test-app/tests/integration/components/new-objective-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | new objective', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('cancel', () => {});

--- a/packages/test-app/tests/integration/components/new-offering-test.js
+++ b/packages/test-app/tests/integration/components/new-offering-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | new offering', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('today', new Date());

--- a/packages/test-app/tests/integration/components/new-session-test.js
+++ b/packages/test-app/tests/integration/components/new-session-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/new-session';
 
 module('Integration | Component | new session', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/not-found-test.js
+++ b/packages/test-app/tests/integration/components/not-found-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/not-found';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/not-found';
 // @todo figure out how to suppress the dashboard route for testing purposes [ST 2021/11/04]
 module('Integration | Component | not-found', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it displays not found message', async function (assert) {
     await render(hbs`<NotFound />

--- a/packages/test-app/tests/integration/components/objective-list-item-terms-test.js
+++ b/packages/test-app/tests/integration/components/objective-list-item-terms-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | objective-list-item-terms', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/objective-sort-manager-test.js
+++ b/packages/test-app/tests/integration/components/objective-sort-manager-test.js
@@ -1,5 +1,4 @@
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, click, findAll } from '@ember/test-helpers';
 import { module, skip, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
@@ -7,7 +6,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | objective sort manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders for session', async function (assert) {

--- a/packages/test-app/tests/integration/components/offering-calendar-test.js
+++ b/packages/test-app/tests/integration/components/offering-calendar-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { DateTime } from 'luxon';
 
 module('Integration | Component | offering-calendar', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('shows events', async function (assert) {

--- a/packages/test-app/tests/integration/components/offering-form-test.js
+++ b/packages/test-app/tests/integration/components/offering-form-test.js
@@ -1,6 +1,5 @@
 import { module, test, todo } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -10,7 +9,6 @@ import { freezeDateAt, unfreezeDate } from 'ilios-common';
 
 module('Integration | Component | offering form', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/offering-url-display-test.js
+++ b/packages/test-app/tests/integration/components/offering-url-display-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | offering-url-display', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders URL', async function (assert) {
     await render(hbs`<OfferingUrlDisplay @url="https://example.edu" />

--- a/packages/test-app/tests/integration/components/pagedlist-controls-test.js
+++ b/packages/test-app/tests/integration/components/pagedlist-controls-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/pagedlist-controls';
 
 module('Integration | Component | pagedlist controls', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<PagedlistControls @limit={{10}} @offset={{11}} @total={{33}} />

--- a/packages/test-app/tests/integration/components/progress-bar-test.js
+++ b/packages/test-app/tests/integration/components/progress-bar-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | progress bar', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders at default 0%', async function (assert) {
     await render(hbs`<ProgressBar />

--- a/packages/test-app/tests/integration/components/publication-status-test.js
+++ b/packages/test-app/tests/integration/components/publication-status-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/publication-stat
 
 module('Integration | Component | publication-status', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders published and is accessible', async function (assert) {
     this.set('item', { isPublished: true, isScheduled: false });

--- a/packages/test-app/tests/integration/components/publish-all-sessions-test.js
+++ b/packages/test-app/tests/integration/components/publish-all-sessions-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/publish-all-sess
 
 module('Integration | Component | publish all sessions', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/pulse-loader-test.js
+++ b/packages/test-app/tests/integration/components/pulse-loader-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | pulse loader', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<PulseLoader />

--- a/packages/test-app/tests/integration/components/save-button-test.js
+++ b/packages/test-app/tests/integration/components/save-button-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | save-button', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('label', 'Save');

--- a/packages/test-app/tests/integration/components/search-box-test.js
+++ b/packages/test-app/tests/integration/components/search-box-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/search-box';
 
 module('Integration | Component | search box', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders and is accessible', async function (assert) {
     await render(hbs`<SearchBox />

--- a/packages/test-app/tests/integration/components/selectable-terms-list-item-test.js
+++ b/packages/test-app/tests/integration/components/selectable-terms-list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/selectable-terms
 
 module('Integration | Component | selectable terms list item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/selectable-terms-list-test.js
+++ b/packages/test-app/tests/integration/components/selectable-terms-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/selectable-terms
 
 module('Integration | Component | selectable terms list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/selected-instructor-group-members-test.js
+++ b/packages/test-app/tests/integration/components/selected-instructor-group-members-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/selected-instructor-group-members';
@@ -9,7 +8,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | selected-instructor-group-members', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/selected-instructor-groups-test.js
+++ b/packages/test-app/tests/integration/components/selected-instructor-groups-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/selected-instructor-groups';
@@ -9,7 +8,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | selected-instructor-groups', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/selected-instructors-test.js
+++ b/packages/test-app/tests/integration/components/selected-instructors-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/selected-instructors';
@@ -9,7 +8,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | selected-instructors', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/selected-learner-groups-test.js
+++ b/packages/test-app/tests/integration/components/selected-learner-groups-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | selected-learner-groups', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/selected-learners-test.js
+++ b/packages/test-app/tests/integration/components/selected-learners-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/selected-learners';
@@ -9,7 +8,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | selected-learners', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/session-copy-test.js
+++ b/packages/test-app/tests/integration/components/session-copy-test.js
@@ -1,7 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, click, find, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -10,7 +9,6 @@ import { findById } from 'ilios-common/utils/array-helpers';
 
 module('Integration | Component | session copy', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/session-offerings-time-block-offerings-test.js
+++ b/packages/test-app/tests/integration/components/session-offerings-time-block-offerings-test.js
@@ -2,13 +2,11 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import { OfferingTimeBlock } from 'ilios-common/utils/offering-date-block';
 import { component } from 'ilios-common/page-objects/components/session-offerings-time-block-offerings';
 
 module('Integration | Component | session-offerings-time-block-offerings', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     const store = this.owner.lookup('service:store');

--- a/packages/test-app/tests/integration/components/session-overview-ilm-duedate-test.js
+++ b/packages/test-app/tests/integration/components/session-overview-ilm-duedate-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | session-overview-ilm-duedate', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/session-publicationcheck-test.js
+++ b/packages/test-app/tests/integration/components/session-publicationcheck-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { component } from 'ilios-common/page-objects/components/session-publicat
 
 module('Integration | Component | session-publicationcheck', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it shows unlink icon', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/collapsed-objectives-test.js
+++ b/packages/test-app/tests/integration/components/session/collapsed-objectives-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/session/collapsed-objectives';
@@ -8,7 +7,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | session/collapsed-objectives', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/session/manage-objective-descriptors-test.js
+++ b/packages/test-app/tests/integration/components/session/manage-objective-descriptors-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/session/manage-o
 
 module('Integration | Component | session/manage-objective-descriptors', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/manage-objective-parents-item-test.js
+++ b/packages/test-app/tests/integration/components/session/manage-objective-parents-item-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | session/manage-objective-parents-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('isSelected', true);

--- a/packages/test-app/tests/integration/components/session/manage-objective-parents-test.js
+++ b/packages/test-app/tests/integration/components/session/manage-objective-parents-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/session/manage-objective-parents';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | session/manage-objective-parents', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/objective-list-item-descriptors-test.js
+++ b/packages/test-app/tests/integration/components/session/objective-list-item-descriptors-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | session/objective-list-item-descriptors', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/session/objective-list-item-parents-test.js
+++ b/packages/test-app/tests/integration/components/session/objective-list-item-parents-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | session/objective-list-item-parents', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/session/objective-list-item-test.js
+++ b/packages/test-app/tests/integration/components/session/objective-list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/session/objective-list-item';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | session/objective-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/objective-list-loading-test.js
+++ b/packages/test-app/tests/integration/components/session/objective-list-loading-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | session/objective-list-loading', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<Session::ObjectiveListLoading @count={{9}} />

--- a/packages/test-app/tests/integration/components/session/objective-list-test.js
+++ b/packages/test-app/tests/integration/components/session/objective-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/session/objective-list';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | session/objective-list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/objectives-test.js
+++ b/packages/test-app/tests/integration/components/session/objectives-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/session/objectives';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | session/objectives', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/postrequisite-editor-test.js
+++ b/packages/test-app/tests/integration/components/session/postrequisite-editor-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/session/postrequ
 
 module('Integration | Component | session/postrequisite-editor', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders with no postrequisite selected', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/publication-menu-test.js
+++ b/packages/test-app/tests/integration/components/session/publication-menu-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/session/publication-menu';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | session/publication-menu', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders and is accessible for draft session', async function (assert) {

--- a/packages/test-app/tests/integration/components/sessions-grid-header-test.js
+++ b/packages/test-app/tests/integration/components/sessions-grid-header-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/sessions-grid-he
 
 module('Integration | Component | sessions-grid-header', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/sessions-grid-last-updated-test.js
+++ b/packages/test-app/tests/integration/components/sessions-grid-last-updated-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { DateTime } from 'luxon';
 
 module('Integration | Component | sessions-grid-last-updated', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   //reset locale for other tests

--- a/packages/test-app/tests/integration/components/sessions-grid-loading-test.js
+++ b/packages/test-app/tests/integration/components/sessions-grid-loading-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | sessions-grid-loading', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<SessionsGridLoading @count={{5}} />

--- a/packages/test-app/tests/integration/components/sessions-grid-offering-table-test.js
+++ b/packages/test-app/tests/integration/components/sessions-grid-offering-table-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import Service from '@ember/service';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -13,7 +12,6 @@ const page = create({ table });
 
 module('Integration | Component | sessions-grid-offering-table', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
   test('it renders', async function (assert) {
     class PermissionCheckerServiceMock extends Service {

--- a/packages/test-app/tests/integration/components/sessions-grid-offering-test.js
+++ b/packages/test-app/tests/integration/components/sessions-grid-offering-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | sessions-grid-offering', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     const offering = {};

--- a/packages/test-app/tests/integration/components/sessions-grid-row-test.js
+++ b/packages/test-app/tests/integration/components/sessions-grid-row-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { DateTime } from 'luxon';
 import { render } from '@ember/test-helpers';
@@ -10,7 +9,6 @@ import { component } from 'ilios-common/page-objects/components/sessions-grid-ro
 
 module('Integration | Component | sessions-grid-row', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/sessions-grid-test.js
+++ b/packages/test-app/tests/integration/components/sessions-grid-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import Service from '@ember/service';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
@@ -8,7 +7,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | sessions-grid', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/test-app/tests/integration/components/single-event-learningmaterial-list-item-test.js
+++ b/packages/test-app/tests/integration/components/single-event-learningmaterial-list-item-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -11,7 +10,6 @@ import Service from '@ember/service';
 
 module('Integration | Component | single-event-learningmaterial-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('blanked', async function (assert) {

--- a/packages/test-app/tests/integration/components/single-event-learningmaterial-list-test.js
+++ b/packages/test-app/tests/integration/components/single-event-learningmaterial-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -9,7 +8,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | single-event-learningmaterial-list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/single-event-objective-list-test.js
+++ b/packages/test-app/tests/integration/components/single-event-objective-list-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/single-event-objective-list';
@@ -8,7 +7,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | ilios calendar single event objective list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     const objectives = [

--- a/packages/test-app/tests/integration/components/single-event-test.js
+++ b/packages/test-app/tests/integration/components/single-event-test.js
@@ -1,6 +1,5 @@
 import { module, test, todo } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import Service from '@ember/service';
 import { hbs } from 'ember-cli-htmlbars';
@@ -11,7 +10,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | ilios calendar single event', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/sortable-heading-test.js
+++ b/packages/test-app/tests/integration/components/sortable-heading-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { click, find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | sortable heading', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders with default options', async function (assert) {
     this.set('label', 'Foo');

--- a/packages/test-app/tests/integration/components/sortable-th-test.js
+++ b/packages/test-app/tests/integration/components/sortable-th-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { click, find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | sortable th', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders with default options', async function (assert) {
     this.set('label', 'Foo');

--- a/packages/test-app/tests/integration/components/taxonomy-manager-test.js
+++ b/packages/test-app/tests/integration/components/taxonomy-manager-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/taxonomy-manager
 
 module('Integration | Component | taxonomy manager', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/time-picker-test.js
+++ b/packages/test-app/tests/integration/components/time-picker-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/time-picker';
@@ -8,7 +7,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | time-picker', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     const date = new Date(2020, 4, 6, 23, 58);

--- a/packages/test-app/tests/integration/components/timed-release-schedule-test.js
+++ b/packages/test-app/tests/integration/components/timed-release-schedule-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -14,7 +13,6 @@ const localeFormatOptions = {
 };
 module('Integration | Component | timed release schedule', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders with no start and end date', async function (assert) {
     await render(hbs`<TimedReleaseSchedule />

--- a/packages/test-app/tests/integration/components/toggle-buttons-test.js
+++ b/packages/test-app/tests/integration/components/toggle-buttons-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/toggle-buttons';
 
 module('Integration | Component | toggle buttons', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<ToggleButtons

--- a/packages/test-app/tests/integration/components/toggle-yesno-test.js
+++ b/packages/test-app/tests/integration/components/toggle-yesno-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/toggle-yesno';
 
 module('Integration | Component | toggle yesno', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('value', true);

--- a/packages/test-app/tests/integration/components/truncate-text-test.js
+++ b/packages/test-app/tests/integration/components/truncate-text-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/truncate-text';
 
 module('Integration | Component | truncate-text', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders empty', async function (assert) {
     await render(hbs`<TruncateText />

--- a/packages/test-app/tests/integration/components/user-material-status-test.js
+++ b/packages/test-app/tests/integration/components/user-material-status-test.js
@@ -4,13 +4,11 @@ import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { setupIntl } from 'ember-intl/test-support';
 import { component } from 'ilios-common/page-objects/components/user-material-status';
 
 module('Integration | Component | user-material-status', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(async function () {
     const user = this.server.create('user');

--- a/packages/test-app/tests/integration/components/user-name-info-test.js
+++ b/packages/test-app/tests/integration/components/user-name-info-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/user-name-info';
@@ -8,7 +7,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | user-name-info', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/user-search-result-instructor-group-test.js
+++ b/packages/test-app/tests/integration/components/user-search-result-instructor-group-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/user-search-resu
 
 module('Integration | Component | user-search-result-instructor-group', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/user-search-result-user-test.js
+++ b/packages/test-app/tests/integration/components/user-search-result-user-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/user-search-resu
 
 module('Integration | Component | user-search-result-user', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/user-search-test.js
+++ b/packages/test-app/tests/integration/components/user-search-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/user-search';
 
 module('Integration | Component | user search', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/test-app/tests/integration/components/validation-error-test.js
+++ b/packages/test-app/tests/integration/components/validation-error-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | validation-error', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders with no errors', async function (assert) {
     await render(hbs`<ValidationError @errors={{(array)}} />

--- a/packages/test-app/tests/integration/components/visualizer-course-instructor-session-type-test.js
+++ b/packages/test-app/tests/integration/components/visualizer-course-instructor-session-type-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/visualizer-cours
 
 module('Integration | Component | visualizer-course-instructor-session-type', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/visualizer-course-instructor-term-test.js
+++ b/packages/test-app/tests/integration/components/visualizer-course-instructor-term-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/visualizer-cours
 
 module('Integration | Component | visualizer-course-instructor-term', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/visualizer-course-instructors-test.js
+++ b/packages/test-app/tests/integration/components/visualizer-course-instructors-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/visualizer-cours
 
 module('Integration | Component | visualizer-course-instructors', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/visualizer-course-objectives-test.js
+++ b/packages/test-app/tests/integration/components/visualizer-course-objectives-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/visualizer-cours
 
 module('Integration | Component | visualizer-course-objectives', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/visualizer-course-session-type-test.js
+++ b/packages/test-app/tests/integration/components/visualizer-course-session-type-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/visualizer-cours
 
 module('Integration | Component | visualizer-course-session-type', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/visualizer-course-session-types-test.js
+++ b/packages/test-app/tests/integration/components/visualizer-course-session-types-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/visualizer-cours
 
 module('Integration | Component | visualizer-course-session-types', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/visualizer-course-term-test.js
+++ b/packages/test-app/tests/integration/components/visualizer-course-term-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, findAll, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | visualizer-course-term', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/visualizer-course-vocabularies-test.js
+++ b/packages/test-app/tests/integration/components/visualizer-course-vocabularies-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/visualizer-cours
 
 module('Integration | Component | visualizer-course-vocabularies', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/visualizer-course-vocabulary-test.js
+++ b/packages/test-app/tests/integration/components/visualizer-course-vocabulary-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -8,7 +7,6 @@ import { component } from 'ilios-common/page-objects/components/visualizer-cours
 
 module('Integration | Component | visualizer-course-vocabulary', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/test-app/tests/integration/components/wait-saving-test.js
+++ b/packages/test-app/tests/integration/components/wait-saving-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { fillIn, render, waitFor, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | wait saving', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     await render(hbs`<WaitSaving />

--- a/packages/test-app/tests/integration/components/week-glance-event-test.js
+++ b/packages/test-app/tests/integration/components/week-glance-event-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -12,7 +11,6 @@ const today = DateTime.fromObject({ hour: 8 });
 
 module('Integration | Component | week-glance-event', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('it renders with some stuff', async function (assert) {

--- a/packages/test-app/tests/integration/components/week-glance-test.js
+++ b/packages/test-app/tests/integration/components/week-glance-test.js
@@ -2,7 +2,6 @@ import Service from '@ember/service';
 import { DateTime } from 'luxon';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, settled, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -11,7 +10,6 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 
 module('Integration | Component | week glance', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
   const testDate = DateTime.fromObject({
     year: 2017,

--- a/packages/test-app/tests/integration/components/week-glance/learning-material-list-item-test.js
+++ b/packages/test-app/tests/integration/components/week-glance/learning-material-list-item-test.js
@@ -2,14 +2,12 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import { component } from 'ilios-common/page-objects/components/week-glance/learning-material';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import createTypedLearningMaterialProxy from 'ilios-common/utils/create-typed-learning-material-proxy';
 
 module('Integration | Component | week-glance/learning-material-list-item', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/week-glance/learning-material-list-test.js
+++ b/packages/test-app/tests/integration/components/week-glance/learning-material-list-test.js
@@ -2,14 +2,12 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupIntl } from 'ember-intl/test-support';
 import { component } from 'ilios-common/page-objects/components/week-glance/learning-material-list';
 import createTypedLearningMaterialProxy from 'ilios-common/utils/create-typed-learning-material-proxy';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | week-glance/learning-material-list', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
   setupMirage(hooks);
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/weekly-calendar-event-test.js
+++ b/packages/test-app/tests/integration/components/weekly-calendar-event-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,7 +8,6 @@ import { component } from 'ilios-common/page-objects/components/weekly-calendar-
 
 module('Integration | Component | weekly-calendar-event', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   this.createEvent = function (startDate, endDate, lastModified, isScheduled, isPublished) {

--- a/packages/test-app/tests/integration/components/weekly-calendar-test.js
+++ b/packages/test-app/tests/integration/components/weekly-calendar-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { settled, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
@@ -10,7 +9,6 @@ import { component } from 'ilios-common/page-objects/components/weekly-calendar'
 
 module('Integration | Component | weekly-calendar', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   hooks.beforeEach(function () {

--- a/packages/test-app/tests/integration/components/weekly-events-test.js
+++ b/packages/test-app/tests/integration/components/weekly-events-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/weekly-events';
 
 module('Integration | Component | weekly events', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
     this.set('year', 2017);

--- a/packages/test-app/tests/integration/helpers/-set-test.js
+++ b/packages/test-app/tests/integration/helpers/-set-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | set', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it works when transformed', async function (assert) {
     this.set('content', 'English');

--- a/packages/test-app/tests/integration/helpers/compute-test.js
+++ b/packages/test-app/tests/integration/helpers/compute-test.js
@@ -1,7 +1,7 @@
 // taken from Ember Composable Helpers (https://github.com/DockYard/ember-composable-helpers), then modified.
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 
 module('Integration | Helper | compute', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/filesize-test.js
+++ b/packages/test-app/tests/integration/helpers/filesize-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('helper:filesize', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it bytes', async function (assert) {
     this.set('inputValue', '42');

--- a/packages/test-app/tests/integration/helpers/get-errors-for-test.js
+++ b/packages/test-app/tests/integration/helpers/get-errors-for-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | get-errors-for', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it calls errorFor', async function (assert) {
     assert.expect(2);

--- a/packages/test-app/tests/integration/helpers/has-error-for-test.js
+++ b/packages/test-app/tests/integration/helpers/has-error-for-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | has-error-for', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it calls hasError', async function (assert) {
     assert.expect(2);

--- a/packages/test-app/tests/integration/helpers/has-many-ids-test.js
+++ b/packages/test-app/tests/integration/helpers/has-many-ids-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | has-many-ids', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   // Replace this with your real tests.
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/helpers/includes-test.js
+++ b/packages/test-app/tests/integration/helpers/includes-test.js
@@ -2,7 +2,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 
 module('Integration | Helper | includes', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/intersect-test.js
+++ b/packages/test-app/tests/integration/helpers/intersect-test.js
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { A as emberArray } from '@ember/array';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 
 module('Integration | Helper | intersect', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/join-test.js
+++ b/packages/test-app/tests/integration/helpers/join-test.js
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { A as emberArray } from '@ember/array';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 
 module('Integration | Helper | join', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/lm-type-test.js
+++ b/packages/test-app/tests/integration/helpers/lm-type-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | lm-type', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('link', async function (assert) {
     const lm = { link: 'whatever' };

--- a/packages/test-app/tests/integration/helpers/map-by-test.js
+++ b/packages/test-app/tests/integration/helpers/map-by-test.js
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { A as emberArray } from '@ember/array';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 
 module('Integration | Helper | map-by', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/noop-test.js
+++ b/packages/test-app/tests/integration/helpers/noop-test.js
@@ -1,7 +1,7 @@
 // taken from Ember Composable Helpers (https://github.com/DockYard/ember-composable-helpers), then modified.
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 
 module('Integration | Helper | noop', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/object-at-test.js
+++ b/packages/test-app/tests/integration/helpers/object-at-test.js
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { A as emberArray } from '@ember/array';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 
 module('Integration | Helper | object-at', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/optional-test.js
+++ b/packages/test-app/tests/integration/helpers/optional-test.js
@@ -1,7 +1,7 @@
 // taken from Ember Composable Helpers (https://github.com/DockYard/ember-composable-helpers), then modified.
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 
 module('Integration | Helper | optional', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/pick-test.js
+++ b/packages/test-app/tests/integration/helpers/pick-test.js
@@ -1,7 +1,7 @@
 // taken from Ember Composable Helpers (https://github.com/DockYard/ember-composable-helpers), then modified.
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { click, render } from '@ember/test-helpers';
 
 module('Integration | Helper | pick', function (hooks) {
@@ -20,7 +20,7 @@ module('Integration | Helper | pick', function (hooks) {
         value="pizza party"
         {{on "focusin" (pipe (pick "target.value") this.onFocus)}}
       />
-    
+
 `);
 
     await click('#test-input');
@@ -39,7 +39,7 @@ module('Integration | Helper | pick', function (hooks) {
         value="pizza party"
         {{on "focusin" (pick "target.value" this.onFocus)}}
       />
-    
+
 `);
 
     await click('#test-input');

--- a/packages/test-app/tests/integration/helpers/pipe-test.js
+++ b/packages/test-app/tests/integration/helpers/pipe-test.js
@@ -2,7 +2,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 
 module('Integration | Helper | pipe', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/queue-test.js
+++ b/packages/test-app/tests/integration/helpers/queue-test.js
@@ -2,7 +2,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 
 module('Integration | Helper | queue', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/remove-html-tags-test.js
+++ b/packages/test-app/tests/integration/helpers/remove-html-tags-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | remove-html-tags', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   // Replace this with your real tests.
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/helpers/repeat-test.js
+++ b/packages/test-app/tests/integration/helpers/repeat-test.js
@@ -1,7 +1,7 @@
 // taken from Ember Composable Helpers (https://github.com/DockYard/ember-composable-helpers), then modified.
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 
 module('Integration | Helper | repeat', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/reverse-test.js
+++ b/packages/test-app/tests/integration/helpers/reverse-test.js
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { A as emberArray } from '@ember/array';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 
 module('Integration | Helper | reverse', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/slice-test.js
+++ b/packages/test-app/tests/integration/helpers/slice-test.js
@@ -1,7 +1,7 @@
 // taken from Ember Composable Helpers (https://github.com/DockYard/ember-composable-helpers), then modified.
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 
 module('Integration | Helper | slice', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/sort-by-position-test.js
+++ b/packages/test-app/tests/integration/helpers/sort-by-position-test.js
@@ -1,13 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | sort-by-position', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   setupMirage(hooks);
 
   test('sort objectives', async function (assert) {

--- a/packages/test-app/tests/integration/helpers/sort-by-test.js
+++ b/packages/test-app/tests/integration/helpers/sort-by-test.js
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { A as emberArray } from '@ember/array';
 import { run } from '@ember/runloop';
 import { module, test, skip } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 
 module('Integration | Helper | sort-by', function (hooks) {

--- a/packages/test-app/tests/integration/helpers/split-test.js
+++ b/packages/test-app/tests/integration/helpers/split-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Helper | split', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
   test('it splits', async function (assert) {
     await render(hbs`
     {{#each (split "," "a,b,c") as |l|}}

--- a/packages/test-app/tests/integration/helpers/toggle-test.js
+++ b/packages/test-app/tests/integration/helpers/toggle-test.js
@@ -1,7 +1,7 @@
 // taken from Ember Composable Helpers (https://github.com/DockYard/ember-composable-helpers), then modified.
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 
 module('Integration | Helper | toggle', function (hooks) {
@@ -13,7 +13,7 @@ module('Integration | Helper | toggle', function (hooks) {
       <button type="button" {{on "click" (toggle "isExpanded" this)}}>
         {{if this.isExpanded "I am expanded" "I am not"}}
       </button>
-    
+
 `);
     await click('button');
 
@@ -26,7 +26,7 @@ module('Integration | Helper | toggle', function (hooks) {
       <button type="button" {{on "click" (toggle "currentName" this "foo" "bar" "baz")}}>
         {{this.currentName}}
       </button>
-    
+
 `);
 
     assert.dom().hasText('foo', 'precondition');
@@ -44,7 +44,7 @@ module('Integration | Helper | toggle', function (hooks) {
       <button type="button" {{on "click" (toggle "currentName" this "foo" "bar")}}>
         {{this.currentName}}
       </button>
-    
+
 `);
 
     assert.dom().hasText('meow', 'precondition');

--- a/packages/test-app/tests/integration/modifiers/autofocus-test.js
+++ b/packages/test-app/tests/integration/modifiers/autofocus-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Modifier | autofocus', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('it focuses', async function (assert) {
     this.set('label', 'foo bar');

--- a/packages/test-app/tests/integration/modifiers/mouse-hover-toggle-test.js
+++ b/packages/test-app/tests/integration/modifiers/mouse-hover-toggle-test.js
@@ -1,12 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { setupIntl } from 'ember-intl/test-support';
 import { render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Modifier | mouse-hover-toggle', function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, 'en-us');
 
   test('action is fired with correct value', async function (assert) {
     assert.expect(2);

--- a/packages/test-app/tests/integration/modifiers/scroll-into-view-test.js
+++ b/packages/test-app/tests/integration/modifiers/scroll-into-view-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 


### PR DESCRIPTION
This is the currently recommended way to setup things we need in all tests. I've configured it for rendering tests (acceptance and integration) and left the few calls that are in unit tests alone. Many of our older tests didn't call their setup methods from the right place so I fixed those imports as well.

Refs #7860

