### PR TITLE
Enable Sourcemaps for Embroider

### DIFF
--- a/packages/frontend/ember-cli-build.js
+++ b/packages/frontend/ember-cli-build.js
@@ -16,9 +16,6 @@ module.exports = async function (defaults) {
     fingerprint: {
       extensions: broccoliAssetRevDefaults.extensions.concat(['webmanifest', 'svg']),
     },
-    sourcemaps: {
-      enabled: true,
-    },
     emberData: {
       compatWith: '5.2',
     },
@@ -107,6 +104,7 @@ module.exports = async function (defaults) {
     packagerOptions: {
       webpackConfig: {
         plugins: [new RetryChunkLoadPlugin() /*, new BundleAnalyzerPlugin()*/],
+        devtool: 'source-map',
         optimization: {
           minimize: true,
           minimizer: [


### PR DESCRIPTION
The old config wasn't working anymore, we need to configure embroider specifically to emit the source maps that we need for sentry.