### PR TITLE
remember Calendar courseFilters setting across hide/show filter toggle

### DIFF
--- a/packages/ilios-common/addon/controllers/dashboard/calendar.js
+++ b/packages/ilios-common/addon/controllers/dashboard/calendar.js
@@ -88,7 +88,6 @@ export default class DashboardCalendarController extends Controller {
     if (this.showFilters) {
       this.showFilters = false;
       this.academicYear = null;
-      this.courseFilters = true;
     } else {
       this.showFilters = true;
     }


### PR DESCRIPTION
Fixes ilios/ilios#3430

Removed setting that was defaulting `this.courseFilters` to true when you hid and then showed the filters. Now it remembers!