### PR TITLE
Configure Our Session Cookie Better

### DIFF
--- a/packages/frontend/app/session-stores/application.js
+++ b/packages/frontend/app/session-stores/application.js
@@ -2,4 +2,5 @@ import Cookie from 'ember-simple-auth/session-stores/cookie';
 
 export default class ApplicationSessionStore extends Cookie {
   cookieName = 'ilios-session';
+  sameSite = 'Strict';
 }


### PR DESCRIPTION
This `ilios-session` cookie is used to store internal frontend authentication data. We don't use it to authenticate against the backend, we pass the `X-JWT-Authorization` header for that. As it's only ever used on the frontend, where it is generated, we should be able to restrict it to that domain (Strict). This has the added benefit of reducing our payload on each request as we're no longer sending our JWT twice.

**Change is trivial, but please check my logic on this one.**

We can also set this to `Lax` and restore our current default. Either way it will remove the annoying cookie warnings from the browser.

For reference: https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Cookies#samesite