### PR TITLE
fix editable headers with extra elements

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/fade-text.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/fade-text.scss
@@ -2,6 +2,8 @@
 
 .fade-text {
   .display-text-wrapper {
+    display: inline-block;
+
     &.is-faded {
       max-height: 200px;
       overflow: hidden;


### PR DESCRIPTION
Fixes ilios/ilios#5730

The new `<FadeText>` component needs its `display-text-wrapper` to `display: inline-block` to account for other elements.