### PR TITLE
Don't search on empty string Global Search Box

### DIFF
--- a/packages/frontend/app/components/global-search-box.js
+++ b/packages/frontend/app/components/global-search-box.js
@@ -96,7 +96,6 @@ export default class GlobalSearchBox extends Component {
 
     if (this.isEscapeKey(keyCode)) {
       this.clear();
-      this.args.search('');
     }
   }
 


### PR DESCRIPTION
Fixes ilios/ilios#5972

Chrome and Safari seem to takeover the `esc` key and just clear the search box (which is what I'd expect), but Firefox actually runs our custom code and does a search on an empty string. Leaving the hook in there, but removing the search, makes the experience the same across the board.