### PR TITLE
rm mulesoft-specific workaround from sonarqube config.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,6 @@ jobs:
           # https://community.sonarsource.com/t/xml-file-extension-is-binded-to-multiple-language/41745/4
           args: >
             -Dsonar.projectKey=ilios_frontend_27a24e39-b0ec-405a-91a6-b6392ffcdd30
-            -Dsonar.lang.patterns.mule=-
-            -Dsonar.excludePlugins=mule
 
   upload-coverage:
     name: Upload Coverage


### PR DESCRIPTION
this issue has been resolved sonarqube-side by reconfiguring Mule-specific settings there - the file suffix has been updated from .xml to .mule.

![image](https://github.com/user-attachments/assets/68d01a4a-cf9f-4c64-84c3-2f897e1dbb9b)
