### PR TITLE
Pass the Pull Request Number to Percy

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -143,3 +143,4 @@ jobs:
         run: pnpm --filter ${{ matrix.workspace }} exec percy exec -- ember test
         env:
           PERCY_TOKEN: ${{ vars.PERCY_TOKEN }}
+          PERCY_PULL_REQUEST: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Without this percy doesn't know how to connect tests with the right PR and report status.