### PR TITLE
replaces ember-feature-flag package with Ember-native equivalent.

### DIFF
--- a/packages/frontend/app/components/program-year/overview.hbs
+++ b/packages/frontend/app/components/program-year/overview.hbs
@@ -4,7 +4,7 @@
       {{t "general.overview"}}
     </h5>
     <div class="programyear-overview-actions" data-test-actions>
-      {{#if (feature-flag "programYearVisualizations")}}
+      {{#if this.showVisualizations}}
         <LinkTo
           @route="program-year-visualize-objectives"
           @model={{@programYear}}

--- a/packages/frontend/app/components/program-year/overview.js
+++ b/packages/frontend/app/components/program-year/overview.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+import { getOwner } from '@ember/owner';
+
+export default class ProgramYearOverviewComponent extends Component {
+  get showVisualizations() {
+    const config = getOwner(this)?.resolveRegistration('config:environment');
+    return !!config?.featureFlags?.programYearVisualizations;
+  }
+}

--- a/packages/frontend/tests/integration/components/program-year/overview-test.js
+++ b/packages/frontend/tests/integration/components/program-year/overview-test.js
@@ -5,7 +5,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupMirage } from 'frontend/tests/test-support/mirage';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { component } from 'frontend/tests/pages/components/program-year/overview';
-import { enableFeature } from 'ember-feature-flags/test-support';
+import { getOwner } from '@ember/owner';
 
 module('Integration | Component | program-year/overview', function (hooks) {
   setupRenderingTest(hooks);
@@ -26,13 +26,14 @@ module('Integration | Component | program-year/overview', function (hooks) {
   });
 
   test('visualizations button present', async function (assert) {
+    const config = getOwner(this)?.resolveRegistration('config:environment');
+    config.featureFlags.programYearVisualizations = true;
     const program = this.server.create('program');
     const programYear = this.server.create('program-year', { program });
     const programYearModel = await this.owner
       .lookup('service:store')
       .findRecord('program-year', programYear.id);
     this.set('program', programYearModel);
-    enableFeature('programYearVisualizations');
     await render(hbs`<ProgramYear::Overview @programYear={{this.programYear}} />`);
     assert.ok(component.actions.visualizations.isPresent);
   });

--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -41,7 +41,6 @@
     "ember-click-outside": "^6.0.0",
     "ember-concurrency": "^4.0.2",
     "ember-event-helpers": "^0.1.0",
-    "ember-feature-flags": "^6.0.0",
     "ember-file-upload": "^9.0.0",
     "ember-focus-trap": "^1.0.0",
     "ember-in-element-polyfill": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,9 +420,6 @@ importers:
       ember-event-helpers:
         specifier: ^0.1.0
         version: 0.1.1
-      ember-feature-flags:
-        specifier: ^6.0.0
-        version: 6.0.0
       ember-file-upload:
         specifier: ^9.0.0
         version: 9.1.0(@ember/test-helpers@4.0.4(@babel/core@7.26.0)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(rsvp@4.8.5)(webpack@5.97.1)))(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glimmer/tracking@1.1.2)(ember-modifier@4.2.0(@babel/core@7.26.0)(ember-source@5.11.1(@glimmer/component@1.1.2(@babel/core@7.26.0))(rsvp@4.8.5)(webpack@5.97.1)))(miragejs@0.1.48)(tracked-built-ins@3.4.0(@babel/core@7.26.0))(webpack@5.97.1)
@@ -5362,10 +5359,6 @@ packages:
       ember-qunit: '*'
       ember-source: '>= 4.0.0'
       qunit: '*'
-
-  ember-feature-flags@6.0.0:
-    resolution: {integrity: sha512-CcKpQ0NI/AMkYcP/4obqfDrzFlLqFngabFUfmAlQNnCic5cz51nlLY9MzYRtbop0+1iyegM4XHJFE4Awlji/1g==}
-    engines: {node: 8.* || >= 10.*}
 
   ember-fetch@8.1.2:
     resolution: {integrity: sha512-TVx24/jrvDIuPL296DV0hBwp7BWLcSMf0I8464KGz01sPytAB+ZAePbc9ooBTJDkKZEGFgatJa4nj3yF1S9Bpw==}
@@ -16252,12 +16245,6 @@ snapshots:
       - '@glint/template'
       - supports-color
       - webpack
-
-  ember-feature-flags@6.0.0:
-    dependencies:
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
 
   ember-fetch@8.1.2:
     dependencies:


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/5928

for reference, please see https://github.com/mansona/ember-get-config?tab=readme-ov-file#ember-get-config as an example for the recommended approach to read from the application config.

