### PR TITLE
Remove Course Objectives render modifiers

### DIFF
--- a/packages/ilios-common/.lint-todo
+++ b/packages/ilios-common/.lint-todo
@@ -38,17 +38,11 @@ add|ember-template-lint|no-at-ember-render-modifiers|3|2|3|2|7491f1d2f4e83f2c87f
 add|ember-template-lint|no-at-ember-render-modifiers|13|6|13|6|1a2522cd1202904fb09a6e811dec6b46d8189ab3|1731542400000|1762646400000|1793750400000|addon/components/user-name-info.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|8|57|8|57|49de9e74a62c8d39ef6a37eaecf07bd389aa57c7|1731542400000|1762646400000|1793750400000|addon/components/wait-saving.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|7|2|7|2|1a2522cd1202904fb09a6e811dec6b46d8189ab3|1731542400000|1762646400000|1793750400000|addon/components/weekly-calendar-event.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|23cd787c79c34a628dadb6e96dd4004d42eebb79|1731542400000|1762646400000|1793750400000|addon/components/course/collapsed-objectives.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|5|2|5|2|164f37088962494b6b2c13759308b890f0edce17|1731542400000|1762646400000|1793750400000|addon/components/course/collapsed-objectives.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|6|2|6|2|4f45b7b5de154ec564345a9fa5b7cc54fe746a9b|1731542400000|1762646400000|1793750400000|addon/components/course/details.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|23cd787c79c34a628dadb6e96dd4004d42eebb79|1731542400000|1762646400000|1793750400000|addon/components/course/header.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|5|2|5|2|32658810aa13672f5981281c562729112a89788f|1731542400000|1762646400000|1793750400000|addon/components/course/header.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|5|2|5|2|50e6b994cb8e60f8f6341ebf8a726f12c6361ad1|1731542400000|1762646400000|1793750400000|addon/components/course/objective-list-item.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|6|2|6|2|6aef42bad78d796a5ba6d0fd4ff60c50b390e426|1731542400000|1762646400000|1793750400000|addon/components/course/objective-list-item.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|23cd787c79c34a628dadb6e96dd4004d42eebb79|1731542400000|1762646400000|1793750400000|addon/components/course/objective-list.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|5|2|5|2|84076f8cf85c554eaf0d9fdec26154bae5bceeb2|1731542400000|1762646400000|1793750400000|addon/components/course/objective-list.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|3|2|3|2|23cd787c79c34a628dadb6e96dd4004d42eebb79|1731542400000|1762646400000|1793750400000|addon/components/course/objectives.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|84076f8cf85c554eaf0d9fdec26154bae5bceeb2|1731542400000|1762646400000|1793750400000|addon/components/course/objectives.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|28|6|28|6|1ef231a97c0ec761eaafb3e76093515e5523ff27|1731542400000|1762646400000|1793750400000|addon/components/course/publication-menu.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|29|6|29|6|df94e6558ff62dea69f6f656f668f29b56bcc378|1731542400000|1762646400000|1793750400000|addon/components/course/publication-menu.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|2bbf15957242a9a3c1e26e14e5d022c858199fde|1731542400000|1762646400000|1793750400000|addon/components/course/rollover-date-picker.hbs

--- a/packages/ilios-common/addon/components/course/collapsed-objectives.hbs
+++ b/packages/ilios-common/addon/components/course/collapsed-objectives.hbs
@@ -1,9 +1,4 @@
-<section
-  class="course-collapsed-objectives"
-  data-test-course-collapsed-objectives
-  {{did-insert (perform this.load)}}
-  {{did-update (perform this.load) @course.courseObjectives}}
->
+<section class="course-collapsed-objectives" data-test-course-collapsed-objectives>
   <div>
     <button
       class="title link-button"
@@ -12,11 +7,12 @@
       data-test-title
       {{on "click" @expand}}
     >
