### PR TITLE
improve Calendar filters display on mobile

### DIFF
--- a/packages/ilios-common/addon/components/dashboard/calendar-filters.hbs
+++ b/packages/ilios-common/addon/components/dashboard/calendar-filters.hbs
@@ -91,7 +91,7 @@
     </div>
     <div
       id="calendar-courselevelfilter"
-      class="calendar-filter-list small-filter-list courselevelfilter"
+      class="calendar-filter-list courselevelfilter"
       data-test-course-level-filter
     >
       <h5>

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
@@ -44,15 +44,17 @@
         width: 33%;
 
         h5 {
-          @include m.ilios-heading-h5;
+          @include m.ilios-heading;
+          @include m.font-size("base");
           display: block;
           background-color: c.$culturedGrey;
           border-bottom: 0.5px solid c.$davysGrey;
+          height: 7vh;
           padding: 0.25em;
           width: 100%;
 
-          @include m.for-phone-only {
-            height: 7vh;
+          @include m.for-tablet-and-up {
+            height: auto;
           }
         }
 
@@ -75,10 +77,6 @@
           overflow-x: hidden;
           overflow-y: scroll;
           padding: 0.25em 0.25em 1em;
-        }
-
-        &.small-filter-list {
-          width: 15%;
         }
 
         &.large-filter-list {

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -274,7 +274,7 @@ general:
   preWork: Pre-work
   printSummary: Print Summary
   program: Program
-  programAndCohort: Program/Cohort
+  programAndCohort: Program / Cohort
   programCohorts: Program Cohorts
   programDetail: Program Detail
   publicationStatus: Publication Status

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -274,7 +274,7 @@ general:
   preWork: Pre Trabajo
   printSummary: Sumario Printado
   program: Programa
-  programAndCohort: Programa/Clase de La Graduación
+  programAndCohort: Programa / Clase de La Graduación
   programCohorts: Clases de La Graduación
   programDetail: Detalle del programa
   publicationStatus: Estado de Publicación


### PR DESCRIPTION
Fixes ilios/ilios#5701

* Reduced font-size of `<h5>`
* Changed `<h5>` height across breakpoints
* Removed `small-filter-list` class from filters so it takes up available width
* Added spaces to 'Program/Cohort' term in `en-us` and `es` (commit message was typo, oops) so that it wraps better