### PR TITLE
fixed ilios-error/style.css file path

### DIFF
--- a/packages/frontend/lib/ilios-error/index.js
+++ b/packages/frontend/lib/ilios-error/index.js
@@ -32,7 +32,7 @@ module.exports = {
 
         if (!document.getElementById('ilios-loading-error')) {
           var link = document.createElement( "link" );
-          link.href = 'ilios-error/style.css';
+          link.href = '/ilios-error/style.css';
           link.type = "text/css";
           link.rel = "stylesheet";
           link.media = "screen";

--- a/packages/frontend/lib/ilios-error/index.js
+++ b/packages/frontend/lib/ilios-error/index.js
@@ -9,8 +9,10 @@ const caniuse = require('caniuse-db/data.json').agents;
 module.exports = {
   name: 'ilios-error',
 
-  contentFor: function (type) {
-    const script = this.getScript();
+  contentFor: function (type, config) {
+    const rootUrl = config.rootUrl || '';
+    const script = this.getScript(rootUrl);
+
     if (type === 'body') {
       return `
         <script>
@@ -20,8 +22,9 @@ module.exports = {
     }
   },
 
-  getScript() {
+  getScript(rootUrl) {
     const supportedBrowsers = this.getSupportedBrowsers().join('');
+
     return `
       // if there is an uncaught runtime error show the error message
       window.addEventListener('error', function (event) {
@@ -32,7 +35,7 @@ module.exports = {
 
         if (!document.getElementById('ilios-loading-error')) {
           var link = document.createElement( "link" );
-          link.href = '/ilios-error/style.css';
+          link.href = '${rootUrl}/ilios-error/style.css';
           link.type = "text/css";
           link.rel = "stylesheet";
           link.media = "screen";

--- a/packages/lti-course-manager/lib/ilios-error/index.js
+++ b/packages/lti-course-manager/lib/ilios-error/index.js
@@ -32,7 +32,7 @@ module.exports = {
 
         if (!document.getElementById('ilios-loading-error')) {
           var link = document.createElement( "link" );
-          link.href = 'ilios-error/style.css';
+          link.href = '/ilios-error/style.css';
           link.type = "text/css";
           link.rel = "stylesheet";
           link.media = "screen";

--- a/packages/lti-dashboard/lib/ilios-error/index.js
+++ b/packages/lti-dashboard/lib/ilios-error/index.js
@@ -32,7 +32,7 @@ module.exports = {
 
         if (!document.getElementById('ilios-loading-error')) {
           var link = document.createElement( "link" );
-          link.href = 'ilios-error/style.css';
+          link.href = '/ilios-error/style.css';
           link.type = "text/css";
           link.rel = "stylesheet";
           link.media = "screen";


### PR DESCRIPTION
Refs ilios/ilios#5566

The stylesheet that gets added in `packages/*/lib/ilios-error/index.js` had a incorrect path, causing a console error. I fixed it so it will now load.