### PR TITLE
Fix course LM search bug

### DIFF
--- a/packages/ilios-common/addon/components/learningmaterial-search.hbs
+++ b/packages/ilios-common/addon/components/learningmaterial-search.hbs
@@ -62,6 +62,7 @@
           <button
             disabled={{if this.searchMore.isRunning true}}
             type="button"
+            data-test-show-more
             {{on "click" (perform this.searchMore)}}
           >
             {{#if this.searchMore.isRunning}}

--- a/packages/ilios-common/addon/components/learningmaterial-search.hbs
+++ b/packages/ilios-common/addon/components/learningmaterial-search.hbs
@@ -30,13 +30,13 @@
               </span>
             </div>
             <span class="learning-material-description">
-            {{! template-lint-disable no-triple-curlies }}
+              {{! template-lint-disable no-triple-curlies }}
               {{{learningMaterial.description}}}
-          </span>
+            </span>
             {{#if learningMaterial.status.title}}
-              <span class="learning-material-status">
-                {{learningMaterial.status.title}}
-              </span>
+            <span class="learning-material-status">
+              {{learningMaterial.status.title}}
+            </span>
             {{/if}}
             <ul class="learning-material-properties">
               <li>
@@ -44,10 +44,10 @@
                 {{learningMaterial.owningUser.fullName}}
               </li>
               {{#if learningMaterial.originalAuthor}}
-                <li>
-                  {{t "general.contentAuthor"}}:
-                  {{learningMaterial.originalAuthor}}
-                </li>
+              <li>
+                {{t "general.contentAuthor"}}:
+                {{learningMaterial.originalAuthor}}
+              </li>
               {{/if}}
               <li>
                 {{t "general.uploadDate"}}:

--- a/packages/ilios-common/addon/components/learningmaterial-search.js
+++ b/packages/ilios-common/addon/components/learningmaterial-search.js
@@ -31,7 +31,7 @@ export default class LearningMaterialSearchComponent extends Component {
       'order_by[title]': 'ASC',
     });
 
-    const lms = results;
+    const lms = results.slice();
     this.searchReturned = true;
     this.searching = false;
     this.searchPage = 1;
@@ -59,7 +59,8 @@ export default class LearningMaterialSearchComponent extends Component {
       offset: this.searchPage * this.searchResultsPerPage,
       'order_by[title]': 'ASC',
     });
-    const lms = results;
+
+    const lms = results.slice();
     this.searchPage = this.searchPage + 1;
     this.hasMoreSearchResults = lms.length > this.searchResultsPerPage;
     if (this.hasMoreSearchResults) {

--- a/packages/test-app/tests/integration/components/learningmaterial-search-test.js
+++ b/packages/test-app/tests/integration/components/learningmaterial-search-test.js
@@ -11,19 +11,35 @@ module('Integration | Component | learningmaterial search', function (hooks) {
 
   test('search shows results', async function (assert) {
     this.server.createList('learning-material', 2);
-    await render(hbs`<LearningmaterialSearch />
-`);
+    await render(hbs`<LearningmaterialSearch />`);
     await component.search.set('material');
     assert.strictEqual(component.searchResults.length, 2);
   });
 
   test('empty search clears results', async function (assert) {
     this.server.createList('learning-material', 2);
-    await render(hbs`<LearningmaterialSearch />
-`);
+    await render(hbs`<LearningmaterialSearch />`);
     await component.search.set('    material    ');
     assert.strictEqual(component.searchResults.length, 2);
     await component.search.set('        ');
     assert.strictEqual(component.searchResults.length, 0);
+  });
+
+  test('search does not show Search More button if result count is same as searchResultsPerPage', async function (assert) {
+    this.set('searchResultsPerPage', 50);
+    this.server.createList('learning-material', this.searchResultsPerPage);
+    await render(hbs`<LearningmaterialSearch />`);
+    await component.search.set('    material    ');
+    assert.strictEqual(component.searchResults.length, this.searchResultsPerPage);
+    assert.dom('[data-test-show-more]').doesNotExist();
+  });
+
+  test('search shows Search More button if result count above searchResultsPerPage', async function (assert) {
+    this.set('searchResultsPerPage', 50);
+    this.server.createList('learning-material', this.searchResultsPerPage + 1);
+    await render(hbs`<LearningmaterialSearch />`);
+    await component.search.set('    material    ');
+    assert.strictEqual(component.searchResults.length, this.searchResultsPerPage + 1);
+    assert.dom('[data-test-show-more]').exists();
   });
 });


### PR DESCRIPTION
Fixes ilios/ilios#5727

Removing two `.slice()` calls in https://github.com/ilios/frontend/pull/8116 from LM search created this bug.

Also added two more integration tests for the "Show More" button's existence depending on how many results are returned.