### PR TITLE
rm unnecessary headline from admin calendar component.

### DIFF
--- a/packages/frontend/app/components/user-profile-calendar.hbs
+++ b/packages/frontend/app/components/user-profile-calendar.hbs
@@ -2,9 +2,6 @@
   class="user-profile-calendar"
   data-test-user-profile-calendar
 >
-  <h2 class="title">
-    {{t "general.calendar"}}
-  </h2>
   <ul class="calendar-time-picker">
     <li>
       <button

--- a/packages/frontend/app/styles/components/user-profile-calendar.scss
+++ b/packages/frontend/app/styles/components/user-profile-calendar.scss
@@ -8,18 +8,14 @@
   margin-bottom: 1rem;
   min-height: 5rem;
   overflow-x: scroll;
-  padding: 0.25rem;
+  padding: 1rem;
   position: relative;
-
-  h2 {
-    @include m.ilios-heading;
-    margin-bottom: 1rem;
-  }
 
   .calendar-time-picker {
     @include m.ilios-list-reset;
 
     margin-bottom: 0.5rem;
+    text-align: center;
 
     li {
       display: inline;

--- a/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar.scss
@@ -24,7 +24,7 @@
     grid-column: 1;
     grid-row: 1;
     justify-self: center;
-    margin: 0 0 0.25rem var(--hour-space);
+    margin: 0 0 0.25rem 0;
     padding: 0;
   }
 


### PR DESCRIPTION
fixes a couple of related issues while at it:
- provide proper padding to calendar container.
- center calendar controls.
- on the weekly calendar, remove left-hand margin (affects all calendars) on the week-of label. this properly centers it with the controls.

fixes https://github.com/ilios/ilios/issues/5613

![image](https://github.com/user-attachments/assets/76d893c4-de49-4e82-9580-be227890ae32)
