### PR TITLE
Sunburst our Loading

### DIFF
--- a/packages/frontend/app/components/loading-sunburst.hbs
+++ b/packages/frontend/app/components/loading-sunburst.hbs
@@ -1,0 +1,1 @@
+<div class="loading-sunburst"></div>

--- a/packages/frontend/app/controllers/error.js
+++ b/packages/frontend/app/controllers/error.js
@@ -11,6 +11,9 @@ export default class ErrorController extends Controller {
     if (this.model?.errors?.length > 0) {
       return Number(this.model.errors[0].status) === 404;
     }
+    if (this.model?.message?.toLowerCase().includes('not found')) {
+      return true;
+    }
 
     return false;
   }

--- a/packages/frontend/app/styles/components.scss
+++ b/packages/frontend/app/styles/components.scss
@@ -16,6 +16,7 @@
 @forward "components/ilios-logo";
 @forward "components/ilios-navigation";
 @forward "components/ilios-users";
+@forward "components/loading-sunburst";
 @forward "components/locale-chooser";
 @forward "components/login-form";
 @forward "components/manage-users-summary";

--- a/packages/frontend/app/styles/components/loading-sunburst.scss
+++ b/packages/frontend/app/styles/components/loading-sunburst.scss
@@ -1,0 +1,18 @@
+.loading-sunburst {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  width: 100%;
+  background-image: url("icons/sunburst-transparent512.png");
+  background-position: center;
+  background-repeat: no-repeat;
+  animation: fadeIn 10s forwards;
+  @keyframes fadeIn {
+    from {
+      opacity: 0.01;
+    }
+    to {
+      opacity: 0.5;
+    }
+  }
+}

--- a/packages/frontend/app/templates/loading.hbs
+++ b/packages/frontend/app/templates/loading.hbs
@@ -1,0 +1,1 @@
+<LoadingSunburst />

--- a/packages/frontend/tests/integration/components/loading-sunburst-test.js
+++ b/packages/frontend/tests/integration/components/loading-sunburst-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | loading-sunburst', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<LoadingSunburst />`);
+    assert.dom('.loading-sunburst').exists();
+    assert.dom('.loading-sunburst').hasStyle({ backgroundRepeat: 'no-repeat' });
+  });
+});


### PR DESCRIPTION
There are a few routes where we don't have a good loading state, plus some inner route transitions where it's hard to tell if clicking on the link did anything. Let's add a white screen with a slowly visible sunburst so the user knows Ilios is doing something.

Ideally we'll do loading routes for everywhere this shows up, but we have a gap right now we need to fill.