### PR TITLE
Fix Browserstack Test Name

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       reviewState: ${{ steps.reviews.outputs.reviewState }}
+    if: github.event.pull_request.draft == false
     steps:
       - id: reviews
         run: |
@@ -64,9 +65,9 @@ jobs:
           # This is in plaintext on purpose. It has no privileged access to anything (this is a free
           # account) and it allows us to run browserstack tests against PRs.
           BROWSERSTACK_ACCESS_KEY: yJjw6sE6izkpUw9oasGT
-          # The following is necessary when using browserstack under matrix builds on Github Actions
-          # The Job ID + Run ID isn't unique across matrix runs and will fail when run simultaneously
-          BROWSERSTACK_LOCAL_ID_SUFFIX: ${{matrix.workspace}}-${{ matrix.launcher }}
+          # Define a local identifier to avoid conflicts with other tests
+          # We concat unique info about this workflow, job, and run along with the specific matrix run to create something unique
+          BROWSERSTACK_LOCAL_IDENTIFIER: ui_browserstack-test-${{ github.run_id}}-${{matrix.workspace}}-${{ matrix.launcher }}
         run: |
           pnpm --filter ${{matrix.workspace}} exec ember browserstack:connect
           pnpm --filter ${{matrix.workspace}} exec ember test --test-port=7774 --host=127.0.0.1 --config-file=testem.browserstack.js --launch=${{ matrix.launcher }}


### PR DESCRIPTION
Sometimes this job runs from a context that ember-cli-browserstack isn't
ready to understand. We can build this id ourselves and save some pain
when tests refuse to run.