### PR TITLE
Update ember data to 5.3.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,6 @@ updates:
       - dependency-name: ember-cli-inject-live-reload
       - dependency-name: ember-cli-sri
       - dependency-name: ember-cli-terser
-      - dependency-name: ember-data
       - dependency-name: ember-fetch
       - dependency-name: ember-load-initializers
       - dependency-name: ember-modifier

--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -43,7 +43,7 @@
     "ember-click-outside": "^6.0.0",
     "ember-concurrency": "^4.0.2",
     "ember-could-get-used-to-this": "^1.0.1",
-    "ember-data": "5.3.0",
+    "ember-data": "~5.3.6",
     "ember-event-helpers": "^0.1.0",
     "ember-feature-flags": "^6.0.0",
     "ember-file-upload": "^9.0.0",

--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -43,7 +43,7 @@
     "ember-click-outside": "^6.0.0",
     "ember-concurrency": "^4.0.2",
     "ember-could-get-used-to-this": "^1.0.1",
-    "ember-data": "~5.3.6",
+    "ember-data": "5.3.8",
     "ember-event-helpers": "^0.1.0",
     "ember-feature-flags": "^6.0.0",
     "ember-file-upload": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,7 +164,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: ^3.0.3
-        version: 3.0.3(@ember-data/model@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
+        version: 3.0.3(@ember-data/model@5.3.6)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
       ember-cli-page-object:
         specifier: ^2.3.0
         version: 2.3.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))
@@ -397,8 +397,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       ember-data:
-        specifier: 5.3.0
-        version: 5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+        specifier: ~5.3.6
+        version: 5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
       ember-event-helpers:
         specifier: ^0.1.0
         version: 0.1.1
@@ -407,7 +407,7 @@ importers:
         version: 6.0.0
       ember-file-upload:
         specifier: ^9.0.0
