### PR TITLE
Split Label and Review Process in Automerge Workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -44,11 +44,13 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v4
         if: ${{contains(steps.metadata.outputs.dependency-names, matrix.safe-dependency) && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') }}
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{contains(steps.metadata.outputs.dependency-names, matrix.safe-dependency) && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') }}
+      - name: Review and Label
         run: |
           gh pr edit --add-label "ready to merge" ${{ steps.cpr.outputs.pull-request-number }}
           gh pr review --approve -b "Auto Approved" ${{ github.event.number }}
-          gh pr merge --merge --auto ${{ github.event.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable Auto Merge
+        run: gh pr merge --merge --auto ${{ github.event.number }}
         env:
           GH_TOKEN: ${{ secrets.ZORGBORT_TOKEN }}


### PR DESCRIPTION
The zorgbort PAT can't label or review pull requests, but the github one can. I've also removed the superfluous if statement, if the first step doesn't run the following ones shouldn't either.