### PR TITLE
fix missing session timed release information

### DIFF
--- a/packages/ilios-common/addon/components/timed-release-schedule.js
+++ b/packages/ilios-common/addon/components/timed-release-schedule.js
@@ -17,6 +17,6 @@ export default class TimedReleaseSchedule extends Component {
     if (!this.args.startDate) {
       return false;
     }
-    return DateTime.fromISO(this.args.startDate) > DateTime.now();
+    return DateTime.fromJSDate(new Date(this.args.startDate)) > DateTime.now();
   }
 }

--- a/packages/ilios-common/addon/components/timed-release-schedule.js
+++ b/packages/ilios-common/addon/components/timed-release-schedule.js
@@ -17,6 +17,6 @@ export default class TimedReleaseSchedule extends Component {
     if (!this.args.startDate) {
       return false;
     }
-    return DateTime.fromJSDate(new Date(this.args.startDate)) > DateTime.now();
+    return DateTime.fromISO(this.args.startDate) > DateTime.now();
   }
 }

--- a/packages/ilios-common/addon/components/timed-release-schedule.js
+++ b/packages/ilios-common/addon/components/timed-release-schedule.js
@@ -17,6 +17,6 @@ export default class TimedReleaseSchedule extends Component {
     if (!this.args.startDate) {
       return false;
     }
-    return DateTime.fromJSDate(this.args.startDate) > DateTime.now();
+    return DateTime.fromJSDate(new Date(this.args.startDate)) > DateTime.now();
   }
 }

--- a/packages/test-app/tests/integration/components/timed-release-schedule-test.js
+++ b/packages/test-app/tests/integration/components/timed-release-schedule-test.js
@@ -65,7 +65,7 @@ module('Integration | Component | timed release schedule', function (hooks) {
     assert.dom(this.element).hasNoText();
   });
 
-  test('it renders nothing with only start date in the past and showNoSchdule set to false', async function (assert) {
+  test('it renders nothing with only start date in the past and showNoSchedule set to false', async function (assert) {
     const yesterday = DateTime.fromObject({ hour: 8 }).minus({ days: 1 });
     this.set('yesterday', yesterday.toJSDate());
     await render(


### PR DESCRIPTION
Fixes ilios/ilios#5697

Looks like `.fromJSDate()` is looking for a JS `Date` object, not a string, so I converted it. There are several `DateTime` functions that could conceivably do the job, too, but this way kept tests passing, so it seemed the most prudent.