### PR TITLE
Attempt to make all top/left/right margin/padding consistent (eek)

### DIFF
--- a/packages/frontend/app/components/curriculum-inventory/new-sequence-block.hbs
+++ b/packages/frontend/app/components/curriculum-inventory/new-sequence-block.hbs
@@ -3,7 +3,7 @@
   data-test-curriculum-inventory-new-sequence-block
   ...attributes
 >
-  <h2 class="title" data-test-title>
+  <h2 class="new-sequence-block-title" data-test-title>
     {{t "general.newSequenceBlock"}}
   </h2>
   {{#let (unique-id) as |templateId|}}

--- a/packages/frontend/app/components/new-user.hbs
+++ b/packages/frontend/app/components/new-user.hbs
@@ -1,8 +1,8 @@
 {{#let (unique-id) as |templateId|}}
   <div class="new-user" data-test-new-user ...attributes>
-    <h3>
+    <h4 class="title">
       {{t "general.newUser"}}
-    </h3>
+    </h4>
     <div class="new-user-form">
       <div class="choose-form-type" data-test-user-type>
         <label>

--- a/packages/frontend/app/styles/components/assign-students/manager.scss
+++ b/packages/frontend/app/styles/components/assign-students/manager.scss
@@ -19,7 +19,7 @@
     align-items: baseline;
     display: flex;
     flex-direction: column;
-    padding: 0.5rem;
+    padding: 0.5rem 0;
 
     @include m.for-laptop-and-up {
       flex-direction: row;
@@ -27,7 +27,7 @@
 
     label {
       @include m.ilios-label;
-      margin: 0 0.5rem;
+      margin: 0 0.5rem 0 0;
     }
 
     .done {

--- a/packages/frontend/app/styles/components/bulk-new-users.scss
+++ b/packages/frontend/app/styles/components/bulk-new-users.scss
@@ -2,10 +2,10 @@
 @use "../ilios-common/mixins" as m;
 
 .bulk-new-users {
-  padding: 1rem;
+  padding: 1rem 0;
 
   h3 {
-    margin: 0.5rem;
+    margin: 0.5rem 0;
   }
 
   .new-user-form {

--- a/packages/frontend/app/styles/components/courses/new.scss
+++ b/packages/frontend/app/styles/components/courses/new.scss
@@ -2,6 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .courses-new {
+  background-color: c.$slightWhite;
   border: 1px solid c.$culturedGrey;
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/courses/new.scss
+++ b/packages/frontend/app/styles/components/courses/new.scss
@@ -3,7 +3,7 @@
 
 .courses-new {
   border: 1px solid c.$culturedGrey;
-  margin: 0.5rem;
+  margin: 0.5rem 0;
   padding: 1rem;
 
   h4 {

--- a/packages/frontend/app/styles/components/courses/root.scss
+++ b/packages/frontend/app/styles/components/courses/root.scss
@@ -12,6 +12,10 @@
     .titlefilter {
       @include m.main-list-filter;
     }
+
+    & > :last-child {
+      padding-right: 0;
+    }
   }
 
   .new .saved-result {

--- a/packages/frontend/app/styles/components/curriculum-inventory/new-report.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/new-report.scss
@@ -2,6 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .curriculum-inventory-new-report {
+  background-color: c.$slightWhite;
   border: 1px solid c.$culturedGrey;
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/curriculum-inventory/new-report.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/new-report.scss
@@ -3,7 +3,7 @@
 
 .curriculum-inventory-new-report {
   border: 1px solid c.$culturedGrey;
-  margin: 0.5rem;
+  margin: 0.5rem 0;
   padding: 1rem;
 
   h4 {

--- a/packages/frontend/app/styles/components/curriculum-inventory/new-sequence-block.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/new-sequence-block.scss
@@ -2,9 +2,15 @@
 @use "../../ilios-common/mixins" as m;
 
 .curriculum-inventory-new-sequence-block {
+  background-color: c.$slightWhite;
   border: 1px solid c.$culturedGrey;
-  margin: 0.5rem;
+  margin: 0.5rem 0;
   padding: 1rem;
+
+  .new-sequence-block-title {
+    @include m.ilios-heading-h4;
+    margin-bottom: 1rem;
+  }
 
   .form {
     @include m.ilios-form;

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
@@ -3,7 +3,7 @@
 
 .curriculum-inventory-report-details {
   @include m.detail-container(c.$orange);
-  margin: 0 0.8rem;
+  margin: 0 0.5rem;
 
   .title {
     @include m.detail-container-title;

--- a/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-header.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-header.scss
@@ -24,4 +24,8 @@
       width: 90%;
     }
   }
+
+  & + .breadcrumbs {
+    margin-left: 0.5rem;
+  }
 }

--- a/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-overview.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-overview.scss
@@ -4,7 +4,7 @@
 .curriculum-inventory-sequence-block-overview {
   .curriculum-inventory-sequence-block-overview-wrapper {
     @include m.ilios-overview(c.$orange);
-    padding: 0.8rem;
+    padding: 0.5rem;
 
     .block {
       @include m.ilios-overview-block;

--- a/packages/frontend/app/styles/components/instructor-group/courses.scss
+++ b/packages/frontend/app/styles/components/instructor-group/courses.scss
@@ -3,7 +3,6 @@
 
 .instructor-group-courses {
   @include m.detail-container(c.$orange);
-  margin-left: 0.8rem;
 
   .instructor-group-courses-header {
     @include m.detail-container-header;

--- a/packages/frontend/app/styles/components/instructor-group/header.scss
+++ b/packages/frontend/app/styles/components/instructor-group/header.scss
@@ -10,7 +10,7 @@
     justify-content: space-between;
     padding: calc(constants.$golden-ratio-large * 1rem) 0
       calc(constants.$golden-ratio-small * 1rem) 0;
-    margin: 0 0.8rem;
+    margin: 0 0 0.8rem 0;
 
     @include m.for-tablet-and-up {
       flex-direction: row;
@@ -34,5 +34,9 @@
     .info {
       @include m.text-align-bottom;
     }
+  }
+
+  .breadcrumbs {
+    margin: 0 0 0.8rem;
   }
 }

--- a/packages/frontend/app/styles/components/instructor-group/root.scss
+++ b/packages/frontend/app/styles/components/instructor-group/root.scss
@@ -1,7 +1,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .instructor-group-root {
-  padding: 0.5rem 0.25rem;
+  padding: 0.5rem;
 
   .backtolink {
     margin: 0.5rem;

--- a/packages/frontend/app/styles/components/instructor-group/users.scss
+++ b/packages/frontend/app/styles/components/instructor-group/users.scss
@@ -3,7 +3,6 @@
 
 .instructor-group-users {
   @include m.detail-container(c.$orange);
-  margin-left: 0.8rem;
 
   .instructor-group-users-header {
     @include m.detail-container-header;

--- a/packages/frontend/app/styles/components/instructor-groups/new.scss
+++ b/packages/frontend/app/styles/components/instructor-groups/new.scss
@@ -3,7 +3,7 @@
 
 .new-instructor-group {
   border: 1px solid c.$culturedGrey;
-  margin: 0.5rem;
+  margin: 0.5rem 0;
   padding: 1rem;
 
   h4 {

--- a/packages/frontend/app/styles/components/instructor-groups/new.scss
+++ b/packages/frontend/app/styles/components/instructor-groups/new.scss
@@ -2,6 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-instructor-group {
+  background-color: c.$slightWhite;
   border: 1px solid c.$culturedGrey;
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/instructor-groups/root.scss
+++ b/packages/frontend/app/styles/components/instructor-groups/root.scss
@@ -9,6 +9,10 @@
     .schools,
     .title {
       @include m.main-list-filter;
+
+      &:last-child {
+        padding-right: 0;
+      }
     }
   }
 

--- a/packages/frontend/app/styles/components/learner-group/cohort-user-manager.scss
+++ b/packages/frontend/app/styles/components/learner-group/cohort-user-manager.scss
@@ -5,6 +5,7 @@
   @include m.detail-container(c.$tealBlue);
   border-bottom: 0;
   border-top: 1px dotted c.$orange;
+  padding-left: 0;
 
   .learner-group-cohort-user-manager-header {
     @include m.detail-container-header;

--- a/packages/frontend/app/styles/components/learner-group/header.scss
+++ b/packages/frontend/app/styles/components/learner-group/header.scss
@@ -10,7 +10,7 @@
     justify-content: space-between;
     padding: calc(constants.$golden-ratio-large * 1rem) 0
       calc(constants.$golden-ratio-small * 1rem) 0;
-    margin: 0 0.8rem;
+    margin: 0 0 0.8rem 0;
 
     @include m.for-tablet-and-up {
       flex-direction: row;
@@ -34,5 +34,9 @@
     .info {
       @include m.text-align-bottom;
     }
+  }
+
+  .breadcrumbs {
+    margin: 0 0 0.8rem;
   }
 }

--- a/packages/frontend/app/styles/components/learner-group/instructors-list.scss
+++ b/packages/frontend/app/styles/components/learner-group/instructors-list.scss
@@ -4,6 +4,7 @@
 .learner-group-instructors-list {
   @include m.detail-container(c.$orange);
   border-top: 1px dotted c.$orange;
+  padding-left: 0;
 
   .detail-header {
     @include m.detail-container-header;

--- a/packages/frontend/app/styles/components/learner-group/members.scss
+++ b/packages/frontend/app/styles/components/learner-group/members.scss
@@ -6,6 +6,7 @@
   border-bottom: 0;
   display: grid;
   grid-template-columns: 3fr 1fr;
+  padding-left: 0;
 
   .title {
     @include m.detail-container-title-style;

--- a/packages/frontend/app/styles/components/learner-group/new.scss
+++ b/packages/frontend/app/styles/components/learner-group/new.scss
@@ -3,7 +3,7 @@
 
 .new-learner-group {
   border: 1px solid c.$culturedGrey;
-  margin: 0.5rem;
+  margin: 0.5rem 0;
   padding: 1rem;
 
   h4 {

--- a/packages/frontend/app/styles/components/learner-group/new.scss
+++ b/packages/frontend/app/styles/components/learner-group/new.scss
@@ -2,6 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-learner-group {
+  background-color: c.$slightWhite;
   border: 1px solid c.$culturedGrey;
   margin: 0.5rem 0;
   padding: 1rem;
@@ -13,7 +14,6 @@
   .multi-mode-chooser {
     align-items: baseline;
     display: flex;
-    margin-left: 0.5rem;
 
     label {
       @include m.ilios-label;

--- a/packages/frontend/app/styles/components/learner-group/root.scss
+++ b/packages/frontend/app/styles/components/learner-group/root.scss
@@ -8,7 +8,6 @@
 
   .learner-group-overview {
     @include m.ilios-overview(c.$orange);
-    margin-left: 0.8rem;
 
     .block {
       @include m.ilios-overview-block;

--- a/packages/frontend/app/styles/components/learner-groups/root.scss
+++ b/packages/frontend/app/styles/components/learner-groups/root.scss
@@ -11,6 +11,10 @@
 
     .filter {
       @include m.main-list-filter;
+
+      &:last-child {
+        padding-right: 0;
+      }
     }
   }
 

--- a/packages/frontend/app/styles/components/new-user.scss
+++ b/packages/frontend/app/styles/components/new-user.scss
@@ -2,9 +2,14 @@
 @use "../ilios-common/mixins" as m;
 
 .new-user {
+  background-color: c.$slightWhite;
   border: 1px solid c.$culturedGrey;
   margin: 0.5rem 0;
   padding: 1rem;
+
+  & > .title {
+    @include m.ilios-heading-h4;
+  }
 
   .new-user-form {
     @include m.ilios-form;

--- a/packages/frontend/app/styles/components/new-user.scss
+++ b/packages/frontend/app/styles/components/new-user.scss
@@ -3,7 +3,7 @@
 
 .new-user {
   border: 1px solid c.$culturedGrey;
-  margin: 0.5rem;
+  margin: 0.5rem 0;
   padding: 1rem;
 
   .new-user-form {

--- a/packages/frontend/app/styles/components/program-overview.scss
+++ b/packages/frontend/app/styles/components/program-overview.scss
@@ -3,7 +3,6 @@
 
 .program-overview {
   @include m.ilios-overview(c.$culturedGrey);
-  margin: 0 0.8rem;
 
   h2 {
     @include m.ilios-overview-title;

--- a/packages/frontend/app/styles/components/program-year/new.scss
+++ b/packages/frontend/app/styles/components/program-year/new.scss
@@ -3,7 +3,7 @@
 
 .new-program-year {
   border: 1px solid c.$culturedGrey;
-  margin: 0.5rem;
+  margin: 0.5rem 0;
   padding: 1rem;
 
   h4 {

--- a/packages/frontend/app/styles/components/program-year/new.scss
+++ b/packages/frontend/app/styles/components/program-year/new.scss
@@ -2,6 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-program-year {
+  background-color: c.$slightWhite;
   border: 1px solid c.$culturedGrey;
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/program/header.scss
+++ b/packages/frontend/app/styles/components/program/header.scss
@@ -9,7 +9,6 @@
   justify-content: space-between;
   padding: calc(constants.$golden-ratio-large * 1rem) 0
     calc(constants.$golden-ratio-small * 1rem) 0;
-  margin: 0 0.8rem;
 
   @include m.for-tablet-and-up {
     flex-direction: row;

--- a/packages/frontend/app/styles/components/program/new.scss
+++ b/packages/frontend/app/styles/components/program/new.scss
@@ -2,6 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-program {
+  background-color: c.$slightWhite;
   border: 1px solid c.$culturedGrey;
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/program/new.scss
+++ b/packages/frontend/app/styles/components/program/new.scss
@@ -3,7 +3,7 @@
 
 .new-program {
   border: 1px solid c.$culturedGrey;
-  margin: 0.5rem;
+  margin: 0.5rem 0;
   padding: 1rem;
 
   h4 {

--- a/packages/frontend/app/styles/components/program/root.scss
+++ b/packages/frontend/app/styles/components/program/root.scss
@@ -4,7 +4,7 @@
   @include m.main-section;
   margin-bottom: 1rem;
 
-  .leadership-collapsed {
-    margin: 0 0.8rem;
+  .backtolink {
+    margin: 0;
   }
 }

--- a/packages/frontend/app/styles/components/reports/new-subject.scss
+++ b/packages/frontend/app/styles/components/reports/new-subject.scss
@@ -9,8 +9,8 @@
   padding: 1rem 1rem 3rem;
 
   .title {
-    @include m.ilios-heading-h5;
-    margin-bottom: 0.5rem;
+    @include m.ilios-heading-h4;
+    margin-bottom: 1rem;
   }
 
   .new-subject-content {

--- a/packages/frontend/app/styles/components/reports/subject.scss
+++ b/packages/frontend/app/styles/components/reports/subject.scss
@@ -3,13 +3,7 @@
 .reports-subject {
   @include cm.main-section;
 
-  .back-to-reports {
-    margin-left: 1rem;
-  }
-
   .content-container {
-    margin-left: 1rem;
-
     .report-results {
       @include cm.ilios-list-reset;
     }

--- a/packages/frontend/app/styles/components/school-list.scss
+++ b/packages/frontend/app/styles/components/school-list.scss
@@ -25,12 +25,14 @@
   }
 
   .new {
+    background-color: c.$slightWhite;
     border: 1px solid c.$culturedGrey;
     margin: 0.5rem 0;
     padding: 1rem;
 
     .new-result-title {
       @include m.ilios-heading-h4;
+      margin-bottom: 1rem;
     }
 
     .form {

--- a/packages/frontend/app/styles/components/school-list.scss
+++ b/packages/frontend/app/styles/components/school-list.scss
@@ -26,11 +26,8 @@
 
   .new {
     border: 1px solid c.$culturedGrey;
+    margin: 0.5rem 0;
     padding: 1rem;
-
-    @include m.for-laptop-and-up {
-      margin-left: 1rem;
-    }
 
     .new-result-title {
       @include m.ilios-heading-h4;

--- a/packages/frontend/app/styles/components/school-manager.scss
+++ b/packages/frontend/app/styles/components/school-manager.scss
@@ -5,6 +5,10 @@
 .school-manager {
   @include m.main-section;
 
+  .backtolink {
+    margin: 0;
+  }
+
   .school-overview {
     border-bottom: 1px solid c.$culturedGrey;
     display: flex;
@@ -15,11 +19,6 @@
 
     h2 {
       @include m.ilios-heading-h4;
-      margin-left: 0.8rem;
     }
-  }
-
-  .school-manager-content {
-    margin-left: 0.8rem;
   }
 }

--- a/packages/frontend/app/styles/components/school-vocabulary-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-manager.scss
@@ -2,6 +2,10 @@
 @use "../ilios-common/mixins" as m;
 
 .school-vocabulary-manager {
+  .breadcrumbs {
+    margin: 0.8rem 0;
+  }
+
   .school-vocabulary-manager-title {
     align-items: baseline;
     display: flex;

--- a/packages/ilios-common/addon/components/dashboard/materials.hbs
+++ b/packages/ilios-common/addon/components/dashboard/materials.hbs
@@ -154,7 +154,7 @@
               <Dashboard::MaterialListItem @lm={{lmObject}} />
             {{else}}
               <tr>
-                <td colspan="27" class="no-results" data-test-none>
+                <td colspan="18" class="no-results" data-test-none>
                   {{t "general.none"}}
                 </td>
               </tr>

--- a/packages/ilios-common/addon/components/new-session.hbs
+++ b/packages/ilios-common/addon/components/new-session.hbs
@@ -4,7 +4,7 @@
   ...attributes
 >
   {{#let (unique-id) as |templateId|}}
-    <h4>{{t "general.newSession"}}</h4>
+    <h4 class="new-session-title">{{t "general.newSession"}}</h4>
     <div class="new-session-content">
       <div class="item">
         <label for="title-{{templateId}}">

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -115,8 +115,7 @@ p {
 }
 
 .backtolink {
-  margin: 1rem 0;
-  padding-left: 0.8rem;
+  margin: 0.5rem;
 }
 
 .link-button {

--- a/packages/ilios-common/app/styles/ilios-common/components/course/rollover.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/rollover.scss
@@ -12,7 +12,7 @@
     border: 1px solid c.$blueMunsell;
     display: block;
     margin-top: 1rem;
-    padding: 1rem;
+    padding: 1rem 0.5rem;
 
     .item {
       @include m.ilios-form-item;

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
@@ -7,7 +7,7 @@
   @include m.dashboard-component;
 
   .dashboard-calendar-content {
-    padding: 0.5em;
+    padding: 0 0 1em;
 
     .calendar-controls {
       .calendar-options-control {

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/materials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/materials.scss
@@ -10,7 +10,7 @@
     text-align: center;
   }
   .dashboard-materials-content {
-    padding: 0.5rem;
+    padding: 0 0 1rem;
 
     .header {
       margin: 0 1em 1em 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/week.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/week.scss
@@ -4,7 +4,7 @@
   @include m.dashboard-component;
 
   .dashboard-week-content {
-    padding: 0 1em 1em;
+    padding: 0 0 1em;
 
     .weeklylink {
       display: flex;

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-instructors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-instructors.scss
@@ -3,6 +3,7 @@
 
 .detail-instructors {
   @include m.detail-container(c.$tealBlue);
+  padding: 1rem 0.5rem;
 
   .detail-instructors-header {
     @include m.detail-container-header;

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learners-and-learner-groups.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learners-and-learner-groups.scss
@@ -3,6 +3,7 @@
 
 .detail-learners-and-learner-groups {
   @include m.detail-container(c.$tealBlue);
+  padding: 1rem 0.5rem;
 
   .detail-learners-and-learner-groups-header {
     @include m.detail-container-header;

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -104,6 +104,7 @@
 
   .detail-learningmaterials-content {
     @include m.detail-container-content;
+    padding: 0.5rem;
 
     table {
       td {

--- a/packages/ilios-common/app/styles/ilios-common/components/new-learningmaterial.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/new-learningmaterial.scss
@@ -2,7 +2,7 @@
 
 .new-learningmaterial {
   @include m.ilios-form;
-  margin-left: 2rem;
+  margin-left: 0;
   min-height: 25vh;
 
   .item {

--- a/packages/ilios-common/app/styles/ilios-common/components/new-session.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/new-session.scss
@@ -2,12 +2,14 @@
 @use "../mixins" as m;
 
 .new-session {
+  background-color: c.$slightWhite;
   border: 1px solid c.$culturedGrey;
   margin: 0.5rem 0;
   padding: 1rem;
 
-  .title {
+  .new-session-title {
     @include m.detail-container-title;
+    margin-bottom: 1rem;
   }
 
   .new-session-content {

--- a/packages/ilios-common/app/styles/ilios-common/components/new-session.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/new-session.scss
@@ -3,7 +3,7 @@
 
 .new-session {
   border: 1px solid c.$culturedGrey;
-  margin: 0.5rem;
+  margin: 0.5rem 0;
   padding: 1rem;
 
   .title {

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
@@ -43,7 +43,7 @@
     .scheduling {
       align-items: start;
       display: grid;
-      grid-gap: 0.25rem 1rem;
+      grid-gap: 0.25rem 0.75rem;
       margin-bottom: 1rem;
       legend {
         @include m.ilios-heading;

--- a/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
@@ -4,7 +4,7 @@
 .print-course {
   .header {
     background-color: c.$culturedGrey;
-    padding: 0 1rem;
+    padding: 0 0.5rem;
     width: 100%;
 
     h2 {
@@ -27,7 +27,7 @@
   .block {
     @include m.detail-container(c.$orange);
     background-color: c.$white;
-    padding: 0 1rem;
+    padding: 0.5rem;
 
     .title {
       @include m.detail-container-title;
@@ -43,6 +43,14 @@
 
     .static-list {
       @include m.ilios-static-list;
+    }
+  }
+
+  .print-course-session {
+    .session-objective-list {
+      .fade-text-control {
+        background-image: linear-gradient(to bottom, transparent, c.$white);
+      }
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
@@ -1,7 +1,7 @@
 @use "../colors" as c;
 
 .publication-menu {
-  margin: 0 0.5rem;
+  margin: 0 0 0 0.5rem;
   position: relative;
   text-align: right;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
@@ -10,7 +10,6 @@
   border-style: solid;
   border-top: 0;
   border-width: 0 2px 2px;
-  padding-left: 0.8rem;
 
   table {
     thead,
@@ -18,5 +17,14 @@
       background-color: c.$tealBlue;
       color: c.$white;
     }
+  }
+
+  .leadership-expanded-header,
+  .detail-learningmaterials-header,
+  .detail-taxonomies-header,
+  .detail-mesh-header,
+  .offering-section-top,
+  .toggle-offering-calendar {
+    padding-right: 0.5rem;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
@@ -19,12 +19,17 @@
     }
   }
 
+  .leadership-collapsed,
   .leadership-expanded-header,
+  .leadership-expanded-content,
+  .session-collapsed-objectives,
+  .session-objectives,
   .detail-learningmaterials-header,
-  .detail-taxonomies-header,
+  .collapsed-taxonomies,
+  .detail-taxonomies,
   .detail-mesh-header,
-  .offering-section-top,
-  .toggle-offering-calendar {
+  .session-offerings {
+    padding-left: 0.5rem;
     padding-right: 0.5rem;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
@@ -42,6 +42,7 @@
 
   .session-overview-header {
     @include m.ilios-overview-header;
+    padding-left: 0.5rem;
 
     .title {
       @include m.ilios-overview-title;
@@ -59,6 +60,7 @@
 
   .session-overview-content {
     @include m.ilios-overview-content;
+    padding-left: 0.5rem;
   }
 
   .block {

--- a/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
@@ -7,8 +7,8 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: calc(constants.$golden-ratio-large * 1rem) 0
-    calc(constants.$golden-ratio-small * 1rem) 0;
+  padding: calc(constants.$golden-ratio-large * 1rem)
+    calc(constants.$golden-ratio-small * 1rem);
 
   @include m.for-tablet-and-up {
     flex-direction: row;

--- a/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar.scss
@@ -16,7 +16,7 @@
   align-items: center;
   grid-template-columns: 1fr;
   grid-template-rows: 2rem auto 1fr;
-  margin: 0.5rem 1rem;
+  margin: 0.5rem 0;
   height: 75vh;
 
   .week-of-year {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/course/overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/course/overview.scss
@@ -5,6 +5,7 @@
 
 @mixin course-overview() {
   @include ilios-overview.ilios-overview(c.$orange);
+  padding: 0.5rem 0;
   @include ilios-form.ilios-form-error;
 
   .title {
@@ -13,19 +14,27 @@
 
   .course-overview-header {
     @include ilios-overview.ilios-overview-header;
+
+    &:last-child {
+      margin-right: 0;
+    }
   }
 
   .course-overview-actions {
     @include ilios-overview.ilios-overview-actions;
 
+    span {
+      color: c.$blueMunsell;
+    }
+
     a,
     span {
       @include font-size.font-size("medium");
       margin-right: 0.5rem;
-    }
 
-    span {
-      color: c.$blueMunsell;
+      &:last-child {
+        margin-right: 0;
+      }
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
@@ -44,6 +44,10 @@
     @include media.for-phone-only {
       margin-top: 0.25em;
     }
+
+    &:last-child {
+      margin-right: 0;
+    }
   }
 
   .bigadd {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
@@ -11,7 +11,6 @@
   display: grid;
   grid-gap: 0.25rem 1rem;
   grid-template-columns: 1fr;
-  margin-bottom: 1rem;
   padding: 0.5rem 1rem 0.5rem 0.5rem;
 
   @include media.for-laptop-and-up {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
@@ -11,7 +11,7 @@
   display: grid;
   grid-gap: 0.25rem 1rem;
   grid-template-columns: 1fr;
-  padding: 0.5rem 1rem 0.5rem 0.5rem;
+  padding: 0.5rem 0;
 
   @include media.for-laptop-and-up {
     grid-template-columns: repeat(2, 1fr);

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
@@ -8,7 +8,7 @@
     border-bottom: 1px dotted $bottom-border-color;
   }
   display: block;
-  padding: 0.8rem 0;
+  padding: 0.5rem 0;
 
   label {
     @include ilios-form.ilios-label;
@@ -40,7 +40,6 @@
   align-items: baseline;
   display: flex;
   justify-content: space-around;
-  margin-right: 0.5rem;
   text-align: right;
   vertical-align: middle;
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
@@ -23,7 +23,7 @@
 }
 
 @mixin main-list-filter() {
-  padding: 0 1rem 1rem 1rem;
+  padding: 0 1rem 1rem 0;
   white-space: nowrap;
 
   @include media.for-laptop-and-up {
@@ -35,6 +35,10 @@
   @include media.for-desktop-and-up {
     margin-right: 2rem;
     width: auto;
+  }
+
+  &:last-child {
+    padding-right: 0;
   }
 
   select {
@@ -57,13 +61,12 @@
   border-bottom: 1px solid c.$culturedGrey;
   display: flex;
   flex-direction: column;
-  padding: 0.5rem 0;
+  padding: 0 0 0.5rem;
   text-align: center;
 
   @include media.for-laptop-and-up {
     flex-direction: row;
     justify-content: space-between;
-    margin-left: 1rem;
   }
 }
 
@@ -78,7 +81,6 @@
 
 @mixin main-list-box-header-actions {
   @include media.for-laptop-and-up {
-    padding-right: 1rem;
     text-align: right;
   }
 
@@ -98,7 +100,7 @@
 @mixin main-list-box-table() {
   clear: both;
   display: block;
-  padding: 1rem;
+  padding: 0;
 
   &.empty {
     padding: 0;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -20,6 +20,10 @@
 
       .expand-collapse-button {
         margin: 0 0.5em;
+
+        &:last-child {
+          margin-right: 0;
+        }
       }
 
       .course-visualize-objectives-graph {
@@ -34,17 +38,17 @@
   }
 
   .new-objective {
+    background-color: c.$slightWhite;
     border: 1px solid c.$culturedGrey;
-    margin: 1rem;
-    padding: 0.5rem;
+    margin: 0.5rem 0;
+    padding: 1rem;
 
     .title {
-      margin-bottom: 0.25em;
+      @include ilios-heading.ilios-heading-h5;
+      margin-bottom: 0.5em;
     }
 
     .new-objective-form {
-      margin-left: 0.5em;
-
       label {
         font-weight: bold;
         margin: 0.25em;
@@ -64,7 +68,6 @@
     display: grid;
     grid-template-columns: 5fr 3fr 3fr 3fr 1fr;
     grid-template-rows: auto;
-    margin-right: 0.5em;
 
     .grid-item {
       border-bottom: 1px solid c.$davysGrey;


### PR DESCRIPTION
Fixes ilios/ilios#5112

Through the changing of many `.scss` files, I've attempted to normalize the top/left/right margin/padding of Ilios's main layout and components.

I'm sure I missed something somewhere, but I tried to do as an exhaustive job as I could. I know this is a huge set of changes, and there was plenty of "what I think it should look like" at play, so expecting pushback, but let's get this one going!