### PR TITLE
programs acceptance test now only uses page objects

### DIFF
--- a/packages/frontend/app/components/program/root.hbs
+++ b/packages/frontend/app/components/program/root.hbs
@@ -1,6 +1,6 @@
 <section class="program" data-test-program-details ...attributes>
   <div class="backtolink">
-    <LinkTo @route="programs">
+    <LinkTo @route="programs" data-test-back-link>
       {{t "general.backToPrograms"}}
     </LinkTo>
   </div>

--- a/packages/frontend/tests/acceptance/programs-test.js
+++ b/packages/frontend/tests/acceptance/programs-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'frontend/tests/helpers';
 import page from 'frontend/tests/pages/programs';
+import detailPage from 'frontend/tests/pages/program';
 import percySnapshot from '@percy/ember';
 
 module('Acceptance | Programs', function (hooks) {
@@ -82,7 +83,7 @@ module('Acceptance | Programs', function (hooks) {
         school: this.school,
       });
       await page.visit();
-      await click('.list tbody tr:nth-of-type(1) td:nth-of-type(1) a');
+      await page.root.list.items[0].open();
       assert.strictEqual(currentURL(), '/programs/1');
     });
   });
@@ -108,9 +109,11 @@ module('Acceptance | Programs', function (hooks) {
       assert.strictEqual(page.root.schoolFilter.selectedSchool, '2');
       assert.strictEqual(currentURL(), '/programs?school=2');
 
-      await click('.list tbody tr:nth-of-type(1) td:nth-of-type(1) a');
+      await page.root.list.items[0].open();
       assert.strictEqual(currentURL(), '/programs/2');
-      await click('.backtolink a');
+
+      await detailPage.root.goBack();
+
       assert.strictEqual(page.root.schoolFilter.selectedSchool, '2');
       assert.strictEqual(currentURL(), '/programs?school=2');
     });

--- a/packages/frontend/tests/pages/components/program/root.js
+++ b/packages/frontend/tests/pages/components/program/root.js
@@ -1,4 +1,4 @@
-import { create } from 'ember-cli-page-object';
+import { clickable, create } from 'ember-cli-page-object';
 import leadershipCollapsed from 'ilios-common/page-objects/components/leadership-collapsed';
 import overview from './overview';
 import header from './header';
@@ -6,6 +6,7 @@ import leadershipExpanded from 'ilios-common/page-objects/components/leadership-
 
 const definition = {
   scope: '[data-test-program-details]',
+  goBack: clickable('[data-test-back-link]'),
   header,
   overview,
   leadershipCollapsed,

--- a/packages/frontend/tests/pages/components/programs/list-item.js
+++ b/packages/frontend/tests/pages/components/programs/list-item.js
@@ -5,6 +5,7 @@ const definition = {
   title: text('[data-test-title]'),
   school: text('[data-test-school]'),
   remove: clickable('[data-test-remove]'),
+  open: clickable('[data-test-link]'),
   canBeRemoved: isVisible('[data-test-remove]'),
   confirmRemoval: {
     scope: '[data-test-confirm-removal]',


### PR DESCRIPTION
Refs ilios/frontend#7935

The acceptance test for Programs still used direct selector access (e.g. `.list tbody`) in some places instead of page objects. I've updated this.