### PR TITLE
Add pnpm onlyBuiltDependencies Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,12 @@
   },
   "devDependencies": {
     "husky": "^9.1.4"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "aws-sdk",
+      "fsevents",
+      "sharp"
+    ]
   }
 }


### PR DESCRIPTION
Only those items listed in this config are allowed to run install scripts. This is a security improvement in pnpm 10.x. I've enabled only three of our dependencies that currently run these types of scripts:

Enabled:
aws-sdk - needed to deploy
fsevents - does some important stuff on osx machines, hard to tell exactly what, but let's keep for now sharp - downloads or builds sharp from source, needed.

Ignored:
@parcel/watcher - not needs as ember-cli-sass does our file watching for us, we don't use `sass` for this. @percy/core - installs chromium, we can just expect this to be available core-js - used to show a fundraising banner, skip