### PR TITLE
Enable Testing with Ember Exam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,13 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
       - name: Run Tests
-        run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance
+        run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance --write-execution-file
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: replay-${{matrix.workspace}}-test.json
+          path: ./packages/${{matrix.workspace}}/test-execution-*.json
+          retention-days: 7
 
   build:
     name: ${{matrix.workspace}} Build (${{ matrix.node-version }})
@@ -163,7 +169,13 @@ jobs:
           firefox-version: ${{ matrix.firefox-version }}
       - run: firefox --version
       - name: test
-        run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance --launch=Firefox
+        run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance --write-execution-file --launch=Firefox
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: replay-${{matrix.workspace}}-firefox-${{ matrix.firefox-version }}.json
+          path: ./packages/${{matrix.workspace}}/test-execution-*.json
+          retention-days: 7
 
   test-with-embroider:
     name: ${{matrix.workspace}} Test With Embroider
@@ -190,7 +202,13 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
       - name: Run Tests
-        run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance
+        run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance --write-execution-file
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: replay-${{matrix.workspace}}-embroider.json
+          path: ./packages/${{matrix.workspace}}/test-execution-*.json
+          retention-days: 7
 
   build-with-embroider:
     name: ${{matrix.workspace}} Build With Embroider

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
       - name: Run Tests
-        run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3
+        run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance
 
   build-with-embroider:
     name: ${{matrix.workspace}} Build With Embroider

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
       - name: Run Tests
-        run: pnpm --filter ${{matrix.workspace}} exec ember test
+        run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance
 
   build:
     name: ${{matrix.workspace}} Build (${{ matrix.node-version }})
@@ -163,7 +163,7 @@ jobs:
           firefox-version: ${{ matrix.firefox-version }}
       - run: firefox --version
       - name: test
-        run: pnpm --filter ${{matrix.workspace}} exec ember test --launch=Firefox
+        run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance --launch=Firefox
 
   test-with-embroider:
     name: ${{matrix.workspace}} Test With Embroider
@@ -190,7 +190,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
       - name: Run Tests
-        run: pnpm --filter ${{matrix.workspace}} exec ember test
+        run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3
 
   build-with-embroider:
     name: ${{matrix.workspace}} Build With Embroider

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage/
 npm-debug.log*
 yarn-error.log
 
+packages/**/test-execution-*.json

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "start:lti-course-manager": "pnpm --filter lti-course-manager exec ember serve",
     "start:lti-dashboard": "pnpm --filter lti-dashboard exec ember serve",
     "start:test-app": "pnpm --filter test-app exec ember serve",
-    "test:frontend": "pnpm run --filter frontend test",
-    "test:lti-course-manager": "pnpm run --filter lti-course-manager test",
-    "test:lti-dashboard": "pnpm run --filter lti-dashboard test",
-    "test:test-app": "pnpm run --filter test-app test",
+    "test:frontend": "pnpm --filter frontend exec ember exam --parallel=8 --load-balance",
+    "test:lti-course-manager": "pnpm --filter lti-course-manager exec ember exam --parallel=8 --load-balance",
+    "test:lti-dashboard": "pnpm --filter lti-dashboard exec ember exam --parallel=8 --load-balance",
+    "test:test-app": "pnpm --filter test-app exec ember exam --parallel=8 --load-balance",
     "prepare": "husky"
   },
   "engines": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -90,6 +90,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^4.0.2",
+    "ember-exam": "^9.0.0",
     "ember-focus-trap": "^1.1.0",
     "ember-load-initializers": "^2.1.2",
     "ember-metrics": "1.5.2",

