### PR TITLE
move the code comment out of the args list.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,9 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarqube.ucsf.edu
         with:
+          # https://community.sonarsource.com/t/xml-file-extension-is-binded-to-multiple-language/41745/4
           args: >
             -Dsonar.projectKey=ilios_frontend_27a24e39-b0ec-405a-91a6-b6392ffcdd30
-            # https://community.sonarsource.com/t/xml-file-extension-is-binded-to-multiple-language/41745/4
             -Dsonar.lang.patterns.mule=- sonar.excludePlugins=mule
 
   upload-coverage:


### PR DESCRIPTION
seems like having the code comment with the reference link in the middle of the arguments list is preventing the second argument from being passed to the JRE correctly.

>Run ${GITHUB_ACTION_PATH}/run-sonar-scanner.sh -Dsonar.projectKey=ilios_frontend_27a24e39-b0ec-405a-91a6-b6392ffcdd30 # https://community.sonarsource.com/t/xml-file-extension-is-binded-to-multiple-language/41745/4 -Dsonar.lang.patterns.mule=- sonar.excludePlugins=mule
  ${GITHUB_ACTION_PATH}/run-sonar-scanner.sh -Dsonar.projectKey=ilios_frontend_27a24e39-b0ec-405a-91a6-b6392ffcdd30 # https://community.sonarsource.com/t/xml-file-extension-is-binded-to-multiple-language/41745/4 -Dsonar.lang.patterns.mule=- sonar.excludePlugins=mule
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    SW_DISABLED: true
    COVERAGE: false
    SONAR_TOKEN: ***
    SONAR_HOST_URL: https://sonarqube.ucsf.edu
    INPUT_PROJECTBASEDIR: 
    SONAR_SCANNER_JRE: /home/runner/work/_temp/sonar-scanner-cli-6.2.1.4610-Linux-X64/jre
>
>\+ sonar-scanner -Dsonar.projectKey=ilios_frontend_27a24e39-b0ec-405a-91a6-b6392ffcdd30

source: https://github.com/ilios/frontend/actions/runs/12120229266/job/33788832882?pr=8250