### PR TITLE
use setLocale() test helper instead of interacting with the intl service directly.

### DIFF
--- a/packages/test-app/tests/integration/components/daily-calendar-test.js
+++ b/packages/test-app/tests/integration/components/daily-calendar-test.js
@@ -1,19 +1,20 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { settled, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { component } from 'ilios-common/page-objects/components/daily-calendar';
+import { setLocale } from 'ember-intl/test-support';
 
 module('Integration | Component | daily-calendar', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
   //reset locale for other tests
-  hooks.afterEach(function () {
-    this.owner.lookup('service:intl').setLocale('en-us');
+  hooks.afterEach(async function () {
+    await setLocale('en-us');
   });
 
   this.createEvent = function (startDate, endDate, color) {
@@ -175,8 +176,7 @@ module('Integration | Component | daily-calendar', function (hooks) {
     assert.strictEqual(component.title.shortDayOfWeek, '12/11/1980');
     assert.strictEqual(component.events.length, 1);
 
-    this.owner.lookup('service:intl').setLocale('es');
-    await settled();
+    await setLocale('es');
 
     assert.strictEqual(component.title.longDayOfWeek, 'jueves, 11 de diciembre de 1980');
     assert.strictEqual(component.title.shortDayOfWeek, '11/12/1980');

--- a/packages/test-app/tests/integration/components/monthly-calendar-test.js
+++ b/packages/test-app/tests/integration/components/monthly-calendar-test.js
@@ -1,15 +1,21 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { render, settled } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import { component } from 'ilios-common/page-objects/components/monthly-calendar';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setLocale } from 'ember-intl/test-support';
 
 module('Integration | Component | monthly-calendar', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+
+  //reset locale for other tests
+  hooks.afterEach(async function () {
+    await setLocale('en-us');
+  });
 
   test('it renders empty and is accessible', async function (assert) {
     assert.expect(68);
@@ -257,8 +263,7 @@ module('Integration | Component | monthly-calendar', function (hooks) {
     assert.ok(component.days[10].isThirdWeek);
     assert.strictEqual(component.days[10].events.length, 1);
 
-    this.owner.lookup('service:intl').setLocale('es');
-    await settled();
+    await setLocale('es');
 
     assert.strictEqual(component.days.length, 31);
     assert.ok(component.days[10].isFirstDayOfWeek);
@@ -296,8 +301,8 @@ module('Integration | Component | monthly-calendar', function (hooks) {
     assert.ok(component.days[0].isSeventhDayOfWeek);
     assert.ok(component.days[0].isFirstWeek);
     assert.strictEqual(component.days[0].events.length, 1);
-    this.owner.lookup('service:intl').setLocale('es');
-    await settled();
+
+    await setLocale('es');
 
     assert.strictEqual(component.days.length, 29);
     assert.ok(component.days[0].isSixthDayOfWeek);

--- a/packages/test-app/tests/integration/components/session-offerings-time-block-offerings-test.js
+++ b/packages/test-app/tests/integration/components/session-offerings-time-block-offerings-test.js
@@ -10,7 +10,6 @@ module('Integration | Component | session-offerings-time-block-offerings', funct
 
   test('it renders', async function (assert) {
     const store = this.owner.lookup('service:store');
-    this.owner.lookup('service:intl').setLocale('en-us');
     const key = '2023005134520240120430'; // value doesn't really matter, although it needs to be parseable
     const offeringTimeBlock = new OfferingTimeBlock(key);
     const course = store.createRecord('course');

--- a/packages/test-app/tests/integration/components/sessions-grid-last-updated-test.js
+++ b/packages/test-app/tests/integration/components/sessions-grid-last-updated-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { render, settled } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { setLocale } from 'ember-intl/test-support';
 import { DateTime } from 'luxon';
 
 module('Integration | Component | sessions-grid-last-updated', function (hooks) {
@@ -14,8 +15,8 @@ module('Integration | Component | sessions-grid-last-updated', function (hooks) 
   });
 
   //reset locale for other tests
-  hooks.afterEach(function () {
-    this.intl.setLocale('en-us');
+  hooks.afterEach(async function () {
+    await setLocale('en-us');
   });
 
   test('it renders', async function (assert) {
@@ -50,11 +51,9 @@ module('Integration | Component | sessions-grid-last-updated', function (hooks) 
     };
 
     assert.dom(this.element).containsText(lastUpdatedText());
-    this.owner.lookup('service:intl').setLocale('es');
-    await settled();
+    await setLocale('es');
     assert.dom(this.element).containsText(lastUpdatedText());
-    this.owner.lookup('service:intl').setLocale('fr');
-    await settled();
+    await setLocale('fr');
     assert.dom(this.element).containsText(lastUpdatedText());
   });
 });

--- a/packages/test-app/tests/integration/components/weekly-calendar-test.js
+++ b/packages/test-app/tests/integration/components/weekly-calendar-test.js
@@ -1,23 +1,20 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { settled, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { DateTime } from 'luxon';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
+import { setLocale } from 'ember-intl/test-support';
 import { component } from 'ilios-common/page-objects/components/weekly-calendar';
 
 module('Integration | Component | weekly-calendar', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(function () {
-    this.owner.lookup('service:intl').setLocale('en-us');
-  });
-
   //reset locale for other tests
-  hooks.afterEach(function () {
-    this.owner.lookup('service:intl').setLocale('en-us');
+  hooks.afterEach(async function () {
+    await setLocale('en-us');
   });
 
   this.createEvent = function (startDate, endDate, color) {
@@ -298,8 +295,7 @@ module('Integration | Component | weekly-calendar', function (hooks) {
     assert.strictEqual(component.events.length, 1);
     assert.ok(component.events[0].isFifthDayOfWeek);
 
-    this.owner.lookup('service:intl').setLocale('es');
-    await settled();
+    await setLocale('es');
 
     assert.strictEqual(component.title.longWeekOfYear, 'Semana de 8 de diciembre de 1980');
     assert.strictEqual(component.title.shortWeekOfYear, '8/12 — 14/12 1980');
@@ -345,8 +341,7 @@ module('Integration | Component | weekly-calendar', function (hooks) {
     assert.strictEqual(component.events.length, 1);
     assert.ok(component.events[0].isThirdDayOfWeek);
 
-    this.owner.lookup('service:intl').setLocale('es');
-    await settled();
+    await setLocale('es');
 
     assert.strictEqual(component.title.longWeekOfYear, 'Semana de 24 de febrero de 2020');
     assert.strictEqual(component.title.shortWeekOfYear, '24/2 — 1/3 2020');

--- a/packages/test-app/tests/unit/services/locale-days-test.js
+++ b/packages/test-app/tests/unit/services/locale-days-test.js
@@ -8,107 +8,107 @@ module('Unit | Service | locale-days', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks, 'en-us');
 
-  hooks.afterEach(() => {
+  hooks.afterEach(async function () {
     unfreezeDate();
-    setLocale('en-us');
+    await setLocale('en-us');
   });
 
-  test('firstDayOfThisWeek respects current locale', function (assert) {
+  test('firstDayOfThisWeek respects current locale', async function (assert) {
     freezeDateAt(new Date('2022-09-22'));
     const service = this.owner.lookup('service:locale-days');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfThisWeek).day, 18);
 
-    setLocale('es');
+    await setLocale('es');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfThisWeek).day, 19);
 
-    setLocale('fr');
+    await setLocale('fr');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfThisWeek).day, 19);
 
-    setLocale('en-us');
+    await setLocale('en-us');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfThisWeek).day, 18);
   });
 
-  test('lastDayOfWeek respects current locale', function (assert) {
+  test('lastDayOfWeek respects current locale', async function (assert) {
     freezeDateAt(new Date('2022-09-22'));
     const service = this.owner.lookup('service:locale-days');
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfThisWeek).day, 24);
 
-    setLocale('es');
+    await setLocale('es');
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfThisWeek).day, 25);
 
-    setLocale('fr');
+    await setLocale('fr');
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfThisWeek).day, 25);
 
-    setLocale('en-us');
+    await setLocale('en-us');
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfThisWeek).day, 24);
   });
 
-  test('works at year boundry', function (assert) {
+  test('works at year boundry', async function (assert) {
     freezeDateAt(new Date('2020-01-02'));
     const service = this.owner.lookup('service:locale-days');
 
-    setLocale('en-us');
+    await setLocale('en-us');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfThisWeek).day, 29);
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfThisWeek).day, 4);
 
-    setLocale('es');
+    await setLocale('es');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfThisWeek).day, 30);
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfThisWeek).day, 5);
 
-    setLocale('fr');
+    await setLocale('fr');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfThisWeek).day, 30);
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfThisWeek).day, 5);
   });
 
-  test('firstDayOfDateWeek respects current locale', function (assert) {
+  test('firstDayOfDateWeek respects current locale', async function (assert) {
     const dt = new Date('2022-09-22');
     const service = this.owner.lookup('service:locale-days');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 18);
 
-    setLocale('es');
+    await setLocale('es');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 19);
 
-    setLocale('fr');
+    await setLocale('fr');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 19);
 
-    setLocale('en-us');
+    await setLocale('en-us');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 18);
   });
 
-  test('lastDayOfDateWeek respects current locale', function (assert) {
+  test('lastDayOfDateWeek respects current locale', async function (assert) {
     const dt = new Date('2022-09-22');
     const service = this.owner.lookup('service:locale-days');
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 24);
 
-    setLocale('es');
+    await setLocale('es');
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 25);
 
-    setLocale('fr');
+    await setLocale('fr');
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 25);
 
-    setLocale('en-us');
+    await setLocale('en-us');
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 24);
   });
 
-  test('of date week works at year boundry', function (assert) {
+  test('of date week works at year boundry', async function (assert) {
     const dt = new Date('2020-01-02');
     const service = this.owner.lookup('service:locale-days');
 
-    setLocale('en-us');
+    await setLocale('en-us');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 29);
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 4);
 
-    setLocale('es');
+    await setLocale('es');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 30);
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 5);
 
-    setLocale('fr');
+    await setLocale('fr');
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 30);
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 5);
   });
 