--- a/packages/frontend/testem.js
+++ b/packages/frontend/testem.js
@@ -8,6 +8,7 @@ module.exports = {
   launch_in_dev: ['Firefox'],
   browser_disconnect_timeout: 300,
   browser_start_timeout: 120,
+  parallel: process.env.EMBER_EXAM_SPLIT_COUNT || -1,
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/frontend/tests/test-helper.js
+++ b/packages/frontend/tests/test-helper.js
@@ -3,7 +3,7 @@ import config from 'frontend/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
-import { start } from 'ember-qunit';
+import start from 'ember-exam/test-support/start';
 import DefaultAdapter from 'ember-cli-page-object/adapters/rfc268';
 import { setAdapter } from 'ember-cli-page-object/adapters';
 import { setRunOptions } from 'ember-a11y-testing/test-support';

--- a/packages/lti-course-manager/package.json
+++ b/packages/lti-course-manager/package.json
@@ -67,6 +67,7 @@
     "ember-cli-sass": "^11.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
+    "ember-exam": "^9.0.0",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",
     "ember-page-title": "^8.2.3",

--- a/packages/lti-course-manager/testem.js
+++ b/packages/lti-course-manager/testem.js
@@ -7,6 +7,7 @@ module.exports = {
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 120,
+  parallel: process.env.EMBER_EXAM_SPLIT_COUNT || -1,
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/lti-course-manager/tests/test-helper.js
+++ b/packages/lti-course-manager/tests/test-helper.js
@@ -3,7 +3,7 @@ import config from 'lti-course-manager/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
-import { start } from 'ember-qunit';
+import start from 'ember-exam/test-support/start';
 import 'qunit-theme-ember/qunit.css';
 
 setApplication(Application.create(config.APP));

--- a/packages/lti-dashboard/package.json
+++ b/packages/lti-dashboard/package.json
@@ -66,6 +66,7 @@
     "ember-cli-sass": "^11.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
+    "ember-exam": "^9.0.0",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",
     "ember-page-title": "^8.2.3",

--- a/packages/lti-dashboard/testem.js
+++ b/packages/lti-dashboard/testem.js
@@ -7,6 +7,7 @@ module.exports = {
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 120,
+  parallel: process.env.EMBER_EXAM_SPLIT_COUNT || -1,
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/lti-dashboard/tests/test-helper.js
+++ b/packages/lti-dashboard/tests/test-helper.js
@@ -3,7 +3,7 @@ import config from 'lti-dashboard/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
-import { start } from 'ember-qunit';
+import start from 'ember-exam/test-support/start';
 import DefaultAdapter from 'ember-cli-page-object/adapters/rfc268';
 import { setAdapter } from 'ember-cli-page-object/adapters';
 import 'qunit-theme-ember/qunit.css';

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -61,6 +61,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^4.0.2",
+    "ember-exam": "^9.0.0",
     "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",

--- a/packages/test-app/testem.js
+++ b/packages/test-app/testem.js
@@ -5,7 +5,9 @@ module.exports = {
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
-  browser_start_timeout: 120,
+  browser_disconnect_timeout: 120,
+  browser_start_timeout: 30,
+  parallel: process.env.EMBER_EXAM_SPLIT_COUNT || -1,
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/test-app/tests/integration/components/learnergroup-selection-cohort-manager-test.js
+++ b/packages/test-app/tests/integration/components/learnergroup-selection-cohort-manager-test.js
@@ -74,7 +74,7 @@ module('Integration | Component | learnergroup-selection-cohort-manager', functi
     assert.expect(2);
     this.set('filter', '');
     this.set('remove', (learnerGroup) => {
-      assert.ok(this.secondLevelLearnerGroup1, learnerGroup);
+      assert.deepEqual(this.secondLevelLearnerGroup1, learnerGroup);
     });
     this.set('learnerGroups', [this.secondLevelLearnerGroup1]);
     this.set('cohort', this.cohort);
@@ -94,7 +94,7 @@ module('Integration | Component | learnergroup-selection-cohort-manager', functi
     assert.expect(2);
     this.set('filter', '');
     this.set('add', (learnerGroup) => {
-      assert.ok(this.secondLevelLearnerGroup1, learnerGroup);
+      assert.deepEqual(this.secondLevelLearnerGroup1, learnerGroup);
     });
     this.set('learnerGroups', []);
     this.set('cohorts', this.cohort);

--- a/packages/test-app/tests/integration/components/learnergroup-selection-manager-test.js
+++ b/packages/test-app/tests/integration/components/learnergroup-selection-manager-test.js
@@ -155,7 +155,7 @@ module('Integration | Component | learnergroup-selection-manager', function (hoo
   test('remove group from selected list', async function (assert) {
     assert.expect(1);
     this.set('remove', (learnerGroup) => {
-      assert.ok(this.secondLevelLearnerGroup1, learnerGroup);
+      assert.deepEqual(this.secondLevelLearnerGroup1, learnerGroup);
     });
     this.set('learnerGroups', [this.secondLevelLearnerGroup1]);
     this.set('cohorts', [this.cohort1]);
@@ -172,7 +172,7 @@ module('Integration | Component | learnergroup-selection-manager', function (hoo
   test('remove group in picker', async function (assert) {
     assert.expect(2);
     this.set('remove', (learnerGroup) => {
-      assert.ok(this.secondLevelLearnerGroup1, learnerGroup);
+      assert.deepEqual(this.secondLevelLearnerGroup1, learnerGroup);
     });
     this.set('learnerGroups', [this.secondLevelLearnerGroup1]);
     this.set('cohorts', [this.cohort1]);
@@ -190,7 +190,7 @@ module('Integration | Component | learnergroup-selection-manager', function (hoo
   test('add available group', async function (assert) {
     assert.expect(2);
     this.set('add', (learnerGroup) => {
-      assert.ok(this.secondLevelLearnerGroup1, learnerGroup);
+      assert.deepEqual(this.secondLevelLearnerGroup1, learnerGroup);
     });
     this.set('learnerGroups', []);
     this.set('cohorts', [this.cohort1]);

--- a/packages/test-app/tests/test-helper.js
+++ b/packages/test-app/tests/test-helper.js
@@ -3,7 +3,7 @@ import config from 'test-app/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
-import { start } from 'ember-qunit';
+import start from 'ember-exam/test-support/start';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
 import 'qunit-theme-ember/qunit.css';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       ember-concurrency:
         specifier: ^4.0.2
         version: 4.0.2(@babel/core@7.24.7)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      ember-exam:
+        specifier: ^9.0.0
+        version: 9.0.0(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)(webpack@5.92.1)
       ember-focus-trap:
         specifier: ^1.1.0
         version: 1.1.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
@@ -781,6 +784,9 @@ importers:
       ember-cli-terser:
         specifier: ^4.0.2
         version: 4.0.2
+      ember-exam:
+        specifier: ^9.0.0
+        version: 9.0.0(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)(webpack@5.92.1)
       ember-load-initializers:
         specifier: ^2.1.2
         version: 2.1.2(@babel/core@7.24.7)
@@ -1003,6 +1009,9 @@ importers:
       ember-cli-terser:
         specifier: ^4.0.2
         version: 4.0.2
+      ember-exam:
+        specifier: ^9.0.0
+        version: 9.0.0(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)(webpack@5.92.1)
       ember-load-initializers:
         specifier: ^2.1.2
         version: 2.1.2(@babel/core@7.24.7)
@@ -1222,6 +1231,9 @@ importers:
       ember-concurrency:
         specifier: ^4.0.2
         version: 4.0.2(@babel/core@7.24.7)(@glimmer/tracking@1.1.2)(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))
+      ember-exam:
+        specifier: ^9.0.0
+        version: 9.0.0(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)(webpack@5.92.1)
       ember-fetch:
         specifier: ^8.1.2
         version: 8.1.2
@@ -3447,6 +3459,11 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  are-we-there-yet@4.0.2:
+    resolution: {integrity: sha512-ncSWAawFhKMJDTdoAeOV+jyW1VCMj5QIAwULIBV0SSR7B/RLPPEQiknKcg/RIIZlUQrxELpsxMiTUoAQ4sIUyg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    deprecated: This package is no longer supported.
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -5310,6 +5327,14 @@ packages:
     resolution: {integrity: sha512-fWcbWd4W4nRv8bbato8JB6oGRpATkR+oGYxMIqnfgTgPWaCS0ww7CuUVNpwg1TulojKMCuTXi8Fem2b1NSF1ZQ==}
     engines: {node: 8.* || >= 10.*}
 
+  ember-exam@9.0.0:
+    resolution: {integrity: sha512-zQBZFlig9SMtCgsU4+0jjtyVdF7RnR539ySxnyesO0mmvhArQOPB576XH598FWawUqkMPbEu7rR/X/NDiozK1g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      ember-qunit: '*'
+      ember-source: '>= 4.0.0'
+      qunit: '*'
+
   ember-feature-flags@6.0.0:
     resolution: {integrity: sha512-CcKpQ0NI/AMkYcP/4obqfDrzFlLqFngabFUfmAlQNnCic5cz51nlLY9MzYRtbop0+1iyegM4XHJFE4Awlji/1g==}
     engines: {node: 8.* || >= 10.*}
@@ -5803,6 +5828,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
@@ -6198,6 +6227,11 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  gauge@5.0.2:
+    resolution: {integrity: sha512-pMaFftXPtiGIHCJHdcUUx9Rby/rFT/Kkt3fIIGCs+9PMDIljSyRiqraTlxNtBReJRDfUefpa263RQ3vnp5G/LQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    deprecated: This package is no longer supported.
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -6229,6 +6263,10 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   get-symbol-description@1.0.2:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
@@ -6533,6 +6571,10 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+
   husky@9.0.11:
     resolution: {integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==}
     engines: {node: '>=18'}
@@ -6833,6 +6875,10 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -7421,6 +7467,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -7661,9 +7711,18 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
+
+  npmlog@7.0.1:
+    resolution: {integrity: sha512-uJ0YFk/mCQpLBt+bxN88AKd+gyqZvZDbtiNxk6Waqcj2aPRyfVx8ITawkyQynxUagInjdYT1+qj4NfA5KJJUxg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     deprecated: This package is no longer supported.
 
   nth-check@1.0.2:
@@ -7726,6 +7785,10 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
 
   open@7.4.2:
     resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
@@ -7920,6 +7983,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -8441,6 +8508,11 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rimraf@5.0.9:
+    resolution: {integrity: sha512-3i7b8OcswU6CpU8Ej89quJD4O98id7TtVM5U4Mybh84zQXdrFmDLouWBEEaD/QfO3gDDfH+AGFCGsR7kngzQnA==}
+    engines: {node: 14 >=14.20 || 16 >=16.20 || >=18}
+    hasBin: true
+
   ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
 
@@ -8919,6 +8991,10 @@ packages:
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -13737,6 +13813,8 @@ snapshots:
       delegates: 1.0.0
       readable-stream: 3.6.2
 
+  are-we-there-yet@4.0.2: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -16586,6 +16664,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ember-exam@9.0.0(ember-qunit@8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)(webpack@5.92.1):
+    dependencies:
+      '@babel/core': 7.24.7
+      chalk: 5.3.0
+      cli-table3: 0.6.5
+      debug: 4.3.5(supports-color@8.1.1)
+      ember-auto-import: 2.7.4(webpack@5.92.1)
+      ember-cli-babel: 8.2.0(@babel/core@7.24.7)
+      ember-qunit: 8.1.0(@ember/test-helpers@3.3.0(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(webpack@5.92.1))(ember-source@5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1))(qunit@2.21.0)
+      ember-source: 5.8.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.92.1)
+      execa: 8.0.1
+      fs-extra: 11.2.0
+      js-yaml: 4.1.0
+      npmlog: 7.0.1
+      qunit: 2.21.0
+      rimraf: 5.0.9
+      semver: 7.6.2
+      silent-error: 1.1.1
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
+
   ember-feature-flags@6.0.0:
     dependencies:
       ember-cli-babel: 7.26.11
@@ -17448,6 +17549,18 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
   exit@0.1.2: {}
 
   expand-brackets@2.1.4:
@@ -18005,6 +18118,17 @@ snapshots:
       strip-ansi: 6.0.1
       wide-align: 1.1.5
 
+  gauge@5.0.2:
+    dependencies:
+      aproba: 2.0.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      signal-exit: 4.1.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -18030,6 +18154,8 @@ snapshots:
       pump: 3.0.0
 
   get-stream@6.0.1: {}
+
+  get-stream@8.0.1: {}
 
   get-symbol-description@1.0.2:
     dependencies:
@@ -18416,6 +18542,8 @@ snapshots:
 
   human-signals@2.1.0: {}
 
+  human-signals@5.0.0: {}
+
   husky@9.0.11: {}
 
   iconv-lite@0.4.24:
@@ -18699,6 +18827,8 @@ snapshots:
   is-stream@1.1.0: {}
 
   is-stream@2.0.1: {}
+
+  is-stream@3.0.0: {}
 
   is-string@1.0.7:
     dependencies:
@@ -19292,6 +19422,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-fn@4.0.0: {}
+
   mimic-response@3.1.0: {}
 
   mini-css-extract-plugin@2.9.0(webpack@5.92.1):
@@ -19550,11 +19682,22 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
+
   npmlog@6.0.2:
     dependencies:
       are-we-there-yet: 3.0.1
       console-control-strings: 1.1.0
       gauge: 4.0.4
+      set-blocking: 2.0.0
+
+  npmlog@7.0.1:
+    dependencies:
+      are-we-there-yet: 4.0.2
+      console-control-strings: 1.1.0
+      gauge: 5.0.2
       set-blocking: 2.0.0
 
   nth-check@1.0.2:
@@ -19613,6 +19756,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
 
   open@7.4.2:
     dependencies:
@@ -19807,6 +19954,8 @@ snapshots:
   path-key@2.0.1: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -20339,6 +20488,10 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rimraf@5.0.9:
+    dependencies:
+      glob: 10.4.3
 
   ripemd160@2.0.2:
     dependencies:
@@ -20943,6 +21096,8 @@ snapshots:
   strip-eof@1.0.0: {}
 
   strip-final-newline@2.0.0: {}
+
+  strip-final-newline@3.0.0: {}
 
   strip-json-comments@2.0.1: {}
 


### PR DESCRIPTION
Splits the tests into chunks and launches a bunch of browsers to run
them. I've defaulted this to 8 for running tests on a local machine, but
only 3 for github where there are less cores available.