### PR TITLE
Disable Array Prototypes

### DIFF
--- a/packages/frontend/config/environment.js
+++ b/packages/frontend/config/environment.js
@@ -66,7 +66,7 @@ module.exports = function (environment) {
         // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
       },
       EXTEND_PROTOTYPES: {
-        Array: true, //waiting on https://github.com/emberjs/data/issues/8202
+        Array: false,
       },
     },
 

--- a/packages/lti-course-manager/config/environment.js
+++ b/packages/lti-course-manager/config/environment.js
@@ -40,7 +40,7 @@ module.exports = function (environment) {
       },
       EXTEND_PROTOTYPES: {
         String: false,
-        Array: true,
+        Array: false,
         Function: false,
         Date: false,
       },

--- a/packages/lti-dashboard/config/environment.js
+++ b/packages/lti-dashboard/config/environment.js
@@ -38,7 +38,7 @@ module.exports = function (environment) {
       },
       EXTEND_PROTOTYPES: {
         String: false,
-        Array: true,
+        Array: false,
         Function: false,
         Date: false,
       },


### PR DESCRIPTION
We don't need this anymore, the issue we were originally hitting was caused by upstream ember issues as well as some of the helpers from ember-composable-helpers (which we have since added directly here). We can go ahead and disable these and silence the deprecation warnings being emitted since updating ember.