### PR TITLE
break style declarations for heading-title and button-title apart.

### DIFF
--- a/packages/ilios-common/addon/components/week-glance.hbs
+++ b/packages/ilios-common/addon/components/week-glance.hbs
@@ -6,7 +6,7 @@
   {{#if @collapsible}}
     <button
       type="button"
-      class="title collapsible"
+      class="collapsible-title"
       aria-expanded={{if @collapsed "false" "true"}}
       data-test-week-title
       {{on "click" (fn (optional @toggleCollapsed) @collapsed)}}

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -6,11 +6,12 @@
   .title {
     @include m.ilios-heading-h3;
     margin-bottom: 1em;
+  }
 
-    &.collapsible {
-      @include m.ilios-button-reset;
-      @include m.font-size("xl");
-    }
+  .collapsible-title {
+    @include m.ilios-button-reset;
+    @include m.font-size("xl");
+    margin-bottom: 1em;
   }
 
   .event {


### PR DESCRIPTION
the SCSS compiler in prod evidently works differently than in non-prod, so we've been getting different CSS output here.
this makes things consistent again in both types of envs.

fixes https://github.com/ilios/ilios/issues/5912