### PR TITLE
Remove Reporting render modifiers

### DIFF
--- a/packages/frontend/.lint-todo
+++ b/packages/frontend/.lint-todo
@@ -5,8 +5,6 @@ add|ember-template-lint|no-at-ember-render-modifiers|5|2|5|2|23cd787c79c34a628da
 add|ember-template-lint|no-at-ember-render-modifiers|6|2|6|2|e5120f87b74c5ae8e4c76b9089e0b4a4504c6e3c|1731542400000|1762646400000|1793750400000|app/components/user-profile-roles.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|3|2|3|2|1fb0566922ce4f066916e5e2931f650f69d7cfba|1731542400000|1762646400000|1793750400000|app/components/visualizer-program-year-objectives.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|38e65b45b56fdfd4160d3b0884114b6643e3a036|1731542400000|1762646400000|1793750400000|app/components/visualizer-program-year-objectives.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|10|6|10|6|d919d2af254f782c01fe2ba15416673e52e91124|1731542400000|1762646400000|1793750400000|app/components/reports/subject/new/academic-year.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|11|6|11|6|940005188b476a060b0e5d3f05baea24ba178878|1731542400000|1762646400000|1793750400000|app/components/reports/subject/new/academic-year.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|10|6|10|6|d919d2af254f782c01fe2ba15416673e52e91124|1731542400000|1762646400000|1793750400000|app/components/reports/subject/new/competency.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|11|6|11|6|940005188b476a060b0e5d3f05baea24ba178878|1731542400000|1762646400000|1793750400000|app/components/reports/subject/new/competency.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|10|6|10|6|d919d2af254f782c01fe2ba15416673e52e91124|1731542400000|1762646400000|1793750400000|app/components/reports/subject/new/instructor-group.hbs

