### PR TITLE
remove unneeded .slice() calls on data in frontend root components

### DIFF
--- a/packages/frontend/app/components/bulk-new-users.js
+++ b/packages/frontend/app/components/bulk-new-users.js
@@ -171,7 +171,7 @@ export default class BulkNewUsersComponent extends Component {
 
   async existingUsernames() {
     const authentications = await this.store.findAll('authentication');
-    return mapBy(authentications.slice(), 'username').filter(Boolean);
+    return mapBy(authentications, 'username').filter(Boolean);
   }
 
   /**
@@ -254,7 +254,7 @@ export default class BulkNewUsersComponent extends Component {
     const selectedSchool = this.bestSelectedSchool;
     const selectedCohort = this.bestSelectedCohort;
     const roles = await this.store.findAll('user-role');
-    const studentRole = findById(roles.slice(), '4');
+    const studentRole = findById(roles, '4');
 
     const proposedUsers = this.selectedUsers;
 

--- a/packages/frontend/app/components/global-search.js
+++ b/packages/frontend/app/components/global-search.js
@@ -50,7 +50,7 @@ export default class GlobalSearchComponent extends Component {
       return [];
     }
     return this.args.ignoredSchoolIds.map((id) => {
-      const school = findById(this.schools.slice(), id);
+      const school = findById(this.schools, id);
       return school ? school.title : '';
     });
   }

--- a/packages/frontend/app/components/new-directory-user.js
+++ b/packages/frontend/app/components/new-directory-user.js
@@ -139,7 +139,7 @@ export default class NewDirectoryUserComponent extends Component {
 
   get bestSelectedCohort() {
     if (this.primaryCohortId) {
-      const currentCohort = findById(this.currentSchoolCohorts.slice(), this.primaryCohortId);
+      const currentCohort = findById(this.currentSchoolCohorts, this.primaryCohortId);
 
       if (currentCohort) {
         return currentCohort;

--- a/packages/frontend/app/components/new-user.js
+++ b/packages/frontend/app/components/new-user.js
@@ -120,14 +120,14 @@ export default class NewUserComponent extends Component {
 
   get bestSelectedCohort() {
     if (this.primaryCohortId) {
-      const currentCohort = findById(this.currentSchoolCohorts.slice(), this.primaryCohortId);
+      const currentCohort = findById(this.currentSchoolCohorts, this.primaryCohortId);
 
       if (currentCohort) {
         return currentCohort;
       }
     }
 
-    return this.currentSchoolCohorts.slice().reverse()[0];
+    return this.currentSchoolCohorts.reverse()[0];
   }
 
   async isUsernameTaken(username) {
@@ -175,7 +175,7 @@ export default class NewUserComponent extends Component {
     });
     if (!this.nonStudentMode) {
       user.set('primaryCohort', primaryCohort);
-      const studentRole = findBy(roles.slice(), 'title', 'Student');
+      const studentRole = findBy(roles, 'title', 'Student');
       user.set('roles', [studentRole]);
     }
     user = await user.save();

--- a/packages/frontend/app/components/pending-updates-summary.js
+++ b/packages/frontend/app/components/pending-updates-summary.js
@@ -50,12 +50,12 @@ export default class PendingUpdatesSummaryComponent extends Component {
   get bestSelectedSchool() {
     const id = this.selectedSchoolId ?? this.user?.belongsTo('school').id();
     if (id) {
-      const school = findById(this.args.schools.slice(), id);
+      const school = findById(this.args.schools, id);
       if (school) {
         return school;
       }
     }
-    return this.args.schools.slice()[0];
+    return this.args.schools[0];
   }
 
   get areUpdatesLoaded() {
@@ -67,11 +67,11 @@ export default class PendingUpdatesSummaryComponent extends Component {
       return [];
     }
 
-    return this.allUpdates.slice();
+    return this.allUpdates;
   }
 
   async getUpdatesForSchool(allUpdates, selectedSchool) {
-    return filter(allUpdates.slice(), async (update) => {
+    return filter(allUpdates, async (update) => {
       const user = await update.user;
       return user.belongsTo('school').id() === selectedSchool.id;
     });

--- a/packages/frontend/app/components/school-competencies-list-item-pcrs.js
+++ b/packages/frontend/app/components/school-competencies-list-item-pcrs.js
@@ -14,6 +14,6 @@ export default class SchoolCompetenciesListItemPcrsComponent extends Component {
   }
 
   get aamcPcrses() {
-    return this.aamcPcrsesData.isResolved ? this.aamcPcrsesData.value.slice() : [];
+    return this.aamcPcrsesData.isResolved ? this.aamcPcrsesData.value : [];
   }
 }

--- a/packages/frontend/app/components/school-competencies-manager.js
+++ b/packages/frontend/app/components/school-competencies-manager.js
@@ -7,7 +7,7 @@ export default class SchoolCompetenciesManagerComponent extends Component {
     if (!this.args.competencies) {
       return [];
     }
-    const domains = this.args.competencies.slice().filter((competency) => {
+    const domains = this.args.competencies.filter((competency) => {
       return !competency.belongsTo('parent').id();
     });
     const objs = uniqueValues(domains).map((domain) => {

--- a/packages/frontend/app/components/school-new-vocabulary-form.js
+++ b/packages/frontend/app/components/school-new-vocabulary-form.js
@@ -38,7 +38,7 @@ export default class SchoolNewVocabularyFormComponent extends Component {
 
   async validateTitleCallback() {
     const allVocabsInSchool = await this.args.school.vocabularies;
-    const titles = mapBy(allVocabsInSchool.slice(), 'title');
+    const titles = mapBy(allVocabsInSchool, 'title');
     return !titles.includes(this.title);
   }
 

--- a/packages/frontend/app/components/school-vocabularies-list.js
+++ b/packages/frontend/app/components/school-vocabularies-list.js
@@ -24,7 +24,7 @@ export default class SchoolVocabulariesListComponent extends Component {
     if (!this.vocabularies) {
       return [];
     }
-    return sortBy(filterBy(this.vocabularies.slice(), 'isNew', false), 'title');
+    return sortBy(filterBy(this.vocabularies, 'isNew', false), 'title');
   }
 
   @action

--- a/packages/frontend/app/components/school-vocabulary-manager.js
+++ b/packages/frontend/app/components/school-vocabulary-manager.js
@@ -32,11 +32,7 @@ export default class SchoolVocabularyManagerComponent extends Component {
       return [];
     }
     return sortBy(
-      filterBy(
-        filterBy(filterBy(this.terms.slice(), 'isTopLevel'), 'isNew', false),
-        'isDeleted',
-        false,
-      ),
+      filterBy(filterBy(filterBy(this.terms, 'isTopLevel'), 'isNew', false), 'isDeleted', false),
       'title',
     );
   }
@@ -75,7 +71,7 @@ export default class SchoolVocabularyManagerComponent extends Component {
   async validateTitleCallback() {
     const school = await this.args.vocabulary.school;
     const allVocabsInSchool = await school.vocabularies;
-    const siblings = allVocabsInSchool.slice().filter((vocab) => {
+    const siblings = allVocabsInSchool.filter((vocab) => {
       return vocab !== this.args.vocabulary;
     });
     const siblingTitles = mapBy(siblings, 'title');

--- a/packages/frontend/app/components/school-vocabulary-new-term.js
+++ b/packages/frontend/app/components/school-vocabulary-new-term.js
@@ -37,7 +37,7 @@ export default class SchoolVocabularyNewTermComponent extends Component {
     const terms = this.args.term
       ? await this.args.term.children
       : await this.args.vocabulary.getTopLevelTerms();
-    return !mapBy(terms.slice(), 'title').includes(this.title);
+    return !mapBy(terms, 'title').includes(this.title);
   }
 
   validateTitleMessageCallback() {

--- a/packages/frontend/app/components/school-vocabulary-term-manager.js
+++ b/packages/frontend/app/components/school-vocabulary-term-manager.js
@@ -97,7 +97,7 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
     const goTo = isEmpty(parent) ? null : parent.id;
     this.args.term.deleteRecord();
     if (parent) {
-      const siblings = (await parent.children).slice();
+      const siblings = await parent.children;
       siblings.splice(siblings.indexOf(this.args.term), 1);
       parent.set('children', siblings);
     }
@@ -119,7 +119,7 @@ export default class SchoolVocabularyTermManagerComponent extends Component {
 
   async validateTitleCallback() {
     const terms = await this.args.term.children;
-    return !mapBy(terms.slice(), 'title').includes(this.title);
+    return !mapBy(terms, 'title').includes(this.title);
   }
 
   validateTitleMessageCallback() {

--- a/packages/frontend/app/components/user-profile-permissions.js
+++ b/packages/frontend/app/components/user-profile-permissions.js
@@ -69,11 +69,11 @@ export default class UserProfilePermissionsComponent extends Component {
   }
 
   get schools() {
-    return this.schoolData.isResolved ? this.schoolData.value.slice() : [];
+    return this.schoolData.isResolved ? this.schoolData.value : [];
   }
 
   get academicYears() {
-    return this.academicYearData.isResolved ? this.academicYearData.value.slice() : [];
+    return this.academicYearData.isResolved ? this.academicYearData.value : [];
   }
 
   @cached

--- a/packages/frontend/app/components/user-profile-roles.js
+++ b/packages/frontend/app/components/user-profile-roles.js
@@ -61,7 +61,7 @@ export default class UserProfileRolesComponent extends Component {
   }
 
   save = dropTask(async () => {
-    const roles = (await this.store.findAll('user-role')).slice();
+    const roles = await this.store.findAll('user-role');
     const studentRole = findBy(roles, 'title', 'Student');
     const formerStudentRole = findBy(roles, 'title', 'Former Student');
     this.args.user.set('enabled', this.isEnabled);

--- a/packages/frontend/app/components/visualizer-program-year-objectives.js
+++ b/packages/frontend/app/components/visualizer-program-year-objectives.js
@@ -38,22 +38,19 @@ export default class VisualizerProgramYearObjectivesComponent extends Component 
     };
     const buildTree = async function (programYearObjective) {
       const courseObjectives = await programYearObjective.courseObjectives;
-      const courseObjectivesTree = await map(courseObjectives.slice(), async (courseObjective) => {
+      const courseObjectivesTree = await map(courseObjectives, async (courseObjective) => {
         const sessionObjectives = await courseObjective.sessionObjectives;
-        const sessionObjectivesTree = await map(
-          sessionObjectives.slice(),
-          async (sessionObjective) => {
-            const session = await sessionObjective.session;
-            return buildTreeLevel(sessionObjective, [], session.title, null);
-          },
-        );
+        const sessionObjectivesTree = await map(sessionObjectives, async (sessionObjective) => {
+          const session = await sessionObjective.session;
+          return buildTreeLevel(sessionObjective, [], session.title, null);
+        });
         const course = await courseObjective.course;
         return buildTreeLevel(courseObjective, sessionObjectivesTree, null, course.title);
       });
       return buildTreeLevel(programYearObjective, courseObjectivesTree, null, null);
     };
     const objectives = await programYear.programYearObjectives;
-    const objectivesWithCompetency = await filter(objectives.slice(), async (objective) => {
+    const objectivesWithCompetency = await filter(objectives, async (objective) => {
       const competency = await objective.competency;
       return !!competency;
     });
@@ -68,7 +65,7 @@ export default class VisualizerProgramYearObjectivesComponent extends Component 
   async getCompetencyObjects(programYear) {
     const objectiveObjects = await this.getObjectiveObjects(programYear);
     const competencies = await programYear.competencies;
-    return await map(competencies.slice(), async (competency) => {
+    return await map(competencies, async (competency) => {
       const domain = await competency.getDomain();
 
       const domainId = domain.id;
@@ -85,7 +82,7 @@ export default class VisualizerProgramYearObjectivesComponent extends Component 
   async getDomainObjects(programYear) {
     const competencies = await programYear.competencies;
     const competencyObjects = await this.getCompetencyObjects(programYear);
-    const domains = await map(competencies.slice(), async (competency) => competency.getDomain());
+    const domains = await map(competencies, async (competency) => competency.getDomain());
     return uniqueValues(domains).map((domain) => {
       const id = domain.id;
       const name = domain.title;

--- a/packages/frontend/tests/integration/components/new-user-test.js
+++ b/packages/frontend/tests/integration/components/new-user-test.js
@@ -112,7 +112,7 @@ module('Integration | Component | new user', function (hooks) {
     assert.strictEqual(newUser.phone, 'phone', 'with the correct phone');
     assert.strictEqual(newUser.email, 'test@test.com', 'with the correct email');
     const roles = await newUser.roles;
-    assert.notOk(mapBy(roles.slice(), 'id').includes(studentRole.id));
+    assert.notOk(mapBy(roles, 'id').includes(studentRole.id));
 
     const authentication = await newUser.authentication;
     assert.strictEqual(authentication.username, 'user123', 'with the correct username');
@@ -162,7 +162,7 @@ module('Integration | Component | new user', function (hooks) {
     assert.strictEqual(newUser.phone, 'phone', 'with the correct phone');
     assert.strictEqual(newUser.email, 'test@test.com', 'with the correct email');
     const roles = await newUser.roles;
-    assert.ok(mapBy(roles.slice(), 'id').includes(studentRole.id));
+    assert.ok(mapBy(roles, 'id').includes(studentRole.id));
 
     const authentication = await newUser.authentication;
     assert.strictEqual(authentication.username, 'user123', 'with the correct username');

--- a/packages/frontend/tests/integration/components/school-list-test.js
+++ b/packages/frontend/tests/integration/components/school-list-test.js
@@ -72,7 +72,7 @@ module('Integration | Component | school list', function (hooks) {
     await render(hbs`<SchoolList @schools={{this.schools}} />`);
     await component.expandCollapseButton.toggle();
 
-    let schools = (await this.owner.lookup('service:store').findAll('school')).slice();
+    let schools = await this.owner.lookup('service:store').findAll('school');
     assert.strictEqual(schools.length, 2);
     assert.notOk(component.savedSchool.isVisible);
     component.newSchoolForm.title.set('school of rocket surgery');

--- a/packages/frontend/tests/integration/components/school-new-vocabulary-form-test.js
+++ b/packages/frontend/tests/integration/components/school-new-vocabulary-form-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | school-new-vocabulary-form', function (hooks) 
 
   test('validation fails if title is not unique', async function (assert) {
     this.set('school', this.schoolModel);
-    const vocabularies = (await this.schoolModel.vocabularies).slice();
+    const vocabularies = await this.schoolModel.vocabularies;
     await render(hbs`<SchoolNewVocabularyForm @school={{this.school}} @close={{(noop)}} />`);
     assert.notOk(component.title.hasError);
     assert.expect(vocabularies[0].title, 'Vocab A');


### PR DESCRIPTION
Refs ilios/ilios#5660

This change removes all the unneeded calls to `.slice()` in all the root `frontend` root components (not located in a `components/**` subdir.