### PR TITLE
Add On-Demand Trigger for Nightly Workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ name: Nightly
 on:
   schedule:
     - cron: "15 9 * * 0-5" # nightly, S-F
+  workflow_dispatch: null
 
 env:
   SW_DISABLED: true


### PR DESCRIPTION
This will allow us to run this, if needed, during the day without waiting for the overnight run.