### PR TITLE
Restore Check on Every Step

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -45,12 +45,14 @@ jobs:
       - uses: actions/checkout@v4
         if: ${{contains(steps.metadata.outputs.dependency-names, matrix.safe-dependency) && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') }}
       - name: Review and Label
+        if: ${{contains(steps.metadata.outputs.dependency-names, matrix.safe-dependency) && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') }}
         run: |
           gh pr edit --add-label "ready to merge" ${{ steps.cpr.outputs.pull-request-number }}
           gh pr review --approve -b "Auto Approved" ${{ github.event.number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable Auto Merge
+        if: ${{contains(steps.metadata.outputs.dependency-names, matrix.safe-dependency) && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch') }}
         run: gh pr merge --merge --auto ${{ github.event.number }}
         env:
           GH_TOKEN: ${{ secrets.ZORGBORT_TOKEN }}


### PR DESCRIPTION
Without this the if causes a skip and then the next job runs. We have to check.