### PR TITLE
Hide the Version in Percy Snapshots

### DIFF
--- a/packages/frontend/app/styles/components/ilios-footer.scss
+++ b/packages/frontend/app/styles/components/ilios-footer.scss
@@ -23,5 +23,9 @@
     justify-content: center;
     margin: 0.25rem;
     padding: 0.25rem;
+
+    @media only percy {
+      visibility: hidden;
+    }
   }
 }


### PR DESCRIPTION
This area of the page changes when we do a release and can cause a lot of instability and false positives. Let's hide it entirely from percy.