### PR TITLE
replaces ember-render-modifier and load() function in taxonomy-manager component with chained getters.

### DIFF
--- a/packages/ilios-common/.lint-todo
+++ b/packages/ilios-common/.lint-todo
@@ -25,7 +25,6 @@ add|ember-template-lint|no-at-ember-render-modifiers|3|2|3|2|23cd787c79c34a628da
 add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|60333f2ba463ca3d2ba17a04d799c8d66d8b99e2|1731542400000|1762646400000|1793750400000|addon/components/session-offerings-list.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|3|2|3|2|7ed3e86f759809c1d3f9de3aec39e22bf5f11d30|1731542400000|1762646400000|1793750400000|addon/components/session-overview.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|60333f2ba463ca3d2ba17a04d799c8d66d8b99e2|1731542400000|1762646400000|1793750400000|addon/components/session-overview.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|3|2|3|2|7491f1d2f4e83f2c87fbb4c84f36a84ba901e218|1731542400000|1762646400000|1793750400000|addon/components/taxonomy-manager.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|13|6|13|6|1a2522cd1202904fb09a6e811dec6b46d8189ab3|1731542400000|1762646400000|1793750400000|addon/components/user-name-info.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|8|57|8|57|49de9e74a62c8d39ef6a37eaecf07bd389aa57c7|1731542400000|1762646400000|1793750400000|addon/components/wait-saving.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|7|2|7|2|1a2522cd1202904fb09a6e811dec6b46d8189ab3|1731542400000|1762646400000|1793750400000|addon/components/weekly-calendar-event.hbs

--- a/packages/ilios-common/addon/components/taxonomy-manager.hbs
+++ b/packages/ilios-common/addon/components/taxonomy-manager.hbs
@@ -1,7 +1,7 @@
 <section
   class="taxonomy-manager"
-  {{did-insert this.load @vocabulary}}
   data-test-taxonomy-manager
+  ...attributes
 >
   {{#let (unique-id) as |templateId|}}
     {{#if @selectedTerms}}
@@ -27,7 +27,7 @@
             {{on "change" this.changeSelectedVocabulary}}
           >
             {{#each this.assignableVocabularies as |vocab|}}
-              <option value={{vocab.id}} selected={{if (eq vocab.id this.vocabId) "selected"}}>
+              <option value={{vocab.id}} selected={{if (eq vocab.id this.selectedVocabularyId) "selected"}}>
                 {{vocab.title}} ({{vocab.school.title}})
               </option>
             {{/each}}

--- a/packages/ilios-common/addon/components/taxonomy-manager.js
+++ b/packages/ilios-common/addon/components/taxonomy-manager.js
@@ -13,7 +13,7 @@ export default class TaxonomyManager extends Component {
   @service intl;
   @service flashMessages;
   @tracked termFilter = '';
-  @tracked vocabId = null;
+  @tracked vocabulary = null;
 
   @cached
   get filteredTopLevelTermsData() {
@@ -24,13 +24,6 @@ export default class TaxonomyManager extends Component {
 
   get filteredTopLevelTerms() {
     return this.filteredTopLevelTermsData.isResolved ? this.filteredTopLevelTermsData.value : [];
-  }
-
-  @action
-  load(element, [vocabulary]) {
-    if (vocabulary) {
-      this.vocabId = vocabulary.id;
-    }
   }
 
   async getFilteredTopLevelTermsFromSelectedVocabulary(vocabulary, termFilter) {
@@ -84,20 +77,28 @@ export default class TaxonomyManager extends Component {
   }
 
   get selectedVocabulary() {
-    if (isPresent(this.vocabId)) {
-      const vocab = this.assignableVocabularies.find((v) => {
-        return v.id === this.vocabId;
-      });
-      if (vocab) {
-        return vocab;
-      }
+    if (this.vocabulary) {
+      return this.vocabulary;
     }
-    return this.assignableVocabularies[0];
+    if (this.args.vocabulary) {
+      return this.args.vocabulary;
+    }
+    if (this.assignableVocabularies.length) {
+      return this.assignableVocabularies[0];
+    }
+    return null;
+  }
+
+  get selectedVocabularyId() {
+    return this.selectedVocabulary?.id;
   }
 
   @action
   changeSelectedVocabulary(event) {
-    this.vocabId = event.target.value;
+    const vocabId = event.target.value;
+    this.vocabulary = this.assignableVocabularies.find((v) => {
+      return v.id === vocabId;
+    });
   }
 
   setTermFilter = restartableTask(async (termFilter) => {


### PR DESCRIPTION
refs https://github.com/ilios/ilios/issues/5374

while at it, i changed the property that tracks user selection of the vocabulary from int (vocab id) to object (vocab model instance). this clarifies what's going on in there a bit, at least for me.