### PR TITLE
Removed 'MeSH Term' as object option when 'Term' is selected as subject

### DIFF
--- a/packages/frontend/app/components/reports/new-subject.js
+++ b/packages/frontend/app/components/reports/new-subject.js
@@ -153,7 +153,7 @@ export default class ReportsNewSubjectComponent extends Component {
     {
       value: 'mesh term',
       label: this.intl.t('general.meshTerm'),
-      subjects: ['course', 'session', 'learning material', 'session type', 'term'],
+      subjects: ['course', 'session', 'learning material', 'session type'],
     },
     {
       value: 'session type',

--- a/packages/frontend/tests/integration/components/reports/new-subject-test.js
+++ b/packages/frontend/tests/integration/components/reports/new-subject-test.js
@@ -227,14 +227,13 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing term selects correct objects', function (assert) {
-    assert.expect(11);
+    assert.expect(10);
     return checkObjects(this, assert, 9, 'term', [
       'academic year',
       'competency',
       'course',
       'instructor',
       'learning material',
-      'mesh term',
       'program',
       'program year',
       'session',


### PR DESCRIPTION
Fixes ilios/ilios#4546