### PR TITLE
Remove VisualizerProgramYearObjectives render modifiers

### DIFF
--- a/packages/frontend/.lint-todo
+++ b/packages/frontend/.lint-todo
@@ -2,5 +2,3 @@ add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|23cd787c79c34a628da
 add|ember-template-lint|no-at-ember-render-modifiers|5|2|5|2|f53982efe02d2bef9e7f12b5b862288c594579c2|1731542400000|1762646400000|1793750400000|app/components/user-profile-bio.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|5|2|5|2|23cd787c79c34a628dadb6e96dd4004d42eebb79|1731542400000|1762646400000|1793750400000|app/components/user-profile-roles.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|6|2|6|2|e5120f87b74c5ae8e4c76b9089e0b4a4504c6e3c|1731542400000|1762646400000|1793750400000|app/components/user-profile-roles.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|3|2|3|2|1fb0566922ce4f066916e5e2931f650f69d7cfba|1731542400000|1762646400000|1793750400000|app/components/visualizer-program-year-objectives.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|38e65b45b56fdfd4160d3b0884114b6643e3a036|1731542400000|1762646400000|1793750400000|app/components/visualizer-program-year-objectives.hbs

--- a/packages/frontend/app/components/visualizer-program-year-objectives.hbs
+++ b/packages/frontend/app/components/visualizer-program-year-objectives.hbs
@@ -1,10 +1,5 @@
-<div
-  class="{{unless @isIcon 'not-icon'}} visualizer-program-year-objectives"
-  {{did-insert (perform this.load) @programYear}}
-  {{did-update (perform this.load) @programYear}}
-  ...attributes
->
-  {{#if this.load.lastSuccessful}}
+<div class="{{unless @isIcon 'not-icon'}} visualizer-program-year-objectives" ...attributes>
+  {{#if this.programYearData.isResolved}}
     {{#if (or @isIcon this.data)}}
       <SimpleChart
         @name="tree"

--- a/packages/frontend/app/components/visualizer-program-year-objectives.hbs
+++ b/packages/frontend/app/components/visualizer-program-year-objectives.hbs
@@ -1,10 +1,10 @@
 <div class="{{unless @isIcon 'not-icon'}} visualizer-program-year-objectives" ...attributes>
-  {{#if this.programYearData.isResolved}}
-    {{#if (or @isIcon this.data)}}
+  {{#if this.chartOutputData.isResolved}}
+    {{#if (or @isIcon this.chartOutput)}}
       <SimpleChart
         @name="tree"
         @isIcon={{@isIcon}}
-        @data={{this.data}}
+        @data={{this.chartOutput}}
         @hover={{perform this.nodeHover}}
         @leave={{perform this.nodeHover}}
         as |chart|

--- a/packages/frontend/app/components/visualizer-program-year-objectives.js
+++ b/packages/frontend/app/components/visualizer-program-year-objectives.js
@@ -14,30 +14,26 @@ export default class VisualizerProgramYearObjectivesComponent extends Component 
   @tracked tooltipSessions;
   @tracked tooltipTitle;
 
-  @tracked programYearName;
-  @tracked data;
-
-  constructor() {
-    super(...arguments);
-    this.load.perform();
-  }
-
-  load = restartableTask(async () => {
-    const cohort = await this.programYear.cohort;
-    const year = await this.programYear.getClassOfYear();
-    const classOfYear = this.intl.t('general.classOf', { year });
-    this.programYearName = cohort.title ?? classOfYear;
-
-    this.data = await this.getData(this.programYear);
-  });
-
   @cached
-  get programYearData() {
-    return new TrackedAsyncData(this.args.programYear);
+  get chartOutputData() {
+    return new TrackedAsyncData(this.loadData(this.args.programYear));
   }
 
-  get programYear() {
-    return this.programYearData.isResolved ? this.programYearData.value : null;
+  get chartOutput() {
+    return this.chartOutputData.isResolved ? this.chartOutputData.value : null;
+  }
+
+  async loadData(programYear) {
+    const cohort = await programYear.cohort;
+    const year = await programYear.getClassOfYear();
+    const classOfYear = this.intl.t('general.classOf', { year });
+    const programYearName = cohort.title ?? classOfYear;
+
+    return {
+      name: programYearName,
+      children: await this.getDomainObjects(programYear),
+      meta: {},
+    };
   }
 
   async getObjectiveObjects(programYear) {
@@ -119,14 +115,6 @@ export default class VisualizerProgramYearObjectivesComponent extends Component 
         meta: {},
       };
     });
-  }
-
-  async getData(programYear) {
-    return {
-      name: this.programYearName,
-      children: await this.getDomainObjects(programYear),
-      meta: {},
-    };
   }
 
   nodeHover = restartableTask(async (obj) => {


### PR DESCRIPTION
Refs ilios/ilios#5374

Two odd things I found:
1. The link to these visualizations don't show up on demo: https://demo.iliosproject.org/programs/15/programyears/21 (no link), but the same route on local there's a visualization link
2. The link only works if you click from the previous ProgramYear route: /programs/15/programyears/21 -> click link -> /data/programyears/21/objectives, but not directly. Or if you go there once, and then refresh, you get Zoinks. I'm assuming there's some routing shenanigans that is only working on transition, and not directly.