### PR TITLE
Reports->Sessions downloads now show objectives and session attributes

### DIFF
--- a/packages/frontend/app/components/reports/subject/session.gjs
+++ b/packages/frontend/app/components/reports/subject/session.gjs
@@ -125,14 +125,14 @@ export default class ReportsSubjectSessionComponent extends Component {
 
   @cached
   get schoolConfigsData() {
-    return new TrackedAsyncData(this.args.school.configurations);
+    return new TrackedAsyncData(this.args.school?.configurations);
   }
 
   @cached
   get schoolConfigs() {
     const rhett = new Map();
     if (this.schoolConfigsData.isResolved) {
-      this.schoolConfigsData.value.forEach((config) => {
+      this.schoolConfigsData.value?.forEach((config) => {
         rhett.set(config.name, JSON.parse(config.value));
       });
     }

--- a/packages/frontend/app/components/reports/subject/session.gjs
+++ b/packages/frontend/app/components/reports/subject/session.gjs
@@ -190,8 +190,8 @@ export default class ReportsSubjectSessionComponent extends Component {
       this.intl.t('general.equipmentRequired'),
       this.intl.t('general.supplementalCurriculum'),
     ];
-    [...Array(maxObjectiveCount + 1).keys()].slice(1).map((key) => {
-      columns.push(`${this.intl.t('general.objective')} ${key}`);
+    [...Array(maxObjectiveCount + 1).keys()].slice(1).map(() => {
+      columns.push(`${this.intl.t('general.objective')}`);
     });
 
     return [columns, ...mappedResults];

--- a/packages/frontend/app/components/reports/subject/session.gjs
+++ b/packages/frontend/app/components/reports/subject/session.gjs
@@ -232,9 +232,7 @@ export default class ReportsSubjectSessionComponent extends Component {
               {{/if}}
               <span data-test-course-title>
                 {{#if this.canViewCourse}}
-                  <LinkTo @route="course" @model={{obj.courseId}}>
-                    {{obj.courseTitle}}:
-                  </LinkTo>
+                  <LinkTo @route="course" @model={{obj.courseId}}>{{obj.courseTitle}}:</LinkTo>
                 {{else}}
                   {{obj.courseTitle}}:
                 {{/if}}

--- a/packages/frontend/app/components/reports/subject/session.gjs
+++ b/packages/frontend/app/components/reports/subject/session.gjs
@@ -168,10 +168,10 @@ export default class ReportsSubjectSessionComponent extends Component {
             ? `${course.year} - ${course.year + 1}`
             : `${course.year}`,
           striptags(description),
-          attendanceRequired,
-          attireRequired,
-          equipmentRequired,
-          supplemental,
+          attendanceRequired ? this.intl.t('general.yes') : this.intl.t('general.no'),
+          attireRequired ? this.intl.t('general.yes') : this.intl.t('general.no'),
+          equipmentRequired ? this.intl.t('general.yes') : this.intl.t('general.no'),
+          supplemental ? this.intl.t('general.yes') : this.intl.t('general.no'),
         ];
         sessionObjectives.forEach((objective) => {
           results.push(striptags(objective.title));

--- a/packages/frontend/app/components/reports/subject/session.gjs
+++ b/packages/frontend/app/components/reports/subject/session.gjs
@@ -136,10 +136,12 @@ export default class ReportsSubjectSessionComponent extends Component {
       'description',
       'sessionObjectives { title }',
       'course { title, year }',
+      'attendanceRequired',
+      'attireRequired',
+      'equipmentRequired',
     ];
     const result = await this.graphql.find('sessions', filters, attributes.join(','));
     const sortedResults = sortBy(result.data.sessions, 'title');
-
     const objectives = sortedResults.map(({ sessionObjectives }) => {
       return mapBy(sessionObjectives, 'title');
     });
@@ -147,26 +149,42 @@ export default class ReportsSubjectSessionComponent extends Component {
       return current.length > longest.length ? current : longest;
     }, []).length;
 
-    const mappedResults = sortedResults.map(({ title, course, sessionObjectives, description }) => {
-      const results = [
+    const mappedResults = sortedResults.map(
+      ({
         title,
-        course.title,
-        this.academicYearCrossesCalendarYearBoundaries
-          ? `${course.year} - ${course.year + 1}`
-          : `${course.year}`,
-        striptags(description),
-      ];
-      sessionObjectives.forEach((objective) => {
-        results.push(striptags(objective.title));
-      });
-      return results;
-    });
+        course,
+        sessionObjectives,
+        description,
+        attendanceRequired,
+        attireRequired,
+        equipmentRequired,
+      }) => {
+        const results = [
+          title,
+          course.title,
+          this.academicYearCrossesCalendarYearBoundaries
+            ? `${course.year} - ${course.year + 1}`
+            : `${course.year}`,
+          striptags(description),
+          attendanceRequired,
+          attireRequired,
+          equipmentRequired,
+        ];
+        sessionObjectives.forEach((objective) => {
+          results.push(striptags(objective.title));
+        });
+        return results;
+      },
+    );
 
     const columns = [
       this.intl.t('general.session'),
       this.intl.t('general.course'),
       this.intl.t('general.academicYear'),
       this.intl.t('general.description'),
+      this.intl.t('general.attendanceRequired'),
+      this.intl.t('general.attireRequired'),
+      this.intl.t('general.equipmentRequired'),
     ];
     [...Array(maxObjectiveCount + 1).keys()].slice(1).map((key) => {
       columns.push(`${this.intl.t('general.objective')} ${key}`);

--- a/packages/frontend/app/components/reports/subject/session.gjs
+++ b/packages/frontend/app/components/reports/subject/session.gjs
@@ -139,6 +139,7 @@ export default class ReportsSubjectSessionComponent extends Component {
       'attendanceRequired',
       'attireRequired',
       'equipmentRequired',
+      'supplemental',
     ];
     const result = await this.graphql.find('sessions', filters, attributes.join(','));
     const sortedResults = sortBy(result.data.sessions, 'title');
@@ -158,6 +159,7 @@ export default class ReportsSubjectSessionComponent extends Component {
         attendanceRequired,
         attireRequired,
         equipmentRequired,
+        supplemental,
       }) => {
         const results = [
           title,
@@ -169,6 +171,7 @@ export default class ReportsSubjectSessionComponent extends Component {
           attendanceRequired,
           attireRequired,
           equipmentRequired,
+          supplemental,
         ];
         sessionObjectives.forEach((objective) => {
           results.push(striptags(objective.title));
@@ -185,6 +188,7 @@ export default class ReportsSubjectSessionComponent extends Component {
       this.intl.t('general.attendanceRequired'),
       this.intl.t('general.attireRequired'),
       this.intl.t('general.equipmentRequired'),
+      this.intl.t('general.supplementalCurriculum'),
     ];
     [...Array(maxObjectiveCount + 1).keys()].slice(1).map((key) => {
       columns.push(`${this.intl.t('general.objective')} ${key}`);

--- a/packages/frontend/tests/integration/components/reports/subject/session-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/subject/session-test.gjs
@@ -555,7 +555,7 @@ module('Integration | Component | reports/subject/session', function (hooks) {
     const csvText = await capturedBlob.text();
     assert.strictEqual(
       csvText.trim(),
-      'Session,Course,Academic Year,Description,Attendance Required,Attire Required,Equipment Required,Supplemental Curriculum,Objective 1,Objective 2\r\nFirst Session,First Course,2023,First Session Description,false,false,true,true,First Objective\r\nSecond Session,First Course,2023,Session 2 Description,false,true,false,true,First Objective,Second Objective\r\nThird Session,Second Course,2020,Three Session Description,true,false,true,false',
+      'Session,Course,Academic Year,Description,Attendance Required,Attire Required,Equipment Required,Supplemental Curriculum,Objective,Objective\r\nFirst Session,First Course,2023,First Session Description,false,false,true,true,First Objective\r\nSecond Session,First Course,2023,Session 2 Description,false,true,false,true,First Objective,Second Objective\r\nThird Session,Second Course,2020,Three Session Description,true,false,true,false',
       'CSV content is correct',
     );
 

--- a/packages/frontend/tests/integration/components/reports/subject/session-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/subject/session-test.gjs
@@ -559,7 +559,7 @@ module('Integration | Component | reports/subject/session', function (hooks) {
     const csvText = await capturedBlob.text();
     assert.strictEqual(
       csvText.trim(),
-      'Session,Course,Academic Year,Description,Attendance Required,Attire Required,Equipment Required,Supplemental Curriculum,Objective,Objective\r\nFirst Session,First Course,2023,First Session Description,false,false,true,true,First Objective\r\nSecond Session,First Course,2023,Session 2 Description,false,true,false,true,First Objective,Second Objective\r\nThird Session,Second Course,2020,Three Session Description,true,false,true,false',
+      'Session,Course,Academic Year,Description,Objective,Objective\r\nFirst Session,First Course,2023,First Session Description,First Objective\r\nSecond Session,First Course,2023,Session 2 Description,First Objective,Second Objective\r\nThird Session,Second Course,2020,Three Session Description',
       'CSV content is correct',
     );
 

--- a/packages/frontend/tests/integration/components/reports/subject/session-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/subject/session-test.gjs
@@ -508,11 +508,15 @@ module('Integration | Component | reports/subject/session', function (hooks) {
     const downloadMockUrl = 'blob:mock-url';
     const downloadFilename = 'All Sessions in All Schools.csv';
 
-    await render(hbs`<Reports::Subject::Session
-  @subject={{this.report.subject}}
-  @prepositionalObject={{this.report.prepositionalObject}}
-  @prepositionalObjectTableRowId={{this.report.prepositionalObjectTableRowId}}
-/>`);
+    await render(
+      <template>
+        <Session
+          @subject={{this.report.subject}}
+          @prepositionalObject={{this.report.prepositionalObject}}
+          @prepositionalObjectTableRowId={{this.report.prepositionalObjectTableRowId}}
+        />
+      </template>,
+    );
 
     // Override URL methods
     const originalCreateObjectURL = URL.createObjectURL;

--- a/packages/ilios-common/addon/utils/create-download-file.js
+++ b/packages/ilios-common/addon/utils/create-download-file.js
@@ -8,6 +8,7 @@ export default function createDownloadFile(title, content, type) {
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
+    URL.revokeObjectURL(a);
   } else {
     location.href = 'data:application/octet-stream,' + encodeURIComponent(content);
   }

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -20,6 +20,7 @@ general:
   attendanceIs_Required_: "Attendance is '<strong><em>'required'</em></strong>'"
   attendanceIsRequired: Attendance is required
   attendanceRequired: Attendance Required
+  attireRequired: Attire Required
   author: Author
   autoUpdatingSeconds: "{count, plural, =1 {Auto updating in 1 second...} other {Auto updating in # seconds...}}"
   availableInstructorsAndInstructorGroups: Available Instructors and Instructor Groups
@@ -122,6 +123,7 @@ general:
   endDate: End Date
   ends: Ends
   endTime: End Time
+  equipmentRequired: Equipment Required
   etAl: et al.
   eventNotFoundTitle: Event Not Found
   eventNotFoundExplanation: "The event you have tried to reach is either no longer available, or you have followed a personalized user link which is not shareable. If you continue to encounter issues, please contact your Ilios help desk."

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -20,6 +20,7 @@ general:
   attendanceIs_Required_: "Se '<strong><em>'require'</em></strong>' asistencia"
   attendanceIsRequired: Se require asistencia
   attendanceRequired: Asistencia Requerida
+  attireRequired: Atuendo Requerida
   author: Autor
   autoUpdatingSeconds: "{count, plural, =1 {Actualización automática en 1 segundo...} other {Actualización automática en # segundos...}}"
   availableInstructorsAndInstructorGroups: Instructores y Grupos de instructores Disponibles
@@ -122,6 +123,7 @@ general:
   endDate: Fecha de Cumplir
   ends: Termina
   endTime: Hora de Cumplir
+  equipmentRequired: Equipo Requerido
   etAl: et al.
   eventNotFoundTitle: Evento no encontrado
   eventNotFoundExplanation: "El evento al que ha intentado acceder ya no está disponible o ha seguido un enlace de usuario personalizado que no se puede compartir. Si sigue teniendo problemas, póngase en contacto con el servicio de asistencia de Ilios."

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -20,6 +20,7 @@ general:
   attendanceIs_Required_: "Présence '<strong><em>'requise'</em></strong>'"
   attendanceIsRequired: Présence requise
   attendanceRequired: Participation Requise
+  attireRequired: Tenue Requise
   author: Auteur
   autoUpdatingSeconds: "{count, plural, =1 { Mise à jour automatique en 1 seconde...} other { Mise à jour automatique en # secondes...}}"
   availableInstructorsAndInstructorGroups: "Instructeurs et groupes d'instructeurs disponibles"
@@ -122,6 +123,7 @@ general:
   endDate: Jour Terminé
   ends: Terminé
   endTime: Heure Terminé
+  equipmentRequired: Équipement Requis
   etAl: et al.
   expand: Étendre
   eventNotFoundTitle: Evénement introuvable


### PR DESCRIPTION
Fixes ilios/ilios#4313

This change adds Session Objectives to their own rows, as opposed to in one long line. It also adds the boolean flag information for `attendanceRequired`, `attireRequired`, `equipmentRequired`, and `supplemental`. Finally, it makes the `download()` test works (did the CSV get created and are its contents correct?) (and courses subjects now does, too).

Old:
![Screenshot 2025-05-06 at 10 36 45 AM](https://github.com/user-attachments/assets/73c3500a-79e3-463b-a1c9-18d5df75dce3)

New:
![Screenshot 2025-05-06 at 10 37 34 AM](https://github.com/user-attachments/assets/a3948313-12d5-42cc-9a59-b1c1fe2d56a7)
