### PR TITLE
Relocate the Learner Group Calendar

### DIFF
--- a/packages/frontend/app/components/learner-group/root.hbs
+++ b/packages/frontend/app/components/learner-group/root.hbs
@@ -193,6 +193,9 @@
             />
           </div>
         {{else}}
+          {{#if this.showLearnerGroupCalendar}}
+            <LearnerGroup::Calendar @learnerGroup={{@learnerGroup}} />
+          {{/if}}
           <div class="learner-group-overview-content">
             <LearnerGroup::Members
               @learnerGroupId={{this.learnerGroupId}}
@@ -201,9 +204,6 @@
               @users={{this.usersToPassToManager}}
             />
           </div>
-        {{/if}}
-        {{#if this.showLearnerGroupCalendar}}
-          <LearnerGroup::Calendar @learnerGroup={{@learnerGroup}} />
         {{/if}}
         <section class="subgroups" data-test-subgroups>
           <div class="header">

--- a/packages/frontend/app/styles/components/learner-group/calendar.scss
+++ b/packages/frontend/app/styles/components/learner-group/calendar.scss
@@ -6,7 +6,7 @@
   border-radius: 5px;
   box-sizing: border-box;
   clear: both;
-  margin-bottom: 1rem;
+  margin: 1rem 0;
   min-height: 5rem;
   padding: 0.25rem 2rem 0.75rem;
   position: relative;


### PR DESCRIPTION
Moving this up by it's toggle so it is instantly visible in groups with many members.

Fixes ilios/ilios#5616