### PR TITLE
Add template protection for filetypes on uploads with restrictions

### DIFF
--- a/packages/frontend/app/components/bulk-new-users.hbs
+++ b/packages/frontend/app/components/bulk-new-users.hbs
@@ -65,6 +65,7 @@
           <input
             id="upload-{{templateId}}"
             type="file"
+            accept=".csv, .tsv, .txt"
             {{on "change" (pick "target.files" (perform this.updateSelectedFile))}}
             disabled={{this.updateSelectedFile.isRunning}}
           />

--- a/packages/frontend/app/components/learner-group/upload-data.hbs
+++ b/packages/frontend/app/components/learner-group/upload-data.hbs
@@ -20,6 +20,7 @@
     <input
       id="user-file"
       type="file"
+      accept=".csv, .tsv, .txt"
       {{on "change" (pick "target.files" this.updateSelectedFile)}}
       data-test-user-upload
     />


### PR DESCRIPTION
Fixes ilios/ilios#5875

Added `accept` attribute to `<input>` elements for file uploads in `BulkNewUsersComponent` and `LearnerGroupUploadDataComponent` components to restrict choosing invalid filetypes.