### PR TITLE
Remove Launcher from Browserstack Job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,18 +98,13 @@ jobs:
     needs: [test]
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         workspace:
           - frontend
           - test-app
           - lti-course-manager
           - lti-dashboard
-        launcher:
-          - BS_OSX_Safari
-          - BS_MS_Edge
-          - BS_IOS_SAFARI
-          - BS_CHROME_ANDROID
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -120,7 +115,7 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install
-      - name: test:browserstack ${{ matrix.launcher }}
+      - name: test:browserstack ${{ matrix.workspace }}
         env:
           BROWSERSTACK_USERNAME: iliosgithub_1UGowwsqE
           # This is in plaintext on purpose. It has no privileged access to anything (this is a free
@@ -128,10 +123,10 @@ jobs:
           BROWSERSTACK_ACCESS_KEY: yJjw6sE6izkpUw9oasGT
           # The following is necessary when using browserstack under matrix builds on Github Actions
           # The Job ID + Run ID isn't unique across matrix runs and will fail when run simultaneously
-          BROWSERSTACK_LOCAL_ID_SUFFIX: ${{ matrix.launcher }}
+          BROWSERSTACK_LOCAL_ID_SUFFIX: ${{ matrix.workspace }}
         run: |
           pnpm --filter ${{matrix.workspace}} exec ember browserstack:connect
-          pnpm --filter ${{matrix.workspace}} exec ember test --test-port=7774 --host=127.0.0.1 --config-file=testem.browserstack.js --launch=${{ matrix.launcher }}
+          pnpm --filter ${{matrix.workspace}} exec ember test --test-port=7774 --host=127.0.0.1 --config-file=testem.browserstack.js
           pnpm --filter ${{matrix.workspace}} exec ember browserstack:disconnect
           pnpm --filter ${{matrix.workspace}} exec ember browserstack:results
 

--- a/packages/frontend/testem.browserstack.js
+++ b/packages/frontend/testem.browserstack.js
@@ -1,4 +1,3 @@
-const FailureOnlyPerBrowserReporter = require('testem-failure-only-reporter/grouped-by-browser');
 const defaultArgs = ['-t', '1800', '--browserstack.video', 'false', '--u', '<url>'];
 
 const BrowserStackLaunchers = {
@@ -61,10 +60,9 @@ const BrowserStackLaunchers = {
 module.exports = {
   test_page: 'tests/index.html?hidepassed&hideskipped&timeout=60000',
   timeout: 1800,
-  reporter: FailureOnlyPerBrowserReporter,
   browser_start_timeout: 2000,
-  browser_disconnect_timeout: 120,
-  parallel: 4,
+  browser_disconnect_timeout: 240,
+  parallel: 1,
   disable_watching: true,
   launchers: BrowserStackLaunchers,
   launch_in_dev: [],

--- a/packages/lti-course-manager/testem.browserstack.js
+++ b/packages/lti-course-manager/testem.browserstack.js
@@ -1,4 +1,3 @@
-const FailureOnlyPerBrowserReporter = require('testem-failure-only-reporter/grouped-by-browser');
 const defaultArgs = ['-t', '1800', '--browserstack.video', 'false', '--u', '<url>'];
 
 const BrowserStackLaunchers = {
@@ -61,10 +60,9 @@ const BrowserStackLaunchers = {
 module.exports = {
   test_page: 'tests/index.html?hidepassed&hideskipped&timeout=60000',
   timeout: 1800,
-  reporter: FailureOnlyPerBrowserReporter,
   browser_start_timeout: 2000,
-  browser_disconnect_timeout: 120,
-  parallel: 4,
+  browser_disconnect_timeout: 240,
+  parallel: 1,
   disable_watching: true,
   launchers: BrowserStackLaunchers,
   launch_in_dev: [],

--- a/packages/lti-dashboard/testem.browserstack.js
+++ b/packages/lti-dashboard/testem.browserstack.js
@@ -1,4 +1,3 @@
-const FailureOnlyPerBrowserReporter = require('testem-failure-only-reporter/grouped-by-browser');
 const defaultArgs = ['-t', '1800', '--browserstack.video', 'false', '--u', '<url>'];
 
 const BrowserStackLaunchers = {
@@ -61,10 +60,9 @@ const BrowserStackLaunchers = {
 module.exports = {
   test_page: 'tests/index.html?hidepassed&hideskipped&timeout=60000',
   timeout: 1800,
-  reporter: FailureOnlyPerBrowserReporter,
   browser_start_timeout: 2000,
-  browser_disconnect_timeout: 120,
-  parallel: 4,
+  browser_disconnect_timeout: 240,
+  parallel: 1,
   disable_watching: true,
   launchers: BrowserStackLaunchers,
   launch_in_dev: [],

--- a/packages/test-app/testem.browserstack.js
+++ b/packages/test-app/testem.browserstack.js
@@ -1,4 +1,3 @@
-const FailureOnlyPerBrowserReporter = require('testem-failure-only-reporter/grouped-by-browser');
 const defaultArgs = ['-t', '1800', '--browserstack.video', 'false', '--u', '<url>'];
 
 const BrowserStackLaunchers = {
@@ -61,10 +60,9 @@ const BrowserStackLaunchers = {
 module.exports = {
   test_page: 'tests/index.html?hidepassed&hideskipped&timeout=60000',
   timeout: 1800,
-  reporter: FailureOnlyPerBrowserReporter,
   browser_start_timeout: 2000,
-  browser_disconnect_timeout: 120,
-  parallel: 4,
+  browser_disconnect_timeout: 240,
+  parallel: 1,
   disable_watching: true,
   launchers: BrowserStackLaunchers,
   launch_in_dev: [],


### PR DESCRIPTION
Looking at the dashboard I think each run may be testing in every browser, going to try switching this up and see what gets reported.