### PR TITLE
Split Frontend and LTI Dashboard Deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -11,16 +11,10 @@ env:
   SENTRY_PROJECT: frontend
 
 jobs:
-  deploy:
-    name: Deploy and Create Sentry Release
+  deploy-frontend:
+    name: Deploy Frontend and Create Sentry Release
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        workspace:
-          - frontend
-          - lti-dashboard
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -33,7 +27,7 @@ jobs:
       - run: pnpm install
       - name: Ember CLI Deploy
         timeout-minutes: 30
-        run: pnpm --filter ${{matrix.workspace}} run deploy:production
+        run: pnpm --filter frontend run deploy:production
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -54,4 +48,31 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          message: Production Deploy Failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}
+          message: Frontend Production Deploy Failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}
+  deploy-lti-dashboard:
+    name: Deploy LTI Dashboard
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - name: Ember CLI Deploy
+        timeout-minutes: 30
+        run: pnpm --filter lti-dashboard run deploy:production
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - uses: act10ns/slack@v2
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ILIOS_DEPLOYMENT_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          message: LTI Dashboard Production Deploy Failed {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}


### PR DESCRIPTION
We don't do anything with sentry and the dashboard so these are different things even though they have many of the same steps. I was considering an optional step or job, but it seems easier to just split them into unique things.