### PR TITLE
change form validation rules to prevent empty school admin emails fro…

### DIFF
--- a/packages/frontend/app/components/school/emails-editor.js
+++ b/packages/frontend/app/components/school/emails-editor.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
-import { validatable, Custom, IsEmail, Length } from 'ilios-common/decorators/validation';
+import { validatable, Custom, IsEmail, Length, NotBlank } from 'ilios-common/decorators/validation';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { isBlank, typeOf } from '@ember/utils';
@@ -11,7 +11,7 @@ import EmailValidator from 'validator/es/lib/isEmail';
 export default class SchoolEmailsEditorComponent extends Component {
   @service intl;
 
-  @tracked @Length(0, 100) @IsEmail() administratorEmail =
+  @tracked @Length(1, 100) @NotBlank() @IsEmail() administratorEmail =
     this.args.school.iliosAdministratorEmail || '';
   @tracked
   @Length(0, 300)

--- a/packages/frontend/tests/integration/components/school/emails-editor-test.js
+++ b/packages/frontend/tests/integration/components/school/emails-editor-test.js
@@ -49,7 +49,7 @@ module('Integration | Component | school/emails-editor', function (hooks) {
     assert.notOk(component.changeAlertRecipients.hasError);
   });
 
-  test('save with empty data', async function (assert) {
+  test('save with empty change alerts recipients', async function (assert) {
     assert.expect(8);
     const school = this.server.create('school', {
       iliosAdministratorEmail: 'admin@school.edu',
@@ -58,7 +58,7 @@ module('Integration | Component | school/emails-editor', function (hooks) {
     const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
     this.set('school', schoolModel);
     this.set('save', (administratorEmail, changeAlertRecipients) => {
-      assert.strictEqual(administratorEmail, '');
+      assert.strictEqual(administratorEmail, 'admin@school.edu');
       assert.strictEqual(changeAlertRecipients, '');
     });
     await render(
@@ -71,14 +71,37 @@ module('Integration | Component | school/emails-editor', function (hooks) {
     );
     assert.notOk(component.administratorEmail.hasError);
     assert.notOk(component.changeAlertRecipients.hasError);
-    await component.administratorEmail.set('');
     await component.changeAlertRecipients.set('');
     await component.save();
     assert.notOk(component.administratorEmail.hasError);
     assert.notOk(component.changeAlertRecipients.hasError);
   });
 
-  test('validation fails', async function (assert) {
+  test('validation fails if given admin email is empty', async function (assert) {
+    assert.expect(6);
+    const school = this.server.create('school', {
+      iliosAdministratorEmail: 'admin@school.edu',
+      changeAlertRecipients: 'email1@school.edu, email2@school.edu',
+    });
+    const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
+    this.set('school', schoolModel);
+    await render(
+      hbs`<School::EmailsEditor @school={{this.school}} @save={{(noop)}} @cancel={{(noop)}} />`,
+    );
+    assert.strictEqual(component.administratorEmail.value, 'admin@school.edu');
+    assert.strictEqual(
+      component.changeAlertRecipients.value,
+      'email1@school.edu, email2@school.edu',
+    );
+    assert.notOk(component.administratorEmail.hasError);
+    assert.notOk(component.changeAlertRecipients.hasError);
+    await component.administratorEmail.set('');
+    await component.save();
+    assert.ok(component.administratorEmail.hasError);
+    assert.notOk(component.changeAlertRecipients.hasError);
+  });
+
+  test('validation fails if input contains invalid emails', async function (assert) {
     const school = this.server.create('school');
     const schoolModel = await this.owner.lookup('service:store').findRecord('school', school.id);
     this.set('school', schoolModel);


### PR DESCRIPTION
…m being submitted.

the corresponding backend model asserts that school admin emails have to be at least one character long.
this realigns the frontend form validation rules with the asserts on the backend data model.

fixes https://github.com/ilios/ilios/issues/5589