### PR TITLE
fixed Ember.js test framework deprecation on ember serve

### DIFF
--- a/packages/frontend/config/dependency-lint.js
+++ b/packages/frontend/config/dependency-lint.js
@@ -3,8 +3,8 @@
 
 module.exports = {
   allowedVersions: {
-    generateTests: false,
     'ember-get-config': '^1.0.0 || ^2.0.0',
     'ember-modifier': '^3.0.0 || ^4.0.0',
   },
+  generateTests: false,
 };


### PR DESCRIPTION
moved generateTests property to correct place in module.exports