### PR TITLE
prevent Percy from being built during installation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "husky": "^9.1.4"
   },
   "pnpm": {
+    "ignoredBuiltDependencies": [
+      "@percy/core"
+    ],
     "onlyBuiltDependencies": [
       "aws-sdk",
       "fsevents",


### PR DESCRIPTION
see https://pnpm.io/package_json#pnpmignoredbuiltdependencies