### PR TITLE
Clean up FaIcon template's class attribute

### DIFF
--- a/packages/ilios-common/addon/components/fa-icon.hbs
+++ b/packages/ilios-common/addon/components/fa-icon.hbs
@@ -1,6 +1,6 @@
 {{! template-lint-disable eol-last }}
 <svg
-  class="awesome-icon fa-{{@icon}} {{if @spin "spin"}} {{this.flip}} {{if @listItem "list-item"}} {{if @fixedWidth "fixed-width"}}"
+  class="awesome-icon fa-{{@icon}}{{this.extraClasses}}"
   data-icon={{@icon}}
   aria-hidden={{this.ariaHidden}}
   focusable={{this.focusable}}

--- a/packages/ilios-common/addon/components/fa-icon.js
+++ b/packages/ilios-common/addon/components/fa-icon.js
@@ -39,7 +39,7 @@ export default class FaIconComponent extends Component {
   }
 
   get extraClasses() {
-    let classes = [this.flip];
+    let classes = [];
 
     if (this.args.spin) {
       classes.push('spin');
@@ -53,6 +53,10 @@ export default class FaIconComponent extends Component {
       classes.push('fixed-width');
     }
 
-    return classes.join(' ');
+    if (this.flip !== '') {
+      classes.push(this.flip);
+    }
+
+    return classes.length ? ` ${classes.join(' ')}` : '';
   }
 }

--- a/packages/ilios-common/addon/components/fa-icon.js
+++ b/packages/ilios-common/addon/components/fa-icon.js
@@ -37,4 +37,22 @@ export default class FaIconComponent extends Component {
 
     return '';
   }
+
+  get extraClasses() {
+    let classes = [this.flip];
+
+    if (this.args.spin) {
+      classes.push('spin');
+    }
+
+    if (this.args.listItem) {
+      classes.push('list-item');
+    }
+
+    if (this.args.fixedWidth) {
+      classes.push('fixed-width');
+    }
+
+    return classes.join(' ');
+  }
 }

--- a/packages/test-app/tests/integration/components/fa-icon-test.js
+++ b/packages/test-app/tests/integration/components/fa-icon-test.js
@@ -34,6 +34,30 @@ module('Integration | Component | fa-icon', function (hooks) {
     assert.dom('svg').hasClass('spin');
   });
 
+  test('it optionally renders fixed-width class', async function (assert) {
+    this.set('fixedWidth', false);
+    await render(hbs`<FaIcon @icon="coffee" @fixedWidth={{this.fixedWidth}} />`);
+    assert.dom('svg').doesNotHaveClass('fixed-width');
+    this.set('fixedWidth', true);
+    assert.dom('svg').hasClass('fixed-width');
+  });
+
+  test('it renders vertically and horizontally flipped', async function (assert) {
+    this.set('flip', '');
+    await render(hbs`<FaIcon @icon="coffee" @flip={{this.flip}} />`);
+    assert.dom('svg').doesNotHaveClass('flip-horizontal');
+    assert.dom('svg').doesNotHaveClass('flip-vertical');
+    this.set('flip', 'horizontal');
+    assert.dom('svg').hasClass('flip-horizontal');
+    assert.dom('svg').doesNotHaveClass('flip-vertical');
+    this.set('flip', 'vertical');
+    assert.dom('svg').doesNotHaveClass('flip-horizontal');
+    assert.dom('svg').hasClass('flip-vertical');
+    this.set('flip', 'both');
+    assert.dom('svg').hasClass('flip-horizontal');
+    assert.dom('svg').hasClass('flip-vertical');
+  });
+
   test('it binds title', async function (assert) {
     const title = 'awesome is as awesome does';
     this.set('title', title);


### PR DESCRIPTION
Currently, the `<FaIcon>` has an overstuffed `class` attribute that often has conditionals that are not met. This moves all the extra optional classes to a class function and only adds them in (and the spaces between them) if they are passed in.