### PR TITLE
Remove unneeded ilios common slices

### DIFF
--- a/packages/ilios-common/addon/classes/events-base.js
+++ b/packages/ilios-common/addon/classes/events-base.js
@@ -40,7 +40,7 @@ export default class EventsBase extends Service {
     const sessionTerms = await session.get('terms');
     const course = await session.get('course');
     const courseTerms = await course.get('terms');
-    return uniqueValues(mapBy([...sessionTerms.slice(), ...courseTerms.slice()], 'id'));
+    return uniqueValues(mapBy([...sessionTerms, ...courseTerms], 'id'));
   }
 
   /**
@@ -86,7 +86,7 @@ export default class EventsBase extends Service {
   async getCohortIdsForEvent(event) {
     const course = await this.getCourseForEvent(event);
     const cohorts = await course.get('cohorts');
-    return mapBy(cohorts.slice(), 'id');
+    return mapBy(cohorts, 'id');
   }
 
   /**

--- a/packages/ilios-common/addon/components/course/collapsed-objectives.js
+++ b/packages/ilios-common/addon/components/course/collapsed-objectives.js
@@ -10,7 +10,7 @@ export default class CourseCollapsedObjectivesComponent extends Component {
   });
 
   get objectives() {
-    return this.objectivesRelationship ? this.objectivesRelationship.slice() : [];
+    return this.objectivesRelationship ? this.objectivesRelationship : [];
   }
 
   get objectivesWithParents() {

--- a/packages/ilios-common/addon/components/course/objective-list-item.js
+++ b/packages/ilios-common/addon/components/course/objective-list-item.js
@@ -67,7 +67,7 @@ export default class CourseObjectiveListItemComponent extends Component {
       return [...set, ...cohortObjectives.flat()];
     }, []);
     const parents = await this.args.courseObjective.programYearObjectives;
-    this.parentsBuffer = parents.slice().map((objective) => {
+    this.parentsBuffer = parents.map((objective) => {
       return findById(objectives, objective.id);
     });
     this.isManagingParents = true;
@@ -75,14 +75,14 @@ export default class CourseObjectiveListItemComponent extends Component {
 
   manageDescriptors = dropTask(async () => {
     const meshDescriptors = await this.args.courseObjective.meshDescriptors;
-    this.descriptorsBuffer = meshDescriptors.slice();
+    this.descriptorsBuffer = meshDescriptors;
     this.isManagingDescriptors = true;
   });
 
   manageTerms = dropTask(async (vocabulary) => {
     this.selectedVocabulary = vocabulary;
     const terms = await this.args.courseObjective.terms;
-    this.termsBuffer = terms.slice();
+    this.termsBuffer = terms;
     this.isManagingTerms = true;
   });
 

--- a/packages/ilios-common/addon/components/course/objective-list-item.js
+++ b/packages/ilios-common/addon/components/course/objective-list-item.js
@@ -74,8 +74,7 @@ export default class CourseObjectiveListItemComponent extends Component {
   });
 
   manageDescriptors = dropTask(async () => {
-    const meshDescriptors = await this.args.courseObjective.meshDescriptors;
-    this.descriptorsBuffer = meshDescriptors;
+    this.descriptorsBuffer = await this.args.courseObjective.meshDescriptors;
     this.isManagingDescriptors = true;
   });
 

--- a/packages/ilios-common/addon/components/course/objective-list.js
+++ b/packages/ilios-common/addon/components/course/objective-list.js
@@ -40,7 +40,7 @@ export default class CourseObjectiveListComponent extends Component {
 
   get courseCohorts() {
     if (this.load.lastSuccessful && this.courseCohortsAsync) {
-      return this.courseCohortsAsync.slice();
+      return this.courseCohortsAsync;
     }
 
     return [];
@@ -81,7 +81,7 @@ export default class CourseObjectiveListComponent extends Component {
         'allowMultipleCourseObjectiveParents',
       );
       const objectives = await programYear.programYearObjectives;
-      const objectiveObjects = await map(objectives.slice(), async (objective) => {
+      const objectiveObjects = await map(objectives, async (objective) => {
         let competencyId = 0;
         let competencyTitle = intl.t('general.noAssociatedCompetency');
         let competencyParent = null;

--- a/packages/ilios-common/addon/components/course/visualize-instructor-session-type-graph.js
+++ b/packages/ilios-common/addon/components/course/visualize-instructor-session-type-graph.js
@@ -74,7 +74,7 @@ export default class CourseVisualizeInstructorSessionTypeGraph extends Component
       return mapBy(allInstructors, 'id').includes(user.id);
     });
 
-    const sessionsWithSessionType = await map(sessionsWithUser.slice(), async (session) => {
+    const sessionsWithSessionType = await map(sessionsWithUser, async (session) => {
       const sessionType = await session.sessionType;
       return {
         session,

--- a/packages/ilios-common/addon/components/course/visualize-instructor.js
+++ b/packages/ilios-common/addon/components/course/visualize-instructor.js
@@ -23,7 +23,7 @@ export default class CourseVisualizeInstructorComponent extends Component {
   }
 
   get sessions() {
-    return this.sessionsData.isResolved ? this.sessionsData.value.slice() : [];
+    return this.sessionsData.isResolved ? this.sessionsData.value : [];
   }
 
   @cached

--- a/packages/ilios-common/addon/components/course/visualize-objectives-graph.js
+++ b/packages/ilios-common/addon/components/course/visualize-objectives-graph.js
@@ -91,7 +91,7 @@ export default class CourseVisualizeObjectivesGraph extends Component {
       async ({ session, minutes }) => {
         const sessionObjectives = await session.sessionObjectives;
         const sessionObjectivesWithParents = await filter(
-          sessionObjectives.slice(),
+          sessionObjectives,
           async (sessionObjective) => {
             const parents = await sessionObjective.courseObjectives;
             return parents.length;
@@ -101,7 +101,7 @@ export default class CourseVisualizeObjectivesGraph extends Component {
           sessionObjectivesWithParents,
           async (sessionObjective) => {
             const parents = await sessionObjective.courseObjectives;
-            return mapBy(parents.slice(), 'id');
+            return mapBy(parents, 'id');
           },
         );
         const flatObjectives = courseSessionObjectives.reduce((flattened, arr) => {
@@ -119,8 +119,8 @@ export default class CourseVisualizeObjectivesGraph extends Component {
 
     // condensed objectives map
     const courseObjectives = await this.args.course.courseObjectives;
-    const mappedObjectives = await map(courseObjectives.slice(), async (courseObjective) => {
-      const programYearObjectives = (await courseObjective.programYearObjectives).slice();
+    const mappedObjectives = await map(courseObjectives, async (courseObjective) => {
+      const programYearObjectives = await courseObjective.programYearObjectives;
       const competencyTitles = (
         await map(programYearObjectives, async (pyObjective) => {
           const competency = await pyObjective.competency;

--- a/packages/ilios-common/addon/components/course/visualize-vocabulary-graph.js
+++ b/packages/ilios-common/addon/components/course/visualize-vocabulary-graph.js
@@ -80,7 +80,7 @@ export default class CourseVisualizeVocabularyGraph extends Component {
       sessionsWithMinutes,
       async ({ session, minutes }) => {
         const sessionTerms = await session.terms;
-        const sessionTermsInThisVocabulary = await filter(sessionTerms.slice(), async (term) => {
+        const sessionTermsInThisVocabulary = await filter(sessionTerms, async (term) => {
           const termVocab = await term.vocabulary;
           return termVocab.id === this.args.vocabulary.id;
         });

--- a/packages/ilios-common/addon/components/dashboard/calendar-filters.js
+++ b/packages/ilios-common/addon/components/dashboard/calendar-filters.js
@@ -38,13 +38,13 @@ export default class DashboardCalendarFiltersComponent extends Component {
   async loadSessionTypes(school) {
     await this.dataLoader.loadSchoolForCalendar(school.id);
     const types = await school.sessionTypes;
-    return sortBy(types.slice(), 'title');
+    return sortBy(types, 'title');
   }
 
   async loadVocabularies(school) {
     await this.dataLoader.loadSchoolForCalendar(school.id);
     const vocabularies = await school.vocabularies;
     await Promise.all(mapBy(vocabularies, 'terms'));
-    return sortBy(vocabularies.slice(), 'title');
+    return sortBy(vocabularies, 'title');
   }
 }

--- a/packages/ilios-common/addon/components/dashboard/calendar.js
+++ b/packages/ilios-common/addon/components/dashboard/calendar.js
@@ -160,9 +160,9 @@ export default class DashboardCalendarComponent extends Component {
   async getSchoolCohorts(school) {
     await this.dataLoader.loadSchoolForCalendar(school.id);
     const programs = await school.programs;
-    const programYears = await map(programs.slice(), async (program) => {
+    const programYears = await map(programs, async (program) => {
       const programYears = await program.programYears;
-      return programYears.slice();
+      return programYears;
     });
     const cohorts = await Promise.all(mapBy(programYears.flat(), 'cohort'));
     return cohorts.filter(Boolean);

--- a/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.js
+++ b/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.js
@@ -43,7 +43,7 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
   }
 
   get courses() {
-    return this.coursesRelationship ? this.coursesRelationship.slice() : [];
+    return this.coursesRelationship ? this.coursesRelationship : [];
   }
 
   get courseYears() {

--- a/packages/ilios-common/addon/components/dashboard/selected-term-tree.js
+++ b/packages/ilios-common/addon/components/dashboard/selected-term-tree.js
@@ -9,7 +9,7 @@ export default class DashboardSelectedTermTreeComponent extends Component {
   }
 
   get children() {
-    return this.childrenData.isResolved ? this.childrenData.value.slice() : [];
+    return this.childrenData.isResolved ? this.childrenData.value : [];
   }
 
   get level() {

--- a/packages/ilios-common/addon/components/detail-cohort-list.js
+++ b/packages/ilios-common/addon/components/detail-cohort-list.js
@@ -14,7 +14,7 @@ export default class DetailCohortListComponent extends Component {
       return false;
     }
 
-    const sortProxies = await map(cohorts.slice(), async (cohort) => {
+    const sortProxies = await map(cohorts, async (cohort) => {
       const programYear = await cohort.programYear;
       const program = await programYear.program;
       const school = await program.school;

--- a/packages/ilios-common/addon/components/detail-cohort-manager.js
+++ b/packages/ilios-common/addon/components/detail-cohort-manager.js
@@ -79,7 +79,7 @@ export default class DetailCohortManagerComponent extends Component {
   async loadCohorts(course) {
     const school = await course.school;
     const allCohorts = await this.store.findAll('cohort');
-    const cohortProxies = await map(allCohorts.slice(), async (cohort) => {
+    const cohortProxies = await map(allCohorts, async (cohort) => {
       const programYear = await cohort.programYear;
       const program = await programYear.program;
       const school = await program.school;

--- a/packages/ilios-common/addon/components/detail-cohorts.js
+++ b/packages/ilios-common/addon/components/detail-cohorts.js
@@ -20,7 +20,7 @@ export default class DetailCohortsComponent extends Component {
 
   manage = dropTask(async () => {
     const cohorts = await this.args.course.cohorts;
-    this.bufferedCohorts = [...cohorts.slice()];
+    this.bufferedCohorts = [...cohorts];
     this.isManaging = true;
   });
 

--- a/packages/ilios-common/addon/components/detail-instructors.js
+++ b/packages/ilios-common/addon/components/detail-instructors.js
@@ -58,8 +58,8 @@ export default class DetailInstructorsComponent extends Component {
       instructors: ilmSession.instructors,
     });
 
-    this.instructorGroupBuffer = instructorGroups.slice();
-    this.instructorBuffer = instructors.slice();
+    this.instructorGroupBuffer = instructorGroups;
+    this.instructorBuffer = instructors;
     this.isManaging = true;
   });
 
@@ -82,14 +82,14 @@ export default class DetailInstructorsComponent extends Component {
     if (!this.ilmInstructors) {
       return [];
     }
-    return this.ilmInstructors.slice();
+    return this.ilmInstructors;
   }
 
   get selectedIlmInstructorGroups() {
     if (!this.ilmInstructorGroups) {
       return [];
     }
-    return this.ilmInstructorGroups.slice();
+    return this.ilmInstructorGroups;
   }
 
   get instructorGroupCount() {

--- a/packages/ilios-common/addon/components/detail-learnergroups-list.js
+++ b/packages/ilios-common/addon/components/detail-learnergroups-list.js
@@ -27,12 +27,12 @@ export default class DetailLearnerGroupsListComponent extends Component {
       return [];
     }
     const cohorts = uniqueValues(
-      await map(this.args.learnerGroups.slice(), async (learnerGroup) => {
+      await map(this.args.learnerGroups, async (learnerGroup) => {
         return learnerGroup.cohort;
       }),
     );
     return map(cohorts, async (cohort) => {
-      const groups = await filter(this.args.learnerGroups.slice(), async (group) => {
+      const groups = await filter(this.args.learnerGroups, async (group) => {
         const groupCohort = await group.cohort;
         return groupCohort === cohort;
       });

--- a/packages/ilios-common/addon/components/detail-learners-and-learner-groups.js
+++ b/packages/ilios-common/addon/components/detail-learners-and-learner-groups.js
@@ -65,8 +65,8 @@ export default class DetailLearnersAndLearnerGroupsComponent extends Component {
       learners: ilmSession.learners,
     });
 
-    this.learnerGroupBuffer = learnerGroups.slice();
-    this.learnerBuffer = learners.slice();
+    this.learnerGroupBuffer = learnerGroups;
+    this.learnerBuffer = learners;
     this.isManaging = true;
   });
 
@@ -96,14 +96,14 @@ export default class DetailLearnersAndLearnerGroupsComponent extends Component {
     if (!this.ilmLearners) {
       return [];
     }
-    return this.ilmLearners.slice();
+    return this.ilmLearners;
   }
 
   get selectedIlmLearnerGroups() {
     if (!this.ilmLearnerGroups) {
       return [];
     }
-    return this.ilmLearnerGroups.slice();
+    return this.ilmLearnerGroups;
   }
 
   @action

--- a/packages/ilios-common/addon/components/detail-learning-materials-item.js
+++ b/packages/ilios-common/addon/components/detail-learning-materials-item.js
@@ -21,7 +21,7 @@ export default class DetailLearningMaterialsItemComponent extends Component {
   }
 
   get meshDescriptors() {
-    return this.meshDescriptorsData.isResolved ? this.meshDescriptorsData.value.slice() : [];
+    return this.meshDescriptorsData.isResolved ? this.meshDescriptorsData.value : [];
   }
 
   get meshDescriptorsLoaded() {

--- a/packages/ilios-common/addon/components/detail-learning-materials.js
+++ b/packages/ilios-common/addon/components/detail-learning-materials.js
@@ -30,8 +30,8 @@ export default class DetailCohortsComponent extends Component {
 
   constructor() {
     super(...arguments);
-    this.learningMaterialStatuses = this.store.peekAll('learning-material-status').slice();
-    this.learningMaterialUserRoles = this.store.peekAll('learning-material-user-role').slice();
+    this.learningMaterialStatuses = this.store.peekAll('learning-material-status');
+    this.learningMaterialUserRoles = this.store.peekAll('learning-material-user-role');
   }
 
   @cached

--- a/packages/ilios-common/addon/components/detail-mesh.js
+++ b/packages/ilios-common/addon/components/detail-mesh.js
@@ -21,7 +21,7 @@ export default class DetailMeshComponent extends Component {
       return [];
     }
 
-    return this.meshDescriptorRelationship.slice();
+    return this.meshDescriptorRelationship;
   }
   @action
   manage() {

--- a/packages/ilios-common/addon/components/detail-taxonomies.js
+++ b/packages/ilios-common/addon/components/detail-taxonomies.js
@@ -29,7 +29,7 @@ export default class DetailTaxonomiesComponent extends Component {
   manage = dropTask(async () => {
     this.args.expand();
     const terms = await this.args.subject.terms;
-    this.bufferedTerms = [...terms.slice()];
+    this.bufferedTerms = [...terms];
     this.isManaging = true;
   });
 

--- a/packages/ilios-common/addon/components/learningmaterial-manager.js
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.js
@@ -177,7 +177,7 @@ export default class LearningMaterialManagerComponent extends Component {
     this.endDate = learningMaterial.endDate;
 
     const meshDescriptors = await learningMaterial.get('meshDescriptors');
-    this.terms = meshDescriptors.slice();
+    this.terms = meshDescriptors;
 
     this.parentMaterial = parentMaterial;
     this.type = parentMaterial.type;

--- a/packages/ilios-common/addon/components/learningmaterial-manager.js
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.js
@@ -176,7 +176,7 @@ export default class LearningMaterialManagerComponent extends Component {
     this.startDate = learningMaterial.startDate;
     this.endDate = learningMaterial.endDate;
 
-    this.terms = await learningMaterial.get('meshDescriptors');
+    this.terms = await learningMaterial.meshDescriptors;
     this.parentMaterial = parentMaterial;
     this.type = parentMaterial.type;
     this.title = parentMaterial.title;
@@ -191,10 +191,10 @@ export default class LearningMaterialManagerComponent extends Component {
     this.filename = parentMaterial.filename;
     this.uploadDate = parentMaterial.uploadDate;
 
-    const status = await parentMaterial.get('status');
+    const status = await parentMaterial.status;
     this.statusId = status.id;
-    this.owningUser = await parentMaterial.get('owningUser');
-    const userRole = await parentMaterial.get('userRole');
+    this.owningUser = await parentMaterial.owningUser;
+    const userRole = await parentMaterial.userRole;
     this.userRoleTitle = userRole.title;
   });
 

--- a/packages/ilios-common/addon/components/learningmaterial-manager.js
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.js
@@ -176,9 +176,7 @@ export default class LearningMaterialManagerComponent extends Component {
     this.startDate = learningMaterial.startDate;
     this.endDate = learningMaterial.endDate;
 
-    const meshDescriptors = await learningMaterial.get('meshDescriptors');
-    this.terms = meshDescriptors;
-
+    this.terms = await learningMaterial.get('meshDescriptors');
     this.parentMaterial = parentMaterial;
     this.type = parentMaterial.type;
     this.title = parentMaterial.title;

--- a/packages/ilios-common/addon/components/learningmaterial-search.js
+++ b/packages/ilios-common/addon/components/learningmaterial-search.js
@@ -31,7 +31,7 @@ export default class LearningMaterialSearchComponent extends Component {
       'order_by[title]': 'ASC',
     });
 
-    const lms = results.slice();
+    const lms = results;
     this.searchReturned = true;
     this.searching = false;
     this.searchPage = 1;
@@ -59,7 +59,7 @@ export default class LearningMaterialSearchComponent extends Component {
       offset: this.searchPage * this.searchResultsPerPage,
       'order_by[title]': 'ASC',
     });
-    const lms = results.slice();
+    const lms = results;
     this.searchPage = this.searchPage + 1;
     this.hasMoreSearchResults = lms.length > this.searchResultsPerPage;
     if (this.hasMoreSearchResults) {

--- a/packages/ilios-common/addon/components/offering-calendar.js
+++ b/packages/ilios-common/addon/components/offering-calendar.js
@@ -70,7 +70,7 @@ export default class OfferingCalendar extends Component {
     } else {
       const data = await map(learnerGroups, async (learnerGroup) => {
         const offerings = await learnerGroup.offerings;
-        return await map(offerings.slice(), async (offering) => {
+        return await map(offerings, async (offering) => {
           const session = await offering.session;
           const course = await session.course;
           return {
@@ -88,7 +88,7 @@ export default class OfferingCalendar extends Component {
       });
 
       this.learnerGroupEvents = data.reduce((flattened, obj) => {
-        return [...flattened, ...obj.slice()];
+        return [...flattened, ...obj];
       }, []);
     }
 
@@ -99,7 +99,7 @@ export default class OfferingCalendar extends Component {
       const offerings = await session.offerings;
       const sessionType = await session.sessionType;
       const course = await session.course;
-      this.sessionEvents = await map(offerings.slice(), async (offering) => {
+      this.sessionEvents = await map(offerings, async (offering) => {
         return {
           startDate: DateTime.fromJSDate(offering.startDate).toISO(),
           endDate: DateTime.fromJSDate(offering.endDate).toISO(),

--- a/packages/ilios-common/addon/components/offering-form.js
+++ b/packages/ilios-common/addon/components/offering-form.js
@@ -294,7 +294,7 @@ export default class OfferingForm extends Component {
     if (isEmpty(cohorts)) {
       associatedSchools = [];
     } else {
-      const cohortSchools = await map(cohorts.slice(), async (cohort) => {
+      const cohortSchools = await map(cohorts, async (cohort) => {
         const programYear = await cohort.programYear;
         const program = await programYear.program;
         return program.school;
@@ -303,7 +303,7 @@ export default class OfferingForm extends Component {
     }
     const allInstructorGroups = await map(associatedSchools, (school) => school.instructorGroups);
     return allInstructorGroups.reduce((flattened, arr) => {
-      return [...flattened, ...arr.slice()];
+      return [...flattened, ...arr];
     }, []);
   }
 
@@ -340,10 +340,10 @@ export default class OfferingForm extends Component {
       instructors: offering.get('instructors'),
       instructorGroups: offering.get('instructorGroups'),
     });
-    this.learnerGroups = obj.learnerGroups.slice();
-    this.learners = obj.learners.slice();
-    this.instructors = obj.instructors.slice();
-    this.instructorGroups = obj.instructorGroups.slice();
+    this.learnerGroups = obj.learnerGroups;
+    this.learners = obj.learners;
+    this.instructors = obj.instructors;
+    this.instructorGroups = obj.instructorGroups;
     this.loaded = true;
   });
 
@@ -504,8 +504,8 @@ export default class OfferingForm extends Component {
         if (isPresent(defaultLocation)) {
           room = defaultLocation;
         }
-        const instructors = (await learnerGroup.instructors).slice();
-        const instructorGroups = (await learnerGroup.instructorGroups).slice();
+        const instructors = await learnerGroup.instructors;
+        const instructorGroups = await learnerGroup.instructorGroups;
         const offering = {
           startDate,
           endDate,

--- a/packages/ilios-common/addon/components/print-course.js
+++ b/packages/ilios-common/addon/components/print-course.js
@@ -92,6 +92,6 @@ export default class PrintCourseComponent extends Component {
       return this.sessionsRelationship.filter((session) => session.isPublishedOrScheduled);
     }
 
-    return this.sessionsRelationship.slice();
+    return this.sessionsRelationship;
   }
 }

--- a/packages/ilios-common/addon/components/selectable-terms-list.js
+++ b/packages/ilios-common/addon/components/selectable-terms-list.js
@@ -14,10 +14,10 @@ export default class SelectableTermsList extends Component {
   }
 
   async getFilteredTerms(parent, termFilter) {
-    const terms = (await parent.children).slice();
+    const terms = await parent.children;
     if (termFilter) {
       const exp = new RegExp(termFilter, 'gi');
-      return await filter(terms.slice(), async (term) => {
+      return await filter(terms, async (term) => {
         const searchString = await term.getTitleWithDescendantTitles();
         return searchString.match(exp);
       });

--- a/packages/ilios-common/addon/components/session-copy.js
+++ b/packages/ilios-common/addon/components/session-copy.js
@@ -37,7 +37,7 @@ export default class SessionCopyComponent extends Component {
       .map((year) => Number(year.id))
       .filter((year) => year >= thisYear - 1)
       .sort();
-    this.allCourses = await filter(schoolCourses.slice(), async (co) => {
+    this.allCourses = await filter(schoolCourses, async (co) => {
       return this.permissionChecker.canCreateSession(co);
     });
   });
@@ -102,8 +102,8 @@ export default class SessionCopyComponent extends Component {
     );
 
     session.set('course', newCourse);
-    session.set('meshDescriptors', (await sessionToCopy.meshDescriptors).slice());
-    session.set('terms', (await sessionToCopy.terms).slice());
+    session.set('meshDescriptors', await sessionToCopy.meshDescriptors);
+    session.set('terms', await sessionToCopy.terms);
     session.set('sessionType', await sessionToCopy.sessionType);
 
     const ilmToCopy = await sessionToCopy.ilmSession;
@@ -142,11 +142,11 @@ export default class SessionCopyComponent extends Component {
     //parse objectives last because it is a many2many relationship
     //and ember data tries to save it too soon
     const relatedSessionObjectives = await sessionToCopy.sessionObjectives;
-    const sessionObjectivesToCopy = sortBy(relatedSessionObjectives, 'id').slice();
+    const sessionObjectivesToCopy = sortBy(relatedSessionObjectives, 'id');
     for (let i = 0, n = sessionObjectivesToCopy.length; i < n; i++) {
       const sessionObjectiveToCopy = sessionObjectivesToCopy[i];
-      const meshDescriptors = (await sessionObjectiveToCopy.meshDescriptors).slice();
-      const terms = (await sessionObjectiveToCopy.terms).slice();
+      const meshDescriptors = await sessionObjectiveToCopy.meshDescriptors;
+      const terms = await sessionObjectiveToCopy.terms;
       const sessionObjective = this.store.createRecord('session-objective', {
         session,
         position: sessionObjectiveToCopy.position,

--- a/packages/ilios-common/addon/components/session-offerings-list.js
+++ b/packages/ilios-common/addon/components/session-offerings-list.js
@@ -15,7 +15,7 @@ export default class SessionOfferingsListComponent extends Component {
   });
 
   get offerings() {
-    return this.offeringsRelationship ? this.offeringsRelationship.slice() : [];
+    return this.offeringsRelationship ? this.offeringsRelationship : [];
   }
 
   get offeringBlocks() {

--- a/packages/ilios-common/addon/components/session-overview.js
+++ b/packages/ilios-common/addon/components/session-overview.js
@@ -85,7 +85,7 @@ export default class SessionOverview extends Component {
   load = restartableTask(async (element, [session]) => {
     const course = await session.course;
     const school = await course.school;
-    const sessionTypes = (await school.sessionTypes).slice();
+    const sessionTypes = await school.sessionTypes;
     const {
       ilmSession,
       sessionType,
@@ -150,7 +150,7 @@ export default class SessionOverview extends Component {
       }
     }
     const school = await course.school;
-    const schoolCourses = (await school.courses).slice();
+    const schoolCourses = await school.courses;
     let schoolCourse;
     for (schoolCourse of schoolCourses) {
       if (await this.permissionChecker.canCreateSession(schoolCourse)) {

--- a/packages/ilios-common/addon/components/session/objective-list-item.js
+++ b/packages/ilios-common/addon/components/session/objective-list-item.js
@@ -59,20 +59,20 @@ export default class SessionObjectiveListItemComponent extends Component {
 
   manageParents = dropTask(async () => {
     const parents = await this.args.sessionObjective.courseObjectives;
-    this.parentsBuffer = parents.slice();
+    this.parentsBuffer = parents;
     this.isManagingParents = true;
   });
 
   manageDescriptors = dropTask(async () => {
     const meshDescriptors = await this.args.sessionObjective.meshDescriptors;
-    this.descriptorsBuffer = meshDescriptors.slice();
+    this.descriptorsBuffer = meshDescriptors;
     this.isManagingDescriptors = true;
   });
 
   manageTerms = dropTask(async (vocabulary) => {
     this.selectedVocabulary = vocabulary;
     const terms = await this.args.sessionObjective.terms;
-    this.termsBuffer = terms.slice();
+    this.termsBuffer = terms;
     this.isManagingTerms = true;
   });
 

--- a/packages/ilios-common/addon/components/session/objective-list-item.js
+++ b/packages/ilios-common/addon/components/session/objective-list-item.js
@@ -58,21 +58,18 @@ export default class SessionObjectiveListItemComponent extends Component {
   });
 
   manageParents = dropTask(async () => {
-    const parents = await this.args.sessionObjective.courseObjectives;
-    this.parentsBuffer = parents;
+    this.parentsBuffer = await this.args.sessionObjective.courseObjectives;
     this.isManagingParents = true;
   });
 
   manageDescriptors = dropTask(async () => {
-    const meshDescriptors = await this.args.sessionObjective.meshDescriptors;
-    this.descriptorsBuffer = meshDescriptors;
+    this.descriptorsBuffer = await this.args.sessionObjective.meshDescriptors;
     this.isManagingDescriptors = true;
   });
 
   manageTerms = dropTask(async (vocabulary) => {
     this.selectedVocabulary = vocabulary;
-    const terms = await this.args.sessionObjective.terms;
-    this.termsBuffer = terms;
+    this.termsBuffer = await this.args.sessionObjective.terms;
     this.isManagingTerms = true;
   });
 

--- a/packages/ilios-common/addon/components/sessions-grid-offering-table.js
+++ b/packages/ilios-common/addon/components/sessions-grid-offering-table.js
@@ -27,7 +27,7 @@ export default class SessionsGridOfferingTable extends Component {
       return [];
     }
     const dateBlocks = {};
-    this.offerings.value.slice().forEach((offering) => {
+    this.offerings.value.forEach((offering) => {
       const key = offering.get('dateKey');
       if (!(key in dateBlocks)) {
         dateBlocks[key] = new OfferingDateBlock(key);

--- a/packages/ilios-common/addon/components/sessions-grid.js
+++ b/packages/ilios-common/addon/components/sessions-grid.js
@@ -86,8 +86,7 @@ export default class SessionsGrid extends Component {
     const sortProxies = await map(sessions, async (session) => {
       const offerings = await session.offerings;
       const learnerGroups = await map(offerings, async (offering) => {
-        const learnerGroups = await offering.learnerGroups;
-        return learnerGroups;
+        return await offering.learnerGroups;
       });
       return {
         session,

--- a/packages/ilios-common/addon/components/sessions-grid.js
+++ b/packages/ilios-common/addon/components/sessions-grid.js
@@ -87,7 +87,7 @@ export default class SessionsGrid extends Component {
       const offerings = await session.offerings;
       const learnerGroups = await map(offerings, async (offering) => {
         const learnerGroups = await offering.learnerGroups;
-        return learnerGroups.slice();
+        return learnerGroups;
       });
       return {
         session,
@@ -116,7 +116,6 @@ export default class SessionsGrid extends Component {
     }
     const offerings = await session.offerings;
     return offerings
-      .slice()
       .filter((offering) => Boolean(offering.startDate))
       .sort((a, b) => {
         const aDate = DateTime.fromJSDate(a.startDate);

--- a/packages/ilios-common/addon/models/curriculum-inventory-report.js
+++ b/packages/ilios-common/addon/models/curriculum-inventory-report.js
@@ -51,7 +51,7 @@ export default class CurriculumInventoryReport extends Model {
   }
 
   async getLinkedCourses() {
-    const courses = await Promise.all(mapBy((await this.sequenceBlocks).slice(), 'course'));
+    const courses = await Promise.all(mapBy(await this.sequenceBlocks, 'course'));
     return courses.filter(Boolean);
   }
 }

--- a/packages/ilios-common/addon/models/curriculum-inventory-sequence-block.js
+++ b/packages/ilios-common/addon/models/curriculum-inventory-sequence-block.js
@@ -102,7 +102,7 @@ export default class CurriculumInventorySequenceBlock extends Model {
     if (!parent) {
       return [];
     }
-    const parentsAncestors = (await parent.getAllParents()).slice();
+    const parentsAncestors = await parent.getAllParents();
     return [parent, ...parentsAncestors];
   }
 }

--- a/packages/ilios-common/addon/models/learner-group.js
+++ b/packages/ilios-common/addon/models/learner-group.js
@@ -189,7 +189,7 @@ export default class LearnerGroup extends Model {
   }
 
   async getAllDescendants() {
-    const children = (await this.children).slice();
+    const children = await this.children;
     const childDescendants = await map(children, (child) => {
       return child.getAllDescendants();
     });
@@ -216,14 +216,14 @@ export default class LearnerGroup extends Model {
   async getAllDescendantUsers() {
     const users = await this.users;
     const descendantUsers = await this._getDescendantUsers();
-    return uniqueValues([...users.slice(), ...descendantUsers]);
+    return uniqueValues([...users, ...descendantUsers]);
   }
 
   async _getDescendantUsers() {
     const allDescendants = await this.getAllDescendants();
     const descendantsUsers = await Promise.all(mapBy(allDescendants, 'users'));
     return descendantsUsers.reduce((all, groups) => {
-      return [...all, ...groups.slice()];
+      return [...all, ...groups];
     }, []);
   }
 
@@ -240,7 +240,7 @@ export default class LearnerGroup extends Model {
   }
 
   async getUsersOnlyAtThisLevel() {
-    const users = (await this.users).slice();
+    const users = await this.users;
     const descendantsUsers = await this._getDescendantUsers();
 
     return users.filter((user) => !descendantsUsers.includes(user));

--- a/packages/ilios-common/addon/models/offering.js
+++ b/packages/ilios-common/addon/models/offering.js
@@ -201,12 +201,12 @@ export default class Offering extends Model {
    * @returns {Promise<Array>}
    */
   async getAllInstructors() {
-    const instructors = (await this.instructors).slice();
-    const instructorGroups = (await this.instructorGroups).slice();
+    const instructors = await this.instructors;
+    const instructorGroups = await this.instructorGroups;
     const instructorsInInstructorGroups = await Promise.all(mapBy(instructorGroups, 'users'));
     return uniqueValues([
       ...instructors,
-      ...instructorsInInstructorGroups.map((instructorGroup) => instructorGroup.slice()).flat(),
+      ...instructorsInInstructorGroups.map((instructorGroup) => instructorGroup).flat(),
     ]);
   }
 }

