### PR TITLE
Drop Support for Safari 15.x

### DIFF
--- a/packages/frontend/config/targets.js
+++ b/packages/frontend/config/targets.js
@@ -9,7 +9,7 @@ if (isCI || isProduction) {
   browsers.push('last 3 edge versions');
   browsers.push('firefox esr'); //sometimes points to the last 2 ESR releases when they overlap
   browsers.push('last 2 iOS major versions');
-  browsers.push('last 3 safari major versions');
+  browsers.push('last 2 safari major versions');
   browsers.push('last 3 ChromeAndroid versions');
   browsers.push('last 3 Chrome versions');
 }

--- a/packages/frontend/testem.browserstack.js
+++ b/packages/frontend/testem.browserstack.js
@@ -8,11 +8,11 @@ const BrowserStackLaunchers = {
       '--os',
       'OS X',
       '--osv',
-      'Monterey',
+      'Ventura',
       '--b',
       'safari',
       '--bv',
-      'latest', // Will always be 15.x on Monterey
+      'latest', // Will always be 16.x on Ventura
       ...defaultArgs,
     ],
     protocol: 'browser',

--- a/packages/ilios-common/addon/utils/load-polyfills.js
+++ b/packages/ilios-common/addon/utils/load-polyfills.js
@@ -1,5 +1,5 @@
 export async function loadPolyfills() {
-  //we need CRYPTO.randomUUID until we drop support for Safari 15.x
+  //we need CRYPTO.randomUUID until we drop support for iOS Safari 16.x as that version doesn't provide it in insecure (aka test) contexts
   installUUIDPolyfill();
 }
 

--- a/packages/lti-course-manager/testem.browserstack.js
+++ b/packages/lti-course-manager/testem.browserstack.js
@@ -8,11 +8,11 @@ const BrowserStackLaunchers = {
       '--os',
       'OS X',
       '--osv',
-      'Monterey',
+      'Ventura',
       '--b',
       'safari',
       '--bv',
-      'latest', // Will always be 15.x on Monterey
+      'latest', // Will always be 16.x on Ventura
       ...defaultArgs,
     ],
     protocol: 'browser',

--- a/packages/lti-dashboard/testem.browserstack.js
+++ b/packages/lti-dashboard/testem.browserstack.js
@@ -8,11 +8,11 @@ const BrowserStackLaunchers = {
       '--os',
       'OS X',
       '--osv',
-      'Monterey',
+      'Ventura',
       '--b',
       'safari',
       '--bv',
-      'latest', // Will always be 15.x on Monterey
+      'latest', // Will always be 16.x on Ventura
       ...defaultArgs,
     ],
     protocol: 'browser',

--- a/packages/test-app/config/targets.js
+++ b/packages/test-app/config/targets.js
@@ -9,7 +9,7 @@ if (isCI || isProduction) {
   browsers.push('last 3 edge versions');
   browsers.push('firefox esr'); //sometimes points to the last 2 ESR releases when they overlap
   browsers.push('last 2 iOS major versions');
-  browsers.push('last 3 safari major versions');
+  browsers.push('last 2 safari major versions');
   browsers.push('last 3 ChromeAndroid versions');
   browsers.push('last 3 Chrome versions');
 }

--- a/packages/test-app/testem.browserstack.js
+++ b/packages/test-app/testem.browserstack.js
@@ -8,11 +8,11 @@ const BrowserStackLaunchers = {
       '--os',
       'OS X',
       '--osv',
-      'Monterey',
+      'Ventura',
       '--b',
       'safari',
       '--bv',
-      'latest', // Will always be 15.x on Monterey
+      'latest', // Will always be 16.x on Ventura
       ...defaultArgs,
     ],
     protocol: 'browser',


### PR DESCRIPTION
Changing our support to only cover the last two major safari versions on OSX as our stats show that this will cover our users and we can move more quickly to some modern Javascript and improve performance for everyone else by not including dead code.

We wern't able to drop the crypto polyfill because ios Safari doesn't
support it in "insecure" contexts at this version. Hoping that will be
fixed in the future.