### PR TITLE
Correct Rollover Year Options

### DIFF
--- a/packages/ilios-common/addon/components/course/rollover.js
+++ b/packages/ilios-common/addon/components/course/rollover.js
@@ -26,10 +26,15 @@ export default class CourseRolloverComponent extends Component {
 
   constructor() {
     super(...arguments);
-    const currentYear = DateTime.now().year;
+    let { month, year } = DateTime.now();
+    year--; // start with the previous year
+    if (month < 7) {
+      // before July 1st (start of a new academic year) show the year before
+      year--;
+    }
     this.years = [];
     for (let i = 0; i < 6; i++) {
-      this.years.push(currentYear + i);
+      this.years.push(year + i);
     }
   }
 


### PR DESCRIPTION
Courses can always be rolled over into the previous, current, and several future years.

The academic year doesn't map to the calendar year, so we always need to ensure we're starting at the right place otherwise the current year will disappear in January.

From January through the end of June we need to back up even further because the previous academic year is now two years behind the current calendar year.

Fixes ilios/ilios#5963