--- a/packages/ilios-common/addon/models/session.js
+++ b/packages/ilios-common/addon/models/session.js
@@ -440,7 +440,7 @@ export default class SessionModel extends Model {
       return [];
     }
 
-    return [...this._ilmSessionInstructors.slice(), ...this._ilmSessionInstructorGroupInstructors];
+    return [...this._ilmSessionInstructors, ...this._ilmSessionInstructorGroupInstructors];
   }
 
   get allInstructors() {
@@ -545,13 +545,13 @@ export default class SessionModel extends Model {
   }
 
   async getAllOfferingInstructors() {
-    const offerings = (await this.offerings).slice();
+    const offerings = await this.offerings;
     if (!offerings.length) {
       return [];
     }
     const allOfferingInstructors = await Promise.all(
       offerings.map(async (offering) => {
-        return (await offering.getAllInstructors()).slice();
+        return await offering.getAllInstructors();
       }),
     );
 

--- a/packages/ilios-common/addon/routes/course-visualize-instructor.js
+++ b/packages/ilios-common/addon/routes/course-visualize-instructor.js
@@ -15,8 +15,6 @@ export default class CourseVisualizeInstructorRoute extends Route {
   }
 
   async afterModel({ course }) {
-    // const sessions = await course.sessions;
-    console.log('CourseVisualizeInstructorRoute');
     return await all([course.school, map(course.sessions, (s) => s.sessionType)]);
   }
 

--- a/packages/ilios-common/addon/routes/course-visualize-instructor.js
+++ b/packages/ilios-common/addon/routes/course-visualize-instructor.js
@@ -15,8 +15,9 @@ export default class CourseVisualizeInstructorRoute extends Route {
   }
 
   async afterModel({ course }) {
-    const sessions = await course.sessions;
-    return await all([course.school, map(sessions, (s) => s.sessionType)]);
+    // const sessions = await course.sessions;
+    console.log('CourseVisualizeInstructorRoute');
+    return await all([course.school, map(course.sessions, (s) => s.sessionType)]);
   }
 
   beforeModel(transition) {

--- a/packages/ilios-common/addon/routes/course-visualize-instructor.js
+++ b/packages/ilios-common/addon/routes/course-visualize-instructor.js
@@ -15,7 +15,7 @@ export default class CourseVisualizeInstructorRoute extends Route {
   }
 
   async afterModel({ course }) {
-    const sessions = (await course.sessions).slice();
+    const sessions = await course.sessions;
     return await all([course.school, map(sessions, (s) => s.sessionType)]);
   }
 

--- a/packages/ilios-common/addon/routes/course-visualize-instructors.js
+++ b/packages/ilios-common/addon/routes/course-visualize-instructors.js
@@ -14,7 +14,7 @@ export default class CourseVisualizeInstructorsRoute extends Route {
   }
 
   async afterModel(course) {
-    const sessions = (await course.sessions).slice();
+    const sessions = await course.sessions;
     return await all([
       map(sessions, (s) => s.offerings),
       map(sessions, (s) => s.totalSumDuration),

--- a/packages/ilios-common/addon/routes/course-visualize-objectives.js
+++ b/packages/ilios-common/addon/routes/course-visualize-objectives.js
@@ -14,7 +14,7 @@ export default class CourseVisualizeObjectivesRoute extends Route {
   }
 
   async afterModel(course) {
-    const sessions = (await course.sessions).slice();
+    const sessions = await course.sessions;
     return await all([course.objectives, map(sessions, (s) => s.objectives)]);
   }
 

--- a/packages/ilios-common/addon/routes/course-visualize-session-type.js
+++ b/packages/ilios-common/addon/routes/course-visualize-session-type.js
@@ -16,7 +16,7 @@ export default class CourseVisualizeSessionTypeRoute extends Route {
   }
 
   async afterModel({ course }) {
-    const sessions = (await course.sessions).slice();
+    const sessions = await course.sessions;
     return await all([
       map(sessions, (s) => s.sessionType),
       map(sessions, (s) => s.terms),

--- a/packages/ilios-common/addon/routes/course-visualize-session-types.js
+++ b/packages/ilios-common/addon/routes/course-visualize-session-types.js
@@ -14,8 +14,8 @@ export default class CourseVisualizeSessionTypesRoute extends Route {
   }
 
   async afterModel(course) {
-    const sessions = (await course.sessions).slice();
-    return await map(sessions.slice(), (s) => s.sessionType);
+    const sessions = await course.sessions;
+    return await map(sessions, (s) => s.sessionType);
   }
 
   beforeModel(transition) {

--- a/packages/ilios-common/addon/routes/course-visualize-term.js
+++ b/packages/ilios-common/addon/routes/course-visualize-term.js
@@ -16,7 +16,7 @@ export default class CourseVisualizeTermRoute extends Route {
   }
 
   async afterModel({ course, term }) {
-    const sessions = (await course.sessions).slice();
+    const sessions = await course.sessions;
     return await all([
       term.vocabulary,
       map(sessions, (s) => s.sessionType),

--- a/packages/ilios-common/addon/routes/course-visualize-vocabularies.js
+++ b/packages/ilios-common/addon/routes/course-visualize-vocabularies.js
@@ -14,7 +14,7 @@ export default class CourseVisualizeVocabulariesRoute extends Route {
   }
 
   async afterModel(course) {
-    const sessions = (await course.sessions).slice();
+    const sessions = await course.sessions;
     return await all([course.get('school'), map(sessions, (s) => s.terms)]);
   }
 

--- a/packages/ilios-common/addon/routes/course-visualize-vocabulary.js
+++ b/packages/ilios-common/addon/routes/course-visualize-vocabulary.js
@@ -17,7 +17,7 @@ export default class CourseVisualizeVocabularyRoute extends Route {
 
   async afterModel(model) {
     const { course, vocabulary } = model;
-    const sessions = (await course.sessions).slice();
+    const sessions = await course.sessions;
     return await all([course.get('school'), vocabulary.terms, map(sessions, (s) => s.terms)]);
   }
 


### PR DESCRIPTION
References ilios/ilios#5660

Went through the `packages/ilios-common` directory and removed a bunch of `slice()`s. Left some I found because they had a `.sort()` or `[1]` or similar access thing that I know has thrown off our tests in the past.