### PR TITLE
fix courses and LG subgroup table headers

### DIFF
--- a/packages/frontend/app/styles/components/courses/list.scss
+++ b/packages/frontend/app/styles/components/courses/list.scss
@@ -1,11 +1,9 @@
 @use "../../mixins" as m;
 
 .courses-list {
+  @include m.main-list-box-table;
+
   i {
     margin-left: 0.5rem;
-  }
-
-  .list {
-    @include m.main-list-box-table;
   }
 }

--- a/packages/frontend/app/styles/components/courses/root.scss
+++ b/packages/frontend/app/styles/components/courses/root.scss
@@ -37,5 +37,9 @@
         @include m.main-list-box-header-actions;
       }
     }
+
+    .list {
+      @include m.main-list-box-table;
+    }
   }
 }

--- a/packages/frontend/app/styles/components/learner-group/root.scss
+++ b/packages/frontend/app/styles/components/learner-group/root.scss
@@ -84,6 +84,8 @@
     }
 
     .list {
+      @include m.main-list-box-table;
+
       .confirm-copy,
       .confirm-copy:nth-child(even),
       .confirm-copy:nth-child(odd) {


### PR DESCRIPTION
A [previous change](https://github.com/ilios/frontend/commit/9c775365c5a7972b5166b3967c56c3936dad42da) removed a too-global `.list` selector, but then was not properly handled with component-specific styles. This PR should hopefully fix that. 