### PR TITLE
re-route users without elevated privileges from course admin pages to error page.

### DIFF
--- a/packages/frontend/app/routes/courses.js
+++ b/packages/frontend/app/routes/courses.js
@@ -7,6 +7,7 @@ export default class CoursesRoute extends Route {
   @service store;
   @service dataLoader;
   @service session;
+  @service router;
 
   queryParams = {
     titleFilter: {
@@ -16,6 +17,11 @@ export default class CoursesRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      // Slash on the route name is necessary here due to this bug:
+      // https://github.com/emberjs/ember.js/issues/12945
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 
   async model() {

--- a/packages/frontend/tests/acceptance/access-denied-test.js
+++ b/packages/frontend/tests/acceptance/access-denied-test.js
@@ -1,0 +1,26 @@
+import { currentURL, visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupAuthentication } from 'ilios-common';
+import { setupApplicationTest } from 'frontend/tests/helpers';
+
+module('Acceptance | Access Denied', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(async function () {
+    await setupAuthentication();
+  });
+
+  test.each(
+    'user not performing non-learner functions is routed to 404 page when accessing administrative pages',
+    [
+      '/courses',
+      '/courses/1',
+      '/courses/1/sessions/1',
+      // Todo: put more routes under test here. [ST 2024/11/21]
+    ],
+    async function (assert, url) {
+      await visit(url);
+      assert.strictEqual(currentURL(), '/four-oh-four');
+    },
+  );
+});

--- a/packages/frontend/tests/acceptance/access-denied-test.js
+++ b/packages/frontend/tests/acceptance/access-denied-test.js
@@ -13,10 +13,25 @@ module('Acceptance | Access Denied', function (hooks) {
   test.each(
     'user not performing non-learner functions is routed to 404 page when accessing administrative pages',
     [
+      '/course/1/print',
       '/courses',
       '/courses/1',
+      '/courses/1/materials',
+      '/courses/1/publicationcheck',
+      '/courses/1/publishall',
+      '/courses/1/rollover',
       '/courses/1/sessions/1',
-      // Todo: put more routes under test here. [ST 2024/11/21]
+      '/courses/1/sessions/1/copy',
+      '/courses/1/sessions/1/publicationcheck',
+      '/data/courses/1',
+      '/data/courses/1/instructors',
+      '/data/courses/1/instructors/1',
+      '/data/courses/1/objectives',
+      '/data/courses/1/session-types',
+      '/data/courses/1/session-types/1',
+      '/data/courses/1/terms/1',
+      '/data/courses/1/vocabularies',
+      '/data/courses/1/vocabularies/1',
     ],
     async function (assert, url) {
       await visit(url);

--- a/packages/frontend/tests/acceptance/course/cohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/cohorts-test.js
@@ -9,10 +9,13 @@ module('Acceptance | Course - Cohorts', function (hooks) {
 
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
-    this.user = await setupAuthentication({
-      school,
-      administeredSchools: [school],
-    });
+    this.user = await setupAuthentication(
+      {
+        school,
+        administeredSchools: [school],
+      },
+      true,
+    );
     const currentYear = new Date().getFullYear();
     this.server.create('academic-year', { id: currentYear });
     const program = this.server.create('program', { school, duration: 4 });
@@ -80,7 +83,6 @@ module('Acceptance | Course - Cohorts', function (hooks) {
   test('list cohorts', async function (assert) {
     assert.expect(4);
     await page.visit({ courseId: this.course.id, details: true });
-
     assert.strictEqual(page.details.cohorts.current.length, 1);
     assert.strictEqual(page.details.cohorts.current[0].school, 'school 0');
     assert.strictEqual(page.details.cohorts.current[0].program, 'program 0');

--- a/packages/frontend/tests/acceptance/course/competencies-test.js
+++ b/packages/frontend/tests/acceptance/course/competencies-test.js
@@ -8,7 +8,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | Course - Competencies', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', {

--- a/packages/frontend/tests/acceptance/course/leadership-test.js
+++ b/packages/frontend/tests/acceptance/course/leadership-test.js
@@ -8,10 +8,13 @@ module('Acceptance | Course - Leadership', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    this.user = await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('academic-year', { id: 2013 });
 
     const users = this.server.createList('user', 6);

--- a/packages/frontend/tests/acceptance/course/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/learningmaterials-test.js
@@ -14,7 +14,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   hooks.beforeEach(async function () {
     this.intl = this.owner.lookup('service:intl');
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
     this.user2 = this.server.create('user', { displayName: 'Clem Chowder' });
     this.server.create('academic-year');
     const statuses = this.server.createList('learningMaterialStatus', 5);

--- a/packages/frontend/tests/acceptance/course/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/mesh-test.js
@@ -7,7 +7,7 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Mesh Terms', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     this.server.create('academic-year');
     this.server.createList('meshTree', 3);

--- a/packages/frontend/tests/acceptance/course/objectivecreate-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivecreate-test.js
@@ -6,7 +6,7 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Objective Create', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);

--- a/packages/frontend/tests/acceptance/course/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivelist-test.js
@@ -7,7 +7,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | Course - Objective List', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     this.server.create('academic-year', { id: 2013 });
   });

--- a/packages/frontend/tests/acceptance/course/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivemesh-test.js
@@ -8,7 +8,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);

--- a/packages/frontend/tests/acceptance/course/objectiveparents-allow-multiple-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-allow-multiple-test.js
@@ -8,7 +8,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | Course - Multiple Objective  Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     this.server.create('schoolConfig', {
       school: this.school,

--- a/packages/frontend/tests/acceptance/course/objectiveparents-inactive-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-inactive-test.js
@@ -7,7 +7,7 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Objective Inactive Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
   });
 

--- a/packages/frontend/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -6,7 +6,7 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course with multiple Cohorts - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     const program = this.server.create('program', { school: this.school });
 

--- a/packages/frontend/tests/acceptance/course/objectiveparents-nocohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-nocohorts-test.js
@@ -7,7 +7,7 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course with no cohorts - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     const program = this.server.create('program', { school: this.school });
 

--- a/packages/frontend/tests/acceptance/course/objectiveparents-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-test.js
@@ -8,7 +8,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | Course - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });

--- a/packages/frontend/tests/acceptance/course/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveterms-test.js
@@ -7,7 +7,7 @@ module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     const school = this.server.create('school');
     this.server.create('academic-year', { id: 2013 });
     const program = this.server.create('program', { school });

--- a/packages/frontend/tests/acceptance/course/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/overview-test.js
@@ -11,7 +11,7 @@ module('Acceptance | Course - Overview', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.intl = this.owner.lookup('service:intl');
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     this.server.createList('course-clerkship-type', 2);
   });

--- a/packages/frontend/tests/acceptance/course/printcourse-test.js
+++ b/packages/frontend/tests/acceptance/course/printcourse-test.js
@@ -8,6 +8,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
+    await setupAuthentication({ school: this.school }, true);
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
     this.server.create('academic-year');
@@ -60,7 +61,6 @@ module('Acceptance | Course - Print Course', function (hooks) {
 
   test('print course header', async function (assert) {
     assert.expect(2);
-    await setupAuthentication({ school: this.school });
     await visit('/course/1/print');
     await percySnapshot(assert);
     assert.dom('[data-test-course-header] [data-test-course-title]').hasText('Back to the Future');
@@ -68,7 +68,6 @@ module('Acceptance | Course - Print Course', function (hooks) {
   });
 
   test('course year shows as range if applicable by configuration', async function (assert) {
-    await setupAuthentication({ school: this.school });
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
     this.server.get('application/config', function () {
       return {
@@ -83,13 +82,11 @@ module('Acceptance | Course - Print Course', function (hooks) {
   });
 
   test('print course mesh terms', async function (assert) {
-    await setupAuthentication({ school: this.school });
     await visit('/course/1/print');
     assert.dom('[data-test-course-mesh] ul li').hasText('Flux Capacitor');
   });
 
   test('print course learning materials', async function (assert) {
-    await setupAuthentication({ school: this.school });
     await visit('/course/1/print');
 
     const values = await findAll('[data-test-course-learningmaterials] .content tbody tr td');
@@ -104,7 +101,6 @@ module('Acceptance | Course - Print Course', function (hooks) {
   });
 
   test('test print unpublished sessions for elevated privileges', async function (assert) {
-    await setupAuthentication({ school: this.school }, true);
     this.server.create('session', {
       course: this.course,
       published: false,
@@ -129,34 +125,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
     assert.dom(sessionHeaders[2]).hasText('session 2');
   });
 
-  test('test does not print unpublished sessions for unprivileged users', async function (assert) {
-    await setupAuthentication({ school: this.school });
-    this.server.create('session', {
-      course: this.course,
-      published: false,
-      publishedAsTbd: false,
-    });
-    this.server.create('session', {
-      course: this.course,
-      published: true,
-      publishedAsTbd: false,
-    });
-    this.server.create('session', {
-      course: this.course,
-      published: true,
-      publishedAsTbd: true,
-    });
-    await visit('/course/1/print?unpublished=true');
-
-    const sessionHeaders = await findAll('[data-test-session-header] h2');
-    assert.strictEqual(sessionHeaders.length, 2);
-    assert.dom(sessionHeaders[0]).hasText('session 1');
-    assert.dom(sessionHeaders[1]).hasText('session 2');
-  });
-
   test('test print ILM details', async function (assert) {
-    await setupAuthentication({ school: this.school });
-
     this.server.create('session', {
       course: this.course,
       published: true,
@@ -185,8 +154,6 @@ module('Acceptance | Course - Print Course', function (hooks) {
   });
 
   test('test print session objectives', async function (assert) {
-    await setupAuthentication({ school: this.school });
-
     const session = this.server.create('session', {
       courseId: 1,
       published: true,
@@ -235,8 +202,6 @@ module('Acceptance | Course - Print Course', function (hooks) {
   });
 
   test('test print course objectives', async function (assert) {
-    await setupAuthentication({ school: this.school });
-
     const competency = this.server.create('competency', {
       school: this.school,
       title: 'Competency 1',
@@ -284,7 +249,6 @@ module('Acceptance | Course - Print Course', function (hooks) {
   });
 
   test('test print session learning materials', async function (assert) {
-    await setupAuthentication({ school: this.school });
     const session = this.server.create('session', {
       course: this.course,
       published: true,
@@ -312,7 +276,6 @@ module('Acceptance | Course - Print Course', function (hooks) {
   });
 
   test('test print session vocabulary terms', async function (assert) {
-    await setupAuthentication({ school: this.school });
     const session = this.server.create('session', {
       course: this.course,
       published: true,

--- a/packages/frontend/tests/acceptance/course/publicationcheck-test.js
+++ b/packages/frontend/tests/acceptance/course/publicationcheck-test.js
@@ -7,7 +7,7 @@ import page from 'ilios-common/page-objects/course-publication-check';
 module('Acceptance | Course - Publication Check', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    await setupAuthentication();
+    await setupAuthentication({}, true);
     const school = this.server.create('school');
     const vocabulary = this.server.create('vocabulary', {
       school,

--- a/packages/frontend/tests/acceptance/course/publish-test.js
+++ b/packages/frontend/tests/acceptance/course/publish-test.js
@@ -6,7 +6,7 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Publish', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     this.cohort = this.server.create('cohort');
   });

--- a/packages/frontend/tests/acceptance/course/publishall-test.js
+++ b/packages/frontend/tests/acceptance/course/publishall-test.js
@@ -8,7 +8,7 @@ import page from 'ilios-common/page-objects/course-publish-all';
 module('Acceptance | Course - Publish All Sessions', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     this.cohort = this.server.create('cohort');
   });

--- a/packages/frontend/tests/acceptance/course/session/ilm-test.js
+++ b/packages/frontend/tests/acceptance/course/session/ilm-test.js
@@ -8,7 +8,7 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
     this.server.createList('user', 6);
     this.server.create('academic-year');
     this.course = this.server.create('course', { school: this.school });

--- a/packages/frontend/tests/acceptance/course/session/leadership-test.js
+++ b/packages/frontend/tests/acceptance/course/session/leadership-test.js
@@ -8,10 +8,13 @@ module('Acceptance | Session - Leadership', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    this.user = await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('academic-year', { id: 2013 });
 
     const users = this.server.createList('user', 5);

--- a/packages/frontend/tests/acceptance/course/session/learner-groups-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learner-groups-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
   });
 
   module('With Fixtures', function (hooks2) {

--- a/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
@@ -13,7 +13,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   hooks.beforeEach(async function () {
     this.intl = this.owner.lookup('service:intl');
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
     this.user2 = this.server.create('user', { displayName: 'Clem Chowder' });
     this.server.create('academic-year');
 

--- a/packages/frontend/tests/acceptance/course/session/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/mesh-test.js
@@ -8,7 +8,7 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
     this.server.create('academic-year');
     this.server.createList('meshTree', 3);
     this.server.createList('meshConcept', 3);

--- a/packages/frontend/tests/acceptance/course/session/objectivecreate-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivecreate-test.js
@@ -8,7 +8,7 @@ module('Acceptance | Session - Objective Create', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
     this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);

--- a/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Session - Objective List', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
 
     this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);

--- a/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);

--- a/packages/frontend/tests/acceptance/course/session/objectiveparents-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveparents-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,

--- a/packages/frontend/tests/acceptance/course/session/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveterms-test.js
@@ -7,7 +7,7 @@ module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     const school = this.server.create('school');
     this.server.create('academic-year', { id: 2013 });
     const program = this.server.create('program', { school });

--- a/packages/frontend/tests/acceptance/course/session/offerings-management-test.js
+++ b/packages/frontend/tests/acceptance/course/session/offerings-management-test.js
@@ -8,10 +8,13 @@ module('Acceptance | Session - Offering Management', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
   });
 
   test('search for instructor who is a course director #2838', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/session/offerings-test.js
+++ b/packages/frontend/tests/acceptance/course/session/offerings-test.js
@@ -17,7 +17,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     );
     this.intl = this.owner.lookup('service:intl');
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });

--- a/packages/frontend/tests/acceptance/course/session/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/session/overview-test.js
@@ -21,10 +21,13 @@ module('Acceptance | Session - Overview', function (hooks) {
 
   test('check fields', async function (assert) {
     assert.expect(4);
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const session = this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -38,10 +41,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('check remove ilm', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const ilmSession = this.server.create('ilm-session');
     this.server.create('session', {
       course: this.course,
@@ -72,10 +78,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('check add ilm', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
     });
@@ -104,10 +113,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change ilm hours', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const ilmSession = this.server.create('ilm-session', {
       hours: 3,
     });
@@ -126,10 +138,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change ilm due date and time', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const ilmSession = this.server.create('ilm-session', {
       hours: 3,
       dueDate: new Date(2021, 4, 18, 17, 0, 0),
@@ -176,10 +191,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change title', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const session = this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -195,10 +213,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('last Updated', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -221,10 +242,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change type', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -240,7 +264,7 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('session attributes are shown by school config', async function (assert) {
-    await setupAuthentication({ school: this.school });
+    await setupAuthentication({ school: this.school }, true);
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -278,7 +302,7 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('session attributes are hidden by school config', async function (assert) {
-    await setupAuthentication({ school: this.school });
+    await setupAuthentication({ school: this.school }, true);
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -312,7 +336,7 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('session attributes are hidden when there is no school config', async function (assert) {
-    await setupAuthentication({ school: this.school });
+    await setupAuthentication({ school: this.school }, true);
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -326,10 +350,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change supplemental', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[1],
@@ -348,10 +375,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change special attire', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[1],
@@ -370,10 +400,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change special equipment', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[1],
@@ -391,11 +424,14 @@ module('Acceptance | Session - Overview', function (hooks) {
     assert.strictEqual(page.details.overview.specialEquipment.yesNoToggle.checked, 'true');
   });
 
-  test('change attendance rquired', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+  test('change attendance required', async function (assert) {
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[1],
@@ -414,10 +450,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change description', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const session = this.server.create('session', {
       course: this.course,
     });
@@ -433,10 +472,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('add description', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       description: null,
@@ -453,10 +495,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('empty description removes description', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       description: null,
@@ -472,10 +517,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('remove description', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const session = this.server.create('session', {
       course: this.course,
     });
@@ -490,10 +538,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('cancel editing empty description #3210', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       description: null,
@@ -509,10 +560,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('click copy', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -524,7 +578,7 @@ module('Acceptance | Session - Overview', function (hooks) {
     assert.strictEqual(currentRouteName(), 'session.copy');
   });
 
-  test('copy hidden from unprivledged users', async function (assert) {
+  test('copy hidden from unprivileged users', async function (assert) {
     await setupAuthentication({ school: this.school });
     this.server.create('session', {
       course: this.course,
@@ -536,10 +590,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('copy visible to privileged users', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -550,10 +607,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('copy hidden on copy route', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -567,10 +627,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change instructionalNotes', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       instructionalNotes: 'instructional note',
@@ -591,10 +654,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('add instructionalNotes', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
     });
@@ -614,10 +680,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('empty instructionalNotes removes instructionalNotes', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
     });
@@ -633,10 +702,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('remove instructionalNotes', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
       instructionalNotes: 'instructional note',
@@ -652,10 +724,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('cancel editing empty instructionalNotes #3210', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
     });
@@ -670,10 +745,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('has no pre-requisite', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
     });
@@ -682,10 +760,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('has pre-requisites', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const session = this.server.create('session', {
       course: this.course,
     });
@@ -704,10 +785,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('has no post-requisite', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const ilmSession = this.server.create('ilm-session');
     this.server.create('session', {
       course: this.course,
@@ -723,10 +807,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('has post-requisite', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const ilmSession = this.server.create('ilm-session');
     const session = this.server.create('session', {
       course: this.course,
@@ -746,10 +833,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change post-requisite', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', {
       course: this.course,
     });
@@ -765,10 +855,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('shows expanded objectives if no objectives exist', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     this.server.create('session', { course: this.course });
     await page.visit({ courseId: 1, sessionId: 1 });
     assert.strictEqual(currentRouteName(), 'session.index');
@@ -776,10 +869,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('shows collapsed objectives if objectives exist', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const session = this.server.create('session', { course: this.course });
     this.server.create('session-objective', { session });
     await page.visit({ courseId: 1, sessionId: 1 });
@@ -788,10 +884,13 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('shows associated learner groups', async function (assert) {
-    await setupAuthentication({
-      school: this.school,
-      administeredSchools: [this.school],
-    });
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
     const session = this.server.create('session', { course: this.course });
     const learnerGroups = this.server.createList('learner-group', 3);
     this.server.create('offering', { session, learnerGroups });

--- a/packages/frontend/tests/acceptance/course/session/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/session/overview-test.js
@@ -578,18 +578,7 @@ module('Acceptance | Session - Overview', function (hooks) {
     assert.strictEqual(currentRouteName(), 'session.copy');
   });
 
-  test('copy hidden from unprivileged users', async function (assert) {
-    await setupAuthentication({ school: this.school });
-    this.server.create('session', {
-      course: this.course,
-      sessionType: this.sessionTypes[0],
-    });
-    await page.visit({ courseId: 1, sessionId: 1 });
-    assert.strictEqual(currentRouteName(), 'session.index');
-    assert.notOk(page.details.overview.copy.isVisible);
-  });
-
-  test('copy visible to privileged users', async function (assert) {
+  test('copy button is visible', async function (assert) {
     await setupAuthentication(
       {
         school: this.school,

--- a/packages/frontend/tests/acceptance/course/session/publicationcheck-test.js
+++ b/packages/frontend/tests/acceptance/course/session/publicationcheck-test.js
@@ -8,7 +8,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | Session - Publication Check', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    await setupAuthentication();
+    await setupAuthentication({}, true);
     const school = this.server.create('school');
     const vocabulary = this.server.create('vocabulary', {
       school,

--- a/packages/frontend/tests/acceptance/course/session/publish-all-test.js
+++ b/packages/frontend/tests/acceptance/course/session/publish-all-test.js
@@ -8,10 +8,13 @@ module('Acceptance | Session - Publish All', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
-    await setupAuthentication({
-      school,
-      administeredSchools: [school],
-    });
+    await setupAuthentication(
+      {
+        school,
+        administeredSchools: [school],
+      },
+      true,
+    );
     const vocabulary = this.server.create('vocabulary', {
       school,
     });

--- a/packages/frontend/tests/acceptance/course/session/publish-test.js
+++ b/packages/frontend/tests/acceptance/course/session/publish-test.js
@@ -16,7 +16,7 @@ module('Acceptance | Session - Publish', function (hooks) {
       }).toJSDate(),
     );
     const school = this.server.create('school');
-    await setupAuthentication({ school, administeredSchools: [school] });
+    await setupAuthentication({ school, administeredSchools: [school] }, true);
     this.course = this.server.create('course', { school });
     this.server.create('session-type');
     this.publishedSession = this.server.create('session', {

--- a/packages/frontend/tests/acceptance/course/session/terms-test.js
+++ b/packages/frontend/tests/acceptance/course/session/terms-test.js
@@ -8,7 +8,7 @@ module('Acceptance | Session - Terms', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
     const vocabulary = this.server.create('vocabulary', {
       school: this.school,
       active: true,

--- a/packages/frontend/tests/acceptance/course/sessionlist-test.js
+++ b/packages/frontend/tests/acceptance/course/sessionlist-test.js
@@ -20,7 +20,7 @@ module('Acceptance | Course - Session List', function (hooks) {
     this.intl = this.owner.lookup('service:intl');
     this.today = DateTime.fromObject({ hour: 8 });
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
     this.sessionType = this.server.create('session-type', {
       school: this.school,
     });

--- a/packages/frontend/tests/acceptance/course/terms-test.js
+++ b/packages/frontend/tests/acceptance/course/terms-test.js
@@ -7,7 +7,7 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Terms', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
     this.server.create('vocabulary', {
       school: this.school,

--- a/packages/frontend/tests/acceptance/course/visualizations-instructor-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-instructor-test.js
@@ -9,7 +9,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | course visualizations - instructor', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
   });
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/visualizations-instructors-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-instructors-test.js
@@ -9,7 +9,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | course visualizations - instructors', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     const instructor1 = this.server.create('user');
     const instructor2 = this.server.create('user');
     const vocabulary1 = this.server.create('vocabulary');

--- a/packages/frontend/tests/acceptance/course/visualizations-objectives-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-objectives-test.js
@@ -8,7 +8,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | course visualizations - objectives', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
   });
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/visualizations-session-type-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-session-type-test.js
@@ -9,7 +9,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | course visualizations - session-type', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
   });
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/visualizations-session-types-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-session-types-test.js
@@ -9,7 +9,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | course visualizations - session-types', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
   });
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/visualizations-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-test.js
@@ -7,7 +7,7 @@ import { setupAuthentication } from 'ilios-common';
 module('Acceptance | course visualizations', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
 
     this.server.create('course', {

--- a/packages/frontend/tests/acceptance/course/visualizations-vocabularies-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-vocabularies-test.js
@@ -9,7 +9,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | course visualizations - vocabularies', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
   });
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/visualizations-vocabulary-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-vocabulary-test.js
@@ -9,7 +9,7 @@ import percySnapshot from '@percy/ember';
 module('Acceptance | course visualizations - vocabulary', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication();
+    this.user = await setupAuthentication({}, true);
     this.vocabulary = this.server.create('vocabulary');
     const term1 = this.server.create('term', {
       vocabulary: this.vocabulary,

--- a/packages/frontend/tests/acceptance/courses-test.js
+++ b/packages/frontend/tests/acceptance/courses-test.js
@@ -12,7 +12,7 @@ module('Acceptance | Courses', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
     this.server.create('school');
   });
 

--- a/packages/frontend/tests/acceptance/four-oh-four-test.js
+++ b/packages/frontend/tests/acceptance/four-oh-four-test.js
@@ -8,7 +8,7 @@ module('Acceptance | FourOhFour', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    await setupAuthentication();
+    await setupAuthentication({}, true);
   });
 
   test('visiting /four-oh-four', async function (assert) {

--- a/packages/frontend/tests/acceptance/instructorgroup-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroup-test.js
@@ -13,7 +13,7 @@ module('Acceptance | Instructor Group', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school });
+    this.user = await setupAuthentication({ school: this.school }, true);
     const users = this.server.createList('user', 4);
     const courses = this.server.createList('course', 2, {
       school: this.school,

--- a/packages/ilios-common/addon/routes/course-materials.js
+++ b/packages/ilios-common/addon/routes/course-materials.js
@@ -6,6 +6,8 @@ import { mapBy } from 'ilios-common/utils/array-helpers';
 export default class CourseMaterialsRoute extends Route {
   @service session;
   @service dataLoader;
+  @service currentUser;
+  @service router;
 
   titleToken = 'general.coursesAndSessions';
 
@@ -22,6 +24,9 @@ export default class CourseMaterialsRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 
   async loadCourseLearningMaterials(course) {

--- a/packages/ilios-common/addon/routes/course-visualizations.js
+++ b/packages/ilios-common/addon/routes/course-visualizations.js
@@ -7,6 +7,8 @@ export default class CourseVisualizationsRoute extends Route {
   @service store;
   @service session;
   @service dataLoader;
+  @service currentUser;
+  @service router;
 
   titleToken = 'general.coursesAndSessions';
 
@@ -59,5 +61,8 @@ export default class CourseVisualizationsRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-instructor.js
+++ b/packages/ilios-common/addon/routes/course-visualize-instructor.js
@@ -5,6 +5,8 @@ import { all, map } from 'rsvp';
 export default class CourseVisualizeInstructorRoute extends Route {
   @service session;
   @service store;
+  @service currentUser;
+  @service router;
 
   titleToken = 'general.coursesAndSessions';
 
@@ -20,5 +22,8 @@ export default class CourseVisualizeInstructorRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-instructors.js
+++ b/packages/ilios-common/addon/routes/course-visualize-instructors.js
@@ -6,6 +6,8 @@ export default class CourseVisualizeInstructorsRoute extends Route {
   @service session;
   @service store;
   @service dataLoader;
+  @service currentUser;
+  @service router;
 
   titleToken = 'general.coursesAndSessions';
 
@@ -24,5 +26,8 @@ export default class CourseVisualizeInstructorsRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-objectives.js
+++ b/packages/ilios-common/addon/routes/course-visualize-objectives.js
@@ -6,6 +6,8 @@ export default class CourseVisualizeObjectivesRoute extends Route {
   @service store;
   @service session;
   @service dataLoader;
+  @service currentUser;
+  @service router;
 
   titleToken = 'general.coursesAndSessions';
 
@@ -20,5 +22,8 @@ export default class CourseVisualizeObjectivesRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-session-type.js
+++ b/packages/ilios-common/addon/routes/course-visualize-session-type.js
@@ -5,6 +5,8 @@ import { all, map } from 'rsvp';
 export default class CourseVisualizeSessionTypeRoute extends Route {
   @service session;
   @service store;
+  @service currentUser;
+  @service router;
 
   titleToken = 'general.coursesAndSessions';
 
@@ -26,5 +28,8 @@ export default class CourseVisualizeSessionTypeRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-session-types.js
+++ b/packages/ilios-common/addon/routes/course-visualize-session-types.js
@@ -6,6 +6,8 @@ export default class CourseVisualizeSessionTypesRoute extends Route {
   @service session;
   @service store;
   @service dataLoader;
+  @service currentUser;
+  @service router;
 
   titleToken = 'general.coursesAndSessions';
 
@@ -20,5 +22,8 @@ export default class CourseVisualizeSessionTypesRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-term.js
+++ b/packages/ilios-common/addon/routes/course-visualize-term.js
@@ -5,6 +5,8 @@ import { all, map } from 'rsvp';
 export default class CourseVisualizeTermRoute extends Route {
   @service session;
   @service store;
+  @service currentUser;
+  @service router;
 
   titleToken = 'general.coursesAndSessions';
 
@@ -26,5 +28,8 @@ export default class CourseVisualizeTermRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-vocabularies.js
+++ b/packages/ilios-common/addon/routes/course-visualize-vocabularies.js
@@ -6,6 +6,8 @@ export default class CourseVisualizeVocabulariesRoute extends Route {
   @service session;
   @service store;
   @service dataLoader;
+  @service currentUser;
+  @service router;
 
   titleToken = 'general.coursesAndSessions';
 
@@ -20,5 +22,8 @@ export default class CourseVisualizeVocabulariesRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-vocabulary.js
+++ b/packages/ilios-common/addon/routes/course-visualize-vocabulary.js
@@ -5,6 +5,8 @@ import { all, map } from 'rsvp';
 export default class CourseVisualizeVocabularyRoute extends Route {
   @service session;
   @service store;
+  @service currentUser;
+  @service router;
 
   titleToken = 'general.coursesAndSessions';
 
@@ -23,5 +25,8 @@ export default class CourseVisualizeVocabularyRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/course.js
+++ b/packages/ilios-common/addon/routes/course.js
@@ -7,6 +7,8 @@ export default class CourseRoute extends Route {
   @service dataLoader;
   @service session;
   @service store;
+  @service router;
+  @service currentUser;
 
   titleToken = 'general.coursesAndSessions';
   editable = false;
@@ -14,6 +16,11 @@ export default class CourseRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      // Slash on the route name is necessary here due to this bug:
+      // https://github.com/emberjs/ember.js/issues/12945
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 
   async model(params) {

--- a/packages/ilios-common/addon/routes/course/index.js
+++ b/packages/ilios-common/addon/routes/course/index.js
@@ -8,6 +8,8 @@ export default class CourseIndexRoute extends Route {
   @service store;
   @service dataLoader;
   @service session;
+  @service router;
+  @service currentUser;
 
   canCreateSession = false;
   canUpdateCourse = false;
@@ -19,6 +21,9 @@ export default class CourseIndexRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 
   setupController(controller, model) {

--- a/packages/ilios-common/addon/routes/course/publication-check.js
+++ b/packages/ilios-common/addon/routes/course/publication-check.js
@@ -3,8 +3,13 @@ import Route from '@ember/routing/route';
 
 export default class CoursePublicationCheckRoute extends Route {
   @service session;
+  @service currentUser;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/course/publishall.js
+++ b/packages/ilios-common/addon/routes/course/publishall.js
@@ -3,8 +3,13 @@ import Route from '@ember/routing/route';
 
 export default class CoursePublishallRoute extends Route {
   @service session;
+  @service currentUser;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/course/rollover.js
+++ b/packages/ilios-common/addon/routes/course/rollover.js
@@ -3,8 +3,13 @@ import Route from '@ember/routing/route';
 
 export default class CourseRolloverRoute extends Route {
   @service session;
+  @service currentUser;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/print-course.js
+++ b/packages/ilios-common/addon/routes/print-course.js
@@ -5,6 +5,7 @@ export default class PrintCourseRoute extends Route {
   @service currentUser;
   @service dataLoader;
   @service session;
+  @service router;
 
   titleToken = 'general.coursesAndSessions';
   canViewUnpublished = false;
@@ -33,5 +34,8 @@ export default class PrintCourseRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/session.js
+++ b/packages/ilios-common/addon/routes/session.js
@@ -5,6 +5,8 @@ import { findById } from 'ilios-common/utils/array-helpers';
 export default class SessionRoute extends Route {
   @service dataLoader;
   @service session;
+  @service currentUser;
+  @service router;
 
   async model(params) {
     const course = this.modelFor('course');
@@ -15,5 +17,8 @@ export default class SessionRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }

--- a/packages/ilios-common/addon/routes/session/copy.js
+++ b/packages/ilios-common/addon/routes/session/copy.js
@@ -4,6 +4,8 @@ import Route from '@ember/routing/route';
 export default class SessionCopyRoute extends Route {
   @service permissionChecker;
   @service session;
+  @service currentUser;
+  @service router;
 
   canUpdate = false;
 
@@ -13,6 +15,9 @@ export default class SessionCopyRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 
   setupController(controller, model) {

--- a/packages/ilios-common/addon/routes/session/index.js
+++ b/packages/ilios-common/addon/routes/session/index.js
@@ -5,6 +5,8 @@ export default class SessionIndexRoute extends Route {
   @service permissionChecker;
   @service store;
   @service session;
+  @service currentUser;
+  @service router;
 
   canUpdate = false;
 
@@ -14,6 +16,9 @@ export default class SessionIndexRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 
   setupController(controller, model) {

--- a/packages/ilios-common/addon/routes/session/publication-check.js
+++ b/packages/ilios-common/addon/routes/session/publication-check.js
@@ -3,8 +3,13 @@ import Route from '@ember/routing/route';
 
 export default class SessionPublicationCheckRoute extends Route {
   @service session;
+  @service currentUser;
+  @service router;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
+    if (!this.currentUser.performsNonLearnerFunction) {
+      this.router.replaceWith('/four-oh-four');
+    }
   }
 }


### PR DESCRIPTION
this affects the course details page and sub-pages (like session management) that share the same root path `/courses/{id}/`, and other course-management related routes.

it's a foot in the door - i'll lock other admin areas such as instructor group/learner group management down in consecutive steps. 

refs https://github.com/ilios/ilios/issues/5721