### PR TITLE
Add a Custom Sentry Login Metric

### DIFF
--- a/packages/frontend/app/services/session.js
+++ b/packages/frontend/app/services/session.js
@@ -21,6 +21,9 @@ export default class SessionService extends ESASessionService {
     //this is also done for authenticated users in the Application Route
     await this.store.findAll('school');
     Sentry.setUser({ id: user.id });
+    Sentry.metrics.increment('login', 1, {
+      tags: { userAgent: navigator.userAgent },
+    });
   }
 
   async handleInvalidation() {


### PR DESCRIPTION
We're incrementing a counter on each login with information about the users browser. This should allow us to get a better idea about our browser usage as well as get some data on usage and logins.