### PR TITLE
Align package version with tag

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "41.7.0",
+  "version": "41.8.0",
   "description": "Curriculum Management System for the Health Professions",
   "repository": "https://github.com/ilios/frontend",
   "license": "MIT",

--- a/packages/lti-dashboard/package.json
+++ b/packages/lti-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lti-dashboard",
-  "version": "41.7.0",
+  "version": "41.8.0",
   "description": "LTI App for ilios integration",
   "license": "MIT",
   "author": "The Ilios team <info@iliosproject.org>",


### PR DESCRIPTION
We tagged [this release](https://github.com/ilios/frontend/releases/tag/v41.8.0), but the package.json didn't get updated because my missconfiguration of the github rules prevented zorgbort from pushing the commit.