### PR TITLE
only allow percy to run installation scripts during build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@percy/core",
       "aws-sdk",
       "fsevents",
       "sharp"


### PR DESCRIPTION
see https://pnpm.io/package_json#pnpmonlybuiltdependenciesfile