### PR TITLE
make froala link edit popup fully visible

### DIFF
--- a/packages/frontend/app/styles/layout/_layout.scss
+++ b/packages/frontend/app/styles/layout/_layout.scss
@@ -93,7 +93,7 @@
       grid-area: nav;
       @include m.for-laptop-and-up {
         display: block;
-        z-index: 5;
+        z-index: 0;
       }
     }
   }


### PR DESCRIPTION
Fixes ilios/ilios#5826

Made sidebar lower so popups show above it. There probably should be a test for this, but I'm not sure where in the suite this kind of thing would go (i.e. external dependency popup making).