### PR TITLE
Clear Glimmer Parser Deprecations

### DIFF
--- a/packages/ilios-common/lib/get-errors-for-transform.js
+++ b/packages/ilios-common/lib/get-errors-for-transform.js
@@ -43,7 +43,7 @@ module.exports = class GetErrorsForTransform {
   }
 
   transformNode(node) {
-    if (node.path.original === 'get-errors-for') {
+    if (node.path.type === 'PathExpression' && node.path.original === 'get-errors-for') {
       if (!node.params[0] || node.params[0].type !== 'PathExpression') {
         throw new Error(
           'the (get-errors-for) helper requires a path to be passed in as its first parameter, received: ' +

--- a/packages/ilios-common/lib/has-error-for-transform.js
+++ b/packages/ilios-common/lib/has-error-for-transform.js
@@ -43,7 +43,7 @@ module.exports = class HasErrorForTransform {
   }
 
   transformNode(node) {
-    if (node.path.original === 'has-error-for') {
+    if (node.path.type === 'PathExpression' && node.path.original === 'has-error-for') {
       if (!node.params[0] || node.params[0].type !== 'PathExpression') {
         throw new Error(
           'the (has-error-for) helper requires a path to be passed in as its first parameter, received: ' +

--- a/packages/ilios-common/lib/set-transform.js
+++ b/packages/ilios-common/lib/set-transform.js
@@ -45,7 +45,7 @@ module.exports = class SetTransform {
   }
 
   transformNode(node) {
-    if (node.path.original === 'set') {
+    if (node.path.type === 'PathExpression' && node.path.original === 'set') {
       if (!node.params[0] || node.params[0].type !== 'PathExpression') {
         throw new Error(
           'the (set) helper requires a path to be passed in as its first parameter, received: ' +


### PR DESCRIPTION
We need to filter out literals here and only deal with the PathExpression types as only they have the `original` property. Calling `.original` on any other type is deprecated (plus it doesn't work).