### PR TITLE
Add Timeouts for Deploys

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -11,6 +11,7 @@ jobs:
   deploy:
     name: Deploy PR Preview
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: contains(github.event.pull_request.labels.*.name, 'safe to deploy')
     steps:
       - uses: actions/checkout@v4
@@ -25,6 +26,7 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - name: Ember CLI Deploy
+        timeout-minutes: 30
         run: pnpm --filter frontend exec ember deploy pr-preview
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,6 +14,7 @@ jobs:
   deploy:
     name: Deploy and Create Sentry Release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -25,6 +26,7 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - name: Ember CLI Deploy
+        timeout-minutes: 30
         run: pnpm -r run --parallel deploy:production
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -12,6 +12,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -23,6 +24,7 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - name: Ember CLI Deploy
+        timeout-minutes: 30
         run: pnpm -r run --parallel deploy:staging
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
These are defaulting to 6 hours, when they hang we don't get a failure message. Adding a step timeout should fail so we get a message, and then adding a job timeout just to save the world a bit if we run long.