### PR TITLE
increase max line length for hbs files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,7 @@ indent_size = 2
 
 [*.hbs]
 insert_final_newline = false
+max_line_length = 100
 
 [*.{diff,md}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
Lines in `.hbs` files going over 80 characters were being wrapped to the next line until I added this.