### PR TITLE
Ignore Scripts in Auto Update Workflow

### DIFF
--- a/.github/workflows/update-transitive-dependencies.yaml
+++ b/.github/workflows/update-transitive-dependencies.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: remove and re-create lock file
         run: |
           rm pnpm-lock.yaml
-          pnpm install --fix-lockfile
+          pnpm install --fix-lockfile --ignore-scripts
           pnpm dedupe
       - name: Create Pull Request
         id: cpr


### PR DESCRIPTION
The scripts is where husky installs the precommit hook and the recommended approach to skipping verification of this commit is to skip installing that hook. The resulting PR will fail validation all on it's own, but at least the error is fixable there. When it fails on commit in this job that failure is hidden.