### PR TITLE
Replace Pixel Device in Browser Tests

### DIFF
--- a/packages/frontend/testem.browserstack.js
+++ b/packages/frontend/testem.browserstack.js
@@ -46,7 +46,7 @@ const BrowserStackLaunchers = {
       '--b',
       'android',
       '--device',
-      'Google Pixel 9',
+      'Google Pixel 8',
       ...defaultArgs,
     ],
     protocol: 'browser',

--- a/packages/lti-course-manager/testem.browserstack.js
+++ b/packages/lti-course-manager/testem.browserstack.js
@@ -46,7 +46,7 @@ const BrowserStackLaunchers = {
       '--b',
       'android',
       '--device',
-      'Google Pixel 9',
+      'Google Pixel 8',
       ...defaultArgs,
     ],
     protocol: 'browser',

--- a/packages/lti-dashboard/testem.browserstack.js
+++ b/packages/lti-dashboard/testem.browserstack.js
@@ -46,7 +46,7 @@ const BrowserStackLaunchers = {
       '--b',
       'android',
       '--device',
-      'Google Pixel 9',
+      'Google Pixel 8',
       ...defaultArgs,
     ],
     protocol: 'browser',

--- a/packages/test-app/testem.browserstack.js
+++ b/packages/test-app/testem.browserstack.js
@@ -46,7 +46,7 @@ const BrowserStackLaunchers = {
       '--b',
       'android',
       '--device',
-      'Google Pixel 9',
+      'Google Pixel 8',
       ...defaultArgs,
     ],
     protocol: 'browser',


### PR DESCRIPTION
For some reason the pixel 9 has disappeared from the browserstack test API for Android 14. It seems like the 8 still works though so let's use that.