### PR TITLE
Upload Coverage Info to Codeclimate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,24 @@ jobs:
         with:
           args: >
             -Dsonar.projectKey=ilios_frontend_27a24e39-b0ec-405a-91a6-b6392ffcdd30
+
+  upload-coverage:
+    name: Upload Coverage
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-frontend
+          path: coverage
+      - run: ls -lh
+      - run: ls -lh coverage
+      - name: Publish code coverage
+        uses: paambaati/codeclimate-action@v9.0.0
+        env:
+          CC_TEST_REPORTER_ID: 8c510ad3aa4b1a2a3d504dfdbcc5605e7966c019dc1e9b68a815de50b946ebc6
+        with:
+          coverageLocations: |
+            coverageLocations: ${{github.workspace}}/coverage/lcov.info:lcov

--- a/packages/frontend/config/coverage.js
+++ b/packages/frontend/config/coverage.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 
 module.exports = {
-  reporters: ['lcov', 'html'],
+  //we need to go up two directories to get to the root of the monorepo
+  reporters: [['lcov', { projectRoot: '../..' }], 'html'],
 };


### PR DESCRIPTION
We're generating code coverage data in our tests, let's upload it somewhere and get some useful reports.

Status:
- [x] We need to await a new release of ember-cli-code-coverage which will have the option needed to configure `projectRoot` and hopefully prefix the Istanbul lcov output with the right information to connect the coverage to code climate (where the monorepo is all that is seen).

It's Alive! (you can see the status in the checks)