### PR TITLE
fix main navigation feed icon spacing

### DIFF
--- a/packages/ilios-common/addon/components/dashboard/navigation.hbs
+++ b/packages/ilios-common/addon/components/dashboard/navigation.hbs
@@ -34,8 +34,6 @@
       >
         {{t "general.calendar"}}
       </LinkTo>
-    </li>
-    <li>
       <IcsFeed
         @url={{this.icsFeedUrl}}
         @instructions={{this.icsInstructions}}

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
@@ -17,20 +17,26 @@
     li {
       margin: 0;
 
+      &:nth-of-type(3) {
+        align-items: center;
+        display: flex;
+        gap: 5px;
+      }
+
       .ilios-calendar-ics-feed {
         padding: 0;
         text-align: center;
         width: 90%;
 
         .highlight {
-          @include m.for-phone-only {
-            /* stylelint-disable property-disallowed-list */
-            width: 7vw;
-          }
           align-items: center;
           display: flex;
           color: c.$orange;
           @include m.font-size("large");
+
+          @include m.for-phone-only {
+            @include m.font-size("medium");
+          }
         }
       }
     }


### PR DESCRIPTION
Makes feed icon snuggle up to calendar button and fixes ilios/ilios#5614

before: 
![image](https://github.com/user-attachments/assets/1654e92e-cd56-4136-b856-b88ea8a520fa)
after:
![image](https://github.com/user-attachments/assets/44809a45-1a09-4492-b2a4-444591425eff)


before:
![image](https://github.com/user-attachments/assets/527a979a-bea7-400f-b45b-dd02eb4d3095)
after:
![image](https://github.com/user-attachments/assets/a8a92d98-766b-4b68-be6d-0ca0396aff45)
