### PR TITLE
Use Better CI Reporter

### DIFF
--- a/packages/frontend/testem.js
+++ b/packages/frontend/testem.js
@@ -1,6 +1,8 @@
 /* eslint camelcase: 0 */
 'use strict';
 
+const FailureOnlyReporter = require('testem-failure-only-reporter');
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
@@ -9,6 +11,7 @@ module.exports = {
   browser_disconnect_timeout: 300,
   browser_start_timeout: 120,
   parallel: process.env.EMBER_EXAM_SPLIT_COUNT || -1,
+  reporter: FailureOnlyReporter,
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/lti-course-manager/testem.js
+++ b/packages/lti-course-manager/testem.js
@@ -1,12 +1,15 @@
 /* eslint camelcase: 0 */
 'use strict';
 
+const FailureOnlyReporter = require('testem-failure-only-reporter');
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 120,
+  reporter: FailureOnlyReporter,
   parallel: process.env.EMBER_EXAM_SPLIT_COUNT || -1,
   browser_args: {
     Chrome: {

--- a/packages/lti-dashboard/testem.js
+++ b/packages/lti-dashboard/testem.js
@@ -1,12 +1,15 @@
 /* eslint camelcase: 0 */
 'use strict';
 
+const FailureOnlyReporter = require('testem-failure-only-reporter');
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 120,
+  reporter: FailureOnlyReporter,
   parallel: process.env.EMBER_EXAM_SPLIT_COUNT || -1,
   browser_args: {
     Chrome: {

--- a/packages/test-app/testem.js
+++ b/packages/test-app/testem.js
@@ -1,4 +1,5 @@
 'use strict';
+const FailureOnlyReporter = require('testem-failure-only-reporter');
 
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
@@ -7,6 +8,7 @@ module.exports = {
   launch_in_dev: ['Chrome'],
   browser_disconnect_timeout: 120,
   browser_start_timeout: 30,
+  reporter: FailureOnlyReporter,
   parallel: process.env.EMBER_EXAM_SPLIT_COUNT || -1,
   browser_args: {
     Chrome: {


### PR DESCRIPTION
This is a version of what we're using for our browser tests and the output is way more readable in CI, making the failures easier to spot and fix. I like it. Let's use it on our other CI tests.