### PR TITLE
Silence the Mixed Declarations SASS Deprecation

### DIFF
--- a/packages/frontend/ember-cli-build.js
+++ b/packages/frontend/ember-cli-build.js
@@ -60,6 +60,9 @@ module.exports = async function (defaults) {
     minifyCSS: {
       enabled: false,
     },
+    sassOptions: {
+      silenceDeprecations: ['mixed-decls'],
+    },
   };
 
   const app = new EmberApp(defaults, config);

--- a/packages/lti-course-manager/ember-cli-build.js
+++ b/packages/lti-course-manager/ember-cli-build.js
@@ -17,6 +17,9 @@ module.exports = async function (defaults) {
       enabled: true,
     },
     hinting: isTestBuild,
+    sassOptions: {
+      silenceDeprecations: ['mixed-decls'],
+    },
   };
   const app = new EmberApp(defaults, config);
 

--- a/packages/lti-dashboard/ember-cli-build.js
+++ b/packages/lti-dashboard/ember-cli-build.js
@@ -18,6 +18,9 @@ module.exports = async function (defaults) {
       enabled: true,
     },
     hinting: isTestBuild,
+    sassOptions: {
+      silenceDeprecations: ['mixed-decls'],
+    },
   };
   const app = new EmberApp(defaults, config);
 

--- a/packages/test-app/ember-cli-build.js
+++ b/packages/test-app/ember-cli-build.js
@@ -18,6 +18,9 @@ module.exports = async function (defaults) {
     autoImport: {
       watchDependencies: ['ilios-common'],
     },
+    sassOptions: {
+      silenceDeprecations: ['mixed-decls'],
+    },
     babel: {
       plugins: [
         require.resolve('ember-auto-import/babel-plugin'),


### PR DESCRIPTION
This is a very noisy deprecation that it looks like we can ignore. Everywhere this is triggered we appear to be expecting the new behavior, we will probably need to wait for the update that changes things and then fix any styles that have an issue.