### PR TITLE
adds faded text effect to long parent objectives in courses/sessions

### DIFF
--- a/packages/frontend/app/styles/components/program-year/objectives.scss
+++ b/packages/frontend/app/styles/components/program-year/objectives.scss
@@ -4,4 +4,8 @@
 .program-year-objectives {
   @include m.detail-container(c.$orange);
   @include m.objectives;
+
+  .fade-text-control {
+    background-image: linear-gradient(to bottom, transparent, c.$slightWhite);
+  }
 }

--- a/packages/ilios-common/addon/components/course/objective-list-item-parents.hbs
+++ b/packages/ilios-common/addon/components/course/objective-list-item-parents.hbs
@@ -28,18 +28,69 @@
       {{#each (sort-by "title" @parents) as |parent|}}
         {{#if @editable}}
           <li data-test-parent>
-            <button
-              type="button"
-              class="link-button"
-              {{on "click" @manage}}
-              data-test-manage
+            <FadeText
+              @text={{html-safe (remove-html-tags parent.title)}}
+              as |displayText expand collapse updateTextDims isFaded expanded|
+            >
+              <button
+                type="button"
+                class="link-button"
+                {{on "click" @manage}}
+                data-test-manage
               >
-                {{html-safe (remove-html-tags parent.title)}}
-            </button>
+                <div class="display-text-wrapper{{if isFaded ' is-faded'}}">
+                  <div
+                    class="display-text"
+                    {{on-resize updateTextDims}}
+                  >
+                    {{displayText}}
+                  </div>
+                </div>
+                {{#if @showIcon}}
+                  <FaIcon
+                    data-test-edit-icon
+                    @icon="pen-to-square"
+                    class="enabled"
+                  />
+                {{/if}}
+              </button>
+              {{#if isFaded}}
+                <div
+                  class="fade-text-control"
+                  data-test-fade-text-control
+                  {{! template-lint-disable no-invalid-interactive}}
+                  {{on "click" @manage}}
+                >
+                  <button
+                    class="expand-text-button"
+                    type="button"
+                    aria-label={{t "general.expand"}}
+                    title={{t "general.expand"}}
+                    data-test-expand
+                    {{on "click" expand}}
+                  >
+                    <FaIcon @icon="angles-down" />
+                  </button>
+                </div>
+              {{else}}
+                {{#if expanded}}
+                  <button
+                    class="expand-text-button"
+                    aria-label={{t "general.collapse"}}
+                    title={{t "general.collapse"}}
+                    type="button"
+                    data-test-collapse
+                    {{on "click" collapse}}
+                  >
+                    <FaIcon @icon="angles-up" />
+                  </button>
+                {{/if}}
+              {{/if}}
+            </FadeText>
           </li>
         {{else}}
           <li data-test-parent>
-            {{html-safe (remove-html-tags parent.title)}}
+            <FadeText @text={{html-safe (remove-html-tags parent.title)}} />
           </li>
         {{/if}}
       {{else}}

--- a/packages/ilios-common/addon/components/session/objective-list-item-parents.hbs
+++ b/packages/ilios-common/addon/components/session/objective-list-item-parents.hbs
@@ -28,18 +28,69 @@
       {{#each (sort-by-position @parents) as |parent|}}
         {{#if @editable}}
           <li data-test-parent>
-            <button
-              type="button"
-              class="link-button"
-              {{on "click" @manage}}
-              data-test-manage
+            <FadeText
+              @text={{html-safe (remove-html-tags parent.title)}}
+              as |displayText expand collapse updateTextDims isFaded expanded|
+            >
+              <button
+                type="button"
+                class="link-button"
+                {{on "click" @manage}}
+                data-test-manage
               >
-                {{html-safe (remove-html-tags parent.title)}}
-            </button>
+                <div class="display-text-wrapper{{if isFaded ' is-faded'}}">
+                  <div
+                    class="display-text"
+                    {{on-resize updateTextDims}}
+                  >
+                    {{displayText}}
+                  </div>
+                </div>
+                {{#if @showIcon}}
+                  <FaIcon
+                    data-test-edit-icon
+                    @icon="pen-to-square"
+                    class="enabled"
+                  />
+                {{/if}}
+              </button>
+              {{#if isFaded}}
+                <div
+                  class="fade-text-control"
+                  data-test-fade-text-control
+                  {{! template-lint-disable no-invalid-interactive}}
+                  {{on "click" @manage}}
+                >
+                  <button
+                    class="expand-text-button"
+                    type="button"
+                    aria-label={{t "general.expand"}}
+                    title={{t "general.expand"}}
+                    data-test-expand
+                    {{on "click" expand}}
+                  >
+                    <FaIcon @icon="angles-down" />
+                  </button>
+                </div>
+              {{else}}
+                {{#if expanded}}
+                  <button
+                    class="expand-text-button"
+                    aria-label={{t "general.collapse"}}
+                    title={{t "general.collapse"}}
+                    type="button"
+                    data-test-collapse
+                    {{on "click" collapse}}
+                  >
+                    <FaIcon @icon="angles-up" />
+                  </button>
+                {{/if}}
+              {{/if}}
+            </FadeText>
           </li>
         {{else}}
           <li data-test-parent>
-            {{html-safe (remove-html-tags parent.title)}}
+            <FadeText @text={{html-safe (remove-html-tags parent.title)}} />
           </li>
         {{/if}}
       {{else}}

--- a/packages/ilios-common/app/styles/ilios-common/components/fade-text.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/fade-text.scss
@@ -1,4 +1,5 @@
 @use "../colors" as c;
+@use "../mixins" as m;
 
 .fade-text {
   .display-text-wrapper {
@@ -17,6 +18,7 @@
     position: relative;
 
     button {
+      @include m.ilios-link-button;
       position: relative;
       top: 110px;
     }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
@@ -58,6 +58,15 @@
         display: inline-block;
       }
 
+      .fade-text-control {
+        button {
+          background: c.$tealBlue;
+          border-radius: 3px;
+          color: c.$white;
+          padding: 0.3em 1em;
+        }
+      }
+
       &.dragging-item {
         opacity: 0.3;
       }


### PR DESCRIPTION
Refs ilios/frontend#8034
Fixes ilios/ilios#5644
Fixes ilios/ilios#5734

Added `<FadeText>` shortening to Course/Session Parent Objectives column. I also fixed the issue with Programs->Program Years->Objectives not faded to the correct color, as well as some `fade-text-control` button coloring here and there that wasn't correct.