### PR TITLE
Change Reporting->[Subject]->Academic Year to work like new Competency

### DIFF
--- a/packages/frontend/app/components/reports/new-subject.js
+++ b/packages/frontend/app/components/reports/new-subject.js
@@ -339,7 +339,9 @@ export default class ReportsNewSubjectComponent extends Component {
     this.addErrorDisplaysFor(['title', 'prepositionalObject', 'prepositionalObjectId']);
     const isValid = await this.isValid();
     if (!isValid) {
-      if (this.prepositionalObject === 'competency' && !this.prepositionalObjectId) {
+      const dropdownObjectTypes = ['academic year', 'competency'];
+
+      if (dropdownObjectTypes.includes(this.prepositionalObject) && !this.prepositionalObjectId) {
         const select = document.querySelector('select[data-test-prepositional-objects]');
         select.classList.add('error');
         select.focus();
@@ -371,6 +373,8 @@ export default class ReportsNewSubjectComponent extends Component {
   validatePrepositionalObjectIdMessageCallback() {
     if (this.prepositionalObjectIdMissing) {
       switch (this.prepositionalObject) {
+        case 'academic year':
+          return this.intl.t('errors.reportMissingAcademicYear');
         case 'competency':
           return this.intl.t('errors.reportMissingCompetency');
         case 'instructor':
@@ -393,6 +397,8 @@ export default class ReportsNewSubjectComponent extends Component {
   validatePrepositionalObjectMessageCallback() {
     if (this.subject && !this.prepositionalObject) {
       switch (this.subject) {
+        case 'academic year':
+          return this.intl.t('errors.reportMissingObjectForAcademicYear');
         case 'competency':
           return this.intl.t('errors.reportMissingObjectForCompetency');
         case 'instructor':

--- a/packages/frontend/app/components/reports/subject/new/academic-year.hbs
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.hbs
@@ -6,8 +6,11 @@
     <select
       id="new-academic-year"
       data-test-prepositional-objects
-      {{on "change" (pick "target.value" @changeId)}}
+      {{on "change" this.updatePrepositionalObjectId}}
     >
+      <option selected={{is-empty @currentId}} value="">
+        {{t "general.selectPolite"}}
+      </option>
       {{#each (sort-by "title" this.academicYears) as |year|}}
         <option selected={{eq year.id this.bestSelectedAcademicYear}} value={{year.id}}>
           {{#if this.academicYearCrossesCalendarYearBoundaries}}

--- a/packages/frontend/app/components/reports/subject/new/academic-year.hbs
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.hbs
@@ -11,7 +11,7 @@
       <option selected={{is-empty @currentId}} value="">
         {{t "general.selectPolite"}}
       </option>
-      {{#each (sort-by "title" this.academicYears) as |year|}}
+      {{#each this.sortedAcademicYears as |year|}}
         <option selected={{eq year.id this.bestSelectedAcademicYear}} value={{year.id}}>
           {{#if this.academicYearCrossesCalendarYearBoundaries}}
             {{year.id}}

--- a/packages/frontend/app/components/reports/subject/new/academic-year.js
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.js
@@ -3,6 +3,7 @@ import { TrackedAsyncData } from 'ember-async-data';
 import { action } from '@ember/object';
 import { cached } from '@glimmer/tracking';
 import { service } from '@ember/service';
+import { sortBy } from 'ilios-common/utils/array-helpers';
 
 export default class ReportsSubjectNewAcademicYearComponent extends Component {
   @service store;
@@ -15,6 +16,10 @@ export default class ReportsSubjectNewAcademicYearComponent extends Component {
 
   get academicYears() {
     return this.academicYearsData.isResolved ? this.academicYearsData.value : [];
+  }
+
+  get sortedAcademicYears() {
+    return sortBy(this.academicYears, ['title']).reverse();
   }
 
   get bestSelectedAcademicYear() {

--- a/packages/frontend/app/components/reports/subject/new/academic-year.js
+++ b/packages/frontend/app/components/reports/subject/new/academic-year.js
@@ -1,8 +1,8 @@
 import Component from '@glimmer/component';
 import { TrackedAsyncData } from 'ember-async-data';
+import { action } from '@ember/object';
 import { cached } from '@glimmer/tracking';
 import { service } from '@ember/service';
-import currentAcademicYear from 'ilios-common/utils/current-academic-year';
 
 export default class ReportsSubjectNewAcademicYearComponent extends Component {
   @service store;
@@ -24,11 +24,7 @@ export default class ReportsSubjectNewAcademicYearComponent extends Component {
       return this.args.currentId;
     }
 
-    const currentYear = currentAcademicYear();
-    const currentYearId = this.academicYears.find(({ id }) => Number(id) === currentYear)?.id;
-    const newId = currentYearId ?? ids.at(-1);
-
-    return newId;
+    return null;
   }
 
   crossesBoundaryConfig = new TrackedAsyncData(
@@ -38,5 +34,15 @@ export default class ReportsSubjectNewAcademicYearComponent extends Component {
   @cached
   get academicYearCrossesCalendarYearBoundaries() {
     return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
+  }
+
+  @action
+  updatePrepositionalObjectId(event) {
+    const value = event.target.value;
+    this.args.changeId(value);
+
+    if (!isNaN(value)) {
+      event.target.classList.remove('error');
+    }
   }
 }

--- a/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
@@ -10,6 +10,7 @@ module('Integration | Component | reports/subject/new/academic-year', function (
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
+    this.intl = this.owner.lookup('service:intl');
     this.server.create('academic-year', {
       id: 2015,
       title: 2015,
@@ -25,7 +26,7 @@ module('Integration | Component | reports/subject/new/academic-year', function (
   });
 
   test('it renders', async function (assert) {
-    assert.expect(12);
+    assert.expect(15);
     this.set('currentId', null);
     this.set('changeId', (id) => {
       assert.strictEqual(id, '2060');
@@ -37,16 +38,22 @@ module('Integration | Component | reports/subject/new/academic-year', function (
   @school={{null}}
 />`);
 
-    assert.strictEqual(component.options.length, 3, 'dropdown has 3 options');
-    assert.strictEqual(component.options[0].text, '2015', 'first option is 2015');
-    assert.strictEqual(component.options[1].text, '2031', 'second option is 2031');
-    assert.strictEqual(component.options[2].text, '2060', 'third option is 2060');
+    assert.strictEqual(component.options.length, 4, 'dropdown has 4 options');
+    assert.strictEqual(
+      component.options[0].text,
+      this.intl.t('general.selectPolite'),
+      'first option is blank',
+    );
+    assert.strictEqual(component.options[1].text, '2015', 'second option is 2015');
+    assert.strictEqual(component.options[2].text, '2031', 'third option is 2031');
+    assert.strictEqual(component.options[3].text, '2060', 'fourth option is 2060');
 
-    assert.strictEqual(component.value, '2060', 'selected option is 2060');
+    assert.strictEqual(component.value, '', 'selected option is blank');
 
-    assert.notOk(component.options[0].isSelected, 'option 0 is not selected');
+    assert.ok(component.options[0].isSelected, 'option 0 is selected');
     assert.notOk(component.options[1].isSelected, 'option 1 is not selected');
-    assert.ok(component.options[2].isSelected, 'option 2 is selected');
+    assert.notOk(component.options[2].isSelected, 'option 2 is not selected');
+    assert.notOk(component.options[3].isSelected, 'option 3 is not selected');
 
     this.set('changeId', (id) => {
       assert.strictEqual(id, '2031');
@@ -55,13 +62,14 @@ module('Integration | Component | reports/subject/new/academic-year', function (
 
     this.set('currentId', '2031');
     assert.notOk(component.options[0].isSelected, 'option 0 is not selected');
-    assert.ok(component.options[1].isSelected, 'option 1 is selected');
-    assert.notOk(component.options[2].isSelected, 'option 2 is not selected');
+    assert.notOk(component.options[1].isSelected, 'option 1 is not selected');
+    assert.ok(component.options[2].isSelected, 'option 2 is selected');
+    assert.notOk(component.options[3].isSelected, 'option 3 is not selected');
     assert.strictEqual(component.value, '2031', 'selected option is 2031');
   });
 
   test('it works', async function (assert) {
-    assert.expect(8);
+    assert.expect(10);
     this.set('currentId', '2015');
     await render(hbs`<Reports::Subject::New::AcademicYear
   @currentId={{this.currentId}}
@@ -72,14 +80,16 @@ module('Integration | Component | reports/subject/new/academic-year', function (
       assert.strictEqual(id, '2031');
       this.set('currentId', id);
     });
-    assert.ok(component.options[0].isSelected, 'option 0 is selected');
-    assert.notOk(component.options[1].isSelected, 'option 1 is not selected');
-    assert.notOk(component.options[2].isSelected, 'option 2 is not selected');
-
-    await component.set('2031');
     assert.notOk(component.options[0].isSelected, 'option 0 is not selected');
     assert.ok(component.options[1].isSelected, 'option 1 is selected');
     assert.notOk(component.options[2].isSelected, 'option 2 is not selected');
+    assert.notOk(component.options[3].isSelected, 'option 3 is not selected');
+
+    await component.set('2031');
+    assert.notOk(component.options[0].isSelected, 'option 0 is not selected');
+    assert.notOk(component.options[1].isSelected, 'option 1 is not selected');
+    assert.ok(component.options[2].isSelected, 'option 2 is selected');
+    assert.notOk(component.options[3].isSelected, 'option 3 is not selected');
     assert.strictEqual(component.value, '2031', 'selected option is 2031');
   });
 });

--- a/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/new/academic-year-test.js
@@ -44,9 +44,9 @@ module('Integration | Component | reports/subject/new/academic-year', function (
       this.intl.t('general.selectPolite'),
       'first option is blank',
     );
-    assert.strictEqual(component.options[1].text, '2015', 'second option is 2015');
+    assert.strictEqual(component.options[1].text, '2060', 'second option is 2060');
     assert.strictEqual(component.options[2].text, '2031', 'third option is 2031');
-    assert.strictEqual(component.options[3].text, '2060', 'fourth option is 2060');
+    assert.strictEqual(component.options[3].text, '2015', 'fourth option is 2015');
 
     assert.strictEqual(component.value, '', 'selected option is blank');
 
@@ -81,9 +81,9 @@ module('Integration | Component | reports/subject/new/academic-year', function (
       this.set('currentId', id);
     });
     assert.notOk(component.options[0].isSelected, 'option 0 is not selected');
-    assert.ok(component.options[1].isSelected, 'option 1 is selected');
+    assert.notOk(component.options[1].isSelected, 'option 1 is selected');
     assert.notOk(component.options[2].isSelected, 'option 2 is not selected');
-    assert.notOk(component.options[3].isSelected, 'option 3 is not selected');
+    assert.ok(component.options[3].isSelected, 'option 3 is not selected');
 
     await component.set('2031');
     assert.notOk(component.options[0].isSelected, 'option 0 is not selected');

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -472,6 +472,7 @@ general:
 errors:
   duplicateUsername: This username is already taken by another user account.
   invalidChangeAlertRecipients: This list of change-alerts recipients contains invalid email addresses.
+  reportMissingAcademicYear: Academic Year is Required
   reportMissingCompetency: Competency is Required
   reportMissingInstructor: Instructor is Required
   reportMissingMeshTerm: MeSH Term is Required

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -472,6 +472,7 @@ general:
 errors:
   duplicateUsername: Este nombre de usuario ya está ocupado por otra cuenta de usuario.
   invalidChangeAlertRecipients: Esta lista de destinatarios de alertas de cambios contiene direcciones de correo electrónico no válidas.
+  reportMissingAcademicYear: Año Academico es Necesario
   reportMissingCompetency: Competencia es Necesario
   reportMissingInstructor: Instructor es Necesario
   reportMissingMeshTerm: Término de MeSH es Necesario

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -473,6 +473,7 @@ general:
 errors:
   duplicateUsername: "Ce nom d'utilisateur est déjà pris par un autre compte utilisateur."
   invalidChangeAlertRecipients: "Cette liste de destinataires d'alertes de changement contient des adresses e-mail invalides."
+  reportMissingAcademicYear: Année Scolaire requis
   reportMissingCompetency: Compétence requis
   reportMissingInstructor: Instructeur requis
   reportMissingMeshTerm: terme de MeSH requis


### PR DESCRIPTION
Refs #8363, #8364

The change in #8363, while successfully removing the `ember-render-modifier` usage, introduced a new bug: a report won't run unless a selection is manually made for the specific Academic Year, as the default selection is no longer made when the options are loaded.

The change made in #8364 does a similar removal of an `ember-render-modifier` for the Competency option, but also changes the way the dropdown default selection works, in that a manual selection _needs_ to be made, and it's more obvious now.

This PR does the same thing for Academic Year.