-        version: 9.0.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glimmer/tracking@1.1.2)(ember-cli-mirage@3.0.3(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1))(ember-modifier@4.1.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(miragejs@0.1.48)(tracked-built-ins@3.3.0)(webpack@5.92.1)
+        version: 9.0.0(lljhyg4imhxayrohxukxbwtrkq)
       ember-focus-trap:
         specifier: ^1.0.0
         version: 1.1.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
@@ -681,7 +681,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: ^3.0.2
-        version: 3.0.3(@ember-data/model@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
+        version: 3.0.3(@ember-data/model@5.3.6)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
       ember-cli-sass:
         specifier: ^11.0.1
         version: 11.0.1
@@ -867,7 +867,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: ^3.0.2
-        version: 3.0.3(@ember-data/model@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
+        version: 3.0.3(@ember-data/model@5.3.6)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
       ember-cli-sass:
         specifier: ^11.0.1
         version: 11.0.1
@@ -1047,7 +1047,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: ^3.0.3
-        version: 3.0.3(@ember-data/model@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
+        version: 3.0.3(@ember-data/model@5.3.6)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
       ember-cli-sass:
         specifier: 11.0.1
         version: 11.0.1
@@ -2040,102 +2040,120 @@ packages:
   '@dual-bundle/import-meta-resolve@4.1.0':
     resolution: {integrity: sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==}
 
-  '@ember-data/adapter@5.3.0':
-    resolution: {integrity: sha512-OKbqtuOn6ZHFvU36P8876TsWtr6BKx1eOAzftnRtS8kD8r9rxdXapCA7M2V3l+Fma4d+MMwm8flLrqMddP5rmA==}
-    engines: {node: 16.* || >= 18.*}
+  '@ember-data/adapter@5.3.6':
+    resolution: {integrity: sha512-w3jVuK5+yQhxJlHlRJQd24BEvztg7t7Cs4RZqKq3e1js7Fg5ys3nSV8Dgx4AOp2k7psgOybqtiOrtCKDxFM+Mw==}
+    engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/store': 5.3.0
-      '@ember/string': ^3.1.1
-      ember-inflector: ^4.0.2
+      '@ember-data/legacy-compat': 5.3.6
+      '@ember-data/request-utils': 5.3.6
+      '@ember-data/store': 5.3.6
+      '@warp-drive/core-types': 0.0.0-beta.9
 
-  '@ember-data/debug@5.3.0':
-    resolution: {integrity: sha512-R5Jo4N7TSlMj4HdP+kGGVM7vtxxmIm1y+RaqKiRFmh3kzf8lL5FYF6vE0Hjkfu+p9KGnGSuTm731kPxYMZnbzQ==}
-    engines: {node: 16.* || >= 18.*}
+  '@ember-data/debug@5.3.6':
+    resolution: {integrity: sha512-LiuuWDZpfivZuq+ND5EciRJMt0B9nIfIfrb6G0trC7bg25wn2CQz9BY34Np4vvyTupHfBTjAFeTOU3c21Hvueg==}
+    engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/store': 5.3.0
-      '@ember/string': ^3.1.1
+      '@ember-data/model': 5.3.6
+      '@ember-data/request-utils': 5.3.6
+      '@ember-data/store': 5.3.6
+      '@warp-drive/core-types': 0.0.0-beta.9
 
-  '@ember-data/graph@5.3.0':
-    resolution: {integrity: sha512-BK1PGJVpW/ioP9IrvPECvbeiMf8cX0o4Ym3PWRlXIgWbfTnN57/XHwqL6qRo46Li2tMyzoranE6q7Jxhu6DCIg==}
-    engines: {node: 16.* || >= 18.*}
+  '@ember-data/graph@5.3.6':
+    resolution: {integrity: sha512-qQxQ7/yLfgMpRm5ONRhPUVGGUAzHxxmHrLKURkflbJMjSSV+VinO+3rP+XUyIfNVT4usYDMM32P2sS0nn590og==}
+    engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/store': 5.3.0
+      '@ember-data/store': 5.3.6
+      '@warp-drive/core-types': 0.0.0-beta.9
 
-  '@ember-data/json-api@5.3.0':
-    resolution: {integrity: sha512-irS0uuotz5VJbmaGEoK7Ad8JjlVzCI2C+lxz22UelR64Vbb1btnBHlw2Tr2n9s0kNxaR1iHUB94Fo2LBbr0Prg==}
-    engines: {node: 16.* || >= 18.*}
+  '@ember-data/json-api@5.3.6':
+    resolution: {integrity: sha512-Ds1+MAEWa0f1nWaq+RaPEwkQV2NrwwVaPFCjHxngmUGumGbWUqFBLXlU7rC8C3j+KChUtVOwF/MtrNX6y+iLfg==}
+    engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/graph': 5.3.0
-      '@ember-data/request-utils': 5.3.0
-      '@ember-data/store': 5.3.0
-      ember-inflector: ^4.0.2
+      '@ember-data/graph': 5.3.6
+      '@ember-data/request-utils': 5.3.6
+      '@ember-data/store': 5.3.6
+      '@warp-drive/core-types': 0.0.0-beta.9
 
-  '@ember-data/legacy-compat@5.3.0':
-    resolution: {integrity: sha512-KST6bMqvr6+DLTY5XRLOyCBgOGIj6QCpZQtyOWOhPwKnfeBXygppF9ys0ZWaNhlAaVZSrQ3uPubUit9Y72ZTYQ==}
-    engines: {node: 16.* || >= 18}
+  '@ember-data/legacy-compat@5.3.6':
+    resolution: {integrity: sha512-Ce08G/YJrZex5WeB02m0zt5bEeRG14uclqiNchDfg0LtnxZCtwRa/nPeD2N02Oj/e+xZyRupq2GGHpK+nT3BSw==}
+    engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/graph': 5.3.0
-      '@ember-data/json-api': 5.3.0
-      '@ember-data/request': 5.3.0
+      '@ember-data/graph': 5.3.6
+      '@ember-data/json-api': 5.3.6
+      '@ember-data/request': 5.3.6
+      '@ember-data/request-utils': 5.3.6
+      '@ember-data/store': 5.3.6
+      '@ember/test-waiters': ^3.1.0
+      '@warp-drive/core-types': 0.0.0-beta.9
     peerDependenciesMeta:
       '@ember-data/graph':
         optional: true
       '@ember-data/json-api':
         optional: true
 
-  '@ember-data/model@5.3.0':
-    resolution: {integrity: sha512-9DckZXu3DZk1fYd1js6kS2SCxuuaQBDE1N3NMc+Zz55n8qu1LKHLxr+dGwVqV+Wtl7LGcAU1ocnm7gKNhC1vuw==}
-    engines: {node: 16.* || >= 18.*}
+  '@ember-data/model@5.3.6':
+    resolution: {integrity: sha512-Tm3B20jcQULQNmrnhqsV0/CKyQzqm4sJDTqAZBwZAyEJNXKE26THbnz5GhEedShrtCpE0aUBSAs9MWo0gYHbdw==}
+    engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/debug': 5.3.0
-      '@ember-data/graph': 5.3.0
-      '@ember-data/json-api': 5.3.0
-      '@ember-data/legacy-compat': 5.3.0
-      '@ember-data/store': 5.3.0
-      '@ember-data/tracking': 5.3.0
-      '@ember/string': ^3.1.1
-      ember-inflector: ^4.0.2
+      '@ember-data/graph': 5.3.6
+      '@ember-data/json-api': 5.3.6
+      '@ember-data/legacy-compat': 5.3.6
+      '@ember-data/request-utils': 5.3.6
+      '@ember-data/store': 5.3.6
+      '@ember-data/tracking': 5.3.6
+      '@warp-drive/core-types': 0.0.0-beta.9
     peerDependenciesMeta:
-      '@ember-data/debug':
-        optional: true
       '@ember-data/graph':
         optional: true
       '@ember-data/json-api':
         optional: true
 
-  '@ember-data/private-build-infra@5.3.0':
-    resolution: {integrity: sha512-n7VCPgvjS0Yza5USBucdYjTvlk5GC6fIdWiQUGdK9QxHnyekFg2Znu932ulKp/Iokoc8iBEaVX3HoiCwM/Hw1w==}
-    engines: {node: 16.* || >= 18.*}
+  '@ember-data/request-utils@5.3.6':
+    resolution: {integrity: sha512-5HcS5csxt/vO2HVdSTbrsH4NZ2H6zmyh7tEkJPD1TMmZIqaiceuB4cPGsQMUf298SSrwkqnM5Z+mRIQ4NkNTHg==}
+    engines: {node: '>= 18.20.3'}
+    peerDependencies:
+      '@ember/string': 3.1.1
+      '@warp-drive/core-types': 0.0.0-beta.9
+      ember-inflector: 4.0.2
+    peerDependenciesMeta:
+      '@ember/string':
+        optional: true
+      ember-inflector:
+        optional: true
 
-  '@ember-data/request-utils@5.3.0':
-    resolution: {integrity: sha512-f/DGyW7tKbx1NCxz/arDBXTwEiV0+a0m8AStTMOlPkGLvnDhuHAH3jVlhuNweFxI6CmfXaL+UAY7g+uWAwCn0Q==}
-    engines: {node: 16.* || >= 18}
-
-  '@ember-data/request@5.3.0':
-    resolution: {integrity: sha512-dsgwnhXYMlgO99DPur2AYQpFigU8DSk628GZ9qDhQQ9IRfGkT3yjFGg9M/Bp0G+U3dJbs56Tiy+VhSl36k0Wsw==}
-    engines: {node: 16.* || >= 18}
+  '@ember-data/request@5.3.6':
+    resolution: {integrity: sha512-SNZhTFMVHUQw+bOfxFgBIKnEPLLtQWdPJZFGEvJ7YfMwhLKDNJBJco9Gts9SmQq6njBir59iEZ3T5ekOB5v+Kw==}
+    engines: {node: '>= 18.20.3'}
+    peerDependencies:
+      '@warp-drive/core-types': 0.0.0-beta.9
 
   '@ember-data/rfc395-data@0.0.4':
     resolution: {integrity: sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==}
 
-  '@ember-data/serializer@5.3.0':
-    resolution: {integrity: sha512-apsfN8qHOVQxIxmPQh6SSxYtzNcb3/jvdjJDrU6L8eklyQXfxcbaBD6r2uUAA2jaI94oNXoSHM/75TZnJjLIZA==}
-    engines: {node: 16.* || >= 18.*}
+  '@ember-data/serializer@5.3.6':
+    resolution: {integrity: sha512-NpScceZg95OHCJvGoeUQWZyVMsdtiEU3PdYdanYB9m4z+QP+/4nNM4hD/OGqN69EPTKkYN1PrVs0Sr+fJ+Utjg==}
+    engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember/string': ^3.1.1
-      ember-inflector: ^4.0.2
+      '@ember-data/legacy-compat': 5.3.6
+      '@ember-data/request-utils': 5.3.6
+      '@ember-data/store': 5.3.6
+      '@warp-drive/core-types': 0.0.0-beta.9
 
-  '@ember-data/store@5.3.0':
-    resolution: {integrity: sha512-okM7AJmgM8Wz+FNgsDXVUVw32UZVLKko2K/2GfBmOjOcKVnfwLKI08HmQNLnT5IXiOsJW5mA4mRESuVgN8L4lQ==}
-    engines: {node: 16.* || >= 18.*}
+  '@ember-data/store@5.3.6':
+    resolution: {integrity: sha512-JM2yd+P1sbp7KQnqMCzlk9bdQ/GvW9ruK/Xa16rKmxAsa4ISoDTHSomyOXNRFgDz2SITiXADka2FTYixzI+7Ug==}
+    engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/tracking': 5.3.0
-      '@ember/string': ^3.1.1
-      '@glimmer/tracking': ^1.1.2
+      '@ember-data/request': 5.3.6
+      '@ember-data/request-utils': 5.3.6
+      '@ember-data/tracking': 5.3.6
+      '@warp-drive/core-types': 0.0.0-beta.9
 
-  '@ember-data/tracking@5.3.0':
-    resolution: {integrity: sha512-CEaV9zbKY40I0c7a7AXIhV4P+veA70plWCGU2fA/AMk69BdT64vKx9r+HPvAVsaz7ER4XCnUqyPAZnCWypa9WA==}
-    engines: {node: 16.* || >= 18}
+  '@ember-data/tracking@5.3.6':
+    resolution: {integrity: sha512-t8mp4cPOCK8ozHARouH9ZIAdcYBFxsim0JlEmBx5KxigTObpcMqQRmFodAioizOpEKY5P4Y/gOAnl4LDrzgqKg==}
+    engines: {node: '>= 18.20.3'}
+    peerDependencies:
+      '@warp-drive/core-types': 0.0.0-beta.9
+      ember-source: '>= 3.28.12'
 
   '@ember/edition-utils@1.2.0':
     resolution: {integrity: sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==}
@@ -2982,6 +3000,14 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
+  '@warp-drive/build-config@0.0.0-beta.4':
+    resolution: {integrity: sha512-LO6OoyuCvL7OiBp8r0OuHeA0b4eFknj/S1jOMCrmRemeQbCOlDVAdPBaHylSHMvUnw0nR9M2QbkjWfVQ+DBbtg==}
+    engines: {node: '>= 18.20.3'}
+
+  '@warp-drive/core-types@0.0.0-beta.9':
+    resolution: {integrity: sha512-CMdkNaBMXXqMm2gR29gWExiZs4NFW6kw4ZVSClLQBxhoZs+D6CwPldSCqjPxaeUFuZP1iBtdQs1Up6V69ctw2Q==}
+    engines: {node: '>= 18.20.3'}
+
   '@webassemblyjs/ast@1.12.1':
     resolution: {integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==}
 
@@ -3379,8 +3405,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-sdk@2.1645.0:
-    resolution: {integrity: sha512-KCKKXes0epWsNppMWt2FkTtKTwRJBGIQre3er1weNay8YmF3JTXueRCB/mEk1WFfFq273SPOxl/pj5kH04KjYw==}
+  aws-sdk@2.1646.0:
+    resolution: {integrity: sha512-PAvDiR8ow3zjO0T5HMda04kXIzQ5e1zeWxWGSUodRwu9W569gZPBnqzcPX3PJFNAKBZnZBdbNgsci1g2nXCcBg==}
     engines: {node: '>= 10.0.0'}
 
   axe-core@4.9.1:
@@ -3514,9 +3540,6 @@ packages:
 
   babel-types@6.26.0:
     resolution: {integrity: sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==}
-
-  babel6-plugin-strip-class-callcheck@6.0.0:
-    resolution: {integrity: sha512-biNFJ7JAK4+9BwswDGL0dmYpvXHvswOFR/iKg3Q/f+pNxPEa5bWZkLHI1fW4spPytkHGMe7f/XtYyhzml9hiWg==}
 
   babylon@6.18.0:
     resolution: {integrity: sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==}
@@ -4816,16 +4839,6 @@ packages:
     resolution: {integrity: sha512-EQzStGYxNvTPYWCFh0X57HFAzAvA2rHHRgBeWNDKHQ/rENNlHw0c0e0i1XebwEfv+yGHOodE4dN+f/mrYkQXLw==}
     engines: {node: 12.* || 14.* || >= 16}
 
-  ember-cache-primitive-polyfill@1.0.1:
-    resolution: {integrity: sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==}
-    engines: {node: 10.* || >= 12}
-
-  ember-cached-decorator-polyfill@1.0.2:
-    resolution: {integrity: sha512-hUX6OYTKltAPAu8vsVZK02BfMTV0OUXrPqvRahYPhgS7D0I6joLjlskd7mhqJMcaXLywqceIy8/s+x8bxF8bpQ==}
-    engines: {node: 14.* || >= 16}
-    peerDependencies:
-      ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
-
   ember-cli-app-version@6.0.1:
     resolution: {integrity: sha512-XA1FwkWA5QytmWF0jcJqEr3jcZoiCl9Fb33TZgOVfClL7Voxe+/RwzISEprBRQgbf7j8z1xf8/RJCKfclUy3rQ==}
     engines: {node: 14.* || 16.* || >= 18}
@@ -5128,11 +5141,20 @@ packages:
     resolution: {integrity: sha512-+BXc8NbJJ/DoUXZk4e3qeRvADw9ThMEW7jm+Nz+QX9jRY/5QYodnFeUEfsC4Sw3Ti2m1+RzI2Lyq0QWpgOqFYg==}
     engines: {node: 8.* || >= 10.*}
 
-  ember-data@5.3.0:
-    resolution: {integrity: sha512-ca8udUa2SrWyYxPckYc89Fdv/9pCG3X360zHvlGxtB4C87o3dWp6sle98tP9G1TjximKhrU/PMrqpdhJ8rOGtA==}
-    engines: {node: 16.* || >= 18.*}
+  ember-data@5.3.6:
+    resolution: {integrity: sha512-SztMOhJLijZNsIO0dsKmUNTh+tv3CrEZC8TV7Z/zrpy4enbS33dvRbxjCZNEcPIzh2bx55wfyPA3ot9rbXyKGA==}
+    engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember/string': ^3.1.1
+      '@ember/test-helpers': ^3.3.0
+      '@ember/test-waiters': ^3.1.0
+      qunit: ^2.18.0
+    peerDependenciesMeta:
+      '@ember/test-helpers':
+        optional: true
+      '@ember/test-waiters':
+        optional: true
+      qunit:
+        optional: true
 
   ember-destroyable-polyfill@2.0.3:
     resolution: {integrity: sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==}
@@ -6432,6 +6454,10 @@ packages:
     resolution: {integrity: sha512-wzkZHqpb4eGrOKBl34xy3umnYHx8Si5R1U4fwmdxLo5gdH6mEK8gclckTj/qWqy4Je0bsDYe/qazZYuO7xe3XQ==}
     engines: {node: '>=14.0.0'}
 
+  inflection@3.0.0:
+    resolution: {integrity: sha512-1zEJU1l19SgJlmwqsEyFTbScw/tkMHFenUo//Y0i+XEP83gDFdMvPizAD/WGcE+l1ku12PcTVHQhO6g5E0UCMw==}
+    engines: {node: '>=18.0.0'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -7478,9 +7504,6 @@ packages:
 
   normalize.css@8.0.1:
     resolution: {integrity: sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==}
-
-  npm-git-info@1.0.3:
-    resolution: {integrity: sha512-i5WBdj4F/ULl16z9ZhsJDMl1EQCMQhHZzBwNnKL2LOA+T8IHNeRkLCVz9uVV9SzUdGTbDq+1oXhIYMe+8148vw==}
 
   npm-package-arg@10.1.0:
     resolution: {integrity: sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==}
@@ -11701,188 +11724,187 @@ snapshots:
 
   '@dual-bundle/import-meta-resolve@4.1.0': {}
 
-  '@ember-data/adapter@5.3.0(@babel/core@7.24.7)(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@ember/string@3.1.1)(ember-inflector@4.0.2)':
+  '@ember-data/adapter@5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)':
     dependencies:
-      '@ember-data/private-build-infra': 5.3.0
-      '@ember-data/store': 5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
-      '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.4
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
-      ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/debug@5.3.0(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@ember/string@3.1.1)':
-    dependencies:
-      '@babel/core': 7.24.7
-      '@ember-data/private-build-infra': 5.3.0
-      '@ember-data/store': 5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
-      '@ember/edition-utils': 1.2.0
-      '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.4
-      ember-auto-import: 2.7.3(webpack@5.92.1)
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
-      webpack: 5.92.1
-    transitivePeerDependencies:
-      - '@glint/template'
-      - '@swc/core'
-      - esbuild
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  '@ember-data/graph@5.3.0(@babel/core@7.24.7)(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))':
-    dependencies:
-      '@ember-data/private-build-infra': 5.3.0
-      '@ember-data/store': 5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
+      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.4
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/json-api@5.3.0(@babel/core@7.24.7)(@ember-data/graph@5.3.0(@babel/core@7.24.7)(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))))(@ember-data/request-utils@5.3.0(@babel/core@7.24.7))(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-inflector@4.0.2)':
-    dependencies:
-      '@ember-data/graph': 5.3.0(@babel/core@7.24.7)(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))
-      '@ember-data/private-build-infra': 5.3.0
-      '@ember-data/request-utils': 5.3.0(@babel/core@7.24.7)
-      '@ember-data/store': 5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.4
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
-      ember-inflector: 4.0.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/legacy-compat@5.3.0(aylcnoamntyhzej35657neh5ou)':
-    dependencies:
-      '@ember-data/private-build-infra': 5.3.0
-      '@ember-data/request': 5.3.0(@babel/core@7.24.7)
-      '@embroider/macros': 1.16.4
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
-    optionalDependencies:
-      '@ember-data/graph': 5.3.0(@babel/core@7.24.7)(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))
-      '@ember-data/json-api': 5.3.0(@babel/core@7.24.7)(@ember-data/graph@5.3.0(@babel/core@7.24.7)(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))))(@ember-data/request-utils@5.3.0(@babel/core@7.24.7))(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-inflector@4.0.2)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/model@5.3.0(ap6xq3i4u52tlbqjcipc7v5rje)':
-    dependencies:
-      '@ember-data/legacy-compat': 5.3.0(aylcnoamntyhzej35657neh5ou)
-      '@ember-data/private-build-infra': 5.3.0
-      '@ember-data/store': 5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
-      '@ember-data/tracking': 5.3.0(@babel/core@7.24.7)
-      '@ember/edition-utils': 1.2.0
-      '@ember/string': 3.1.1
-      '@embroider/macros': 1.16.4
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.24.7)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
-      ember-cli-string-utils: 1.1.0
-      ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.2
-      inflection: 2.0.1
-    optionalDependencies:
-      '@ember-data/debug': 5.3.0(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@ember/string@3.1.1)
-      '@ember-data/graph': 5.3.0(@babel/core@7.24.7)(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))
-      '@ember-data/json-api': 5.3.0(@babel/core@7.24.7)(@ember-data/graph@5.3.0(@babel/core@7.24.7)(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))))(@ember-data/request-utils@5.3.0(@babel/core@7.24.7))(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-inflector@4.0.2)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - ember-source
-      - supports-color
-
-  '@ember-data/private-build-infra@5.3.0':
-    dependencies:
-      '@babel/core': 7.24.7
-      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.7)
-      '@babel/runtime': 7.24.7
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.4
-      babel-import-util: 1.4.1
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.7)
-      babel-plugin-filter-imports: 4.0.0
-      babel6-plugin-strip-class-callcheck: 6.0.0
-      broccoli-debug: 0.6.5
-      broccoli-file-creator: 2.1.1
-      broccoli-merge-trees: 4.2.0
-      calculate-cache-key-for-tree: 2.0.0
-      chalk: 4.1.2
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-cli-version-checker: 5.1.2
-      git-repo-info: 2.1.1
-      npm-git-info: 1.0.3
-      semver: 7.6.2
-      silent-error: 1.1.1
+      ember-cli-test-info: 1.0.0
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/request-utils@5.3.0(@babel/core@7.24.7)':
+  '@ember-data/debug@5.3.6(@ember-data/model@5.3.6(aadxxgrx75vhdk33kqgy5e53ku))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)':
     dependencies:
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
+      '@ember-data/model': 5.3.6(aadxxgrx75vhdk33kqgy5e53ku)
+      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
     transitivePeerDependencies:
