### PR TITLE
either left or right align headers and body in session grid.

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/mixins/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sessions-grid.scss
@@ -5,6 +5,7 @@
 @mixin sessions-grid() {
   display: grid;
   grid-template-columns: 1fr 8fr 2fr 1fr;
+  grid-gap: 0.5rem;
 
   .session-grid-type,
   .session-grid-groups,
@@ -15,17 +16,17 @@
     display: none;
   }
 
+  .session-grid-title,
+  .session-grid-type,
+  .session-grid-first-offering {
+    text-align: left;
+  }
+
   .session-grid-groups,
   .session-grid-objectives,
   .session-grid-terms,
-  .session-grid-offerings {
-    text-align: center;
-  }
-
-  .session-grid-status,
-  .session-grid-status.sortable-heading,
-  .session-grid-actions {
-    padding-right: 0.5rem;
+  .session-grid-offerings,
+  .session-grid-status {
     text-align: right;
   }
 


### PR DESCRIPTION
fixes ilios/ilios#5542


![image](https://github.com/user-attachments/assets/98216508-27f5-4e65-979a-35c5143805fa)
