### PR TITLE
Increase Test Timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
   browserstack-test:
     name: Browserstack ${{matrix.workspace}} ${{ matrix.launcher }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 120
     needs: [test]
     strategy:
       fail-fast: false


### PR DESCRIPTION
Bigger timeout for the browserstack tests as these sometimes get queued up and wait causing a failure when nothing is wrong.