### PR TITLE
Fix New Year Errors

### DIFF
--- a/packages/ilios-common/addon/components/dashboard/week.js
+++ b/packages/ilios-common/addon/components/dashboard/week.js
@@ -1,25 +1,37 @@
 import Component from '@glimmer/component';
 import { DateTime } from 'luxon';
+
 export default class DashboardWeekComponent extends Component {
   get expanded() {
-    const now = DateTime.now();
-    const lastSunday = now.set({ weekday: 1 }).minus({ week: 1 }).toFormat('W');
-    const thisSunday = now.set({ weekday: 1 }).toFormat('W');
-    const nextSunday = now.set({ weekday: 1 }).plus({ week: 1 }).toFormat('W');
+    const lastSunday = this.thisThursday.minus({ week: 1 }).toFormat('W');
+    const thisSunday = this.thisThursday.toFormat('W');
+    const nextSunday = this.thisThursday.plus({ week: 1 }).toFormat('W');
 
     return `${lastSunday}-${thisSunday}-${nextSunday}`;
   }
-  get year() {
-    return DateTime.now().year;
-  }
-  get week() {
-    const today = DateTime.now();
+
+  get thisThursday() {
+    const thursday = DateTime.fromObject({
+      weekday: 4,
+      hour: 0,
+      minute: 0,
+      second: 0,
+    });
+
     // In this component the week always starts on Sunday, but luxon's starts on Monday
-    // so we need to adjust the week number to account for that.
-    if (today.weekday === 7) {
-      return today.weekNumber + 1;
-    } else {
-      return today.weekNumber;
+    // If today is sunday, we need to add a week to get the correct Thursday
+    if (DateTime.now().weekday === 7) {
+      return thursday.plus({ weeks: 1 });
     }
+
+    return thursday;
+  }
+
+  get year() {
+    return this.thisThursday.weekYear;
+  }
+
+  get week() {
+    return this.thisThursday.weekNumber;
   }
 }

--- a/packages/ilios-common/addon/components/week-glance.js
+++ b/packages/ilios-common/addon/components/week-glance.js
@@ -29,21 +29,33 @@ export default class WeeklyGlance extends Component {
   }
 
   get thursdayOfTheWeek() {
-    return DateTime.fromObject({
+    const thursday = DateTime.fromObject({
       weekYear: this.args.year,
       weekNumber: this.args.week,
       weekday: 4,
       hour: 0,
       minute: 0,
       second: 0,
-    }).toJSDate();
+    });
+
+    if (!thursday.isValid) {
+      console.error('Invalid date', thursday.invalidReason, this.args.year, this.args.week);
+      return null;
+    }
+    return thursday.toJSDate();
   }
 
   get midnightAtTheStartOfTheWeekDateTime() {
+    if (!this.thursdayOfTheWeek) {
+      return null;
+    }
     return DateTime.fromJSDate(this.localeDays.firstDayOfDateWeek(this.thursdayOfTheWeek));
   }
 
   get midnightAtTheEndOfTheWeekDateTime() {
+    if (!this.thursdayOfTheWeek) {
+      return null;
+    }
     return DateTime.fromJSDate(this.localeDays.lastDayOfDateWeek(this.thursdayOfTheWeek));
   }
 

--- a/packages/ilios-common/addon/components/weekly-events.js
+++ b/packages/ilios-common/addon/components/weekly-events.js
@@ -4,9 +4,9 @@ import { DateTime } from 'luxon';
 
 export default class WeeklyEvents extends Component {
   get weeksInYear() {
-    const weeksInTheYear = DateTime.now().set({ year: this.args.year }).weeksInWeekYear;
+    const { weeksInWeekYear } = DateTime.fromObject({ year: this.args.year });
     const weeks = [];
-    for (let i = 1; i <= weeksInTheYear; i++) {
+    for (let i = 1; i <= weeksInWeekYear; i++) {
       weeks.push(`${i}`);
     }
     return weeks;

--- a/packages/test-app/tests/integration/components/dashboard/week-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/week-test.js
@@ -34,6 +34,15 @@ module('Integration | Component | dashboard/week', function (hooks) {
 
       return expectedTitle;
     };
+
+    this.setupEmptyEvents = function () {
+      class UserEvents extends Service {
+        async getEvents() {
+          return [];
+        }
+      }
+      this.owner.register('service:user-events', UserEvents);
+    };
   });
 
   hooks.afterEach(() => {
@@ -92,14 +101,7 @@ module('Integration | Component | dashboard/week', function (hooks) {
   });
 
   test('it renders blank', async function (assert) {
-    class UserEvents extends Service {
-      async getEvents() {
-        return [];
-      }
-    }
-    this.owner.register('service:user-events', UserEvents);
-    this.userEvents = this.owner.lookup('service:user-events');
-
+    this.setupEmptyEvents();
     await render(hbs`<Dashboard::Week />`);
     const expectedTitle = this.getTitle();
     assert.strictEqual(component.weeklyLink, 'All Weeks');
@@ -108,13 +110,7 @@ module('Integration | Component | dashboard/week', function (hooks) {
   });
 
   test('right week on sunday #5308', async function (assert) {
-    class UserEvents extends Service {
-      async getEvents() {
-        return [];
-      }
-    }
-    this.owner.register('service:user-events', UserEvents);
-    this.userEvents = this.owner.lookup('service:user-events');
+    this.setupEmptyEvents();
     freezeDateAt(DateTime.fromObject({ year: 2024, month: 3, day: 10 }).toJSDate());
 
     await render(hbs`<Dashboard::Week />`);
@@ -122,13 +118,7 @@ module('Integration | Component | dashboard/week', function (hooks) {
   });
 
   test('right week on monday #5308', async function (assert) {
-    class UserEvents extends Service {
-      async getEvents() {
-        return [];
-      }
-    }
-    this.owner.register('service:user-events', UserEvents);
-    this.userEvents = this.owner.lookup('service:user-events');
+    this.setupEmptyEvents();
     freezeDateAt(DateTime.fromObject({ year: 2023, month: 8, day: 7 }).toJSDate());
 
     await render(hbs`<Dashboard::Week />`);
@@ -136,67 +126,85 @@ module('Integration | Component | dashboard/week', function (hooks) {
   });
 
   test('right week on tuesday #5308', async function (assert) {
-    class UserEvents extends Service {
-      async getEvents() {
-        return [];
-      }
-    }
-    this.owner.register('service:user-events', UserEvents);
-    this.userEvents = this.owner.lookup('service:user-events');
+    this.setupEmptyEvents();
     freezeDateAt(DateTime.fromObject({ year: 2022, month: 12, day: 6 }).toJSDate());
     await render(hbs`<Dashboard::Week />`);
     assert.strictEqual(component.weekGlance.title, 'December 4-10 Week at a Glance');
   });
 
   test('right week on wednesday #5308', async function (assert) {
-    class UserEvents extends Service {
-      async getEvents() {
-        return [];
-      }
-    }
-    this.owner.register('service:user-events', UserEvents);
-    this.userEvents = this.owner.lookup('service:user-events');
+    this.setupEmptyEvents();
     freezeDateAt(DateTime.fromObject({ year: 2022, month: 7, day: 13 }).toJSDate());
     await render(hbs`<Dashboard::Week />`);
     assert.strictEqual(component.weekGlance.title, 'July 10-16 Week at a Glance');
   });
 
   test('right week on thursday #5308', async function (assert) {
-    class UserEvents extends Service {
-      async getEvents() {
-        return [];
-      }
-    }
-    this.owner.register('service:user-events', UserEvents);
-    this.userEvents = this.owner.lookup('service:user-events');
+    this.setupEmptyEvents();
     freezeDateAt(DateTime.fromObject({ year: 2021, month: 5, day: 13 }).toJSDate());
     await render(hbs`<Dashboard::Week />`);
     assert.strictEqual(component.weekGlance.title, 'May 9-15 Week at a Glance');
   });
 
   test('right week on friday #5308', async function (assert) {
-    class UserEvents extends Service {
-      async getEvents() {
-        return [];
-      }
-    }
-    this.owner.register('service:user-events', UserEvents);
-    this.userEvents = this.owner.lookup('service:user-events');
+    this.setupEmptyEvents();
     freezeDateAt(DateTime.fromObject({ year: 2021, month: 9, day: 24 }).toJSDate());
     await render(hbs`<Dashboard::Week />`);
     assert.strictEqual(component.weekGlance.title, 'September 19-25 Week at a Glance');
   });
 
   test('right week on saturday #5308', async function (assert) {
-    class UserEvents extends Service {
-      async getEvents() {
-        return [];
-      }
-    }
-    this.owner.register('service:user-events', UserEvents);
-    this.userEvents = this.owner.lookup('service:user-events');
+    this.setupEmptyEvents();
     freezeDateAt(DateTime.fromObject({ year: 2022, month: 7, day: 30 }).toJSDate());
     await render(hbs`<Dashboard::Week />`);
     assert.strictEqual(component.weekGlance.title, 'July 24-30 Week at a Glance');
+  });
+
+  test('correct at the start of 2024 ilios/ilios#5908', async function (assert) {
+    this.setupEmptyEvents();
+    freezeDateAt(DateTime.fromObject({ year: 2024, month: 1, day: 2 }).toJSDate());
+    await render(hbs`<Dashboard::Week />`);
+
+    assert.strictEqual(component.weekGlance.title, 'December 31 - January 6 Week at a Glance');
+  });
+
+  test('correct at the end of 2024 ilios/ilios#5908', async function (assert) {
+    this.setupEmptyEvents();
+    freezeDateAt(DateTime.fromObject({ year: 2024, month: 12, day: 30 }).toJSDate());
+    await render(hbs`<Dashboard::Week />`);
+
+    assert.strictEqual(component.weekGlance.title, 'December 29 - January 4 Week at a Glance');
+  });
+
+  test('correct at the start of 2025 ilios/ilios#5908', async function (assert) {
+    this.setupEmptyEvents();
+    freezeDateAt(DateTime.fromObject({ year: 2025, month: 1, day: 3 }).toJSDate());
+    await render(hbs`<Dashboard::Week />`);
+
+    assert.strictEqual(component.weekGlance.title, 'December 29 - January 4 Week at a Glance');
+  });
+
+  test('correct at the end of 2025 ilios/ilios#5908', async function (assert) {
+    this.setupEmptyEvents();
+    freezeDateAt(DateTime.fromObject({ year: 2025, month: 12, day: 30 }).toJSDate());
+    await render(hbs`<Dashboard::Week />`);
+
+    assert.strictEqual(component.weekGlance.title, 'December 28 - January 3 Week at a Glance');
+  });
+
+  test('correct at the start of 2026 ilios/ilios#5908', async function (assert) {
+    this.setupEmptyEvents();
+    freezeDateAt(DateTime.fromObject({ year: 2026, month: 1, day: 2 }).toJSDate());
+    await render(hbs`<Dashboard::Week />`);
+
+    assert.strictEqual(component.weekGlance.title, 'December 28 - January 3 Week at a Glance');
+  });
+
+  test('correct on some random day ilios/ilios#5908', async function (assert) {
+    this.setupEmptyEvents();
+    freezeDateAt(DateTime.fromObject({ year: 2005, month: 6, day: 24 }).toJSDate());
+    await render(hbs`<Dashboard::Week />`);
+
+    assert.strictEqual(component.weekGlance.title, 'June 19-25 Week at a Glance');
   });
 });

--- a/packages/test-app/tests/integration/components/dashboard/week-test.js
+++ b/packages/test-app/tests/integration/components/dashboard/week-test.js
@@ -178,7 +178,7 @@ module('Integration | Component | dashboard/week', function (hooks) {
     );
   });
 
-  test('correct at the end of 2023 and the start of 2024 ilios/ilios#5908', async function (assert) {
+  test('correct at the end of 2023 and the start of 2024', async function (assert) {
     assert.expect(7);
     this.setupEvents([]);
     const title = 'December 31 - January 6 Week at a Glance';
@@ -191,7 +191,7 @@ module('Integration | Component | dashboard/week', function (hooks) {
     await this.testTitleOnDate(assert, { year: 2024, month: 1, day: 6 }, title);
   });
 
-  test('correct at the end of 2024 and start of 2025 ilios/ilios#5908', async function (assert) {
+  test('correct at the end of 2024 and start of 2025', async function (assert) {
     assert.expect(7);
     this.setupEvents([]);
     const title = 'December 29 - January 4 Week at a Glance';
@@ -204,7 +204,7 @@ module('Integration | Component | dashboard/week', function (hooks) {
     await this.testTitleOnDate(assert, { year: 2025, month: 1, day: 4 }, title);
   });
 
-  test('correct at the end of 2025 and start of 2026 ilios/ilios#5908', async function (assert) {
+  test('correct at the end of 2025 and start of 2026', async function (assert) {
     assert.expect(7);
     this.setupEvents([]);
     const title = 'December 28 - January 3 Week at a Glance';
@@ -217,7 +217,7 @@ module('Integration | Component | dashboard/week', function (hooks) {
     await this.testTitleOnDate(assert, { year: 2026, month: 1, day: 3 }, title);
   });
 
-  test('correct on some random day ilios/ilios#5908', async function (assert) {
+  test('correct on some random day', async function (assert) {
     assert.expect(1);
     this.setupEvents([]);
     await this.testTitleOnDate(

--- a/packages/test-app/tests/integration/components/weekly-events-test.js
+++ b/packages/test-app/tests/integration/components/weekly-events-test.js
@@ -114,4 +114,50 @@ module('Integration | Component | weekly events', function (hooks) {
     assert.strictEqual(component.topNavigation.title, '2016');
     assert.strictEqual(component.bottomNavigation.title, '2016');
   });
+
+  test('it renders 2024 ilios/ilios#5908', async function (assert) {
+    await render(
+      hbs`<WeeklyEvents
+  @year={{2024}}
+  @expandedWeeks={{(array)}}
+  @setYear={{(noop)}}
+  @toggleOpenWeek={{(noop)}}
+/>`,
+    );
+    assert.strictEqual(component.topNavigation.title, '2024');
+    assert.strictEqual(component.weeks.length, 52);
+    assert.strictEqual(component.weeks[0].title, 'December 31 - January 6');
+    assert.strictEqual(component.weeks[51].title, 'December 22-28');
+  });
+
+  test('it renders 2025 ilios/ilios#5908', async function (assert) {
+    await render(
+      hbs`<WeeklyEvents
+  @year={{2025}}
+  @expandedWeeks={{(array)}}
+  @setYear={{(noop)}}
+  @toggleOpenWeek={{(noop)}}
+/>`,
+    );
+    assert.strictEqual(component.topNavigation.title, '2025');
+    assert.strictEqual(component.weeks.length, 52);
+    assert.strictEqual(component.weeks[0].title, 'December 29 - January 4');
+    assert.strictEqual(component.weeks[51].title, 'December 21-27');
+  });
+
+  test('it renders 2026 ilios/ilios#5908', async function (assert) {
+    assert.expect(4);
+    await render(
+      hbs`<WeeklyEvents
+  @year={{2026}}
+  @expandedWeeks={{(array)}}
+  @setYear={{(noop)}}
+  @toggleOpenWeek={{(noop)}}
+/>`,
+    );
+    assert.strictEqual(component.topNavigation.title, '2026');
+    assert.strictEqual(component.weeks.length, 53);
+    assert.strictEqual(component.weeks[0].title, 'December 28 - January 3');
+    assert.strictEqual(component.weeks[52].title, 'December 27 - January 2');
+  });
 });


### PR DESCRIPTION
Discovered several interconnected issues around the end of 2024 and the start of 2025. The most serious of these was that opening week at a glance all weeks for 2025 blew up as we were asking for 53 weeks in a 52 week year. This fixes ilios/ilios#5908.

I also discovered that the wrong title was appearing at the top of the dashboard week view during this time period as well.