### PR TITLE
Make UserProfileCalendar event blocks routable

### DIFF
--- a/packages/frontend/app/components/user-profile-calendar.hbs
+++ b/packages/frontend/app/components/user-profile-calendar.hbs
@@ -32,9 +32,10 @@
     <IliosCalendarWeek
       @calendarEvents={{this.calendarEvents}}
       @date={{this.date}}
-      @areEventsSelectable={{false}}
+      @areEventsSelectable={{true}}
       @areDaysSelectable={{false}}
       @isLoadingEvents={{this.eventsData.isPending}}
+      @selectEvent={{@selectEvent}}
     />
   </div>
 </div>

--- a/packages/frontend/app/components/user-profile.hbs
+++ b/packages/frontend/app/components/user-profile.hbs
@@ -26,7 +26,7 @@
   </div>
   <div class="blocks">
     {{#if this.showCalendar}}
-      <UserProfileCalendar @user={{@user}} />
+      <UserProfileCalendar @user={{@user}} @selectEvent={{@selectEvent}} />
     {{/if}}
     <UserProfileBio
       @user={{@user}}

--- a/packages/frontend/app/controllers/user.js
+++ b/packages/frontend/app/controllers/user.js
@@ -1,10 +1,12 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { filter } from 'rsvp';
 import { cached, tracked } from '@glimmer/tracking';
 import { TrackedAsyncData } from 'ember-async-data';
 
 export default class UserController extends Controller {
+  @service router;
   @service store;
   @service permissionChecker;
   @service iliosConfig;
@@ -61,5 +63,10 @@ export default class UserController extends Controller {
       return this.permissionChecker.canCreateUser(school);
     });
     return schoolsWithCreateUserPermission.length > 0;
+  }
+
+  @action
+  selectEvent(event) {
+    this.router.transitionTo('events', event.slug);
   }
 }

--- a/packages/frontend/app/templates/user.hbs
+++ b/packages/frontend/app/templates/user.hbs
@@ -17,4 +17,5 @@
   @permissionsYear={{this.permissionsYear}}
   @setPermissionsSchool={{set this "permissionsSchool"}}
   @setPermissionsYear={{set this "permissionsYear"}}
+  @selectEvent={{this.selectEvent}}
 />


### PR DESCRIPTION
Fixes ilios/ilios#4295

Clicking on an event in the calendar does nothing, but clicking on an event when on the `Dashboard::Calendar` component routes the user to an event detail, so I changed it so they work the same way.