### PR TITLE
Fix Courses by Mesh Term Report

### DIFF
--- a/packages/frontend/app/components/reports/subject/course.js
+++ b/packages/frontend/app/components/reports/subject/course.js
@@ -100,12 +100,14 @@ export default class ReportsSubjectCourseComponent extends Component {
     );
     const { courses, courseObjectives, sessions, sessionObjectives } =
       result.data.meshDescriptors[0];
-    return [
+    const ids = [
       ...courses.map((course) => course.id),
       ...courseObjectives.map((objective) => objective.course.id),
       ...sessions.map((session) => session.course.id),
       ...sessionObjectives.map((objective) => objective.session.course.id),
-    ].sort();
+    ];
+
+    return [...new Set(ids)].sort();
   }
 
   async getReportResults(subject, prepositionalObject, prepositionalObjectTableRowId, school) {

--- a/packages/frontend/app/components/reports/subject/mesh-term.js
+++ b/packages/frontend/app/components/reports/subject/mesh-term.js
@@ -40,7 +40,7 @@ export default class ReportsSubjectMeshTermComponent extends Component {
     if (prepositionalObject && prepositionalObjectTableRowId) {
       if (prepositionalObject === 'course') {
         const ids = await this.getMeshIdsForCourse(prepositionalObjectTableRowId);
-        filters.push(`ids: [${ids.join(', ')}]`);
+        filters = [`ids: [${ids.join(', ')}]`]; //drop school filter, a course is only in one school
       } else {
         const what = pluralize(camelize(prepositionalObject));
         filters.push(`${what}: [${prepositionalObjectTableRowId}]`);

--- a/packages/frontend/tests/integration/components/reports/subject/course-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/course-test.js
@@ -216,9 +216,9 @@ module('Integration | Component | reports/subject/course', function (hooks) {
             data: {
               meshDescriptors: [
                 {
-                  courses: [{ id: 1 }, { id: 3 }, { id: 5 }],
+                  courses: [{ id: 1 }, { id: 3 }, { id: 5 }, { id: 1 }],
                   courseObjectives: [{ course: { id: 2 } }],
-                  sessions: [{ course: { id: 4 } }],
+                  sessions: [{ course: { id: 4 } }, { course: { id: 3 } }],
                   sessionObjectives: [{ session: { course: { id: 6 } } }],
                 },
               ],

--- a/packages/frontend/tests/integration/components/reports/subject/course-test.js
+++ b/packages/frontend/tests/integration/components/reports/subject/course-test.js
@@ -200,14 +200,43 @@ module('Integration | Component | reports/subject/course', function (hooks) {
   });
 
   test('filter by mesh', async function (assert) {
-    assert.expect(1);
+    assert.expect(2);
+    let graphQueryCounter = 0;
     this.server.post('api/graphql', function (schema, { requestBody }) {
+      graphQueryCounter++;
       const { query } = JSON.parse(requestBody);
-      assert.strictEqual(
-        query,
-        'query { courses(meshDescriptors: ["ABC"]) { id, title, year, externalId } }',
-      );
-      return responseData;
+      let rhett;
+      switch (graphQueryCounter) {
+        case 1:
+          assert.strictEqual(
+            query,
+            'query { meshDescriptors(id: "ABC") { courses { id }, courseObjectives { course { id } }, sessions { course { id } }, sessionObjectives { session { course { id } } } } }',
+          );
+          rhett = {
+            data: {
+              meshDescriptors: [
+                {
+                  courses: [{ id: 1 }, { id: 3 }, { id: 5 }],
+                  courseObjectives: [{ course: { id: 2 } }],
+                  sessions: [{ course: { id: 4 } }],
+                  sessionObjectives: [{ session: { course: { id: 6 } } }],
+                },
+              ],
+            },
+          };
+          break;
+        case 2:
+          assert.strictEqual(
+            query,
+            'query { courses(ids: [1, 2, 3, 4, 5, 6]) { id, title, year, externalId } }',
+          );
+          rhett = responseData;
+          break;
+        default:
+          assert.ok(false, 'too many queries');
+      }
+
+      return rhett;
     });
     const { id } = this.server.create('report', {
       subject: 'course',


### PR DESCRIPTION
The SQL query we need to run on the API has way too many joins and performs terribly for the courses by meshDescriptors filter. Instead we can reverse the lookup here and first pull the descriptor and all of it's relationships and then turn that into course ids and query them like we do any other filter.

Makes for messy tests because the graphQL responses have to use a counter, but it's 100x faster and won't crash the API DB anymore so that seems worth it.

Refs ilios/ilios#5650
Fixes ilios/ilios#4540