### PR TITLE
Disabled nextPage button on Admin-Users list if no more results to show

### DIFF
--- a/packages/frontend/app/components/ilios-users.hbs
+++ b/packages/frontend/app/components/ilios-users.hbs
@@ -19,6 +19,9 @@
     <div class="header" data-test-header>
       <span class="title" data-test-title>
         {{t "general.users"}}
+        {{#if this.getTotalUsers.lastSuccessful.value.length}}
+          ({{this.getTotalUsers.lastSuccessful.value.length}})
+        {{/if}}
       </span>
       <div class="actions">
         {{#if (or @showNewUserForm @showBulkNewUserForm)}}
@@ -65,6 +68,7 @@
     {{#if this.searchForUsers.lastSuccessful}}
       <div data-test-top-paged-list-controls>
         <PagedlistControls
+          @total={{this.getTotalUsers.lastSuccessful.value.length}}
           @offset={{@offset}}
           @limit={{@limit}}
           @limitless={{true}}
@@ -83,6 +87,7 @@
       </div>
       <div data-test-bottom-paged-list-controls>
         <PagedlistControls
+          @total={{this.getTotalUsers.lastSuccessful.value.length}}
           @offset={{@offset}}
           @limit={{@limit}}
           @limitless={{true}}

--- a/packages/frontend/app/components/ilios-users.hbs
+++ b/packages/frontend/app/components/ilios-users.hbs
@@ -19,9 +19,6 @@
     <div class="header" data-test-header>
       <span class="title" data-test-title>
         {{t "general.users"}}
-        {{#if this.getTotalUsers.lastSuccessful.value.length}}
-          ({{this.getTotalUsers.lastSuccessful.value.length}})
-        {{/if}}
       </span>
       <div class="actions">
         {{#if (or @showNewUserForm @showBulkNewUserForm)}}
@@ -68,7 +65,7 @@
     {{#if this.searchForUsers.lastSuccessful}}
       <div data-test-top-paged-list-controls>
         <PagedlistControls
-          @total={{this.getTotalUsers.lastSuccessful.value.length}}
+          @total={{this.searchForUsers.lastSuccessful.value.length}}
           @offset={{@offset}}
           @limit={{@limit}}
           @limitless={{true}}
@@ -77,6 +74,9 @@
         />
       </div>
       <div class="list">
+      {{#if this.searchForUsers.isRunning}}
+        <LoadingSpinner />
+      {{else}}
         {{#if (gt this.searchForUsers.lastSuccessful.value.length 0)}}
           <UserList @users={{this.searchForUsers.lastSuccessful.value}} />
         {{else}}
@@ -84,10 +84,11 @@
             {{t "general.noResultsFound"}}
           </span>
         {{/if}}
+      {{/if}}
       </div>
       <div data-test-bottom-paged-list-controls>
         <PagedlistControls
-          @total={{this.getTotalUsers.lastSuccessful.value.length}}
+          @total={{this.searchForUsers.lastSuccessful.value.length}}
           @offset={{@offset}}
           @limit={{@limit}}
           @limitless={{true}}

--- a/packages/frontend/app/components/ilios-users.js
+++ b/packages/frontend/app/components/ilios-users.js
@@ -37,20 +37,12 @@ export default class IliosUsersComponent extends Component {
     return ensureSafeComponent(component, this);
   }
 
-  getTotalUsers = restartableTask(async () => {
-    const q = cleanQuery(this.args.query);
-    await timeout(DEBOUNCE_TIMEOUT);
-    return this.store.query('user', {
-      q,
-    });
-  });
-
   searchForUsers = restartableTask(async () => {
     const q = cleanQuery(this.args.query);
     await timeout(DEBOUNCE_TIMEOUT);
-    this.getTotalUsers.perform();
     return this.store.query('user', {
-      limit: this.args.limit,
+      // overfetch for nextPage functionality
+      limit: this.args.limit + 1,
       q,
       offset: this.args.offset,
       'order_by[lastName]': 'ASC',

--- a/packages/frontend/app/components/ilios-users.js
+++ b/packages/frontend/app/components/ilios-users.js
@@ -37,9 +37,18 @@ export default class IliosUsersComponent extends Component {
     return ensureSafeComponent(component, this);
   }
 
+  getTotalUsers = restartableTask(async () => {
+    const q = cleanQuery(this.args.query);
+    await timeout(DEBOUNCE_TIMEOUT);
+    return this.store.query('user', {
+      q,
+    });
+  });
+
   searchForUsers = restartableTask(async () => {
     const q = cleanQuery(this.args.query);
     await timeout(DEBOUNCE_TIMEOUT);
+    this.getTotalUsers.perform();
     return this.store.query('user', {
       limit: this.args.limit,
       q,

--- a/packages/ilios-common/addon/components/pagedlist-controls.js
+++ b/packages/ilios-common/addon/components/pagedlist-controls.js
@@ -52,6 +52,7 @@ export default class PagedlistControlsComponent extends Component {
 
   get lastPage() {
     if (this.args.limitless) {
+      // return false;
       return this.limit >= this.total;
     }
     return this.offset + this.limit >= this.total;

--- a/packages/ilios-common/addon/components/pagedlist-controls.js
+++ b/packages/ilios-common/addon/components/pagedlist-controls.js
@@ -52,7 +52,8 @@ export default class PagedlistControlsComponent extends Component {
 
   get lastPage() {
     if (this.args.limitless) {
-      return false;
+      // return false;
+      return this.limit >= this.total;
     }
     return this.offset + this.limit >= this.total;
   }

--- a/packages/ilios-common/addon/components/pagedlist-controls.js
+++ b/packages/ilios-common/addon/components/pagedlist-controls.js
@@ -52,7 +52,6 @@ export default class PagedlistControlsComponent extends Component {
 
   get lastPage() {
     if (this.args.limitless) {
-      // return false;
       return this.limit >= this.total;
     }
     return this.offset + this.limit >= this.total;


### PR DESCRIPTION
Fixes ilios/ilios#5544

My approach required adding another Ember Data query to be run to get the total users (as the main query limits the user count for the UI), but we get the benefit of disabling the nextPage button if appropriate AND a user count.

I understand if this is not ideal, so if it needs to be rejected (or maybe just modified?) I understand.