### PR TITLE
set phone-only cutoff at 399 so it covers the 380->400 pixel gap

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/mixins/media.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/media.scss
@@ -1,5 +1,5 @@
 @mixin for-phone-only {
-  @media screen and (max-width: 380px) {
+  @media screen and (max-width: 399px) {
     @content;
   }
 }


### PR DESCRIPTION
This should fix navigation buttons in non-English languages that cause the layout to careen ever so too much to the side on small screens

Fixes ilios/ilios#5607