### PR TITLE
Admin->Users->View All spacing fix

### DIFF
--- a/packages/frontend/app/styles/components/manage-users-summary.scss
+++ b/packages/frontend/app/styles/components/manage-users-summary.scss
@@ -19,6 +19,10 @@
 
     h2 {
       @include m.ilios-heading-h3;
+
+      a {
+        display: inline-block;
+      }
     }
 
     .actions {


### PR DESCRIPTION
Minor annoyance, but making the "View All" link display as `inline-block` removes the extra spacing created by using the `<LinkTo>` component.

Sorry! It's been bugging me (especially when you hover it)!

![Screenshot 2024-09-24 at 2 51 53 PM](https://github.com/user-attachments/assets/634c19fc-950c-4172-b236-df381b4ebf68)
![Screenshot 2024-09-24 at 2 54 54 PM](https://github.com/user-attachments/assets/26ea4a23-13d3-4c81-ac46-13bdb97ca317)
