### PR TITLE
Removes dependency on ember-cli-clean-css.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,6 @@ updates:
       - dependency-name: ember-cli
       - dependency-name: ember-cli-app-version
       - dependency-name: ember-cli-babel
-      - dependency-name: ember-cli-clean-css
       - dependency-name: ember-cli-dependency-checker
       - dependency-name: ember-cli-htmlbars
       - dependency-name: ember-cli-inject-live-reload

--- a/packages/frontend/ember-cli-build.js
+++ b/packages/frontend/ember-cli-build.js
@@ -57,9 +57,6 @@ module.exports = async function (defaults) {
     'ember-simple-auth': {
       useSessionSetupMethod: true, //can be removed in ESA v5.x
     },
-    minifyCSS: {
-      enabled: false,
-    },
     sassOptions: {
       silenceDeprecations: ['mixed-decls'],
     },

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -66,7 +66,6 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-browserstack": "^3.0.0",
     "ember-cli-bundle-analyzer": "^1.0.0",
-    "ember-cli-clean-css": "^3.0.0",
     "ember-cli-code-coverage": "^3.0.1",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-dependency-lint": "2.0.1",

--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -115,7 +115,6 @@
     "@warp-drive/build-config": "0.0.0-beta.7",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~5.11.0",
-    "ember-cli-clean-css": "^3.0.0",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "11.0.1",

--- a/packages/lti-course-manager/package.json
+++ b/packages/lti-course-manager/package.json
@@ -56,7 +56,6 @@
     "ember-cli-app-version": "^6.0.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-browserstack": "^3.0.0",
-    "ember-cli-clean-css": "^3.0.0",
     "ember-cli-code-coverage": "^3.0.1",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-dependency-lint": "2.0.1",

--- a/packages/lti-dashboard/package.json
+++ b/packages/lti-dashboard/package.json
@@ -56,7 +56,6 @@
     "ember-cli-app-version": "^6.0.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-browserstack": "^3.0.0",
-    "ember-cli-clean-css": "^3.0.0",
     "ember-cli-code-coverage": "^3.0.1",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-dependency-lint": "2.0.1",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -50,7 +50,6 @@
     "ember-cli-app-version": "^6.0.1",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-browserstack": "^3.0.0",
-    "ember-cli-clean-css": "^3.0.0",
     "ember-cli-code-coverage": "^3.0.1",
     "ember-cli-dependency-checker": "^3.3.2",
     "ember-cli-htmlbars": "^6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,9 +141,6 @@ importers:
       ember-cli-bundle-analyzer:
         specifier: ^1.0.0
         version: 1.0.0
-      ember-cli-clean-css:
-        specifier: ^3.0.0
-        version: 3.0.0
       ember-cli-code-coverage:
         specifier: ^3.0.1
         version: 3.1.0(@embroider/compat@3.7.1(@embroider/core@3.4.20))(@embroider/core@3.4.20)
@@ -571,9 +568,6 @@ importers:
       ember-cli:
         specifier: ~5.11.0
         version: 5.11.0(babel-core@6.26.3)(ejs@3.1.10)(handlebars@4.7.8)(underscore@1.13.7)
-      ember-cli-clean-css:
-        specifier: ^3.0.0
-        version: 3.0.0
       ember-cli-dependency-checker:
         specifier: ^3.3.2
         version: 3.3.3(ember-cli@5.11.0(babel-core@6.26.3)(ejs@3.1.10)(handlebars@4.7.8)(underscore@1.13.7))
@@ -755,9 +749,6 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@babel/core@7.26.0)
       ember-cli-browserstack:
-        specifier: ^3.0.0
-        version: 3.0.0
-      ember-cli-clean-css:
         specifier: ^3.0.0
         version: 3.0.0
       ember-cli-code-coverage:
@@ -991,9 +982,6 @@ importers:
       ember-cli-browserstack:
         specifier: ^3.0.0
         version: 3.0.0
-      ember-cli-clean-css:
-        specifier: ^3.0.0
-        version: 3.0.0
       ember-cli-code-coverage:
         specifier: ^3.0.1
         version: 3.1.0(@embroider/compat@3.7.1(@embroider/core@3.4.20))(@embroider/core@3.4.20)
@@ -1214,9 +1202,6 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@babel/core@7.26.0)
       ember-cli-browserstack:
-        specifier: ^3.0.0
-        version: 3.0.0
-      ember-cli-clean-css:
         specifier: ^3.0.0
         version: 3.0.0
       ember-cli-code-coverage:
@@ -4223,10 +4208,6 @@ packages:
   clean-base-url@1.0.0:
     resolution: {integrity: sha512-9q6ZvUAhbKOSRFY7A/irCQ/rF0KIpa3uXpx6izm8+fp7b2H4hLeUJ+F1YYk9+gDQ/X8Q0MEyYs+tG3cht//HTg==}
 
-  clean-css@5.3.3:
-    resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
-    engines: {node: '>= 10.0'}
-
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
@@ -5112,10 +5093,6 @@ packages:
 
   ember-cli-bundle-analyzer@1.0.0:
     resolution: {integrity: sha512-c35N8XIdg+5zS+Mxj3lSihuqsQQa8kLpoUXJts8TqMR+owHidClzVKOX7dy5rJGlQdM6qcbpSh5kQfKBaCu2DQ==}
-    engines: {node: 16.* || >= 18}
-
-  ember-cli-clean-css@3.0.0:
-    resolution: {integrity: sha512-BbveJCyRvzzkaTH1llLW+MpHe/yzA5zpHOpMIg2vp/3JD9mban9zUm7lphaB0TSpPuMuby9rAhTI8pgXq0ifIA==}
     engines: {node: 16.* || >= 18}
 
   ember-cli-code-coverage@3.1.0:
@@ -14655,10 +14632,6 @@ snapshots:
 
   clean-base-url@1.0.0: {}
 
-  clean-css@5.3.3:
-    dependencies:
-      source-map: 0.6.1
-
   clean-stack@2.2.0: {}
 
   clean-up-path@1.0.0: {}
@@ -15576,14 +15549,6 @@ snapshots:
       intercept-stdout: 0.1.2
       node-html-light: 1.4.0
       source-map-explorer: 2.5.3
-    transitivePeerDependencies:
-      - supports-color
-
-  ember-cli-clean-css@3.0.0:
-    dependencies:
-      broccoli-persistent-filter: 3.1.3
-      clean-css: 5.3.3
-      json-stable-stringify: 1.2.1
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
from this plugin's [README](https://github.com/ember-cli/ember-cli-clean-css?tab=readme-ov-file):

> Note
>
> This addon is not needed and is NOT used when [embroider](https://github.com/embroider-build/embroider) is enabled.

we're building with embroider in frontend, so let's remove this dependency.

refs https://github.com/ilios/ilios/issues/5912