-      - '@babel/core'
+      - '@glint/template'
       - supports-color
 
-  '@ember-data/request@5.3.0(@babel/core@7.24.7)':
+  '@ember-data/debug@5.3.6(@ember-data/model@5.3.6(eqf63xu3ypidrgzgnedouwi4bm))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)':
     dependencies:
-      '@ember-data/private-build-infra': 5.3.0
+      '@ember-data/model': 5.3.6(eqf63xu3ypidrgzgnedouwi4bm)
+      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+    optional: true
+
+  '@ember-data/graph@5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)':
+    dependencies:
+      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/json-api@5.3.6(4niswjrocysofsw5zndkhmw33m)':
+    dependencies:
+      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym)':
+    dependencies:
+      '@ember-data/request': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.16.4
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+    optionalDependencies:
+      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/json-api': 5.3.6(4niswjrocysofsw5zndkhmw33m)
     transitivePeerDependencies:
-      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/model@5.3.6(aadxxgrx75vhdk33kqgy5e53ku)':
+    dependencies:
+      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
+      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/tracking': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+      ember-cli-string-utils: 1.1.0
+      ember-cli-test-info: 1.0.0
+      inflection: 3.0.0
+    optionalDependencies:
+      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/json-api': 5.3.6(4niswjrocysofsw5zndkhmw33m)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/model@5.3.6(eqf63xu3ypidrgzgnedouwi4bm)':
+    dependencies:
+      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
+      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/tracking': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+      ember-cli-string-utils: 1.1.0
+      ember-cli-test-info: 1.0.0
+      inflection: 3.0.0
+    optionalDependencies:
+      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/json-api': 5.3.6(4niswjrocysofsw5zndkhmw33m)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+    optional: true
+
+  '@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)':
+    dependencies:
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+    optionalDependencies:
+      '@ember/string': 3.1.1
+      ember-inflector: 4.0.2
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9)':
+    dependencies:
+      '@ember/test-waiters': 3.1.0
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+    transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
   '@ember-data/rfc395-data@0.0.4': {}
 
-  '@ember-data/serializer@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(ember-inflector@4.0.2)':
+  '@ember-data/serializer@5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)':
     dependencies:
-      '@ember-data/private-build-infra': 5.3.0
-      '@ember/string': 3.1.1
+      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
+      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.4
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+      ember-cli-path-utils: 1.0.0
+      ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.2
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))':
+  '@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)':
     dependencies:
-      '@ember-data/private-build-infra': 5.3.0
-      '@ember-data/tracking': 5.3.0(@babel/core@7.24.7)
-      '@ember/string': 3.1.1
+      '@ember-data/request': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
+      '@ember-data/tracking': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
       '@embroider/macros': 1.16.4
-      '@glimmer/tracking': 1.1.2
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.24.7)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
-      - ember-source
       - supports-color
 
-  '@ember-data/tracking@5.3.0(@babel/core@7.24.7)':
+  '@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))':
     dependencies:
-      '@ember-data/private-build-infra': 5.3.0
       '@embroider/macros': 1.16.4
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+      ember-source: 5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
 
@@ -13269,6 +13291,25 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
+  '@warp-drive/build-config@0.0.0-beta.4':
+    dependencies:
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.16.4
+      babel-import-util: 2.1.1
+      broccoli-funnel: 3.0.8
+      semver: 7.6.2
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@warp-drive/core-types@0.0.0-beta.9':
+    dependencies:
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.4
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
   '@webassemblyjs/ast@1.12.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.11.6
@@ -13706,7 +13747,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-sdk@2.1645.0:
+  aws-sdk@2.1646.0:
     dependencies:
       buffer: 4.9.2
       events: 1.1.1
@@ -13978,8 +14019,6 @@ snapshots:
       esutils: 2.0.3
       lodash: 4.17.21
       to-fast-properties: 1.0.3
-
-  babel6-plugin-strip-class-callcheck@6.0.0: {}
 
   babylon@6.18.0: {}
 
@@ -14647,7 +14686,7 @@ snapshots:
   buffer@4.9.2:
     dependencies:
       base64-js: 1.5.1
-      ieee754: 1.2.1
+      ieee754: 1.1.13
       isarray: 1.0.0
 
   buffer@5.7.1:
@@ -15623,30 +15662,6 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-cache-primitive-polyfill@1.0.1(@babel/core@7.24.7):
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 5.1.2
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.24.7)
-      silent-error: 1.1.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.24.7)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)):
-    dependencies:
-      '@embroider/macros': 1.16.4
-      '@glimmer/tracking': 1.1.2
-      babel-import-util: 1.4.1
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.7)
-      ember-cli-babel: 7.26.11
-      ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
   ember-cli-app-version@6.0.1(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)):
     dependencies:
       ember-cli-babel: 7.26.11
@@ -15841,7 +15856,7 @@ snapshots:
 
   ember-cli-deploy-cloudfront@4.0.0:
     dependencies:
-      aws-sdk: 2.1645.0
+      aws-sdk: 2.1646.0
       core-object: 3.1.5
       ember-cli-deploy-plugin: 0.2.9
       rsvp: 4.8.5
@@ -15849,7 +15864,7 @@ snapshots:
 
   ember-cli-deploy-cloudfront@5.0.0:
     dependencies:
-      aws-sdk: 2.1645.0
+      aws-sdk: 2.1646.0
       core-object: 3.1.5
       ember-cli-deploy-plugin: 0.2.9
       rsvp: 4.8.5
@@ -15933,7 +15948,7 @@ snapshots:
 
   ember-cli-deploy-s3@3.3.0:
     dependencies:
-      aws-sdk: 2.1645.0
+      aws-sdk: 2.1646.0
       chalk: 4.1.2
       core-object: 3.1.5
       ember-cli-deploy-plugin: 0.2.9
@@ -16050,7 +16065,7 @@ snapshots:
 
   ember-cli-lodash-subset@2.0.1: {}
 
-  ember-cli-mirage@3.0.3(@ember-data/model@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1):
+  ember-cli-mirage@3.0.3(@ember-data/model@5.3.6(aadxxgrx75vhdk33kqgy5e53ku))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1):
     dependencies:
       '@babel/core': 7.24.7
       '@embroider/macros': 1.16.4
@@ -16064,9 +16079,32 @@ snapshots:
       ember-source: 5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)
       miragejs: 0.1.48
     optionalDependencies:
-      '@ember-data/model': 5.3.0(ap6xq3i4u52tlbqjcipc7v5rje)
+      '@ember-data/model': 5.3.6(aadxxgrx75vhdk33kqgy5e53ku)
       '@ember/test-helpers': 3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1)
-      ember-data: 5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      ember-data: 5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+    optional: true
+
+  ember-cli-mirage@3.0.3(@ember-data/model@5.3.6)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1):
+    dependencies:
+      '@babel/core': 7.24.7
+      '@embroider/macros': 1.16.4
+      broccoli-file-creator: 2.1.1
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      ember-auto-import: 2.7.3(webpack@5.92.1)
+      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
+      ember-get-config: 2.1.1
+      ember-inflector: 4.0.2
+      ember-source: 5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)
+      miragejs: 0.1.48
+    optionalDependencies:
+      '@ember-data/model': 5.3.6(aadxxgrx75vhdk33kqgy5e53ku)
+      '@ember/test-helpers': 3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1)
+      ember-data: 5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
       ember-qunit: 8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
     transitivePeerDependencies:
       - '@glint/template'
@@ -16433,38 +16471,61 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-data@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)):
+  ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0):
     dependencies:
-      '@ember-data/adapter': 5.3.0(@babel/core@7.24.7)(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@ember/string@3.1.1)(ember-inflector@4.0.2)
-      '@ember-data/debug': 5.3.0(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@ember/string@3.1.1)
-      '@ember-data/graph': 5.3.0(@babel/core@7.24.7)(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))
-      '@ember-data/json-api': 5.3.0(@babel/core@7.24.7)(@ember-data/graph@5.3.0(@babel/core@7.24.7)(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))))(@ember-data/request-utils@5.3.0(@babel/core@7.24.7))(@ember-data/store@5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-inflector@4.0.2)
-      '@ember-data/legacy-compat': 5.3.0(aylcnoamntyhzej35657neh5ou)
-      '@ember-data/model': 5.3.0(ap6xq3i4u52tlbqjcipc7v5rje)
-      '@ember-data/private-build-infra': 5.3.0
-      '@ember-data/request': 5.3.0(@babel/core@7.24.7)
-      '@ember-data/request-utils': 5.3.0(@babel/core@7.24.7)
-      '@ember-data/serializer': 5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(ember-inflector@4.0.2)
-      '@ember-data/store': 5.3.0(@babel/core@7.24.7)(@ember-data/tracking@5.3.0(@babel/core@7.24.7))(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
-      '@ember-data/tracking': 5.3.0(@babel/core@7.24.7)
+      '@ember-data/adapter': 5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/debug': 5.3.6(@ember-data/model@5.3.6(aadxxgrx75vhdk33kqgy5e53ku))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/json-api': 5.3.6(4niswjrocysofsw5zndkhmw33m)
+      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
+      '@ember-data/model': 5.3.6(aadxxgrx75vhdk33kqgy5e53ku)
+      '@ember-data/request': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
+      '@ember-data/serializer': 5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/tracking': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
       '@ember/edition-utils': 1.2.0
-      '@ember/string': 3.1.1
       '@embroider/macros': 1.16.4
-      broccoli-merge-trees: 4.2.0
-      ember-auto-import: 2.7.3(webpack@5.92.1)
-      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
-      ember-inflector: 4.0.2
-      webpack: 5.92.1
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+    optionalDependencies:
+      '@ember/test-helpers': 3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1)
+      '@ember/test-waiters': 3.1.0
+      qunit: 2.21.0
     transitivePeerDependencies:
-      - '@babel/core'
-      - '@glimmer/tracking'
+      - '@ember/string'
       - '@glint/template'
-      - '@swc/core'
+      - ember-inflector
       - ember-source
-      - esbuild
       - supports-color
-      - uglify-js
-      - webpack-cli
+
+  ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0):
+    dependencies:
+      '@ember-data/adapter': 5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/debug': 5.3.6(@ember-data/model@5.3.6(eqf63xu3ypidrgzgnedouwi4bm))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/json-api': 5.3.6(4niswjrocysofsw5zndkhmw33m)
+      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
+      '@ember-data/model': 5.3.6(eqf63xu3ypidrgzgnedouwi4bm)
+      '@ember-data/request': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
+      '@ember-data/serializer': 5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/tracking': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/core-types': 0.0.0-beta.9
+    optionalDependencies:
+      '@ember/test-helpers': 3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1)
+      qunit: 2.21.0
+    transitivePeerDependencies:
+      - '@ember/string'
+      - '@glint/template'
+      - ember-inflector
+      - ember-source
+      - supports-color
+    optional: true
 
   ember-destroyable-polyfill@2.0.3(@babel/core@7.24.7):
     dependencies:
@@ -16518,7 +16579,7 @@ snapshots:
       - encoding
       - supports-color
 
-  ember-file-upload@9.0.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@glimmer/component@1.1.2(@babel/core@7.24.7))(@glimmer/tracking@1.1.2)(ember-cli-mirage@3.0.3(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1))(ember-modifier@4.1.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(miragejs@0.1.48)(tracked-built-ins@3.3.0)(webpack@5.92.1):
+  ember-file-upload@9.0.0(lljhyg4imhxayrohxukxbwtrkq):
     dependencies:
       '@ember/test-helpers': 3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1)
       '@ember/test-waiters': 3.1.0
@@ -16530,7 +16591,7 @@ snapshots:
       ember-modifier: 4.1.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
       tracked-built-ins: 3.3.0
     optionalDependencies:
-      ember-cli-mirage: 3.0.3(@ember-data/model@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.0(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
+      ember-cli-mirage: 3.0.3(@ember-data/model@5.3.6(aadxxgrx75vhdk33kqgy5e53ku))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
       miragejs: 0.1.48
     transitivePeerDependencies:
       - '@glint/template'
@@ -18358,6 +18419,8 @@ snapshots:
 
   inflection@2.0.1: {}
 
+  inflection@3.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -19432,8 +19495,6 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize.css@8.0.1: {}
-
-  npm-git-info@1.0.3: {}
 
   npm-package-arg@10.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,13 +62,13 @@ importers:
         version: 1.1.2
       '@percy/cli':
         specifier: ^1.28.7
-        version: 1.28.7
+        version: 1.28.8
       '@percy/ember':
         specifier: ^4.2.0
         version: 4.2.0
       '@sentry/ember':
         specifier: ^8.10.0
-        version: 8.10.0(webpack@5.92.1)
+        version: 8.11.0(webpack@5.92.1)
       broccoli-asset-rev:
         specifier: ^3.0.0
         version: 3.0.0
@@ -164,7 +164,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: ^3.0.3
-        version: 3.0.3(@ember-data/model@5.3.6)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
+        version: 3.0.3(@ember-data/model@5.3.8)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
       ember-cli-page-object:
         specifier: ^2.3.0
         version: 2.3.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))
