### PR TITLE
Remove Unused Config

### DIFF
--- a/packages/frontend/config/environment.js
+++ b/packages/frontend/config/environment.js
@@ -13,12 +13,6 @@ module.exports = function (environment) {
       types: ['success', 'warning', 'info', 'alert'],
       injectionFactories: [],
     },
-    'ember-simple-auth-token': {
-      serverTokenEndpoint: '/auth/login',
-      tokenPropertyName: 'jwt',
-      refreshAccessTokens: false,
-      authorizationPrefix: 'Token ',
-    },
     i18n: {
       defaultLocale: 'en',
     },

--- a/packages/lti-course-manager/config/environment.js
+++ b/packages/lti-course-manager/config/environment.js
@@ -10,14 +10,6 @@ module.exports = function (environment) {
       authorizer: 'authorizer:token',
       authenticationRoute: 'login-error',
     },
-    'ember-simple-auth-token': {
-      serverTokenEndpoint: '/auth/login',
-      serverTokenRefreshEndpoint: '/auth/token',
-      tokenPropertyName: 'jwt',
-      authorizationHeaderName: 'X-JWT-Authorization',
-      authorizationPrefix: 'Token ',
-      refreshLeeway: 300,
-    },
     i18n: {
       defaultLocale: 'en',
     },

--- a/packages/lti-dashboard/config/environment.js
+++ b/packages/lti-dashboard/config/environment.js
@@ -10,14 +10,6 @@ module.exports = function (environment) {
       authorizer: 'authorizer:token',
       authenticationRoute: 'login-error',
     },
-    'ember-simple-auth-token': {
-      serverTokenEndpoint: '/auth/login',
-      serverTokenRefreshEndpoint: '/auth/token',
-      tokenPropertyName: 'jwt',
-      authorizationHeaderName: 'X-JWT-Authorization',
-      authorizationPrefix: 'Token ',
-      refreshLeeway: 300,
-    },
     'ember-local-storage': {
       namespace: true,
       keyDelimiter: '/',


### PR DESCRIPTION
We dropped this library in favor of rolling our own auth in ilios-jwt.js which is configured in code [2e8feed] and not through the environment.