### PR TITLE
Undoes the effects of FadeText when printing course summary

### DIFF
--- a/packages/ilios-common/addon/components/course/objective-list-item.js
+++ b/packages/ilios-common/addon/components/course/objective-list-item.js
@@ -19,7 +19,7 @@ export default class CourseObjectiveListItemComponent extends Component {
   @tracked isManagingTerms;
   @tracked termsBuffer = [];
   @tracked selectedVocabulary;
-  @tracked fadeTextExpanded = false;
+  @tracked fadeTextExpanded = this.args.printable ?? false;
 
   constructor() {
     super(...arguments);

--- a/packages/ilios-common/addon/components/course/objective-list.hbs
+++ b/packages/ilios-common/addon/components/course/objective-list.hbs
@@ -28,6 +28,7 @@
           @editable={{@editable}}
           @cohortObjectives={{this.cohortObjectives}}
           @course={{@course}}
+          @printable={{@printable}}
         />
       {{/each}}
     {{else}}

--- a/packages/ilios-common/addon/components/print-course.hbs
+++ b/packages/ilios-common/addon/components/print-course.hbs
@@ -117,6 +117,7 @@
           <Course::ObjectiveList
             @course={{@course}}
             @editable={{false}}
+            @printable={{true}}
           />
         </div>
       {{/if}}

--- a/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
@@ -48,13 +48,36 @@
 
   .print-course-session {
     .session-objective-list {
-      .fade-text-control {
-        background-image: linear-gradient(to bottom, transparent, c.$white);
+      .grid-row {
+        .grid-item {
+          &:has(.faded) {
+            max-height: none;
+          }
+        }
       }
     }
   }
 
   .offering-instructors {
     @include m.ilios-list-reset;
+  }
+
+  .fade-text {
+    .fade-text-control {
+      height: auto;
+    }
+
+    .display-text-wrapper {
+      &.faded {
+        max-height: none;
+        overflow: auto;
+      }
+    }
+
+    button {
+      &.expand-text-button {
+        display: none;
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes ilios/ilios#5969

When printing a course, there shouldn't be any truncation of objective descriptions like when viewing on a screen, so I changed the `PrintCourseComponent` template to push through a flag that forces `FadeText` instances to be expanded, and undid all the styling they normally apply.