@@ -296,7 +296,7 @@ importers:
         version: 14.0.0(postcss@8.4.38)(stylelint@16.6.1)
       stylelint-config-standard:
         specifier: ^36.0.0
-        version: 36.0.0(stylelint@16.6.1)
+        version: 36.0.1(stylelint@16.6.1)
       stylelint-prettier:
         specifier: ^5.0.0
         version: 5.0.0(prettier@3.3.2)(stylelint@16.6.1)
@@ -397,8 +397,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       ember-data:
-        specifier: ~5.3.6
-        version: 5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
+        specifier: 5.3.8
+        version: 5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
       ember-event-helpers:
         specifier: ^0.1.0
         version: 0.1.1
@@ -407,7 +407,7 @@ importers:
         version: 6.0.0
       ember-file-upload:
         specifier: ^9.0.0
-        version: 9.0.0(lljhyg4imhxayrohxukxbwtrkq)
+        version: 9.0.0(s47qe4fgslqe2qmtec2srscfpu)
       ember-focus-trap:
         specifier: ^1.0.0
         version: 1.1.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
@@ -573,7 +573,7 @@ importers:
         version: 14.0.0(postcss@8.4.38)(stylelint@16.6.1)
       stylelint-config-standard:
         specifier: ^36.0.0
-        version: 36.0.0(stylelint@16.6.1)
+        version: 36.0.1(stylelint@16.6.1)
       stylelint-prettier:
         specifier: ^5.0.0
         version: 5.0.0(prettier@3.3.2)(stylelint@16.6.1)
@@ -681,7 +681,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: ^3.0.2
-        version: 3.0.3(@ember-data/model@5.3.6)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
+        version: 3.0.3(@ember-data/model@5.3.8)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
       ember-cli-sass:
         specifier: ^11.0.1
         version: 11.0.1
@@ -765,7 +765,7 @@ importers:
         version: 14.0.0(postcss@8.4.38)(stylelint@16.6.1)
       stylelint-config-standard:
         specifier: ^36.0.0
-        version: 36.0.0(stylelint@16.6.1)
+        version: 36.0.1(stylelint@16.6.1)
       stylelint-prettier:
         specifier: ^5.0.0
         version: 5.0.0(prettier@3.3.2)(stylelint@16.6.1)
@@ -867,7 +867,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: ^3.0.2
-        version: 3.0.3(@ember-data/model@5.3.6)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
+        version: 3.0.3(@ember-data/model@5.3.8)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
       ember-cli-sass:
         specifier: ^11.0.1
         version: 11.0.1
@@ -954,7 +954,7 @@ importers:
         version: 14.0.0(postcss@8.4.38)(stylelint@16.6.1)
       stylelint-config-standard:
         specifier: ^36.0.0
-        version: 36.0.0(stylelint@16.6.1)
+        version: 36.0.1(stylelint@16.6.1)
       stylelint-prettier:
         specifier: ^5.0.0
         version: 5.0.0(prettier@3.3.2)(stylelint@16.6.1)
@@ -1008,7 +1008,7 @@ importers:
         version: 1.1.2
       '@percy/cli':
         specifier: ^1.28.7
-        version: 1.28.7
+        version: 1.28.8
       '@percy/ember':
         specifier: ^4.2.0
         version: 4.2.0
@@ -1047,7 +1047,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: ^3.0.3
-        version: 3.0.3(@ember-data/model@5.3.6)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
+        version: 3.0.3(@ember-data/model@5.3.8)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
       ember-cli-sass:
         specifier: 11.0.1
         version: 11.0.1
@@ -1143,7 +1143,7 @@ importers:
         version: 14.0.0(postcss@8.4.38)(stylelint@16.6.1)
       stylelint-config-standard:
         specifier: ^36.0.0
-        version: 36.0.0(stylelint@16.6.1)
+        version: 36.0.1(stylelint@16.6.1)
       stylelint-prettier:
         specifier: ^5.0.0
         version: 5.0.0(prettier@3.3.2)(stylelint@16.6.1)
@@ -2040,80 +2040,80 @@ packages:
   '@dual-bundle/import-meta-resolve@4.1.0':
     resolution: {integrity: sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==}
 
