### PR TITLE
Dasherize Model Names

### DIFF
--- a/packages/frontend/app/components/assign-students/manager.js
+++ b/packages/frontend/app/components/assign-students/manager.js
@@ -20,7 +20,7 @@ export default class AssignStudentsManagerComponent extends Component {
   get data() {
     return {
       programs: this.store.peekAll('program'),
-      programYears: this.store.peekAll('programYear'),
+      programYears: this.store.peekAll('program-year'),
       cohorts: this.store.peekAll('cohort'),
     };
   }

--- a/packages/frontend/app/components/bulk-new-users.js
+++ b/packages/frontend/app/components/bulk-new-users.js
@@ -66,7 +66,7 @@ export default class BulkNewUsersComponent extends Component {
     return {
       schools: this.store.peekAll('school'),
       programs: this.store.peekAll('program'),
-      programYears: this.store.peekAll('programYear'),
+      programYears: this.store.peekAll('program-year'),
       cohorts: this.store.peekAll('cohort'),
     };
   }

--- a/packages/frontend/app/components/curriculum-inventory/new-report.js
+++ b/packages/frontend/app/components/curriculum-inventory/new-report.js
@@ -54,7 +54,7 @@ export default class CurriculumInventoryNewReportComponent extends Component {
     const endDate = this.academicYearCrossesCalendarYearBoundaries
       ? new Date(year + 1, 5, 30)
       : new Date(year, 11, 31);
-    const report = this.store.createRecord('curriculumInventoryReport', {
+    const report = this.store.createRecord('curriculum-inventory-report', {
       name: this.name,
       program: this.args.currentProgram,
       year: year,

--- a/packages/frontend/app/components/curriculum-inventory/new-sequence-block.js
+++ b/packages/frontend/app/components/curriculum-inventory/new-sequence-block.js
@@ -277,7 +277,7 @@ export default class CurriculumInventoryNewSequenceBlock extends Component {
     if (!isValid) {
       return false;
     }
-    const block = this.store.createRecord('curriculumInventorySequenceBlock', {
+    const block = this.store.createRecord('curriculum-inventory-sequence-block', {
       title: this.title,
       description: this.description,
       parent: this.args.parent,

--- a/packages/frontend/app/components/curriculum-inventory/report-details.js
+++ b/packages/frontend/app/components/curriculum-inventory/report-details.js
@@ -16,7 +16,7 @@ export default class CurriculumInventoryReportDetailsComponent extends Component
   }
 
   finalize = dropTask(async () => {
-    const newExport = this.store.createRecord('curriculumInventoryExport', {
+    const newExport = this.store.createRecord('curriculum-inventory-export', {
       report: this.args.report,
     });
     this.showFinalizeConfirmation = false;

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-list.js
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-list.js
@@ -33,7 +33,7 @@ export default class SequenceBlockListComponent extends Component {
     // therefore, we must reload them here in order to get those updated sort order values.
     // [ST 2021/03/16]
     if (this.args.parent) {
-      await this.store.findRecord('curriculum_inventory_sequence_block', this.args.parent.id, {
+      await this.store.findRecord('curriculum-inventory-sequence-block', this.args.parent.id, {
         include: 'children',
         reload: true,
       });

--- a/packages/frontend/app/components/school-session-types-expanded.js
+++ b/packages/frontend/app/components/school-session-types-expanded.js
@@ -37,7 +37,7 @@ export default class SchoolSessionTypesExpandedComponent extends Component {
   save = dropTask(
     async (title, calendarColor, assessment, assessmentOption, aamcMethod, isActive) => {
       this.args.setSchoolNewSessionType(null);
-      const sessionType = this.store.createRecord('sessionType');
+      const sessionType = this.store.createRecord('session-type');
       const aamcMethods = aamcMethod ? [aamcMethod] : [];
       sessionType.setProperties({
         school: this.args.school,

--- a/packages/frontend/app/controllers/curriculum-inventory-sequence-block.js
+++ b/packages/frontend/app/controllers/curriculum-inventory-sequence-block.js
@@ -35,7 +35,7 @@ export default class CurriculumInventorySequenceBlockController extends Controll
     // inside an "ordered" sequence block. they all get re-sorted server-side.
     // therefore, we must reload them here in order to get those updated sort order values.
     // [ST 2021/03/16]
-    await this.store.findRecord('curriculum_inventory_sequence_block', this.model.id, {
+    await this.store.findRecord('curriculum-inventory-sequence-block', this.model.id, {
       include: 'children',
       reload: true,
     });

--- a/packages/frontend/app/deprecation-workflow.js
+++ b/packages/frontend/app/deprecation-workflow.js
@@ -6,7 +6,6 @@ const SHOULD_THROW = config.environment !== 'production';
 const SILENCED_DEPRECATIONS = [
   // Add ids of deprecations we temporarily want to silence here.
   'ember-data:deprecate-legacy-imports',
-  'ember-data:deprecate-non-strict-types',
   'ember-data:deprecate-non-unique-relationship-entries',
   'ember-data:deprecate-many-array-duplicates',
 ];

--- a/packages/frontend/tests/acceptance/assign-students-test.js
+++ b/packages/frontend/tests/acceptance/assign-students-test.js
@@ -13,7 +13,7 @@ module('Acceptance | assign students', function (hooks) {
     this.school = this.server.create('school');
     this.school2 = this.server.create('school');
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program,
       startYear: DateTime.now().year,
     });

--- a/packages/frontend/tests/acceptance/course-visualizations-instructor-test.js
+++ b/packages/frontend/tests/acceptance/course-visualizations-instructor-test.js
@@ -26,8 +26,8 @@ module('Acceptance | course visualizations - instructor', function (hooks) {
     const term3 = this.server.create('term', {
       vocabulary: vocabulary2,
     });
-    const sessionType1 = this.server.create('sessionType');
-    const sessionType2 = this.server.create('sessionType');
+    const sessionType1 = this.server.create('session-type');
+    const sessionType2 = this.server.create('session-type');
     const session1 = this.server.create('session', {
       sessionType: sessionType1,
       terms: [term1],
@@ -37,12 +37,12 @@ module('Acceptance | course visualizations - instructor', function (hooks) {
       terms: [term2, term3],
     });
     const session3 = this.server.create('session');
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       session: session3,
       hours: 2,
       instructors: [instructor],
     });
-    const instructorGroup1 = this.server.create('instructorGroup', {
+    const instructorGroup1 = this.server.create('instructor-group', {
       users: [instructor],
     });
     this.server.create('offering', {

--- a/packages/frontend/tests/acceptance/course-visualizations-instructors-test.js
+++ b/packages/frontend/tests/acceptance/course-visualizations-instructors-test.js
@@ -23,8 +23,8 @@ module('Acceptance | course visualizations - instructors', function (hooks) {
     const term3 = this.server.create('term', {
       vocabulary: vocabulary2,
     });
-    const sessionType1 = this.server.create('sessionType');
-    const sessionType2 = this.server.create('sessionType');
+    const sessionType1 = this.server.create('session-type');
+    const sessionType2 = this.server.create('session-type');
     const session1 = this.server.create('session', {
       sessionType: sessionType1,
       terms: [term1],
@@ -34,10 +34,10 @@ module('Acceptance | course visualizations - instructors', function (hooks) {
       terms: [term2, term3],
     });
     const session3 = this.server.create('session');
-    const instructorGroup1 = this.server.create('instructorGroup', {
+    const instructorGroup1 = this.server.create('instructor-group', {
       users: [instructor1],
     });
-    const instructorGroup2 = this.server.create('instructorGroup', {
+    const instructorGroup2 = this.server.create('instructor-group', {
       users: [instructor2],
     });
     this.server.create('offering', {

--- a/packages/frontend/tests/acceptance/course-visualizations-objectives-test.js
+++ b/packages/frontend/tests/acceptance/course-visualizations-objectives-test.js
@@ -15,7 +15,7 @@ module('Acceptance | course visualizations - objectives', function (hooks) {
     assert.expect(14);
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
-    const courseObjectives = this.server.createList('courseObjective', 3, {
+    const courseObjectives = this.server.createList('course-objective', 3, {
       course,
     });
     const session1 = this.server.create('session', {
@@ -30,15 +30,15 @@ module('Acceptance | course visualizations - objectives', function (hooks) {
       title: 'Empty Session',
       course,
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session1,
       courseObjectives: [courseObjectives[0]],
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session2,
       courseObjectives: [courseObjectives[1]],
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session3,
       courseObjectives: [courseObjectives[2]],
     });

--- a/packages/frontend/tests/acceptance/course-visualizations-session-type-test.js
+++ b/packages/frontend/tests/acceptance/course-visualizations-session-type-test.js
@@ -14,7 +14,7 @@ module('Acceptance | course visualizations - session-type', function (hooks) {
 
   test('it renders', async function (assert) {
     assert.expect(16);
-    const sessionType = this.server.create('sessionType');
+    const sessionType = this.server.create('session-type');
     const vocabulary1 = this.server.create('vocabulary');
     const vocabulary2 = this.server.create('vocabulary');
     const term1 = this.server.create('term', {
@@ -35,7 +35,7 @@ module('Acceptance | course visualizations - session-type', function (hooks) {
       terms: [term2, term3],
     });
     const session3 = this.server.create('session', sessionType);
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       session: session3,
       hours: 2,
     });

--- a/packages/frontend/tests/acceptance/course-visualizations-session-types-test.js
+++ b/packages/frontend/tests/acceptance/course-visualizations-session-types-test.js
@@ -14,9 +14,9 @@ module('Acceptance | course visualizations - session-types', function (hooks) {
 
   test('it renders', async function (assert) {
     assert.expect(14);
-    const sessionType1 = this.server.create('sessionType');
-    const sessionType2 = this.server.create('sessionType');
-    const sessionType3 = this.server.create('sessionType');
+    const sessionType1 = this.server.create('session-type');
+    const sessionType2 = this.server.create('session-type');
+    const sessionType3 = this.server.create('session-type');
     const vocabulary1 = this.server.create('vocabulary');
     const vocabulary2 = this.server.create('vocabulary');
     const term1 = this.server.create('term', {
@@ -39,7 +39,7 @@ module('Acceptance | course visualizations - session-types', function (hooks) {
     const session3 = this.server.create('session', {
       sessionType: sessionType3,
     });
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       session: session3,
       hours: 2,
     });

--- a/packages/frontend/tests/acceptance/course-visualizations-vocabularies-test.js
+++ b/packages/frontend/tests/acceptance/course-visualizations-vocabularies-test.js
@@ -14,7 +14,7 @@ module('Acceptance | course visualizations - vocabularies', function (hooks) {
 
   test('it renders', async function (assert) {
     assert.expect(12);
-    const sessionType = this.server.create('sessionType');
+    const sessionType = this.server.create('session-type');
     const vocabulary1 = this.server.create('vocabulary');
     const vocabulary2 = this.server.create('vocabulary');
     const term1 = this.server.create('term', {
@@ -37,7 +37,7 @@ module('Acceptance | course visualizations - vocabularies', function (hooks) {
     const session3 = this.server.create('session', {
       sessionType,
     });
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       session: session3,
       hours: 2,
     });

--- a/packages/frontend/tests/acceptance/course-visualizations-vocabulary-test.js
+++ b/packages/frontend/tests/acceptance/course-visualizations-vocabulary-test.js
@@ -20,7 +20,7 @@ module('Acceptance | course visualizations - vocabulary', function (hooks) {
     const term3 = this.server.create('term', {
       vocabulary: this.vocabulary,
     });
-    const sessionType = this.server.create('sessionType');
+    const sessionType = this.server.create('session-type');
     const session1 = this.server.create('session', {
       sessionType,
       terms: [term1],
@@ -33,7 +33,7 @@ module('Acceptance | course visualizations - vocabulary', function (hooks) {
       sessionType,
       terms: [term3],
     });
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       session: session3,
       hours: 2,
     });

--- a/packages/frontend/tests/acceptance/course/cohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/cohorts-test.js
@@ -14,7 +14,7 @@ module('Acceptance | Course - Cohorts', function (hooks) {
       administeredSchools: [school],
     });
     const currentYear = new Date().getFullYear();
-    this.server.create('academicYear', { id: currentYear });
+    this.server.create('academic-year', { id: currentYear });
     const program = this.server.create('program', { school, duration: 4 });
     const cohort1 = this.server.create('cohort');
     const cohort2 = this.server.create('cohort');
@@ -22,12 +22,12 @@ module('Acceptance | Course - Cohorts', function (hooks) {
     const cohort4 = this.server.create('cohort');
 
     // first two should get through the filter
-    const programYear1 = this.server.create('programYear', {
+    const programYear1 = this.server.create('program-year', {
       program,
       cohort: cohort1,
       startYear: currentYear - program.duration,
     });
-    const programYear2 = this.server.create('programYear', {
+    const programYear2 = this.server.create('program-year', {
       program,
       cohort: cohort2,
       startYear: currentYear - program.duration - 4,
@@ -37,26 +37,26 @@ module('Acceptance | Course - Cohorts', function (hooks) {
     // (startYear + duration) <= (currentYear + duration)
     // &&
     // (startYear + duration) >= (currentYear + duration)
-    const programYear3 = this.server.create('programYear', {
+    const programYear3 = this.server.create('program-year', {
       program,
       cohort: cohort3,
       startYear: currentYear - program.duration - 5,
     });
-    const programYear4 = this.server.create('programYear', {
+    const programYear4 = this.server.create('program-year', {
       program,
       cohort: cohort4,
       startYear: currentYear - program.duration + 5,
     });
-    const programYearObjective1 = this.server.create('programYearObjective', {
+    const programYearObjective1 = this.server.create('program-year-objective', {
       programYear: programYear1,
     });
-    const programYearObjective2 = this.server.create('programYearObjective', {
+    const programYearObjective2 = this.server.create('program-year-objective', {
       programYear: programYear2,
     });
-    const programYearObjective3 = this.server.create('programYearObjective', {
+    const programYearObjective3 = this.server.create('program-year-objective', {
       programYear: programYear3,
     });
-    const programYearObjective4 = this.server.create('programYearObjective', {
+    const programYearObjective4 = this.server.create('program-year-objective', {
       programYear: programYear4,
     });
 
@@ -66,7 +66,7 @@ module('Acceptance | Course - Cohorts', function (hooks) {
       cohorts: [programYear1.cohort], //instead of just cohort1 otherwise the relationship gets munged
     });
 
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course: this.course,
       programYearObjectives: [
         programYearObjective1,

--- a/packages/frontend/tests/acceptance/course/competencies-test.js
+++ b/packages/frontend/tests/acceptance/course/competencies-test.js
@@ -11,7 +11,7 @@ module('Acceptance | Course - Competencies', function (hooks) {
     this.user = await setupAuthentication();
     this.school = this.server.create('school');
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program,
     });
     const cohort = this.server.create('cohort', {
@@ -26,11 +26,11 @@ module('Acceptance | Course - Competencies', function (hooks) {
       programYears: [programYear],
     });
 
-    const programYearObjective = this.server.create('programYearObjective', {
+    const programYearObjective = this.server.create('program-year-objective', {
       competency: competency1,
       programYear,
     });
-    this.server.create('programYearObjective', {
+    this.server.create('program-year-objective', {
       competency: competency2,
       programYear,
     });
@@ -40,11 +40,11 @@ module('Acceptance | Course - Competencies', function (hooks) {
       school: this.school,
       cohorts: [cohort],
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       programYearObjectives: [programYearObjective],
       course: this.course,
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       programYearObjectives: [programYearObjective],
       course: this.course,
     });

--- a/packages/frontend/tests/acceptance/course/leadership-test.js
+++ b/packages/frontend/tests/acceptance/course/leadership-test.js
@@ -12,7 +12,7 @@ module('Acceptance | Course - Leadership', function (hooks) {
       school: this.school,
       administeredSchools: [this.school],
     });
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
 
     const users = this.server.createList('user', 6);
     this.course = this.server.create('course', {

--- a/packages/frontend/tests/acceptance/course/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/learningmaterials-test.js
@@ -16,13 +16,13 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
     this.user2 = this.server.create('user', { displayName: 'Clem Chowder' });
-    this.server.create('academicYear');
+    this.server.create('academic-year');
     this.server.create('learningMaterialStatus', {
       learningMaterialIds: [1],
     });
     this.server.createList('learningMaterialStatus', 5);
     this.server.createList('learningMaterialUserRole', 3);
-    this.server.createList('meshDescriptor', 6);
+    this.server.createList('mesh-descriptor', 6);
   });
   module('Single Linked Materials', function (hooks2) {
     hooks2.beforeEach(function () {
@@ -30,7 +30,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
         year: 2013,
         school: this.school,
       });
-      this.server.create('learningMaterial', {
+      this.server.create('learning-material', {
         originalAuthor: 'Jennifer Johnson',
         owningUserId: this.user.id,
         statusId: 1,
@@ -40,7 +40,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
         absoluteFileUri: 'http://somethingsomething.com/something.pdf',
         uploadDate: DateTime.fromObject({ year: 2015, month: 2, day: 12, hour: 8 }).toJSDate(),
       });
-      this.server.create('learningMaterial', {
+      this.server.create('learning-material', {
         originalAuthor: 'Jennifer Johnson',
         owningUserId: this.user2.id,
         statusId: 1,
@@ -51,7 +51,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
         absoluteFileUri: 'http://example.com/file',
         uploadDate: DateTime.fromObject({ year: 2011, month: 3, day: 14, hour: 8 }).toJSDate(),
       });
-      this.server.create('learningMaterial', {
+      this.server.create('learning-material', {
         originalAuthor: 'Hunter Pence',
         link: 'www.example.com',
         statusId: 1,
@@ -59,7 +59,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
         userRoleId: 1,
         uploadDate: today.toJSDate(),
       });
-      this.server.create('learningMaterial', {
+      this.server.create('learning-material', {
         originalAuthor: 'Willie Mays',
         citation: 'a citation',
         statusId: 1,
@@ -67,7 +67,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
         owningUserId: this.user.id,
         uploadDate: DateTime.fromObject({ year: 2016, month: 12, day: 12, hour: 8 }).toJSDate(),
       });
-      this.server.create('learningMaterial', {
+      this.server.create('learning-material', {
         title: 'Letter to Doc Brown',
         originalAuthor: 'Marty McFly',
         owningUserId: this.user.id,
@@ -830,7 +830,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
         year: 2013,
         school: this.school,
       });
-      this.server.create('learningMaterial', {
+      this.server.create('learning-material', {
         originalAuthor: 'Jennifer Johnson',
         owningUserId: this.user.id,
         statusId: 1,

--- a/packages/frontend/tests/acceptance/course/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/mesh-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
     this.school = this.server.create('school');
-    this.server.create('academicYear');
+    this.server.create('academic-year');
     this.server.createList('meshTree', 3);
     this.server.createList('meshConcept', 3);
 
@@ -17,14 +17,14 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
       scopeNote: '1234567890'.repeat(30),
     });
 
-    this.server.create('meshDescriptor', {
+    this.server.create('mesh-descriptor', {
       conceptIds: [1, 2, 3, 4],
       treeIds: [1, 2, 3],
     });
-    this.server.create('meshDescriptor', {
+    this.server.create('mesh-descriptor', {
       deleted: true,
     });
-    this.server.createList('meshDescriptor', 4);
+    this.server.createList('mesh-descriptor', 4);
 
     this.course = this.server.create('course', {
       year: 2014,

--- a/packages/frontend/tests/acceptance/course/objectivecreate-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivecreate-test.js
@@ -8,7 +8,7 @@ module('Acceptance | Course - Objective Create', function (hooks) {
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
     this.school = this.server.create('school');
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);
     this.server.createList('cohort', 2);

--- a/packages/frontend/tests/acceptance/course/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivelist-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Course - Objective List', function (hooks) {
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
     this.school = this.server.create('school');
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
   });
 
   test('list objectives', async function (assert) {
@@ -18,27 +18,27 @@ module('Acceptance | Course - Objective List', function (hooks) {
     const competencies = this.server.createList('competency', 2, {
       school: this.school,
     });
-    const meshDescriptors = this.server.createList('meshDescriptor', 3);
+    const meshDescriptors = this.server.createList('mesh-descriptor', 3);
     const vocabulary = this.server.create('vocabulary', {
       school: this.school,
     });
-    const programYearObjectiveWithCompetency = this.server.create('programYearObjective', {
+    const programYearObjectiveWithCompetency = this.server.create('program-year-objective', {
       competency: competencies[0],
     });
-    const programYearObjectiveWithoutCompetency = this.server.create('programYearObjective');
+    const programYearObjectiveWithoutCompetency = this.server.create('program-year-objective');
     const term1 = this.server.create('term', { vocabulary });
     const term2 = this.server.create('term', { vocabulary });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [programYearObjectiveWithCompetency],
       meshDescriptors: [meshDescriptors[0]],
       terms: [term1],
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [programYearObjectiveWithoutCompetency],
       meshDescriptors: [meshDescriptors[0], meshDescriptors[1]],

--- a/packages/frontend/tests/acceptance/course/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivemesh-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
     this.school = this.server.create('school');
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);
     this.server.createList('cohort', 2);
@@ -19,19 +19,19 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
       school: this.school,
     });
 
-    const meshDescriptors = this.server.createList('meshDescriptor', 6);
-    this.server.create('courseObjective', {
+    const meshDescriptors = this.server.createList('mesh-descriptor', 6);
+    this.server.create('course-objective', {
       meshDescriptors: [meshDescriptors.shift()],
       course: this.course,
     });
-    this.server.create('courseObjective', { meshDescriptors, course: this.course });
-    this.server.create('courseObjective', { course: this.course });
+    this.server.create('course-objective', { meshDescriptors, course: this.course });
+    this.server.create('course-objective', { course: this.course });
 
     // create some other objectives not in this course
     //this.server.createList('objective', 2);
 
     //create some extra descriptors that shouldn't be found in search
-    this.server.createList('meshDescriptor', 10, {
+    this.server.createList('mesh-descriptor', 10, {
       name: 'nope',
       annotation: 'nope',
     });

--- a/packages/frontend/tests/acceptance/course/objectiveparents-allow-multiple-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-allow-multiple-test.js
@@ -24,7 +24,7 @@ module('Acceptance | Course - Multiple Objective  Parents', function (hooks) {
       school: this.school,
       programYears: [programYear],
     });
-    const programYearObjectives = this.server.createList('programYearObjective', 3, {
+    const programYearObjectives = this.server.createList('program-year-objective', 3, {
       programYear,
       competency,
     });
@@ -34,7 +34,7 @@ module('Acceptance | Course - Multiple Objective  Parents', function (hooks) {
       cohorts: [cohort],
     });
 
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       programYearObjectives: [programYearObjectives[0], programYearObjectives[1]],
       course: this.course,
     });

--- a/packages/frontend/tests/acceptance/course/objectiveparents-inactive-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-inactive-test.js
@@ -13,7 +13,7 @@ module('Acceptance | Course - Objective Inactive Parents', function (hooks) {
 
   test('inactive program year objectives are hidden unless they are selected', async function (assert) {
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', {
       programYear,
     });

--- a/packages/frontend/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -24,19 +24,19 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
       programYears,
     });
 
-    const programYearObjective1 = this.server.create('programYearObjective', {
+    const programYearObjective1 = this.server.create('program-year-objective', {
       programYear: programYears[0],
       competency: competencies[0],
     });
-    this.server.create('programYearObjective', {
+    this.server.create('program-year-objective', {
       programYear: programYears[0],
       competency: competencies[1],
     });
-    this.server.create('programYearObjective', {
+    this.server.create('program-year-objective', {
       programYear: programYears[1],
       competency: competencies[0],
     });
-    const programYearObjective4 = this.server.create('programYearObjective', {
+    const programYearObjective4 = this.server.create('program-year-objective', {
       programYear: programYears[1],
       competency: competencies[1],
     });
@@ -46,11 +46,11 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
       school: this.school,
       cohorts: [cohort1, cohort2],
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course: this.course,
       programYearObjectives: [programYearObjective1, programYearObjective4],
     });
-    this.server.create('courseObjective', { course: this.course });
+    this.server.create('course-objective', { course: this.course });
   });
 
   test('list parent objectives by competency', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/objectiveparents-nocohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-nocohorts-test.js
@@ -12,7 +12,7 @@ module('Acceptance | Course with no cohorts - Objective Parents', function (hook
     const program = this.server.create('program', { school: this.school });
 
     const year = new Date().getFullYear();
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program,
       startYear: year,
     });
@@ -21,12 +21,12 @@ module('Acceptance | Course with no cohorts - Objective Parents', function (hook
       school: this.school,
       programYears: [programYear],
     });
-    this.server.create('programYearObjective', { programYear, competency });
+    this.server.create('program-year-objective', { programYear, competency });
     this.course = this.server.create('course', {
       year: 2013,
       school: this.school,
     });
-    this.server.create('courseObjective', { course: this.course });
+    this.server.create('course-objective', { course: this.course });
   });
 
   test('add and remove a new cohort', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/objectiveparents-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-test.js
@@ -10,7 +10,7 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
     this.user = await setupAuthentication();
     this.school = this.server.create('school');
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
     const competency1 = this.server.create('competency', {
       school: this.school,
@@ -20,15 +20,15 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
       school: this.school,
       programYears: [programYear],
     });
-    const parent = this.server.create('programYearObjective', {
+    const parent = this.server.create('program-year-objective', {
       programYear,
       competency: competency1,
     });
-    this.server.create('programYearObjective', {
+    this.server.create('program-year-objective', {
       programYear,
       competency: competency2,
     });
-    this.server.create('programYearObjective', {
+    this.server.create('program-year-objective', {
       programYear,
       competency: competency2,
     });
@@ -37,11 +37,11 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
       school: this.school,
       cohorts: [cohort],
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course: this.course,
       programYearObjectives: [parent],
     });
-    this.server.create('courseObjective', { course: this.course });
+    this.server.create('course-objective', { course: this.course });
   });
 
   test('list parent objectives by competency', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveterms-test.js
@@ -9,9 +9,9 @@ module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
     const school = this.server.create('school');
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     this.server.create('cohort', { programYear });
     const vocabulary = this.server.create('vocabulary', {
       school,

--- a/packages/frontend/tests/acceptance/course/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/overview-test.js
@@ -12,13 +12,13 @@ module('Acceptance | Course - Overview', function (hooks) {
     this.intl = this.owner.lookup('service:intl');
     this.user = await setupAuthentication();
     this.school = this.server.create('school');
-    this.server.createList('courseClerkshipType', 2);
+    this.server.createList('course-clerkship-type', 2);
   });
 
   module('check fields', function (hooks2) {
     hooks2.beforeEach(function () {
       this.user.update({ administeredSchools: [this.school] });
-      this.clerkshipType = this.server.create('courseClerkshipType');
+      this.clerkshipType = this.server.create('course-clerkship-type');
       this.course = this.server.create('course', {
         year: 2013,
         school: this.school,
@@ -40,7 +40,7 @@ module('Acceptance | Course - Overview', function (hooks) {
         .findRecord('course', this.course.id);
       const clerkshipTypeModel = await this.owner
         .lookup('service:store')
-        .findRecord('courseClerkshipType', this.clerkshipType.id);
+        .findRecord('course-clerkship-type', this.clerkshipType.id);
       await page.visit({ courseId: courseModel.id });
       await percySnapshot(assert);
       assert.strictEqual(
@@ -77,7 +77,7 @@ module('Acceptance | Course - Overview', function (hooks) {
         .findRecord('course', this.course.id);
       const clerkshipTypeModel = await this.owner
         .lookup('service:store')
-        .findRecord('courseClerkshipType', this.clerkshipType.id);
+        .findRecord('course-clerkship-type', this.clerkshipType.id);
       await page.visit({ courseId: courseModel.id, details: true });
       await percySnapshot(assert);
       assert.strictEqual(
@@ -150,7 +150,7 @@ module('Acceptance | Course - Overview', function (hooks) {
 
   test('remove clerkship type', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const clerkshipType = this.server.create('courseClerkshipType');
+    const clerkshipType = this.server.create('course-clerkship-type');
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,

--- a/packages/frontend/tests/acceptance/course/printcourse-test.js
+++ b/packages/frontend/tests/acceptance/course/printcourse-test.js
@@ -10,7 +10,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
     this.school = this.server.create('school');
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
-    this.server.create('academicYear');
+    this.server.create('academic-year');
     this.server.create('cohort', { programYear });
     this.learningMaterialUserRole = this.server.create('learning-material-user-role');
     this.learningMaterialStatus = this.server.create('learning-material-status');
@@ -35,7 +35,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
       firstName: 'Emmet',
       id: 1,
     });
-    this.server.create('learningMaterial', {
+    this.server.create('learning-material', {
       title: 'Save the Clock Tower',
       originalAuthor: 'Jennifer Johnson',
       filename: 'Clock Tower Flyer',
@@ -52,7 +52,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
       courseId: 1,
       required: false,
     });
-    this.server.create('meshDescriptor', {
+    this.server.create('mesh-descriptor', {
       courseIds: [1],
       name: 'Flux Capacitor',
     });
@@ -163,7 +163,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
       publishedAsTbd: false,
     });
 
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       sessionId: 1,
       hours: 1.5,
       dueDate: new Date(1995, 11, 17, 3, 24, 0),
@@ -192,7 +192,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
       published: true,
       publishedAsTbd: false,
     });
-    const courseObjective = this.server.create('courseObjective', {
+    const courseObjective = this.server.create('course-objective', {
       course: this.course,
       title: 'Course Objective 1',
     });
@@ -200,19 +200,19 @@ module('Acceptance | Course - Print Course', function (hooks) {
       school: this.school,
     });
     const term = this.server.create('term', { vocabulary });
-    const sessionObjective = this.server.create('sessionObjective', {
+    const sessionObjective = this.server.create('session-objective', {
       session,
       title: 'Session Objective 1',
       courseObjectives: [courseObjective],
       terms: [term],
     });
 
-    this.server.create('meshDescriptor', {
+    this.server.create('mesh-descriptor', {
       sessionObjectives: [sessionObjective],
       name: 'MeSH Descriptor 1',
     });
 
-    this.server.create('meshDescriptor', {
+    this.server.create('mesh-descriptor', {
       sessionObjectives: [sessionObjective],
       name: 'MeSH Descriptor 2',
     });
@@ -241,7 +241,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
       school: this.school,
       title: 'Competency 1',
     });
-    const programYearObjective = this.server.create('programYearObjective', {
+    const programYearObjective = this.server.create('program-year-objective', {
       competency,
       title: 'Program Year Objective 1',
     });
@@ -249,19 +249,19 @@ module('Acceptance | Course - Print Course', function (hooks) {
       school: this.school,
     });
     const term = this.server.create('term', { vocabulary });
-    const courseObjective = this.server.create('courseObjective', {
+    const courseObjective = this.server.create('course-objective', {
       course: this.course,
       title: 'Course Objective 1',
       programYearObjectives: [programYearObjective],
       terms: [term],
     });
 
-    this.server.create('meshDescriptor', {
+    this.server.create('mesh-descriptor', {
       courseObjectives: [courseObjective],
       name: 'MeSH Descriptor 1',
     });
 
-    this.server.create('meshDescriptor', {
+    this.server.create('mesh-descriptor', {
       courseObjectives: [courseObjective],
       name: 'MeSH Descriptor 2',
     });
@@ -290,7 +290,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
       published: true,
       publishedAsTbd: false,
     });
-    const learningMaterial = this.server.create('learningMaterial', {
+    const learningMaterial = this.server.create('learning-material', {
       title: 'Foo',
       originalAuthor: 'Bar',
       owningUser: this.user,
@@ -299,7 +299,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
       copyrightPermission: true,
       citation: 'lorem ipsum',
     });
-    this.server.create('sessionLearningMaterial', {
+    this.server.create('session-learning-material', {
       learningMaterial,
       session,
       required: false,

--- a/packages/frontend/tests/acceptance/course/publicationcheck-test.js
+++ b/packages/frontend/tests/acceptance/course/publicationcheck-test.js
@@ -15,7 +15,7 @@ module('Acceptance | Course - Publication Check', function (hooks) {
     const program = this.server.create('program', {
       school,
     });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program,
     });
     const cohort = this.server.create('cohort', {
@@ -24,7 +24,7 @@ module('Acceptance | Course - Publication Check', function (hooks) {
     const term = this.server.create('term', {
       vocabulary,
     });
-    const meshDescriptor = this.server.create('meshDescriptor');
+    const meshDescriptor = this.server.create('mesh-descriptor');
     this.fullCourse = this.server.create('course', {
       year: 2013,
       school,
@@ -32,7 +32,7 @@ module('Acceptance | Course - Publication Check', function (hooks) {
       terms: [term],
       meshDescriptors: [meshDescriptor],
     });
-    this.server.create('courseObjective', { course: this.fullCourse });
+    this.server.create('course-objective', { course: this.fullCourse });
     this.emptyCourse = this.server.create('course', {
       year: 2013,
       school,

--- a/packages/frontend/tests/acceptance/course/publishall-test.js
+++ b/packages/frontend/tests/acceptance/course/publishall-test.js
@@ -14,7 +14,7 @@ module('Acceptance | Course - Publish All Sessions', function (hooks) {
   });
 
   test('published sessions do not appear in the cannot publish list #1658', async function (assert) {
-    const meshDescriptor = this.server.create('meshDescriptor');
+    const meshDescriptor = this.server.create('mesh-descriptor');
     const term = this.server.create('term');
 
     const course = this.server.create('course', {
@@ -30,7 +30,7 @@ module('Acceptance | Course - Publish All Sessions', function (hooks) {
       meshDescriptors: [meshDescriptor],
       terms: [term],
     });
-    this.server.create('sessionObjective', { session: session1 });
+    this.server.create('session-objective', { session: session1 });
     this.server.create('offering', { sessionId: 1 });
     const session2 = this.server.create('session', {
       course,
@@ -39,10 +39,10 @@ module('Acceptance | Course - Publish All Sessions', function (hooks) {
       meshDescriptors: [meshDescriptor],
       terms: [term],
     });
-    this.server.create('sessionObjective', { session: session2 });
+    this.server.create('session-objective', { session: session2 });
 
     this.server.create('offering', { session: session2 });
-    this.server.create('ilmSession', { session: session2 });
+    this.server.create('ilm-session', { session: session2 });
     const session3 = this.server.create('session', {
       course,
       published: true,
@@ -50,7 +50,7 @@ module('Acceptance | Course - Publish All Sessions', function (hooks) {
       meshDescriptors: [meshDescriptor],
       terms: [term],
     });
-    this.server.create('sessionObjective', { session: session3 });
+    this.server.create('session-objective', { session: session3 });
 
     this.server.create('offering', { session: session3 });
 
@@ -99,7 +99,7 @@ module('Acceptance | Course - Publish All Sessions', function (hooks) {
   });
 
   test('After publishing user is returned to the courses route #4099', async function (assert) {
-    const meshDescriptors = this.server.createList('meshDescriptor', 1);
+    const meshDescriptors = this.server.createList('mesh-descriptor', 1);
     const terms = this.server.createList('term', 1);
 
     const course = this.server.create('course', {
@@ -115,8 +115,8 @@ module('Acceptance | Course - Publish All Sessions', function (hooks) {
       meshDescriptors,
       terms,
     });
-    this.server.create('sessionObjective', { session });
-    this.server.create('sessionType', {
+    this.server.create('session-objective', { session });
+    this.server.create('session-type', {
       sessions: [session],
     });
     this.server.create('offering', { session });
@@ -157,7 +157,7 @@ module('Acceptance | Course - Publish All Sessions', function (hooks) {
       published: false,
       publishedAsTbd: false,
     });
-    this.server.create('sessionType', {
+    this.server.create('session-type', {
       sessions: [session],
     });
     await page.visit({

--- a/packages/frontend/tests/acceptance/course/session/ilm-test.js
+++ b/packages/frontend/tests/acceptance/course/session/ilm-test.js
@@ -10,13 +10,13 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
     this.server.createList('user', 6);
-    this.server.create('academicYear');
+    this.server.create('academic-year');
     this.course = this.server.create('course', { school: this.school });
-    this.server.createList('instructorGroup', 5, { school: this.school });
+    this.server.createList('instructor-group', 5, { school: this.school });
     this.server.createList('user', 2, { instructorGroupIds: [1] });
     this.server.createList('user', 3, { instructorGroupIds: [2] });
-    this.server.create('sessionType', { school: this.school });
-    const ilmSession = this.server.create('ilmSession', {
+    this.server.create('session-type', { school: this.school });
+    const ilmSession = this.server.create('ilm-session', {
       instructorGroupIds: [1, 2, 3],
       instructorIds: [2, 3, 4],
     });

--- a/packages/frontend/tests/acceptance/course/session/leadership-test.js
+++ b/packages/frontend/tests/acceptance/course/session/leadership-test.js
@@ -12,7 +12,7 @@ module('Acceptance | Session - Leadership', function (hooks) {
       school: this.school,
       administeredSchools: [this.school],
     });
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
 
     const users = this.server.createList('user', 5);
     const course = this.server.create('course', {

--- a/packages/frontend/tests/acceptance/course/session/learner-groups-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learner-groups-test.js
@@ -17,7 +17,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       this.program = this.server.create('program', {
         school: this.school,
       });
-      const programYear = this.server.create('programYear', {
+      const programYear = this.server.create('program-year', {
         program: this.program,
       });
       this.server.create('cohort', {
@@ -27,15 +27,15 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
         school: this.school,
         cohortIds: [1],
       });
-      this.server.create('sessionType');
-      this.server.createList('learnerGroup', 5, {
+      this.server.create('session-type');
+      this.server.createList('learner-group', 5, {
         cohortId: 1,
       });
-      this.server.createList('learnerGroup', 2, {
+      this.server.createList('learner-group', 2, {
         cohortId: 1,
         parentId: 4,
       });
-      this.server.create('learnerGroup', {
+      this.server.create('learner-group', {
         cohortId: 1,
         parentId: 5,
       });
@@ -53,7 +53,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('initial selected learner groups', async function (assert) {
       assert.expect(10);
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
         learnerIds: [2, 3],
@@ -89,7 +89,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('manager display', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
         learnerIds: [2, 3],
@@ -212,7 +212,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('learner group manager display with no selected groups or learners', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [],
         learnerIds: [],
@@ -300,7 +300,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('filter learner groups by top group should include all subgroups', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
       });
@@ -351,7 +351,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('filter learner groups by subgroup should include top group', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
       });
@@ -402,7 +402,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('add learner group', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
       });
@@ -531,7 +531,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('add learner sub group', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
       });
@@ -646,7 +646,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('add learner group with children', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2],
       });
@@ -778,7 +778,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('add learner group with children and remove one child', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2],
       });
@@ -927,7 +927,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('undo learner group change', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
       });
@@ -1006,7 +1006,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('add learner', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerIds: [2, 3],
       });
@@ -1057,7 +1057,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('remove learner', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerIds: [2, 3],
       });
@@ -1091,7 +1091,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
     test('undo learner change', async function (assert) {
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('ilmSession', {
+      this.server.create('ilm-session', {
         sessionId: 1,
         learnerIds: [2, 3],
       });
@@ -1126,11 +1126,11 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
 
   test('initial state with save works as expected #1773', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    this.server.create('sessionType');
+    this.server.create('session-type');
     this.server.create('program', {
       school: this.school,
     });
-    this.server.create('programYear', {
+    this.server.create('program-year', {
       programId: 1,
     });
     this.server.create('cohort', {
@@ -1140,13 +1140,13 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       school: this.school,
       cohortIds: [1],
     });
-    this.server.createList('learnerGroup', 2, {
+    this.server.createList('learner-group', 2, {
       cohortId: 1,
     });
     this.server.create('session', {
       courseId: 1,
     });
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       sessionId: 1,
     });
     await page.visit({ courseId: 1, sessionId: 1 });

--- a/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
@@ -15,17 +15,17 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
     this.user2 = this.server.create('user', { displayName: 'Clem Chowder' });
-    this.server.create('academicYear');
+    this.server.create('academic-year');
     this.server.create('learningMaterialStatus', {
       learningMaterialIds: [1],
     });
     this.server.createList('learningMaterialStatus', 5);
     this.server.createList('learningMaterialUserRole', 3);
-    this.server.createList('meshDescriptor', 6);
+    this.server.createList('mesh-descriptor', 6);
   });
   module('Single Linked Materials', function (hooks2) {
     hooks2.beforeEach(function () {
-      this.server.create('learningMaterial', {
+      this.server.create('learning-material', {
         originalAuthor: 'Jennifer Johnson',
         owningUserId: this.user.id,
         statusId: 1,
@@ -35,7 +35,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
         absoluteFileUri: 'http://somethingsomething.com/something.pdf',
         uploadDate: DateTime.fromObject({ year: 2015, month: 2, day: 12, hour: 8 }).toJSDate(),
       });
-      this.server.create('learningMaterial', {
+      this.server.create('learning-material', {
         originalAuthor: 'Jennifer Johnson',
         owningUserId: this.user2.id,
         statusId: 1,
@@ -46,7 +46,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
         absoluteFileUri: 'http://example.com/file',
         uploadDate: DateTime.fromObject({ year: 2011, month: 3, day: 14, hour: 8 }).toJSDate(),
       });
-      this.server.create('learningMaterial', {
+      this.server.create('learning-material', {
         originalAuthor: 'Hunter Pence',
         link: 'www.example.com',
         statusId: 1,
@@ -54,7 +54,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
         userRoleId: 1,
         uploadDate: today.toJSDate(),
       });
-      this.server.create('learningMaterial', {
+      this.server.create('learning-material', {
         originalAuthor: 'Willie Mays',
         citation: 'a citation',
         statusId: 1,
@@ -62,7 +62,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
         owningUserId: this.user.id,
         uploadDate: DateTime.fromObject({ year: 2016, month: 12, day: 12, hour: 8 }).toJSDate(),
       });
-      this.server.create('learningMaterial', {
+      this.server.create('learning-material', {
         title: 'Letter to Doc Brown',
         originalAuthor: 'Marty McFly',
         owningUserId: this.user.id,
@@ -80,26 +80,26 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       const session = this.server.create('session', {
         course,
       });
-      this.server.create('sessionLearningMaterial', {
+      this.server.create('session-learning-material', {
         learningMaterialId: 1,
         session,
         required: false,
         meshDescriptorIds: [2, 3],
         position: 0,
       });
-      this.server.create('sessionLearningMaterial', {
+      this.server.create('session-learning-material', {
         learningMaterialId: 2,
         session,
         required: false,
         position: 1,
       });
-      this.server.create('sessionLearningMaterial', {
+      this.server.create('session-learning-material', {
         learningMaterialId: 3,
         session,
         publicNotes: false,
         position: 2,
       });
-      this.server.create('sessionLearningMaterial', {
+      this.server.create('session-learning-material', {
         learningMaterialId: 4,
         session,
         position: 3,
@@ -830,7 +830,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       const session = this.server.create('session', {
         course,
       });
-      const learningMaterial = this.server.create('learningMaterial', {
+      const learningMaterial = this.server.create('learning-material', {
         originalAuthor: 'Jennifer Johnson',
         owningUserId: this.user.id,
         statusId: 1,
@@ -840,7 +840,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
         absoluteFileUri: 'http://somethingsomething.com/something.pdf',
         uploadDate: DateTime.fromObject({ year: 2015, month: 2, day: 12, hour: 8 }).toJSDate(),
       });
-      this.server.create('sessionLearningMaterial', {
+      this.server.create('session-learning-material', {
         learningMaterial,
         session,
         required: false,

--- a/packages/frontend/tests/acceptance/course/session/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/mesh-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
-    this.server.create('academicYear');
+    this.server.create('academic-year');
     this.server.createList('meshTree', 3);
     this.server.createList('meshConcept', 3);
 
@@ -17,14 +17,14 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
       scopeNote: '1234567890'.repeat(30),
     });
 
-    this.server.create('meshDescriptor', {
+    this.server.create('mesh-descriptor', {
       conceptIds: [1, 2, 3, 4],
       treeIds: [1, 2, 3],
     });
-    this.server.create('meshDescriptor', {
+    this.server.create('mesh-descriptor', {
       deleted: true,
     });
-    this.server.createList('meshDescriptor', 4);
+    this.server.createList('mesh-descriptor', 4);
 
     const course = this.server.create('course', {
       year: 2014,

--- a/packages/frontend/tests/acceptance/course/session/objectivecreate-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivecreate-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Session - Objective Create', function (hooks) {
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);
     this.server.createList('cohort', 2);

--- a/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
@@ -11,7 +11,7 @@ module('Acceptance | Session - Objective List', function (hooks) {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
 
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);
     this.server.createList('cohort', 2);
@@ -28,22 +28,22 @@ module('Acceptance | Session - Objective List', function (hooks) {
     const vocabulary = this.server.create('vocabulary', {
       school: this.school,
     });
-    const courseObjectives = this.server.createList('courseObjective', 2);
-    const meshDescriptors = this.server.createList('meshDescriptor', 3);
+    const courseObjectives = this.server.createList('course-objective', 2);
+    const meshDescriptors = this.server.createList('mesh-descriptor', 3);
     const terms = this.server.createList('term', 2, { vocabulary });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session,
       courseObjectives: [courseObjectives.shift()],
       meshDescriptors: [meshDescriptors.shift()],
       terms: [terms.shift()],
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session,
       courseObjectives,
       meshDescriptors,
       terms: terms,
     });
-    this.server.createList('sessionObjective', 11, { session });
+    this.server.createList('session-objective', 11, { session });
     await page.visit({
       courseId: 1,
       sessionId: 1,

--- a/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
     this.user = await setupAuthentication();
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);
     this.server.createList('cohort', 2);
@@ -18,16 +18,16 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
       school: this.school,
     });
     const session = this.server.create('session', { course });
-    const meshDescriptors = this.server.createList('meshDescriptor', 6);
-    this.server.create('sessionObjective', {
+    const meshDescriptors = this.server.createList('mesh-descriptor', 6);
+    this.server.create('session-objective', {
       session,
       meshDescriptors: [meshDescriptors.shift()],
     });
-    this.server.create('sessionObjective', { session, meshDescriptors });
-    this.server.create('sessionObjective', { session });
+    this.server.create('session-objective', { session, meshDescriptors });
+    this.server.create('session-objective', { session });
 
     //create some extra descriptors that shouldn't be found in search
-    this.server.createList('meshDescriptor', 10, {
+    this.server.createList('mesh-descriptor', 10, {
       name: 'nope',
       annotation: 'nope',
     });

--- a/packages/frontend/tests/acceptance/course/session/objectiveparents-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveparents-test.js
@@ -13,15 +13,15 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
       year: 2013,
       school: this.school,
     });
-    const courseObjectives = this.server.createList('courseObjective', 3, {
+    const courseObjectives = this.server.createList('course-objective', 3, {
       course,
     });
     const session = this.server.create('session', { course });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session,
       courseObjectives: courseObjectives.slice(0, 2),
     });
-    this.server.create('sessionObjective', { session });
+    this.server.create('session-objective', { session });
   });
 
   test('list parent objectives', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/session/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveterms-test.js
@@ -9,9 +9,9 @@ module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
     const school = this.server.create('school');
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     this.server.create('cohort', { programYear });
     const vocabulary = this.server.create('vocabulary', {
       school,
@@ -21,7 +21,7 @@ module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
     this.server.createList('term', 3, { vocabulary, active: true });
     const course = this.server.create('course', { school });
     const session = this.server.create('session', { course });
-    this.server.create('sessionObjective', { session, terms: [term] });
+    this.server.create('session-objective', { session, terms: [term] });
     this.school = school;
   });
 

--- a/packages/frontend/tests/acceptance/course/session/offerings-management-test.js
+++ b/packages/frontend/tests/acceptance/course/session/offerings-management-test.js
@@ -144,21 +144,21 @@ module('Acceptance | Session - Offering Management', function (hooks) {
   test('Learner Group parents are shown in tooltip if applicable', async function (assert) {
     const course = this.server.create('course', { school: this.school });
     const session = this.server.create('session', { course });
-    const learnerGroup = this.server.create('learnerGroup', {
+    const learnerGroup = this.server.create('learner-group', {
       title: 'Top Group',
     });
-    const learnerGroup2 = this.server.create('learnerGroup', {
+    const learnerGroup2 = this.server.create('learner-group', {
       title: 'Other Top Group',
     });
-    const subLearnerGroup = this.server.create('learnerGroup', {
+    const subLearnerGroup = this.server.create('learner-group', {
       parent: learnerGroup,
       title: 'Sub-Group',
     });
-    const subSubLearnerGroup = this.server.create('learnerGroup', {
+    const subSubLearnerGroup = this.server.create('learner-group', {
       parent: subLearnerGroup,
       title: 'Sub-sub Group',
     });
-    const subLearnerGroup2 = this.server.create('learnerGroup', {
+    const subLearnerGroup2 = this.server.create('learner-group', {
       parent: learnerGroup,
       title: 'Sub-Group 2',
     });
@@ -232,16 +232,16 @@ module('Acceptance | Session - Offering Management', function (hooks) {
   test('Offerings are sorted by first learner group name', async function (assert) {
     const course = this.server.create('course', { school: this.school });
     const session = this.server.create('session', { course });
-    const learnerGroup = this.server.create('learnerGroup', {
+    const learnerGroup = this.server.create('learner-group', {
       title: 'Alpha',
     });
-    const learnerGroup2 = this.server.create('learnerGroup', {
+    const learnerGroup2 = this.server.create('learner-group', {
       title: 'Beta',
     });
-    const learnerGroup3 = this.server.create('learnerGroup', {
+    const learnerGroup3 = this.server.create('learner-group', {
       title: 'Gamma',
     });
-    const learnerGroup4 = this.server.create('learnerGroup', {
+    const learnerGroup4 = this.server.create('learner-group', {
       title: 'Delta',
     });
     this.server.create('offering', {

--- a/packages/frontend/tests/acceptance/course/session/offerings-test.js
+++ b/packages/frontend/tests/acceptance/course/session/offerings-test.js
@@ -19,14 +19,14 @@ module('Acceptance | Session - Offerings', function (hooks) {
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
     const course = this.server.create('course', {
       cohorts: [cohort],
       school: this.school,
       directors: [this.user],
     });
-    this.server.create('sessionType', {
+    this.server.create('session-type', {
       school: this.school,
     });
     const users = this.server.createList('user', 8);
@@ -661,18 +661,18 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
   test('edit offerings twice #2850', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohortId: 1,
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohortId: 1,
       parentId: 3,
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohortId: 1,
       parentId: 4,
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohortId: 1,
       parentId: 5,
     });

--- a/packages/frontend/tests/acceptance/course/session/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/session/overview-test.js
@@ -10,11 +10,11 @@ module('Acceptance | Session - Overview', function (hooks) {
   hooks.beforeEach(async function () {
     this.intl = this.owner.lookup('service:intl');
     this.school = this.server.create('school');
-    this.server.create('academicYear');
+    this.server.create('academic-year');
     this.course = this.server.create('course', {
       school: this.school,
     });
-    this.sessionTypes = this.server.createList('sessionType', 2, {
+    this.sessionTypes = this.server.createList('session-type', 2, {
       school: this.school,
     });
   });
@@ -42,7 +42,7 @@ module('Acceptance | Session - Overview', function (hooks) {
       school: this.school,
       administeredSchools: [this.school],
     });
-    const ilmSession = this.server.create('ilmSession');
+    const ilmSession = this.server.create('ilm-session');
     this.server.create('session', {
       course: this.course,
       ilmSession,
@@ -108,7 +108,7 @@ module('Acceptance | Session - Overview', function (hooks) {
       school: this.school,
       administeredSchools: [this.school],
     });
-    const ilmSession = this.server.create('ilmSession', {
+    const ilmSession = this.server.create('ilm-session', {
       hours: 3,
     });
     this.server.create('session', {
@@ -130,7 +130,7 @@ module('Acceptance | Session - Overview', function (hooks) {
       school: this.school,
       administeredSchools: [this.school],
     });
-    const ilmSession = this.server.create('ilmSession', {
+    const ilmSession = this.server.create('ilm-session', {
       hours: 3,
       dueDate: new Date(2021, 4, 18, 17, 0, 0),
     });
@@ -708,7 +708,7 @@ module('Acceptance | Session - Overview', function (hooks) {
       school: this.school,
       administeredSchools: [this.school],
     });
-    const ilmSession = this.server.create('ilmSession');
+    const ilmSession = this.server.create('ilm-session');
     this.server.create('session', {
       course: this.course,
       ilmSession,
@@ -727,7 +727,7 @@ module('Acceptance | Session - Overview', function (hooks) {
       school: this.school,
       administeredSchools: [this.school],
     });
-    const ilmSession = this.server.create('ilmSession');
+    const ilmSession = this.server.create('ilm-session');
     const session = this.server.create('session', {
       course: this.course,
       ilmSession,
@@ -781,7 +781,7 @@ module('Acceptance | Session - Overview', function (hooks) {
       administeredSchools: [this.school],
     });
     const session = this.server.create('session', { course: this.course });
-    this.server.create('sessionObjective', { session });
+    this.server.create('session-objective', { session });
     await page.visit({ courseId: 1, sessionId: 1 });
     assert.strictEqual(currentRouteName(), 'session.index');
     assert.ok(page.details.collapsedObjectives.isPresent);

--- a/packages/frontend/tests/acceptance/course/session/publicationcheck-test.js
+++ b/packages/frontend/tests/acceptance/course/session/publicationcheck-test.js
@@ -14,11 +14,11 @@ module('Acceptance | Session - Publication Check', function (hooks) {
       school,
     });
     this.course = this.server.create('course', { school });
-    this.sessionTypes = this.server.createList('sessionType', 2, {
+    this.sessionTypes = this.server.createList('session-type', 2, {
       school,
     });
     this.term = this.server.create('term', { vocabulary });
-    this.meshDescriptor = this.server.create('meshDescriptor');
+    this.meshDescriptor = this.server.create('mesh-descriptor');
   });
 
   test('full session count', async function (assert) {
@@ -29,7 +29,7 @@ module('Acceptance | Session - Publication Check', function (hooks) {
       meshDescriptors: [this.meshDescriptor],
       sessionType: this.sessionTypes[0],
     });
-    this.server.create('sessionObjective', { session });
+    this.server.create('session-objective', { session });
     this.server.create('offering', { session });
     await page.visit({ courseId: this.course.id, sessionId: session.id });
     await percySnapshot(assert);
@@ -55,7 +55,7 @@ module('Acceptance | Session - Publication Check', function (hooks) {
 
   test('unlink icon transitions properly', async function (assert) {
     const session = this.server.create('session', { course: this.course });
-    this.server.create('sessionObjective', { session });
+    this.server.create('session-objective', { session });
     await page.visit({ courseId: this.course.id, sessionId: session.id });
     await page.unlink.click();
     assert.ok(currentURL().startsWith('/courses/1/sessions/1'));

--- a/packages/frontend/tests/acceptance/course/session/publish-all-test.js
+++ b/packages/frontend/tests/acceptance/course/session/publish-all-test.js
@@ -16,11 +16,11 @@ module('Acceptance | Session - Publish All', function (hooks) {
       school,
     });
     this.course = this.server.create('course', { school });
-    this.sessionTypes = this.server.createList('sessionType', 2, {
+    this.sessionTypes = this.server.createList('session-type', 2, {
       school,
     });
     this.term = this.server.create('term', { vocabulary });
-    this.meshDescriptor = this.server.create('meshDescriptor');
+    this.meshDescriptor = this.server.create('mesh-descriptor');
   });
 
   test('publish publishable sessions', async function (assert) {
@@ -29,7 +29,7 @@ module('Acceptance | Session - Publish All', function (hooks) {
       terms: [this.term],
       meshDescriptors: [this.meshDescriptor],
       sessionType: this.sessionTypes[0],
-      sessionObjectives: [this.server.create('sessionObjective')],
+      sessionObjectives: [this.server.create('session-objective')],
       offerings: this.server.createList('offering', 2),
     });
     this.server.create('session', {
@@ -37,7 +37,7 @@ module('Acceptance | Session - Publish All', function (hooks) {
       terms: [this.term],
       meshDescriptors: [this.meshDescriptor],
       sessionType: this.sessionTypes[0],
-      sessionObjectives: [this.server.create('sessionObjective')],
+      sessionObjectives: [this.server.create('session-objective')],
       offerings: this.server.createList('offering', 2),
     });
 

--- a/packages/frontend/tests/acceptance/course/session/publish-test.js
+++ b/packages/frontend/tests/acceptance/course/session/publish-test.js
@@ -18,7 +18,7 @@ module('Acceptance | Session - Publish', function (hooks) {
     const school = this.server.create('school');
     await setupAuthentication({ school, administeredSchools: [school] });
     this.course = this.server.create('course', { school });
-    this.server.create('sessionType');
+    this.server.create('session-type');
     this.publishedSession = this.server.create('session', {
       published: true,
       course: this.course,
@@ -34,7 +34,7 @@ module('Acceptance | Session - Publish', function (hooks) {
     this.ilmSession = this.server.create('session', {
       course: this.course,
     });
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       session: this.ilmSession,
       dueDate: DateTime.now().toJSDate(),
     });

--- a/packages/frontend/tests/acceptance/course/session/terms-test.js
+++ b/packages/frontend/tests/acceptance/course/session/terms-test.js
@@ -13,7 +13,7 @@ module('Acceptance | Session - Terms', function (hooks) {
       school: this.school,
       active: true,
     });
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
 
     const term1 = this.server.create('term', {
       vocabulary,

--- a/packages/frontend/tests/acceptance/course/sessionlist-test.js
+++ b/packages/frontend/tests/acceptance/course/sessionlist-test.js
@@ -20,7 +20,7 @@ module('Acceptance | Course - Session List', function (hooks) {
     this.today = DateTime.fromObject({ hour: 8 });
     this.school = this.server.create('school');
     this.user = await setupAuthentication({ school: this.school });
-    this.sessionType = this.server.create('sessionType', {
+    this.sessionType = this.server.create('session-type', {
       school: this.school,
     });
 
@@ -29,11 +29,11 @@ module('Acceptance | Course - Session List', function (hooks) {
     const instructor1 = this.server.create('user');
     const instructor2 = this.server.create('user');
     const instructor3 = this.server.create('user');
-    const learnerGroup1 = this.server.create('learnerGroup', {
+    const learnerGroup1 = this.server.create('learner-group', {
       users: [learner1, learner2],
     });
-    const learnerGroup2 = this.server.create('learnerGroup');
-    const instructorGroup = this.server.create('instructorGroup', {
+    const learnerGroup2 = this.server.create('learner-group');
+    const instructorGroup = this.server.create('instructor-group', {
       users: [instructor1, instructor2, instructor3],
     });
     this.course = this.server.create('course', {
@@ -288,7 +288,7 @@ module('Acceptance | Course - Session List', function (hooks) {
   });
 
   test('new session', async function (assert) {
-    this.server.create('sessionType', { school: this.school });
+    this.server.create('session-type', { school: this.school });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.courseSessions.header.title, 'Sessions (4)');
     const { sessions } = page.courseSessions.sessionsGrid;

--- a/packages/frontend/tests/acceptance/course/terms-test.js
+++ b/packages/frontend/tests/acceptance/course/terms-test.js
@@ -13,7 +13,7 @@ module('Acceptance | Course - Terms', function (hooks) {
       school: this.school,
       active: true,
     });
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
 
     this.server.create('term', {
       vocabularyId: 1,

--- a/packages/frontend/tests/acceptance/courses-test.js
+++ b/packages/frontend/tests/acceptance/courses-test.js
@@ -23,7 +23,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('visiting /courses with title filter', async function (assert) {
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     this.server.create('course', {
       title: 'specialfirstcourse',
       year: 2014,
@@ -52,7 +52,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('filters by title', async function (assert) {
     assert.expect(35);
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     const firstCourse = this.server.create('course', {
       title: 'specialfirstcourse',
       year: 2014,
@@ -140,8 +140,8 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('filters by year', async function (assert) {
-    this.server.create('academicYear', { id: 2013 });
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2013 });
+    this.server.create('academic-year', { id: 2014 });
     assert.expect(5);
     const firstCourse = this.server.create('course', {
       year: 2013,
@@ -163,8 +163,8 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('initial filter by year', async function (assert) {
-    this.server.create('academicYear', { id: 2013 });
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2013 });
+    this.server.create('academic-year', { id: 2014 });
     assert.expect(4);
     const firstCourse = this.server.create('course', {
       year: 2013,
@@ -184,7 +184,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('filters by mycourses', async function (assert) {
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     assert.expect(5);
     const firstCourse = this.server.create('course', {
       year: 2014,
@@ -211,8 +211,8 @@ module('Acceptance | Courses', function (hooks) {
     this.server.createList('school', 2);
     this.server.db.users.update(this.user.id, { schoolId: 2 });
 
-    this.server.create('academicYear', { id: 2013 });
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2013 });
+    this.server.create('academic-year', { id: 2014 });
 
     await page.visit();
     assert.strictEqual(page.root.yearFilters.length, 2);
@@ -233,7 +233,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('unprivileged users can not delete courses', async function (assert) {
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     assert.expect(2);
     this.server.create('course', {
       year: 2014,
@@ -259,7 +259,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('privileged users can only delete unpublished courses', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     assert.expect(2);
     this.server.create('course', {
       year: 2014,
@@ -283,7 +283,7 @@ module('Acceptance | Courses', function (hooks) {
   test('new course', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     const year = DateTime.now().year;
-    this.server.create('academicYear', { id: year });
+    this.server.create('academic-year', { id: year });
     await page.visit({ year });
     await page.root.toggleNewCourseForm();
     await page.root.newCourse.title('Course 1');
@@ -296,7 +296,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('new course toggle does not show up for unprivileged users', async function (assert) {
     const year = DateTime.now().year;
-    this.server.create('academicYear', { id: year });
+    this.server.create('academic-year', { id: year });
     assert.expect(1);
     await page.visit({ year });
     assert.notOk(page.root.toggleNewCourseFormExists);
@@ -304,8 +304,8 @@ module('Acceptance | Courses', function (hooks) {
 
   test('new course in another year does not display in list', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    this.server.create('academicYear', { id: 2012 });
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2012 });
+    this.server.create('academic-year', { id: 2013 });
     assert.expect(2);
 
     const newTitle = 'new course title, woohoo';
@@ -322,7 +322,7 @@ module('Acceptance | Courses', function (hooks) {
   test('new course does not appear twice when navigating back', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     const year = DateTime.now().year;
-    this.server.create('academicYear', { id: year });
+    this.server.create('academic-year', { id: year });
     assert.expect(4);
 
     const courseTitle = 'Course 1';
@@ -344,7 +344,7 @@ module('Acceptance | Courses', function (hooks) {
   test('new course can be deleted', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     const year = DateTime.now().year;
-    this.server.create('academicYear', { id: year });
+    this.server.create('academic-year', { id: year });
     this.server.create('userRole', {
       title: 'Developer',
     });
@@ -373,7 +373,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('locked courses', async function (assert) {
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     assert.expect(7);
     this.server.create('course', {
       year: 2014,
@@ -424,7 +424,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('sort by title', async function (assert) {
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     const firstCourse = this.server.create('course', {
       year: 2014,
       schoolId: 1,
@@ -445,7 +445,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('sort by level', async function (assert) {
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     const firstCourse = this.server.create('course', {
       year: 2014,
       schoolId: 1,
@@ -470,7 +470,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('sort by startDate', async function (assert) {
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     const firstCourse = this.server.create('course', {
       year: 2014,
       schoolId: 1,
@@ -495,7 +495,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('sort by endDate', async function (assert) {
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     const firstCourse = this.server.create('course', {
       year: 2014,
       schoolId: 1,
@@ -520,7 +520,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('sort by status', async function (assert) {
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     const firstCourse = this.server.create('course', {
       year: 2014,
       schoolId: 1,
@@ -557,7 +557,7 @@ module('Acceptance | Courses', function (hooks) {
   test('privileged users can lock and unlock course', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     assert.expect(5);
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     this.server.create('course', {
       year: 2014,
       schoolId: 1,
@@ -585,7 +585,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('non-privileged users cannot lock and unlock course but can see the icon', async function (assert) {
     assert.expect(5);
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     this.server.create('course', {
       year: 2014,
       schoolId: 1,
@@ -610,7 +610,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('title filter escapes regex', async function (assert) {
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     assert.expect(4);
     const firstCourse = this.server.create('course', {
       title: 'yes\\no',
@@ -631,7 +631,7 @@ module('Acceptance | Courses', function (hooks) {
   test('can not delete course with descendants #3620', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     const year = DateTime.now().year.toString();
-    this.server.create('academicYear', { id: year });
+    this.server.create('academic-year', { id: year });
     const course1 = this.server.create('course', {
       year,
       school: this.school,
@@ -660,8 +660,8 @@ module('Acceptance | Courses', function (hooks) {
     this.user.update({ administeredSchools: [this.school] });
     freezeDateAt(new Date('1/1/2021'));
     const year = DateTime.now().year;
-    this.server.create('academicYear', { id: year - 1 });
-    this.server.create('academicYear', { id: year });
+    this.server.create('academic-year', { id: year - 1 });
+    this.server.create('academic-year', { id: year });
     this.server.get('application/config', function () {
       return {
         config: {
@@ -681,8 +681,8 @@ module('Acceptance | Courses', function (hooks) {
     this.user.update({ administeredSchools: [this.school] });
     freezeDateAt(new Date('10/10/2021'));
     const year = DateTime.now().year;
-    this.server.create('academicYear', { id: year - 1 });
-    this.server.create('academicYear', { id: year });
+    this.server.create('academic-year', { id: year - 1 });
+    this.server.create('academic-year', { id: year });
     this.server.get('application/config', function () {
       return {
         config: {
@@ -702,8 +702,8 @@ module('Acceptance | Courses', function (hooks) {
     this.user.update({ administeredSchools: [this.school] });
     freezeDateAt(new Date('1/1/2021'));
     const year = DateTime.now().year;
-    this.server.create('academicYear', { id: year - 1 });
-    this.server.create('academicYear', { id: year });
+    this.server.create('academic-year', { id: year - 1 });
+    this.server.create('academic-year', { id: year });
     this.server.get('application/config', function () {
       return {
         config: {
@@ -723,8 +723,8 @@ module('Acceptance | Courses', function (hooks) {
     this.user.update({ administeredSchools: [this.school] });
     freezeDateAt(new Date('10/10/2021'));
     const year = DateTime.now().year;
-    this.server.create('academicYear', { id: year - 1 });
-    this.server.create('academicYear', { id: year });
+    this.server.create('academic-year', { id: year - 1 });
+    this.server.create('academic-year', { id: year });
     this.server.get('application/config', function () {
       return {
         config: {
@@ -740,7 +740,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('title filter does not lose focus #6417', async function (assert) {
-    this.server.create('academicYear', { id: 2014 });
+    this.server.create('academic-year', { id: 2014 });
     this.server.create('course', {
       year: 2014,
       school: this.school,

--- a/packages/frontend/tests/acceptance/curriculum-inventory/leadership-test.js
+++ b/packages/frontend/tests/acceptance/curriculum-inventory/leadership-test.js
@@ -20,7 +20,7 @@ module('Acceptance | curriculum inventory leadership', function (hooks) {
     });
     this.reportModel = await this.owner
       .lookup('service:store')
-      .findRecord('curriculumInventoryReport', this.report.id);
+      .findRecord('curriculum-inventory-report', this.report.id);
   });
 
   test('collapsed leadership', async function (assert) {

--- a/packages/frontend/tests/acceptance/curriculum-inventory/report-test.js
+++ b/packages/frontend/tests/acceptance/curriculum-inventory/report-test.js
@@ -15,11 +15,11 @@ module('Acceptance | curriculum inventory report', function (hooks) {
   test('create new sequence block Issue #2108', async function (assert) {
     this.user.update({ directedSchools: [this.school] });
     const program = this.server.create('program', { school: this.school });
-    const report = this.server.create('curriculumInventoryReport', { program });
+    const report = this.server.create('curriculum-inventory-report', { program });
     this.server.create('curriculumInventorySequence', { report });
     const reportModel = await this.owner
       .lookup('service:store')
-      .findRecord('curriculumInventoryReport', report.id);
+      .findRecord('curriculum-inventory-report', report.id);
     await page.visit({ reportId: reportModel.id });
     assert.strictEqual(currentRouteName(), 'curriculum-inventory-report.index');
     assert.notOk(page.blocks.newBlock.form.isVisible);
@@ -32,7 +32,7 @@ module('Acceptance | curriculum inventory report', function (hooks) {
       school: this.school,
       title: 'Doctor of Medicine',
     });
-    const report = this.server.create('curriculumInventoryReport', {
+    const report = this.server.create('curriculum-inventory-report', {
       year: 2013,
       name: 'foo bar',
       description: 'lorem ipsum',
@@ -40,7 +40,7 @@ module('Acceptance | curriculum inventory report', function (hooks) {
     });
     const reportModel = await this.owner
       .lookup('service:store')
-      .findRecord('curriculumInventoryReport', report.id);
+      .findRecord('curriculum-inventory-report', report.id);
     await page.visit({ reportId: reportModel.id });
     assert.strictEqual(currentRouteName(), 'curriculum-inventory-report.index');
     assert.notOk(page.details.overview.rolloverLink.isVisible);
@@ -52,7 +52,7 @@ module('Acceptance | curriculum inventory report', function (hooks) {
       school: this.school,
       title: 'Doctor of Medicine',
     });
-    const report = this.server.create('curriculumInventoryReport', {
+    const report = this.server.create('curriculum-inventory-report', {
       year: 2013,
       name: 'foo bar',
       description: 'lorem ipsum',
@@ -60,7 +60,7 @@ module('Acceptance | curriculum inventory report', function (hooks) {
     });
     const reportModel = await this.owner
       .lookup('service:store')
-      .findRecord('curriculumInventoryReport', report.id);
+      .findRecord('curriculum-inventory-report', report.id);
     await page.visit({ reportId: reportModel.id });
     assert.strictEqual(currentRouteName(), 'curriculum-inventory-report.index');
     assert.ok(page.details.overview.rolloverLink.isVisible);
@@ -72,18 +72,18 @@ module('Acceptance | curriculum inventory report', function (hooks) {
       school: this.school,
       title: 'Doctor of Medicine',
     });
-    const report = this.server.create('curriculumInventoryReport', {
+    const report = this.server.create('curriculum-inventory-report', {
       year: 2013,
       name: 'foo bar',
       description: 'lorem ipsum',
       program,
     });
-    this.server.create('curriculumInventorySequenceBlock', {
+    this.server.create('curriculum-inventory-sequence-block', {
       report,
     });
     const reportModel = await this.owner
       .lookup('service:store')
-      .findRecord('curriculumInventoryReport', report.id);
+      .findRecord('curriculum-inventory-report', report.id);
     await page.visit({ reportId: reportModel.id });
     assert.ok(page.details.overview.rolloverLink.isVisible);
     assert.strictEqual(page.blocks.list.items.length, 1);

--- a/packages/frontend/tests/acceptance/curriculum-inventory/reports-test.js
+++ b/packages/frontend/tests/acceptance/curriculum-inventory/reports-test.js
@@ -17,7 +17,7 @@ module('Acceptance | curriculum inventory reports', function (hooks) {
   });
 
   test('report title is correctly linked to report details page', async function (assert) {
-    this.server.create('curriculumInventoryReport', {
+    this.server.create('curriculum-inventory-report', {
       program: this.program,
     });
     await visit(url);

--- a/packages/frontend/tests/acceptance/curriculum-inventory/rollover-test.js
+++ b/packages/frontend/tests/acceptance/curriculum-inventory/rollover-test.js
@@ -20,7 +20,7 @@ module('Acceptance | curriculum inventory report/rollover', function (hooks) {
       school: this.school,
       title: 'Doctor of Medicine',
     });
-    const report = this.server.create('curriculumInventoryReport', {
+    const report = this.server.create('curriculum-inventory-report', {
       year: 2013,
       name: 'foo bar',
       description: 'lorem ipsum',
@@ -28,7 +28,7 @@ module('Acceptance | curriculum inventory report/rollover', function (hooks) {
     });
     const reportModel = await this.owner
       .lookup('service:store')
-      .findRecord('curriculumInventoryReport', report.id);
+      .findRecord('curriculum-inventory-report', report.id);
     await page.visit({ reportId: reportModel.id });
     assert.strictEqual(currentRouteName(), 'curriculum-inventory-report.rollover');
     assert.notOk(page.details.overview.rolloverLink.isVisible);
@@ -42,7 +42,7 @@ module('Acceptance | curriculum inventory report/rollover', function (hooks) {
       school: this.school,
       title: 'Doctor of Medicine',
     });
-    const report = this.server.create('curriculumInventoryReport', {
+    const report = this.server.create('curriculum-inventory-report', {
       year: thisYear,
       name: 'foo bar',
       description: 'lorem ipsum',
@@ -50,7 +50,7 @@ module('Acceptance | curriculum inventory report/rollover', function (hooks) {
     });
     const reportModel = await this.owner
       .lookup('service:store')
-      .findRecord('curriculumInventoryReport', report.id);
+      .findRecord('curriculum-inventory-report', report.id);
 
     this.server.post(
       `/api/curriculuminventoryreports/:id/rollover`,

--- a/packages/frontend/tests/acceptance/curriculum-inventory/sequence-blocks-test.js
+++ b/packages/frontend/tests/acceptance/curriculum-inventory/sequence-blocks-test.js
@@ -46,7 +46,7 @@ module('Acceptance | curriculum inventory sequence blocks', function (hooks) {
     });
     const reportModel = await this.owner
       .lookup('service:store')
-      .findRecord('curriculumInventoryReport', this.report.id);
+      .findRecord('curriculum-inventory-report', this.report.id);
     await page.visit({ reportId: reportModel.id });
     assert.strictEqual(page.blocks.list.items.length, 2);
     await page.blocks.list.items[0].remove();

--- a/packages/frontend/tests/acceptance/dashboard/calendar-test.js
+++ b/packages/frontend/tests/acceptance/dashboard/calendar-test.js
@@ -26,11 +26,11 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
     const program = this.server.create('program', {
       school: this.school,
     });
-    const programYear1 = this.server.create('programYear', {
+    const programYear1 = this.server.create('program-year', {
       program,
       startYear: 2015,
     });
-    const programYear2 = this.server.create('programYear', {
+    const programYear2 = this.server.create('program-year', {
       program,
       startYear: 2016,
     });
@@ -73,7 +73,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
       course: course2,
       sessionType: sessionType2,
     });
-    this.server.create('academicYear', {
+    this.server.create('academic-year', {
       id: 2015,
     });
     this.server.create('offering', {

--- a/packages/frontend/tests/acceptance/instructorgroup-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroup-test.js
@@ -27,14 +27,14 @@ module('Acceptance | Instructor Group', function (hooks) {
       course: courses[1],
       sessionType,
     });
-    const instructorGroup1 = this.server.create('instructorGroup', {
+    const instructorGroup1 = this.server.create('instructor-group', {
       school: this.school,
       users: [users[0], users[1]],
     });
-    const instructorGroup2 = this.server.create('instructorGroup', {
+    const instructorGroup2 = this.server.create('instructor-group', {
       school: this.school,
     });
-    this.server.create('instructorGroup', {
+    this.server.create('instructor-group', {
       school: this.school,
     });
     this.server.create('offering', {

--- a/packages/frontend/tests/acceptance/instructorgroups-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroups-test.js
@@ -30,11 +30,11 @@ module('Acceptance | Instructor Groups', function (hooks) {
       this.server.create('session', {
         courseId: 2,
       });
-      const firstInstructorGroup = this.server.create('instructorGroup', {
+      const firstInstructorGroup = this.server.create('instructor-group', {
         school: this.school,
         userIds: [2, 3, 4, 5, 6],
       });
-      const secondInstructorGroup = this.server.create('instructorGroup', {
+      const secondInstructorGroup = this.server.create('instructor-group', {
         school: this.school,
       });
       this.server.create('offering', {
@@ -60,19 +60,19 @@ module('Acceptance | Instructor Groups', function (hooks) {
 
     test('filters by title', async function (assert) {
       this.server.create('school');
-      const firstInstructorGroup = this.server.create('instructorGroup', {
+      const firstInstructorGroup = this.server.create('instructor-group', {
         title: 'specialfirstinstructorgroup',
         school: this.school,
       });
-      const secondInstructorGroup = this.server.create('instructorGroup', {
+      const secondInstructorGroup = this.server.create('instructor-group', {
         title: 'specialsecondinstructorgroup',
         school: this.school,
       });
-      const regularInstructorGroup = this.server.create('instructorGroup', {
+      const regularInstructorGroup = this.server.create('instructor-group', {
         title: 'regularinstructorgroup',
         school: this.school,
       });
-      const regexInstructorGroup = this.server.create('instructorGroup', {
+      const regexInstructorGroup = this.server.create('instructor-group', {
         title: '\\yoo hoo',
         school: this.school,
       });
@@ -139,7 +139,7 @@ module('Acceptance | Instructor Groups', function (hooks) {
     test('cancel adding new instructor group', async function (assert) {
       assert.expect(6);
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('instructorGroup', {
+      this.server.create('instructor-group', {
         school: this.school,
       });
       await page.visit();
@@ -156,7 +156,7 @@ module('Acceptance | Instructor Groups', function (hooks) {
     test('remove instructor group', async function (assert) {
       assert.expect(6);
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('instructorGroup', {
+      this.server.create('instructor-group', {
         school: this.school,
       });
       await page.visit();
@@ -173,7 +173,7 @@ module('Acceptance | Instructor Groups', function (hooks) {
     test('cancel remove instructor group', async function (assert) {
       assert.expect(4);
       this.user.update({ administeredSchools: [this.school] });
-      this.server.create('instructorGroup', {
+      this.server.create('instructor-group', {
         school: this.school,
       });
       await page.visit();
@@ -189,7 +189,7 @@ module('Acceptance | Instructor Groups', function (hooks) {
       assert.expect(3);
       this.user.update({ administeredSchools: [this.school] });
       const users = this.server.createList('user', 5);
-      this.server.create('instructorGroup', {
+      this.server.create('instructor-group', {
         school: this.school,
         users,
       });
@@ -206,7 +206,7 @@ module('Acceptance | Instructor Groups', function (hooks) {
 
     test('click title takes you to instructor group route', async function (assert) {
       assert.expect(1);
-      this.server.create('instructorGroup', {
+      this.server.create('instructor-group', {
         school: this.school,
       });
       await page.visit();
@@ -216,7 +216,7 @@ module('Acceptance | Instructor Groups', function (hooks) {
 
     test('title filter escapes regex', async function (assert) {
       assert.expect(4);
-      this.server.create('instructorGroup', {
+      this.server.create('instructor-group', {
         title: 'yes\\no',
         school: this.school,
       });
@@ -231,10 +231,10 @@ module('Acceptance | Instructor Groups', function (hooks) {
     test('cannot delete instructor group with attached courses #3767', async function (assert) {
       assert.expect(5);
       this.user.update({ administeredSchools: [this.school] });
-      const group1 = this.server.create('instructorGroup', {
+      const group1 = this.server.create('instructor-group', {
         school: this.school,
       });
-      const group2 = this.server.create('instructorGroup', {
+      const group2 = this.server.create('instructor-group', {
         school: this.school,
       });
       const course = this.server.create('course');

--- a/packages/frontend/tests/acceptance/learner-group/bulk-assignment-test.js
+++ b/packages/frontend/tests/acceptance/learner-group/bulk-assignment-test.js
@@ -27,12 +27,12 @@ module('Acceptance | learner-group/bulk-assignment', function (hooks) {
       title: 'group 1',
       cohort,
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       title: 'group 1 child 0',
       cohort,
       parent: group1,
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       title: 'group 1 child 1',
       cohort,
       parent: group1,

--- a/packages/frontend/tests/acceptance/learnergroup-test.js
+++ b/packages/frontend/tests/acceptance/learnergroup-test.js
@@ -18,9 +18,9 @@ module('Acceptance | Learner Group', function (hooks) {
 
   test('move learners individually from cohort to group', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
-    this.server.create('learnerGroup', { cohort });
+    this.server.create('learner-group', { cohort });
     this.server.createList('user', 2, { cohorts: [cohort] });
 
     await page.visit({ learnerGroupId: 1 });
@@ -50,9 +50,9 @@ module('Acceptance | Learner Group', function (hooks) {
 
   test('remove learners individually from group', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
-    const learnerGroup = this.server.create('learnerGroup', { cohort });
+    const learnerGroup = this.server.create('learner-group', { cohort });
     this.server.createList('user', 2, { cohorts: [cohort], learnerGroups: [learnerGroup] });
 
     await page.visit({ learnerGroupId: 1 });
@@ -83,22 +83,22 @@ module('Acceptance | Learner Group', function (hooks) {
   test('generate new subgroups', async function (assert) {
     assert.expect(23);
     this.user.update({ administeredSchools: [this.school] });
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     this.server.createList('user', 2);
-    const parent = this.server.create('learnerGroup', {
+    const parent = this.server.create('learner-group', {
       cohort,
     });
-    const parent2 = this.server.create('learnerGroup', {
+    const parent2 = this.server.create('learner-group', {
       cohort,
       parent,
       userIds: [2, 3],
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohort,
       parent,
     });
-    this.server.createList('learnerGroup', 2, {
+    this.server.createList('learner-group', 2, {
       cohort,
       parent: parent2,
     });
@@ -148,18 +148,18 @@ module('Acceptance | Learner Group', function (hooks) {
 
   test('copy learnergroup without learners', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', {
       programYear,
     });
-    const parent = this.server.create('learnerGroup', {
+    const parent = this.server.create('learner-group', {
       cohort,
     });
-    const subGroup = this.server.create('learnerGroup', {
+    const subGroup = this.server.create('learner-group', {
       cohort,
       parent,
     });
-    this.server.createList('learnerGroup', 2, {
+    this.server.createList('learner-group', 2, {
       cohort,
       parent: subGroup,
     });
@@ -203,19 +203,19 @@ module('Acceptance | Learner Group', function (hooks) {
   test('cannot copy learnergroup with learners', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     const users = this.server.createList('user', 3);
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', {
       programYear,
     });
-    const parent = this.server.create('learnerGroup', {
+    const parent = this.server.create('learner-group', {
       cohort,
     });
-    const subGroup = this.server.create('learnerGroup', {
+    const subGroup = this.server.create('learner-group', {
       cohort,
       parent,
       users,
     });
-    this.server.createList('learnerGroup', 2, {
+    this.server.createList('learner-group', 2, {
       cohort,
       parent: subGroup,
     });
@@ -233,23 +233,23 @@ module('Acceptance | Learner Group', function (hooks) {
   test('cannot copy learnergroup with learners in subgroup', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
     const users = this.server.createList('user', 3);
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', {
       programYear,
     });
-    const parent = this.server.create('learnerGroup', {
+    const parent = this.server.create('learner-group', {
       cohort,
     });
-    const subGroup = this.server.create('learnerGroup', {
+    const subGroup = this.server.create('learner-group', {
       cohort,
       parent,
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohort,
       parent: subGroup,
       users,
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohort,
       parent: subGroup,
     });
@@ -265,11 +265,11 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('Cohort members not in learner group appear after navigating to learner group #3428', async function (assert) {
-    this.server.create('programYear', { program: this.program });
+    this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', {
       programYearId: 1,
     });
-    const learnerGroup = this.server.create('learnerGroup', {
+    const learnerGroup = this.server.create('learner-group', {
       cohort,
     });
     this.server.createList('user', 5, {
@@ -292,9 +292,9 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('learner group calendar', async function (assert) {
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
-    const learnerGroup = this.server.create('learnerGroup', { cohort });
+    const learnerGroup = this.server.create('learner-group', { cohort });
     const course = this.server.create('course', { cohorts: [cohort] });
     const session = this.server.create('session', { course });
     this.server.create('offering', {
@@ -320,12 +320,12 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('learner group calendar with subgroup events', async function (assert) {
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
-    const learnerGroup = this.server.create('learnerGroup', { cohort });
+    const learnerGroup = this.server.create('learner-group', { cohort });
     const course = this.server.create('course', { cohorts: [cohort] });
     const session = this.server.create('session', { course });
-    const subgroup = this.server.create('learnerGroup', {
+    const subgroup = this.server.create('learner-group', {
       cohort,
       parent: learnerGroup,
     });
@@ -355,14 +355,14 @@ module('Acceptance | Learner Group', function (hooks) {
 
   test('Learners with missing parent group affiliation still appear in subgroup manager #3476', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    this.server.create('programYear', { program: this.program });
+    this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', {
       programYearId: 1,
     });
-    const learnerGroup = this.server.create('learnerGroup', {
+    const learnerGroup = this.server.create('learner-group', {
       cohort,
     });
-    const subGroup = this.server.create('learnerGroup', {
+    const subGroup = this.server.create('learner-group', {
       cohort,
       parent: learnerGroup,
     });
@@ -385,9 +385,9 @@ module('Acceptance | Learner Group', function (hooks) {
 
   test('moving learners to group updates count #3570', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
-    const learnerGroup = this.server.create('learnerGroup', { cohort });
+    const learnerGroup = this.server.create('learner-group', { cohort });
     this.server.createList('user', 2, {
       cohorts: [cohort],
       learnerGroups: [learnerGroup],
@@ -407,9 +407,9 @@ module('Acceptance | Learner Group', function (hooks) {
 
   test('moving learners out of group updates count #3570', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
-    const learnerGroup = this.server.create('learnerGroup', { cohort });
+    const learnerGroup = this.server.create('learner-group', { cohort });
     this.server.createList('user', 2, {
       cohorts: [cohort],
       learnerGroups: [learnerGroup],
@@ -430,10 +430,10 @@ module('Acceptance | Learner Group', function (hooks) {
 
   test('manage subgroup members does not duplicate members #3936', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
-    const parent = this.server.create('learnerGroup', { cohort });
-    const child = this.server.create('learnerGroup', { cohort, parent });
+    const parent = this.server.create('learner-group', { cohort });
+    const child = this.server.create('learner-group', { cohort, parent });
     this.server.createList('user', 2, { cohorts: [cohort], learnerGroups: [parent, child] });
 
     await page.visit({ learnerGroupId: child.id });
@@ -446,10 +446,10 @@ module('Acceptance | Learner Group', function (hooks) {
 
   test('move learners individually from subgroup to subgroup #4953', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     const parent = this.server.create('learner-group', { cohort });
-    this.server.createList('learnerGroup', 2, { cohort, parent });
+    this.server.createList('learner-group', 2, { cohort, parent });
     this.server.createList('user', 3, { cohorts: [cohort] });
 
     await page.visit({ learnerGroupId: 1 });

--- a/packages/frontend/tests/acceptance/learnergroups-test.js
+++ b/packages/frontend/tests/acceptance/learnergroups-test.js
@@ -23,7 +23,7 @@ module('Acceptance | Learner Groups', function (hooks) {
   test('single option filters', async function (assert) {
     assert.expect(6);
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     this.server.create('cohort', { programYear });
     await page.visit();
     await percySnapshot(assert);
@@ -38,15 +38,15 @@ module('Acceptance | Learner Groups', function (hooks) {
   test('multiple options filter', async function (assert) {
     assert.expect(31);
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
     const program2 = this.server.create('program', { school: this.school });
-    const programYear3 = this.server.create('programYear', { program: program2 });
-    const programYear2 = this.server.create('programYear', { program });
+    const programYear3 = this.server.create('program-year', { program: program2 });
+    const programYear2 = this.server.create('program-year', { program });
     this.server.create('cohort', { programYear: programYear2 });
     const cohort3 = this.server.create('cohort', { programYear: programYear3 });
-    this.server.create('learnerGroup', { cohort });
-    this.server.create('learnerGroup', { cohort: cohort3 });
+    this.server.create('learner-group', { cohort });
+    this.server.create('learner-group', { cohort: cohort3 });
     this.server.create('school');
 
     await page.visit();
@@ -96,24 +96,24 @@ module('Acceptance | Learner Groups', function (hooks) {
     assert.expect(8);
     this.server.createList('user', 11);
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    const firstLearnerGroup = this.server.create('learnerGroup', {
+    const firstLearnerGroup = this.server.create('learner-group', {
       cohort,
       userIds: [2, 3, 4, 5, 6],
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohort,
     });
-    const firstChildGroup = this.server.create('learnerGroup', {
+    const firstChildGroup = this.server.create('learner-group', {
       parent: firstLearnerGroup,
       userIds: [7, 8],
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       parent: firstLearnerGroup,
       userIds: [9, 10],
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       parent: firstChildGroup,
       userIds: [11, 12],
     });
@@ -135,17 +135,17 @@ module('Acceptance | Learner Groups', function (hooks) {
 
   test('filters by title', async function (assert) {
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    const firstLearnerGroup = this.server.create('learnerGroup', {
+    const firstLearnerGroup = this.server.create('learner-group', {
       title: 'specialfirstlearnergroup',
       cohort,
     });
-    const secondLearnerGroup = this.server.create('learnerGroup', {
+    const secondLearnerGroup = this.server.create('learner-group', {
       title: 'specialsecondlearnergroup',
       cohort,
     });
-    const regularLearnerGroup = this.server.create('learnerGroup', {
+    const regularLearnerGroup = this.server.create('learner-group', {
       title: 'regularlearnergroup',
       cohort,
     });
@@ -190,7 +190,7 @@ module('Acceptance | Learner Groups', function (hooks) {
     this.user.update({ administeredSchools: [this.school] });
 
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     this.server.create('cohort', { programYear });
 
     const newTitle = 'A New Test Title';
@@ -217,9 +217,9 @@ module('Acceptance | Learner Groups', function (hooks) {
     assert.expect(6);
     this.user.update({ administeredSchools: [this.school] });
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    this.server.create('learnerGroup', { cohort });
+    this.server.create('learner-group', { cohort });
 
     await page.visit();
 
@@ -239,10 +239,10 @@ module('Acceptance | Learner Groups', function (hooks) {
     this.user.update({ administeredSchools: [this.school] });
 
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    const parent = this.server.create('learnerGroup', { cohort });
-    this.server.create('learnerGroup', { cohort, parent });
+    const parent = this.server.create('learner-group', { cohort });
+    this.server.create('learner-group', { cohort, parent });
 
     await page.visit();
     assert.strictEqual(page.headerTitle, 'Learner Groups (1)');
@@ -262,9 +262,9 @@ module('Acceptance | Learner Groups', function (hooks) {
     this.user.update({ administeredSchools: [this.school] });
 
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    this.server.create('learnerGroup', { cohort });
+    this.server.create('learner-group', { cohort });
     await page.visit();
     assert.strictEqual(page.list.items.length, 1);
     assert.strictEqual(page.list.items[0].title, 'learner group 0');
@@ -282,10 +282,10 @@ module('Acceptance | Learner Groups', function (hooks) {
 
     this.server.createList('user', 5);
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    const parent = this.server.create('learnerGroup', { cohort });
-    this.server.createList('learnerGroup', 2, { parent });
+    const parent = this.server.create('learner-group', { cohort });
+    this.server.createList('learner-group', 2, { parent });
     await page.visit();
     assert.strictEqual(page.list.items.length, 1);
     assert.strictEqual(page.list.items[0].title, 'learner group 0');
@@ -304,9 +304,9 @@ module('Acceptance | Learner Groups', function (hooks) {
 
     this.server.createList('user', 5);
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohort,
       userIds: [2, 3, 4],
     });
@@ -321,38 +321,38 @@ module('Acceptance | Learner Groups', function (hooks) {
     assert.expect(9);
     this.user.update({ administeredSchools: [this.school] });
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
     const course = this.server.create('course');
     const session = this.server.create('session', { course });
-    const ilm = this.server.create('ilmSession', {
+    const ilm = this.server.create('ilm-session', {
       session,
     });
     const offering = this.server.create('offering', { session });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       title: 'is linked to offering',
       cohort,
       offerings: [offering],
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       title: 'is linked to ilm',
       cohort,
       ilmSessions: [ilm],
     });
-    const parentGroup1 = this.server.create('learnerGroup', {
+    const parentGroup1 = this.server.create('learner-group', {
       title: 'has sub-group linked to offering',
       cohort,
     });
-    const parentGroup2 = this.server.create('learnerGroup', {
+    const parentGroup2 = this.server.create('learner-group', {
       title: 'has sub-group linked to ilm',
       cohort,
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohort,
       parent: parentGroup1,
       offerings: [offering],
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohort,
       parent: parentGroup2,
       ilmSessions: [ilm],
@@ -373,9 +373,9 @@ module('Acceptance | Learner Groups', function (hooks) {
   test('click title takes you to learnergroup route', async function (assert) {
     assert.expect(3);
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    this.server.create('learnerGroup', { cohort });
+    this.server.create('learner-group', { cohort });
 
     await page.visit();
     assert.strictEqual(page.list.items.length, 1);
@@ -388,7 +388,7 @@ module('Acceptance | Learner Groups', function (hooks) {
     assert.expect(8);
     this.user.update({ administeredSchools: [this.school] });
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
     this.server.createList('user', 5, {
       cohorts: [cohort],
@@ -422,10 +422,10 @@ module('Acceptance | Learner Groups', function (hooks) {
   test('title filter escapes regex', async function (assert) {
     assert.expect(5);
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
     this.server.create('learner-group', { cohort });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       title: 'yes\\no',
       cohort,
     });
@@ -444,18 +444,18 @@ module('Acceptance | Learner Groups', function (hooks) {
     this.user.update({ administeredSchools: [this.school] });
 
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    const parent = this.server.create('learnerGroup', { cohort });
-    const parent2 = this.server.create('learnerGroup', {
+    const parent = this.server.create('learner-group', { cohort });
+    const parent2 = this.server.create('learner-group', {
       cohort,
       parent,
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohort,
       parent,
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohort,
       parent: parent2,
     });
@@ -503,23 +503,23 @@ module('Acceptance | Learner Groups', function (hooks) {
 
     this.server.createList('user', 10);
     const program = this.server.create('program', { school: this.school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    const parent = this.server.create('learnerGroup', {
+    const parent = this.server.create('learner-group', {
       cohort,
       userIds: [2, 3, 4, 5, 6, 7, 8],
     });
-    const parent2 = this.server.create('learnerGroup', {
+    const parent2 = this.server.create('learner-group', {
       cohort,
       parent,
       userIds: [8],
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohort,
       parent,
       userIds: [5, 6, 7],
     });
-    this.server.create('learnerGroup', {
+    this.server.create('learner-group', {
       cohort,
       parent: parent2,
       userIds: [8],

--- a/packages/frontend/tests/acceptance/program-year/competencies-test.js
+++ b/packages/frontend/tests/acceptance/program-year/competencies-test.js
@@ -13,7 +13,7 @@ module('Acceptance | Program Year - Competencies', function (hooks) {
     this.server.create('program', {
       school: this.school,
     });
-    this.server.create('programYear', {
+    this.server.create('program-year', {
       programId: 1,
     });
     this.server.create('cohort', {

--- a/packages/frontend/tests/acceptance/program-year/leadership-test.js
+++ b/packages/frontend/tests/acceptance/program-year/leadership-test.js
@@ -17,7 +17,7 @@ module('Acceptance | Program Year - Leadership', function (hooks) {
     const program = this.server.create('program', {
       school: this.school,
     });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program,
       directors: [users[2], users[3]],
     });

--- a/packages/frontend/tests/acceptance/program-year/objectives-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectives-test.js
@@ -16,7 +16,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     const vocabulary = this.server.create('vocabulary', { school: this.school });
     const term1 = this.server.create('term', { vocabulary });
     const term2 = this.server.create('term', { vocabulary });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program,
     });
     this.server.create('cohort', {
@@ -45,22 +45,22 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
       programYears: [programYear],
     });
     this.server.createList('competency', 3, { school: this.school });
-    const meshDescriptors = this.server.createList('meshDescriptor', 4);
-    const programYearObjective = this.server.create('programYearObjective', {
+    const meshDescriptors = this.server.createList('mesh-descriptor', 4);
+    const programYearObjective = this.server.create('program-year-objective', {
       programYear,
       competency: competency1,
       meshDescriptors: [meshDescriptors[0], meshDescriptors[1]],
       terms: [term1],
     });
-    this.server.create('programYearObjective', {
+    this.server.create('program-year-objective', {
       programYear,
       competency: competency4,
       active: false,
       terms: [term2],
     });
-    this.server.create('programYearObjective', { programYear });
+    this.server.create('program-year-objective', { programYear });
     const course = this.server.create('course');
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [programYearObjective],
     });

--- a/packages/frontend/tests/acceptance/program-year/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectiveterms-test.js
@@ -10,9 +10,9 @@ module('Acceptance | Program Year - Objective Vocabulary Terms', function (hooks
   hooks.beforeEach(async function () {
     this.user = await setupAuthentication();
     const school = this.server.create('school');
-    this.server.create('academicYear', { id: 2013 });
+    this.server.create('academic-year', { id: 2013 });
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     this.server.create('cohort', { programYear });
     const vocabulary = this.server.create('vocabulary', { school, active: true });
     const term = this.server.create('term', { vocabulary, active: true });

--- a/packages/frontend/tests/acceptance/program-year/terms-test.js
+++ b/packages/frontend/tests/acceptance/program-year/terms-test.js
@@ -17,7 +17,7 @@ module('Acceptance | Program Year - Terms', function (hooks) {
     const program = this.server.create('program', {
       school: this.school,
     });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program,
     });
     this.server.create('cohort', { programYear });

--- a/packages/frontend/tests/acceptance/program/programyear-list-test.js
+++ b/packages/frontend/tests/acceptance/program/programyear-list-test.js
@@ -20,22 +20,22 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
     this.user.update({ administeredSchools: [this.school] });
     const thisYear = new Date().getFullYear();
     const cohorts = this.server.createList('cohort', 4);
-    this.server.create('programYear', {
+    this.server.create('program-year', {
       program: this.program,
       startYear: thisYear,
       cohort: cohorts[0],
     });
-    this.server.create('programYear', {
+    this.server.create('program-year', {
       program: this.program,
       startYear: thisYear - 2,
       cohort: cohorts[1],
     });
-    this.server.create('programYear', {
+    this.server.create('program-year', {
       program: this.program,
       startYear: thisYear - 1,
       cohort: cohorts[2],
     });
-    this.server.create('programYear', {
+    this.server.create('program-year', {
       program: this.program,
       startYear: thisYear - 3,
       cohort: cohorts[3],
@@ -56,7 +56,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
   });
 
   test('check competencies', async function (assert) {
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program: this.program,
     });
     this.server.createList('competency', 5, {
@@ -69,8 +69,8 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
   });
 
   test('check objectives', async function (assert) {
-    const programYear = this.server.create('programYear', { program: this.program });
-    this.server.createList('programYearObjective', 5, { programYear });
+    const programYear = this.server.create('program-year', { program: this.program });
+    this.server.createList('program-year-objective', 5, { programYear });
     this.server.create('cohort', { programYear });
     await page.visit({ programId: this.program.id });
     assert.strictEqual(page.programYears.items[0].objectives.text, '5');
@@ -78,7 +78,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
   });
 
   test('check directors', async function (assert) {
-    const programYear = this.server.create('programYear', { program: this.program });
+    const programYear = this.server.create('program-year', { program: this.program });
     this.server.createList('user', 5, {
       programYears: [programYear],
     });
@@ -92,7 +92,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
     const vocabulary = this.server.create('vocabulary', {
       school: this.school,
     });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program: this.program,
     });
     this.server.createList('term', 5, {
@@ -106,7 +106,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
   });
 
   test('check warnings', async function (assert) {
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program: this.program,
     });
     this.server.create('cohort', { programYear });
@@ -118,7 +118,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
   });
 
   test('check link', async function (assert) {
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program: this.program,
     });
     this.server.create('cohort', { programYear });
@@ -129,7 +129,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
 
   test('can delete a program-year', async function (assert) {
     this.user.update({ administeredSchools: [this.school] });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program: this.program,
     });
     this.server.create('cohort', { programYear });
@@ -174,7 +174,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
     const vocabulary = this.server.create('vocabulary', { school: this.school });
     const terms = this.server.createList('term', 3, { vocabulary });
     const currentYear = DateTime.now().year;
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program: this.program,
       startYear: currentYear,
       directors,
@@ -182,9 +182,9 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
       terms,
     });
     this.server.create('cohort', { programYear });
-    this.server.createList('programYearObjective', 2, { programYear });
-    const ancestor = this.server.create('programYearObjective');
-    this.server.create('programYearObjective', { programYear, ancestor });
+    this.server.createList('program-year-objective', 2, { programYear });
+    const ancestor = this.server.create('program-year-objective');
+    this.server.create('program-year-objective', { programYear, ancestor });
     await page.visit({ programId: this.program.id });
     assert.strictEqual(page.programYears.items.length, 1);
     assert.strictEqual(parseInt(page.programYears.items[0].link.text, 10), thisYear);
@@ -212,14 +212,14 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
     assert.expect(5);
     this.user.update({ administeredSchools: [this.school] });
     const cohorts = this.server.createList('cohort', 2);
-    this.server.create('programYear', {
+    this.server.create('program-year', {
       program: this.program,
       startYear: 2014,
       cohort: cohorts[0],
       locked: true,
       directorIds: [this.user.id],
     });
-    this.server.create('programYear', {
+    this.server.create('program-year', {
       program: this.program,
       startYear: 2015,
       cohort: cohorts[1],

--- a/packages/frontend/tests/acceptance/program/publicationcheck-test.js
+++ b/packages/frontend/tests/acceptance/program/publicationcheck-test.js
@@ -14,7 +14,7 @@ module('Acceptance | Program - Publication Check', function (hooks) {
       startYear: 2013,
       school,
     });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     this.server.create('cohort', { programYear });
     this.fullProgram = program;
     this.emptyProgram = this.server.create('program', {

--- a/packages/frontend/tests/acceptance/user-test.js
+++ b/packages/frontend/tests/acceptance/user-test.js
@@ -27,7 +27,7 @@ module('Acceptance | User', function (hooks) {
     this.cohort1 = this.server.create('cohort', { title: 'Medicine', programYearId: 1 });
     this.cohort2 = this.server.create('cohort', { programYearId: 2 });
     this.cohort3 = this.server.create('cohort', { programYearId: 3 });
-    this.server.createList('learnerGroup', 5, { title: 'Group 1', cohortId: 1 });
+    this.server.createList('learner-group', 5, { title: 'Group 1', cohortId: 1 });
     await setupAuthentication(userObject);
   });
 

--- a/packages/frontend/tests/integration/components/assign-students/manager-test.js
+++ b/packages/frontend/tests/integration/components/assign-students/manager-test.js
@@ -15,15 +15,15 @@ module('Integration | Component | assign-students/manager', function (hooks) {
     const school1 = this.server.create('school');
     const school2 = this.server.create('school');
     const program = this.server.create('program', { school: school1 });
-    const programYear1 = this.server.create('programYear', {
+    const programYear1 = this.server.create('program-year', {
       program,
       startYear: thisYear,
     });
-    const programYear2 = this.server.create('programYear', {
+    const programYear2 = this.server.create('program-year', {
       program,
       startYear: thisYear + 1,
     });
-    const programYear3 = this.server.create('programYear', {
+    const programYear3 = this.server.create('program-year', {
       program,
       startYear: thisYear + 2,
     });
@@ -67,7 +67,7 @@ module('Integration | Component | assign-students/manager', function (hooks) {
     this.user5 = await store.findRecord('user', user5.id);
     // ensure that the store is pre-populated with programs, program-years, and cohorts
     await store.findAll('program');
-    await store.findAll('programYear');
+    await store.findAll('program-year');
     await store.findAll('cohort');
   });
 

--- a/packages/frontend/tests/integration/components/assign-students/root-test.js
+++ b/packages/frontend/tests/integration/components/assign-students/root-test.js
@@ -15,15 +15,15 @@ module('Integration | Component | assign-students/root', function (hooks) {
     const school1 = this.server.create('school');
     const school2 = this.server.create('school');
     const program = this.server.create('program', { school: school1 });
-    const programYear1 = this.server.create('programYear', {
+    const programYear1 = this.server.create('program-year', {
       program,
       startYear: thisYear,
     });
-    const programYear2 = this.server.create('programYear', {
+    const programYear2 = this.server.create('program-year', {
       program,
       startYear: thisYear + 1,
     });
-    const programYear3 = this.server.create('programYear', {
+    const programYear3 = this.server.create('program-year', {
       program,
       startYear: thisYear + 2,
     });
@@ -67,7 +67,7 @@ module('Integration | Component | assign-students/root', function (hooks) {
     this.user5 = await store.findRecord('user', user5.id);
     // ensure that the store is pre-populated with programs, program-years, and cohorts
     await store.findAll('program');
-    await store.findAll('programYear');
+    await store.findAll('program-year');
     await store.findAll('cohort');
   });
 

--- a/packages/frontend/tests/integration/components/courses/new-test.js
+++ b/packages/frontend/tests/integration/components/courses/new-test.js
@@ -36,7 +36,7 @@ module('Integration | Component | courses/new', function (hooks) {
 
   test('given year is pre-selected', async function (assert) {
     const thisYear = new Date().getFullYear();
-    const academicYear = this.server.create('academicYear', { id: thisYear });
+    const academicYear = this.server.create('academic-year', { id: thisYear });
     const academicYearModel = await this.owner
       .lookup('service:store')
       .findRecord('academic-year', academicYear.id);
@@ -54,7 +54,7 @@ module('Integration | Component | courses/new', function (hooks) {
 
   test('given year is not pre-selected if it falls out of range', async function (assert) {
     const thisYear = new Date('1824-09-04').getFullYear();
-    const academicYear = this.server.create('academicYear', { id: thisYear });
+    const academicYear = this.server.create('academic-year', { id: thisYear });
     const academicYearModel = await this.owner
       .lookup('service:store')
       .findRecord('academic-year', academicYear.id);
@@ -104,7 +104,7 @@ module('Integration | Component | courses/new', function (hooks) {
   test('save', async function (assert) {
     assert.expect(4);
     const thisYear = new Date().getFullYear();
-    const academicYear = this.server.create('academicYear', { id: thisYear });
+    const academicYear = this.server.create('academic-year', { id: thisYear });
     const academicYearModel = await this.owner
       .lookup('service:store')
       .findRecord('academic-year', academicYear.id);
@@ -126,7 +126,7 @@ module('Integration | Component | courses/new', function (hooks) {
   test('save on pressing enter in title field', async function (assert) {
     assert.expect(4);
     const thisYear = new Date().getFullYear();
-    const academicYear = this.server.create('academicYear', { id: thisYear });
+    const academicYear = this.server.create('academic-year', { id: thisYear });
     const academicYearModel = await this.owner
       .lookup('service:store')
       .findRecord('academic-year', academicYear.id);
@@ -148,7 +148,7 @@ module('Integration | Component | courses/new', function (hooks) {
   test('input validation fails if title is too short', async function (assert) {
     assert.expect(2);
     const thisYear = new Date().getFullYear();
-    const academicYear = this.server.create('academicYear', { id: thisYear });
+    const academicYear = this.server.create('academic-year', { id: thisYear });
     const academicYearModel = await this.owner
       .lookup('service:store')
       .findRecord('academic-year', academicYear.id);
@@ -168,7 +168,7 @@ module('Integration | Component | courses/new', function (hooks) {
   test('input validation fails if title is too long', async function (assert) {
     assert.expect(2);
     const thisYear = new Date().getFullYear();
-    const academicYear = this.server.create('academicYear', { id: thisYear });
+    const academicYear = this.server.create('academic-year', { id: thisYear });
     const academicYearModel = await this.owner
       .lookup('service:store')
       .findRecord('academic-year', academicYear.id);

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-overview-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-overview-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       title: 'Doctor of Rocket Surgery',
       shortTitle: 'DRS',
     });
-    this.report = this.server.create('curriculumInventoryReport', {
+    this.report = this.server.create('curriculum-inventory-report', {
       academicLevels,
       year: currentYear.toString(),
       program: this.program,
@@ -335,7 +335,7 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
 
   test('academic year unchangeable if course has been linked', async function (assert) {
     const course = this.server.create('course');
-    this.server.create('curriculumInventorySequenceBlock', {
+    this.server.create('curriculum-inventory-sequence-block', {
       course,
       report: this.report,
     });

--- a/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-details-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/sequence-block-details-test.js
@@ -19,20 +19,20 @@ module('Integration | Component | curriculum-inventory/sequence-block-details', 
       );
     }
     const program = this.server.create('program', { school });
-    const report = this.server.create('curriculumInventoryReport', {
+    const report = this.server.create('curriculum-inventory-report', {
       academicLevels,
       year: '2016',
       program,
     });
-    const grandParentBlock = this.server.create('curriculumInventorySequenceBlock', {
+    const grandParentBlock = this.server.create('curriculum-inventory-sequence-block', {
       title: 'Okely Dokely',
       report,
     });
-    const parentBlock = this.server.create('curriculumInventorySequenceBlock', {
+    const parentBlock = this.server.create('curriculum-inventory-sequence-block', {
       title: 'Foo',
       parent: grandParentBlock,
     });
-    const block = this.server.create('curriculumInventorySequenceBlock', {
+    const block = this.server.create('curriculum-inventory-sequence-block', {
       title: 'bar',
       description: 'lorem ipsum',
       report,

--- a/packages/frontend/tests/integration/components/instructor-group/root-test.js
+++ b/packages/frontend/tests/integration/components/instructor-group/root-test.js
@@ -24,14 +24,14 @@ module('Integration | Component | instructor-group/root', function (hooks) {
     const session2 = this.server.create('session', { course: course2 });
     const offering1 = this.server.create('offering', { session: session1 });
     const offering2 = this.server.create('offering', { session: session2 });
-    const instructorGroup = this.server.create('instructorGroup', {
+    const instructorGroup = this.server.create('instructor-group', {
       users: [user1, user2],
       offerings: [offering1, offering2],
       school,
     });
     this.instructorGroup = await this.owner
       .lookup('service:store')
-      .findRecord('instructorGroup', instructorGroup.id);
+      .findRecord('instructor-group', instructorGroup.id);
   });
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/instructor-groups/list-item-test.js
+++ b/packages/frontend/tests/integration/components/instructor-groups/list-item-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | instructor-groups/list-item', function (hooks)
     };
     this.owner.register('service:permissionChecker', this.permissionCheckerMock);
     this.school = this.server.create('school');
-    this.instructorGroup = this.server.create('instructorGroup', {
+    this.instructorGroup = this.server.create('instructor-group', {
       school: this.school,
       users: this.server.createList('user', 3),
     });

--- a/packages/frontend/tests/integration/components/instructor-groups/list-test.js
+++ b/packages/frontend/tests/integration/components/instructor-groups/list-test.js
@@ -113,12 +113,12 @@ module('Integration | Component | instructor-groups/list', function (hooks) {
         this.server.create('offering', { session: sessions[0] }),
         this.server.create('offering', { session: sessions[1] }),
       ],
-      ilmSessions: [this.server.create('ilmSession', { session: sessions[3] })],
+      ilmSessions: [this.server.create('ilm-session', { session: sessions[3] })],
     });
     this.server.create('instructor-group', {
       school,
       offerings: [],
-      ilmSessions: [this.server.create('ilmSession', { session: sessions[2] })],
+      ilmSessions: [this.server.create('ilm-session', { session: sessions[2] })],
     });
     this.server.create('instructor-group', {
       school,

--- a/packages/frontend/tests/integration/components/learner-group/instructor-manager-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/instructor-manager-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     this.cohort = this.server.create('cohort', { programYear });
     this.school = school;
   });
@@ -33,11 +33,11 @@ module('Integration | Component | learner-group/instructor-manager', function (h
       lastName: 'person2',
       middleName: '',
     });
-    const instructorGroup = this.server.create('instructorGroup', {
+    const instructorGroup = this.server.create('instructor-group', {
       title: 'test group',
       users: [instructor3],
     });
-    const learnerGroup = this.server.create('learnerGroup', {
+    const learnerGroup = this.server.create('learner-group', {
       title: 'this group',
       cohort: this.cohort,
       instructors: [instructor, instructor2],
@@ -45,7 +45,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
     });
     const learnerGroupModel = await this.owner
       .lookup('service:store')
-      .findRecord('learnerGroup', learnerGroup.id);
+      .findRecord('learner-group', learnerGroup.id);
 
     this.set('learnerGroup', learnerGroupModel);
     await render(hbs`<LearnerGroup::InstructorManager
@@ -85,13 +85,13 @@ module('Integration | Component | learner-group/instructor-manager', function (h
   });
 
   test('no selected instructors', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', {
+    const learnerGroup = this.server.create('learner-group', {
       title: 'this group',
       cohort: this.cohort,
     });
     const learnerGroupModel = await this.owner
       .lookup('service:store')
-      .findRecord('learnerGroup', learnerGroup.id);
+      .findRecord('learner-group', learnerGroup.id);
 
     this.set('learnerGroup', learnerGroupModel);
     await render(hbs`<LearnerGroup::InstructorManager
@@ -114,14 +114,14 @@ module('Integration | Component | learner-group/instructor-manager', function (h
       lastName: 'z00ber',
       displayName: 'aardvark',
     });
-    const learnerGroup = this.server.create('learnerGroup', {
+    const learnerGroup = this.server.create('learner-group', {
       title: 'this group',
       cohort: this.cohort,
       instructors: [instructor, instructor2],
     });
     const learnerGroupModel = await this.owner
       .lookup('service:store')
-      .findRecord('learnerGroup', learnerGroup.id);
+      .findRecord('learner-group', learnerGroup.id);
 
     this.set('learnerGroup', learnerGroupModel);
     await render(hbs`<LearnerGroup::InstructorManager
@@ -144,7 +144,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
       lastName: 'z00ber',
       displayName: 'aardvark',
     });
-    const learnerGroup = this.server.create('learnerGroup', {
+    const learnerGroup = this.server.create('learner-group', {
       title: 'this group',
       cohort: this.cohort,
       instructors: [instructor, instructor2],
@@ -152,7 +152,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
 
     const learnerGroupModel = await this.owner
       .lookup('service:store')
-      .findRecord('learnerGroup', learnerGroup.id);
+      .findRecord('learner-group', learnerGroup.id);
     this.set('learnerGroup', learnerGroupModel);
 
     await render(hbs`<LearnerGroup::InstructorManager
@@ -186,12 +186,12 @@ module('Integration | Component | learner-group/instructor-manager', function (h
       lastName: 'person2',
       middleName: '',
     });
-    const instructorGroup = this.server.create('instructorGroup', {
+    const instructorGroup = this.server.create('instructor-group', {
       title: 'test group',
       users: [instructor3],
     });
-    const instructorGroup2 = this.server.create('instructorGroup', { title: 'test group 2' });
-    const learnerGroup = this.server.create('learnerGroup', {
+    const instructorGroup2 = this.server.create('instructor-group', { title: 'test group 2' });
+    const learnerGroup = this.server.create('learner-group', {
       title: 'this group',
       cohort: this.cohort,
       instructors: [instructor, instructor2],
@@ -199,7 +199,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
     });
     const learnerGroupModel = await this.owner
       .lookup('service:store')
-      .findRecord('learnerGroup', learnerGroup.id);
+      .findRecord('learner-group', learnerGroup.id);
 
     this.set('save', (users, groups) => {
       assert.strictEqual(users.length, 1);
@@ -227,14 +227,14 @@ module('Integration | Component | learner-group/instructor-manager', function (h
   });
 
   test('search and add instructor group', async function (assert) {
-    this.server.create('instructorGroup', { title: 'test group', school: this.school });
-    const learnerGroup = this.server.create('learnerGroup', {
+    this.server.create('instructor-group', { title: 'test group', school: this.school });
+    const learnerGroup = this.server.create('learner-group', {
       title: 'this group',
       cohort: this.cohort,
     });
     const learnerGroupModel = await this.owner
       .lookup('service:store')
-      .findRecord('learnerGroup', learnerGroup.id);
+      .findRecord('learner-group', learnerGroup.id);
 
     this.set('learnerGroup', learnerGroupModel);
     await render(hbs`<LearnerGroup::InstructorManager
@@ -256,13 +256,13 @@ module('Integration | Component | learner-group/instructor-manager', function (h
     });
 
     this.server.create('user', { firstName: 'test', lastName: 'person', middleName: '' });
-    const learnerGroup = this.server.create('learnerGroup', {
+    const learnerGroup = this.server.create('learner-group', {
       title: 'this group',
       cohort: this.cohort,
     });
     const learnerGroupModel = await this.owner
       .lookup('service:store')
-      .findRecord('learnerGroup', learnerGroup.id);
+      .findRecord('learner-group', learnerGroup.id);
 
     this.set('learnerGroup', learnerGroupModel);
     await render(hbs`<LearnerGroup::InstructorManager

--- a/packages/frontend/tests/integration/components/learner-group/list-item-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/list-item-test.js
@@ -25,7 +25,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
     const program = this.server.create('program', { school });
     const programYear = this.server.create('program-year', { program });
     this.cohort = this.server.create('cohort', { programYear });
-    this.learnerGroup = this.server.create('learnerGroup', {
+    this.learnerGroup = this.server.create('learner-group', {
       cohort: this.cohort,
     });
   });
@@ -126,7 +126,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
   });
 
   test('can not delete group with sub-group linked to offering', async function (assert) {
-    const subGroup = this.server.create('learnerGroup', {
+    const subGroup = this.server.create('learner-group', {
       parent: this.learnerGroup,
     });
     this.server.create('offering', {
@@ -142,7 +142,7 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
   });
 
   test('can not delete group linked to ILM', async function (assert) {
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       learnerGroups: [this.learnerGroup],
     });
     const learnerGroupModel = await this.owner
@@ -155,10 +155,10 @@ module('Integration | Component | learner-group/list-item', function (hooks) {
   });
 
   test('can not delete group with sub-group linked to ILM', async function (assert) {
-    const subGroup = this.server.create('learnerGroup', {
+    const subGroup = this.server.create('learner-group', {
       parent: this.learnerGroup,
     });
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       learnerGroups: [subGroup],
     });
     const learnerGroupModel = await this.owner

--- a/packages/frontend/tests/integration/components/learner-group/members-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/members-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | learner-group/members', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user1 = this.server.create('user', {
       firstName: 'Jasper',
       lastName: 'Dog',

--- a/packages/frontend/tests/integration/components/learner-group/root-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/root-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    this.programYear = this.server.create('programYear', { program });
+    this.programYear = this.server.create('program-year', { program });
     this.cohort = this.server.create('cohort', { programYear: this.programYear });
 
     const user = this.server.create('user', { school });

--- a/packages/frontend/tests/integration/components/learner-group/user-manager-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/user-manager-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   setupMirage(hooks);
 
   test('it renders when editing', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user1 = this.server.create('user', {
       firstName: 'Jasper',
       lastName: 'Dog',
@@ -88,7 +88,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('sort by full name', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user1 = this.server.create('user', {
       firstName: 'Jasper',
       learnerGroups: [learnerGroup],
@@ -154,8 +154,8 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
 
   test('add multiple users', async function (assert) {
     assert.expect(5);
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
-    const subGroup = this.server.create('learnerGroup', { parent: learnerGroup });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
+    const subGroup = this.server.create('learner-group', { parent: learnerGroup });
     const user = this.server.create('user', { enabled: true, learnerGroups: [subGroup] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     const learnerGroupModel = await this.owner
@@ -199,7 +199,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
 
   test('remove multiple users', async function (assert) {
     assert.expect(5);
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     const learnerGroupModel = await this.owner
@@ -241,7 +241,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   test('remove single user', async function (assert) {
     assert.expect(1);
 
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     const learnerGroupModel = await this.owner
@@ -279,8 +279,8 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   test('add single user', async function (assert) {
     assert.expect(1);
 
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
-    const learnerGroup2 = this.server.create('learnerGroup', { id: 2 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
+    const learnerGroup2 = this.server.create('learner-group', { id: 2 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup2] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     const learnerGroupModel = await this.owner
@@ -318,8 +318,8 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('when users are selected single action is disabled', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
-    const learnerGroup2 = this.server.create('learnerGroup', { id: 2 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
+    const learnerGroup2 = this.server.create('learner-group', { id: 2 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup] });
     const user2 = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup2] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
@@ -367,7 +367,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
 
   test('check all users in group', async function (assert) {
     assert.expect(7);
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup] });
     const user2 = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
@@ -417,8 +417,8 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
 
   test('check all users not in group', async function (assert) {
     assert.expect(7);
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
-    const subGroup = this.server.create('learnerGroup', { parent: learnerGroup });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
+    const subGroup = this.server.create('learner-group', { parent: learnerGroup });
     const user = this.server.create('user', { enabled: true, learnerGroups: [subGroup] });
     const user2 = this.server.create('user', { enabled: true, learnerGroups: [subGroup] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
@@ -469,7 +469,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('checking one puts checkall box into indeterminate state', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup] });
     const user2 = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
@@ -523,7 +523,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('filtering and bulk-selection of users in group', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user1 = this.server.create('user', { enabled: true, displayName: 'Alpha' });
     const user2 = this.server.create('user', { enabled: true, displayName: 'Beta' });
     const user3 = this.server.create('user', { enabled: true, displayName: 'Gamma' });
@@ -628,8 +628,8 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('filtering and bulk-selection of users not in group', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
-    const subGroup = this.server.create('learnerGroup', { parent: learnerGroup });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
+    const subGroup = this.server.create('learner-group', { parent: learnerGroup });
     const user1 = this.server.create('user', { enabled: true, displayName: 'Alpha' });
     const user2 = this.server.create('user', { enabled: true, displayName: 'Beta' });
     const user3 = this.server.create('user', { enabled: true, displayName: 'Gamma' });
@@ -737,7 +737,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('filter users', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user1 = this.server.create('user', {
       firstName: 'Jasper',
       lastName: 'Dog',
@@ -822,8 +822,8 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('user not in group: click on name', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
-    const learnerGroup2 = this.server.create('learnerGroup', { id: 2 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
+    const learnerGroup2 = this.server.create('learner-group', { id: 2 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup2] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     const learnerGroupModel = await this.owner
@@ -860,8 +860,8 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('user not in group: click on campus id', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
-    const learnerGroup2 = this.server.create('learnerGroup', { id: 2 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
+    const learnerGroup2 = this.server.create('learner-group', { id: 2 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup2] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     const learnerGroupModel = await this.owner
@@ -898,8 +898,8 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('user not in group: click on email', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
-    const learnerGroup2 = this.server.create('learnerGroup', { id: 2 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
+    const learnerGroup2 = this.server.create('learner-group', { id: 2 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup2] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     const learnerGroupModel = await this.owner
@@ -936,7 +936,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('user in group: click on name', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     const learnerGroupModel = await this.owner
@@ -970,7 +970,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('user in group: click on campus id', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     const learnerGroupModel = await this.owner
@@ -1004,7 +1004,7 @@ module('Integration | Component | learner-group/user-manager', function (hooks) 
   });
 
   test('user in group: click on email', async function (assert) {
-    const learnerGroup = this.server.create('learnerGroup', { id: 1 });
+    const learnerGroup = this.server.create('learner-group', { id: 1 });
     const user = this.server.create('user', { enabled: true, learnerGroups: [learnerGroup] });
     const userModel = await this.owner.lookup('service:store').findRecord('user', user.id);
     const learnerGroupModel = await this.owner

--- a/packages/frontend/tests/integration/components/new-user-test.js
+++ b/packages/frontend/tests/integration/components/new-user-test.js
@@ -127,7 +127,7 @@ module('Integration | Component | new user', function (hooks) {
       title: 'Student',
     });
     const program = this.server.create('program', { school: this.schools[0] });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program,
       startYear: new Date().getFullYear(),
     });
@@ -135,7 +135,7 @@ module('Integration | Component | new user', function (hooks) {
 
     //load all created data into the store
     await this.owner.lookup('service:store').findAll('program');
-    await this.owner.lookup('service:store').findAll('programYear');
+    await this.owner.lookup('service:store').findAll('program-year');
     await this.owner.lookup('service:store').findAll('cohort');
     this.set('transitionToUser', (userId) => {
       assert.strictEqual(Number(userId), 2);
@@ -183,21 +183,21 @@ module('Integration | Component | new user', function (hooks) {
 
   test('change school', async function (assert) {
     const program1 = this.server.create('program', { school: this.schools[0] });
-    const programYear1 = this.server.create('programYear', {
+    const programYear1 = this.server.create('program-year', {
       program: program1,
       startYear: new Date().getFullYear(),
     });
     this.server.create('cohort', { programYear: programYear1 });
 
     const program2 = this.server.create('program', { school: this.schools[1] });
-    const programYear2 = this.server.create('programYear', {
+    const programYear2 = this.server.create('program-year', {
       program: program2,
       startYear: new Date().getFullYear() - 1,
       duration: 4,
     });
     this.server.create('cohort', { programYear: programYear2 });
     // this program is too old and will not show as option in the dropdown
-    const programYear3 = this.server.create('programYear', {
+    const programYear3 = this.server.create('program-year', {
       program: program2,
       startYear: new Date().getFullYear() - 5,
     });
@@ -205,7 +205,7 @@ module('Integration | Component | new user', function (hooks) {
 
     //load all created data into the store
     await this.owner.lookup('service:store').findAll('program');
-    await this.owner.lookup('service:store').findAll('programYear');
+    await this.owner.lookup('service:store').findAll('program-year');
     await this.owner.lookup('service:store').findAll('cohort');
 
     await render(hbs`<NewUser @close={{(noop)}}  />`);

--- a/packages/frontend/tests/integration/components/program-year/collapsed-objectives-test.js
+++ b/packages/frontend/tests/integration/components/program-year/collapsed-objectives-test.js
@@ -10,19 +10,19 @@ module('Integration | Component | program-year/collapsed-objectives', function (
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const meshDescriptor = this.server.create('meshDescriptor');
+    const meshDescriptor = this.server.create('mesh-descriptor');
     const term = this.server.create('term');
     const competency = this.server.create('competency');
-    this.objective = this.server.create('programYearObjective');
-    this.objectiveWithMesh = this.server.create('programYearObjective', {
+    this.objective = this.server.create('program-year-objective');
+    this.objectiveWithMesh = this.server.create('program-year-objective', {
       meshDescriptors: [meshDescriptor],
     });
-    this.objectiveWithTerms = this.server.create('programYearObjective', { terms: [term] });
-    this.objectiveWithCompetency = this.server.create('programYearObjective', { competency });
+    this.objectiveWithTerms = this.server.create('program-year-objective', { terms: [term] });
+    this.objectiveWithCompetency = this.server.create('program-year-objective', { competency });
   });
 
   test('displays summary data', async function (assert) {
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       programYearObjectives: [
         this.objective,
         this.objectiveWithMesh,
@@ -52,7 +52,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
   test('clicking expand icon opens full view', async function (assert) {
     assert.expect(2);
 
-    const programYear = this.server.create('programYear');
+    const programYear = this.server.create('program-year');
     const programYearModel = await this.owner
       .lookup('service:store')
       .findRecord('program-year', programYear.id);
@@ -70,7 +70,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
   });
 
   test('icons all linked competencies correctly', async function (assert) {
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       programYearObjectives: [this.objectiveWithCompetency],
     });
     const programYearModel = await this.owner
@@ -86,7 +86,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
   });
 
   test('icons no parents correctly', async function (assert) {
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       programYearObjectives: [this.objective],
     });
     const programYearModel = await this.owner
@@ -102,7 +102,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
   });
 
   test('icons all mesh correctly', async function (assert) {
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       programYearObjectives: [this.objectiveWithMesh],
     });
     const programYearModel = await this.owner
@@ -118,7 +118,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
   });
 
   test('icons no mesh correctly', async function (assert) {
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       programYearObjectives: [this.objective],
     });
     const programYearModel = await this.owner
@@ -134,7 +134,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
   });
 
   test('icons all terms correctly', async function (assert) {
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       programYearObjectives: [this.objectiveWithTerms],
     });
     const programYearModel = await this.owner
@@ -150,7 +150,7 @@ module('Integration | Component | program-year/collapsed-objectives', function (
   });
 
   test('icons no terms correctly', async function (assert) {
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       programYearObjectives: [this.objective],
     });
     const programYearModel = await this.owner

--- a/packages/frontend/tests/integration/components/program-year/competencies-test.js
+++ b/packages/frontend/tests/integration/components/program-year/competencies-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | program-year/competencies', function (hooks) {
     const program = this.server.create('program', {
       school,
     });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     this.server.create('cohort', { programYear });
     const domain = this.server.create('competency', { school });
     this.server.createList('competency', 2, {

--- a/packages/frontend/tests/integration/components/program-year/list-test.js
+++ b/packages/frontend/tests/integration/components/program-year/list-test.js
@@ -28,17 +28,17 @@ module('Integration | Component | program-year/list', function (hooks) {
     const school = this.server.create('school');
     const programYears = [1, 2, 3].map((i) => {
       const cohort = this.server.create('cohort');
-      const meshDescriptors = this.server.createList('meshDescriptor', 3);
+      const meshDescriptors = this.server.createList('mesh-descriptor', 3);
       const vocabulary = this.server.create('vocabulary', { school });
       const terms = this.server.createList('term', 4, { vocabulary });
       const competencies = this.server.createList('competency', 2);
       const directors = this.server.createList('user', 2);
-      const programYearAncestor = this.server.create('programYearObjective');
-      const programYearObjectives = this.server.createList('programYearObjective', 2, {
+      const programYearAncestor = this.server.create('program-year-objective');
+      const programYearObjectives = this.server.createList('program-year-objective', 2, {
         meshDescriptors,
         terms,
       });
-      const programYearObjectiveWithAncestor = this.server.create('programYearObjective', {
+      const programYearObjectiveWithAncestor = this.server.create('program-year-objective', {
         ancestor: programYearAncestor,
       });
       return this.server.create('program-year', {
@@ -95,7 +95,7 @@ module('Integration | Component | program-year/list', function (hooks) {
     await component.expandCollapse.toggle();
     await component.newProgramYear.years.select(thisYear);
     await component.newProgramYear.done.click();
-    const programYears = await this.owner.lookup('service:store').findAll('programYear');
+    const programYears = await this.owner.lookup('service:store').findAll('program-year');
     const sortedProgramYears = sortBy(programYears.slice(), 'id');
     const newProgramYear = sortedProgramYears.slice().reverse()[0];
     const originalProgramYear = sortedProgramYears[sortedProgramYears.length - 2];

--- a/packages/frontend/tests/integration/components/program-year/manage-objective-descriptors-test.js
+++ b/packages/frontend/tests/integration/components/program-year/manage-objective-descriptors-test.js
@@ -10,10 +10,10 @@ module('Integration | Component | program-year/manage-objective-descriptors', fu
   setupMirage(hooks);
 
   test('it renders', async function (assert) {
-    const descriptors = this.server.createList('meshDescriptor', 4);
+    const descriptors = this.server.createList('mesh-descriptor', 4);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', descriptors[0].id);
+      .findRecord('mesh-descriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     await render(hbs`<ProgramYear::ManageObjectiveDescriptors
       @selected={{this.selected}}
@@ -39,10 +39,10 @@ module('Integration | Component | program-year/manage-objective-descriptors', fu
 
   test('add works', async function (assert) {
     assert.expect(16);
-    const descriptors = this.server.createList('meshDescriptor', 2);
+    const descriptors = this.server.createList('mesh-descriptor', 2);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', descriptors[0].id);
+      .findRecord('mesh-descriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     this.set('add', (descriptor) => {
       this.set('selected', [descriptorModel, descriptor]);
@@ -78,10 +78,10 @@ module('Integration | Component | program-year/manage-objective-descriptors', fu
 
   test('remove works', async function (assert) {
     assert.expect(15);
-    const descriptors = this.server.createList('meshDescriptor', 2);
+    const descriptors = this.server.createList('mesh-descriptor', 2);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', descriptors[0].id);
+      .findRecord('mesh-descriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     this.set('remove', (descriptor) => {
       assert.strictEqual(descriptor.id, descriptorModel.id);

--- a/packages/frontend/tests/integration/components/program-year/objective-list-item-competency-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-item-competency-test.js
@@ -27,7 +27,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
   });
 
   test('it renders and is accessible empty and un-editable', async function (assert) {
-    const objective = this.server.create('programYearObjective');
+    const objective = this.server.create('program-year-objective');
     const objectiveModel = await this.owner
       .lookup('service:store')
       .findRecord('program-year-objective', objective.id);
@@ -49,7 +49,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
   test('it renders and is accessible un-editable', async function (assert) {
     const domain = this.server.create('competency');
     const competency = this.server.create('competency', { parent: domain });
-    const objective = this.server.create('programYearObjective', { competency });
+    const objective = this.server.create('program-year-objective', { competency });
     const objectiveModel = await this.owner
       .lookup('service:store')
       .findRecord('program-year-objective', objective.id);
@@ -70,7 +70,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
 
   test('it renders and is accessible un-editable with no domain', async function (assert) {
     const competency = this.server.create('competency');
-    const objective = this.server.create('programYearObjective', { competency });
+    const objective = this.server.create('program-year-objective', { competency });
     const objectiveModel = await this.owner
       .lookup('service:store')
       .findRecord('program-year-objective', objective.id);
@@ -92,7 +92,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
   test('it renders and is accessible editable', async function (assert) {
     const domain = this.server.create('competency');
     const competency = this.server.create('competency', { parent: domain });
-    const objective = this.server.create('programYearObjective', {
+    const objective = this.server.create('program-year-objective', {
       competency,
     });
     const objectiveModel = await this.owner
@@ -115,7 +115,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
 
   test('it renders and is accessible editable with no domain', async function (assert) {
     const competency = this.server.create('competency');
-    const objective = this.server.create('programYearObjective', {
+    const objective = this.server.create('program-year-objective', {
       competency,
     });
     const objectiveModel = await this.owner
@@ -140,7 +140,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
     assert.expect(1);
     const domain = this.server.create('competency');
     const competency = this.server.create('competency', { parent: domain });
-    const objective = this.server.create('programYearObjective', {
+    const objective = this.server.create('program-year-objective', {
       competency,
     });
     const objectiveModel = await this.owner
@@ -166,7 +166,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
     assert.expect(1);
     const domain = this.server.create('competency');
     const competency = this.server.create('competency', { parent: domain });
-    const objective = this.server.create('programYearObjective', {
+    const objective = this.server.create('program-year-objective', {
       competency,
     });
     const objectiveModel = await this.owner
@@ -192,7 +192,7 @@ module('Integration | Component | program-year/objective-list-item-competency', 
     assert.expect(1);
     const domain = this.server.create('competency');
     const competency = this.server.create('competency', { parent: domain });
-    const objective = this.server.create('programYearObjective', {
+    const objective = this.server.create('program-year-objective', {
       competency,
     });
     const objectiveModel = await this.owner

--- a/packages/frontend/tests/integration/components/program-year/objective-list-item-expanded-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-item-expanded-test.js
@@ -12,15 +12,15 @@ module('Integration | Component | program-year/objective-list-item-expanded', fu
 
   test('it renders and is accessible', async function (assert) {
     assert.expect(14);
-    const programYear = this.server.create('programYear');
-    const programYearObjective = this.server.create('programYearObjective', { programYear });
+    const programYear = this.server.create('program-year');
+    const programYearObjective = this.server.create('program-year-objective', { programYear });
     const course1 = this.server.create('course');
     const course2 = this.server.create('course');
-    this.server.createList('courseObjective', 3, {
+    this.server.createList('course-objective', 3, {
       course: course1,
       programYearObjectives: [programYearObjective],
     });
-    this.server.createList('courseObjective', 3, {
+    this.server.createList('course-objective', 3, {
       course: course2,
       programYearObjectives: [programYearObjective],
     });

--- a/packages/frontend/tests/integration/components/program-year/objective-list-item-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-item-test.js
@@ -13,8 +13,8 @@ module('Integration | Component | program-year/objective-list-item', function (h
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
-    const programYearObjective = this.server.create('programYearObjective', { programYear });
+    const programYear = this.server.create('program-year', { program });
+    const programYearObjective = this.server.create('program-year-objective', { programYear });
     this.model = await this.owner
       .lookup('service:store')
       .findRecord('program-year-objective', programYearObjective.id);

--- a/packages/frontend/tests/integration/components/program-year/objective-list-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-test.js
@@ -13,17 +13,17 @@ module('Integration | Component | program-year/objective-list', function (hooks)
   test('it renders and is accessible', async function (assert) {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const vocabulary = this.server.create('vocabulary', { school });
     const term1 = this.server.create('term', { vocabulary });
     const term2 = this.server.create('term', { vocabulary });
-    this.server.create('programYearObjective', {
+    this.server.create('program-year-objective', {
       programYear,
       title: 'Objective A',
       position: 0,
       terms: [term1],
     });
-    this.server.create('programYearObjective', {
+    this.server.create('program-year-objective', {
       programYear,
       title: 'Objective B',
       position: 0,
@@ -68,7 +68,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
   test('empty list', async function (assert) {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const programYearModel = await this.owner
       .lookup('service:store')
       .findRecord('program-year', programYear.id);
@@ -87,8 +87,8 @@ module('Integration | Component | program-year/objective-list', function (hooks)
   test('no "sort objectives" button in list with one item', async function (assert) {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
-    this.server.create('programYearObjective', { programYear, position: 0 });
+    const programYear = this.server.create('program-year', { program });
+    this.server.create('program-year-objective', { programYear, position: 0 });
     const programYearModel = await this.owner
       .lookup('service:store')
       .findRecord('program-year', programYear.id);
@@ -114,11 +114,11 @@ module('Integration | Component | program-year/objective-list', function (hooks)
     const competency1 = this.server.create('competency', { school, parent: domain1 });
     const domain2 = this.server.create('competency', { school });
     this.server.createList('competency', 2, { school, parent: domain2 });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program,
       competencies: [competency1, domain2],
     });
-    this.server.create('programYearObjective', { programYear });
+    this.server.create('program-year-objective', { programYear });
     const programYearModel = await this.owner
       .lookup('service:store')
       .findRecord('program-year', programYear.id);

--- a/packages/frontend/tests/integration/components/program-year/objectives-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objectives-test.js
@@ -13,14 +13,14 @@ module('Integration | Component | program-year/objectives', function (hooks) {
   test('it renders and is accessible', async function (assert) {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const domains = this.server.createList('competency', 2, { school });
 
     const competencies = this.server.createList('competency', 2, { school, parent: domains[0] });
     this.server.createList('competency', 2, { school, parent: domains[1] });
 
-    this.server.create('programYearObjective', { programYear, competency: competencies[0] });
-    this.server.create('programYearObjective', { programYear });
+    this.server.create('program-year-objective', { programYear, competency: competencies[0] });
+    this.server.create('program-year-objective', { programYear });
 
     const programYearModel = await this.owner
       .lookup('service:store')
@@ -64,7 +64,7 @@ module('Integration | Component | program-year/objectives', function (hooks) {
   test('it loads data for program year domains', async function (assert) {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const domain1 = this.server.create('competency', {
       school,
       programYears: [programYear],

--- a/packages/frontend/tests/integration/components/program-year/overview-test.js
+++ b/packages/frontend/tests/integration/components/program-year/overview-test.js
@@ -13,10 +13,10 @@ module('Integration | Component | program-year/overview', function (hooks) {
 
   test('it renders', async function (assert) {
     const program = this.server.create('program');
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const programYearModel = await this.owner
       .lookup('service:store')
-      .findRecord('programYear', programYear.id);
+      .findRecord('program-year', programYear.id);
     this.set('program', programYearModel);
     await render(hbs`<ProgramYear::Overview
       @programYear={{this.programYear}}
@@ -29,10 +29,10 @@ module('Integration | Component | program-year/overview', function (hooks) {
 
   test('visualizations button present', async function (assert) {
     const program = this.server.create('program');
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const programYearModel = await this.owner
       .lookup('service:store')
-      .findRecord('programYear', programYear.id);
+      .findRecord('program-year', programYear.id);
     this.set('program', programYearModel);
     enableFeature('programYearVisualizations');
     await render(hbs`<ProgramYear::Overview

--- a/packages/frontend/tests/integration/components/program-year/visualize-objectives-test.js
+++ b/packages/frontend/tests/integration/components/program-year/visualize-objectives-test.js
@@ -67,7 +67,7 @@ module('Integration | Component | program-year/visualize-objectives', function (
     });
     const programYearModel = await this.owner
       .lookup('service:store')
-      .findRecord('programYear', programYear.id);
+      .findRecord('program-year', programYear.id);
     this.set('model', programYearModel);
     await render(hbs`<ProgramYear::VisualizeObjectives @model={{this.model}}/>`);
     assert.strictEqual(component.title.text, 'program 0 Class of 2022');

--- a/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
@@ -10,15 +10,15 @@ module('Integration | Component | reports/subject/new/academic-year', function (
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.server.create('academicYear', {
+    this.server.create('academic-year', {
       id: 2015,
       title: 2015,
     });
-    this.server.create('academicYear', {
+    this.server.create('academic-year', {
       id: 2031,
       title: 2031,
     });
-    this.server.create('academicYear', {
+    this.server.create('academic-year', {
       id: 2060,
       title: 2060,
     });

--- a/packages/frontend/tests/integration/components/reports/subject/new/course-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/course-test.js
@@ -10,8 +10,8 @@ module('Integration | Component | reports/subject/new/course', function (hooks) 
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.server.create('academicYear', { id: 2022 });
-    this.server.create('academicYear', { id: 2015 });
+    this.server.create('academic-year', { id: 2022 });
+    this.server.create('academic-year', { id: 2015 });
     const [school1, school2] = this.server.createList('school', 2);
     this.server.createList('course', 2, { school: school1, year: 2015 });
     this.server.createList('course', 3, { school: school2, year: 2022 });

--- a/packages/frontend/tests/integration/components/reports/subject/new/session-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/session-test.js
@@ -10,8 +10,8 @@ module('Integration | Component | reports/subject/new/session', function (hooks)
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.server.create('academicYear', { id: 2027 });
-    this.server.create('academicYear', { id: 2006 });
+    this.server.create('academic-year', { id: 2027 });
+    this.server.create('academic-year', { id: 2006 });
     const [school1, school2] = this.server.createList('school', 2);
 
     const course1 = this.server.create('course', {

--- a/packages/frontend/tests/integration/components/school-competencies-list-item-pcrs-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-list-item-pcrs-test.js
@@ -11,17 +11,17 @@ module('Integration | Component | school-competencies-list-item-pcrs', function 
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const pcrs1 = this.server.create('aamcPcrs', {
+    const pcrs1 = this.server.create('aamc-pcrs', {
       description: 'Zylinder',
     });
-    const pcrs2 = this.server.create('aamcPcrs', {
+    const pcrs2 = this.server.create('aamc-pcrs', {
       description: 'Alfons',
     });
     const competency = this.server.create('competency', {
       aamcPcrses: [pcrs1, pcrs2],
     });
-    this.pcrsModel1 = await this.owner.lookup('service:store').findRecord('aamcPcrs', pcrs1.id);
-    this.pcrsModel2 = await this.owner.lookup('service:store').findRecord('aamcPcrs', pcrs2.id);
+    this.pcrsModel1 = await this.owner.lookup('service:store').findRecord('aamc-pcrs', pcrs1.id);
+    this.pcrsModel2 = await this.owner.lookup('service:store').findRecord('aamc-pcrs', pcrs2.id);
     this.competencyModel = await this.owner
       .lookup('service:store')
       .findRecord('competency', competency.id);

--- a/packages/frontend/tests/integration/components/school-competencies-list-item-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-list-item-test.js
@@ -11,10 +11,10 @@ module('Integration | Component | school-competencies-list-item', function (hook
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const pcrs1 = this.server.create('aamcPcrs', {
+    const pcrs1 = this.server.create('aamc-pcrs', {
       description: 'Zylinder',
     });
-    const pcrs2 = this.server.create('aamcPcrs', {
+    const pcrs2 = this.server.create('aamc-pcrs', {
       description: 'Alfons',
     });
     const domain = this.server.create('competency', {
@@ -23,8 +23,8 @@ module('Integration | Component | school-competencies-list-item', function (hook
     const competency = this.server.create('competency', {
       parent: domain,
     });
-    this.pcrsModel1 = await this.owner.lookup('service:store').findRecord('aamcPcrs', pcrs1.id);
-    this.pcrsModel2 = await this.owner.lookup('service:store').findRecord('aamcPcrs', pcrs2.id);
+    this.pcrsModel1 = await this.owner.lookup('service:store').findRecord('aamc-pcrs', pcrs1.id);
+    this.pcrsModel2 = await this.owner.lookup('service:store').findRecord('aamc-pcrs', pcrs2.id);
     this.competencyModel = await this.owner
       .lookup('service:store')
       .findRecord('competency', competency.id);

--- a/packages/frontend/tests/integration/components/school-competencies-list-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-list-test.js
@@ -11,9 +11,9 @@ module('Integration | Component | school competencies list', function (hooks) {
   setupMirage(hooks);
 
   test('it renders', async function (assert) {
-    const pcrs1 = this.server.create('aamcPcrs');
-    const pcrs2 = this.server.create('aamcPcrs');
-    const pcrs3 = this.server.create('aamcPcrs');
+    const pcrs1 = this.server.create('aamc-pcrs');
+    const pcrs2 = this.server.create('aamc-pcrs');
+    const pcrs3 = this.server.create('aamc-pcrs');
     const domain = this.server.create('competency', { title: 'domain 0' });
     this.server.create('competency', {
       title: 'competency 0',

--- a/packages/frontend/tests/integration/components/school-competencies-manager-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-manager-test.js
@@ -10,7 +10,7 @@ module('Integration | Component | school competencies manager', function (hooks)
   setupMirage(hooks);
 
   test('it renders', async function (assert) {
-    const programYearObjectives = this.server.createList('programYearObjective', 3);
+    const programYearObjectives = this.server.createList('program-year-objective', 3);
     const competency1 = this.server.create('competency', {
       title: 'competency1',
       programYearObjectives,

--- a/packages/frontend/tests/integration/components/school-competencies-pcrs-mapper-test.js
+++ b/packages/frontend/tests/integration/components/school-competencies-pcrs-mapper-test.js
@@ -11,31 +11,31 @@ module('Integration | Component | school-competencies-pcrs-mapper', function (ho
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const pcrs1 = this.server.create('aamcPcrs', {
+    const pcrs1 = this.server.create('aamc-pcrs', {
       id: 'aamc-pcrs-comp-c0201',
       description: 'Foo',
     });
-    const pcrs2 = this.server.create('aamcPcrs', {
+    const pcrs2 = this.server.create('aamc-pcrs', {
       id: 'aamc-pcrs-comp-c0555',
       description: 'Bar',
     });
-    const pcrs3 = this.server.create('aamcPcrs', {
+    const pcrs3 = this.server.create('aamc-pcrs', {
       id: 'aamc-pcrs-comp-c0125',
       description: 'Baz',
     });
-    const pcrs4 = this.server.create('aamcPcrs', {
+    const pcrs4 = this.server.create('aamc-pcrs', {
       id: 'aamc-pcrs-comp-c0033',
       description: 'Fiz',
     });
-    const pcrs5 = this.server.create('aamcPcrs', {
+    const pcrs5 = this.server.create('aamc-pcrs', {
       id: 'aamc-pcrs-comp-c1522',
       description: 'Far',
     });
-    this.pcrs1 = await this.owner.lookup('service:store').findRecord('aamcPcrs', pcrs1.id);
-    this.pcrs2 = await this.owner.lookup('service:store').findRecord('aamcPcrs', pcrs2.id);
-    this.pcrs3 = await this.owner.lookup('service:store').findRecord('aamcPcrs', pcrs3.id);
-    this.pcrs4 = await this.owner.lookup('service:store').findRecord('aamcPcrs', pcrs4.id);
-    this.pcrs5 = await this.owner.lookup('service:store').findRecord('aamcPcrs', pcrs5.id);
+    this.pcrs1 = await this.owner.lookup('service:store').findRecord('aamc-pcrs', pcrs1.id);
+    this.pcrs2 = await this.owner.lookup('service:store').findRecord('aamc-pcrs', pcrs2.id);
+    this.pcrs3 = await this.owner.lookup('service:store').findRecord('aamc-pcrs', pcrs3.id);
+    this.pcrs4 = await this.owner.lookup('service:store').findRecord('aamc-pcrs', pcrs4.id);
+    this.pcrs5 = await this.owner.lookup('service:store').findRecord('aamc-pcrs', pcrs5.id);
     this.allPcrses = [this.pcrs1, this.pcrs2, this.pcrs3, this.pcrs4, this.pcrs5];
   });
 

--- a/packages/frontend/tests/integration/components/school-manager-test.js
+++ b/packages/frontend/tests/integration/components/school-manager-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | school manager', function (hooks) {
     this.server.create('user', { school, administeredSchools: [school] });
     this.server.create('user', { school, administeredSchools: [school] });
     this.server.createList('vocabulary', 2, { school });
-    this.server.createList('sessionType', 2, { school });
+    this.server.createList('session-type', 2, { school });
     this.server.createList('competency', 2, { school });
     this.store = this.owner.lookup('service:store');
     this.school = await this.store.findRecord('school', school.id);

--- a/packages/frontend/tests/integration/components/school/session-type-visualize-vocabularies-test.js
+++ b/packages/frontend/tests/integration/components/school/session-type-visualize-vocabularies-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | school/session-type-visualize-vocabularies', f
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
-    const sessionType = this.server.create('sessionType', { school });
+    const sessionType = this.server.create('session-type', { school });
     const vocabularies = this.server.createList('vocabulary', 2, { school });
     const termsVocab1 = this.server.createList('term', 5, {
       vocabulary: vocabularies[0],
@@ -25,7 +25,7 @@ module('Integration | Component | school/session-type-visualize-vocabularies', f
 
     this.sessionType = await this.owner
       .lookup('service:store')
-      .findRecord('sessionType', sessionType.id);
+      .findRecord('session-type', sessionType.id);
   });
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/school/session-type-visualize-vocabulary-test.js
+++ b/packages/frontend/tests/integration/components/school/session-type-visualize-vocabulary-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | school/session-type-visualize-vocabulary', fun
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
-    const sessionType = this.server.create('sessionType', { school });
+    const sessionType = this.server.create('session-type', { school });
     const vocabulary = this.server.create('vocabulary', { school });
     const terms = this.server.createList('term', 5, { vocabulary });
     this.server.create('session', { course, sessionType, terms: [terms[0], terms[1]] });
@@ -26,7 +26,7 @@ module('Integration | Component | school/session-type-visualize-vocabulary', fun
       .findRecord('vocabulary', vocabulary.id);
     this.sessionType = await this.owner
       .lookup('service:store')
-      .findRecord('sessionType', sessionType.id);
+      .findRecord('session-type', sessionType.id);
   });
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/user-profile-permissions-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-permissions-test.js
@@ -236,7 +236,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
     const session = this.server.create('session', {
       course,
     });
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       session,
       instructors: [user],
     });
@@ -320,7 +320,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       administrators: [user],
       studentAdvisors: [user],
     });
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       session,
       instructors: [user],
     });
@@ -430,7 +430,7 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
       administrators: [user],
       studentAdvisors: [user],
     });
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       session,
       instructors: [user],
     });

--- a/packages/frontend/tests/integration/components/user-profile-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | user-profile', function (hooks) {
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    this.programYear = this.server.create('programYear', { program });
+    this.programYear = this.server.create('program-year', { program });
     this.cohort = this.server.create('cohort', { programYear: this.programYear });
 
     const user = this.server.create('user', { school });

--- a/packages/frontend/tests/integration/components/user-profile/learner-group-test.js
+++ b/packages/frontend/tests/integration/components/user-profile/learner-group-test.js
@@ -13,14 +13,14 @@ module('Integration | Component | user-profile/learner-group', function (hooks) 
     const program = this.server.create('program', {
       school,
     });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program,
       archived: false,
     });
     const cohort = this.server.create('cohort', {
       programYear,
     });
-    const learnerGroup = this.server.create('learnerGroup', {
+    const learnerGroup = this.server.create('learner-group', {
       cohort,
     });
     const model = await this.owner

--- a/packages/frontend/tests/integration/components/user-profile/learner-groups-test.js
+++ b/packages/frontend/tests/integration/components/user-profile/learner-groups-test.js
@@ -24,11 +24,11 @@ module('Integration | Component | user-profile/learner-groups', function (hooks)
       title: 'Program2',
       school: sod,
     });
-    const programYear1 = this.server.create('programYear', {
+    const programYear1 = this.server.create('program-year', {
       program: program1,
       archived: false,
     });
-    const programYear2 = this.server.create('programYear', {
+    const programYear2 = this.server.create('program-year', {
       program: program2,
       archived: false,
     });
@@ -40,11 +40,11 @@ module('Integration | Component | user-profile/learner-groups', function (hooks)
       title: 'Cohort2',
       programYear: programYear2,
     });
-    const learnerGroup1 = this.server.create('learnerGroup', {
+    const learnerGroup1 = this.server.create('learner-group', {
       title: 'LearnerGroup1',
       cohort: cohort1,
     });
-    const learnerGroup2 = this.server.create('learnerGroup', {
+    const learnerGroup2 = this.server.create('learner-group', {
       title: 'LearnerGroup2',
       cohort: cohort2,
     });

--- a/packages/ilios-common/addon/classes/events-base.js
+++ b/packages/ilios-common/addon/classes/events-base.js
@@ -14,7 +14,7 @@ export default class EventsBase extends Service {
     if (event.offering) {
       intermediary = await this.store.findRecord('offering', event.offering);
     } else {
-      intermediary = await this.store.findRecord('ilmSession', event.ilmSession);
+      intermediary = await this.store.findRecord('ilm-session', event.ilmSession);
     }
     return await intermediary.get('session');
   }

--- a/packages/ilios-common/addon/components/learningmaterial-search.js
+++ b/packages/ilios-common/addon/components/learningmaterial-search.js
@@ -25,7 +25,7 @@ export default class LearningMaterialSearchComponent extends Component {
     }
     this.searchReturned = false;
     this.query = query;
-    const results = await this.store.query('learningMaterial', {
+    const results = await this.store.query('learning-material', {
       q: query,
       limit: this.searchResultsPerPage + 1,
       'order_by[title]': 'ASC',
@@ -53,7 +53,7 @@ export default class LearningMaterialSearchComponent extends Component {
   }
 
   searchMore = dropTask(async () => {
-    const results = await this.store.query('learningMaterial', {
+    const results = await this.store.query('learning-material', {
       q: this.query,
       limit: this.searchResultsPerPage + 1,
       offset: this.searchPage * this.searchResultsPerPage,

--- a/packages/ilios-common/addon/components/new-learningmaterial.js
+++ b/packages/ilios-common/addon/components/new-learningmaterial.js
@@ -102,7 +102,7 @@ export default class NewLearningmaterialComponent extends Component {
       return false;
     }
     const owningUser = await this.currentUser.getModel();
-    const learningMaterial = this.store.createRecord('learningMaterial', {
+    const learningMaterial = this.store.createRecord('learning-material', {
       title: this.title,
       status: this.selectedStatus,
       userRole: this.selectedUserRole,

--- a/packages/ilios-common/addon/components/session-copy.js
+++ b/packages/ilios-common/addon/components/session-copy.js
@@ -24,7 +24,7 @@ export default class SessionCopyComponent extends Component {
     const course = await session.course;
     const school = await course.school;
     const { years, schoolCourses } = await hash({
-      years: this.store.findAll('academicYear'),
+      years: this.store.findAll('academic-year'),
       schoolCourses: this.store.query('course', {
         filters: {
           school: school.id,
@@ -121,7 +121,7 @@ export default class SessionCopyComponent extends Component {
       const learningMaterialToCopy = learningMaterialsToCopy.slice()[i];
       const lm = await learningMaterialToCopy.learningMaterial;
       const learningMaterial = this.store.createRecord(
-        'sessionLearningMaterial',
+        'session-learning-material',
         learningMaterialToCopy.getProperties('notes', 'required', 'publicNotes', 'position'),
       );
       learningMaterial.set('learningMaterial', lm);

--- a/packages/ilios-common/addon/models/course-learning-material.js
+++ b/packages/ilios-common/addon/models/course-learning-material.js
@@ -25,6 +25,6 @@ export default class CourseLearningMaterial extends Model {
   @belongsTo('learning-material', { async: true, inverse: 'courseLearningMaterials' })
   learningMaterial;
 
-  @hasMany('mesh-descriptors', { async: true, inverse: 'courseLearningMaterials' })
+  @hasMany('mesh-descriptor', { async: true, inverse: 'courseLearningMaterials' })
   meshDescriptors;
 }

--- a/packages/ilios-common/addon/models/school.js
+++ b/packages/ilios-common/addon/models/school.js
@@ -12,7 +12,7 @@ export default class School extends Model {
   iliosAdministratorEmail;
   @attr('string')
   changeAlertRecipients;
-  @hasMany('competencies', { async: true, inverse: 'school' })
+  @hasMany('competency', { async: true, inverse: 'school' })
   competencies;
   @hasMany('course', { async: true, inverse: 'school' })
   courses;

--- a/packages/ilios-common/addon/models/session-learning-material.js
+++ b/packages/ilios-common/addon/models/session-learning-material.js
@@ -25,6 +25,6 @@ export default class SessionLearningMaterial extends Model {
   @belongsTo('learning-material', { async: true, inverse: 'sessionLearningMaterials' })
   learningMaterial;
 
-  @hasMany('mesh-descriptors', { async: true, inverse: 'sessionLearningMaterials' })
+  @hasMany('mesh-descriptor', { async: true, inverse: 'sessionLearningMaterials' })
   meshDescriptors;
 }

--- a/packages/ilios-common/addon/models/term.js
+++ b/packages/ilios-common/addon/models/term.js
@@ -18,7 +18,7 @@ export default class Term extends Model {
   @hasMany('term', { inverse: 'parent', async: true })
   children;
 
-  @hasMany('programYear', { async: true, inverse: 'terms' })
+  @hasMany('program-year', { async: true, inverse: 'terms' })
   programYears;
 
   @hasMany('session', { async: true, inverse: 'terms' })
@@ -27,7 +27,7 @@ export default class Term extends Model {
   @hasMany('course', { async: true, inverse: 'terms' })
   courses;
 
-  @hasMany('aamcResourceType', { async: true, inverse: null })
+  @hasMany('aamc-resource-type', { async: true, inverse: null })
   aamcResourceTypes;
 
   @attr('boolean')

--- a/packages/lti-course-manager/app/deprecation-workflow.js
+++ b/packages/lti-course-manager/app/deprecation-workflow.js
@@ -6,7 +6,6 @@ const SHOULD_THROW = config.environment !== 'production';
 const SILENCED_DEPRECATIONS = [
   // Add ids of deprecations we temporarily want to silence here.
   'ember-data:deprecate-legacy-imports',
-  'ember-data:deprecate-non-strict-types',
   'ember-data:deprecate-many-array-duplicates',
 ];
 

--- a/packages/lti-dashboard/app/deprecation-workflow.js
+++ b/packages/lti-dashboard/app/deprecation-workflow.js
@@ -6,7 +6,6 @@ const SHOULD_THROW = config.environment !== 'production';
 const SILENCED_DEPRECATIONS = [
   // Add ids of deprecations we temporarily want to silence here.
   'ember-data:deprecate-legacy-imports',
-  'ember-data:deprecate-non-strict-types',
   'ember-data:deprecate-many-array-duplicates',
 ];
 

--- a/packages/test-app/app/deprecation-workflow.js
+++ b/packages/test-app/app/deprecation-workflow.js
@@ -6,7 +6,6 @@ const SHOULD_THROW = config.environment !== 'production';
 const SILENCED_DEPRECATIONS = [
   // Add ids of deprecations we temporarily want to silence here.
   'ember-data:deprecate-legacy-imports',
-  'ember-data:deprecate-non-strict-types',
   'ember-data:deprecate-non-strict-id',
   'ember-data:deprecate-non-unique-relationship-entries',
   'ember-data:deprecate-many-array-duplicates',

--- a/packages/test-app/tests/integration/components/collapsed-competencies-test.js
+++ b/packages/test-app/tests/integration/components/collapsed-competencies-test.js
@@ -15,34 +15,34 @@ module('Integration | Component | collapsed competencies', function (hooks) {
     const competencyA = this.server.create('competency', { school: schoolA });
     const competencyB = this.server.create('competency', { school: schoolB });
     const competencyC = this.server.create('competency', { school: schoolB });
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       competencies: [
         ...this.server.createList('competency', 2, { school: schoolB }),
         ...this.server.createList('competency', 3, { school: schoolA }),
       ],
     });
-    const pyObjectiveA = this.server.create('programYearObjective', {
+    const pyObjectiveA = this.server.create('program-year-objective', {
       programYear,
       competency: competencyA,
     });
-    const pyObjectiveB = this.server.create('programYearObjective', {
+    const pyObjectiveB = this.server.create('program-year-objective', {
       programYear,
       competency: competencyB,
     });
-    const pyObjectiveC = this.server.create('programYearObjective', {
+    const pyObjectiveC = this.server.create('program-year-objective', {
       programYear,
       competency: competencyC,
     });
     const course = this.server.create('course');
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [pyObjectiveA, pyObjectiveC],
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [pyObjectiveB],
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [pyObjectiveC],
     });

--- a/packages/test-app/tests/integration/components/course/manage-objective-descriptors-test.js
+++ b/packages/test-app/tests/integration/components/course/manage-objective-descriptors-test.js
@@ -10,10 +10,10 @@ module('Integration | Component | course/manage-objective-descriptors', function
   setupMirage(hooks);
 
   test('it renders', async function (assert) {
-    const descriptors = this.server.createList('meshDescriptor', 4);
+    const descriptors = this.server.createList('mesh-descriptor', 4);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', descriptors[0].id);
+      .findRecord('mesh-descriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     await render(hbs`<Course::ManageObjectiveDescriptors
       @selected={{this.selected}}
@@ -40,10 +40,10 @@ module('Integration | Component | course/manage-objective-descriptors', function
 
   test('add works', async function (assert) {
     assert.expect(16);
-    const descriptors = this.server.createList('meshDescriptor', 2);
+    const descriptors = this.server.createList('mesh-descriptor', 2);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', descriptors[0].id);
+      .findRecord('mesh-descriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     this.set('add', (descriptor) => {
       this.set('selected', [descriptorModel, descriptor]);
@@ -80,10 +80,10 @@ module('Integration | Component | course/manage-objective-descriptors', function
 
   test('remove works', async function (assert) {
     assert.expect(15);
-    const descriptors = this.server.createList('meshDescriptor', 2);
+    const descriptors = this.server.createList('mesh-descriptor', 2);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', descriptors[0].id);
+      .findRecord('mesh-descriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     this.set('remove', (descriptor) => {
       assert.strictEqual(descriptor.id, descriptorModel.id);

--- a/packages/test-app/tests/integration/components/course/manage-objective-parents-test.js
+++ b/packages/test-app/tests/integration/components/course/manage-objective-parents-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | course/manage-objective-parents', function (ho
   setupMirage(hooks);
 
   test('it renders and is accessible with a single cohort', async function (assert) {
-    const programYearObjective = this.server.create('programYearObjective');
+    const programYearObjective = this.server.create('program-year-objective');
     const cohortObjectives = [
       {
         title: 'cohort 0',
@@ -56,7 +56,7 @@ module('Integration | Component | course/manage-objective-parents', function (ho
   });
 
   test('it renders and is accessible with multiple cohorts', async function (assert) {
-    const programYearObjective = this.server.create('programYearObjective');
+    const programYearObjective = this.server.create('program-year-objective');
     const cohortObjectives = [
       {
         title: 'cohort 0',
@@ -118,11 +118,11 @@ module('Integration | Component | course/manage-objective-parents', function (ho
   });
 
   test('inactive parents are hidden unless they are selected', async function (assert) {
-    const activeProgramYearObjective = this.server.create('programYearObjective');
-    const inactiveProgramYearObjective = this.server.create('programYearObjective', {
+    const activeProgramYearObjective = this.server.create('program-year-objective');
+    const inactiveProgramYearObjective = this.server.create('program-year-objective', {
       active: false,
     });
-    const inactiveSelectedProgramYearObjective = this.server.create('programYearObjective', {
+    const inactiveSelectedProgramYearObjective = this.server.create('program-year-objective', {
       active: false,
     });
 

--- a/packages/test-app/tests/integration/components/course/objective-list-item-descriptors-test.js
+++ b/packages/test-app/tests/integration/components/course/objective-list-item-descriptors-test.js
@@ -11,13 +11,13 @@ module('Integration | Component | course/objective-list-item-descriptors', funct
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const meshDescriptors = this.server.createList('meshDescriptor', 2);
+    const meshDescriptors = this.server.createList('mesh-descriptor', 2);
     this.meshDescriptor1 = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', meshDescriptors[0].id);
+      .findRecord('mesh-descriptor', meshDescriptors[0].id);
     this.meshDescriptor2 = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', meshDescriptors[1].id);
+      .findRecord('mesh-descriptor', meshDescriptors[1].id);
   });
 
   test('it renders and is accessible when managing', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/objective-list-item-parents-test.js
+++ b/packages/test-app/tests/integration/components/course/objective-list-item-parents-test.js
@@ -11,16 +11,16 @@ module('Integration | Component | course/objective-list-item-parents', function 
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const programYearObjective1 = this.server.create('programYearObjective', {
+    const programYearObjective1 = this.server.create('program-year-objective', {
       title: '<p>Country &amp; Western</p>',
     });
-    const programYearObjective2 = this.server.create('programYearObjective');
+    const programYearObjective2 = this.server.create('program-year-objective');
     this.programYearObjective1 = await this.owner
       .lookup('service:store')
-      .findRecord('programYearObjective', programYearObjective1.id);
+      .findRecord('program-year-objective', programYearObjective1.id);
     this.programYearObjective2 = await this.owner
       .lookup('service:store')
-      .findRecord('programYearObjective', programYearObjective2.id);
+      .findRecord('program-year-objective', programYearObjective2.id);
   });
 
   test('it renders and is accessible when managing', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/objective-list-item-test.js
+++ b/packages/test-app/tests/integration/components/course/objective-list-item-test.js
@@ -13,10 +13,10 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
   test('it renders and is accessible', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
-    const courseObjective = this.server.create('courseObjective', { course });
+    const courseObjective = this.server.create('course-objective', { course });
     const store = this.owner.lookup('service:store');
     const courseModel = await store.findRecord('course', course.id);
-    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
+    const courseObjectiveModel = await store.findRecord('course-objective', courseObjective.id);
     this.set('course', courseModel);
     this.set('courseObjective', courseObjectiveModel);
     await render(
@@ -40,10 +40,10 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
   test('can change title', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
-    const courseObjective = this.server.create('courseObjective', { course });
+    const courseObjective = this.server.create('course-objective', { course });
     const store = this.owner.lookup('service:store');
     const courseModel = await store.findRecord('course', course.id);
-    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
+    const courseObjectiveModel = await store.findRecord('course-objective', courseObjective.id);
     this.set('course', courseModel);
     this.set('courseObjective', courseObjectiveModel);
     await render(
@@ -66,10 +66,10 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
   test('can manage parents', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
-    const courseObjective = this.server.create('courseObjective', { course });
+    const courseObjective = this.server.create('course-objective', { course });
     const store = this.owner.lookup('service:store');
     const courseModel = await store.findRecord('course', course.id);
-    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
+    const courseObjectiveModel = await store.findRecord('course-objective', courseObjective.id);
     this.set('course', courseModel);
     this.set('courseObjective', courseObjectiveModel);
     await render(
@@ -88,10 +88,10 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
   test('can manage descriptors', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
-    const courseObjective = this.server.create('courseObjective', { course });
+    const courseObjective = this.server.create('course-objective', { course });
     const store = this.owner.lookup('service:store');
     const courseModel = await store.findRecord('course', course.id);
-    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
+    const courseObjectiveModel = await store.findRecord('course-objective', courseObjective.id);
     this.set('course', courseModel);
     this.set('courseObjective', courseObjectiveModel);
     await render(
@@ -110,10 +110,10 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
   test('can manage terms', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
-    const courseObjective = this.server.create('courseObjective', { course });
+    const courseObjective = this.server.create('course-objective', { course });
     const store = this.owner.lookup('service:store');
     const courseModel = await store.findRecord('course', course.id);
-    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
+    const courseObjectiveModel = await store.findRecord('course-objective', courseObjective.id);
     this.set('courseObjective', courseObjectiveModel);
     this.set('course', courseModel);
     await render(
@@ -133,10 +133,10 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
   test('can trigger removal', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
-    const courseObjective = this.server.create('courseObjective', { course });
+    const courseObjective = this.server.create('course-objective', { course });
     const store = this.owner.lookup('service:store');
     const courseModel = await store.findRecord('course', course.id);
-    const courseObjectiveModel = await store.findRecord('courseObjective', courseObjective.id);
+    const courseObjectiveModel = await store.findRecord('course-objective', courseObjective.id);
     this.set('course', courseModel);
     this.set('courseObjective', courseObjectiveModel);
     await render(

--- a/packages/test-app/tests/integration/components/course/objectives-test.js
+++ b/packages/test-app/tests/integration/components/course/objectives-test.js
@@ -13,23 +13,23 @@ module('Integration | Component | course/objectives', function (hooks) {
   test('it renders and is accessible with a single cohort', async function (assert) {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
     const competencies = this.server.createList('competency', 2);
     const course = this.server.create('course', { cohorts: [cohort] });
-    const pyObjectives = this.server.createList('programYearObjective', 3, {
+    const pyObjectives = this.server.createList('program-year-objective', 3, {
       programYear,
       competency: competencies[0],
     });
-    this.server.createList('programYearObjective', 2, {
+    this.server.createList('program-year-objective', 2, {
       programYear,
       competency: competencies[1],
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [pyObjectives[0]],
     });
-    this.server.create('courseObjective', { course });
+    this.server.create('course-objective', { course });
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);
@@ -67,19 +67,19 @@ module('Integration | Component | course/objectives', function (hooks) {
   test('it loads data for a single cohort', async function (assert) {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
     const competencies = this.server.createList('competency', 2);
     const course = this.server.create('course', { cohorts: [cohort] });
-    const pyObjectives = this.server.createList('programYearObjective', 3, {
+    const pyObjectives = this.server.createList('program-year-objective', 3, {
       programYear,
       competency: competencies[0],
     });
-    this.server.createList('programYearObjective', 2, {
+    this.server.createList('program-year-objective', 2, {
       programYear,
       competency: competencies[1],
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [pyObjectives[0]],
     });
@@ -133,30 +133,30 @@ module('Integration | Component | course/objectives', function (hooks) {
   test('it loads data for multiple cohorts', async function (assert) {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear1 = this.server.create('programYear', { program });
+    const programYear1 = this.server.create('program-year', { program });
     const cohort1 = this.server.create('cohort', { programYear: programYear1 });
-    const programYear2 = this.server.create('programYear', { program });
+    const programYear2 = this.server.create('program-year', { program });
     const cohort2 = this.server.create('cohort', { programYear: programYear2 });
     const competencies = this.server.createList('competency', 2);
     const course = this.server.create('course', {
       cohorts: [cohort1, cohort2],
     });
-    const pyObjectives1 = this.server.createList('programYearObjective', 2, {
+    const pyObjectives1 = this.server.createList('program-year-objective', 2, {
       competency: competencies[0],
       programYear: programYear1,
     });
-    this.server.createList('programYearObjective', 2, {
+    this.server.createList('program-year-objective', 2, {
       competency: competencies[1],
       programYear: programYear2,
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [pyObjectives1[0]],
     });
-    this.server.createList('programYearObjective', 2, {
+    this.server.createList('program-year-objective', 2, {
       competency: competencies[0],
     });
-    this.server.createList('programYearObjective', 4, {
+    this.server.createList('program-year-objective', 4, {
       competency: competencies[1],
     });
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
@@ -210,7 +210,7 @@ module('Integration | Component | course/objectives', function (hooks) {
 
   test('deleting objective', async function (assert) {
     const course = this.server.create('course');
-    this.server.create('courseObjective', { course });
+    this.server.create('course-objective', { course });
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
 
     this.set('course', courseModel);

--- a/packages/test-app/tests/integration/components/course/publicationcheck-test.js
+++ b/packages/test-app/tests/integration/components/course/publicationcheck-test.js
@@ -10,13 +10,13 @@ module('Integration | Component | course/publicationcheck', function (hooks) {
   setupMirage(hooks);
 
   test('it shows unlink icon', async function (assert) {
-    const programYearObjective = this.server.create('programYearObjective');
+    const programYearObjective = this.server.create('program-year-objective');
     const course = this.server.create('course');
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [programYearObjective],
     });
-    this.server.create('courseObjective', { course });
+    this.server.create('course-objective', { course });
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('model', courseModel);
     await render(hbs`<Course::Publicationcheck @course={{this.model}} />
@@ -25,13 +25,13 @@ module('Integration | Component | course/publicationcheck', function (hooks) {
   });
 
   test('it does not shows unlink icon', async function (assert) {
-    const programYearObjective = this.server.create('programYearObjective');
+    const programYearObjective = this.server.create('program-year-objective');
     const course = this.server.create('course');
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [programYearObjective],
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       course,
       programYearObjectives: [programYearObjective],
     });

--- a/packages/test-app/tests/integration/components/course/rollover-test.js
+++ b/packages/test-app/tests/integration/components/course/rollover-test.js
@@ -506,7 +506,7 @@ module('Integration | Component | course/rollover', function (hooks) {
       school,
     });
     const startYear = new Date().getFullYear();
-    const programYear = this.server.create('programYear', {
+    const programYear = this.server.create('program-year', {
       program,
       published: true,
       archived: false,

--- a/packages/test-app/tests/integration/components/course/sessions-test.js
+++ b/packages/test-app/tests/integration/components/course/sessions-test.js
@@ -44,7 +44,7 @@ module('Integration | Component | course/sessions', function (hooks) {
   test('expand/collapse all session not visible if no session with offerings in list', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
-    const sessionType = this.server.create('sessionType', { school });
+    const sessionType = this.server.create('session-type', { school });
     this.server.createList('session', 2, { course, sessionType });
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
@@ -64,7 +64,7 @@ module('Integration | Component | course/sessions', function (hooks) {
   test('expand/collapse all session is visible if at least one session in list has offerings', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
-    const sessionType = this.server.create('sessionType', { school });
+    const sessionType = this.server.create('session-type', { school });
     const sessions = this.server.createList('session', 2, { course, sessionType });
     this.server.create('offering', {
       session: sessions[0],

--- a/packages/test-app/tests/integration/components/course/visualize-instructor-test.js
+++ b/packages/test-app/tests/integration/components/course/visualize-instructor-test.js
@@ -92,8 +92,8 @@ module('Integration | Component | course/visualize-instructor', function (hooks)
     const term3 = this.server.create('term', {
       vocabulary: vocabulary2,
     });
-    const sessionType1 = this.server.create('sessionType');
-    const sessionType2 = this.server.create('sessionType');
+    const sessionType1 = this.server.create('session-type');
+    const sessionType2 = this.server.create('session-type');
     const session1 = this.server.create('session', {
       sessionType: sessionType1,
       terms: [term1],
@@ -103,12 +103,12 @@ module('Integration | Component | course/visualize-instructor', function (hooks)
       terms: [term2, term3],
     });
     const session3 = this.server.create('session');
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       session: session3,
       hours: 2,
       instructors: [instructor],
     });
-    const instructorGroup1 = this.server.create('instructorGroup', {
+    const instructorGroup1 = this.server.create('instructor-group', {
       users: [instructor],
     });
     this.server.create('offering', {

--- a/packages/test-app/tests/integration/components/course/visualize-objectives-graph-test.js
+++ b/packages/test-app/tests/integration/components/course/visualize-objectives-graph-test.js
@@ -12,27 +12,27 @@ module('Integration | Component | course/visualize-objectives-graph', function (
   hooks.beforeEach(async function () {
     const course = this.server.create('course');
     const competencies = this.server.createList('competency', 3);
-    const programYearObjective1 = this.server.create('programYearObjective', {
+    const programYearObjective1 = this.server.create('program-year-objective', {
       competency: competencies[0],
     });
-    const programYearObjective2 = this.server.create('programYearObjective', {
+    const programYearObjective2 = this.server.create('program-year-objective', {
       competency: competencies[1],
     });
-    const programYearObjective3 = this.server.create('programYearObjective', {
+    const programYearObjective3 = this.server.create('program-year-objective', {
       competency: competencies[2],
     });
-    const programYearObjective4 = this.server.create('programYearObjective', {
+    const programYearObjective4 = this.server.create('program-year-objective', {
       competency: competencies[1],
     });
-    const courseObjective1 = this.server.create('courseObjective', {
+    const courseObjective1 = this.server.create('course-objective', {
       course,
       programYearObjectives: [programYearObjective1, programYearObjective2, programYearObjective4],
     });
-    const courseObjective2 = this.server.create('courseObjective', {
+    const courseObjective2 = this.server.create('course-objective', {
       course,
       programYearObjectives: [programYearObjective2],
     });
-    const courseObjective3 = this.server.create('courseObjective', {
+    const courseObjective3 = this.server.create('course-objective', {
       course,
       programYearObjectives: [programYearObjective3],
     });
@@ -48,15 +48,15 @@ module('Integration | Component | course/visualize-objectives-graph', function (
       title: 'Empty Session',
       course,
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session1,
       courseObjectives: [courseObjective1],
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session2,
       courseObjectives: [courseObjective2],
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session3,
       courseObjectives: [courseObjective3],
     });
@@ -240,13 +240,13 @@ module('Integration | Component | course/visualize-objectives-graph', function (
       title: 'Empty Session',
       course,
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session1,
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session2,
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session3,
     });
     this.server.create('offering', {
@@ -282,8 +282,8 @@ module('Integration | Component | course/visualize-objectives-graph', function (
   // See https://github.com/ilios/ilios/issues/5305
   test('a course without mapped course objectives shows 0 percent for each objective in the data table', async function (assert) {
     const course = this.server.create('course');
-    this.server.create('courseObjective', { course });
-    this.server.create('courseObjective', { course });
+    this.server.create('course-objective', { course });
+    this.server.create('course-objective', { course });
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
     await render(

--- a/packages/test-app/tests/integration/components/course/visualize-objectives-test.js
+++ b/packages/test-app/tests/integration/components/course/visualize-objectives-test.js
@@ -59,7 +59,7 @@ module('Integration | Component | course/visualize-objectives', function (hooks)
   test('chart', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
-    const courseObjectives = this.server.createList('courseObjective', 3, {
+    const courseObjectives = this.server.createList('course-objective', 3, {
       course,
     });
     const session1 = this.server.create('session', {
@@ -74,15 +74,15 @@ module('Integration | Component | course/visualize-objectives', function (hooks)
       title: 'Empty Session',
       course,
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session1,
       courseObjectives: [courseObjectives[0]],
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session2,
       courseObjectives: [courseObjectives[1]],
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: session3,
       courseObjectives: [courseObjectives[2]],
     });

--- a/packages/test-app/tests/integration/components/course/visualize-session-type-test.js
+++ b/packages/test-app/tests/integration/components/course/visualize-session-type-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | course/visualize-session-type', function (hook
     const school = this.server.create('school');
     const course = this.server.create('course', { year: 2021, school });
     const session = this.server.create('session', { course });
-    const sessionType = this.server.create('sessionType', { school, sessions: [session] });
+    const sessionType = this.server.create('session-type', { school, sessions: [session] });
     this.sessionTypeModel = await this.owner
       .lookup('service:store')
       .findRecord('session-type', sessionType.id);

--- a/packages/test-app/tests/integration/components/course/visualize-vocabulary-test.js
+++ b/packages/test-app/tests/integration/components/course/visualize-vocabulary-test.js
@@ -23,7 +23,7 @@ module('Integration | Component | course/visualize-vocabulary', function (hooks)
       course,
       terms: [term2],
     });
-    this.server.create('ilmSession', {
+    this.server.create('ilm-session', {
       session: session1,
       hours: 2.5,
     });

--- a/packages/test-app/tests/integration/components/detail-learners-and-learnergroups-test.js
+++ b/packages/test-app/tests/integration/components/detail-learners-and-learnergroups-test.js
@@ -53,7 +53,7 @@ module('Integration | Component | detail-learners-and-learner-groups', function 
     const session = this.server.create('session', {
       course,
     });
-    const ilmSession = this.server.create('ilmSession', {
+    const ilmSession = this.server.create('ilm-session', {
       session,
       learners: [learners[0], learners[1], learners[2]],
       learnerGroups: [secondLevelLearnerGroup1, secondLevelLearnerGroup2, topLevelLearnerGroup3],
@@ -82,7 +82,7 @@ module('Integration | Component | detail-learners-and-learner-groups', function 
     this.learner3 = await store.findRecord('user', learners[2].id);
     this.learner4 = await store.findRecord('user', learners[3].id);
     this.session = await store.findRecord('session', session.id);
-    this.ilmSession = await store.findRecord('ilmSession', ilmSession.id);
+    this.ilmSession = await store.findRecord('ilm-session', ilmSession.id);
   });
 
   test('it renders', async function (assert) {

--- a/packages/test-app/tests/integration/components/instructor-selection-manager-test.js
+++ b/packages/test-app/tests/integration/components/instructor-selection-manager-test.js
@@ -23,15 +23,15 @@ module('Integration | Component | instructor selection manager', function (hooks
     const instructor3 = this.server.create('user', {
       displayName: 'Aardvark',
     });
-    const group1 = this.server.create('instructorGroup', {
+    const group1 = this.server.create('instructor-group', {
       users: [instructor1],
       title: 'Beta',
     });
-    const group2 = this.server.create('instructorGroup', {
+    const group2 = this.server.create('instructor-group', {
       users: [instructor2, instructor3],
       title: 'Alpha',
     });
-    const group3 = this.server.create('instructorGroup', { title: 'Gamma' });
+    const group3 = this.server.create('instructor-group', { title: 'Gamma' });
     this.instructor1 = await this.owner.lookup('service:store').findRecord('user', instructor1.id);
     this.instructor2 = await this.owner.lookup('service:store').findRecord('user', instructor2.id);
     this.instructor3 = await this.owner.lookup('service:store').findRecord('user', instructor3.id);

--- a/packages/test-app/tests/integration/components/leadership-expanded-test.js
+++ b/packages/test-app/tests/integration/components/leadership-expanded-test.js
@@ -330,13 +330,13 @@ module('Integration | Component | leadership expanded', function (hooks) {
         lastName: 'person',
       });
       const program = this.server.create('program');
-      const programYear = this.server.create('programYear', {
+      const programYear = this.server.create('program-year', {
         directors: [user1, user2],
         program,
       });
       const programYearModel = await this.owner
         .lookup('service:store')
-        .findRecord('programYear', programYear.id);
+        .findRecord('program-year', programYear.id);
       this.set('programYear', programYearModel);
       await render(hbs`<LeadershipExpanded
       @model={{this.programYear}}
@@ -355,12 +355,12 @@ module('Integration | Component | leadership expanded', function (hooks) {
     test('clicking the header collapses', async function (assert) {
       assert.expect(1);
       const program = this.server.create('program');
-      const programYear = this.server.create('programYear', {
+      const programYear = this.server.create('program-year', {
         program,
       });
       const programYearModel = await this.owner
         .lookup('service:store')
-        .findRecord('programYear', programYear.id);
+        .findRecord('program-year', programYear.id);
       this.set('programYear', programYearModel);
       this.set('click', () => {
         assert.ok(true, 'Action was fired');
@@ -379,12 +379,12 @@ module('Integration | Component | leadership expanded', function (hooks) {
     test('clicking manage fires action', async function (assert) {
       assert.expect(1);
       const program = this.server.create('program');
-      const programYear = this.server.create('programYear', {
+      const programYear = this.server.create('program-year', {
         program,
       });
       const programYearModel = await this.owner
         .lookup('service:store')
-        .findRecord('programYear', programYear.id);
+        .findRecord('program-year', programYear.id);
       this.set('programYear', programYearModel);
       this.set('click', () => {
         assert.ok(true, 'Action was fired');

--- a/packages/test-app/tests/integration/components/mesh-manager-test.js
+++ b/packages/test-app/tests/integration/components/mesh-manager-test.js
@@ -21,14 +21,14 @@ module('Integration | Component | mesh-manager', function (hooks) {
 
   test('searching works', async function (assert) {
     assert.expect(15);
-    this.server.create('meshDescriptor', {
+    this.server.create('mesh-descriptor', {
       concepts: this.concepts,
       trees: this.trees,
     });
-    this.server.create('meshDescriptor', {
+    this.server.create('mesh-descriptor', {
       deleted: true,
     });
-    const descriptors = this.server.createList('meshDescriptor', 3);
+    const descriptors = this.server.createList('mesh-descriptor', 3);
 
     this.set('terms', [descriptors[0], descriptors[2]]);
     await render(hbs`<MeshManager
@@ -58,7 +58,7 @@ module('Integration | Component | mesh-manager', function (hooks) {
 
   test('searching with more than 50 results', async function (assert) {
     assert.expect(153);
-    this.server.createList('meshDescriptor', 200);
+    this.server.createList('mesh-descriptor', 200);
     await render(hbs`<MeshManager
       @editable={{true}}
       @terms={{(array)}}
@@ -82,7 +82,7 @@ module('Integration | Component | mesh-manager', function (hooks) {
 
   test('clicking on unselected term adds it.', async function (assert) {
     assert.expect(3);
-    const descriptors = this.server.createList('meshDescriptor', 3);
+    const descriptors = this.server.createList('mesh-descriptor', 3);
     this.set('add', (term) => {
       assert.strictEqual(term.name, 'descriptor 1');
     });
@@ -102,7 +102,7 @@ module('Integration | Component | mesh-manager', function (hooks) {
 
   test('clicking on selected term does not add it.', async function (assert) {
     assert.expect(1);
-    const descriptors = this.server.createList('meshDescriptor', 3);
+    const descriptors = this.server.createList('mesh-descriptor', 3);
     this.set('add', () => {
       // this function should never be invoked.
       assert.ok(false);
@@ -121,7 +121,7 @@ module('Integration | Component | mesh-manager', function (hooks) {
   });
 
   test('no terms', async function (assert) {
-    this.server.createList('meshDescriptor', 3);
+    this.server.createList('mesh-descriptor', 3);
     await render(hbs`<MeshManager @editable={{true}} @add={{(noop)}} @remove={{(noop)}} />
 `);
     await component.search.set('descriptor');
@@ -131,7 +131,7 @@ module('Integration | Component | mesh-manager', function (hooks) {
   });
 
   test('search term less than 3 characters', async function (assert) {
-    this.server.createList('meshDescriptor', 3);
+    this.server.createList('mesh-descriptor', 3);
     await render(hbs`<MeshManager @editable={{true}} @add={{(noop)}} @remove={{(noop)}} />
 `);
     await component.search.set('ab');
@@ -140,7 +140,7 @@ module('Integration | Component | mesh-manager', function (hooks) {
   });
 
   test('no search results', async function (assert) {
-    this.server.createList('meshDescriptor', 3);
+    this.server.createList('mesh-descriptor', 3);
     await render(hbs`<MeshManager @editable={{true}} @add={{(noop)}} @remove={{(noop)}} />
 `);
     await component.search.set('geflarknik');
@@ -149,7 +149,7 @@ module('Integration | Component | mesh-manager', function (hooks) {
   });
 
   test('clicking outside of search results dismissed them.', async function (assert) {
-    const descriptors = this.server.createList('meshDescriptor', 3);
+    const descriptors = this.server.createList('mesh-descriptor', 3);
     this.set('terms', [descriptors[0], descriptors[2]]);
     await render(hbs`<MeshManager
       @editable={{true}}

--- a/packages/test-app/tests/integration/components/new-session-test.js
+++ b/packages/test-app/tests/integration/components/new-session-test.js
@@ -10,8 +10,8 @@ module('Integration | Component | new session', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const sessionType = this.server.create('sessionType');
-    const sessionType2 = this.server.create('sessionType');
+    const sessionType = this.server.create('session-type');
+    const sessionType2 = this.server.create('session-type');
     this.sessionType = await this.owner
       .lookup('service:store')
       .findRecord('session-type', sessionType.id);

--- a/packages/test-app/tests/integration/components/objective-list-item-terms-test.js
+++ b/packages/test-app/tests/integration/components/objective-list-item-terms-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | objective-list-item-terms', function (hooks) {
     const term1 = this.server.create('term', { vocabulary: vocabulary1 });
     const term2 = this.server.create('term', { vocabulary: vocabulary1 });
     const term3 = this.server.create('term', { vocabulary: vocabulary2 });
-    const courseObjective = this.server.create('courseObjective', {
+    const courseObjective = this.server.create('course-objective', {
       course: this.course,
       terms: [term1, term2, term3],
     });
@@ -88,7 +88,7 @@ module('Integration | Component | objective-list-item-terms', function (hooks) {
 
   test('manage new', async function (assert) {
     assert.expect(1);
-    const courseObjective = this.server.create('courseObjective', {
+    const courseObjective = this.server.create('course-objective', {
       course: this.course,
     });
     const subject = await this.owner

--- a/packages/test-app/tests/integration/components/objective-sort-manager-test.js
+++ b/packages/test-app/tests/integration/components/objective-sort-manager-test.js
@@ -10,8 +10,8 @@ module('Integration | Component | objective sort manager', function (hooks) {
 
   test('it renders for session', async function (assert) {
     const session = this.server.create('session');
-    this.server.create('sessionObjective', { session, position: 1 });
-    this.server.create('sessionObjective', { session, position: 0 });
+    this.server.create('session-objective', { session, position: 1 });
+    this.server.create('session-objective', { session, position: 0 });
     const subject = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('subject', subject);
     await render(hbs`<ObjectiveSortManager @subject={{this.subject}} @close={{(noop)}} />
@@ -25,8 +25,8 @@ module('Integration | Component | objective sort manager', function (hooks) {
 
   test('it renders for course', async function (assert) {
     const course = this.server.create('course');
-    this.server.create('courseObjective', { course, position: 1 });
-    this.server.create('courseObjective', { course, position: 0 });
+    this.server.create('course-objective', { course, position: 1 });
+    this.server.create('course-objective', { course, position: 0 });
     const subject = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('subject', subject);
     await render(hbs`<ObjectiveSortManager @subject={{this.subject}} @close={{(noop)}} />
@@ -39,12 +39,12 @@ module('Integration | Component | objective sort manager', function (hooks) {
   });
 
   test('it renders for program-year', async function (assert) {
-    const programYear = this.server.create('programYear');
-    this.server.create('programYearObjective', { programYear, position: 1 });
-    this.server.create('programYearObjective', { programYear, position: 0 });
+    const programYear = this.server.create('program-year');
+    this.server.create('program-year-objective', { programYear, position: 1 });
+    this.server.create('program-year-objective', { programYear, position: 0 });
     const subject = await this.owner
       .lookup('service:store')
-      .findRecord('programYear', programYear.id);
+      .findRecord('program-year', programYear.id);
     this.set('subject', subject);
     await render(hbs`<ObjectiveSortManager @subject={{this.subject}} @close={{(noop)}} />
 `);

--- a/packages/test-app/tests/integration/components/offering-form-test.js
+++ b/packages/test-app/tests/integration/components/offering-form-test.js
@@ -658,11 +658,11 @@ module('Integration | Component | offering form', function (hooks) {
   test('learner groups sort order', async function (assert) {
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    this.server.create('learnerGroup', { cohort, title: 'Learner Group 1' });
-    this.server.create('learnerGroup', { cohort, title: 'Learner Group 10' });
-    this.server.create('learnerGroup', { cohort, title: 'Learner Group 2' });
+    this.server.create('learner-group', { cohort, title: 'Learner Group 1' });
+    this.server.create('learner-group', { cohort, title: 'Learner Group 10' });
+    this.server.create('learner-group', { cohort, title: 'Learner Group 2' });
 
     const cohortModel = await this.owner.lookup('service:store').findRecord('cohort', cohort.id);
     this.set('cohorts', [cohortModel]);

--- a/packages/test-app/tests/integration/components/publish-all-sessions-test.js
+++ b/packages/test-app/tests/integration/components/publish-all-sessions-test.js
@@ -10,13 +10,13 @@ module('Integration | Component | publish all sessions', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const programYearObjective = this.server.create('programYearObjective');
+    const programYearObjective = this.server.create('program-year-objective');
     const term = this.server.create('term');
-    const meshDescriptor = this.server.create('meshDescriptor');
-    const linkedCourseObjective = this.server.create('courseObjective', {
+    const meshDescriptor = this.server.create('mesh-descriptor');
+    const linkedCourseObjective = this.server.create('course-objective', {
       programYearObjectives: [programYearObjective],
     });
-    const unlinkedCourseObjective = this.server.create('courseObjective');
+    const unlinkedCourseObjective = this.server.create('course-objective');
     const unpublishableSession = this.server.create('session', {
       title: 'session 1',
       published: false,
@@ -38,11 +38,11 @@ module('Integration | Component | publish all sessions', function (hooks) {
       title: 'session 4',
       published: true,
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: completeSession,
       courseObjectives: [linkedCourseObjective],
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session: fullyPublishedByIncompleteSession,
     });
     this.server.create('offering', { session: publishableSession });
@@ -50,7 +50,7 @@ module('Integration | Component | publish all sessions', function (hooks) {
     this.server.create('offering', {
       session: fullyPublishedByIncompleteSession,
     });
-    this.server.create('sessionObjective', { session: completeSession });
+    this.server.create('session-objective', { session: completeSession });
     const course = this.server.create('course', {
       courseObjectives: [linkedCourseObjective, unlinkedCourseObjective],
       sessions: [

--- a/packages/test-app/tests/integration/components/session-copy-test.js
+++ b/packages/test-app/tests/integration/components/session-copy-test.js
@@ -110,9 +110,9 @@ module('Integration | Component | session copy', function (hooks) {
       learningMaterials: [sessionLearningMaterial],
     });
 
-    const courseObjective = this.server.create('courseObjective');
+    const courseObjective = this.server.create('course-objective');
     const objectiveTerm = this.server.create('term');
-    const sessionObjective = this.server.create('sessionObjective', {
+    const sessionObjective = this.server.create('session-objective', {
       session,
       title: 'session objective title',
       courseObjectives: [courseObjective],

--- a/packages/test-app/tests/integration/components/session-overview-ilm-duedate-test.js
+++ b/packages/test-app/tests/integration/components/session-overview-ilm-duedate-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | session-overview-ilm-duedate', function (hooks
     });
     this.ilmSession = await this.owner
       .lookup('service:store')
-      .findRecord('ilmSession', ilmSession.id);
+      .findRecord('ilm-session', ilmSession.id);
   });
 
   test('it renders and is accessible', async function (assert) {

--- a/packages/test-app/tests/integration/components/session-publicationcheck-test.js
+++ b/packages/test-app/tests/integration/components/session-publicationcheck-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | session-publicationcheck', function (hooks) {
   setupMirage(hooks);
 
   test('it shows unlink icon', async function (assert) {
-    const courseObjective = this.server.create('courseObjective');
+    const courseObjective = this.server.create('course-objective');
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
     const session = this.server.create('session', { course });
@@ -30,7 +30,7 @@ module('Integration | Component | session-publicationcheck', function (hooks) {
   });
 
   test('it does not shows unlink icon', async function (assert) {
-    const courseObjective = this.server.create('courseObjective');
+    const courseObjective = this.server.create('course-objective');
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
     const session = this.server.create('session', { course });

--- a/packages/test-app/tests/integration/components/session/manage-objective-descriptors-test.js
+++ b/packages/test-app/tests/integration/components/session/manage-objective-descriptors-test.js
@@ -10,10 +10,10 @@ module('Integration | Component | session/manage-objective-descriptors', functio
   setupMirage(hooks);
 
   test('it renders', async function (assert) {
-    const descriptors = this.server.createList('meshDescriptor', 4);
+    const descriptors = this.server.createList('mesh-descriptor', 4);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', descriptors[0].id);
+      .findRecord('mesh-descriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     await render(hbs`<Session::ManageObjectiveDescriptors
       @selected={{this.selected}}
@@ -40,10 +40,10 @@ module('Integration | Component | session/manage-objective-descriptors', functio
 
   test('add works', async function (assert) {
     assert.expect(16);
-    const descriptors = this.server.createList('meshDescriptor', 2);
+    const descriptors = this.server.createList('mesh-descriptor', 2);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', descriptors[0].id);
+      .findRecord('mesh-descriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     this.set('add', (descriptor) => {
       this.set('selected', [descriptorModel, descriptor]);
@@ -80,10 +80,10 @@ module('Integration | Component | session/manage-objective-descriptors', functio
 
   test('remove works', async function (assert) {
     assert.expect(15);
-    const descriptors = this.server.createList('meshDescriptor', 2);
+    const descriptors = this.server.createList('mesh-descriptor', 2);
     const descriptorModel = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', descriptors[0].id);
+      .findRecord('mesh-descriptor', descriptors[0].id);
     this.set('selected', [descriptorModel]);
     this.set('remove', (descriptor) => {
       assert.strictEqual(descriptor.id, descriptorModel.id);

--- a/packages/test-app/tests/integration/components/session/manage-objective-parents-test.js
+++ b/packages/test-app/tests/integration/components/session/manage-objective-parents-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | session/manage-objective-parents', function (h
 
   test('it renders and is accessible', async function (assert) {
     const course = this.server.create('course');
-    this.server.create('courseObjective', { course });
+    this.server.create('course-objective', { course });
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('courseObjectives', await courseModel.courseObjectives);
     this.set('courseTitle', course.title);
@@ -35,17 +35,17 @@ module('Integration | Component | session/manage-objective-parents', function (h
 
   test('parent objectives are sorted correctly', async function (assert) {
     const course = this.server.create('course');
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       title: 'Aardvark',
       position: 3,
       course,
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       title: 'Zeppelin',
       position: 2,
       course,
     });
-    this.server.create('courseObjective', {
+    this.server.create('course-objective', {
       title: 'Oscar',
       position: 1,
       course,

--- a/packages/test-app/tests/integration/components/session/objective-list-item-descriptors-test.js
+++ b/packages/test-app/tests/integration/components/session/objective-list-item-descriptors-test.js
@@ -11,13 +11,13 @@ module('Integration | Component | session/objective-list-item-descriptors', func
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const meshDescriptors = this.server.createList('meshDescriptor', 2);
+    const meshDescriptors = this.server.createList('mesh-descriptor', 2);
     this.meshDescriptor1 = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', meshDescriptors[0].id);
+      .findRecord('mesh-descriptor', meshDescriptors[0].id);
     this.meshDescriptor2 = await this.owner
       .lookup('service:store')
-      .findRecord('meshDescriptor', meshDescriptors[1].id);
+      .findRecord('mesh-descriptor', meshDescriptors[1].id);
   });
 
   test('it renders and is accessible when managing', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/objective-list-item-parents-test.js
+++ b/packages/test-app/tests/integration/components/session/objective-list-item-parents-test.js
@@ -11,16 +11,16 @@ module('Integration | Component | session/objective-list-item-parents', function
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const courseObjective1 = this.server.create('courseObjective', {
+    const courseObjective1 = this.server.create('course-objective', {
       title: '<p>Country &amp; Western</p>',
     });
-    const courseObjective2 = this.server.create('courseObjective');
+    const courseObjective2 = this.server.create('course-objective');
     this.courseObjective1 = await this.owner
       .lookup('service:store')
-      .findRecord('courseObjective', courseObjective1.id);
+      .findRecord('course-objective', courseObjective1.id);
     this.courseObjective2 = await this.owner
       .lookup('service:store')
-      .findRecord('courseObjective', courseObjective2.id);
+      .findRecord('course-objective', courseObjective2.id);
   });
 
   test('it renders and is accessible when managing', async function (assert) {
@@ -152,27 +152,27 @@ module('Integration | Component | session/objective-list-item-parents', function
   });
 
   test('parent objectives are correctly sorted', async function (assert) {
-    const courseObjective1 = this.server.create('courseObjective', {
+    const courseObjective1 = this.server.create('course-objective', {
       title: 'Aardvark',
       position: 3,
     });
-    const courseObjective2 = this.server.create('courseObjective', {
+    const courseObjective2 = this.server.create('course-objective', {
       title: 'Zeppelin',
       position: 2,
     });
-    const courseObjective3 = this.server.create('courseObjective', {
+    const courseObjective3 = this.server.create('course-objective', {
       title: 'Oscar',
       position: 1,
     });
     const model1 = await this.owner
       .lookup('service:store')
-      .findRecord('courseObjective', courseObjective1.id);
+      .findRecord('course-objective', courseObjective1.id);
     const model2 = await this.owner
       .lookup('service:store')
-      .findRecord('courseObjective', courseObjective2.id);
+      .findRecord('course-objective', courseObjective2.id);
     const model3 = await this.owner
       .lookup('service:store')
-      .findRecord('courseObjective', courseObjective3.id);
+      .findRecord('course-objective', courseObjective3.id);
     this.set('parents', [model1, model2, model3]);
     await render(hbs`<Session::ObjectiveListItemParents
       @parents={{this.parents}}

--- a/packages/test-app/tests/integration/components/session/objective-list-item-test.js
+++ b/packages/test-app/tests/integration/components/session/objective-list-item-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
     const session = this.server.create('session', { course });
-    const sessionObjective = this.server.create('sessionObjective', {
+    const sessionObjective = this.server.create('session-objective', {
       session,
     });
     const store = await this.owner.lookup('service:store');
@@ -42,7 +42,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
 
   test('can change title', async function (assert) {
     const session = this.server.create('session');
-    const sessionObjective = this.server.create('sessionObjective', {
+    const sessionObjective = this.server.create('session-objective', {
       session,
     });
     const store = await this.owner.lookup('service:store');
@@ -71,7 +71,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
     const session = this.server.create('session', { course });
-    const sessionObjective = this.server.create('sessionObjective', {
+    const sessionObjective = this.server.create('session-objective', {
       session,
     });
     const store = await this.owner.lookup('service:store');
@@ -94,7 +94,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
 
   test('can manage descriptors', async function (assert) {
     const session = this.server.create('session');
-    const sessionObjective = this.server.create('sessionObjective', {
+    const sessionObjective = this.server.create('session-objective', {
       session,
     });
     const store = await this.owner.lookup('service:store');
@@ -119,7 +119,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
     const session = this.server.create('session', { course });
-    const sessionObjective = this.server.create('sessionObjective', {
+    const sessionObjective = this.server.create('session-objective', {
       session,
     });
     const store = await this.owner.lookup('service:store');
@@ -143,7 +143,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
 
   test('can trigger removal', async function (assert) {
     const session = this.server.create('session');
-    const sessionObjective = this.server.create('sessionObjective', {
+    const sessionObjective = this.server.create('session-objective', {
       session,
     });
     const store = await this.owner.lookup('service:store');

--- a/packages/test-app/tests/integration/components/session/objective-list-test.js
+++ b/packages/test-app/tests/integration/components/session/objective-list-test.js
@@ -17,13 +17,13 @@ module('Integration | Component | session/objective-list', function (hooks) {
     const vocabulary = this.server.create('vocabulary', { school });
     const term1 = this.server.create('term', { vocabulary });
     const term2 = this.server.create('term', { vocabulary });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session,
       title: 'Objective A',
       position: 0,
       terms: [term1],
     });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', {
       session,
       title: 'Objective B',
       position: 0,
@@ -84,7 +84,7 @@ module('Integration | Component | session/objective-list', function (hooks) {
   test('no "sort objectives" button in list with one item', async function (assert) {
     const course = this.server.create('course');
     const session = this.server.create('session', { course });
-    this.server.create('sessionObjective', { session });
+    this.server.create('session-objective', { session });
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
 

--- a/packages/test-app/tests/integration/components/session/objectives-test.js
+++ b/packages/test-app/tests/integration/components/session/objectives-test.js
@@ -12,11 +12,11 @@ module('Integration | Component | session/objectives', function (hooks) {
 
   test('it renders and is accessible', async function (assert) {
     const course = this.server.create('course');
-    const courseObjective = this.server.create('courseObjective', { course });
+    const courseObjective = this.server.create('course-objective', { course });
     const session = this.server.create('session', { course });
-    this.server.create('sessionObjective', { session });
-    this.server.create('sessionObjective', { session });
-    this.server.create('sessionObjective', {
+    this.server.create('session-objective', { session });
+    this.server.create('session-objective', { session });
+    this.server.create('session-objective', {
       session,
       courseObjectives: [courseObjective],
     });
@@ -64,7 +64,7 @@ module('Integration | Component | session/objectives', function (hooks) {
   test('deleting objective', async function (assert) {
     const course = this.server.create('course');
     const session = this.server.create('session', { course });
-    this.server.create('sessionObjective', { session });
+    this.server.create('session-objective', { session });
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
 
     this.set('session', sessionModel);

--- a/packages/test-app/tests/integration/components/sessions-grid-row-test.js
+++ b/packages/test-app/tests/integration/components/sessions-grid-row-test.js
@@ -18,9 +18,9 @@ module('Integration | Component | sessions-grid-row', function (hooks) {
   test('it renders', async function (assert) {
     const date = DateTime.fromObject({ year: 2019, month: 7, day: 9, hour: 17 });
     const session = this.server.create('session');
-    this.server.create('sessionType', { sessions: [session] });
+    this.server.create('session-type', { sessions: [session] });
     this.server.createList('term', 2, { sessions: [session] });
-    this.server.createList('sessionObjective', 3, { session });
+    this.server.createList('session-objective', 3, { session });
     const offering1 = this.server.create('offering', {
       session,
       startDate: date.toJSDate(),
@@ -29,8 +29,8 @@ module('Integration | Component | sessions-grid-row', function (hooks) {
       session,
       startDate: date.plus({ hour: 1 }).toJSDate(),
     });
-    this.server.create('learnerGroup', { offerings: [offering1] });
-    this.server.createList('learnerGroup', 3, { offerings: [offering2] });
+    this.server.create('learner-group', { offerings: [offering1] });
+    this.server.createList('learner-group', 3, { offerings: [offering2] });
     const model = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', model);
     await render(hbs`<SessionsGridRow

--- a/packages/test-app/tests/integration/helpers/map-by-test.js
+++ b/packages/test-app/tests/integration/helpers/map-by-test.js
@@ -107,7 +107,7 @@ module('Integration | Helper | map-by', function (hooks) {
 
   test('it accepts a fulfilled ember data promise as a value', async function (assert) {
     let store = this.owner.lookup('service:store');
-    let learnerGroup = store.createRecord('learnerGroup');
+    let learnerGroup = store.createRecord('learner-group');
 
     let users = await learnerGroup.users;
     users.push(

--- a/packages/test-app/tests/integration/helpers/sort-by-test.js
+++ b/packages/test-app/tests/integration/helpers/sort-by-test.js
@@ -266,7 +266,7 @@ module('Integration | Helper | sort-by', function (hooks) {
 
   test('it accepts a fulfilled ember data promise as a value', async function (assert) {
     let store = this.owner.lookup('service:store');
-    let learnerGroup = store.createRecord('learnerGroup');
+    let learnerGroup = store.createRecord('learner-group');
 
     let users = await learnerGroup.users;
     users.push(

--- a/packages/test-app/tests/unit/models/course-test.js
+++ b/packages/test-app/tests/unit/models/course-test.js
@@ -34,7 +34,7 @@ module('Unit | Model | Course', function (hooks) {
     });
     (await model.courseObjectives).push(courseObjective);
     assert.strictEqual(model.get('optionalPublicationIssues').length, 1);
-    (await model.meshDescriptors).push(store.createRecord('meshDescriptor'));
+    (await model.meshDescriptors).push(store.createRecord('mesh-descriptor'));
     assert.strictEqual(model.get('optionalPublicationIssues').length, 0);
   });
 
@@ -202,13 +202,13 @@ module('Unit | Model | Course', function (hooks) {
     const program1 = store.createRecord('program', { school: school2 });
     const program2 = store.createRecord('program', { school: school2 });
     const program3 = store.createRecord('program', { school: school3 });
-    const programYear1 = store.createRecord('programYear', {
+    const programYear1 = store.createRecord('program-year', {
       program: program1,
     });
-    const programYear2 = store.createRecord('programYear', {
+    const programYear2 = store.createRecord('program-year', {
       program: program2,
     });
-    const programYear3 = store.createRecord('programYear', {
+    const programYear3 = store.createRecord('program-year', {
       program: program3,
     });
     const cohort1 = store.createRecord('cohort', { programYear: programYear1 });
@@ -248,7 +248,7 @@ module('Unit | Model | Course', function (hooks) {
       school: school2,
     });
     const program = store.createRecord('program', { school: school1 });
-    const programYear = store.createRecord('programYear', { program });
+    const programYear = store.createRecord('program-year', { program });
     const cohort = store.createRecord('cohort', { programYear });
     (await course.cohorts).push(cohort);
     course.set('school', school2);

--- a/packages/test-app/tests/unit/models/curriculum-inventory-report-test.js
+++ b/packages/test-app/tests/unit/models/curriculum-inventory-report-test.js
@@ -12,15 +12,15 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
   test('get top level sequence blocks', async function (assert) {
     const model = this.owner.lookup('service:store').createRecord('curriculum-inventory-report');
     const store = this.owner.lookup('service:store');
-    const block1 = store.createRecord('curriculumInventorySequenceBlock', {
+    const block1 = store.createRecord('curriculum-inventory-sequence-block', {
       id: 1,
       report: model,
     });
-    const block2 = store.createRecord('curriculumInventorySequenceBlock', {
+    const block2 = store.createRecord('curriculum-inventory-sequence-block', {
       id: 2,
       report: model,
     });
-    const block3 = store.createRecord('curriculumInventorySequenceBlock', {
+    const block3 = store.createRecord('curriculum-inventory-sequence-block', {
       id: 3,
       report: model,
       parent: block2,
@@ -36,7 +36,7 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
     const store = this.owner.lookup('service:store');
     const model = this.owner.lookup('service:store').createRecord('curriculum-inventory-report');
     assert.notOk(model.belongsTo('export')?.id());
-    store.createRecord('curriculumInventoryExport', { id: 1, report: model });
+    store.createRecord('curriculum-inventory-export', { id: 1, report: model });
     assert.ok(model.belongsTo('export')?.id());
   });
 
@@ -47,15 +47,15 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
     const course2 = store.createRecord('course');
     const course3 = store.createRecord('course');
 
-    const block1 = store.createRecord('curriculumInventorySequenceBlock', {
+    const block1 = store.createRecord('curriculum-inventory-sequence-block', {
       course: course1,
       report: model,
     });
-    const block2 = store.createRecord('curriculumInventorySequenceBlock', {
+    const block2 = store.createRecord('curriculum-inventory-sequence-block', {
       course: course2,
       report: model,
     });
-    const block3 = store.createRecord('curriculumInventorySequenceBlock', {
+    const block3 = store.createRecord('curriculum-inventory-sequence-block', {
       report: model,
     });
     (await model.sequenceBlocks).push(block1, block2, block3);
@@ -75,7 +75,7 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
     const model = this.owner.lookup('service:store').createRecord('curriculum-inventory-report');
     const store = this.owner.lookup('service:store');
     (await model.sequenceBlocks).push(
-      store.createRecord('curriculumInventorySequenceBlock', {
+      store.createRecord('curriculum-inventory-sequence-block', {
         report: model,
       }),
     );
@@ -88,7 +88,7 @@ module('Unit | Model | CurriculumInventoryReport', function (hooks) {
     const store = this.owner.lookup('service:store');
     const course = store.createRecord('course');
     (await model.sequenceBlocks).push(
-      store.createRecord('curriculumInventorySequenceBlock', {
+      store.createRecord('curriculum-inventory-sequence-block', {
         report: model,
         course,
       }),

--- a/packages/test-app/tests/unit/models/curriculum-inventory-sequence-block-test.js
+++ b/packages/test-app/tests/unit/models/curriculum-inventory-sequence-block-test.js
@@ -9,10 +9,10 @@ module('Unit | Model | CurriculumInventorySequenceBlock ', function (hooks) {
       .lookup('service:store')
       .createRecord('curriculum-inventory-sequence-block');
     const store = this.owner.lookup('service:store');
-    const parentBlock = store.createRecord('curriculumInventorySequenceBlock', {
+    const parentBlock = store.createRecord('curriculum-inventory-sequence-block', {
       children: [model],
     });
-    const grandParent = store.createRecord('curriculumInventorySequenceBlock', {
+    const grandParent = store.createRecord('curriculum-inventory-sequence-block', {
       children: [parentBlock],
     });
     parentBlock.set('parent', grandParent);

--- a/packages/test-app/tests/unit/models/ilm-session-test.js
+++ b/packages/test-app/tests/unit/models/ilm-session-test.js
@@ -15,10 +15,10 @@ module('Unit | Model | IlmSession', function (hooks) {
     const instructor2 = store.createRecord('user');
     const instructor3 = store.createRecord('user');
     const instructor4 = store.createRecord('user');
-    const instructorGroup1 = store.createRecord('instructorGroup', {
+    const instructorGroup1 = store.createRecord('instructor-group', {
       users: [instructor1, instructor2],
     });
-    const instructorGroup2 = store.createRecord('instructorGroup', {
+    const instructorGroup2 = store.createRecord('instructor-group', {
       users: [instructor3],
     });
     const model = store.createRecord('ilm-session', {

--- a/packages/test-app/tests/unit/models/instructor-group-test.js
+++ b/packages/test-app/tests/unit/models/instructor-group-test.js
@@ -25,8 +25,8 @@ module('Unit | Model | InstructorGroup', function (hooks) {
       store.createRecord('offering', { session: session3 }),
     );
     (await model.ilmSessions).push(
-      store.createRecord('ilmSession', { session: session3 }),
-      store.createRecord('ilmSession', { session: session4 }),
+      store.createRecord('ilm-session', { session: session3 }),
+      store.createRecord('ilm-session', { session: session4 }),
     );
     const courses = await waitForResource(model, 'courses');
     assert.strictEqual(courses.length, 3);
@@ -51,8 +51,8 @@ module('Unit | Model | InstructorGroup', function (hooks) {
       store.createRecord('offering', { session: session3 }),
     );
     (await model.ilmSessions).push(
-      store.createRecord('ilmSession', { session: session3 }),
-      store.createRecord('ilmSession', { session: session4 }),
+      store.createRecord('ilm-session', { session: session3 }),
+      store.createRecord('ilm-session', { session: session4 }),
     );
     const sessions = await waitForResource(model, 'sessions');
     assert.strictEqual(sessions.length, 4);

--- a/packages/test-app/tests/unit/models/learner-group-test.js
+++ b/packages/test-app/tests/unit/models/learner-group-test.js
@@ -50,8 +50,8 @@ module('Unit | Model | LearnerGroup', function (hooks) {
       store.createRecord('offering', { session: session3 }),
     );
     (await model.ilmSessions).push(
-      store.createRecord('ilmSession', { session: session3 }),
-      store.createRecord('ilmSession', { session: session4 }),
+      store.createRecord('ilm-session', { session: session3 }),
+      store.createRecord('ilm-session', { session: session4 }),
     );
     const sessions = await waitForResource(model, 'sessions');
     assert.strictEqual(sessions.length, 4);

--- a/packages/test-app/tests/unit/models/offering-test.js
+++ b/packages/test-app/tests/unit/models/offering-test.js
@@ -187,10 +187,10 @@ module('Unit | Model | Offering', function (hooks) {
     const instructor2 = store.createRecord('user');
     const instructor3 = store.createRecord('user');
     const instructor4 = store.createRecord('user');
-    const instructorGroup1 = store.createRecord('instructorGroup', {
+    const instructorGroup1 = store.createRecord('instructor-group', {
       users: [instructor1, instructor2],
     });
-    const instructorGroup2 = store.createRecord('instructorGroup', {
+    const instructorGroup2 = store.createRecord('instructor-group', {
       users: [instructor3],
     });
     const model = store.createRecord('offering', {

--- a/packages/test-app/tests/unit/models/session-test.js
+++ b/packages/test-app/tests/unit/models/session-test.js
@@ -21,7 +21,7 @@ module('Unit | Model | Session', function (hooks) {
     const store = this.owner.lookup('service:store');
     model.set('title', 'nothing');
     assert.strictEqual(model.get('requiredPublicationIssues').length, 1);
-    const ilmSession = store.createRecord('ilmSession');
+    const ilmSession = store.createRecord('ilm-session');
     model.set('ilmSession', ilmSession);
     assert.strictEqual(model.get('requiredPublicationIssues').length, 1);
   });
@@ -41,7 +41,7 @@ module('Unit | Model | Session', function (hooks) {
     (await model.sessionObjectives).push(store.createRecord('session-objective'));
     assert.strictEqual(model.optionalPublicationIssues.length, 1);
     assert.deepEqual(model.optionalPublicationIssues, ['meshDescriptors']);
-    (await model.meshDescriptors).push(store.createRecord('meshDescriptor'));
+    (await model.meshDescriptors).push(store.createRecord('mesh-descriptor'));
     assert.strictEqual(model.optionalPublicationIssues.length, 0);
   });
 
@@ -211,7 +211,7 @@ module('Unit | Model | Session', function (hooks) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('session');
     assert.notOk(model.get('isIndependentLearning'));
-    await store.createRecord('ilmSession', { id: 1, session: model });
+    await store.createRecord('ilm-session', { id: 1, session: model });
     assert.ok(await waitForResource(model, 'isIndependentLearning'));
   });
 
@@ -349,7 +349,7 @@ module('Unit | Model | Session', function (hooks) {
   test('firstOfferingDate - ILM', async function (assert) {
     const subject = this.owner.lookup('service:store').createRecord('session');
     const store = this.owner.lookup('service:store');
-    const ilm = store.createRecord('ilmSession', {
+    const ilm = store.createRecord('ilm-session', {
       dueDate: DateTime.fromObject({ year: 2015, month: 1, day: 1 }).toJSDate(),
     });
     subject.set('ilmSession', ilm);
@@ -421,7 +421,7 @@ module('Unit | Model | Session', function (hooks) {
       }).toJSDate(),
     });
     (await subject.offerings).push(allDayOffering, halfAnHourOffering);
-    const ilmSession = store.createRecord('ilmSession', { hours: 2.1 });
+    const ilmSession = store.createRecord('ilm-session', { hours: 2.1 });
     subject.set('ilmSession', ilmSession);
 
     const max = await waitForResource(subject, 'maxDuration');
@@ -464,7 +464,7 @@ module('Unit | Model | Session', function (hooks) {
     const subject = this.owner.lookup('service:store').createRecord('session');
     const store = this.owner.lookup('service:store');
 
-    const ilmSession = store.createRecord('ilmSession', { hours: 2 });
+    const ilmSession = store.createRecord('ilm-session', { hours: 2 });
     subject.set('ilmSession', ilmSession);
 
     const max = await waitForResource(subject, 'maxDuration');
@@ -500,7 +500,7 @@ module('Unit | Model | Session', function (hooks) {
       }).toJSDate(),
     });
     (await subject.offerings).push(allDayOffering, halfAnHourOffering);
-    const ilmSession = store.createRecord('ilmSession', { hours: 2.1 });
+    const ilmSession = store.createRecord('ilm-session', { hours: 2.1 });
     subject.set('ilmSession', ilmSession);
 
     const total = await waitForResource(subject, 'totalSumDuration');
@@ -543,7 +543,7 @@ module('Unit | Model | Session', function (hooks) {
     const subject = this.owner.lookup('service:store').createRecord('session');
     const store = this.owner.lookup('service:store');
 
-    const ilmSession = store.createRecord('ilmSession', { hours: 2 });
+    const ilmSession = store.createRecord('ilm-session', { hours: 2 });
     subject.set('ilmSession', ilmSession);
 
     const total = await waitForResource(subject, 'totalSumDuration');
@@ -555,7 +555,7 @@ module('Unit | Model | Session', function (hooks) {
     const subject = this.owner.lookup('service:store').createRecord('session');
 
     const offering = store.createRecord('offering');
-    const instructorGroup = store.createRecord('instructorGroup', {
+    const instructorGroup = store.createRecord('instructor-group', {
       offerings: [offering],
     });
     const user1 = store.createRecord('user', {
@@ -576,8 +576,8 @@ module('Unit | Model | Session', function (hooks) {
     const subject = this.owner.lookup('service:store').createRecord('session');
     const store = this.owner.lookup('service:store');
 
-    const ilmSession = store.createRecord('ilmSession', { id: 24 });
-    const instructorGroup = store.createRecord('instructorGroup', {
+    const ilmSession = store.createRecord('ilm-session', { id: 24 });
+    const instructorGroup = store.createRecord('instructor-group', {
       ilmSessions: [ilmSession],
     });
     const user1 = store.createRecord('user', {
@@ -660,16 +660,16 @@ module('Unit | Model | Session', function (hooks) {
     const instructor7 = store.createRecord('user');
     const instructor8 = store.createRecord('user');
     const instructor9 = store.createRecord('user');
-    const instructorGroup1 = store.createRecord('instructorGroup', {
+    const instructorGroup1 = store.createRecord('instructor-group', {
       users: [instructor1, instructor2],
     });
-    const instructorGroup2 = store.createRecord('instructorGroup', {
+    const instructorGroup2 = store.createRecord('instructor-group', {
       users: [instructor3],
     });
-    const instructorGroup3 = store.createRecord('instructorGroup', {
+    const instructorGroup3 = store.createRecord('instructor-group', {
       users: [instructor4, instructor5],
     });
-    const ilmSession = store.createRecord('ilmSession', {
+    const ilmSession = store.createRecord('ilm-session', {
       instructorGroups: [instructorGroup1],
       instructors: [instructor6, instructor1],
     });
@@ -728,7 +728,7 @@ module('Unit | Model | Session', function (hooks) {
       }).toJSDate(),
     });
     (await subject.offerings).push(allDayOffering, halfAnHourOffering);
-    const ilmSession = store.createRecord('ilmSession', { hours: 2.1 });
+    const ilmSession = store.createRecord('ilm-session', { hours: 2.1 });
     subject.set('ilmSession', ilmSession);
 
     const total = await subject.getTotalSumDuration();
@@ -771,7 +771,7 @@ module('Unit | Model | Session', function (hooks) {
     const store = this.owner.lookup('service:store');
     const subject = store.createRecord('session');
 
-    const ilmSession = store.createRecord('ilmSession', { hours: 2 });
+    const ilmSession = store.createRecord('ilm-session', { hours: 2 });
     subject.set('ilmSession', ilmSession);
 
     const total = await subject.getTotalSumDuration();
@@ -783,10 +783,10 @@ module('Unit | Model | Session', function (hooks) {
     const instructor1 = store.createRecord('user', { id: 1 });
     const instructor2 = store.createRecord('user', { id: 2 });
     const instructor3 = store.createRecord('user', { id: 3 });
-    const instructorGroup1 = store.createRecord('instructorGroup', {
+    const instructorGroup1 = store.createRecord('instructor-group', {
       users: [instructor1],
     });
-    const ilmSession = store.createRecord('ilmSession', {
+    const ilmSession = store.createRecord('ilm-session', {
       hours: 1.5,
       instructorGroups: [instructorGroup1],
       instructors: [instructor2],
@@ -846,7 +846,7 @@ module('Unit | Model | Session', function (hooks) {
     const instructor1 = store.createRecord('user', { id: 1 });
     const instructor2 = store.createRecord('user', { id: 2 });
     const instructor3 = store.createRecord('user', { id: 3 });
-    const instructorGroup1 = store.createRecord('instructorGroup', {
+    const instructorGroup1 = store.createRecord('instructor-group', {
       users: [instructor1],
     });
     const offering1 = store.createRecord('offering', {
@@ -903,10 +903,10 @@ module('Unit | Model | Session', function (hooks) {
     const instructor1 = store.createRecord('user', { id: 1 });
     const instructor2 = store.createRecord('user', { id: 2 });
     const instructor3 = store.createRecord('user', { id: 3 });
-    const instructorGroup1 = store.createRecord('instructorGroup', {
+    const instructorGroup1 = store.createRecord('instructor-group', {
       users: [instructor1],
     });
-    const ilmSession = store.createRecord('ilmSession', {
+    const ilmSession = store.createRecord('ilm-session', {
       hours: 1.5,
       instructorGroups: [instructorGroup1],
       instructors: [instructor2],
@@ -936,8 +936,8 @@ module('Unit | Model | Session', function (hooks) {
     const session = this.owner.lookup('service:store').createRecord('session');
     const store = this.owner.lookup('service:store');
     assert.strictEqual(session.objectiveCount, 0);
-    const sessionObjective1 = store.createRecord('sessionObjective', { id: 1, session });
-    const sessionObjective2 = store.createRecord('sessionObjective', { id: 2, session });
+    const sessionObjective1 = store.createRecord('session-objective', { id: 1, session });
+    const sessionObjective2 = store.createRecord('session-objective', { id: 2, session });
     (await session.sessionObjectives).push(sessionObjective1, sessionObjective2);
     assert.strictEqual(session.objectiveCount, 2);
   });

--- a/packages/test-app/tests/unit/models/term-test.js
+++ b/packages/test-app/tests/unit/models/term-test.js
@@ -95,7 +95,7 @@ module('Unit | Model | term', function (hooks) {
 
   test('associations', async function (assert) {
     assert.expect(9);
-    const programYear = this.store.createRecord('programYear');
+    const programYear = this.store.createRecord('program-year');
     const course = this.store.createRecord('course');
     const session = this.store.createRecord('session');
     const programYearObjective = this.store.createRecord('program-year-objective');

--- a/packages/test-app/tests/unit/models/user-test.js
+++ b/packages/test-app/tests/unit/models/user-test.js
@@ -207,7 +207,7 @@ module('Unit | Model | User', function (hooks) {
     const offering2 = store.createRecord('offering', {
       session: session1,
     });
-    store.createRecord('learnerGroup', {
+    store.createRecord('learner-group', {
       offerings: [offering1, offering2],
       users: [model],
     });
@@ -218,7 +218,7 @@ module('Unit | Model | User', function (hooks) {
     const offering3 = store.createRecord('offering', {
       session: session2,
     });
-    store.createRecord('learnerGroup', {
+    store.createRecord('learner-group', {
       offerings: [offering3],
       users: [model],
     });
@@ -245,7 +245,7 @@ module('Unit | Model | User', function (hooks) {
     const offering2 = store.createRecord('offering', {
       session: session1,
     });
-    store.createRecord('instructorGroup', {
+    store.createRecord('instructor-group', {
       offerings: [offering1, offering2],
       users: [model],
     });
@@ -256,7 +256,7 @@ module('Unit | Model | User', function (hooks) {
     const offering3 = store.createRecord('offering', {
       session: session2,
     });
-    store.createRecord('instructorGroup', {
+    store.createRecord('instructor-group', {
       offerings: [offering3],
       users: [model],
     });
@@ -346,13 +346,13 @@ module('Unit | Model | User', function (hooks) {
     const session2 = store.createRecord('session', {
       course: course1,
     });
-    const ilm1 = store.createRecord('ilmSession', {
+    const ilm1 = store.createRecord('ilm-session', {
       session: session1,
     });
-    const ilm2 = store.createRecord('ilmSession', {
+    const ilm2 = store.createRecord('ilm-session', {
       session: session2,
     });
-    store.createRecord('learnerGroup', {
+    store.createRecord('learner-group', {
       ilmSessions: [ilm1, ilm2],
       users: [model],
     });
@@ -360,10 +360,10 @@ module('Unit | Model | User', function (hooks) {
     const session3 = store.createRecord('session', {
       course: course2,
     });
-    const ilm3 = store.createRecord('ilmSession', {
+    const ilm3 = store.createRecord('ilm-session', {
       session: session3,
     });
-    store.createRecord('learnerGroup', {
+    store.createRecord('learner-group', {
       ilmSessions: [ilm3],
       users: [model],
     });
@@ -387,15 +387,15 @@ module('Unit | Model | User', function (hooks) {
     const session2 = store.createRecord('session', {
       course: course1,
     });
-    const ilm1 = store.createRecord('ilmSession', {
+    const ilm1 = store.createRecord('ilm-session', {
       id: 1,
       session: session1,
     });
-    const ilm2 = store.createRecord('ilmSession', {
+    const ilm2 = store.createRecord('ilm-session', {
       id: 2,
       session: session2,
     });
-    store.createRecord('instructorGroup', {
+    store.createRecord('instructor-group', {
       ilmSessions: [ilm1, ilm2],
       users: [model],
     });
@@ -403,11 +403,11 @@ module('Unit | Model | User', function (hooks) {
     const session3 = store.createRecord('session', {
       course: course2,
     });
-    const ilm3 = store.createRecord('ilmSession', {
+    const ilm3 = store.createRecord('ilm-session', {
       id: 3,
       session: session3,
     });
-    store.createRecord('instructorGroup', {
+    store.createRecord('instructor-group', {
       ilmSessions: [ilm3],
       users: [model],
     });
@@ -428,7 +428,7 @@ module('Unit | Model | User', function (hooks) {
     const session1 = store.createRecord('session', {
       course: course1,
     });
-    store.createRecord('ilmSession', {
+    store.createRecord('ilm-session', {
       session: session1,
       learners: [model],
     });
@@ -436,7 +436,7 @@ module('Unit | Model | User', function (hooks) {
     const session2 = store.createRecord('session', {
       course: course2,
     });
-    store.createRecord('ilmSession', {
+    store.createRecord('ilm-session', {
       session: session2,
       learners: [model],
     });
@@ -532,7 +532,7 @@ module('Unit | Model | User', function (hooks) {
   test('performsNonLearnerFunction - instructedIlmSessions', async function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('user');
-    store.createRecord('ilmSession', { instructors: [model] });
+    store.createRecord('ilm-session', { instructors: [model] });
     const performsNonLearnerFunction = await waitForResource(model, 'performsNonLearnerFunction');
     assert.ok(performsNonLearnerFunction);
   });
@@ -611,7 +611,7 @@ module('Unit | Model | User', function (hooks) {
     const session1 = store.createRecord('session', {
       course: course1,
     });
-    store.createRecord('ilmSession', {
+    store.createRecord('ilm-session', {
       session: session1,
       instructors: [model],
     });
@@ -619,7 +619,7 @@ module('Unit | Model | User', function (hooks) {
     const session2 = store.createRecord('session', {
       course: course2,
     });
-    store.createRecord('ilmSession', {
+    store.createRecord('ilm-session', {
       session: session2,
       instructors: [model],
     });
@@ -635,15 +635,15 @@ module('Unit | Model | User', function (hooks) {
   test('find lowest group at top of tree', async function (assert) {
     const model = this.owner.lookup('service:store').createRecord('user');
     const store = this.owner.lookup('service:store');
-    const learnerGroup = store.createRecord('learnerGroup', {
+    const learnerGroup = store.createRecord('learner-group', {
       id: 1,
       users: [model],
     });
-    const learnerGroup2 = store.createRecord('learnerGroup', {
+    const learnerGroup2 = store.createRecord('learner-group', {
       id: 2,
       parent: learnerGroup,
     });
-    const learnerGroup3 = store.createRecord('learnerGroup', {
+    const learnerGroup3 = store.createRecord('learner-group', {
       id: 3,
       parent: learnerGroup2,
     });
@@ -659,16 +659,16 @@ module('Unit | Model | User', function (hooks) {
   test('find lowest group in middle of tree', async function (assert) {
     const model = this.owner.lookup('service:store').createRecord('user');
     const store = this.owner.lookup('service:store');
-    const learnerGroup = store.createRecord('learnerGroup', {
+    const learnerGroup = store.createRecord('learner-group', {
       id: 1,
       users: [model],
     });
-    const learnerGroup2 = store.createRecord('learnerGroup', {
+    const learnerGroup2 = store.createRecord('learner-group', {
       id: 2,
       parent: learnerGroup,
       users: [model],
     });
-    const learnerGroup3 = store.createRecord('learnerGroup', {
+    const learnerGroup3 = store.createRecord('learner-group', {
       id: 3,
       parent: learnerGroup2,
     });
@@ -684,16 +684,16 @@ module('Unit | Model | User', function (hooks) {
   test('find lowest group in bottom of tree', async function (assert) {
     const model = this.owner.lookup('service:store').createRecord('user');
     const store = this.owner.lookup('service:store');
-    const learnerGroup = store.createRecord('learnerGroup', {
+    const learnerGroup = store.createRecord('learner-group', {
       id: 1,
       users: [model],
     });
-    const learnerGroup2 = store.createRecord('learnerGroup', {
+    const learnerGroup2 = store.createRecord('learner-group', {
       id: 2,
       parent: learnerGroup,
       users: [model],
     });
-    const learnerGroup3 = store.createRecord('learnerGroup', {
+    const learnerGroup3 = store.createRecord('learner-group', {
       id: 3,
       parent: learnerGroup2,
       users: [model],
@@ -710,12 +710,12 @@ module('Unit | Model | User', function (hooks) {
   test('return null when there is no group in the tree', async function (assert) {
     const model = this.owner.lookup('service:store').createRecord('user');
     const store = this.owner.lookup('service:store');
-    const learnerGroup = store.createRecord('learnerGroup');
-    const learnerGroup2 = store.createRecord('learnerGroup', {
+    const learnerGroup = store.createRecord('learner-group');
+    const learnerGroup2 = store.createRecord('learner-group', {
       id: 2,
       parent: learnerGroup,
     });
-    const learnerGroup3 = store.createRecord('learnerGroup', {
+    const learnerGroup3 = store.createRecord('learner-group', {
       id: 3,
       parent: learnerGroup2,
     });
@@ -769,7 +769,7 @@ module('Unit | Model | User', function (hooks) {
 
     const course3 = store.createRecord('course');
     const session3 = store.createRecord('session', { course: course3 });
-    store.createRecord('ilmSession', {
+    store.createRecord('ilm-session', {
       session: session3,
       instructors: [model],
     });
@@ -779,7 +779,7 @@ module('Unit | Model | User', function (hooks) {
     });
     const course4 = store.createRecord('course');
     const session4 = store.createRecord('session', { course: course4 });
-    store.createRecord('ilmSession', {
+    store.createRecord('ilm-session', {
       session: session4,
       instructorGroups: [instructorGroup2],
     });
@@ -811,7 +811,7 @@ module('Unit | Model | User', function (hooks) {
     });
 
     const session3 = store.createRecord('session');
-    store.createRecord('ilmSession', {
+    store.createRecord('ilm-session', {
       session: session3,
       instructors: [model],
     });
@@ -820,7 +820,7 @@ module('Unit | Model | User', function (hooks) {
       users: [model],
     });
     const session4 = store.createRecord('session');
-    store.createRecord('ilmSession', {
+    store.createRecord('ilm-session', {
       session: session4,
       instructorGroups: [instructorGroup2],
     });

--- a/packages/test-app/tests/unit/services/permission-checker-test.js
+++ b/packages/test-app/tests/unit/services/permission-checker-test.js
@@ -104,9 +104,9 @@ module('Unit | Service | permission-checker', function (hooks) {
     assert.expect(2);
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    const group = this.server.create('learnerGroup', { cohort });
+    const group = this.server.create('learner-group', { cohort });
     const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
     const currentUserMock = Service.extend({
@@ -127,9 +127,9 @@ module('Unit | Service | permission-checker', function (hooks) {
     assert.expect(2);
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    const group = this.server.create('learnerGroup', { cohort });
+    const group = this.server.create('learner-group', { cohort });
     const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
     const currentUserMock = Service.extend({
@@ -150,9 +150,9 @@ module('Unit | Service | permission-checker', function (hooks) {
     assert.expect(2);
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    const group = this.server.create('learnerGroup', { cohort });
+    const group = this.server.create('learner-group', { cohort });
     const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
     const currentUserMock = Service.extend({
@@ -173,9 +173,9 @@ module('Unit | Service | permission-checker', function (hooks) {
     assert.expect(2);
     const school = this.server.create('school');
     const program = this.server.create('program', { school });
-    const programYear = this.server.create('programYear', { program });
+    const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
-    const group = this.server.create('learnerGroup', { cohort });
+    const group = this.server.create('learner-group', { cohort });
     const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
     const currentUserMock = Service.extend({


### PR DESCRIPTION
This clears the deprecate-non-strict-types ember-data deprecation. My find a replace got a little bit carried away and I ended up updating the mirage declarations as well, but I don't mind the consistency so I left them in.