### PR TITLE
fixes broken getter and moves it from model into component where it belongs

### DIFF
--- a/packages/frontend/app/components/program-year/objective-list.hbs
+++ b/packages/frontend/app/components/program-year/objective-list.hbs
@@ -37,8 +37,8 @@
       <span class="grid-item" data-test-header>{{t "general.meshTerms"}}</span>
       <span class="actions grid-item" data-test-header>{{t "general.actions"}}</span>
     </div>
-    {{#if (and (is-array @programYear.sortedProgramYearObjectives) (is-array this.domainTrees))}}
-      {{#each @programYear.sortedProgramYearObjectives as |programYearObjective|}}
+    {{#if (is-array this.domainTrees)}}
+      {{#each this.sortedProgramYearObjectives as |programYearObjective|}}
         <ProgramYear::ObjectiveListItem
           @programYearObjective={{programYearObjective}}
           @editable={{@editable}}

--- a/packages/frontend/app/components/program-year/objective-list.js
+++ b/packages/frontend/app/components/program-year/objective-list.js
@@ -5,6 +5,8 @@ import { map } from 'rsvp';
 import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import { mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
+import sortableByPosition from 'ilios-common/utils/sortable-by-position';
+
 export default class ProgramYearObjectiveListComponent extends Component {
   @service iliosConfig;
   @service session;
@@ -30,6 +32,17 @@ export default class ProgramYearObjectiveListComponent extends Component {
 
   get domainTrees() {
     return this.domainTreesData.isResolved ? this.domainTreesData.value : [];
+  }
+
+  @cached
+  get programYearObjectivesData() {
+    return new TrackedAsyncData(this.args.programYear.programYearObjectives);
+  }
+
+  get sortedProgramYearObjectives() {
+    return this.programYearObjectivesData.isResolved
+      ? this.programYearObjectivesData.value.slice().sort(sortableByPosition)
+      : [];
   }
 
   get programYearObjectiveCount() {

--- a/packages/ilios-common/addon/models/program-year.js
+++ b/packages/ilios-common/addon/models/program-year.js
@@ -1,5 +1,4 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
-import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 import { sortBy, uniqueValues } from 'ilios-common/utils/array-helpers';
@@ -33,11 +32,6 @@ export default class ProgramYear extends Model {
 
   @hasMany('program-year-objective', { async: true, inverse: 'programYear' })
   programYearObjectives;
-
-  @cached
-  get _programYearObjectivesData() {
-    return new TrackedAsyncData(this.programYearObjectives);
-  }
 
   @hasMany('term', { async: true, inverse: 'programYears' })
   terms;
@@ -89,16 +83,6 @@ export default class ProgramYear extends Model {
   async getClassOfYear() {
     const program = await this.program;
     return Number(this.startYear) + Number(program.duration);
-  }
-
-  /**
-   * A list of program-year objectives, sorted by position.
-   */
-  get sortedProgramYearObjectives() {
-    if (!this._programYearObjectivesData.isResolved) {
-      return null;
-    }
-    return this._programYearObjectivesData.value.slice().sort(sortableByPosition);
   }
 
   @cached

--- a/packages/test-app/tests/unit/models/program-year-test.js
+++ b/packages/test-app/tests/unit/models/program-year-test.js
@@ -23,34 +23,6 @@ module('Unit | Model | ProgramYear', function (hooks) {
     assert.strictEqual(await waitForResource(model, 'classOfYear'), '2006');
   });
 
-  test('sortedProgramYearObjectives', async function (assert) {
-    const store = this.owner.lookup('service:store');
-    const programYear = store.createRecord('program-year');
-    const programYearObjective1 = store.createRecord('program-year-objective', {
-      id: 1,
-      programYear,
-      title: 'Aardvark',
-      position: 3,
-    });
-    const programYearObjective2 = store.createRecord('program-year-objective', {
-      id: 2,
-      programYear,
-      title: 'Bar',
-      position: 2,
-    });
-    const programYearObjective3 = store.createRecord('program-year-objective', {
-      id: 3,
-      programYear,
-      title: 'Foo',
-      position: 2,
-    });
-    const objectives = await waitForResource(programYear, 'sortedProgramYearObjectives');
-    assert.strictEqual(objectives.length, 3);
-    assert.strictEqual(objectives[0], programYearObjective3);
-    assert.strictEqual(objectives[1], programYearObjective2);
-    assert.strictEqual(objectives[2], programYearObjective1);
-  });
-
   test('assignableVocabularies', async function (assert) {
     const store = this.owner.lookup('service:store');
     const programYear = store.createRecord('program-year');


### PR DESCRIPTION
this broke during the conversion from Resource to TrackedAsyncData. it's a one-off, so i moved it into the component that actually needs sorted objectives.

interesting observation - EmberData relationships do not like `.sort()` invoked on them directly (yet), so we need to keep `slice()` in there for the time being. 

**UPDATE:** using `toSorted()` allows us to get rid of `slice()`.

**UPDATE 2:** Safari is not having it. reverted back to `.slice().sort(...)`.
