### PR TITLE
Fix Broken Test

### DIFF
--- a/packages/frontend/tests/integration/components/learner-group/instructor-manager-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/instructor-manager-test.js
@@ -71,7 +71,7 @@ module('Integration | Component | learner-group/instructor-manager', function (h
     assert.strictEqual(component.title, 'Manage Default Instructors');
     assert.strictEqual(component.selectedInstructors.length, 2);
     assert.strictEqual(component.selectedInstructors[0].userNameInfo.fullName, 'aardvark');
-    assert.dom(component.selectedInstructors[0].userNameInfo.hasAdditionalInfo);
+    assert.ok(component.selectedInstructors[0].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.selectedInstructors[1].userNameInfo.fullName, 'test person');
     assert.notOk(component.selectedInstructors[1].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.selectedInstructorGroups.length, 1);

--- a/packages/frontend/tests/integration/components/learner-group/instructors-list-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/instructors-list-test.js
@@ -57,7 +57,7 @@ module('Integration | Component | learner-group/instructors-list', function (hoo
     assert.strictEqual(component.title, 'Default Instructors (3)');
     assert.strictEqual(component.assignedInstructors.length, 3);
     assert.strictEqual(component.assignedInstructors[0].userNameInfo.fullName, 'aardvark');
-    assert.dom(component.assignedInstructors[0].userNameInfo.hasAdditionalInfo);
+    assert.ok(component.assignedInstructors[0].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.assignedInstructors[1].userNameInfo.fullName, 'test person');
     assert.notOk(component.assignedInstructors[1].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(component.assignedInstructors[2].userNameInfo.fullName, 'test person2');

--- a/packages/frontend/tests/integration/components/learner-group/root-test.js
+++ b/packages/frontend/tests/integration/components/learner-group/root-test.js
@@ -774,7 +774,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       component.instructorsList.assignedInstructors[0].userNameInfo.fullName,
       'aardvark',
     );
-    assert.dom(component.instructorsList.assignedInstructors[0].userNameInfo.hasAdditionalInfo);
+    assert.ok(component.instructorsList.assignedInstructors[0].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(
       component.instructorsList.assignedInstructors[1].userNameInfo.fullName,
       'test person',
@@ -794,7 +794,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       component.instructorManager.selectedInstructors[0].userNameInfo.fullName,
       'aardvark',
     );
-    assert.dom(component.instructorManager.selectedInstructors[0].userNameInfo.hasAdditionalInfo);
+    assert.ok(component.instructorManager.selectedInstructors[0].userNameInfo.hasAdditionalInfo);
     assert.strictEqual(
       component.instructorManager.selectedInstructors[1].userNameInfo.fullName,
       'test person',


### PR DESCRIPTION
This test isn't doing anything right now. `assert.dom` is used to grab an element and then run additional assertions on it. This is a typo and it should always have been `assert.ok`.