### PR TITLE
fix Course and Session LM summary counts

### DIFF
--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/materials.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/materials.js
@@ -10,6 +10,7 @@ import {
 
 const definition = {
   scope: '[data-test-course-materials]',
+  courseMaterialsCount: text('[data-test-course-materials-count]'),
   courseFilter: fillable('[data-test-course-filter]'),
   sortCoursesBy: {
     scope: '[data-test-course-table] thead',
@@ -24,6 +25,7 @@ const definition = {
     type: text('td', { at: 1 }),
     author: text('td', { at: 2 }),
   }),
+  sessionMaterialsCount: text('[data-test-session-materials-count]'),
   sessionFilter: fillable('[data-test-session-filter]'),
   sortSessionsBy: {
     scope: '[data-test-session-table] thead',

--- a/packages/ilios-common/addon/components/course/materials.hbs
+++ b/packages/ilios-common/addon/components/course/materials.hbs
@@ -3,8 +3,8 @@
   data-test-course-materials
 >
   <div class="material-list">
-    <h3>
-      {{t "general.courseLearningMaterials"}} ({{this.filteredCourseLearningMaterials.length}})
+    <h3 class="course-material-title">
+      {{t "general.courseLearningMaterials"}} (<span data-test-course-materials-count>{{this.filteredCourseLearningMaterials.length}}</span>)
     </h3>
     <span class="filter-course-lms">
       <input
@@ -96,7 +96,7 @@
   </div>
   <div class="material-list">
     <h3 class="session-material-title">
-      {{t "general.sessionLearningMaterials"}} ({{this.filteredSessionLearningMaterialObjects.length}})
+      {{t "general.sessionLearningMaterials"}} (<span data-test-session-materials-count>{{this.filteredSessionLearningMaterialObjects.length}}</span>)
     </h3>
     <span class="filter-session-lms">
       <input

--- a/packages/ilios-common/addon/components/course/materials.hbs
+++ b/packages/ilios-common/addon/components/course/materials.hbs
@@ -96,7 +96,7 @@
   </div>
   <div class="material-list">
     <h3 class="session-material-title">
-      {{t "general.sessionLearningMaterials"}} ({{this.sessionMaterials.length}})
+      {{t "general.sessionLearningMaterials"}} ({{this.filteredSessionLearningMaterialObjects.length}})
     </h3>
     <span class="filter-session-lms">
       <input

--- a/packages/ilios-common/addon/components/course/materials.hbs
+++ b/packages/ilios-common/addon/components/course/materials.hbs
@@ -4,7 +4,7 @@
 >
   <div class="material-list">
     <h3>
-      {{t "general.courseLearningMaterials"}} ({{@course.learningMaterials.length}})
+      {{t "general.courseLearningMaterials"}} ({{this.filteredCourseLearningMaterials.length}})
     </h3>
     <span class="filter-course-lms">
       <input

--- a/packages/test-app/tests/integration/components/course/materials-test.js
+++ b/packages/test-app/tests/integration/components/course/materials-test.js
@@ -116,6 +116,7 @@ module('Integration | Component | course/materials', function (hooks) {
 />`);
 
     assert.strictEqual(component.courses.length, 3);
+    assert.strictEqual(component.courseMaterialsCount, '3');
     assert.strictEqual(component.courses[0].title, 'title1');
     assert.ok(component.courses[0].hasLink);
     assert.strictEqual(component.courses[0].link, 'http://myhost.com/url1');
@@ -123,6 +124,7 @@ module('Integration | Component | course/materials', function (hooks) {
     assert.strictEqual(component.courses[0].author, 'author1');
 
     assert.strictEqual(component.sessions.length, 3);
+    assert.strictEqual(component.sessionMaterialsCount, '3');
     assert.strictEqual(component.sessions[0].title, 'title1');
     assert.ok(component.sessions[0].hasLink);
     assert.strictEqual(component.sessions[0].link, 'http://myhost.com/url1');
@@ -132,6 +134,7 @@ module('Integration | Component | course/materials', function (hooks) {
     assert.strictEqual(component.sessions[0].firstOffering, '02/02/2020');
 
     assert.strictEqual(component.sessions.length, 3);
+    assert.strictEqual(component.sessionMaterialsCount, '3');
     assert.strictEqual(component.sessions[1].title, 'title2');
     assert.ok(component.sessions[1].hasLink);
     assert.strictEqual(component.sessions[1].link, 'http://myhost.com/url2');
@@ -141,6 +144,7 @@ module('Integration | Component | course/materials', function (hooks) {
     assert.strictEqual(component.sessions[1].firstOffering, '02/02/2020');
 
     assert.strictEqual(component.sessions.length, 3);
+    assert.strictEqual(component.sessionMaterialsCount, '3');
     assert.strictEqual(component.sessions[2].title, 'title3 citationtext');
     assert.notOk(component.sessions[2].hasLink);
     assert.strictEqual(component.sessions[2].type, 'Citation');
@@ -232,9 +236,15 @@ module('Integration | Component | course/materials', function (hooks) {
 />`);
 
     assert.strictEqual(component.courses.length, 3);
+    assert.strictEqual(component.courseMaterialsCount, '3');
     await component.courseFilter('title1');
     assert.strictEqual(component.courses.length, 1);
+    assert.strictEqual(component.courseMaterialsCount, '1');
     assert.strictEqual(component.courses[0].title, 'title1');
+    await component.courseFilter('foo-course-title');
+    assert.strictEqual(component.courses.length, 1);
+    assert.strictEqual(component.courseMaterialsCount, '0');
+    assert.strictEqual(component.courses[0].title, 'No results found. Please try again.');
   });
 
   test('filter course lms by type', async function (assert) {
@@ -252,9 +262,15 @@ module('Integration | Component | course/materials', function (hooks) {
 />`);
 
     assert.strictEqual(component.courses.length, 3);
+    assert.strictEqual(component.courseMaterialsCount, '3');
     await component.courseFilter('file');
     assert.strictEqual(component.courses.length, 1);
+    assert.strictEqual(component.courseMaterialsCount, '1');
     assert.strictEqual(component.courses[0].title, 'title2');
+    await component.courseFilter('foo-course-type');
+    assert.strictEqual(component.courses.length, 1);
+    assert.strictEqual(component.courseMaterialsCount, '0');
+    assert.strictEqual(component.courses[0].title, 'No results found. Please try again.');
   });
 
   test('filter course lms by author', async function (assert) {
@@ -272,9 +288,15 @@ module('Integration | Component | course/materials', function (hooks) {
 />`);
 
     assert.strictEqual(component.courses.length, 3);
+    assert.strictEqual(component.courseMaterialsCount, '3');
     await component.courseFilter('author2');
     assert.strictEqual(component.courses.length, 1);
+    assert.strictEqual(component.courseMaterialsCount, '1');
     assert.strictEqual(component.courses[0].title, 'title2');
+    await component.courseFilter('foo-course-author');
+    assert.strictEqual(component.courses.length, 1);
+    assert.strictEqual(component.courseMaterialsCount, '0');
+    assert.strictEqual(component.courses[0].title, 'No results found. Please try again.');
   });
 
   test('filter course lms by citation', async function (assert) {
@@ -292,9 +314,15 @@ module('Integration | Component | course/materials', function (hooks) {
 />`);
 
     assert.strictEqual(component.courses.length, 3);
+    assert.strictEqual(component.courseMaterialsCount, '3');
     await component.courseFilter('citationtext');
     assert.strictEqual(component.courses.length, 1);
+    assert.strictEqual(component.courseMaterialsCount, '1');
     assert.strictEqual(component.courses[0].title, 'title3 citationtext');
+    await component.courseFilter('foo-course-citation');
+    assert.strictEqual(component.courses.length, 1);
+    assert.strictEqual(component.courseMaterialsCount, '0');
+    assert.strictEqual(component.courses[0].title, 'No results found. Please try again.');
   });
 
   test('filter session lms by title', async function (assert) {
@@ -312,9 +340,15 @@ module('Integration | Component | course/materials', function (hooks) {
 />`);
 
     assert.strictEqual(component.sessions.length, 3);
+    assert.strictEqual(component.sessionMaterialsCount, '3');
     await component.sessionFilter('title1');
     assert.strictEqual(component.sessions.length, 1);
+    assert.strictEqual(component.sessionMaterialsCount, '1');
     assert.strictEqual(component.sessions[0].title, 'title1');
+    await component.sessionFilter('foo-session-title');
+    assert.strictEqual(component.sessions.length, 1);
+    assert.strictEqual(component.sessionMaterialsCount, '0');
+    assert.strictEqual(component.sessions[0].title, 'No results found. Please try again.');
   });
 
   test('filter session lms by type', async function (assert) {
@@ -332,9 +366,15 @@ module('Integration | Component | course/materials', function (hooks) {
 />`);
 
     assert.strictEqual(component.sessions.length, 3);
+    assert.strictEqual(component.sessionMaterialsCount, '3');
     await component.sessionFilter('file');
     assert.strictEqual(component.sessions.length, 1);
+    assert.strictEqual(component.sessionMaterialsCount, '1');
     assert.strictEqual(component.sessions[0].title, 'title2');
+    await component.sessionFilter('foo-session-type');
+    assert.strictEqual(component.sessions.length, 1);
+    assert.strictEqual(component.sessionMaterialsCount, '0');
+    assert.strictEqual(component.sessions[0].title, 'No results found. Please try again.');
   });
 
   test('filter session lms by author', async function (assert) {
@@ -352,9 +392,15 @@ module('Integration | Component | course/materials', function (hooks) {
 />`);
 
     assert.strictEqual(component.sessions.length, 3);
+    assert.strictEqual(component.sessionMaterialsCount, '3');
     await component.sessionFilter('author2');
     assert.strictEqual(component.sessions.length, 1);
+    assert.strictEqual(component.sessionMaterialsCount, '1');
     assert.strictEqual(component.sessions[0].title, 'title2');
+    await component.sessionFilter('foo-session-author');
+    assert.strictEqual(component.sessions.length, 1);
+    assert.strictEqual(component.sessionMaterialsCount, '0');
+    assert.strictEqual(component.sessions[0].title, 'No results found. Please try again.');
   });
 
   test('filter session lms by citation', async function (assert) {
@@ -372,9 +418,15 @@ module('Integration | Component | course/materials', function (hooks) {
 />`);
 
     assert.strictEqual(component.sessions.length, 3);
+    assert.strictEqual(component.sessionMaterialsCount, '3');
     await component.sessionFilter('citationtext');
     assert.strictEqual(component.sessions.length, 1);
+    assert.strictEqual(component.sessionMaterialsCount, '1');
     assert.strictEqual(component.sessions[0].title, 'title3 citationtext');
+    await component.sessionFilter('foo-session-citation');
+    assert.strictEqual(component.sessions.length, 1);
+    assert.strictEqual(component.sessionMaterialsCount, '0');
+    assert.strictEqual(component.sessions[0].title, 'No results found. Please try again.');
   });
 
   test('no materials', async function (assert) {
@@ -387,8 +439,10 @@ module('Integration | Component | course/materials', function (hooks) {
     );
 
     assert.strictEqual(component.courses.length, 1);
+    assert.strictEqual(component.courseMaterialsCount, '0');
     assert.strictEqual(component.courses[0].title, 'No Course Learning Materials Available');
     assert.strictEqual(component.sessions.length, 1);
+    assert.strictEqual(component.courseMaterialsCount, '0');
     assert.strictEqual(component.sessions[0].title, 'No Session Learning Materials Available');
   });
 });

--- a/packages/test-app/tests/integration/components/course/materials-test.js
+++ b/packages/test-app/tests/integration/components/course/materials-test.js
@@ -442,7 +442,7 @@ module('Integration | Component | course/materials', function (hooks) {
     assert.strictEqual(component.courseMaterialsCount, '0');
     assert.strictEqual(component.courses[0].title, 'No Course Learning Materials Available');
     assert.strictEqual(component.sessions.length, 1);
-    assert.strictEqual(component.courseMaterialsCount, '0');
+    assert.strictEqual(component.sessionMaterialsCount, '0');
     assert.strictEqual(component.sessions[0].title, 'No Session Learning Materials Available');
   });
 });


### PR DESCRIPTION
Fixes ilios/ilios#5784
Fixes ilios/ilios#5785

Course/Session Learning Materials summary lists now properly display the number of LMs for both, whether they're filtered by the input or not. Bolstered existing tests to check for filters that return no results