### PR TITLE
downgrade ember-a11y-refocus.

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -57,7 +57,7 @@
     "browserslist": "^4.23.3",
     "caniuse-db": "^1.0.30001651",
     "class-validator": "^0.14.0",
-    "ember-a11y-refocus": "4.1.3",
+    "ember-a11y-refocus": "4.1.1",
     "ember-a11y-testing": "^6.1.1",
     "ember-async-data": "^1.0.3",
     "ember-auto-import": "^2.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: ^0.14.0
         version: 0.14.1
       ember-a11y-refocus:
-        specifier: 4.1.3
-        version: 4.1.3
+        specifier: 4.1.1
+        version: 4.1.1
       ember-a11y-testing:
         specifier: ^6.1.1
         version: 6.1.1(@babel/core@7.25.2)(@ember/test-helpers@3.3.1(@babel/core@7.25.2)(ember-source@5.9.0(@babel/core@7.25.2)(@glimmer/component@1.1.2(@babel/core@7.25.2))(rsvp@4.8.5)(webpack@5.93.0))(webpack@5.93.0))(qunit@2.21.1)(webpack@5.93.0)
@@ -4960,8 +4960,8 @@ packages:
   elliptic@6.5.7:
     resolution: {integrity: sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==}
 
-  ember-a11y-refocus@4.1.3:
-    resolution: {integrity: sha512-g2gLJq67oOib2oC8o5QoCHiLI1uYBuD6luYKafL1BkLRqm07+V1JpwEFSwKwtQV7yC8LBYdIZ+JaIib5IvaGIA==}
+  ember-a11y-refocus@4.1.1:
+    resolution: {integrity: sha512-cNeNA4rg+yMny0hXBoxz0F61X7aaI860zD2Ljx8syL0PAZWMR3QjtdG7JEwNwaMrO5MSrPgsdJh+ZjyEvnFWMQ==}
     engines: {node: 16.* || >= 18.*}
 
   ember-a11y-testing@6.1.1:
@@ -15682,7 +15682,7 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
-  ember-a11y-refocus@4.1.3:
+  ember-a11y-refocus@4.1.1:
     dependencies:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0


### PR DESCRIPTION
hot-fix for https://github.com/ilios/ilios/issues/5662

real resolution pending, but this should get us back on stable grounds.