### PR TITLE
Change the UI Test Label Process

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           gh pr merge --merge --auto ${{ github.event.number }}
-          gh pr edit --add-label "ready to merge"  ${{ github.event.number }}
+          gh pr edit --add-label "run ui tests"  ${{ github.event.number }}
           gh pr review --approve -b "Auto Approved" ${{ github.event.number }}
         env:
           GH_TOKEN: ${{ secrets.ZORGBORT_TOKEN }}

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -4,16 +4,6 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:
-  enforce--ready-label:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: mheap/github-action-required-labels@v5
-      with:
-        mode: exactly
-        count: 1
-        labels: |
-          ready to merge
-        message: "Add the 'ready to merge' label to merge this PR"
   prevent-donotmerge-label:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -17,7 +17,7 @@ jobs:
     name: Browser Stack Test
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
+    if: contains(github.event.pull_request.labels.*.name, 'run ui tests')
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -58,7 +58,7 @@ jobs:
     name: Firefox Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
+    if: contains(github.event.pull_request.labels.*.name, 'run ui tests')
     strategy:
       fail-fast: false
       matrix:
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [firefox-test, browserstack-test]
     timeout-minutes: 20
-    if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
+    if: contains(github.event.pull_request.labels.*.name, 'run ui tests')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/update-transitive-dependencies.yaml
+++ b/.github/workflows/update-transitive-dependencies.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Enable Pull Request Automerge and Label for Tests
         if: steps.cpr.outputs.pull-request-operation == 'created'
         run: |
-          gh pr edit --add-label "ready to merge" ${{ steps.cpr.outputs.pull-request-number }}
+          gh pr edit --add-label "run ui tests" ${{ steps.cpr.outputs.pull-request-number }}
           gh pr merge --merge --auto ${{ steps.cpr.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ secrets.ZORGBORT_TOKEN }}


### PR DESCRIPTION
I think the "ready to merge" label was a bit off, we don't need to add any more automation to this process. It is working well as is today. Updating the label to "run ui tests" is more accurate.

I also removed the test to ensure the label is present, it's just annoying. We require the ui tests that are run before merging so it will need to get added eventually anyway.