### PR TITLE
dashboard->calendar scrolly fixxy

### DIFF
--- a/packages/ilios-common/.lint-todo
+++ b/packages/ilios-common/.lint-todo
@@ -74,6 +74,5 @@ add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|23cd787c79c34a628da
 add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|23cd787c79c34a628dadb6e96dd4004d42eebb79|1722902400000|1730682000000|1754006400000|addon/components/dashboard/courses-calendar-filter.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|5|2|5|2|a90be151f45cd8ab32827e9247a9a9eb7f1baef2|1722902400000|1730682000000|1754006400000|addon/components/dashboard/courses-calendar-filter.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|25|10|25|10|4913c92cf4c945ea3970261ab1c1da9fa97d4bbc|1722902400000|1730682000000|1754006400000|addon/components/dashboard/courses-calendar-filter.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|3|2|3|2|29f70eb97c23ab052135966472e94c23fcbb063e|1725580800000|1728172800000|1730768400000|addon/components/dashboard/courses-calendar-filter.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|29|6|29|6|df94e6558ff62dea69f6f656f668f29b56bcc378|1722902400000|1730682000000|1754006400000|addon/components/session/publication-menu.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|28|6|28|6|1ef231a97c0ec761eaafb3e76093515e5523ff27|1725580800000|1728172800000|1730768400000|addon/components/session/publication-menu.hbs

--- a/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.hbs
+++ b/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.hbs
@@ -1,6 +1,5 @@
 <div
   class="calendar-filter-list large-filter-list dashboard-courses-calendar-filter"
-  {{did-insert (set this "el")}}
   {{did-insert (perform this.load)}}
   {{did-update (perform this.load) @school}}
   data-test-courses-calendar-filter

--- a/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.js
+++ b/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.js
@@ -97,8 +97,9 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
   @action
   scrollToLastYear(element, [year]) {
     if (year === this.academicYear - 1) {
-      const element = this.el.querySelector('.filters');
-      scrollIntoView(element, { align: { top: 0 } });
+      scrollIntoView(element.parentElement.parentElement, {
+        align: { top: 0 },
+      });
     }
   }
 

--- a/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.js
+++ b/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.js
@@ -12,7 +12,6 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
   @service iliosConfig;
 
   @tracked _expandedYears;
-  @tracked el;
   @tracked yearsInView = [];
   @tracked titlesInView = [];
   @tracked coursesRelationship;


### PR DESCRIPTION
Somewhat fixes ilios/ilios#5716

This PR does two things: 1) it removes an unnecessary `{did-insert}`, and 2) it moves the Dashboard->Calendar window scroll up a bit so the top of the viewport sits just above the filter headers, instead of hiding them.