### PR TITLE
Update Some Automation Timings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: "sunday"
+      day: "monday"
     open-pull-requests-limit: 10
     groups:
       embroider:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly
 
 on:
   schedule:
-    - cron: "15 9 * * 1-5" # nightly, M-F
+    - cron: "15 9 * * 0-5" # nightly, S-F
 
 env:
   SW_DISABLED: true

--- a/.github/workflows/update-transitive-dependencies.yaml
+++ b/.github/workflows/update-transitive-dependencies.yaml
@@ -2,7 +2,7 @@ name: Update Transitive Dependencies
 
 on:
   schedule:
-    - cron: "15 11 * * 0" # weekly, on Sunday morning (UTC)
+    - cron: "15 15 * * 0" # weekly, on Sunday morning (UTC)
   workflow_dispatch: null
 
 jobs:


### PR DESCRIPTION
After a few weeks of running I see some adjustments we can make here to smooth out this process. We need to run the percy nightly job on Sunday so our Transitive Dependency job gets the latest screenshots, we shoudl run dependabot on Monday so we don't waste time when the auto update would have caught all the updates, and we can push back running the transitive dependency update job a few hours.