### PR TITLE
Only Build Good Sourcemaps in Production

### DIFF
--- a/packages/frontend/ember-cli-build.js
+++ b/packages/frontend/ember-cli-build.js
@@ -104,7 +104,7 @@ module.exports = async function (defaults) {
     packagerOptions: {
       webpackConfig: {
         plugins: [new RetryChunkLoadPlugin() /*, new BundleAnalyzerPlugin()*/],
-        devtool: 'source-map',
+        devtool: env === 'production' ? 'source-map' : 'eval',
         optimization: {
           minimize: true,
           minimizer: [


### PR DESCRIPTION
[devtool](https://webpack.js.org/configuration/devtool/) is what webpack uses to generate source maps and it can be configured to work in different ways for our production builds where we need high quality source maps to connect to sentry we want only the best, but for our other builds we need something with a much faster rebuild time.

Refs #8093