-  test('firstDayOfThisWeek works on Sunday in en-us', function (assert) {
-    setLocale('en-us');
+  test('firstDayOfThisWeek works on Sunday in en-us', async function (assert) {
+    await setLocale('en-us');
     freezeDateAt(
       DateTime.fromObject({
         year: 2022,
@@ -121,8 +121,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfThisWeek).day, 9);
   });
 
-  test('firstDayOfDateWeek works for a Sunday in en-us', function (assert) {
-    setLocale('en-us');
+  test('firstDayOfDateWeek works for a Sunday in en-us', async function (assert) {
+    await setLocale('en-us');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -133,8 +133,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 9);
   });
 
-  test('firstDayOfDateWeek works for a Monday in en-us', function (assert) {
-    setLocale('en-us');
+  test('firstDayOfDateWeek works for a Monday in en-us', async function (assert) {
+    await setLocale('en-us');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -145,8 +145,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 9);
   });
 
-  test('firstDayOfDateWeek works for a Saturday in en-us', function (assert) {
-    setLocale('en-us');
+  test('firstDayOfDateWeek works for a Saturday in en-us', async function (assert) {
+    await setLocale('en-us');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -157,8 +157,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 2);
   });
 
-  test('firstDayOfThisWeek works on Sunday in fr', function (assert) {
-    setLocale('fr');
+  test('firstDayOfThisWeek works on Sunday in fr', async function (assert) {
+    await setLocale('fr');
     freezeDateAt(
       DateTime.fromObject({
         year: 2022,
@@ -171,8 +171,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfThisWeek).day, 3);
   });
 
-  test('firstDayOfDateWeek works for a Sunday in fr', function (assert) {
-    setLocale('fr');
+  test('firstDayOfDateWeek works for a Sunday in fr', async function (assert) {
+    await setLocale('fr');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -183,8 +183,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 3);
   });
 
-  test('firstDayOfDateWeek works for a Monday in fr', function (assert) {
-    setLocale('fr');
+  test('firstDayOfDateWeek works for a Monday in fr', async function (assert) {
+    await setLocale('fr');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -195,8 +195,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 10);
   });
 
-  test('firstDayOfDateWeek works for a Saturday in fr', function (assert) {
-    setLocale('fr');
+  test('firstDayOfDateWeek works for a Saturday in fr', async function (assert) {
+    await setLocale('fr');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -207,8 +207,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 3);
   });
 
-  test('firstDayOfThisWeek works on Sunday in es', function (assert) {
-    setLocale('es');
+  test('firstDayOfThisWeek works on Sunday in es', async function (assert) {
+    await setLocale('es');
     freezeDateAt(
       DateTime.fromObject({
         year: 2022,
@@ -221,8 +221,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfThisWeek).day, 3);
   });
 
-  test('firstDayOfDateWeek works for a Sunday in es', function (assert) {
-    setLocale('es');
+  test('firstDayOfDateWeek works for a Sunday in es', async function (assert) {
+    await setLocale('es');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -233,8 +233,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 3);
   });
 
-  test('firstDayOfDateWeek works for a Monday in es', function (assert) {
-    setLocale('es');
+  test('firstDayOfDateWeek works for a Monday in es', async function (assert) {
+    await setLocale('es');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -245,8 +245,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 10);
   });
 
-  test('firstDayOfDateWeek works for a Saturday in es', function (assert) {
-    setLocale('es');
+  test('firstDayOfDateWeek works for a Saturday in es', async function (assert) {
+    await setLocale('es');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -257,8 +257,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.firstDayOfDateWeek(dt)).day, 3);
   });
 
-  test('lastDayOfThisWeek works on Sunday in en-us', function (assert) {
-    setLocale('en-us');
+  test('lastDayOfThisWeek works on Sunday in en-us', async function (assert) {
+    await setLocale('en-us');
     freezeDateAt(
       DateTime.fromObject({
         year: 2022,
@@ -271,8 +271,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfThisWeek).day, 15);
   });
 
-  test('lastDayOfDateWeek works for a Sunday in en-us', function (assert) {
-    setLocale('en-us');
+  test('lastDayOfDateWeek works for a Sunday in en-us', async function (assert) {
+    await setLocale('en-us');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -283,8 +283,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 15);
   });
 
-  test('lastDayOfDateWeek works for a Monday in en-us', function (assert) {
-    setLocale('en-us');
+  test('lastDayOfDateWeek works for a Monday in en-us', async function (assert) {
+    await setLocale('en-us');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -295,8 +295,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 15);
   });
 
-  test('lastDayOfDateWeek works for a Friday in en-us', function (assert) {
-    setLocale('en-us');
+  test('lastDayOfDateWeek works for a Friday in en-us', async function (assert) {
+    await setLocale('en-us');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -307,8 +307,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 8);
   });
 
-  test('lastDayOfDateWeek works for a Saturday in en-us', function (assert) {
-    setLocale('en-us');
+  test('lastDayOfDateWeek works for a Saturday in en-us', async function (assert) {
+    await setLocale('en-us');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -319,8 +319,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 8);
   });
 
-  test('lastDayOfThisWeek works on Sunday in fr', function (assert) {
-    setLocale('fr');
+  test('lastDayOfThisWeek works on Sunday in fr', async function (assert) {
+    await setLocale('fr');
     freezeDateAt(
       DateTime.fromObject({
         year: 2022,
@@ -333,8 +333,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfThisWeek).day, 9);
   });
 
-  test('lastDayOfDateWeek works for a Sunday in fr', function (assert) {
-    setLocale('fr');
+  test('lastDayOfDateWeek works for a Sunday in fr', async function (assert) {
+    await setLocale('fr');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -345,8 +345,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 9);
   });
 
-  test('lastDayOfDateWeek works for a Monday in fr', function (assert) {
-    setLocale('fr');
+  test('lastDayOfDateWeek works for a Monday in fr', async function (assert) {
+    await setLocale('fr');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -357,8 +357,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 16);
   });
 
-  test('lastDayOfDateWeek works for a Friday in fr', function (assert) {
-    setLocale('fr');
+  test('lastDayOfDateWeek works for a Friday in fr', async function (assert) {
+    await setLocale('fr');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -369,8 +369,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 9);
   });
 
-  test('lastDayOfDateWeek works for a Saturday in fr', function (assert) {
-    setLocale('fr');
+  test('lastDayOfDateWeek works for a Saturday in fr', async function (assert) {
+    await setLocale('fr');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -381,8 +381,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 9);
   });
 
-  test('lastDayOfThisWeek works on Sunday in es', function (assert) {
-    setLocale('es');
+  test('lastDayOfThisWeek works on Sunday in es', async function (assert) {
+    await setLocale('es');
     freezeDateAt(
       DateTime.fromObject({
         year: 2022,
@@ -395,8 +395,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfThisWeek).day, 9);
   });
 
-  test('lastDayOfDateWeek works for a Sunday in es', function (assert) {
-    setLocale('es');
+  test('lastDayOfDateWeek works for a Sunday in es', async function (assert) {
+    await setLocale('es');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -407,8 +407,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 9);
   });
 
-  test('lastDayOfDateWeek works for a Monday in es', function (assert) {
-    setLocale('es');
+  test('lastDayOfDateWeek works for a Monday in es', async function (assert) {
+    await setLocale('es');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -419,8 +419,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 16);
   });
 
-  test('lastDayOfDateWeek works for a Friday in es', function (assert) {
-    setLocale('es');
+  test('lastDayOfDateWeek works for a Friday in es', async function (assert) {
+    await setLocale('es');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,
@@ -431,8 +431,8 @@ module('Unit | Service | locale-days', function (hooks) {
     assert.strictEqual(DateTime.fromJSDate(service.lastDayOfDateWeek(dt)).day, 9);
   });
 
-  test('lastDayOfDateWeek works for a Saturday in es', function (assert) {
-    setLocale('es');
+  test('lastDayOfDateWeek works for a Saturday in es', async function (assert) {
+    await setLocale('es');
     const dt = DateTime.fromObject({
       year: 2022,
       month: 10,

--- a/packages/test-app/tests/unit/utils/calendar-event-tooltip-test.js
+++ b/packages/test-app/tests/unit/utils/calendar-event-tooltip-test.js
@@ -2,13 +2,14 @@ import calendarEventTooltip from 'test-app/utils/calendar-event-tooltip';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { DateTime } from 'luxon';
+import { setupIntl } from 'ember-intl/test-support';
 
 module('Unit | Utility | calendar-event-tooltip', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks, 'en-us');
 
   hooks.beforeEach(function () {
     this.intl = this.owner.lookup('service:intl');
-    this.intl.setLocale('en-us');
   });
 
   test('it works for blanked event', function (assert) {


### PR DESCRIPTION
see https://ember-intl.github.io/ember-intl/docs/test-helpers/set-locale