### PR TITLE
created "on-insert" custom modifier; updated LocaleChooser

### DIFF
--- a/packages/frontend/.lint-todo
+++ b/packages/frontend/.lint-todo
@@ -98,3 +98,5 @@ add|ember-template-lint|no-at-ember-render-modifiers|10|6|10|6|d919d2af254f782c0
 add|ember-template-lint|no-at-ember-render-modifiers|11|6|11|6|940005188b476a060b0e5d3f05baea24ba178878|1719360000000|1734915600000|1750464000000|app/components/reports/subject/new/session-type.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|10|6|10|6|d919d2af254f782c01fe2ba15416673e52e91124|1719360000000|1734915600000|1750464000000|app/components/reports/subject/new/term.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|11|6|11|6|940005188b476a060b0e5d3f05baea24ba178878|1719360000000|1734915600000|1750464000000|app/components/reports/subject/new/term.hbs
+remove|ember-template-lint|no-at-ember-render-modifiers|16|4|16|4|46d995f60904f6b6f4b1b6b24bb65b9c97441bc1|1719360000000|1734915600000|1750464000000|app/components/locale-chooser.hbs
+remove|ember-template-lint|no-at-ember-render-modifiers|28|6|28|6|df94e6558ff62dea69f6f656f668f29b56bcc378|1719360000000|1734915600000|1750464000000|app/components/locale-chooser.hbs

--- a/packages/frontend/app/components/locale-chooser.hbs
+++ b/packages/frontend/app/components/locale-chooser.hbs
@@ -13,7 +13,7 @@
     data-test-toggle
     {{on "click" (toggle "isOpen" this)}}
     {{on "keyup" this.toggleMenu}}
-    {{did-insert this.setMenuButton}}
+    {{on-insert this.setMenuButton}}
   >
     <FaIcon @icon="globe" />
     <span id="{{this.uniqueId}}-locale-chooser-title">
@@ -25,7 +25,7 @@
     <div
       class="menu"
       role="menu"
-      {{did-insert this.focusOnFirstItem}}
+      {{on-insert this.focusOnFirstItem}}
     >
       {{#each this.locales as |loc|}}
         <button

--- a/packages/ilios-common/addon/modifiers/on-insert.js
+++ b/packages/ilios-common/addon/modifiers/on-insert.js
@@ -1,0 +1,9 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier((element, [callback]) => {
+  if (typeof callback === 'function') {
+    callback(element);
+  } else {
+    console.error('Invalid callback provided');
+  }
+});

--- a/packages/ilios-common/app/modifiers/on-insert.js
+++ b/packages/ilios-common/app/modifiers/on-insert.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/modifiers/on-insert';

--- a/packages/test-app/tests/integration/modifiers/on-insert-test.js
+++ b/packages/test-app/tests/integration/modifiers/on-insert-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Modifier | on-insert', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it runs valid callback after insertion', async function (assert) {
+    assert.expect(1);
+
+    this.set('validCallback', () => {
+      assert.ok(true, 'Valid callback was called');
+    });
+
+    await render(hbs`<div {{on-insert this.validCallback}}></div>`);
+  });
+
+  test('it errs out if invalid callback is provided', async function (assert) {
+    assert.expect(1);
+
+    const ogConsoleError = console.error;
+
+    console.error = (msg) => {
+      assert.strictEqual(msg, 'Invalid callback provided', 'Logged expected message');
+    };
+
+    await render(hbs`<div {{on-insert this.invalidCallback}}></div>`);
+
+    console.error = ogConsoleError;
+  });
+});


### PR DESCRIPTION
Refs ilios/ilios#5374

In order to fix the deprecated `{{did-insert}}` modifier, I created an `{{on-insert}}` custom modifier that just takes a callback, runs if valid, or performs a `console.error` if not.

I tested this on the `<LocaleChooser>` component, and it seems to work as expected. Can probably reuse this in other spots where we are doing a simple "did this thing load? if so, do this other thing" check.