### PR TITLE
Remove @ember/edition-utils dependency

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -36,7 +36,6 @@
     "@ember-data/serializer": "5.3.9",
     "@ember-data/store": "5.3.9",
     "@ember-data/tracking": "5.3.9",
-    "@ember/edition-utils": "^1.2.0",
     "@ember/optional-features": "^2.1.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.1",

--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -107,7 +107,6 @@
     "@ember-data/serializer": "5.3.9",
     "@ember-data/store": "5.3.9",
     "@ember-data/tracking": "5.3.9",
-    "@ember/edition-utils": "^1.1.1",
     "@ember/optional-features": "^2.1.0",
     "@ember/test-helpers": "^4.0.4",
     "@embroider/test-setup": "^4.0.0",

--- a/packages/lti-course-manager/package.json
+++ b/packages/lti-course-manager/package.json
@@ -34,7 +34,6 @@
     "@ember-data/serializer": "5.3.9",
     "@ember-data/store": "5.3.9",
     "@ember-data/tracking": "5.3.9",
-    "@ember/edition-utils": "^1.2.0",
     "@ember/optional-features": "^2.1.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^4.0.4",

--- a/packages/lti-dashboard/package.json
+++ b/packages/lti-dashboard/package.json
@@ -35,7 +35,6 @@
     "@ember-data/serializer": "5.3.9",
     "@ember-data/store": "5.3.9",
     "@ember-data/tracking": "5.3.9",
-    "@ember/edition-utils": "^1.2.0",
     "@ember/optional-features": "^2.1.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ importers:
       '@ember-data/tracking':
         specifier: 5.3.9
         version: 5.3.9(@warp-drive/core-types@0.0.0-beta.12)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(rsvp@4.8.5)(webpack@5.97.1))
-      '@ember/edition-utils':
-        specifier: ^1.2.0
-        version: 1.2.0
       '@ember/optional-features':
         specifier: ^2.1.0
         version: 2.2.0
@@ -547,9 +544,6 @@ importers:
       '@ember-data/tracking':
         specifier: 5.3.9
         version: 5.3.9(@warp-drive/core-types@0.0.0-beta.12)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(rsvp@4.8.5)(webpack@5.97.1))
-      '@ember/edition-utils':
-        specifier: ^1.1.1
-        version: 1.2.0
       '@ember/optional-features':
         specifier: ^2.1.0
         version: 2.2.0
@@ -688,9 +682,6 @@ importers:
       '@ember-data/tracking':
         specifier: 5.3.9
         version: 5.3.9(@warp-drive/core-types@0.0.0-beta.12)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(rsvp@4.8.5)(webpack@5.97.1))
-      '@ember/edition-utils':
-        specifier: ^1.2.0
-        version: 1.2.0
       '@ember/optional-features':
         specifier: ^2.1.0
         version: 2.2.0
@@ -922,9 +913,6 @@ importers:
       '@ember-data/tracking':
         specifier: 5.3.9
         version: 5.3.9(@warp-drive/core-types@0.0.0-beta.12)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(rsvp@4.8.5)(webpack@5.97.1))
-      '@ember/edition-utils':
-        specifier: ^1.2.0
-        version: 1.2.0
       '@ember/optional-features':
         specifier: ^2.1.0
         version: 2.2.0


### PR DESCRIPTION
This dependency is included, but seems to not be used, and hasn't had an update in years. Let's remove it.