### PR TITLE
add proper mixin to school list actions

### DIFF
--- a/packages/frontend/app/styles/components/school-list.scss
+++ b/packages/frontend/app/styles/components/school-list.scss
@@ -18,6 +18,10 @@
       .title {
         @include m.main-list-box-header-title;
       }
+
+      .actions {
+        @include m.main-list-box-header-actions;
+      }
     }
   }
 


### PR DESCRIPTION
The "+" button was missing the proper padding that other routes had.