-  '@ember-data/adapter@5.3.6':
-    resolution: {integrity: sha512-w3jVuK5+yQhxJlHlRJQd24BEvztg7t7Cs4RZqKq3e1js7Fg5ys3nSV8Dgx4AOp2k7psgOybqtiOrtCKDxFM+Mw==}
+  '@ember-data/adapter@5.3.8':
+    resolution: {integrity: sha512-mlyGQyiNv3C5SN0jRqVboixnSW/h0r1g7wsCus35p51zKYtq7HGyp3EaEQZOt+4dRS0wNfDx4Z95PPbH/rmH0Q==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/legacy-compat': 5.3.6
-      '@ember-data/request-utils': 5.3.6
-      '@ember-data/store': 5.3.6
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@ember-data/legacy-compat': 5.3.8
+      '@ember-data/request-utils': 5.3.8
+      '@ember-data/store': 5.3.8
+      '@warp-drive/core-types': 0.0.0-beta.11
 
-  '@ember-data/debug@5.3.6':
-    resolution: {integrity: sha512-LiuuWDZpfivZuq+ND5EciRJMt0B9nIfIfrb6G0trC7bg25wn2CQz9BY34Np4vvyTupHfBTjAFeTOU3c21Hvueg==}
+  '@ember-data/debug@5.3.8':
+    resolution: {integrity: sha512-cqats3thXCd5UJbswF/ZGDFJPqBZ7tgHZjDGWa8NuRuDn7YgB3PqAz+I4CjxPkQokOPeYzk/0JvNvTOlp4IjuA==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/model': 5.3.6
-      '@ember-data/request-utils': 5.3.6
-      '@ember-data/store': 5.3.6
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@ember-data/model': 5.3.8
+      '@ember-data/request-utils': 5.3.8
+      '@ember-data/store': 5.3.8
+      '@warp-drive/core-types': 0.0.0-beta.11
 
-  '@ember-data/graph@5.3.6':
-    resolution: {integrity: sha512-qQxQ7/yLfgMpRm5ONRhPUVGGUAzHxxmHrLKURkflbJMjSSV+VinO+3rP+XUyIfNVT4usYDMM32P2sS0nn590og==}
+  '@ember-data/graph@5.3.8':
+    resolution: {integrity: sha512-JNaR41QlA4R1mXJKbI2S2+Zdy3ysoArAQmfnHouDXWezQD6NpgKgmfLmCqxtdHkAVQ8ttnAMx/S/A2fPTVaeyw==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/store': 5.3.6
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@ember-data/store': 5.3.8
+      '@warp-drive/core-types': 0.0.0-beta.11
 
-  '@ember-data/json-api@5.3.6':
-    resolution: {integrity: sha512-Ds1+MAEWa0f1nWaq+RaPEwkQV2NrwwVaPFCjHxngmUGumGbWUqFBLXlU7rC8C3j+KChUtVOwF/MtrNX6y+iLfg==}
+  '@ember-data/json-api@5.3.8':
+    resolution: {integrity: sha512-n0Woiu4oEiJmqfLa5xM9fbhY7+nntncdgWrJfYO1IMEcuO0fbmZVLPye1wTjUIog7uwmjD1uP0u63MnKyqOSeA==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/graph': 5.3.6
-      '@ember-data/request-utils': 5.3.6
-      '@ember-data/store': 5.3.6
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@ember-data/graph': 5.3.8
+      '@ember-data/request-utils': 5.3.8
+      '@ember-data/store': 5.3.8
+      '@warp-drive/core-types': 0.0.0-beta.11
 
-  '@ember-data/legacy-compat@5.3.6':
-    resolution: {integrity: sha512-Ce08G/YJrZex5WeB02m0zt5bEeRG14uclqiNchDfg0LtnxZCtwRa/nPeD2N02Oj/e+xZyRupq2GGHpK+nT3BSw==}
+  '@ember-data/legacy-compat@5.3.8':
+    resolution: {integrity: sha512-b043cU5k+gT+E2YT4ujHoea/81gmYrZTu6Yvt5n87YoCP0p5UxJWji11BTYfJAYN0sf1QAl+OkxI1BX7Ed1Q0g==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/graph': 5.3.6
-      '@ember-data/json-api': 5.3.6
-      '@ember-data/request': 5.3.6
-      '@ember-data/request-utils': 5.3.6
-      '@ember-data/store': 5.3.6
+      '@ember-data/graph': 5.3.8
+      '@ember-data/json-api': 5.3.8
+      '@ember-data/request': 5.3.8
+      '@ember-data/request-utils': 5.3.8
+      '@ember-data/store': 5.3.8
       '@ember/test-waiters': ^3.1.0
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/core-types': 0.0.0-beta.11
     peerDependenciesMeta:
       '@ember-data/graph':
         optional: true
       '@ember-data/json-api':
         optional: true
 
-  '@ember-data/model@5.3.6':
-    resolution: {integrity: sha512-Tm3B20jcQULQNmrnhqsV0/CKyQzqm4sJDTqAZBwZAyEJNXKE26THbnz5GhEedShrtCpE0aUBSAs9MWo0gYHbdw==}
+  '@ember-data/model@5.3.8':
+    resolution: {integrity: sha512-vg7hIzQmDXCDapUZc6kawKE2IAD9A4RowQBmBD7gR7TWtzinmoSygHYHjZpVdAEV4JE3EI1gjbyQesRLoAub1A==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/graph': 5.3.6
-      '@ember-data/json-api': 5.3.6
-      '@ember-data/legacy-compat': 5.3.6
-      '@ember-data/request-utils': 5.3.6
-      '@ember-data/store': 5.3.6
-      '@ember-data/tracking': 5.3.6
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@ember-data/graph': 5.3.8
+      '@ember-data/json-api': 5.3.8
+      '@ember-data/legacy-compat': 5.3.8
+      '@ember-data/request-utils': 5.3.8
+      '@ember-data/store': 5.3.8
+      '@ember-data/tracking': 5.3.8
+      '@warp-drive/core-types': 0.0.0-beta.11
     peerDependenciesMeta:
       '@ember-data/graph':
         optional: true
       '@ember-data/json-api':
         optional: true
 
-  '@ember-data/request-utils@5.3.6':
-    resolution: {integrity: sha512-5HcS5csxt/vO2HVdSTbrsH4NZ2H6zmyh7tEkJPD1TMmZIqaiceuB4cPGsQMUf298SSrwkqnM5Z+mRIQ4NkNTHg==}
+  '@ember-data/request-utils@5.3.8':
+    resolution: {integrity: sha512-cMcSoxRLv7mhHABeFWLivZhp7k9Lp0UZB+KPNrnbCXZ7T+b4C/BhQvbpTXYJwj7V/m47dlPzM/c0I2cfdmhzNg==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
       '@ember/string': 3.1.1
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/core-types': 0.0.0-beta.11
       ember-inflector: 4.0.2
     peerDependenciesMeta:
       '@ember/string':
@@ -2121,38 +2121,38 @@ packages:
       ember-inflector:
         optional: true
 
-  '@ember-data/request@5.3.6':
-    resolution: {integrity: sha512-SNZhTFMVHUQw+bOfxFgBIKnEPLLtQWdPJZFGEvJ7YfMwhLKDNJBJco9Gts9SmQq6njBir59iEZ3T5ekOB5v+Kw==}
+  '@ember-data/request@5.3.8':
+    resolution: {integrity: sha512-urAzDc+MvpmIzr2olMphG9DhwKrdYJOyywhT+fHnzCvezQoMgoBpkr40uCM2IX4Ge0+a9MklcSViA6kpLq2izQ==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/core-types': 0.0.0-beta.11
 
   '@ember-data/rfc395-data@0.0.4':
     resolution: {integrity: sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==}
 
-  '@ember-data/serializer@5.3.6':
-    resolution: {integrity: sha512-NpScceZg95OHCJvGoeUQWZyVMsdtiEU3PdYdanYB9m4z+QP+/4nNM4hD/OGqN69EPTKkYN1PrVs0Sr+fJ+Utjg==}
+  '@ember-data/serializer@5.3.8':
+    resolution: {integrity: sha512-EjESckhiZTDtdetihMeup/PXU/pbOTAK8o2SsYGGICwVNpcguH3su9NhoCJQ97/5XL+X5I4KCMm7V8/Lode8vw==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/legacy-compat': 5.3.6
-      '@ember-data/request-utils': 5.3.6
-      '@ember-data/store': 5.3.6
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@ember-data/legacy-compat': 5.3.8
+      '@ember-data/request-utils': 5.3.8
+      '@ember-data/store': 5.3.8
+      '@warp-drive/core-types': 0.0.0-beta.11
 
-  '@ember-data/store@5.3.6':
-    resolution: {integrity: sha512-JM2yd+P1sbp7KQnqMCzlk9bdQ/GvW9ruK/Xa16rKmxAsa4ISoDTHSomyOXNRFgDz2SITiXADka2FTYixzI+7Ug==}
+  '@ember-data/store@5.3.8':
+    resolution: {integrity: sha512-ZxqHgiKZrqXdetlriv4VOPjqrEre2rqaLFWOHkjjKqzsp2AkmGkcrh/DS6i9Y4/5F9hYxb9lxyyJqOW7sr57yQ==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@ember-data/request': 5.3.6
-      '@ember-data/request-utils': 5.3.6
-      '@ember-data/tracking': 5.3.6
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@ember-data/request': 5.3.8
+      '@ember-data/request-utils': 5.3.8
+      '@ember-data/tracking': 5.3.8
+      '@warp-drive/core-types': 0.0.0-beta.11
 
-  '@ember-data/tracking@5.3.6':
-    resolution: {integrity: sha512-t8mp4cPOCK8ozHARouH9ZIAdcYBFxsim0JlEmBx5KxigTObpcMqQRmFodAioizOpEKY5P4Y/gOAnl4LDrzgqKg==}
+  '@ember-data/tracking@5.3.8':
+    resolution: {integrity: sha512-1zbz1yDgx8HDditG3DHnl8xsvBAwguT/WcBRZRj5kEtDVELwCY1N+cCtxMRPVgunKgP2UCVJPfnXkgqYvEsG4Q==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/core-types': 0.0.0-beta.11
       ember-source: '>= 3.28.12'
 
   '@ember/edition-utils@1.2.0':
@@ -2525,73 +2525,73 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@percy/cli-app@1.28.7':
-    resolution: {integrity: sha512-5Dgtx3m+eX2NPYrt11gOAhH0q4UYFORzOTkocELQZ6+9naKOi0PD9e9/T8A6yRQ5dbfMoNfi/xQ9tLoxCPcM5g==}
+  '@percy/cli-app@1.28.8':
+    resolution: {integrity: sha512-UQzO/I2WKhhh18M5zKzOdqSOGLzViIKDX/77r+pEvz3DC/wlEB4bVTrEKFVvLdj1F4WGLfYCpGh2yIf/+OoDEg==}
     engines: {node: '>=14'}
 
-  '@percy/cli-build@1.28.7':
-    resolution: {integrity: sha512-LXDXbE3G994K1Wovivukjbzj7wqENPa/A3WvveVdLqfTLepTcJZ3LvPV79BsgJgIMN2vksaeCxwIgjMn1vT8mQ==}
+  '@percy/cli-build@1.28.8':
+    resolution: {integrity: sha512-4PiMffATEsr3CKaHUU9dXPKUu5gWfpVnp2YLawsSjxZj4XsOPqkWC8MsBv7CFVpNBbfjYufSzMe9YLHVcPS14A==}
     engines: {node: '>=14'}
 
-  '@percy/cli-command@1.28.7':
-    resolution: {integrity: sha512-Rs66JVZLdb4D/+hPXNdd9Qi9+FA9xCgrzpmdKak8HzstcfsRdJ999J5exQZc7dM1N3Th76wrA5d4woCgDskYDQ==}
-    engines: {node: '>=14'}
-    hasBin: true
-
-  '@percy/cli-config@1.28.7':
-    resolution: {integrity: sha512-26Wo9EYQt2uDROSjNyYMX8XuJ30IPIwR4JsNKO0DbQUBqq071to5AiaROXs2QLH0m2KGFyYavLxHJ54ZCDbMQQ==}
-    engines: {node: '>=14'}
-
-  '@percy/cli-exec@1.28.7':
-    resolution: {integrity: sha512-0HEOmMNexRbn09Ju3Etd5agEhBtgqNrT3eiRMcX4ThbQgOFkAQIll6IFfVqafujJHNL1SF+HjcyZmyoEF9tJOw==}
-    engines: {node: '>=14'}
-
-  '@percy/cli-snapshot@1.28.7':
-    resolution: {integrity: sha512-nWk2/sjIh8Vy6+T7BNwSVdtXUdR0cYpXJrbO1hfxRB56pUf8KFcG7GqUzOZ7QDHqlyQGH/posAjAoPmy8okyAQ==}
-    engines: {node: '>=14'}
-
-  '@percy/cli-upload@1.28.7':
-    resolution: {integrity: sha512-hcIe9RGHDk+G+lanlLy1IrDRgODsTYzjmtPex9wEg4yo/JzubVwkF3r/0iQuT+srkELKUcTSJ1iX7/d0kK61uQ==}
-    engines: {node: '>=14'}
-
-  '@percy/cli@1.28.7':
-    resolution: {integrity: sha512-FvvyTFTGuIiBsSs8epENGq2U62oKnzfXW6F80JFShaZ5ZjMc2t6riVq4EPEsBANstql+j4Y853tYe2aGVX9pbw==}
+  '@percy/cli-command@1.28.8':
+    resolution: {integrity: sha512-pXV0RqFQYK8bcYvMmf04Bp0HFprq+gqF0B8MrevhqA2YJldISln6TrOEpymQI89Sfj261xdOe6tl0WMIbawAiw==}
     engines: {node: '>=14'}
     hasBin: true
 
-  '@percy/client@1.28.7':
-    resolution: {integrity: sha512-3ocKEej268Xj3q98seUi88mtFcTYNy3F/zMTwk+pdnoWc1QVOGsCQ3elIS2X35hhBFgYw2i1bbuzmt7UdOK79A==}
+  '@percy/cli-config@1.28.8':
+    resolution: {integrity: sha512-uD13cLYZAhCFdh2zBCCk73LqG/Dx4MUBybs4lLMlAwQZsWRnn4X//99dgVyzOUDzLS8oRWzouFx7Z/5SOcMPvA==}
     engines: {node: '>=14'}
 
-  '@percy/config@1.28.7':
-    resolution: {integrity: sha512-N8fZAj8ejgddxz4lzNIK9cCQdoIuISK7a/JyGAD5vY+CuZutCBM0zuN9g/Higv/LI78Sct69Qpik/+rLIyBZxA==}
+  '@percy/cli-exec@1.28.8':
+    resolution: {integrity: sha512-a2EhPuuykz9WTIdEEdf9zmqGOu1MATz+Ss4rzIIpXlto5k40K42hn/lzRRIQzGNok6ADXJ0vZ0lLgoBX+SMEPw==}
     engines: {node: '>=14'}
 
-  '@percy/core@1.28.7':
-    resolution: {integrity: sha512-OOTVMHU+0O7Qh3TIL21fxX9H5ctRWPIG03IJsFpIXIIh2Wni5nf8tSUWroFwSSneZihxaA8ETQxCtJXBVe+JUA==}
+  '@percy/cli-snapshot@1.28.8':
+    resolution: {integrity: sha512-mIOI9uD0GiOqo4jhaJPRShrgy8isAir3ID9vMQ96B+g2ziUhRWceNdFr+N/OwHFRJ8wyUmJnji2Fr0bNagOWGA==}
     engines: {node: '>=14'}
 
-  '@percy/dom@1.28.7':
-    resolution: {integrity: sha512-aYm/xTqNWaLodRdmWqiA0zekaUMkE8boJ1ApljO8KTKihv7eJWpgSDJT7m73xOd/JAplER5LSGjrUpnWLOTDYQ==}
+  '@percy/cli-upload@1.28.8':
+    resolution: {integrity: sha512-qgj610GPo3a5cbRXoP6LPfqp9+Qrgo8Sg7aYswomrt6j7zdoV1RAf419eNfP4pYtLoMji4EIGcSMQ91tWv2DoA==}
+    engines: {node: '>=14'}
+
+  '@percy/cli@1.28.8':
+    resolution: {integrity: sha512-sbbiC7Kfs1i+4AsLpHgEx3f6rntXiRShuQa3aNuAQMugXuKgZrr2kI6wzygfO352mYeplblyZNxC0zhXPxtyFA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  '@percy/client@1.28.8':
+    resolution: {integrity: sha512-icBiRmLwODrnbxSDmhhN1KLz6W4xE+0bM8rEF/qcUC8SRKecBrz0RA60kyg/jn3H01iv0TOe4NXEMHHk+f7s7w==}
+    engines: {node: '>=14'}
+
+  '@percy/config@1.28.8':
+    resolution: {integrity: sha512-jsH1CdJQDHfnqRNiR+apugxz3HuMq129LH2+qrf1Ow3nFLRbYfeGD25xiCGMaeDfYCHkY26oSo6409/asBdvpA==}
+    engines: {node: '>=14'}
+
+  '@percy/core@1.28.8':
+    resolution: {integrity: sha512-6YfhDoTqUhn3Zs8L9xLNHyGVcRzTjCdi51gwZtf9by/+pDCe8eaqpd5QrkoLocdEcV7Oi+FJcoZxE4OZlQNlyQ==}
+    engines: {node: '>=14'}
+
+  '@percy/dom@1.28.8':
+    resolution: {integrity: sha512-0e/357X13C5lt/49ZiB7WHcYDgRs9nEz0hPFA7qnBa+Q0N5pemZCgUZzY1ltge2v9XYT0IAwYgO7P0V0xObRVQ==}
 
   '@percy/ember@4.2.0':
     resolution: {integrity: sha512-D/WckDD2tQetdn8uq46nQA1rOVgov8jsZG4uN7snAq6SrOpxNxacONg37QPwczmICBc7o/NlipCAUteukmtKzg==}
     engines: {node: '>= 14'}
 
-  '@percy/env@1.28.7':
-    resolution: {integrity: sha512-ExpCDSm2bMwTlF7LOuE6dDB0QFa2VzpuFF/t9O0TyUgBgaiDZzcdsMQrLxDlUbuqjA8vc+vo8931x0i2sN5LBQ==}
+  '@percy/env@1.28.8':
+    resolution: {integrity: sha512-ZuyOPaaQxpCIVs1lgFeb2DRFAfhbAX7LaK8RAKtcAzoKW86YUosL/OWUtmmzQUvnGMWZb611WLIcV48lspkrQQ==}
     engines: {node: '>=14'}
 
-  '@percy/logger@1.28.7':
-    resolution: {integrity: sha512-OktqjykPT3FMUKkwyafjQdRWMQ8jnXOOcSkvyVIT9P7cbU1USeRUWw8Z6+W1cLk50RdsimChnab6F/GRWRdBew==}
+  '@percy/logger@1.28.8':
+    resolution: {integrity: sha512-yw5O8ZJjA9wNaHv/AgzvPDxDEWpHVFBmF6BDKZ+bT2xErgJt8UFgm0+Zv7pRbqXdoEAEHQbBeaYMrI7QkFaebg==}
     engines: {node: '>=14'}
 
-  '@percy/sdk-utils@1.28.7':
-    resolution: {integrity: sha512-LIhfHnkcS0fyIdo3gvKn7rwodZjbEtyLkgiDRSRulcBOatI2mhn2Bh269sXXiiFTyAW2BDQjyE3DWc4hkGbsbQ==}
+  '@percy/sdk-utils@1.28.8':
+    resolution: {integrity: sha512-eqeIloD3OvHtPVUn08jDKt8m46oakKliEWDGliPdeWTtrfnoTJZtk8yNKe7jn8N3gzNYgU8iytwWFQV00zHBjQ==}
     engines: {node: '>=14'}
 
-  '@percy/webdriver-utils@1.28.7':
-    resolution: {integrity: sha512-BviRMj/oHgdniHoz1nzInpIXl4JTk4vZ0+9azWntGCThITc/HhQE1sLDcHhZGYvviY+NQ4ofCcBSzZRu1z1GcQ==}
+  '@percy/webdriver-utils@1.28.8':
+    resolution: {integrity: sha512-xrL3zBw+coeBs1nrKxHo6Fa3xqLjVACnR9KYc+GR/KrltK3TZF4gmGOHUtFHq7Y+OK9iKFyWqpl0RRwq0Ne2eg==}
     engines: {node: '>=14'}
 
   '@pkgjs/parseargs@0.11.0':
@@ -2627,40 +2627,40 @@ packages:
     resolution: {integrity: sha512-C5DHU6YlKaISB5utGQ+jpsMB57ZtY0uZ8UkD29j855BjqG6eJ98lhA2h/BoJbyPw89RKLP1EEXroy9+5JPoyVw==}
     engines: {node: 12.* || >= 14}
 
-  '@sentry-internal/browser-utils@8.10.0':
-    resolution: {integrity: sha512-Hdqv8KfQDCj7H92ft2walDwCiyaTxgegHnR4ZtCI8NQR0hqdU/PzIKashTwc+Ho6OAQtdy/HNqhcHEznuBNW3A==}
+  '@sentry-internal/browser-utils@8.11.0':
+    resolution: {integrity: sha512-PCnmzeLm7eTdMleVWa1jbdNcB6M5R17CSX8oQF6A/5a2w9qW6HbjEwK6X4yc9MzsFXFaTNekvPQLMRhIE1MgpA==}
     engines: {node: '>=14.18'}
 
-  '@sentry-internal/feedback@8.10.0':
-    resolution: {integrity: sha512-pzc4s5X6wvY0BMQBFAMObQBjRKiKzoF2APD5H5eBcxkX8deIykjm8VC8mgpVpxYm6mfjytvgpZyPpZ6KgpRt9Q==}
+  '@sentry-internal/feedback@8.11.0':
+    resolution: {integrity: sha512-cMiFAuHP4jXCqWD7/UA5cvl0ee3hN5klAWTDVCZutnZ30pbUurg+nIggYBcaxdtLlqW6BCwyVs2nb/OB75CCSQ==}
     engines: {node: '>=14.18'}
 
-  '@sentry-internal/replay-canvas@8.10.0':
-    resolution: {integrity: sha512-M4yM8ZqtsW1wER7jNpGq019jmhn/RkcmdIyWksRpBSvRppZRf0yR9dbVhdO/oBL8DB3fDTbv8Qtd/oXlkj/i+Q==}
+  '@sentry-internal/replay-canvas@8.11.0':
+    resolution: {integrity: sha512-SrBFI0vwyeyUjibCbYfxzCNMd07QMDNoi+0SYzhBagp6ALbU8r/pa02JRsnr//qhZt2NOM6S2kks9e2VHr6hYg==}
     engines: {node: '>=14.18'}
 
-  '@sentry-internal/replay@8.10.0':
-    resolution: {integrity: sha512-MISdD0Q0sVcQELHbYSH5SuKHlrI8RFvmU6aNcjWEoKxhd4Vzr126h98naVPoo7WOOI0e7Fd0Lrn/59wNI4AJxQ==}
+  '@sentry-internal/replay@8.11.0':
+    resolution: {integrity: sha512-NyuHW1Ds2GGW6PjN7nnRl/XoM31Y/BUnOhhLbNmbxWj5mgWuUP/7tOlz2PhP0YqZxVteZ99QIssfSRgtYOeQlg==}
     engines: {node: '>=14.18'}
 
-  '@sentry/browser@8.10.0':
-    resolution: {integrity: sha512-6yGax6vUNV28cANMJCTrLFrGTvvgC0h4k+lzjrgstCf1k+CNQmodXDyWcRzbL4im5DTH4jF74ZAYpqrptloxJw==}
+  '@sentry/browser@8.11.0':
+    resolution: {integrity: sha512-++5IrBpzkaAptNjAYnGTnQ2lCjmU6nlu/ABFjUTgi7Vu+ZNiY8qYKEUw65mSxD3EoFLt8IwtjvfAwSMVTB2q8w==}
     engines: {node: '>=14.18'}
 
-  '@sentry/core@8.10.0':
-    resolution: {integrity: sha512-NzrFqYsEHMd4TYYYxOvf+f+Z02u0nt12cIYYN9pOM3xBLKR+ORs7jhVnN0cB/H2yqtmtBaIzSehk/M/qUXFJGw==}
+  '@sentry/core@8.11.0':
+    resolution: {integrity: sha512-rZaM55j5Fw0IGb8lNXOTVoq7WR6JmUzm9x5cURGsjL9gzAurGl817oK3iyOvYQ3JZnfijjh0QF0SQr4NZHKbIg==}
     engines: {node: '>=14.18'}
 
-  '@sentry/ember@8.10.0':
-    resolution: {integrity: sha512-/qNGpi87OckXjSEM+tcCoazbStsjm9lfheviZcDq/p05KJk+vTUYEzJkacBaHc2q09Id92aHl+idTgeiiWagBg==}
+  '@sentry/ember@8.11.0':
+    resolution: {integrity: sha512-6KQJzhiLoqTPUOrBey+9SxJPzkPWXcQRHCdxNnd0QjFALz8GHJrSge95TLxDS7GujIMjFjQln+wTkqc7bN4DSg==}
     engines: {node: '>=14.18'}
 
-  '@sentry/types@8.10.0':
-    resolution: {integrity: sha512-6kgh6NqgQHcnnD7dOe3THcVkzv2nor/f94x3odmPShN2AWBfPRprHZZsLTjh/3aC7l76V2nfuQ4wgRvwsddTWw==}
+  '@sentry/types@8.11.0':
+    resolution: {integrity: sha512-kz9/d2uw7wEXcK8DnCrCuMI75hZnpVAjYr8mq1uatltOx+2JOYPNdaK6ispxXlhb5KXOnVWNgfVDbGlLp0w+Gg==}
     engines: {node: '>=14.18'}
 
-  '@sentry/utils@8.10.0':
-    resolution: {integrity: sha512-tQPgB7lX1XqbEw2EXvWNsBQlmG+yJHVhBKKDPy5HZMjuTP3zlpVdP6NF87qwonmdtFNHxdrKbfOVRiLx71/JwA==}
+  '@sentry/utils@8.11.0':
+    resolution: {integrity: sha512-iDt5YVMYNgT151bPYVGo8XlpM0MHWy8DH+czmAiAlFTV7ns7lAeHGF6tsFYo7wOZOPDHxtF6F2CM7AvuYnOZGw==}
     engines: {node: '>=14.18'}
 
   '@simple-dom/document@1.4.0':
@@ -2955,8 +2955,8 @@ packages:
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
 
-  '@types/node@20.14.6':
-    resolution: {integrity: sha512-JbA0XIJPL1IiNnU7PFxDXyfAwcwVVrOoqyzzyQTyMeVhBzkJVMSkC1LlVsRQ2lpqiY4n6Bb9oCS6lzDKVQxbZw==}
+  '@types/node@20.14.7':
+    resolution: {integrity: sha512-uTr2m2IbJJucF3KUxgnGOZvYbN0QgkGyWxG6973HCpMYFy2KfcgYuIwkJQMQkt1VbBMlvWRbpshFTLxnxCZjKQ==}
 
   '@types/node@9.6.61':
     resolution: {integrity: sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ==}
@@ -3000,12 +3000,12 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  '@warp-drive/build-config@0.0.0-beta.4':
-    resolution: {integrity: sha512-LO6OoyuCvL7OiBp8r0OuHeA0b4eFknj/S1jOMCrmRemeQbCOlDVAdPBaHylSHMvUnw0nR9M2QbkjWfVQ+DBbtg==}
+  '@warp-drive/build-config@0.0.0-beta.6':
+    resolution: {integrity: sha512-ANSjWRV5kSJyIIO+5rRv7/lqfwYazQ9wDpi4vr1rjGogsmVteRCnflV5qYqt9W9T4JXRjSimjSfKwCgEwl+jUA==}
     engines: {node: '>= 18.20.3'}
 
-  '@warp-drive/core-types@0.0.0-beta.9':
-    resolution: {integrity: sha512-CMdkNaBMXXqMm2gR29gWExiZs4NFW6kw4ZVSClLQBxhoZs+D6CwPldSCqjPxaeUFuZP1iBtdQs1Up6V69ctw2Q==}
+  '@warp-drive/core-types@0.0.0-beta.11':
+    resolution: {integrity: sha512-GHQE+woaGdRDGj6VG3Qt0uGBNog1zq5XO2Ccce35cYPpM3FOCOdmqB4Wt0miD1bBdbAuWQZmmQOIYAMSMCOdZQ==}
     engines: {node: '>= 18.20.3'}
 
   '@webassemblyjs/ast@1.12.1':
@@ -4806,8 +4806,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.4.807:
-    resolution: {integrity: sha512-kSmJl2ZwhNf/bcIuCH/imtNOKlpkLDn2jqT5FJ+/0CXjhnFaOa9cOe9gHKKy71eM49izwuQjZhKk+lWQ1JxB7A==}
+  electron-to-chromium@1.4.808:
+    resolution: {integrity: sha512-0ItWyhPYnww2VOuCGF4s1LTfbrdAV2ajy/TN+ZTuhR23AHI6rWHCrBXJ/uxoXOvRRqw8qjYVrG81HFI7x/2wdQ==}
 
   elliptic@6.5.5:
     resolution: {integrity: sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==}
@@ -5141,8 +5141,8 @@ packages:
     resolution: {integrity: sha512-+BXc8NbJJ/DoUXZk4e3qeRvADw9ThMEW7jm+Nz+QX9jRY/5QYodnFeUEfsC4Sw3Ti2m1+RzI2Lyq0QWpgOqFYg==}
     engines: {node: 8.* || >= 10.*}
 
-  ember-data@5.3.6:
-    resolution: {integrity: sha512-SztMOhJLijZNsIO0dsKmUNTh+tv3CrEZC8TV7Z/zrpy4enbS33dvRbxjCZNEcPIzh2bx55wfyPA3ot9rbXyKGA==}
+  ember-data@5.3.8:
+    resolution: {integrity: sha512-ZFd0dxTCkX5OHe/Xdfpglg+3OELsd0xNFziogoKV0JPLzyXmasn/8vAeHeUta9rAJDYH8lix3/1t6iIeY+DzYQ==}
     engines: {node: '>= 18.20.3'}
     peerDependencies:
       '@ember/test-helpers': ^3.3.0
@@ -6561,8 +6561,9 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
-  is-core-module@2.13.1:
-    resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
+  is-core-module@2.14.0:
+    resolution: {integrity: sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==}
+    engines: {node: '>= 0.4'}
 
   is-data-descriptor@1.0.1:
     resolution: {integrity: sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==}
@@ -8812,14 +8813,14 @@ packages:
       postcss:
         optional: true
 
-  stylelint-config-recommended@14.0.0:
-    resolution: {integrity: sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==}
+  stylelint-config-recommended@14.0.1:
+    resolution: {integrity: sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
-      stylelint: ^16.0.0
+      stylelint: ^16.1.0
 
-  stylelint-config-standard@36.0.0:
-    resolution: {integrity: sha512-3Kjyq4d62bYFp/Aq8PMKDwlgUyPU4nacXsjDLWJdNPRUgpuxALu1KnlAHIj36cdtxViVhXexZij65yM0uNIHug==}
+  stylelint-config-standard@36.0.1:
+    resolution: {integrity: sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       stylelint: ^16.1.0
@@ -11724,15 +11725,15 @@ snapshots:
 
   '@dual-bundle/import-meta-resolve@4.1.0': {}
 
-  '@ember-data/adapter@5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)':
+  '@ember-data/adapter@5.3.8(@ember-data/legacy-compat@5.3.8(nvrgy75jw3pssoln5yuvxtipgu))(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)':
     dependencies:
-      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
-      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
-      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/legacy-compat': 5.3.8(nvrgy75jw3pssoln5yuvxtipgu)
+      '@ember-data/request-utils': 5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
@@ -11740,117 +11741,117 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/debug@5.3.6(@ember-data/model@5.3.6(aadxxgrx75vhdk33kqgy5e53ku))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)':
+  '@ember-data/debug@5.3.8(@ember-data/model@5.3.8(kmrusw53vkag3hgasesvkgmvka))(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)':
     dependencies:
-      '@ember-data/model': 5.3.6(aadxxgrx75vhdk33kqgy5e53ku)
-      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
-      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/model': 5.3.8(kmrusw53vkag3hgasesvkgmvka)
+      '@ember-data/request-utils': 5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/debug@5.3.6(@ember-data/model@5.3.6(eqf63xu3ypidrgzgnedouwi4bm))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)':
-    dependencies:
-      '@ember-data/model': 5.3.6(eqf63xu3ypidrgzgnedouwi4bm)
-      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
-      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
     optional: true
 
-  '@ember-data/graph@5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)':
+  '@ember-data/debug@5.3.8(@ember-data/model@5.3.8(ueu55puezsfvwcbmsvklkjcesq))(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)':
     dependencies:
-      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/model': 5.3.8(ueu55puezsfvwcbmsvklkjcesq)
+      '@ember-data/request-utils': 5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/json-api@5.3.6(4niswjrocysofsw5zndkhmw33m)':
+  '@ember-data/graph@5.3.8(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)':
     dependencies:
-      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
-      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/store': 5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym)':
+  '@ember-data/json-api@5.3.8(6bbrrqfh2tga4w2lsjgq36ehuq)':
     dependencies:
-      '@ember-data/request': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
-      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/graph': 5.3.8(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/request-utils': 5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/legacy-compat@5.3.8(nvrgy75jw3pssoln5yuvxtipgu)':
+    dependencies:
+      '@ember-data/request': 5.3.8(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/request-utils': 5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
     optionalDependencies:
-      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/json-api': 5.3.6(4niswjrocysofsw5zndkhmw33m)
+      '@ember-data/graph': 5.3.8(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/json-api': 5.3.8(6bbrrqfh2tga4w2lsjgq36ehuq)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/model@5.3.6(aadxxgrx75vhdk33kqgy5e53ku)':
+  '@ember-data/model@5.3.8(kmrusw53vkag3hgasesvkgmvka)':
     dependencies:
-      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
-      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
-      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/tracking': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      '@ember-data/legacy-compat': 5.3.8(nvrgy75jw3pssoln5yuvxtipgu)
+      '@ember-data/request-utils': 5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/tracking': 5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
       inflection: 3.0.0
     optionalDependencies:
-      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/json-api': 5.3.6(4niswjrocysofsw5zndkhmw33m)
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/model@5.3.6(eqf63xu3ypidrgzgnedouwi4bm)':
-    dependencies:
-      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
-      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
-      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/tracking': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
-      '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
-      ember-cli-string-utils: 1.1.0
-      ember-cli-test-info: 1.0.0
-      inflection: 3.0.0
-    optionalDependencies:
-      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/json-api': 5.3.6(4niswjrocysofsw5zndkhmw33m)
+      '@ember-data/graph': 5.3.8(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/json-api': 5.3.8(6bbrrqfh2tga4w2lsjgq36ehuq)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
     optional: true
 
-  '@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)':
+  '@ember-data/model@5.3.8(ueu55puezsfvwcbmsvklkjcesq)':
+    dependencies:
+      '@ember-data/legacy-compat': 5.3.8(nvrgy75jw3pssoln5yuvxtipgu)
+      '@ember-data/request-utils': 5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/tracking': 5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      '@ember/edition-utils': 1.2.0
+      '@embroider/macros': 1.16.4
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
+      ember-cli-string-utils: 1.1.0
+      ember-cli-test-info: 1.0.0
+      inflection: 3.0.0
+    optionalDependencies:
+      '@ember-data/graph': 5.3.8(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/json-api': 5.3.8(6bbrrqfh2tga4w2lsjgq36ehuq)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)':
     dependencies:
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
     optionalDependencies:
       '@ember/string': 3.1.1
       ember-inflector: 4.0.2
@@ -11858,27 +11859,27 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9)':
+  '@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11)':
     dependencies:
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
   '@ember-data/rfc395-data@0.0.4': {}
 
-  '@ember-data/serializer@5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)':
+  '@ember-data/serializer@5.3.8(@ember-data/legacy-compat@5.3.8(nvrgy75jw3pssoln5yuvxtipgu))(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)':
     dependencies:
-      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
-      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
-      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
+      '@ember-data/legacy-compat': 5.3.8(nvrgy75jw3pssoln5yuvxtipgu)
+      '@ember-data/request-utils': 5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
@@ -11886,23 +11887,23 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)':
+  '@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)':
     dependencies:
-      '@ember-data/request': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
-      '@ember-data/tracking': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      '@ember-data/request': 5.3.8(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/request-utils': 5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)
+      '@ember-data/tracking': 5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))':
+  '@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))':
     dependencies:
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
       ember-source: 5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)
     transitivePeerDependencies:
       - '@glint/template'
@@ -12569,48 +12570,49 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@percy/cli-app@1.28.7':
+  '@percy/cli-app@1.28.8':
     dependencies:
-      '@percy/cli-command': 1.28.7
-      '@percy/cli-exec': 1.28.7
+      '@percy/cli-command': 1.28.8
+      '@percy/cli-exec': 1.28.8
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/cli-build@1.28.7':
+  '@percy/cli-build@1.28.8':
     dependencies:
-      '@percy/cli-command': 1.28.7
+      '@percy/cli-command': 1.28.8
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/cli-command@1.28.7':
+  '@percy/cli-command@1.28.8':
     dependencies:
-      '@percy/config': 1.28.7
-      '@percy/core': 1.28.7
-      '@percy/logger': 1.28.7
+      '@percy/config': 1.28.8
+      '@percy/core': 1.28.8
+      '@percy/logger': 1.28.8
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/cli-config@1.28.7':
+  '@percy/cli-config@1.28.8':
     dependencies:
-      '@percy/cli-command': 1.28.7
+      '@percy/cli-command': 1.28.8
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/cli-exec@1.28.7':
+  '@percy/cli-exec@1.28.8':
     dependencies:
-      '@percy/cli-command': 1.28.7
+      '@percy/cli-command': 1.28.8
+      '@percy/logger': 1.28.8
       cross-spawn: 7.0.3
       which: 2.0.2
     transitivePeerDependencies:
@@ -12619,9 +12621,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/cli-snapshot@1.28.7':
+  '@percy/cli-snapshot@1.28.8':
     dependencies:
-      '@percy/cli-command': 1.28.7
+      '@percy/cli-command': 1.28.8
       yaml: 2.4.5
     transitivePeerDependencies:
       - bufferutil
@@ -12629,9 +12631,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/cli-upload@1.28.7':
+  '@percy/cli-upload@1.28.8':
     dependencies:
-      '@percy/cli-command': 1.28.7
+      '@percy/cli-command': 1.28.8
       fast-glob: 3.3.2
       image-size: 1.1.1
     transitivePeerDependencies:
@@ -12640,45 +12642,45 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/cli@1.28.7':
+  '@percy/cli@1.28.8':
     dependencies:
-      '@percy/cli-app': 1.28.7
-      '@percy/cli-build': 1.28.7
-      '@percy/cli-command': 1.28.7
-      '@percy/cli-config': 1.28.7
-      '@percy/cli-exec': 1.28.7
-      '@percy/cli-snapshot': 1.28.7
-      '@percy/cli-upload': 1.28.7
-      '@percy/client': 1.28.7
-      '@percy/logger': 1.28.7
+      '@percy/cli-app': 1.28.8
+      '@percy/cli-build': 1.28.8
+      '@percy/cli-command': 1.28.8
+      '@percy/cli-config': 1.28.8
+      '@percy/cli-exec': 1.28.8
+      '@percy/cli-snapshot': 1.28.8
+      '@percy/cli-upload': 1.28.8
+      '@percy/client': 1.28.8
+      '@percy/logger': 1.28.8
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@percy/client@1.28.7':
+  '@percy/client@1.28.8':
     dependencies:
-      '@percy/env': 1.28.7
-      '@percy/logger': 1.28.7
+      '@percy/env': 1.28.8
+      '@percy/logger': 1.28.8
       pako: 2.1.0
 
-  '@percy/config@1.28.7':
+  '@percy/config@1.28.8':
     dependencies:
-      '@percy/logger': 1.28.7
+      '@percy/logger': 1.28.8
       ajv: 8.16.0
       cosmiconfig: 8.3.6
       yaml: 2.4.5
     transitivePeerDependencies:
       - typescript
 
-  '@percy/core@1.28.7':
+  '@percy/core@1.28.8':
     dependencies:
-      '@percy/client': 1.28.7
-      '@percy/config': 1.28.7
-      '@percy/dom': 1.28.7
-      '@percy/logger': 1.28.7
-      '@percy/webdriver-utils': 1.28.7
+      '@percy/client': 1.28.8
+      '@percy/config': 1.28.8
+      '@percy/dom': 1.28.8
+      '@percy/logger': 1.28.8
+      '@percy/webdriver-utils': 1.28.8
       content-disposition: 0.5.4
       cross-spawn: 7.0.3
       extract-zip: 2.0.1
@@ -12696,27 +12698,27 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@percy/dom@1.28.7': {}
+  '@percy/dom@1.28.8': {}
 
   '@percy/ember@4.2.0':
     dependencies:
-      '@percy/sdk-utils': 1.28.7
+      '@percy/sdk-utils': 1.28.8
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - supports-color
 
-  '@percy/env@1.28.7':
+  '@percy/env@1.28.8':
     dependencies:
-      '@percy/logger': 1.28.7
+      '@percy/logger': 1.28.8
 
-  '@percy/logger@1.28.7': {}
+  '@percy/logger@1.28.8': {}
 
-  '@percy/sdk-utils@1.28.7': {}
+  '@percy/sdk-utils@1.28.8': {}
 
-  '@percy/webdriver-utils@1.28.7':
+  '@percy/webdriver-utils@1.28.8':
     dependencies:
-      '@percy/config': 1.28.7
-      '@percy/sdk-utils': 1.28.7
+      '@percy/config': 1.28.8
+      '@percy/sdk-utils': 1.28.8
     transitivePeerDependencies:
       - typescript
 
@@ -12751,55 +12753,55 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry-internal/browser-utils@8.10.0':
+  '@sentry-internal/browser-utils@8.11.0':
     dependencies:
-      '@sentry/core': 8.10.0
-      '@sentry/types': 8.10.0
-      '@sentry/utils': 8.10.0
+      '@sentry/core': 8.11.0
+      '@sentry/types': 8.11.0
+      '@sentry/utils': 8.11.0
 
-  '@sentry-internal/feedback@8.10.0':
+  '@sentry-internal/feedback@8.11.0':
     dependencies:
-      '@sentry/core': 8.10.0
-      '@sentry/types': 8.10.0
-      '@sentry/utils': 8.10.0
+      '@sentry/core': 8.11.0
+      '@sentry/types': 8.11.0
+      '@sentry/utils': 8.11.0
 
-  '@sentry-internal/replay-canvas@8.10.0':
+  '@sentry-internal/replay-canvas@8.11.0':
     dependencies:
-      '@sentry-internal/replay': 8.10.0
-      '@sentry/core': 8.10.0
-      '@sentry/types': 8.10.0
-      '@sentry/utils': 8.10.0
+      '@sentry-internal/replay': 8.11.0
+      '@sentry/core': 8.11.0
+      '@sentry/types': 8.11.0
+      '@sentry/utils': 8.11.0
 
-  '@sentry-internal/replay@8.10.0':
+  '@sentry-internal/replay@8.11.0':
     dependencies:
-      '@sentry-internal/browser-utils': 8.10.0
-      '@sentry/core': 8.10.0
-      '@sentry/types': 8.10.0
-      '@sentry/utils': 8.10.0
+      '@sentry-internal/browser-utils': 8.11.0
+      '@sentry/core': 8.11.0
+      '@sentry/types': 8.11.0
+      '@sentry/utils': 8.11.0
 
-  '@sentry/browser@8.10.0':
+  '@sentry/browser@8.11.0':
     dependencies:
-      '@sentry-internal/browser-utils': 8.10.0
-      '@sentry-internal/feedback': 8.10.0
-      '@sentry-internal/replay': 8.10.0
-      '@sentry-internal/replay-canvas': 8.10.0
-      '@sentry/core': 8.10.0
-      '@sentry/types': 8.10.0
-      '@sentry/utils': 8.10.0
+      '@sentry-internal/browser-utils': 8.11.0
+      '@sentry-internal/feedback': 8.11.0
+      '@sentry-internal/replay': 8.11.0
+      '@sentry-internal/replay-canvas': 8.11.0
+      '@sentry/core': 8.11.0
+      '@sentry/types': 8.11.0
+      '@sentry/utils': 8.11.0
 
-  '@sentry/core@8.10.0':
+  '@sentry/core@8.11.0':
     dependencies:
-      '@sentry/types': 8.10.0
-      '@sentry/utils': 8.10.0
+      '@sentry/types': 8.11.0
+      '@sentry/utils': 8.11.0
 
-  '@sentry/ember@8.10.0(webpack@5.92.1)':
+  '@sentry/ember@8.11.0(webpack@5.92.1)':
     dependencies:
       '@babel/core': 7.24.7
       '@embroider/macros': 1.16.4
-      '@sentry/browser': 8.10.0
-      '@sentry/core': 8.10.0
-      '@sentry/types': 8.10.0
-      '@sentry/utils': 8.10.0
+      '@sentry/browser': 8.11.0
+      '@sentry/core': 8.11.0
+      '@sentry/types': 8.11.0
+      '@sentry/utils': 8.11.0
       ember-auto-import: 2.7.3(webpack@5.92.1)
       ember-cli-babel: 8.2.0(@babel/core@7.24.7)
       ember-cli-htmlbars: 6.3.0
@@ -12809,11 +12811,11 @@ snapshots:
       - supports-color
       - webpack
 
-  '@sentry/types@8.10.0': {}
+  '@sentry/types@8.11.0': {}
 
-  '@sentry/utils@8.10.0':
+  '@sentry/utils@8.11.0':
     dependencies:
-      '@sentry/types': 8.10.0
+      '@sentry/types': 8.11.0
 
   '@simple-dom/document@1.4.0':
     dependencies:
@@ -13164,7 +13166,7 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
 
   '@types/chai-as-promised@7.1.8':
     dependencies:
@@ -13174,13 +13176,13 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
 
   '@types/cookie@0.4.1': {}
 
   '@types/cors@2.8.17':
     dependencies:
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -13196,7 +13198,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.5':
     dependencies:
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
       '@types/qs': 6.9.15
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -13210,25 +13212,25 @@ snapshots:
 
   '@types/fs-extra@5.1.0':
     dependencies:
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
 
   '@types/fs-extra@8.1.5':
     dependencies:
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
 
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
 
   '@types/http-errors@2.0.4': {}
 
@@ -13244,7 +13246,7 @@ snapshots:
 
   '@types/minimatch@5.1.2': {}
 
-  '@types/node@20.14.6':
+  '@types/node@20.14.7':
     dependencies:
       undici-types: 5.26.5
 
@@ -13257,17 +13259,17 @@ snapshots:
   '@types/rimraf@2.0.5':
     dependencies:
       '@types/glob': 8.1.0
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
 
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
       '@types/send': 0.17.4
 
   '@types/sizzle@2.3.8': {}
@@ -13286,12 +13288,12 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
     optional: true
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@warp-drive/build-config@0.0.0-beta.4':
+  '@warp-drive/build-config@0.0.0-beta.6':
     dependencies:
       '@embroider/addon-shim': 1.8.9
       '@embroider/macros': 1.16.4
@@ -13302,10 +13304,10 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/core-types@0.0.0-beta.9':
+  '@warp-drive/core-types@0.0.0-beta.11':
     dependencies:
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
+      '@warp-drive/build-config': 0.0.0-beta.6
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -14651,7 +14653,7 @@ snapshots:
   browserslist@4.23.1:
     dependencies:
       caniuse-lite: 1.0.30001636
-      electron-to-chromium: 1.4.807
+      electron-to-chromium: 1.4.808
       node-releases: 2.0.14
       update-browserslist-db: 1.0.16(browserslist@4.23.1)
 
@@ -15535,7 +15537,7 @@ snapshots:
     dependencies:
       jake: 10.9.1
 
-  electron-to-chromium@1.4.807: {}
+  electron-to-chromium@1.4.808: {}
 
   elliptic@6.5.5:
     dependencies:
@@ -16065,7 +16067,7 @@ snapshots:
 
   ember-cli-lodash-subset@2.0.1: {}
 
-  ember-cli-mirage@3.0.3(@ember-data/model@5.3.6(aadxxgrx75vhdk33kqgy5e53ku))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1):
+  ember-cli-mirage@3.0.3(@ember-data/model@5.3.8(ueu55puezsfvwcbmsvklkjcesq))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1):
     dependencies:
       '@babel/core': 7.24.7
       '@embroider/macros': 1.16.4
@@ -16079,16 +16081,16 @@ snapshots:
       ember-source: 5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)
       miragejs: 0.1.48
     optionalDependencies:
-      '@ember-data/model': 5.3.6(aadxxgrx75vhdk33kqgy5e53ku)
+      '@ember-data/model': 5.3.8(ueu55puezsfvwcbmsvklkjcesq)
       '@ember/test-helpers': 3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1)
-      ember-data: 5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
+      ember-data: 5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
       - webpack
     optional: true
 
-  ember-cli-mirage@3.0.3(@ember-data/model@5.3.6)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1):
+  ember-cli-mirage@3.0.3(@ember-data/model@5.3.8)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1):
     dependencies:
       '@babel/core': 7.24.7
       '@embroider/macros': 1.16.4
@@ -16102,9 +16104,9 @@ snapshots:
       ember-source: 5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)
       miragejs: 0.1.48
     optionalDependencies:
-      '@ember-data/model': 5.3.6(aadxxgrx75vhdk33kqgy5e53ku)
+      '@ember-data/model': 5.3.8(ueu55puezsfvwcbmsvklkjcesq)
       '@ember/test-helpers': 3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1)
-      ember-data: 5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
+      ember-data: 5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
       ember-qunit: 8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
     transitivePeerDependencies:
       - '@glint/template'
@@ -16471,23 +16473,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0):
+  ember-data@5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0):
     dependencies:
-      '@ember-data/adapter': 5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/debug': 5.3.6(@ember-data/model@5.3.6(aadxxgrx75vhdk33kqgy5e53ku))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/json-api': 5.3.6(4niswjrocysofsw5zndkhmw33m)
-      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
-      '@ember-data/model': 5.3.6(aadxxgrx75vhdk33kqgy5e53ku)
-      '@ember-data/request': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
-      '@ember-data/serializer': 5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/tracking': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      '@ember-data/adapter': 5.3.8(@ember-data/legacy-compat@5.3.8(nvrgy75jw3pssoln5yuvxtipgu))(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/debug': 5.3.8(@ember-data/model@5.3.8(ueu55puezsfvwcbmsvklkjcesq))(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/graph': 5.3.8(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/json-api': 5.3.8(6bbrrqfh2tga4w2lsjgq36ehuq)
+      '@ember-data/legacy-compat': 5.3.8(nvrgy75jw3pssoln5yuvxtipgu)
+      '@ember-data/model': 5.3.8(ueu55puezsfvwcbmsvklkjcesq)
+      '@ember-data/request': 5.3.8(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/request-utils': 5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)
+      '@ember-data/serializer': 5.3.8(@ember-data/legacy-compat@5.3.8(nvrgy75jw3pssoln5yuvxtipgu))(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/store': 5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/tracking': 5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
     optionalDependencies:
       '@ember/test-helpers': 3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1)
       '@ember/test-waiters': 3.1.0
@@ -16499,23 +16501,23 @@ snapshots:
       - ember-source
       - supports-color
 
-  ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0):
+  ember-data@5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0):
     dependencies:
-      '@ember-data/adapter': 5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/debug': 5.3.6(@ember-data/model@5.3.6(eqf63xu3ypidrgzgnedouwi4bm))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/graph': 5.3.6(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/json-api': 5.3.6(4niswjrocysofsw5zndkhmw33m)
-      '@ember-data/legacy-compat': 5.3.6(sbkvnogex5gg4uwhiks424acym)
-      '@ember-data/model': 5.3.6(eqf63xu3ypidrgzgnedouwi4bm)
-      '@ember-data/request': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/request-utils': 5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2)
-      '@ember-data/serializer': 5.3.6(@ember-data/legacy-compat@5.3.6(sbkvnogex5gg4uwhiks424acym))(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/store@5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/store': 5.3.6(@ember-data/request-utils@5.3.6(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.9)(ember-inflector@4.0.2))(@ember-data/request@5.3.6(@warp-drive/core-types@0.0.0-beta.9))(@ember-data/tracking@5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.9)
-      '@ember-data/tracking': 5.3.6(@warp-drive/core-types@0.0.0-beta.9)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      '@ember-data/adapter': 5.3.8(@ember-data/legacy-compat@5.3.8(nvrgy75jw3pssoln5yuvxtipgu))(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/debug': 5.3.8(@ember-data/model@5.3.8(kmrusw53vkag3hgasesvkgmvka))(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/graph': 5.3.8(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/json-api': 5.3.8(6bbrrqfh2tga4w2lsjgq36ehuq)
+      '@ember-data/legacy-compat': 5.3.8(nvrgy75jw3pssoln5yuvxtipgu)
+      '@ember-data/model': 5.3.8(kmrusw53vkag3hgasesvkgmvka)
+      '@ember-data/request': 5.3.8(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/request-utils': 5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2)
+      '@ember-data/serializer': 5.3.8(@ember-data/legacy-compat@5.3.8(nvrgy75jw3pssoln5yuvxtipgu))(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/store@5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/store': 5.3.8(@ember-data/request-utils@5.3.8(@ember/string@3.1.1)(@warp-drive/core-types@0.0.0-beta.11)(ember-inflector@4.0.2))(@ember-data/request@5.3.8(@warp-drive/core-types@0.0.0-beta.11))(@ember-data/tracking@5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)))(@warp-drive/core-types@0.0.0-beta.11)
+      '@ember-data/tracking': 5.3.8(@warp-drive/core-types@0.0.0-beta.11)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.16.4
-      '@warp-drive/build-config': 0.0.0-beta.4
-      '@warp-drive/core-types': 0.0.0-beta.9
+      '@warp-drive/build-config': 0.0.0-beta.6
+      '@warp-drive/core-types': 0.0.0-beta.11
     optionalDependencies:
       '@ember/test-helpers': 3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1)
       qunit: 2.21.0
@@ -16579,7 +16581,7 @@ snapshots:
       - encoding
       - supports-color
 
-  ember-file-upload@9.0.0(lljhyg4imhxayrohxukxbwtrkq):
+  ember-file-upload@9.0.0(s47qe4fgslqe2qmtec2srscfpu):
     dependencies:
       '@ember/test-helpers': 3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1)
       '@ember/test-waiters': 3.1.0
@@ -16591,7 +16593,7 @@ snapshots:
       ember-modifier: 4.1.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
       tracked-built-ins: 3.3.0
     optionalDependencies:
-      ember-cli-mirage: 3.0.3(@ember-data/model@5.3.6(aadxxgrx75vhdk33kqgy5e53ku))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.6(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
+      ember-cli-mirage: 3.0.3(@ember-data/model@5.3.8(ueu55puezsfvwcbmsvklkjcesq))(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-data@5.3.8(@ember/string@3.1.1)(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(@ember/test-waiters@3.1.0)(ember-inflector@4.0.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(miragejs@0.1.48)(webpack@5.92.1)
       miragejs: 0.1.48
     transitivePeerDependencies:
       - '@glint/template'
@@ -17011,7 +17013,7 @@ snapshots:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.17
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -18560,7 +18562,7 @@ snapshots:
 
   is-callable@1.2.7: {}
 
-  is-core-module@2.13.1:
+  is-core-module@2.14.0:
     dependencies:
       hasown: 2.0.2
 
@@ -18773,7 +18775,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.14.6
+      '@types/node': 20.14.7
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -20269,7 +20271,7 @@ snapshots:
 
   resolve@1.22.8:
     dependencies:
-      is-core-module: 2.13.1
+      is-core-module: 2.14.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -20929,19 +20931,19 @@ snapshots:
     dependencies:
       postcss-scss: 4.0.9(postcss@8.4.38)
       stylelint: 16.6.1
-      stylelint-config-recommended: 14.0.0(stylelint@16.6.1)
+      stylelint-config-recommended: 14.0.1(stylelint@16.6.1)
       stylelint-scss: 6.3.2(stylelint@16.6.1)
     optionalDependencies:
       postcss: 8.4.38
 
-  stylelint-config-recommended@14.0.0(stylelint@16.6.1):
+  stylelint-config-recommended@14.0.1(stylelint@16.6.1):
     dependencies:
       stylelint: 16.6.1
 
-  stylelint-config-standard@36.0.0(stylelint@16.6.1):
+  stylelint-config-standard@36.0.1(stylelint@16.6.1):
     dependencies:
       stylelint: 16.6.1
-      stylelint-config-recommended: 14.0.0(stylelint@16.6.1)
+      stylelint-config-recommended: 14.0.1(stylelint@16.6.1)
 
   stylelint-prettier@5.0.0(prettier@3.3.2)(stylelint@16.6.1):
     dependencies:


### PR DESCRIPTION
We shouldn't have ignored this with dependabot, updating now and removing the ignore instruction so we get future updates as well.