### PR TITLE
main-list mixin consistency

### DIFF
--- a/packages/frontend/app/styles/components/assign-students/manager.scss
+++ b/packages/frontend/app/styles/components/assign-students/manager.scss
@@ -1,5 +1,4 @@
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .assign-students-manager {
   @include m.main-list-box;
@@ -8,7 +7,7 @@
     @include m.main-list-box-header;
 
     h2 {
-      @include cm.ilios-heading;
+      @include m.ilios-heading;
     }
 
     .title {
@@ -22,12 +21,12 @@
     flex-direction: column;
     padding: 0.5rem;
 
-    @include cm.for-laptop-and-up {
+    @include m.for-laptop-and-up {
       flex-direction: row;
     }
 
     label {
-      @include cm.ilios-label;
+      @include m.ilios-label;
       margin: 0 0.5rem;
     }
 

--- a/packages/frontend/app/styles/components/assign-students/root.scss
+++ b/packages/frontend/app/styles/components/assign-students/root.scss
@@ -1,8 +1,7 @@
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .assign-students-root {
-  @include cm.main-section;
+  @include m.main-section;
 
   .filters {
     @include m.main-list-filters;

--- a/packages/frontend/app/styles/components/courses/list.scss
+++ b/packages/frontend/app/styles/components/courses/list.scss
@@ -1,4 +1,4 @@
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .courses-list {
   @include m.main-list-box-table;

--- a/packages/frontend/app/styles/components/courses/root.scss
+++ b/packages/frontend/app/styles/components/courses/root.scss
@@ -1,8 +1,7 @@
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .courses-root {
-  @include cm.main-section;
+  @include m.main-section;
 
   .filters {
     @include m.main-list-filters;
@@ -26,7 +25,7 @@
       @include m.main-list-box-header;
 
       h2 {
-        @include cm.ilios-heading;
+        @include m.ilios-heading;
       }
 
       .title {

--- a/packages/frontend/app/styles/components/curriculum-inventory/reports-list.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/reports-list.scss
@@ -1,13 +1,12 @@
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .curriculum-inventory-reports {
-  @include cm.main-section;
+  @include m.main-section;
 
   .filters {
     @include m.main-list-filters;
 
-    @include cm.for-laptop-and-up {
+    @include m.for-laptop-and-up {
       justify-content: flex-start;
     }
 
@@ -28,7 +27,7 @@
       @include m.main-list-box-header;
 
       h2 {
-        @include cm.ilios-heading;
+        @include m.ilios-heading;
       }
 
       .title {

--- a/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-list.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-list.scss
@@ -33,8 +33,6 @@
   }
 
   .saved-result {
-    border: 1px solid c.$fernGreen;
-    margin: 1rem;
-    padding: 0.75rem;
+    @include m.main-list-saved-new;
   }
 }

--- a/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-list.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-list.scss
@@ -1,15 +1,14 @@
 @use "../../ilios-common/colors" as c;
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .curriculum-inventory-sequence-block-list {
-  @include cm.main-section;
+  @include m.main-section;
 
   .header {
     @include m.main-list-box-header;
 
     h2 {
-      @include cm.ilios-heading;
+      @include m.ilios-heading;
     }
 
     .title {

--- a/packages/frontend/app/styles/components/ilios-users.scss
+++ b/packages/frontend/app/styles/components/ilios-users.scss
@@ -1,8 +1,7 @@
-@use "../ilios-common/mixins" as cm;
-@use "../mixins" as m;
+@use "../ilios-common/mixins" as m;
 
 .ilios-users {
-  @include cm.main-section;
+  @include m.main-section;
 
   .filters {
     @include m.main-list-filters;
@@ -19,7 +18,7 @@
       @include m.main-list-box-header;
 
       h2 {
-        @include cm.ilios-heading;
+        @include m.ilios-heading;
       }
 
       .title {

--- a/packages/frontend/app/styles/components/instructor-groups/loading.scss
+++ b/packages/frontend/app/styles/components/instructor-groups/loading.scss
@@ -1,4 +1,4 @@
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .instructor-groups-loading {
   @include m.main-list-loading-table;

--- a/packages/frontend/app/styles/components/instructor-groups/root.scss
+++ b/packages/frontend/app/styles/components/instructor-groups/root.scss
@@ -1,8 +1,7 @@
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .instructor-groups-root {
-  @include cm.main-section;
+  @include m.main-section;
 
   .filters {
     @include m.main-list-filters;
@@ -24,7 +23,7 @@
       @include m.main-list-box-header;
 
       h2 {
-        @include cm.ilios-heading;
+        @include m.ilios-heading;
       }
 
       .title {

--- a/packages/frontend/app/styles/components/learner-group/cohort-user-manager.scss
+++ b/packages/frontend/app/styles/components/learner-group/cohort-user-manager.scss
@@ -1,29 +1,28 @@
 @use "../../ilios-common/colors" as c;
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .learner-group-cohort-user-manager {
-  @include cm.detail-container(c.$tealBlue);
+  @include m.detail-container(c.$tealBlue);
   border-bottom: 0;
   border-top: 1px dotted c.$orange;
 
   .learner-group-cohort-user-manager-header {
-    @include cm.detail-container-header;
+    @include m.detail-container-header;
 
     .title {
-      @include cm.detail-container-title;
+      @include m.detail-container-title;
     }
 
     .actions {
       input {
-        @include cm.ilios-input;
+        @include m.ilios-input;
         width: 15rem;
       }
     }
   }
 
   .learner-group-cohort-user-manager-content {
-    @include cm.detail-container-content;
+    @include m.detail-container-content;
 
     .list {
       @include m.main-list-box-table;
@@ -33,7 +32,7 @@
   }
 
   .inline-button {
-    @include cm.ilios-button-reset;
+    @include m.ilios-button-reset;
     text-align: left;
     width: 100%;
   }

--- a/packages/frontend/app/styles/components/learner-group/members.scss
+++ b/packages/frontend/app/styles/components/learner-group/members.scss
@@ -1,31 +1,30 @@
 @use "../../ilios-common/colors" as c;
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .learner-group-members {
-  @include cm.detail-container(c.$tealBlue);
+  @include m.detail-container(c.$tealBlue);
   border-bottom: 0;
   display: grid;
   grid-template-columns: 3fr 1fr;
 
   .title {
-    @include cm.detail-container-title-style;
+    @include m.detail-container-title-style;
   }
 
   .actions {
     input {
-      @include cm.ilios-input;
+      @include m.ilios-input;
       width: 15rem;
     }
   }
 
   .learner-group-members-content {
-    @include cm.detail-container-content;
+    @include m.detail-container-content;
     grid-column: 1 / -1;
 
     .list {
       @include m.main-list-box-table;
-      @include cm.ilios-zebra-table;
+      @include m.ilios-zebra-table;
       grid-column: 1 / -1;
       max-height: 540px;
       overflow: auto;
@@ -33,7 +32,7 @@
   }
 
   .inline-button {
-    @include cm.ilios-button-reset;
+    @include m.ilios-button-reset;
     text-align: left;
     width: 100%;
   }

--- a/packages/frontend/app/styles/components/learner-group/root.scss
+++ b/packages/frontend/app/styles/components/learner-group/root.scss
@@ -1,18 +1,17 @@
 @use "../../ilios-common/colors" as c;
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 @use "sass:color";
 
 .learner-group-root {
-  @include cm.main-section;
+  @include m.main-section;
 
   .learner-group-overview {
-    @include cm.ilios-overview(c.$orange);
+    @include m.ilios-overview(c.$orange);
     margin-left: 0.8rem;
 
     .block {
-      @include cm.ilios-overview-block;
+      @include m.ilios-overview-block;
 
       &.associatedcourses {
         align-items: flex-start;
@@ -23,7 +22,7 @@
           white-space: nowrap;
         }
         ul {
-          @include cm.ilios-tag-list;
+          @include m.ilios-tag-list;
 
           li {
             margin-top: 0;
@@ -41,16 +40,16 @@
     }
 
     .learner-group-overview-actions {
-      @include cm.detail-container-header;
+      @include m.detail-container-header;
       margin-top: 0.25rem;
       padding-top: 0.5rem;
 
       .title {
-        @include cm.detail-container-title;
+        @include m.detail-container-title;
       }
 
       .actions {
-        @include cm.for-phone-and-up {
+        @include m.for-phone-and-up {
           .toggle-buttons {
             display: inline;
           }
@@ -66,20 +65,20 @@
   .cohortmembers {
     .cohortmembers-loading {
       display: block;
-      @include cm.font-size("xxl");
+      @include m.font-size("xxl");
       margin: auto;
       text-align: center;
     }
   }
 
   .subgroups {
-    @include cm.detail-container-content;
+    @include m.detail-container-content;
 
     .header {
-      @include cm.detail-container-header;
+      @include m.detail-container-header;
 
       .title {
-        @include cm.detail-container-title;
+        @include m.detail-container-title;
       }
     }
 

--- a/packages/frontend/app/styles/components/learner-group/user-manager.scss
+++ b/packages/frontend/app/styles/components/learner-group/user-manager.scss
@@ -1,31 +1,30 @@
 @use "../../ilios-common/colors" as c;
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .learner-group-user-manager {
-  @include cm.detail-container(c.$tealBlue);
+  @include m.detail-container(c.$tealBlue);
   border-bottom: 0;
   display: grid;
   grid-template-columns: 3fr 1fr;
 
   .title {
-    @include cm.detail-container-title-style;
+    @include m.detail-container-title-style;
   }
 
   .actions {
     input {
-      @include cm.ilios-input;
+      @include m.ilios-input;
       width: 15rem;
     }
   }
 
   .learner-group-user-manager-content {
-    @include cm.detail-container-content;
+    @include m.detail-container-content;
     grid-column: 1 / -1;
 
     .list {
       @include m.main-list-box-table;
-      @include cm.ilios-zebra-table;
+      @include m.ilios-zebra-table;
       grid-column: 1 / -1;
       max-height: 540px;
       overflow: auto;
@@ -33,7 +32,7 @@
   }
 
   .inline-button {
-    @include cm.ilios-button-reset;
+    @include m.ilios-button-reset;
     text-align: left;
     width: 100%;
   }

--- a/packages/frontend/app/styles/components/learner-groups/loading.scss
+++ b/packages/frontend/app/styles/components/learner-groups/loading.scss
@@ -1,4 +1,4 @@
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .learner-groups-loading {
   @include m.main-list-loading-table;

--- a/packages/frontend/app/styles/components/learner-groups/root.scss
+++ b/packages/frontend/app/styles/components/learner-groups/root.scss
@@ -1,11 +1,10 @@
 @use "../../ilios-common/colors" as c;
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 @use "sass:color";
 
 .learner-groups-root {
-  @include cm.main-section;
+  @include m.main-section;
 
   .filters {
     @include m.main-list-filters;
@@ -26,7 +25,7 @@
       @include m.main-list-box-header;
 
       h2 {
-        @include cm.ilios-heading;
+        @include m.ilios-heading;
       }
 
       .title {

--- a/packages/frontend/app/styles/components/pending-user-updates.scss
+++ b/packages/frontend/app/styles/components/pending-user-updates.scss
@@ -1,8 +1,7 @@
-@use "../ilios-common/mixins" as cm;
-@use "../mixins" as m;
+@use "../ilios-common/mixins" as m;
 
 .pending-user-updates {
-  @include cm.main-section;
+  @include m.main-section;
 
   .filters {
     @include m.main-list-filters;
@@ -21,7 +20,7 @@
     @include m.main-list-box-table;
 
     button {
-      @include cm.ilios-button-reset;
+      @include m.ilios-button-reset;
       white-space: nowrap;
     }
   }

--- a/packages/frontend/app/styles/components/program-year/list.scss
+++ b/packages/frontend/app/styles/components/program-year/list.scss
@@ -1,8 +1,7 @@
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .program-year-list {
-  @include cm.main-section;
+  @include m.main-section;
 
   .program-years {
     @include m.main-list-box;
@@ -11,7 +10,7 @@
       @include m.main-list-box-header;
 
       h2 {
-        @include cm.ilios-heading;
+        @include m.ilios-heading;
       }
 
       .title {
@@ -35,6 +34,6 @@
   .fa-lock,
   .fa-trash,
   .fa-unlock {
-    @include cm.icon;
+    @include m.icon;
   }
 }

--- a/packages/frontend/app/styles/components/programs/list.scss
+++ b/packages/frontend/app/styles/components/programs/list.scss
@@ -1,4 +1,4 @@
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .programs-root {
   .list {

--- a/packages/frontend/app/styles/components/programs/root.scss
+++ b/packages/frontend/app/styles/components/programs/root.scss
@@ -1,8 +1,7 @@
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .programs-root {
-  @include cm.main-section;
+  @include m.main-section;
 
   .filters {
     @include m.main-list-filters;
@@ -24,7 +23,7 @@
       @include m.main-list-box-header;
 
       h2 {
-        @include cm.ilios-heading;
+        @include m.ilios-heading;
       }
 
       .title {

--- a/packages/frontend/app/styles/components/reports/root.scss
+++ b/packages/frontend/app/styles/components/reports/root.scss
@@ -1,8 +1,7 @@
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .reports-root {
-  @include cm.main-section;
+  @include m.main-section;
 
   .filters {
     @include m.main-list-filters;
@@ -23,7 +22,7 @@
       @include m.main-list-box-header;
 
       h2 {
-        @include cm.ilios-heading;
+        @include m.ilios-heading;
       }
 
       .title {

--- a/packages/frontend/app/styles/components/reports/subjects.scss
+++ b/packages/frontend/app/styles/components/reports/subjects.scss
@@ -1,14 +1,13 @@
-@use "../../ilios-common/mixins" as cm;
-@use "../../mixins" as m;
+@use "../../ilios-common/mixins" as m;
 
 .reports-subjects {
-  @include cm.main-section;
+  @include m.main-section;
 
   .header {
     @include m.main-list-box-header;
 
     h2 {
-      @include cm.ilios-heading;
+      @include m.ilios-heading;
     }
 
     .title {
@@ -20,7 +19,7 @@
     margin-left: 1rem;
 
     .saved-reports {
-      @include cm.ilios-list-reset;
+      @include m.ilios-list-reset;
       margin: 0.5rem 0;
 
       li {
@@ -30,7 +29,7 @@
     }
 
     .fa-trash {
-      @include cm.icon;
+      @include m.icon;
     }
   }
 }

--- a/packages/frontend/app/styles/components/school-list.scss
+++ b/packages/frontend/app/styles/components/school-list.scss
@@ -1,9 +1,8 @@
 @use "../ilios-common/colors" as c;
-@use "../ilios-common/mixins" as cm;
-@use "../mixins" as m;
+@use "../ilios-common/mixins" as m;
 
 .school-list {
-  @include cm.main-section;
+  @include m.main-section;
 
   .schools {
     @include m.main-list-box;
@@ -12,7 +11,7 @@
       @include m.main-list-box-header;
 
       h2 {
-        @include cm.ilios-heading;
+        @include m.ilios-heading;
       }
 
       .title {
@@ -29,23 +28,23 @@
     border: 1px solid c.$culturedGrey;
     padding: 1rem;
 
-    @include cm.for-laptop-and-up {
+    @include m.for-laptop-and-up {
       margin-left: 1rem;
     }
 
     .new-result-title {
-      @include cm.ilios-heading-h4;
+      @include m.ilios-heading-h4;
     }
 
     .form {
-      @include cm.ilios-form;
+      @include m.ilios-form;
 
       .item {
-        @include cm.ilios-form-item;
+        @include m.ilios-form-item;
       }
 
       .buttons {
-        @include cm.ilios-form-buttons;
+        @include m.ilios-form-buttons;
       }
     }
   }

--- a/packages/frontend/app/styles/components/school-vocabularies-list.scss
+++ b/packages/frontend/app/styles/components/school-vocabularies-list.scss
@@ -23,9 +23,7 @@
     }
 
     .savedvocabulary {
-      border: 1px solid c.$fernGreen;
-      margin: 1rem;
-      padding: 1rem;
+      @include m.main-list-saved-new;
     }
   }
 

--- a/packages/frontend/app/styles/components/school-vocabulary-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-manager.scss
@@ -1,6 +1,5 @@
 @use "../ilios-common/colors" as c;
-@use "../ilios-common/mixins" as cm;
-@use "../mixins" as m;
+@use "../ilios-common/mixins" as m;
 
 .school-vocabulary-manager {
   .school-vocabulary-manager-title {
@@ -9,12 +8,12 @@
     margin-bottom: 1rem;
 
     label {
-      @include cm.ilios-label;
-      @include cm.ilios-heading-h4;
+      @include m.ilios-label;
+      @include m.ilios-heading-h4;
     }
 
     .editinplace {
-      @include cm.ilios-heading-h4;
+      @include m.ilios-heading-h4;
       margin-left: 0.5rem;
     }
 
@@ -33,15 +32,17 @@
     width: 80%;
 
     .saved-result {
-      @include m.main-list-saved-new;
+      border: 1px solid c.$fernGreen;
+      margin: 1rem;
+      padding: 1rem;
 
-      @include cm.for-laptop-and-up {
+      @include m.for-laptop-and-up {
         width: 40%;
       }
     }
 
     ul {
-      @include cm.ilios-selectable-list;
+      @include m.ilios-selectable-list;
 
       em {
         color: c.$crimson;

--- a/packages/frontend/app/styles/components/school-vocabulary-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-manager.scss
@@ -1,5 +1,6 @@
 @use "../ilios-common/colors" as c;
-@use "../ilios-common/mixins" as m;
+@use "../ilios-common/mixins" as cm;
+@use "../mixins" as m;
 
 .school-vocabulary-manager {
   .school-vocabulary-manager-title {
@@ -8,12 +9,12 @@
     margin-bottom: 1rem;
 
     label {
-      @include m.ilios-label;
-      @include m.ilios-heading-h4;
+      @include cm.ilios-label;
+      @include cm.ilios-heading-h4;
     }
 
     .editinplace {
-      @include m.ilios-heading-h4;
+      @include cm.ilios-heading-h4;
       margin-left: 0.5rem;
     }
 
@@ -32,17 +33,15 @@
     width: 80%;
 
     .saved-result {
-      border: 1px solid c.$fernGreen;
-      margin: 1rem;
-      padding: 1rem;
+      @include m.main-list-saved-new;
 
-      @include m.for-laptop-and-up {
+      @include cm.for-laptop-and-up {
         width: 40%;
       }
     }
 
     ul {
-      @include m.ilios-selectable-list;
+      @include cm.ilios-selectable-list;
 
       em {
         color: c.$crimson;

--- a/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
@@ -1,5 +1,6 @@
 @use "../ilios-common/colors" as c;
-@use "../ilios-common/mixins" as m;
+@use "../ilios-common/mixins" as cm;
+@use "../mixins" as m;
 
 .school-vocabulary-term-manager {
   .school-vocabulary-term-manager-properties {
@@ -8,7 +9,7 @@
     padding: 0.8rem;
 
     label {
-      @include m.ilios-label;
+      @include cm.ilios-label;
       margin: 0 0.5rem 0 0;
     }
 
@@ -22,12 +23,12 @@
       }
 
       &.term-title {
-        @include m.ilios-heading-h4;
+        @include cm.ilios-heading-h4;
       }
 
       &.term-description {
         textarea {
-          @include m.ilios-textarea;
+          @include cm.ilios-textarea;
         }
       }
     }
@@ -43,11 +44,9 @@
     width: 80%;
 
     .saved-result {
-      border: 1px solid c.$fernGreen;
-      margin: 1rem;
-      padding: 1rem;
+      @include m.main-list-saved-new;
 
-      @include m.for-laptop-and-up {
+      @include cm.for-laptop-and-up {
         width: 40%;
       }
     }
@@ -57,7 +56,7 @@
       margin-bottom: 0.5rem;
 
       .item {
-        @include m.ilios-form-item;
+        @include cm.ilios-form-item;
       }
 
       button {
@@ -66,7 +65,7 @@
     }
 
     ul {
-      @include m.ilios-selectable-list;
+      @include cm.ilios-selectable-list;
 
       em {
         color: c.$crimson;

--- a/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
@@ -1,6 +1,5 @@
 @use "../ilios-common/colors" as c;
-@use "../ilios-common/mixins" as cm;
-@use "../mixins" as m;
+@use "../ilios-common/mixins" as m;
 
 .school-vocabulary-term-manager {
   .school-vocabulary-term-manager-properties {
@@ -9,7 +8,7 @@
     padding: 0.8rem;
 
     label {
-      @include cm.ilios-label;
+      @include m.ilios-label;
       margin: 0 0.5rem 0 0;
     }
 
@@ -23,12 +22,12 @@
       }
 
       &.term-title {
-        @include cm.ilios-heading-h4;
+        @include m.ilios-heading-h4;
       }
 
       &.term-description {
         textarea {
-          @include cm.ilios-textarea;
+          @include m.ilios-textarea;
         }
       }
     }
@@ -46,7 +45,7 @@
     .saved-result {
       @include m.main-list-saved-new;
 
-      @include cm.for-laptop-and-up {
+      @include m.for-laptop-and-up {
         width: 40%;
       }
     }
@@ -56,7 +55,7 @@
       margin-bottom: 0.5rem;
 
       .item {
-        @include cm.ilios-form-item;
+        @include m.ilios-form-item;
       }
 
       button {
@@ -65,7 +64,7 @@
     }
 
     ul {
-      @include cm.ilios-selectable-list;
+      @include m.ilios-selectable-list;
 
       em {
         color: c.$crimson;

--- a/packages/frontend/app/styles/mixins.scss
+++ b/packages/frontend/app/styles/mixins.scss
@@ -1,4 +1,3 @@
-@forward "mixins/main-list";
 @forward "mixins/admin-blocks";
 @forward "mixins/header-menu";
 @forward "mixins/verification-preview-table";

--- a/packages/ilios-common/addon/components/course/sessions.hbs
+++ b/packages/ilios-common/addon/components/course/sessions.hbs
@@ -34,7 +34,7 @@
     </div>
   {{/if}}
   {{#if this.saveSession.lastSuccessful.value}}
-    <div class="saved-result" data-test-new-saved-session>
+    <div class="save-result" data-test-new-saved-session>
       <LinkTo
         @route="session.index"
         @models={{array @course this.saveSession.lastSuccessful.value}}

--- a/packages/ilios-common/addon/components/course/sessions.hbs
+++ b/packages/ilios-common/addon/components/course/sessions.hbs
@@ -34,7 +34,7 @@
     </div>
   {{/if}}
   {{#if this.saveSession.lastSuccessful.value}}
-    <div class="save-result" data-test-new-saved-session>
+    <div class="saved-result" data-test-new-saved-session>
       <LinkTo
         @route="session.index"
         @models={{array @course this.saveSession.lastSuccessful.value}}

--- a/packages/ilios-common/addon/components/course/sessions.hbs
+++ b/packages/ilios-common/addon/components/course/sessions.hbs
@@ -5,7 +5,8 @@
 >
   <div class="course-sessions-header" data-test-course-sessions-header>
     <div class="title" data-test-title>
-      {{t "general.sessions"}} ({{this.sessionsCount}})
+      {{t "general.sessions"}}
+      ({{this.sessionsCount}})
     </div>
     <div class="actions" data-test-actions>
       {{#if @canCreateSession}}
@@ -46,41 +47,41 @@
   {{/if}}
 
   {{#if this.sessionsCount}}
-  <div class="filter">
-    <input
-      aria-label={{t "general.sessionTitleFilterPlaceholder"}}
-      value={{this.filterByDebounced}}
-      placeholder={{t "general.sessionTitleFilterPlaceholder"}}
-      data-test-session-filter
-      {{on "input" (fn (perform this.changeFilterBy))}}
-    >
-  </div>
-  <section>
-    <SessionsGridHeader
-      @showExpandAll={{this.showExpandAll}}
-      @setSortBy={{@setSortBy}}
-      @sortBy={{@sortBy}}
-      @allSessionsExpanded={{and
-        (eq this.expandedSessionIds.length this.sessionsWithOfferings.length)
-        (gt this.sessionsWithOfferings.length 0)
-      }}
-      @toggleExpandAll={{this.toggleExpandAll}}
-      @headerIsLocked={{this.tableHeadersLocked}}
-    />
-    {{#if this.sessions}}
-      <SessionsGrid
-        @sessions={{this.sessions}}
-        @sortBy={{@sortBy}}
-        @filterBy={{@filterBy}}
-        @expandedSessionIds={{this.expandedSessionIds}}
-        @closeSession={{perform this.closeSession}}
-        @expandSession={{perform this.expandSession}}
-        @headerIsLocked={{this.tableHeadersLocked}}
-        @setHeaderLockedStatus={{this.setHeaderLockedStatus}}
+    <div class="filter">
+      <input
+        aria-label={{t "general.sessionTitleFilterPlaceholder"}}
+        value={{this.filterByDebounced}}
+        placeholder={{t "general.sessionTitleFilterPlaceholder"}}
+        data-test-session-filter
+        {{on "input" (fn (perform this.changeFilterBy))}}
       />
-    {{else}}
-      <SessionsGridLoading @count={{this.sessionsCount}} />
-    {{/if}}
-  </section>
+    </div>
+    <section>
+      <SessionsGridHeader
+        @showExpandAll={{this.showExpandAll}}
+        @setSortBy={{@setSortBy}}
+        @sortBy={{@sortBy}}
+        @allSessionsExpanded={{and
+          (eq this.expandedSessionIds.length this.sessionsWithOfferings.length)
+          (gt this.sessionsWithOfferings.length 0)
+        }}
+        @toggleExpandAll={{this.toggleExpandAll}}
+        @headerIsLocked={{this.tableHeadersLocked}}
+      />
+      {{#if this.sessions}}
+        <SessionsGrid
+          @sessions={{this.sessions}}
+          @sortBy={{@sortBy}}
+          @filterBy={{@filterBy}}
+          @expandedSessionIds={{this.expandedSessionIds}}
+          @closeSession={{perform this.closeSession}}
+          @expandSession={{perform this.expandSession}}
+          @headerIsLocked={{this.tableHeadersLocked}}
+          @setHeaderLockedStatus={{this.setHeaderLockedStatus}}
+        />
+      {{else}}
+        <SessionsGridLoading @count={{this.sessionsCount}} />
+      {{/if}}
+    </section>
   {{/if}}
 </section>

--- a/packages/ilios-common/app/styles/ilios-common/components/course/sessions.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/sessions.scss
@@ -24,7 +24,7 @@
     @include m.detail-container-actions;
   }
 
-  .save-result {
+  .saved-result {
     border: 1px solid c.$fernGreen;
     margin: 1rem;
     padding: 0.75rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/course/sessions.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/sessions.scss
@@ -25,9 +25,7 @@
   }
 
   .save-result {
-    border: 1px solid c.$fernGreen;
-    margin: 1rem;
-    padding: 0.75rem;
+    @include m.main-list-saved-new;
   }
 
   .filter {

--- a/packages/ilios-common/app/styles/ilios-common/components/course/sessions.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/sessions.scss
@@ -24,7 +24,7 @@
     @include m.detail-container-actions;
   }
 
-  .saved-result {
+  .save-result {
     border: 1px solid c.$fernGreen;
     margin: 1rem;
     padding: 0.75rem;

--- a/packages/ilios-common/app/styles/ilios-common/mixins.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins.scss
@@ -19,6 +19,7 @@
 @forward "mixins/ilios-select";
 @forward "mixins/ilios-table";
 @forward "mixins/ilios-textarea";
+@forward "mixins/main-list";
 @forward "mixins/main-section";
 @forward "mixins/multi-button";
 @forward "mixins/objectives";

--- a/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
@@ -1,18 +1,23 @@
-@use "../ilios-common/mixins" as cm;
-@use "../ilios-common/colors" as c;
+@use "../colors" as c;
+@use "font-size";
+@use "ilios-heading";
+@use "ilios-input";
+@use "ilios-select";
+@use "ilios-table";
+@use "media";
 
 @mixin main-list-filters() {
   display: flex;
   flex-direction: column;
   margin-bottom: 1rem;
 
-  @include cm.for-laptop-and-up {
+  @include media.for-laptop-and-up {
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: space-between;
   }
 
-  @include cm.for-desktop-and-up {
+  @include media.for-desktop-and-up {
     justify-content: flex-start;
   }
 }
@@ -21,24 +26,24 @@
   padding: 0 1rem 1rem 1rem;
   white-space: nowrap;
 
-  @include cm.for-laptop-and-up {
+  @include media.for-laptop-and-up {
     align-content: center;
     padding-bottom: 0;
     width: 25%;
   }
 
-  @include cm.for-desktop-and-up {
+  @include media.for-desktop-and-up {
     margin-right: 2rem;
     width: auto;
   }
 
   select {
-    @include cm.ilios-select;
+    @include ilios-select.ilios-select;
     width: 90%;
   }
 
   input {
-    @include cm.ilios-input;
+    @include ilios-input.ilios-input;
     width: 100%;
   }
 }
@@ -55,7 +60,7 @@
   padding: 0.5rem 0;
   text-align: center;
 
-  @include cm.for-laptop-and-up {
+  @include media.for-laptop-and-up {
     flex-direction: row;
     justify-content: space-between;
     margin-left: 1rem;
@@ -63,21 +68,21 @@
 }
 
 @mixin main-list-box-header-title {
-  @include cm.ilios-heading-h4;
-  @include cm.text-align-bottom;
+  @include ilios-heading.ilios-heading-h4;
+  @include font-size.text-align-bottom;
   margin-bottom: 0.5rem;
-  @include cm.for-laptop-and-up {
+  @include media.for-laptop-and-up {
     margin-bottom: 0;
   }
 }
 
 @mixin main-list-box-header-actions {
-  @include cm.for-laptop-and-up {
+  @include media.for-laptop-and-up {
     padding-right: 1rem;
     text-align: right;
   }
 
-  @include cm.for-phone-only {
+  @include media.for-phone-only {
     & > * {
       margin-top: 0.25em;
     }
@@ -100,10 +105,10 @@
   }
 
   table {
-    @include cm.ilios-table-structure;
-    @include cm.ilios-table-colors;
-    @include cm.ilios-removable-table;
-    @include cm.ilios-zebra-table;
+    @include ilios-table.ilios-table-structure;
+    @include ilios-table.ilios-table-colors;
+    @include ilios-table.ilios-removable-table;
+    @include ilios-table.ilios-zebra-table;
 
     thead {
       background-color: c.$culturedGrey;


### PR DESCRIPTION
Fixes ilios/ilios#5759

This PR got a whole lot more complicated than I thought, but it was needed to fix the issue.

The `mixins/main-list.scss` mixin file is in `frontend`, but had a mixin that needed to be called by `ilios-common`, so...I moved it! :-O This, of course, broke a lot of `@import`s, so I had to fix them. In the end, I was able to make the "you made a new thing" template chunk's class more consistent.

No idea why changing `.save-result` -> `.saved-result` (to be consistent with every other instance of this kind of thing) in Courses->Sessions breaks that route (gives me a Zoinks!), so I changed it back for now.