### PR TITLE
corrects prefix for brand icons to get the Black Tie icon back on screen.

### DIFF
--- a/packages/ilios-common/addon/components/single-event.hbs
+++ b/packages/ilios-common/addon/components/single-event.hbs
@@ -86,7 +86,7 @@
           {{{t "general.specialAttireIs_Required_"}}}
           <FaIcon
             @icon="black-tie"
-            @prefix="fab"
+            @prefix="brands"
             @title={{t "general.whitecoatsSlashSpecialAttire"}}
           />
         </div>

--- a/packages/ilios-common/addon/components/week-glance-event.hbs
+++ b/packages/ilios-common/addon/components/week-glance-event.hbs
@@ -36,7 +36,7 @@
       {{#if @event.attireRequired}}
         <FaIcon
           @icon="black-tie"
-          @prefix="fab"
+          @prefix="brands"
           @ariaHidden={{false}}
           @title={{t "general.whitecoatsSlashSpecialAttire"}}
         />


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/5944