-      {{t "general.objectives"}} ({{get this.objectives "length"}})
+      {{t "general.objectives"}}
+      ({{get this.objectives "length"}})
       <FaIcon @icon="caret-right" />
     </button>
   </div>
-  {{#if this.load.lastSuccessful}}
+  {{#if this.objectives}}
     <div class="content">
       <table>
         <thead>
@@ -41,12 +37,7 @@
               {{t "general.objectiveCount" count=(get this.objectives "length")}}
             </td>
             <td class="text-middle text-center" rowspan="3" data-test-parent-status>
-              {{#if
-                (eq
-                  (get this.objectivesWithParents "length")
-                  (get this.objectives "length")
-                )
-              }}
+              {{#if (eq (get this.objectivesWithParents "length") (get this.objectives "length"))}}
                 <FaIcon @icon="circle" class="yes" />
               {{else if (gte (get this.objectivesWithParents "length") 1)}}
                 <FaIcon @icon="circle" class="maybe" />
@@ -55,12 +46,7 @@
               {{/if}}
             </td>
             <td class="text-middle text-center" rowspan="3" data-test-term-status>
-              {{#if
-                (eq
-                  (get this.objectivesWithTerms "length")
-                  (get this.objectives "length")
-                )
-              }}
+              {{#if (eq (get this.objectivesWithTerms "length") (get this.objectives "length"))}}
                 <FaIcon @icon="circle" class="yes" />
               {{else if (gte (get this.objectivesWithTerms "length") 1)}}
                 <FaIcon @icon="circle" class="maybe" />
@@ -69,12 +55,7 @@
               {{/if}}
             </td>
             <td class="text-middle text-center" rowspan="3" data-test-mesh-status>
-              {{#if
-                (eq
-                  (get this.objectivesWithMesh "length")
-                  (get this.objectives "length")
-                )
-              }}
+              {{#if (eq (get this.objectivesWithMesh "length") (get this.objectives "length"))}}
                 <FaIcon @icon="circle" class="yes" />
               {{else if (gte (get this.objectivesWithMesh "length") 1)}}
                 <FaIcon @icon="circle" class="maybe" />
@@ -85,26 +66,17 @@
           </tr>
           <tr>
             <td data-test-parent-count class="count">
-              {{t
-                  "general.parentCount"
-                  count=(get this.objectivesWithParents "length")
-              }}
+              {{t "general.parentCount" count=(get this.objectivesWithParents "length")}}
             </td>
           </tr>
           <tr>
             <td data-test-term-count class="count">
-              {{t
-                "general.termCount"
-                count=(get this.objectivesWithTerms "length")
-              }}
+              {{t "general.termCount" count=(get this.objectivesWithTerms "length")}}
             </td>
           </tr>
           <tr>
             <td data-test-mesh-count class="count">
-              {{t
-                "general.meshCount"
-                count=(get this.objectivesWithMesh "length")
-              }}
+              {{t "general.meshCount" count=(get this.objectivesWithMesh "length")}}
             </td>
           </tr>
         </tbody>

--- a/packages/ilios-common/addon/components/course/collapsed-objectives.hbs
+++ b/packages/ilios-common/addon/components/course/collapsed-objectives.hbs
@@ -8,11 +8,11 @@
       {{on "click" @expand}}
     >
       {{t "general.objectives"}}
-      ({{get this.objectives "length"}})
+      ({{this.objectives.length}})
       <FaIcon @icon="caret-right" />
     </button>
   </div>
-  {{#if this.objectives}}
+  {{#if this.objectives.length}}
     <div class="content">
       <table>
         <thead>
@@ -34,10 +34,10 @@
         <tbody>
           <tr>
             <td data-test-objective-count>
-              {{t "general.objectiveCount" count=(get this.objectives "length")}}
+              {{t "general.objectiveCount" count=this.objectives.length}}
             </td>
             <td class="text-middle text-center" rowspan="3" data-test-parent-status>
-              {{#if (eq (get this.objectivesWithParents "length") (get this.objectives "length"))}}
+              {{#if (eq this.objectivesWithParents.length this.objectives.length)}}
                 <FaIcon @icon="circle" class="yes" />
               {{else if (gte (get this.objectivesWithParents "length") 1)}}
                 <FaIcon @icon="circle" class="maybe" />
@@ -46,7 +46,7 @@
               {{/if}}
             </td>
             <td class="text-middle text-center" rowspan="3" data-test-term-status>
-              {{#if (eq (get this.objectivesWithTerms "length") (get this.objectives "length"))}}
+              {{#if (eq this.objectivesWithTerms.length this.objectives.length)}}
                 <FaIcon @icon="circle" class="yes" />
               {{else if (gte (get this.objectivesWithTerms "length") 1)}}
                 <FaIcon @icon="circle" class="maybe" />
@@ -55,7 +55,7 @@
               {{/if}}
             </td>
             <td class="text-middle text-center" rowspan="3" data-test-mesh-status>
-              {{#if (eq (get this.objectivesWithMesh "length") (get this.objectives "length"))}}
+              {{#if (eq this.objectivesWithMesh.length this.objectives.length)}}
                 <FaIcon @icon="circle" class="yes" />
               {{else if (gte (get this.objectivesWithMesh "length") 1)}}
                 <FaIcon @icon="circle" class="maybe" />
@@ -66,17 +66,17 @@
           </tr>
           <tr>
             <td data-test-parent-count class="count">
-              {{t "general.parentCount" count=(get this.objectivesWithParents "length")}}
+              {{t "general.parentCount" count=this.objectivesWithParents.length}}
             </td>
           </tr>
           <tr>
             <td data-test-term-count class="count">
-              {{t "general.termCount" count=(get this.objectivesWithTerms "length")}}
+              {{t "general.termCount" count=this.objectivesWithTerms.length}}
             </td>
           </tr>
           <tr>
             <td data-test-mesh-count class="count">
-              {{t "general.meshCount" count=(get this.objectivesWithMesh "length")}}
+              {{t "general.meshCount" count=this.objectivesWithMesh.length}}
             </td>
           </tr>
         </tbody>

--- a/packages/ilios-common/addon/components/course/collapsed-objectives.js
+++ b/packages/ilios-common/addon/components/course/collapsed-objectives.js
@@ -1,16 +1,15 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { restartableTask } from 'ember-concurrency';
+import { cached } from '@glimmer/tracking';
+import { TrackedAsyncData } from 'ember-async-data';
 
 export default class CourseCollapsedObjectivesComponent extends Component {
-  @tracked objectivesRelationship;
-
-  load = restartableTask(async () => {
-    this.objectivesRelationship = await this.args.course.courseObjectives;
-  });
+  @cached
+  get objectivesData() {
+    return new TrackedAsyncData(this.args.course.courseObjectives);
+  }
 
   get objectives() {
-    return this.objectivesRelationship ? this.objectivesRelationship : [];
+    return this.objectivesData.isResolved ? this.objectivesData.value : null;
   }
 
   get objectivesWithParents() {

--- a/packages/ilios-common/addon/components/course/collapsed-objectives.js
+++ b/packages/ilios-common/addon/components/course/collapsed-objectives.js
@@ -9,7 +9,7 @@ export default class CourseCollapsedObjectivesComponent extends Component {
   }
 
   get objectives() {
-    return this.objectivesData.isResolved ? this.objectivesData.value : null;
+    return this.objectivesData.isResolved ? this.objectivesData.value : [];
   }
 
   get objectivesWithParents() {

--- a/packages/ilios-common/addon/components/course/objective-list-item.hbs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.hbs
@@ -1,9 +1,10 @@
 <div
   id="objective-{{@courseObjective.id}}"
-  class="grid-row objective-row{{if this.showRemoveConfirmation " confirm-removal"}}{{if this.highlightSave.isRunning " highlight-ok"}}{{if this.isManaging " is-managing"}}"
+  class="grid-row objective-row{{if this.showRemoveConfirmation ' confirm-removal'}}{{if
+      this.highlightSave.isRunning
+      ' highlight-ok'
+    }}{{if this.isManaging ' is-managing'}}"
   data-test-course-objective-list-item
-  {{did-insert this.load @courseObjective}}
-  {{did-update this.load @courseObjective}}
 >
   <div class="description grid-item" data-test-description>
     {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
@@ -14,7 +15,11 @@
         @save={{perform this.saveTitleChanges}}
         @close={{this.revertTitleChanges}}
       >
-        <HtmlEditor @content={{@courseObjective.title}} @update={{this.changeTitle}} @autofocus={{true}} />
+        <HtmlEditor
+          @content={{@courseObjective.title}}
+          @update={{this.changeTitle}}
+          @autofocus={{true}}
+        />
         <ValidationError @validatable={{this}} @property="title" />
       </EditableField>
     {{else}}
@@ -32,13 +37,13 @@
   />
 
   <ObjectiveListItemTerms
-      @subject={{@courseObjective}}
-      @editable={{and @editable (not this.isManaging) (not this.showRemoveConfirmation)}}
-      @manage={{perform this.manageTerms}}
-      @isManaging={{this.isManagingTerms}}
-      @save={{perform this.saveTerms}}
-      @isSaving={{this.saveTerms.isRunning}}
-      @cancel={{this.cancel}}
+    @subject={{@courseObjective}}
+    @editable={{and @editable (not this.isManaging) (not this.showRemoveConfirmation)}}
+    @manage={{perform this.manageTerms}}
+    @isManaging={{this.isManagingTerms}}
+    @save={{perform this.saveTerms}}
+    @isSaving={{this.saveTerms.isRunning}}
+    @cancel={{this.cancel}}
   />
 
   <Course::ObjectiveListItemDescriptors
@@ -52,7 +57,14 @@
   />
 
   <div class="actions grid-item" data-test-actions>
-    {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation) (not this.showRemoveConfirmation))}}
+    {{#if
+      (and
+        @editable
+        (not this.isManaging)
+        (not this.showRemoveConfirmation)
+        (not this.showRemoveConfirmation)
+      )
+    }}
       <button
         class="link-button"
         type="button"

--- a/packages/ilios-common/addon/components/course/objective-list-item.js
+++ b/packages/ilios-common/addon/components/course/objective-list-item.js
@@ -52,14 +52,6 @@ export default class CourseObjectiveListItemComponent extends Component {
     return this.meshDescriptorsData.isResolved ? this.meshDescriptorsData.value : null;
   }
 
-  // @action
-  // load(element, [courseObjective]) {
-  //   if (!courseObjective) {
-  //     return;
-  //   }
-  //   this.title = courseObjective.title;
-  // }
-
   get isManaging() {
     return this.isManagingParents || this.isManagingDescriptors || this.isManagingTerms;
   }

--- a/packages/ilios-common/addon/components/course/objective-list-item.js
+++ b/packages/ilios-common/addon/components/course/objective-list-item.js
@@ -20,6 +20,11 @@ export default class CourseObjectiveListItemComponent extends Component {
   @tracked termsBuffer = [];
   @tracked selectedVocabulary;
 
+  constructor() {
+    super(...arguments);
+    this.title = this.args.courseObjective.title;
+  }
+
   @cached
   get hasErrorForTitleData() {
     return new TrackedAsyncData(this.hasErrorFor('title'));
@@ -47,13 +52,13 @@ export default class CourseObjectiveListItemComponent extends Component {
     return this.meshDescriptorsData.isResolved ? this.meshDescriptorsData.value : null;
   }
 
-  @action
-  load(element, [courseObjective]) {
-    if (!courseObjective) {
-      return;
-    }
-    this.title = courseObjective.title;
-  }
+  // @action
+  // load(element, [courseObjective]) {
+  //   if (!courseObjective) {
+  //     return;
+  //   }
+  //   this.title = courseObjective.title;
+  // }
 
   get isManaging() {
     return this.isManagingParents || this.isManagingDescriptors || this.isManagingTerms;

--- a/packages/ilios-common/addon/components/course/objectives.hbs
+++ b/packages/ilios-common/addon/components/course/objectives.hbs
@@ -10,14 +10,14 @@
           {{on "click" this.collapse}}
         >
           {{t "general.objectives"}}
-          ({{this.objectiveCount}})
+          ({{this.objectives.length}})
           <FaIcon @icon="caret-down" />
         </button>
       </div>
     {{else}}
       <h3 class="title" data-test-title>
         {{t "general.objectives"}}
-        ({{this.objectiveCount}})
+        ({{this.objectives.length}})
       </h3>
     {{/if}}
     {{#if @editable}}

--- a/packages/ilios-common/addon/components/course/objectives.hbs
+++ b/packages/ilios-common/addon/components/course/objectives.hbs
@@ -1,9 +1,4 @@
-<section
-  class="course-objectives"
-  {{did-insert (perform this.load)}}
-  {{did-update (perform this.load) @course}}
-  data-test-course-objectives
->
+<section class="course-objectives" data-test-course-objectives>
   <div class="header">
     {{#if this.showCollapsible}}
       <div>
@@ -14,13 +9,15 @@
           data-test-title
           {{on "click" this.collapse}}
         >
-          {{t "general.objectives"}} ({{this.objectiveCount}})
+          {{t "general.objectives"}}
+          ({{this.objectiveCount}})
           <FaIcon @icon="caret-down" />
         </button>
       </div>
     {{else}}
       <h3 class="title" data-test-title>
-        {{t "general.objectives"}} ({{this.objectiveCount}})
+        {{t "general.objectives"}}
+        ({{this.objectiveCount}})
       </h3>
     {{/if}}
     {{#if @editable}}
@@ -52,9 +49,6 @@
         @cancel={{this.toggleNewObjectiveEditor}}
       />
     {{/if}}
-    <Course::ObjectiveList
-      @course={{@course}}
-      @editable={{@editable}}
-    />
+    <Course::ObjectiveList @course={{@course}} @editable={{@editable}} />
   </div>
 </section>

--- a/packages/ilios-common/addon/components/course/objectives.js
+++ b/packages/ilios-common/addon/components/course/objectives.js
@@ -14,11 +14,7 @@ export default class CourseObjectivesComponent extends Component {
   @tracked newObjectiveTitle;
 
   get showCollapsible() {
-    return this.hasObjectives && !this.isManaging;
-  }
-
-  get hasObjectives() {
-    return this.objectiveCount > 0;
+    return this.objectives.length > 0 && !this.isManaging;
   }
 
   @cached
@@ -27,11 +23,7 @@ export default class CourseObjectivesComponent extends Component {
   }
 
   get objectives() {
-    return this.objectivesData.isResolved ? this.objectivesData.value : null;
-  }
-
-  get objectiveCount() {
-    return this.objectives ? this.objectives.length : 0;
+    return this.objectivesData.isResolved ? this.objectivesData.value : [];
   }
 
   saveNewObjective = dropTask(async (title) => {
@@ -62,7 +54,7 @@ export default class CourseObjectivesComponent extends Component {
   }
   @action
   collapse() {
-    if (this.hasObjectives) {
+    if (this.objectives.length > 0) {
       this.args.collapse();
     }
   }


### PR DESCRIPTION
Refs ilios/ilios#5374

The only one left in the Course area is `ObjectiveList`, but it uses a `DataLoader` mechanism, and I'm not yet sure how to refactor it.