### PR TITLE
Stop using the pnpm cache for updating dependencies

### DIFF
--- a/.github/workflows/update-transitive-dependencies.yaml
+++ b/.github/workflows/update-transitive-dependencies.yaml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
       - name: remove and re-create lock file
         run: |
           rm pnpm-lock.yaml


### PR DESCRIPTION
This job shouldn't be cached at all, we want everything fresh.