### PR TITLE
rm obsolete repo url

### DIFF
--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -5,7 +5,6 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "https://github.com/ilios/common",
   "license": "MIT",
   "author": "The Ilios Team",
   "directories": {


### PR DESCRIPTION
removes link to old, pre-mono-repo repository.