### PR TITLE
[api bump] rm obsolete attribute from MeSH concept model.

### DIFF
--- a/packages/ilios-common/addon/models/mesh-concept.js
+++ b/packages/ilios-common/addon/models/mesh-concept.js
@@ -13,9 +13,6 @@ export default class MeshConcept extends Model {
   @attr('string')
   cash1Name;
 
-  @attr('string')
-  registryNumber;
-
   @attr('date')
   createdAt;
 

--- a/packages/ilios-common/config/api-version.js
+++ b/packages/ilios-common/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v3.11';
+module.exports = 'v3.12';


### PR DESCRIPTION
can be removed without further steps, this attr is not being processed anywhere in the frontend.

companion PR to https://github.com/ilios/ilios/pull/5891

refs https://github.com/ilios/ilios/issues/5890

i'm slapping "DO NOT MERGE" on this, for now.