--- a/packages/frontend/app/components/reports/new-subject.js
+++ b/packages/frontend/app/components/reports/new-subject.js
@@ -215,6 +215,8 @@ export default class ReportsNewSubjectComponent extends Component {
 
   get newPrepositionalObjectComponent() {
     switch (this.prepositionalObject) {
+      case 'academic year':
+        return ensureSafeComponent(NewAcademicYearComponent, this);
       case 'competency':
         return ensureSafeComponent(NewCompetencyComponent, this);
       case 'course':
@@ -237,8 +239,6 @@ export default class ReportsNewSubjectComponent extends Component {
         return ensureSafeComponent(NewSessionTypeComponent, this);
       case 'term':
         return ensureSafeComponent(NewTermComponent, this);
-      case 'academic year':
-        return ensureSafeComponent(NewAcademicYearComponent, this);
     }
 
     return null;

--- a/packages/frontend/app/components/reports/subject/new/academic-year.hbs
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.hbs
@@ -7,10 +7,9 @@
       id="new-academic-year"
       data-test-prepositional-objects
       {{on "change" (pick "target.value" @changeId)}}
-      {{this.loadLatest this.setInitialValue @school}}
     >
       {{#each (sort-by "title" this.academicYears) as |year|}}
-        <option selected={{eq year.id @currentId}} value={{year.id}}>
+        <option selected={{eq year.id this.bestSelectedAcademicYear}} value={{year.id}}>
           {{#if this.academicYearCrossesCalendarYearBoundaries}}
             {{year.id}}
             -

--- a/packages/frontend/app/components/reports/subject/new/academic-year.hbs
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.hbs
@@ -2,13 +2,12 @@
   <label for="new-term">
     {{t "general.whichIs"}}
   </label>
-  {{#if this.isLoaded}}
+  {{#if this.academicYearsData.isResolved}}
     <select
       id="new-academic-year"
       data-test-prepositional-objects
       {{on "change" (pick "target.value" @changeId)}}
-      {{did-insert (perform this.setInitialValue)}}
-      {{did-update (perform this.setInitialValue) @school}}
+      {{this.loadLatest this.setInitialValue @school}}
     >
       {{#each (sort-by "title" this.academicYears) as |year|}}
         <option selected={{eq year.id @currentId}} value={{year.id}}>

--- a/packages/frontend/app/components/reports/subject/new/academic-year.js
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 import { service } from '@ember/service';
-import { modifier } from 'ember-modifier';
 import { task, timeout } from 'ember-concurrency';
 import currentAcademicYear from 'ilios-common/utils/current-academic-year';
 
@@ -10,22 +9,32 @@ export default class ReportsSubjectNewAcademicYearComponent extends Component {
   @service store;
   @service iliosConfig;
 
+  constructor() {
+    super(...arguments);
+    console.log('this.args', this.args);
+    // this.setInitialValue.perform();
+  }
+
   @cached
   get academicYearsData() {
     return new TrackedAsyncData(this.store.findAll('academic-year'));
   }
 
   get academicYears() {
-    return this.academicYearsData.isResolved ? this.academicYearsData.value : null;
+    return this.academicYearsData.isResolved ? this.academicYearsData.value : [];
+  }
+
+  get bestSelectedAcademicYear() {
+    if (this.academicYears.map(({ id }) => id).includes(this.args.currentId)) {
+      return this.args.currentId;
+    }
+
+    return this.academicYears.find(({ id }) => Number(id) === currentAcademicYear())?.id;
   }
 
   crossesBoundaryConfig = new TrackedAsyncData(
     this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
   );
-
-  loadLatest = modifier((element, [taskInstance]) => {
-    taskInstance.perform();
-  });
 
   @cached
   get academicYearCrossesCalendarYearBoundaries() {

--- a/packages/frontend/app/components/reports/subject/new/academic-year.js
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.js
@@ -23,7 +23,7 @@ export default class ReportsSubjectNewAcademicYearComponent extends Component {
     this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
   );
 
-  loadLatest = modifier((element, [taskInstance] = null) => {
+  loadLatest = modifier((element, [taskInstance]) => {
     taskInstance.perform();
   });
 

--- a/packages/frontend/app/components/reports/subject/new/academic-year.js
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.js
@@ -2,18 +2,11 @@ import Component from '@glimmer/component';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 import { service } from '@ember/service';
-import { task, timeout } from 'ember-concurrency';
 import currentAcademicYear from 'ilios-common/utils/current-academic-year';
 
 export default class ReportsSubjectNewAcademicYearComponent extends Component {
   @service store;
   @service iliosConfig;
-
-  constructor() {
-    super(...arguments);
-    console.log('this.args', this.args);
-    // this.setInitialValue.perform();
-  }
 
   @cached
   get academicYearsData() {
@@ -25,11 +18,17 @@ export default class ReportsSubjectNewAcademicYearComponent extends Component {
   }
 
   get bestSelectedAcademicYear() {
-    if (this.academicYears.map(({ id }) => id).includes(this.args.currentId)) {
+    const ids = this.academicYears.map(({ id }) => id);
+
+    if (ids.includes(this.args.currentId)) {
       return this.args.currentId;
     }
 
-    return this.academicYears.find(({ id }) => Number(id) === currentAcademicYear())?.id;
+    const currentYear = currentAcademicYear();
+    const currentYearId = this.academicYears.find(({ id }) => Number(id) === currentYear)?.id;
+    const newId = currentYearId ?? ids.at(-1);
+
+    return newId;
   }
 
   crossesBoundaryConfig = new TrackedAsyncData(
@@ -40,16 +39,4 @@ export default class ReportsSubjectNewAcademicYearComponent extends Component {
   get academicYearCrossesCalendarYearBoundaries() {
     return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
   }
-
-  setInitialValue = task(async () => {
-    await timeout(1); //wait a moment so we can render before setting
-    const ids = this.academicYears.map(({ id }) => id);
-    if (ids.includes(this.args.currentId)) {
-      return;
-    }
-    const currentYear = currentAcademicYear();
-    const currentYearId = this.academicYears.find(({ id }) => Number(id) === currentYear)?.id;
-    const newId = currentYearId ?? ids.at(-1);
-    this.args.changeId(newId);
-  });
 }

--- a/packages/frontend/app/components/reports/subject/new/academic-year.js
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.js
@@ -31,9 +31,8 @@ export default class ReportsSubjectNewAcademicYearComponent extends Component {
     return this.data.isResolved;
   }
 
-  @task
-  *setInitialValue() {
-    yield timeout(1); //wait a moment so we can render before setting
+  setInitialValue = task(async () => {
+    await timeout(1); //wait a moment so we can render before setting
     const ids = this.academicYears.map(({ id }) => id);
     if (ids.includes(this.args.currentId)) {
       return;
@@ -41,5 +40,5 @@ export default class ReportsSubjectNewAcademicYearComponent extends Component {
     const currentYear = currentAcademicYear();
     const currentYearId = this.academicYears.find(({ id }) => Number(id) === currentYear)?.id;
     this.args.changeId(currentYearId ?? ids.at(-1));
-  }
+  });
 }

--- a/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
@@ -25,7 +25,7 @@ module('Integration | Component | reports/subject/new/academic-year', function (
   });
 
   test('it renders', async function (assert) {
-    assert.expect(13);
+    assert.expect(12);
     this.set('currentId', null);
     this.set('changeId', (id) => {
       assert.strictEqual(id, '2060');

--- a/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
@@ -25,7 +25,7 @@ module('Integration | Component | reports/subject/new/academic-year', function (
   });
 
   test('it renders', async function (assert) {
-    assert.expect(14);
+    assert.expect(13);
     this.set('currentId', null);
     this.set('changeId', (id) => {
       assert.strictEqual(id, '2060');
@@ -37,16 +37,16 @@ module('Integration | Component | reports/subject/new/academic-year', function (
   @school={{null}}
 />`);
 
-    assert.strictEqual(component.options.length, 3);
-    assert.strictEqual(component.options[0].text, '2015');
-    assert.strictEqual(component.options[1].text, '2031');
-    assert.strictEqual(component.options[2].text, '2060');
+    assert.strictEqual(component.options.length, 3, 'dropdown has 3 options');
+    assert.strictEqual(component.options[0].text, '2015', 'first option is 2015');
+    assert.strictEqual(component.options[1].text, '2031', 'second option is 2031');
+    assert.strictEqual(component.options[2].text, '2060', 'third option is 2060');
 
-    assert.strictEqual(component.value, '2060');
+    assert.strictEqual(component.value, '2060', 'selected option is 2060');
 
-    assert.notOk(component.options[0].isSelected);
-    assert.notOk(component.options[1].isSelected);
-    assert.ok(component.options[2].isSelected);
+    assert.notOk(component.options[0].isSelected, 'option 0 is not selected');
+    assert.notOk(component.options[1].isSelected, 'option 1 is not selected');
+    assert.ok(component.options[2].isSelected, 'option 2 is selected');
 
     this.set('changeId', (id) => {
       assert.strictEqual(id, '2031');
@@ -54,11 +54,10 @@ module('Integration | Component | reports/subject/new/academic-year', function (
     });
 
     this.set('currentId', '2031');
-    assert.notOk(component.options[0].isSelected);
-    assert.notOk(component.options[0].isSelected);
-    assert.ok(component.options[1].isSelected);
-    assert.notOk(component.options[2].isSelected);
-    assert.strictEqual(component.value, '2031');
+    assert.notOk(component.options[0].isSelected, 'option 0 is not selected');
+    assert.ok(component.options[1].isSelected, 'option 1 is selected');
+    assert.notOk(component.options[2].isSelected, 'option 2 is not selected');
+    assert.strictEqual(component.value, '2031', 'selected option is 2031');
   });
 
   test('it works', async function (assert) {
@@ -73,14 +72,14 @@ module('Integration | Component | reports/subject/new/academic-year', function (
       assert.strictEqual(id, '2031');
       this.set('currentId', id);
     });
-    assert.ok(component.options[0].isSelected);
-    assert.notOk(component.options[1].isSelected);
-    assert.notOk(component.options[2].isSelected);
+    assert.ok(component.options[0].isSelected, 'option 0 is selected');
+    assert.notOk(component.options[1].isSelected, 'option 1 is not selected');
+    assert.notOk(component.options[2].isSelected, 'option 2 is not selected');
 
     await component.set('2031');
-    assert.notOk(component.options[0].isSelected);
-    assert.ok(component.options[1].isSelected);
-    assert.notOk(component.options[2].isSelected);
-    assert.strictEqual(component.value, '2031');
+    assert.notOk(component.options[0].isSelected, 'option 0 is not selected');
+    assert.ok(component.options[1].isSelected, 'option 1 is selected');
+    assert.notOk(component.options[2].isSelected, 'option 2 is not selected');
+    assert.strictEqual(component.value, '2031', 'selected option is 2031');
   });
 });


### PR DESCRIPTION
Refs ilios/ilios#5374

This is the first of seven `ember-render-modifiers` to remove in reporting, but wanted to see if this is a good approach. Could potentially abstract the `modifier` into its own file and pull it in, but dunno.