### PR TITLE
More Improvements to Calendar Courses Filter

### DIFF
--- a/packages/ilios-common/.lint-todo
+++ b/packages/ilios-common/.lint-todo
@@ -73,6 +73,6 @@ add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|23cd787c79c34a628da
 add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|23cd787c79c34a628dadb6e96dd4004d42eebb79|1722902400000|1730682000000|1754006400000|addon/components/course/visualize-term.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|23cd787c79c34a628dadb6e96dd4004d42eebb79|1722902400000|1730682000000|1754006400000|addon/components/dashboard/courses-calendar-filter.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|5|2|5|2|a90be151f45cd8ab32827e9247a9a9eb7f1baef2|1722902400000|1730682000000|1754006400000|addon/components/dashboard/courses-calendar-filter.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|25|10|25|10|4913c92cf4c945ea3970261ab1c1da9fa97d4bbc|1722902400000|1730682000000|1754006400000|addon/components/dashboard/courses-calendar-filter.hbs
+add|ember-template-lint|no-at-ember-render-modifiers|24|10|24|10|2ed3ce70b879732dc85047f9f546c5dbd5376dba|1727049600000|1729641600000|1732237200000|addon/components/dashboard/courses-calendar-filter.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|29|6|29|6|df94e6558ff62dea69f6f656f668f29b56bcc378|1722902400000|1730682000000|1754006400000|addon/components/session/publication-menu.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|28|6|28|6|1ef231a97c0ec761eaafb3e76093515e5523ff27|1725580800000|1728172800000|1730768400000|addon/components/session/publication-menu.hbs

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/dashboard/courses-calendar-filter.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/dashboard/courses-calendar-filter.js
@@ -1,10 +1,11 @@
-import { collection, clickable, create, property, text } from 'ember-cli-page-object';
+import { collection, clickable, create, hasClass, property, text } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-courses-calendar-filter]',
   years: collection('[data-test-year]', {
     title: text('[data-test-year-title]'),
     toggle: clickable('[data-test-year-title] button'),
+    isExpanded: hasClass('expanded'),
     courses: collection('[data-test-course]', {
       title: text(),
       toggle: clickable('[data-test-target]'),

--- a/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.hbs
+++ b/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.hbs
@@ -21,7 +21,7 @@
       {{#each this.courseYears as |year|}}
         <div
           class="year {{if (includes year.year this.expandedYears) "expanded" "collapsed"}}"
-          {{did-insert this.scrollToLastYear year.year}}
+          {{did-insert this.scrollToDefaultExpandedYear year.year}}
           {{in-viewport
             onEnter=(fn this.addYearInView year.year)
             onExit=(fn this.removeYearInView year.year)

--- a/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.js
+++ b/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.js
@@ -5,7 +5,6 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { DateTime } from 'luxon';
 import { findBy, sortBy } from 'ilios-common/utils/array-helpers';
-import scrollIntoView from 'scroll-into-view';
 
 export default class DashboardCoursesCalendarFilterComponent extends Component {
   @service dataLoader;
@@ -67,20 +66,21 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
     return sortBy(courseYears, 'year').reverse();
   }
 
+  get defaultExpandedYear() {
+    if (this.courseYears.length) {
+      const coursesThisYear = findBy(this.courseYears, 'year', this.academicYear);
+      return coursesThisYear ? this.academicYear : this.courseYears[0].year;
+    }
+
+    return false;
+  }
+
   get expandedYears() {
     if (this._expandedYears !== undefined) {
       return this._expandedYears;
     }
-    if (this.courseYears.length) {
-      const coursesThisYear = findBy(this.courseYears, 'year', this.academicYear);
-      if (coursesThisYear) {
-        return [this.academicYear];
-      } else {
-        return [this.courseYears[this.courseYears.length - 1].year];
-      }
-    }
 
-    return [];
+    return this.defaultExpandedYear ? [this.defaultExpandedYear] : [];
   }
 
   load = restartableTask(async () => {
@@ -95,9 +95,11 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
 
   @action
   scrollToLastYear(element, [year]) {
-    if (year === this.academicYear - 1) {
-      scrollIntoView(element.parentElement.parentElement, {
-        align: { top: 0 },
+    if (year === this.defaultExpandedYear) {
+      const { offsetTop } = element;
+      element.parentElement.scrollTo({
+        top: offsetTop,
+        behavior: 'instant',
       });
     }
   }

--- a/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.js
+++ b/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.js
@@ -94,7 +94,7 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
   });
 
   @action
-  scrollToLastYear(element, [year]) {
+  scrollToDefaultExpandedYear(element, [year]) {
     if (year === this.defaultExpandedYear) {
       const { offsetTop } = element;
       element.parentElement.scrollTo({

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/courses-calendar-filter.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/courses-calendar-filter.scss
@@ -1,6 +1,9 @@
 @use "../../mixins" as m;
 
 .dashboard-courses-calendar-filter {
+  .filters {
+    position: relative;
+  }
   .year {
     button {
       @include m.ilios-button-reset;


### PR DESCRIPTION
By marking the filter parent as relative positioned we can lookup the distance of each year from the top of that filter and scroll the correct one into view without opening anything else.

I discovered while testing this that if the current academic year doesn't have any course we were opening the oldest year instead of the latest year with courses. That seems wrong to me so I modified that behavior as well.

Refs ilios/ilios#5716