### PR TITLE
normalize date display format across calendar components and views

### DIFF
--- a/packages/frontend/tests/acceptance/dashboard/calendar-test.js
+++ b/packages/frontend/tests/acceptance/dashboard/calendar-test.js
@@ -123,12 +123,12 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
     const events = findAll('[data-test-ilios-calendar-event]');
     assert.strictEqual(events.length, 2);
     const startOfMonthStartFormat = this.intl.formatTime(startOfMonth.toJSDate(), {
-      hour: 'numeric',
-      minute: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
     });
     const startOfMonthEndFormat = this.intl.formatTime(startOfMonth.plus({ hour: 1 }).toJSDate(), {
-      hour: 'numeric',
-      minute: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
     });
     assert
       .dom(events[0])

--- a/packages/ilios-common/addon/components/daily-calendar-event.hbs
+++ b/packages/ilios-common/addon/components/daily-calendar-event.hbs
@@ -33,11 +33,11 @@
     {{#if this.isIlm}}
       <span class="ilios-calendar-event-start">
         {{t "general.ilmDue"}}:
-        {{format-date @event.startDate hour12=true hour="numeric" minute="numeric"}}
+        {{format-date @event.startDate hour12=true hour="2-digit" minute="2-digit"}}
       </span>
     {{else}}
       <span class="ilios-calendar-event-start">
-        {{format-date @event.startDate hour12=true hour="numeric" minute="numeric"}}
+        {{format-date @event.startDate hour12=true hour="2-digit" minute="2-digit"}}
       </span>
     {{/if}}
   </span>

--- a/packages/ilios-common/addon/components/daily-calendar.hbs
+++ b/packages/ilios-common/addon/components/daily-calendar.hbs
@@ -11,7 +11,7 @@
       ...
     {{else}}
       <span class="short" data-test-short>
-        {{format-date @date}}
+        {{format-date @date month="2-digit" day="2-digit" year="numeric"}}
       </span>
       <span class="long" data-test-long>{{format-date @date weekday="long" month="long" day="numeric" year="numeric"}}</span>
     {{/if}}

--- a/packages/ilios-common/addon/components/ilios-calendar-event-month.hbs
+++ b/packages/ilios-common/addon/components/ilios-calendar-event-month.hbs
@@ -24,11 +24,11 @@
     {{/if}}
     <span class="ilios-calendar-event-time">
       <span class="ilios-calendar-event-start">
-        {{format-date @event.startDate  hour12=true hour="numeric" minute="numeric"}}
+        {{format-date @event.startDate hour12=true hour="2-digit" minute="2-digit"}}
       </span>
       <span class="ilios-calendar-event-end">
         -
-        {{format-date @event.endDate  hour12=true hour="numeric" minute="numeric"}}
+        {{format-date @event.endDate hour12=true hour="2-digit" minute="2-digit"}}
       </span>
     </span>
     {{#unless @event.isMulti}}

--- a/packages/ilios-common/addon/components/ilios-calendar-multiday-event.hbs
+++ b/packages/ilios-common/addon/components/ilios-calendar-multiday-event.hbs
@@ -5,9 +5,9 @@
     disabled={{not this.enabled}}
     {{on "click" (fn this.selectEvent @event)}}
   >
-    {{format-date @event.startDate month="numeric" day="numeric" year="2-digit" hour="numeric" minute="numeric"}}
+    {{format-date @event.startDate month="2-digit" day="2-digit" year="2-digit" hour="2-digit" minute="2-digit"}}
     &ndash;
-    {{format-date @event.endDate month="numeric" day="numeric" year="2-digit" hour="numeric" minute="numeric"}}
+    {{format-date @event.endDate month="2-digit" day="2-digit" year="2-digit" hour="2-digit" minute="2-digit"}}
     <span data-test-event-name>
       {{@event.name}}
     </span>

--- a/packages/ilios-common/addon/components/single-event.hbs
+++ b/packages/ilios-common/addon/components/single-event.hbs
@@ -27,19 +27,19 @@
           <p>
             {{t "general.dueBefore"}}
             <a href={{this.postrequisiteLink}}>{{get (object-at 0 @event.postrequisites) "name"}}</a>
-            ({{format-date (get (object-at 0 @event.postrequisites) "startDate") month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="numeric" minute="numeric"}})
+            ({{format-date (get (object-at 0 @event.postrequisites) "startDate") month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="2-digit" minute="2-digit"}})
           </p>
         {{/if}}
         {{#unless @event.ilmSession}}
           <p>
             {{#if (eq @event.startDate @event.endDate)}}
-              {{format-date @event.startDate month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="numeric" minute="numeric"}}
+              {{format-date @event.startDate month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="2-digit" minute="2-digit"}}
             {{else if this.startsAndEndsOnSameDay}}
-              {{format-date @event.startDate month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="numeric" minute="numeric"}}
-              - {{format-date @event.endDate hour12=true hour="numeric" minute="numeric"}}
+              {{format-date @event.startDate month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="2-digit" minute="2-digit"}}
+              - {{format-date @event.endDate hour12=true hour="2-digit" minute="2-digit"}}
             {{else}}
-              {{format-date @event.startDate month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="numeric" minute="numeric"}}
-              - {{format-date @event.endDate month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="numeric" minute="numeric"}}
+              {{format-date @event.startDate month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="2-digit" minute="2-digit"}}
+              - {{format-date @event.endDate month="long" weekday="long" day="numeric" year="numeric" hour12=true hour="2-digit" minute="2-digit"}}
             {{/if}}
           </p>
         {{/unless}}

--- a/packages/ilios-common/addon/components/week-glance-event.hbs
+++ b/packages/ilios-common/addon/components/week-glance-event.hbs
@@ -19,7 +19,7 @@
           {{t "general.dueBy"}}
         </span>
       {{/if}}
-      {{format-date @event.startDate weekday="long" hour="numeric" minute="numeric"}}
+      {{format-date @event.startDate weekday="long" hour="2-digit" minute="2-digit"}}
     </span>
   </h3>
   <div>

--- a/packages/ilios-common/addon/components/weekly-calendar-event.hbs
+++ b/packages/ilios-common/addon/components/weekly-calendar-event.hbs
@@ -33,11 +33,11 @@
     {{#if this.isIlm}}
       <span class="ilios-calendar-event-start">
         {{t "general.ilmDue"}}:
-        {{format-date this.startDate  hour12=true hour="numeric" minute="numeric"}}
+        {{format-date this.startDate hour12=true hour="2-digit" minute="2-digit"}}
       </span>
     {{else}}
       <span class="ilios-calendar-event-start">
-        {{format-date this.startDate  hour12=true hour="numeric" minute="numeric"}}
+        {{format-date this.startDate hour12=true hour="2-digit" minute="2-digit"}}
       </span>
     {{/if}}
   </span>

--- a/packages/ilios-common/addon/components/weekly-calendar.hbs
+++ b/packages/ilios-common/addon/components/weekly-calendar.hbs
@@ -11,8 +11,8 @@
       ...
     {{else}}
       <span class="short" data-test-short>
-        {{format-date this.firstDayOfWeek month="numeric" day="numeric"}} &mdash;
-        {{format-date this.lastDayOfWeek month="numeric" day="numeric"}}
+        {{format-date this.firstDayOfWeek month="2-digit" day="2-digit"}} &mdash;
+        {{format-date this.lastDayOfWeek month="2-digit" day="2-digit"}}
         {{format-date this.lastDayOfWeek year="numeric"}}
       </span>
       <span class="long" data-test-long>{{t "general.weekOf" date=(format-date this.firstDayOfWeek month="long" day="numeric" year="numeric")}}</span>

--- a/packages/test-app/tests/integration/components/daily-calendar-event-test.js
+++ b/packages/test-app/tests/integration/components/daily-calendar-event-test.js
@@ -92,7 +92,7 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 0');
-      assert.strictEqual(component.time, '8:00 AM');
+      assert.strictEqual(component.time, '08:00 AM');
     });
 
     test('check event 0', async function (assert) {
@@ -108,7 +108,7 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 0');
-      assert.strictEqual(component.time, '8:00 AM');
+      assert.strictEqual(component.time, '08:00 AM');
     });
 
     test('check event 1', async function (assert) {
@@ -124,7 +124,7 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 1');
-      assert.strictEqual(component.time, '8:00 AM');
+      assert.strictEqual(component.time, '08:00 AM');
     });
 
     test('check event 2', async function (assert) {
@@ -140,7 +140,7 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 2');
-      assert.strictEqual(component.time, '8:10 AM');
+      assert.strictEqual(component.time, '08:10 AM');
     });
 
     test('check event 3', async function (assert) {
@@ -287,7 +287,7 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 0');
-      assert.strictEqual(component.time, '8:10 AM');
+      assert.strictEqual(component.time, '08:10 AM');
     });
 
     test('check event 1', async function (assert) {
@@ -303,7 +303,7 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 1');
-      assert.strictEqual(component.time, '8:10 AM');
+      assert.strictEqual(component.time, '08:10 AM');
     });
 
     test('check event 2', async function (assert) {
@@ -319,7 +319,7 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 2');
-      assert.strictEqual(component.time, '9:40 AM');
+      assert.strictEqual(component.time, '09:40 AM');
     });
 
     test('check event 3', async function (assert) {

--- a/packages/test-app/tests/integration/components/daily-calendar-test.js
+++ b/packages/test-app/tests/integration/components/daily-calendar-test.js
@@ -43,7 +43,7 @@ module('Integration | Component | daily-calendar', function (hooks) {
 `);
     assert.strictEqual(component.ariaBusy, 'false');
     assert.strictEqual(component.title.longDayOfWeek, 'Wednesday, January 9, 2019');
-    assert.strictEqual(component.title.shortDayOfWeek, '1/9/2019');
+    assert.strictEqual(component.title.shortDayOfWeek, '01/09/2019');
     assert.ok(component.hasNoEvents);
 
     await a11yAudit(this.element);

--- a/packages/test-app/tests/integration/components/ilios-calendar-event-month-test.js
+++ b/packages/test-app/tests/integration/components/ilios-calendar-event-month-test.js
@@ -28,6 +28,6 @@ module('Integration | Component | ilios calendar event month', function (hooks) 
       'border-left-style': 'solid',
       'border-left-color': 'rgb(0, 173, 86)',
     });
-    assert.dom(s).hasText('8:00 AM - 9:00 AM : test');
+    assert.dom(s).hasText('08:00 AM - 09:00 AM : test');
   });
 });

--- a/packages/test-app/tests/integration/components/ilios-calendar-month-test.js
+++ b/packages/test-app/tests/integration/components/ilios-calendar-month-test.js
@@ -115,11 +115,11 @@ module('Integration | Component | ilios calendar month', function (hooks) {
     assert.strictEqual(component.multiday.events.length, 2);
     assert.strictEqual(
       component.multiday.events[0].text,
-      '9/20/15, 12:00 PM – 9/21/15, 12:00 PM Rm. 160',
+      '09/20/15, 12:00 PM – 09/21/15, 12:00 PM Rm. 160',
     );
     assert.strictEqual(
       component.multiday.events[1].text,
-      '9/22/15, 12:00 PM – 9/23/15, 12:00 PM Rm. 160',
+      '09/22/15, 12:00 PM – 09/23/15, 12:00 PM Rm. 160',
     );
   });
 });

--- a/packages/test-app/tests/integration/components/single-event-test.js
+++ b/packages/test-app/tests/integration/components/single-event-test.js
@@ -269,8 +269,8 @@ module('Integration | Component | ilios calendar single event', function (hooks)
         year: 'numeric',
         month: 'long',
         day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
       }),
     );
   });
@@ -311,8 +311,8 @@ module('Integration | Component | ilios calendar single event', function (hooks)
       year: 'numeric',
       month: 'long',
       day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
     });
     assert.strictEqual(
       component.summary.offeredAt,
@@ -442,16 +442,16 @@ module('Integration | Component | ilios calendar single event', function (hooks)
       year: 'numeric',
       month: 'long',
       day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
     });
     const formattedToday = this.intl.formatDate(today.toJSDate(), {
       weekday: 'long',
       year: 'numeric',
       month: 'long',
       day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
     });
     assert.strictEqual(
       component.summary.offeredAt,
@@ -532,8 +532,8 @@ module('Integration | Component | ilios calendar single event', function (hooks)
         year: 'numeric',
         month: 'long',
         day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
       }),
     );
   });
@@ -566,13 +566,13 @@ module('Integration | Component | ilios calendar single event', function (hooks)
         year: 'numeric',
         month: 'long',
         day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
       }) +
         ' - ' +
         this.intl.formatDate(laterToday.toJSDate(), {
-          hour: 'numeric',
-          minute: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
         }),
     );
   });
@@ -605,8 +605,8 @@ module('Integration | Component | ilios calendar single event', function (hooks)
         year: 'numeric',
         month: 'long',
         day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
       }) +
         ' - ' +
         this.intl.formatDate(notToday.toJSDate(), {
@@ -614,8 +614,8 @@ module('Integration | Component | ilios calendar single event', function (hooks)
           year: 'numeric',
           month: 'long',
           day: 'numeric',
-          hour: 'numeric',
-          minute: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
         }),
     );
   });

--- a/packages/test-app/tests/integration/components/weekly-calendar-event-test.js
+++ b/packages/test-app/tests/integration/components/weekly-calendar-event-test.js
@@ -92,7 +92,7 @@ module('Integration | Component | weekly-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 0');
-      assert.strictEqual(component.time, '8:00 AM');
+      assert.strictEqual(component.time, '08:00 AM');
     });
 
     test('check event 0', async function (assert) {
@@ -108,7 +108,7 @@ module('Integration | Component | weekly-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 0');
-      assert.strictEqual(component.time, '8:00 AM');
+      assert.strictEqual(component.time, '08:00 AM');
     });
 
     test('check event 1', async function (assert) {
@@ -124,7 +124,7 @@ module('Integration | Component | weekly-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 1');
-      assert.strictEqual(component.time, '8:00 AM');
+      assert.strictEqual(component.time, '08:00 AM');
     });
 
     test('check event 2', async function (assert) {
@@ -140,7 +140,7 @@ module('Integration | Component | weekly-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 2');
-      assert.strictEqual(component.time, '8:10 AM');
+      assert.strictEqual(component.time, '08:10 AM');
     });
 
     test('check event 3', async function (assert) {
@@ -287,7 +287,7 @@ module('Integration | Component | weekly-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 0');
-      assert.strictEqual(component.time, '8:10 AM');
+      assert.strictEqual(component.time, '08:10 AM');
     });
 
     test('check event 1', async function (assert) {
@@ -303,7 +303,7 @@ module('Integration | Component | weekly-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 1');
-      assert.strictEqual(component.time, '8:10 AM');
+      assert.strictEqual(component.time, '08:10 AM');
     });
 
     test('check event 2', async function (assert) {
@@ -319,7 +319,7 @@ module('Integration | Component | weekly-calendar-event', function (hooks) {
       assert.ok(component.style.includes(styles['grid-row-end']));
       assert.ok(component.style.includes(styles['grid-column-start']));
       assert.strictEqual(component.name, 'event 2');
-      assert.strictEqual(component.time, '9:40 AM');
+      assert.strictEqual(component.time, '09:40 AM');
     });
 
     test('check event 3', async function (assert) {

--- a/packages/test-app/tests/integration/components/weekly-calendar-test.js
+++ b/packages/test-app/tests/integration/components/weekly-calendar-test.js
@@ -48,7 +48,7 @@ module('Integration | Component | weekly-calendar', function (hooks) {
 `);
     assert.strictEqual(component.ariaBusy, 'false');
     assert.strictEqual(component.title.longWeekOfYear, 'Week of January 6, 2019');
-    assert.strictEqual(component.title.shortWeekOfYear, '1/6 — 1/12 2019');
+    assert.strictEqual(component.title.shortWeekOfYear, '01/06 — 01/12 2019');
     assert.strictEqual(component.dayHeadings.length, 7);
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
     assert.strictEqual(component.dayHeadings[0].text, 'Sunday Sun Jan 6 6');
@@ -290,7 +290,7 @@ module('Integration | Component | weekly-calendar', function (hooks) {
 `);
 
     assert.strictEqual(component.title.longWeekOfYear, 'Week of December 7, 1980');
-    assert.strictEqual(component.title.shortWeekOfYear, '12/7 — 12/13 1980');
+    assert.strictEqual(component.title.shortWeekOfYear, '12/07 — 12/13 1980');
 
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
     assert.strictEqual(component.dayHeadings[0].text, 'Sunday Sun Dec 7 7');
@@ -337,7 +337,7 @@ module('Integration | Component | weekly-calendar', function (hooks) {
 `);
 
     assert.strictEqual(component.title.longWeekOfYear, 'Week of February 23, 2020');
-    assert.strictEqual(component.title.shortWeekOfYear, '2/23 — 2/29 2020');
+    assert.strictEqual(component.title.shortWeekOfYear, '02/23 — 02/29 2020');
 
     assert.ok(component.dayHeadings[0].isFirstDayOfWeek);
     assert.strictEqual(component.dayHeadings[0].text, 'Sunday Sun Feb 23 23');


### PR DESCRIPTION
Contributes to fixing ilios/ilios#5532

Any dates or times on the calendar, be it day, week, or month, as well as the Week at a Glance events (and single-event detail pages linked from it), should now use the 2-digit format.

The one exception is if the date is written out in "long" format, e.g. `Friday, June 7, 2024`