### PR TITLE
Reduce our Dependabot Runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,13 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
-      time: "02:30"
-      timezone: America/Los_Angeles
+      interval: weekly
+      day: "sunday"
     open-pull-requests-limit: 10
     groups:
       embroider:


### PR DESCRIPTION
Tamping down our dependabot runs to Sunday after our lock file update job runs. This will reduce the number of PRs we need to test and ensure we don't have to spend time on ones that would get auto updated with a lock file update anyway. Those that do need attention will be easier to handle once a week.