### PR TITLE
Week at a Glance now translates month names when displaying

### DIFF
--- a/packages/ilios-common/addon/components/week-glance.js
+++ b/packages/ilios-common/addon/components/week-glance.js
@@ -62,15 +62,23 @@ export default class WeeklyGlance extends Component {
       return '';
     }
 
-    const from = this.midnightAtTheStartOfTheWeekDateTime.toFormat('MMMM d');
+    const from =
+      this.intl.formatDate(this.midnightAtTheStartOfTheWeekDateTime, { month: 'long' }) +
+      ' ' +
+      this.midnightAtTheStartOfTheWeekDateTime.toFormat('d');
+
     let to = this.midnightAtTheEndOfTheWeekDateTime.toFormat('d');
+
     if (
       !this.midnightAtTheStartOfTheWeekDateTime.hasSame(
         this.midnightAtTheEndOfTheWeekDateTime,
         'month',
       )
     ) {
-      to = this.midnightAtTheEndOfTheWeekDateTime.toFormat('MMMM d');
+      to =
+        this.intl.formatDate(this.midnightAtTheEndOfTheWeekDateTime, { month: 'long' }) +
+        ' ' +
+        this.midnightAtTheEndOfTheWeekDateTime.toFormat('d');
       return `${from} - ${to}`;
     }
     return `${from}-${to}`;

--- a/packages/test-app/tests/integration/components/week-glance-test.js
+++ b/packages/test-app/tests/integration/components/week-glance-test.js
@@ -213,7 +213,7 @@ module('Integration | Component | week glance', function (hooks) {
     assert.ok(true, 'no a11y errors found!');
   });
 
-  test('click to expend', async function (assert) {
+  test('click to expand', async function (assert) {
     assert.expect(1);
     this.owner.register('service:user-events', this.blankEventsMock);
     this.userEvents = this.owner.lookup('service:user-events');

--- a/packages/test-app/tests/integration/components/weekly-events-test.js
+++ b/packages/test-app/tests/integration/components/weekly-events-test.js
@@ -3,11 +3,14 @@ import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { component } from 'ilios-common/page-objects/components/weekly-events';
+import { setLocale, setupIntl } from 'ember-intl/test-support';
 
 module('Integration | Component | weekly events', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us');
 
   test('it renders', async function (assert) {
+    this.intl = this.owner.lookup('service:intl');
     this.set('year', 2017);
     await render(hbs`<WeeklyEvents
       @year={{this.year}}
@@ -23,6 +26,14 @@ module('Integration | Component | weekly events', function (hooks) {
     assert.strictEqual(component.bottomNavigation.previousYear.title, 'Go to previous year');
     assert.strictEqual(component.bottomNavigation.nextYear.title, 'Go to next year');
     assert.strictEqual(component.weeks.length, 52);
+
+    assert.strictEqual(component.weeks[0].title, 'January 1-7');
+
+    await setLocale('es');
+    assert.strictEqual(component.weeks[0].title, 'enero 2-8');
+
+    await setLocale('fr');
+    assert.strictEqual(component.weeks[0].title, 'janvier 2-8');
   });
 
   test('top navigation - go to next year', async function (assert) {


### PR DESCRIPTION
Fixes ilios/ilios#5606

Need to add more tests, probably