### PR TITLE
Add a permissions check for User creation UI

### DIFF
--- a/packages/frontend/app/components/ilios-users.gjs
+++ b/packages/frontend/app/components/ilios-users.gjs
@@ -110,37 +110,39 @@ export default class IliosUsersComponent extends Component {
             {{t "general.users"}}
           </span>
           <div class="actions">
-            {{#if (or @showNewUserForm @showBulkNewUserForm)}}
-              <button
-                type="button"
-                {{on
-                  "click"
-                  (if
-                    @showNewUserForm
-                    (fn @setShowNewUserForm false)
-                    (fn @setShowBulkNewUserForm false)
-                  )
-                }}
-                data-test-collapse
-              >
-                <FaIcon @icon="minus" />
-              </button>
-            {{else}}
-              <button
-                type="button"
-                {{on "click" (fn @setShowNewUserForm true)}}
-                data-test-show-new-user-form
-              >
-                {{t "general.create"}}
-              </button>
-              {{#if (notEq this.userSearchType "ldap")}}
+            {{#if @canCreate}}
+              {{#if (or @showNewUserForm @showBulkNewUserForm)}}
                 <button
                   type="button"
-                  {{on "click" (fn @setShowBulkNewUserForm true)}}
-                  data-test-show-bulk-new-user-form
+                  {{on
+                    "click"
+                    (if
+                      @showNewUserForm
+                      (fn @setShowNewUserForm false)
+                      (fn @setShowBulkNewUserForm false)
+                    )
+                  }}
+                  data-test-collapse
                 >
-                  {{t "general.createBulk"}}
+                  <FaIcon @icon="minus" />
                 </button>
+              {{else}}
+                <button
+                  type="button"
+                  {{on "click" (fn @setShowNewUserForm true)}}
+                  data-test-show-new-user-form
+                >
+                  {{t "general.create"}}
+                </button>
+                {{#if (notEq this.userSearchType "ldap")}}
+                  <button
+                    type="button"
+                    {{on "click" (fn @setShowBulkNewUserForm true)}}
+                    data-test-show-bulk-new-user-form
+                  >
+                    {{t "general.createBulk"}}
+                  </button>
+                {{/if}}
               {{/if}}
             {{/if}}
           </div>

--- a/packages/frontend/app/controllers/users.js
+++ b/packages/frontend/app/controllers/users.js
@@ -1,8 +1,12 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { filter } from 'rsvp';
+import { cached } from '@glimmer/tracking';
+import { TrackedAsyncData } from 'ember-async-data';
 
 export default class UsersController extends Controller {
+  @service store;
   @service router;
 
   queryParams = [
@@ -23,6 +27,34 @@ export default class UsersController extends Controller {
   showNewUserForm = false;
   showBulkNewUserForm = false;
   searchTerms = null;
+
+  @cached
+  get canCreateData() {
+    return new TrackedAsyncData(this.canCreateInSomeSchool(this.allSchools));
+  }
+
+  get canCreate() {
+    return this.canCreateData.isResolved ? this.canCreateData.value : false;
+  }
+
+  @cached
+  get allSchoolsData() {
+    return new TrackedAsyncData(this.store.findAll('school'));
+  }
+
+  get allSchools() {
+    return this.allSchoolsData.isResolved ? this.allSchoolsData.value : [];
+  }
+
+  async canCreateInSomeSchool(schools) {
+    if (!schools) {
+      return false;
+    }
+    const schoolsWithCreateUserPermission = await filter(schools, async (school) => {
+      return this.permissionChecker.canCreateUser(school);
+    });
+    return schoolsWithCreateUserPermission.length > 0;
+  }
 
   @action
   transitionToUser(userId) {

--- a/packages/frontend/app/controllers/users.js
+++ b/packages/frontend/app/controllers/users.js
@@ -1,9 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { filter } from 'rsvp';
-import { cached } from '@glimmer/tracking';
-import { TrackedAsyncData } from 'ember-async-data';
 
 export default class UsersController extends Controller {
   @service store;
@@ -27,34 +24,6 @@ export default class UsersController extends Controller {
   showNewUserForm = false;
   showBulkNewUserForm = false;
   searchTerms = null;
-
-  @cached
-  get canCreateData() {
-    return new TrackedAsyncData(this.canCreateInSomeSchool(this.allSchools));
-  }
-
-  get canCreate() {
-    return this.canCreateData.isResolved ? this.canCreateData.value : false;
-  }
-
-  @cached
-  get allSchoolsData() {
-    return new TrackedAsyncData(this.store.findAll('school'));
-  }
-
-  get allSchools() {
-    return this.allSchoolsData.isResolved ? this.allSchoolsData.value : [];
-  }
-
-  async canCreateInSomeSchool(schools) {
-    if (!schools) {
-      return false;
-    }
-    const schoolsWithCreateUserPermission = await filter(schools, async (school) => {
-      return this.permissionChecker.canCreateUser(school);
-    });
-    return schoolsWithCreateUserPermission.length > 0;
-  }
 
   @action
   transitionToUser(userId) {

--- a/packages/frontend/app/templates/users.hbs
+++ b/packages/frontend/app/templates/users.hbs
@@ -9,6 +9,7 @@
   @setLimit={{set this "limit"}}
   @query={{this.query}}
   @setQuery={{set this "query"}}
+  @canCreate={{this.canCreate}}
   @showNewUserForm={{this.showNewUserForm}}
   @setShowNewUserForm={{set this "showNewUserForm"}}
   @showBulkNewUserForm={{this.showBulkNewUserForm}}

--- a/packages/frontend/app/templates/users.hbs
+++ b/packages/frontend/app/templates/users.hbs
@@ -9,7 +9,7 @@
   @setLimit={{set this "limit"}}
   @query={{this.query}}
   @setQuery={{set this "query"}}
-  @canCreate={{this.canCreate}}
+  @canCreate={{@model.canCreate}}
   @showNewUserForm={{this.showNewUserForm}}
   @setShowNewUserForm={{set this "showNewUserForm"}}
   @showBulkNewUserForm={{this.showBulkNewUserForm}}

--- a/packages/frontend/tests/integration/components/ilios-users-test.gjs
+++ b/packages/frontend/tests/integration/components/ilios-users-test.gjs
@@ -40,6 +40,7 @@ module('Integration | Component | ilios users', function (hooks) {
     await render(
       <template>
         <IliosUsers
+          @sortBy="fullName"
           @limit="25"
           @offset="25"
           @query=""

--- a/packages/frontend/tests/integration/components/ilios-users-test.gjs
+++ b/packages/frontend/tests/integration/components/ilios-users-test.gjs
@@ -34,6 +34,37 @@ module('Integration | Component | ilios users', function (hooks) {
     assert.strictEqual(component.title.text, 'Users');
   });
 
+  test('it shows/hides new user creation buttons depending on user permission', async function (assert) {
+    this.set('canCreate', false);
+
+    await render(
+      <template>
+        <IliosUsers
+          @limit="25"
+          @offset="25"
+          @query=""
+          @canCreate={{this.canCreate}}
+          @searchTerms={{(array)}}
+          @setQuery={{(noop)}}
+          @setLimit={{(noop)}}
+          @setOffset={{(noop)}}
+          @setShowNewUserForm={{(noop)}}
+          @setShowBulkNewUserForm={{(noop)}}
+          @setSearchTerms={{(noop)}}
+          @transitionToUser={{(noop)}}
+        />
+      </template>,
+    );
+
+    assert.notOk(component.showNewUserFormButton.isVisible);
+    assert.notOk(component.showBulkUsersFormButton.isVisible);
+
+    this.set('canCreate', true);
+
+    assert.ok(component.showNewUserFormButton.isVisible);
+    assert.ok(component.showBulkUsersFormButton.isVisible);
+  });
+
   test('param passing', async function (assert) {
     assert.expect(2);
 
@@ -306,6 +337,7 @@ module('Integration | Component | ilios users', function (hooks) {
       <template>
         <IliosUsers
           @sortBy="fullName"
+          @canCreate={{true}}
           @showBulkNewUserForm={{true}}
           @searchTerms={{(array)}}
           @setQuery={{(noop)}}


### PR DESCRIPTION
Fixes ilios/ilios#5979

If the site is in read-only mode, the user creation buttons are gone when you're at `/admin`, but not when you click "View All" and go to `/users`, so I brought in the same permissions check.