### PR TITLE
replace nonexistent this.load with proper async check

### DIFF
--- a/packages/ilios-common/addon/components/course/visualize-term.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-term.hbs
@@ -2,7 +2,7 @@
   class="course-visualize-term"
   data-test-course-visualize-term
 >
-  {{#unless this.academicYearCrossesCalendarYearBoundariesData.isResolved}}
+  {{#if this.academicYearCrossesCalendarYearBoundariesData.isResolved}}
     <div class="breadcrumbs" data-test-breadcrumb>
       <span>
         <LinkTo @route="course" @model={{@model.course}}>
@@ -51,5 +51,5 @@
         @showDataTable={{true}}
       />
     </div>
-  {{/unless}}
+  {{/if}}
 </section>


### PR DESCRIPTION
Refs ilios/frontend#8383

Updated the CourseVisualizeTerm component by removing its render modifier, but forgot to change the template to check the proper async value.