### PR TITLE
Remove Classic Classes from Tests

### DIFF
--- a/packages/frontend/eslint.config.mjs
+++ b/packages/frontend/eslint.config.mjs
@@ -52,7 +52,6 @@ export default [
     },
     rules: {
       'ember/classic-decorator-no-classic-methods': 'off',
-      'ember/no-classic-classes': 'off',
       'ember/no-mixins': 'off',
       'ember/no-new-mixins': 'off',
       'no-duplicate-imports': 'error',

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-details-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-details-test.js
@@ -12,12 +12,12 @@ module('Integration | Component | curriculum-inventory/report-details', function
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    this.permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       canCreateCurriculumInventoryReport() {
         return true;
-      },
-    });
-    this.owner.register('service:permission-checker', this.permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permission-checker', PermissionCheckerMock);
   });
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-overview-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-overview-test.js
@@ -31,12 +31,12 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       endDate: DateTime.fromObject({ year: currentYear, month: 4, day: 11 }).toJSDate(),
       description: 'Lorem Ipsum',
     });
-    this.permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       canCreateCurriculumInventoryReport() {
         return true;
-      },
-    });
-    this.owner.register('service:permission-checker', this.permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permission-checker', PermissionCheckerMock);
   });
 
   test('it renders', async function (assert) {
@@ -190,11 +190,12 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
       .lookup('service:store')
       .findRecord('curriculum-inventory-report', this.report.id);
     this.set('report', reportModel);
-    this.permissionCheckerMock.reopen({
+    class PermissionCheckerMock extends Service {
       canCreateCurriculumInventoryReport() {
         return false;
-      },
-    });
+      }
+    }
+    this.owner.register('service:permission-checker', PermissionCheckerMock);
     await render(
       hbs`<CurriculumInventory::ReportOverview @report={{this.report}} @canUpdate={{true}} />`,
     );

--- a/packages/frontend/tests/integration/components/curriculum-inventory/reports-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/reports-test.js
@@ -41,12 +41,12 @@ module('Integration | Component | curriculum-inventory/reports', function (hooks
       }
     }
     this.owner.register('service:currentUser', CurrentUserMock);
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       async canCreateCurriculumInventoryReport() {
         return true;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
   });
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/integration/components/ilios-navigation-test.js
+++ b/packages/frontend/tests/integration/components/ilios-navigation-test.js
@@ -10,10 +10,10 @@ module('Integration | Component | ilios-navigation', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders for privileged user', async function (assert) {
-    const currentUserMock = Service.extend({
-      performsNonLearnerFunction: true,
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+    class CurrentUserMock extends Service {
+      performsNonLearnerFunction = true;
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     await render(hbs`<IliosNavigation />`);
     await a11yAudit(this.element);
@@ -31,10 +31,10 @@ module('Integration | Component | ilios-navigation', function (hooks) {
   });
 
   test('navigation does not render for non-privileged user', async function (assert) {
-    const currentUserMock = Service.extend({
-      performsNonLearnerFunction: false,
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+    class CurrentUserMock extends Service {
+      performsNonLearnerFunction = false;
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     await render(hbs`<IliosNavigation />`);
     await a11yAudit(this.element);
@@ -44,11 +44,11 @@ module('Integration | Component | ilios-navigation', function (hooks) {
   });
 
   test('Super-privileged Users can access Admin', async function (assert) {
-    const currentUserMock = Service.extend({
-      performsNonLearnerFunction: true,
-      canCreateOrUpdateUserInAnySchool: true,
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+    class CurrentUserMock extends Service {
+      performsNonLearnerFunction = true;
+      canCreateOrUpdateUserInAnySchool = true;
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     await render(hbs`<IliosNavigation />`);
     await a11yAudit(this.element);

--- a/packages/frontend/tests/integration/components/my-profile-test.js
+++ b/packages/frontend/tests/integration/components/my-profile-test.js
@@ -226,14 +226,14 @@ module('Integration | Component | my profile', function (hooks) {
         jwt: 'new token',
       };
     });
-    const sessionMock = Service.extend({
+    class SessionMock extends Service {
       authenticate(how, obj) {
         assert.strictEqual(how, 'authenticator:ilios-jwt');
         assert.ok(obj.jwt);
         assert.strictEqual(obj.jwt, 'new token');
-      },
-    });
-    this.owner.register('service:session', sessionMock);
+      }
+    }
+    this.owner.register('service:session', SessionMock);
     this.session = this.owner.lookup('service:session');
     this.flashMessages = this.owner.lookup('service:flashMessages');
     const school = this.server.create('school');

--- a/packages/frontend/tests/integration/components/new-user-test.js
+++ b/packages/frontend/tests/integration/components/new-user-test.js
@@ -32,13 +32,13 @@ module('Integration | Component | new user', function (hooks) {
       }
     }
 
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       async canCreateUser() {
         return resolve(true);
-      },
-    });
+      }
+    }
     this.owner.register('service:current-user', CurrentUserMock);
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
   });
 
   test('it renders', async function (assert) {
@@ -281,12 +281,12 @@ module('Integration | Component | new user', function (hooks) {
 
   test('create new user in another school without permission in primary school #4830', async function (assert) {
     assert.expect(2);
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       async canCreateUser(school) {
         return Number(school.id) === 2;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
 
     this.set('transitionToUser', (userId) => {
       assert.strictEqual(Number(userId), 2);

--- a/packages/frontend/tests/integration/components/school-list-test.js
+++ b/packages/frontend/tests/integration/components/school-list-test.js
@@ -26,30 +26,30 @@ module('Integration | Component | school list', function (hooks) {
   });
 
   test('create school button is visible to root', async function (assert) {
-    const currentUserMock = Service.extend({
-      isRoot: true,
-    });
-    this.owner.register('service:current-user', currentUserMock);
+    class CurrentUserMock extends Service {
+      isRoot = true;
+    }
+    this.owner.register('service:current-user', CurrentUserMock);
     this.set('schools', []);
     await render(hbs`<SchoolList @schools={{this.schools}} />`);
     assert.ok(component.expandCollapseButton.isVisible);
   });
 
   test('create school button is not visible to non root users', async function (assert) {
-    const currentUserMock = Service.extend({
-      isRoot: false,
-    });
-    this.owner.register('service:current-user', currentUserMock);
+    class CurrentUserMock extends Service {
+      isRoot = false;
+    }
+    this.owner.register('service:current-user', CurrentUserMock);
     this.set('schools', []);
     await render(hbs`<SchoolList @schools={{this.schools}} />`);
     assert.notOk(component.expandCollapseButton.isVisible);
   });
 
   test('toggle visibility of new school form', async function (assert) {
-    const currentUserMock = Service.extend({
-      isRoot: true,
-    });
-    this.owner.register('service:current-user', currentUserMock);
+    class CurrentUserMock extends Service {
+      isRoot = true;
+    }
+    this.owner.register('service:current-user', CurrentUserMock);
     this.set('schools', []);
     await render(hbs`<SchoolList @schools={{this.schools}} />`);
     assert.notOk(component.newSchoolForm.isVisible);
@@ -64,10 +64,10 @@ module('Integration | Component | school list', function (hooks) {
   });
 
   test('create new school', async function (assert) {
-    const currentUserMock = Service.extend({
-      isRoot: true,
-    });
-    this.owner.register('service:current-user', currentUserMock);
+    class CurrentUserMock extends Service {
+      isRoot = true;
+    }
+    this.owner.register('service:current-user', CurrentUserMock);
     this.set('schools', []);
     await render(hbs`<SchoolList @schools={{this.schools}} />`);
     await component.expandCollapseButton.toggle();
@@ -87,10 +87,10 @@ module('Integration | Component | school list', function (hooks) {
   });
 
   test('submit empty form fails', async function (assert) {
-    const currentUserMock = Service.extend({
-      isRoot: true,
-    });
-    this.owner.register('service:current-user', currentUserMock);
+    class CurrentUserMock extends Service {
+      isRoot = true;
+    }
+    this.owner.register('service:current-user', CurrentUserMock);
     this.set('schools', []);
     await render(hbs`<SchoolList @schools={{this.schools}} />`);
     await component.expandCollapseButton.toggle();
@@ -102,10 +102,10 @@ module('Integration | Component | school list', function (hooks) {
   });
 
   test('email validation works', async function (assert) {
-    const currentUserMock = Service.extend({
-      isRoot: true,
-    });
-    this.owner.register('service:current-user', currentUserMock);
+    class CurrentUserMock extends Service {
+      isRoot = true;
+    }
+    this.owner.register('service:current-user', CurrentUserMock);
     this.set('schools', []);
     await render(hbs`<SchoolList @schools={{this.schools}} />`);
     await component.expandCollapseButton.toggle();

--- a/packages/frontend/tests/integration/components/user-profile-calendar-test.js
+++ b/packages/frontend/tests/integration/components/user-profile-calendar-test.js
@@ -12,10 +12,10 @@ module('Integration | Component | user profile calendar', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const iliosConfigMock = Service.extend({
-      namespace: '',
-    });
-    this.owner.register('service:iliosConfig', iliosConfigMock);
+    class IliosConfigMock extends Service {
+      namespace = '';
+    }
+    this.owner.register('service:iliosConfig', IliosConfigMock);
   });
 
   test('shows events for this week', async function (assert) {

--- a/packages/frontend/tests/unit/adapters/application-test.js
+++ b/packages/frontend/tests/unit/adapters/application-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('ApplicationAdapter', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     var adapter = this.owner.lookup('adapter:application');
     assert.ok(adapter);

--- a/packages/frontend/tests/unit/controllers/admin-dashboard-test.js
+++ b/packages/frontend/tests/unit/controllers/admin-dashboard-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | AdminDashboard ', function (hooks) {
     this.owner.register('controller:admin-dashboard', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     var controller = this.owner.lookup('controller:admin-dashboard');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/application-test.js
+++ b/packages/frontend/tests/unit/controllers/application-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('ApplicationController', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     var controller = this.owner.lookup('controller:application');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/assign-students-test.js
+++ b/packages/frontend/tests/unit/controllers/assign-students-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | assign students', function (hooks) {
     this.owner.register('controller:assign-students', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:assign-students');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/courses-test.js
+++ b/packages/frontend/tests/unit/controllers/courses-test.js
@@ -9,7 +9,6 @@ module('CoursesController', function (hooks) {
     this.owner.register('controller:courses', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     var controller = this.owner.lookup('controller:courses');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/curriculum-inventory-report/index-test.js
+++ b/packages/frontend/tests/unit/controllers/curriculum-inventory-report/index-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | curriculum inventory report/index', function (hooks)
     this.owner.register('controller:curriculum-inventory-report/index', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:curriculum-inventory-report/index');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/curriculum-inventory-report/rollover-test.js
+++ b/packages/frontend/tests/unit/controllers/curriculum-inventory-report/rollover-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | curriculum inventory report/rollover', function (hoo
     this.owner.register('controller:curriculum-inventory-report/rollover', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:curriculum-inventory-report/rollover');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/curriculum-inventory-sequence-block-test.js
+++ b/packages/frontend/tests/unit/controllers/curriculum-inventory-sequence-block-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | curriculum inventory sequence block', function (hook
     this.owner.register('controller:curriculum-inventory-sequence-block', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:curriculum-inventory-sequence-block');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/instructor-groups-test.js
+++ b/packages/frontend/tests/unit/controllers/instructor-groups-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | InstructorGroups ', function (hooks) {
     this.owner.register('controller:instructor-groups', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     var controller = this.owner.lookup('controller:instructor-groups');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/learner-group-test.js
+++ b/packages/frontend/tests/unit/controllers/learner-group-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | learner group', function (hooks) {
     this.owner.register('controller:learner-group', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:learner-group');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/learner-groups-test.js
+++ b/packages/frontend/tests/unit/controllers/learner-groups-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | LearnerGroups ', function (hooks) {
     this.owner.register('controller:learner-groups', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     var controller = this.owner.lookup('controller:learner-groups');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/pending-user-updates-test.js
+++ b/packages/frontend/tests/unit/controllers/pending-user-updates-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | pending user updates', function (hooks) {
     this.owner.register('controller:pending-user-updates', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:pending-user-updates');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/program-test.js
+++ b/packages/frontend/tests/unit/controllers/program-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | Program ', function (hooks) {
     this.owner.register('controller:program', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     var controller = this.owner.lookup('controller:program');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/school-test.js
+++ b/packages/frontend/tests/unit/controllers/school-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | school', function (hooks) {
     this.owner.register('controller:school', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:school');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/search-test.js
+++ b/packages/frontend/tests/unit/controllers/search-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | search', function (hooks) {
     this.owner.register('controller:search', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:search');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/controllers/user-test.js
+++ b/packages/frontend/tests/unit/controllers/user-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | user', function (hooks) {
     this.owner.register('controller:user', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:user');
     assert.ok(controller);

--- a/packages/frontend/tests/unit/mixins/live-search-item-test.js
+++ b/packages/frontend/tests/unit/mixins/live-search-item-test.js
@@ -3,7 +3,6 @@ import LiveSearchItemMixin from 'frontend/mixins/live-search-item';
 import { module, test } from 'qunit';
 
 module('LiveSearchItemMixin', function () {
-  // Replace this with your real tests.
   test('it works', function (assert) {
     var LiveSearchItemObject = EmberObject.extend(LiveSearchItemMixin);
     var subject = LiveSearchItemObject.create();

--- a/packages/frontend/tests/unit/services/user-events-test.js
+++ b/packages/frontend/tests/unit/services/user-events-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Service | user events', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     var service = this.owner.lookup('service:user-events');
     assert.ok(service);

--- a/packages/frontend/tests/unit/utils/random-string-test.js
+++ b/packages/frontend/tests/unit/utils/random-string-test.js
@@ -2,7 +2,6 @@ import randomString from '../../../utils/random-string';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | random string', function () {
-  // Replace this with your real tests.
   test('gives some random strings', function (assert) {
     var result1 = randomString();
     var result2 = randomString();

--- a/packages/lti-course-manager/tests/unit/adapters/application-test.js
+++ b/packages/lti-course-manager/tests/unit/adapters/application-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('ApplicationAdapter', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const adapter = this.owner.lookup('adapter:application');
     assert.ok(adapter);

--- a/packages/lti-course-manager/tests/unit/services/server-variables-test.js
+++ b/packages/lti-course-manager/tests/unit/services/server-variables-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Service | server-variables', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const service = this.owner.lookup('service:server-variables');
     assert.ok(service);

--- a/packages/lti-dashboard/tests/unit/adapters/application-test.js
+++ b/packages/lti-dashboard/tests/unit/adapters/application-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('ApplicationAdapter', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     var adapter = this.owner.lookup('adapter:application');
     assert.ok(adapter);

--- a/packages/lti-dashboard/tests/unit/services/server-variables-test.js
+++ b/packages/lti-dashboard/tests/unit/services/server-variables-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Service | server variables', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     var service = this.owner.lookup('service:server-variables');
     assert.ok(service);

--- a/packages/test-app/eslint.config.mjs
+++ b/packages/test-app/eslint.config.mjs
@@ -51,10 +51,6 @@ export default [
       reportUnusedDisableDirectives: 'error',
     },
     rules: {
-      // 'ember/classic-decorator-no-classic-methods': "off",
-      'ember/no-classic-classes': 'off',
-      // 'ember/no-mixins': "off",
-      // 'ember/no-new-mixins': "off",
       'ember/no-get': 'off',
       'no-duplicate-imports': 'error',
     },

--- a/packages/test-app/tests/integration/components/api-version-notice-test.js
+++ b/packages/test-app/tests/integration/components/api-version-notice-test.js
@@ -9,12 +9,12 @@ module('Integration | Component | api-version-notice', function (hooks) {
   setupRenderingTest(hooks);
 
   test('hidden when version match', async function (assert) {
-    const apiVersionMock = Service.extend({
+    class ApiVersionMock extends Service {
       async getIsMismatched() {
         return false;
-      },
-    });
-    this.owner.register('service:apiVersion', apiVersionMock);
+      }
+    }
+    this.owner.register('service:apiVersion', ApiVersionMock);
     await render(hbs`<ApiVersionNotice />`);
     await waitFor('[data-test-load-finished]');
     assert.ok(component.isHidden);
@@ -23,12 +23,12 @@ module('Integration | Component | api-version-notice', function (hooks) {
   });
 
   test('visible when versions do not match', async function (assert) {
-    const apiVersionMock = Service.extend({
+    class ApiVersionMock extends Service {
       async getIsMismatched() {
         return true;
-      },
-    });
-    this.owner.register('service:apiVersion', apiVersionMock);
+      }
+    }
+    this.owner.register('service:apiVersion', ApiVersionMock);
     await render(hbs`<ApiVersionNotice />`);
     await waitFor('[data-test-load-finished]');
     assert.ok(component.isVisible);

--- a/packages/test-app/tests/integration/components/course/overview-test.js
+++ b/packages/test-app/tests/integration/components/course/overview-test.js
@@ -12,12 +12,12 @@ module('Integration | Component | course overview', function (hooks) {
 
   hooks.beforeEach(function () {
     this.intl = this.owner.lookup('service:intl');
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       async canCreateCourse() {
         return true;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
     this.store = this.owner.lookup('service:store');
   });
 

--- a/packages/test-app/tests/integration/components/course/rollover-test.js
+++ b/packages/test-app/tests/integration/components/course/rollover-test.js
@@ -1,6 +1,5 @@
 import Service from '@ember/service';
 import { resolve } from 'rsvp';
-import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render, click, find, findAll, fillIn, blur as emberBlur } from '@ember/test-helpers';
@@ -510,12 +509,10 @@ module('Integration | Component | course/rollover', function (hooks) {
       );
     });
 
-    const mockCurrentUser = EmberObject.create({});
-
-    const currentUserMock = Service.extend({
-      model: resolve(mockCurrentUser),
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+    class CurrentUserMock extends Service {
+      model = resolve({});
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     this.set('course', course);
     await render(hbs`<Course::Rollover @course={{this.course}} @visit={{(noop)}} />`);

--- a/packages/test-app/tests/integration/components/course/summary-header-test.js
+++ b/packages/test-app/tests/integration/components/course/summary-header-test.js
@@ -10,10 +10,10 @@ module('Integration | Component | course summary header', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUserMock = Service.extend({
-      userIsCourseDirector: true,
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+    class CurrentUserMock extends Service {
+      userIsCourseDirector = true;
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     class PermissionCheckerStub extends Service {
       async canCreateCourse() {

--- a/packages/test-app/tests/integration/components/learning-material-uploader-test.js
+++ b/packages/test-app/tests/integration/components/learning-material-uploader-test.js
@@ -13,12 +13,12 @@ module('Integration | Component | learning-material-uploader', function (hooks) 
 
   test('upload file', async function (assert) {
     assert.expect(5);
-    const iliosConfigMock = Service.extend({
+    class IliosConfigMock extends Service {
       async getMaxUploadSize() {
         return 1000;
-      },
-    });
-    this.owner.register('service:iliosConfig', iliosConfigMock);
+      }
+    }
+    this.owner.register('service:iliosConfig', IliosConfigMock);
 
     this.server.post('/upload', (schema, request) => {
       assert.ok(request.requestBody.has('file'));
@@ -56,12 +56,12 @@ module('Integration | Component | learning-material-uploader', function (hooks) 
   });
 
   test('shows error when file is too big', async function (assert) {
-    const iliosConfigMock = Service.extend({
+    class IliosConfigMock extends Service {
       async getMaxUploadSize() {
         return 1;
-      },
-    });
-    this.owner.register('service:iliosConfig', iliosConfigMock);
+      }
+    }
+    this.owner.register('service:iliosConfig', IliosConfigMock);
 
     await render(
       hbs`<LearningMaterialUploader @for='test' @setFilename={{(noop)}} @setFileHash={{(noop)}} />`,

--- a/packages/test-app/tests/integration/components/session-copy-test.js
+++ b/packages/test-app/tests/integration/components/session-copy-test.js
@@ -40,12 +40,12 @@ module('Integration | Component | session copy', function (hooks) {
       course,
     });
 
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       canCreateSession() {
         return true;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
 
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
@@ -119,12 +119,12 @@ module('Integration | Component | session copy', function (hooks) {
       position: 3,
     });
 
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       canCreateSession() {
         return true;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
@@ -187,12 +187,12 @@ module('Integration | Component | session copy', function (hooks) {
       sessionType,
     });
 
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       canCreateSession() {
         return true;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
 
@@ -231,12 +231,12 @@ module('Integration | Component | session copy', function (hooks) {
       sessionType,
     });
 
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       canCreateSession() {
         return true;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     await render(hbs`<SessionCopy @session={{this.session}} />`);
@@ -289,12 +289,12 @@ module('Integration | Component | session copy', function (hooks) {
       sessionType,
     });
 
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       canCreateSession() {
         return true;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
@@ -342,12 +342,12 @@ module('Integration | Component | session copy', function (hooks) {
       postrequisite,
     });
 
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       canCreateSession() {
         return true;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
@@ -398,12 +398,12 @@ module('Integration | Component | session copy', function (hooks) {
       postrequisite,
     });
 
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       canCreateSession() {
         return true;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
@@ -455,12 +455,12 @@ module('Integration | Component | session copy', function (hooks) {
       prerequisites: [firstPrerequisite, secondPrerequisite],
     });
 
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       canCreateSession() {
         return true;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
@@ -515,12 +515,12 @@ module('Integration | Component | session copy', function (hooks) {
       prerequisites: [firstPrerequisite, secondPrerequisite],
     });
 
-    const permissionCheckerMock = Service.extend({
+    class PermissionCheckerMock extends Service {
       canCreateSession() {
         return true;
-      },
-    });
-    this.owner.register('service:permissionChecker', permissionCheckerMock);
+      }
+    }
+    this.owner.register('service:permissionChecker', PermissionCheckerMock);
     const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {

--- a/packages/test-app/tests/integration/components/week-glance-test.js
+++ b/packages/test-app/tests/integration/components/week-glance-test.js
@@ -23,6 +23,26 @@ module('Integration | Component | week glance', function (hooks) {
     second: 0,
   });
 
+  const setupUserEvents = (context) => {
+    class Mock extends Service {
+      async getEvents() {
+        return context.server.db.userevents;
+      }
+    }
+
+    context.owner.register('service:user-events', Mock);
+  };
+
+  const setupBlankEvents = (context) => {
+    class Mock extends Service {
+      async getEvents() {
+        return [];
+      }
+    }
+
+    context.owner.register('service:user-events', Mock);
+  };
+
   hooks.beforeEach(function () {
     this.server.create('userevent', {
       name: 'Learn to Learn',
@@ -68,18 +88,6 @@ module('Integration | Component | week glance', function (hooks) {
       offering: 1,
       slug: 'c',
     });
-    const events = this.server.db.userevents;
-
-    this.userEventsMock = Service.extend({
-      async getEvents() {
-        return events;
-      },
-    });
-    this.blankEventsMock = Service.extend({
-      async getEvents() {
-        return [];
-      },
-    });
 
     this.getTitle = function (fullTitle) {
       this.intl = this.owner.lookup('service:intl');
@@ -109,7 +117,7 @@ module('Integration | Component | week glance', function (hooks) {
   });
 
   test('it renders with events', async function (assert) {
-    this.owner.register('service:user-events', this.userEventsMock);
+    setupUserEvents(this);
     this.set('today', testDate.toJSDate());
     this.set('week', testDate.weekNumber);
     await render(hbs`<WeekGlance
@@ -132,8 +140,7 @@ module('Integration | Component | week glance', function (hooks) {
   });
 
   test('it renders blank', async function (assert) {
-    this.owner.register('service:user-events', this.blankEventsMock);
-    this.userEvents = this.owner.lookup('service:user-events');
+    setupBlankEvents(this);
 
     this.set('today', testDate.toJSDate());
     this.set('week', testDate.weekNumber);
@@ -158,8 +165,7 @@ module('Integration | Component | week glance', function (hooks) {
   });
 
   test('renders short title', async function (assert) {
-    this.owner.register('service:user-events', this.blankEventsMock);
-    this.userEvents = this.owner.lookup('service:user-events');
+    setupBlankEvents(this);
 
     this.set('today', testDate.toJSDate());
     this.set('week', testDate.weekNumber);
@@ -181,8 +187,7 @@ module('Integration | Component | week glance', function (hooks) {
   });
 
   test('it renders collapsed', async function (assert) {
-    this.owner.register('service:user-events', this.blankEventsMock);
-    this.userEvents = this.owner.lookup('service:user-events');
+    setupBlankEvents(this);
 
     this.set('today', testDate.toJSDate());
     this.set('week', testDate.weekNumber);
@@ -211,8 +216,7 @@ module('Integration | Component | week glance', function (hooks) {
 
   test('click to expand', async function (assert) {
     assert.expect(1);
-    this.owner.register('service:user-events', this.blankEventsMock);
-    this.userEvents = this.owner.lookup('service:user-events');
+    setupBlankEvents(this);
 
     this.set('today', testDate.toJSDate());
     this.set('toggle', (value) => {
@@ -233,8 +237,7 @@ module('Integration | Component | week glance', function (hooks) {
 
   test('click to collapse', async function (assert) {
     assert.expect(1);
-    this.owner.register('service:user-events', this.blankEventsMock);
-    this.userEvents = this.owner.lookup('service:user-events');
+    setupBlankEvents(this);
 
     this.set('today', testDate.toJSDate());
     this.set('toggle', (value) => {
@@ -258,7 +261,7 @@ module('Integration | Component | week glance', function (hooks) {
     const nextYear = testDate.plus({ years: 1 });
     let count = 1;
     const service = this.owner.lookup('service:locale-days');
-    class blankEventsMock extends Service {
+    class BlankEventsMock extends Service {
       async getEvents(fromStamp, toStamp) {
         const from = DateTime.fromSeconds(fromStamp);
         const to = DateTime.fromSeconds(toStamp);
@@ -289,8 +292,7 @@ module('Integration | Component | week glance', function (hooks) {
         return [];
       }
     }
-    this.owner.register('service:user-events', blankEventsMock);
-    this.userEvents = this.owner.lookup('service:user-events');
+    this.owner.register('service:user-events', BlankEventsMock);
 
     this.set('year', testDate.year);
     this.set('week', testDate.weekNumber);

--- a/packages/test-app/tests/integration/helpers/has-many-ids-test.js
+++ b/packages/test-app/tests/integration/helpers/has-many-ids-test.js
@@ -6,7 +6,6 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Helper | has-many-ids', function (hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
   test('it renders', async function (assert) {
     assert.expect(2);
     this.set('model', {

--- a/packages/test-app/tests/integration/helpers/remove-html-tags-test.js
+++ b/packages/test-app/tests/integration/helpers/remove-html-tags-test.js
@@ -6,7 +6,6 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Helper | remove-html-tags', function (hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
   test('it renders', async function (assert) {
     this.set('inputValue', '<p>Tags should</p><p> not show up</p>');
 

--- a/packages/test-app/tests/integration/modifiers/scroll-into-view-test.js
+++ b/packages/test-app/tests/integration/modifiers/scroll-into-view-test.js
@@ -6,7 +6,6 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Modifier | scroll-into-view', function (hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
   test('it renders', async function (assert) {
     await render(hbs`<div {{scroll-into-view}}></div>`);
 

--- a/packages/test-app/tests/integration/services/school-events-test.js
+++ b/packages/test-app/tests/integration/services/school-events-test.js
@@ -60,10 +60,10 @@ module('Integration | Service | school events', function (hooks) {
 
   test('getEvents - with configured namespace', async function (assert) {
     assert.expect(4);
-    const iliosConfigMock = Service.extend({
-      apiNameSpace: 'geflarknik',
-    });
-    this.owner.register('service:iliosConfig', iliosConfigMock);
+    class IliosConfigMock extends Service {
+      apiNameSpace = 'geflarknik';
+    }
+    this.owner.register('service:iliosConfig', IliosConfigMock);
 
     const from = DateTime.fromObject({ year: 2015, month: 3, day: 5, hour: 0 });
     const to = from.set({ hour: 24 });

--- a/packages/test-app/tests/integration/services/user-events-test.js
+++ b/packages/test-app/tests/integration/services/user-events-test.js
@@ -10,13 +10,13 @@ module('Integration | Service | user events', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const MockCurrentUserService = Service.extend({
+    class MockCurrentUserService extends Service {
       async getModel() {
         return EmberObject.create({
           id: 1,
         });
-      },
-    });
+      }
+    }
     this.owner.register('service:current-user', MockCurrentUserService);
     this.currentUser = this.owner.lookup('service:current-user');
   });
@@ -86,10 +86,10 @@ module('Integration | Service | user events', function (hooks) {
 
   test('getEvents - with configured namespace', async function (assert) {
     assert.expect(2);
-    const iliosConfigMock = Service.extend({
-      apiNameSpace: 'geflarknik',
-    });
-    this.owner.register('service:iliosConfig', iliosConfigMock);
+    class IliosConfigMock extends Service {
+      apiNameSpace = 'geflarknik';
+    }
+    this.owner.register('service:iliosConfig', IliosConfigMock);
     const from = DateTime.fromObject({ year: 2015, month: 3, day: 5, hour: 0 });
     const to = from.set({ hour: 24 });
     this.server.get(`/geflarknik/userevents/:id`, (scheme, { params }) => {

--- a/packages/test-app/tests/unit/adapters/application-test.js
+++ b/packages/test-app/tests/unit/adapters/application-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Adapter | application', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const adapter = this.owner.lookup('adapter:application');
     assert.ok(adapter);

--- a/packages/test-app/tests/unit/controllers/course-materials-test.js
+++ b/packages/test-app/tests/unit/controllers/course-materials-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | course-materials', function (hooks) {
     this.owner.register('controller:course-materials', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:course-materials');
     assert.ok(controller);

--- a/packages/test-app/tests/unit/controllers/course-test.js
+++ b/packages/test-app/tests/unit/controllers/course-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | course', function (hooks) {
     this.owner.register('controller:course', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:course');
     assert.ok(controller);

--- a/packages/test-app/tests/unit/controllers/course-visualize-instructors-test.js
+++ b/packages/test-app/tests/unit/controllers/course-visualize-instructors-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | course-visualize-instructors', function (hooks) {
     this.owner.register('controller:course-visualize-instructors', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:course-visualize-instructors');
     assert.ok(controller);

--- a/packages/test-app/tests/unit/controllers/course/index-test.js
+++ b/packages/test-app/tests/unit/controllers/course/index-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | course/index', function (hooks) {
     this.owner.register('controller:course/index', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:course/index');
     assert.ok(controller);

--- a/packages/test-app/tests/unit/controllers/course/publishall-test.js
+++ b/packages/test-app/tests/unit/controllers/course/publishall-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | course/publishall', function (hooks) {
     this.owner.register('controller:course/publishal', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:course/publishall');
     assert.ok(controller);

--- a/packages/test-app/tests/unit/controllers/course/rollover-test.js
+++ b/packages/test-app/tests/unit/controllers/course/rollover-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | course/rollover', function (hooks) {
     this.owner.register('controller:course/rollover', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:course/rollover');
     assert.ok(controller);

--- a/packages/test-app/tests/unit/controllers/print-course-test.js
+++ b/packages/test-app/tests/unit/controllers/print-course-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | print-course', function (hooks) {
     this.owner.register('controller:print-course', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:print-course');
     assert.ok(controller);

--- a/packages/test-app/tests/unit/controllers/session/copy-test.js
+++ b/packages/test-app/tests/unit/controllers/session/copy-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | session/copy', function (hooks) {
     this.owner.register('controller:session/copy', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:session/copy');
     assert.ok(controller);

--- a/packages/test-app/tests/unit/controllers/session/index-test.js
+++ b/packages/test-app/tests/unit/controllers/session/index-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | session/index', function (hooks) {
     this.owner.register('controller:session/index', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:session/index');
     assert.ok(controller);

--- a/packages/test-app/tests/unit/controllers/weeklyevents-test.js
+++ b/packages/test-app/tests/unit/controllers/weeklyevents-test.js
@@ -9,7 +9,6 @@ module('Unit | Controller | weeklyevents', function (hooks) {
     this.owner.register('controller:weeklyevents', Controller);
   });
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:weeklyevents');
     assert.ok(controller);

--- a/packages/test-app/tests/unit/models/course-objective-test.js
+++ b/packages/test-app/tests/unit/models/course-objective-test.js
@@ -5,7 +5,6 @@ import { waitForResource } from 'ilios-common';
 module('Unit | Model | course objective', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('course-objective', {});

--- a/packages/test-app/tests/unit/models/program-year-objective-test.js
+++ b/packages/test-app/tests/unit/models/program-year-objective-test.js
@@ -5,7 +5,6 @@ import { waitForResource } from 'ilios-common';
 module('Unit | Model | program year objective', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('program-year-objective', {});

--- a/packages/test-app/tests/unit/models/session-objective-test.js
+++ b/packages/test-app/tests/unit/models/session-objective-test.js
@@ -5,7 +5,6 @@ import { waitForResource } from 'ilios-common';
 module('Unit | Model | session objective', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('session-objective', {});

--- a/packages/test-app/tests/unit/models/user-session-material-status-test.js
+++ b/packages/test-app/tests/unit/models/user-session-material-status-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Model | user session material status', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     let store = this.owner.lookup('service:store');
     let model = store.createRecord('user-session-material-status', {});

--- a/packages/test-app/tests/unit/services/api-version-test.js
+++ b/packages/test-app/tests/unit/services/api-version-test.js
@@ -5,7 +5,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Service | api-version', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const service = this.owner.lookup('service:api-version');
     assert.ok(service);
@@ -14,24 +13,24 @@ module('Unit | Service | api-version', function (hooks) {
   test('returns false when versions match', async function (assert) {
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
     assert.ok(apiVersion);
-    const iliosConfigMock = Service.extend({
+    class IliosConfigMock extends Service {
       async getApiVersion() {
         return apiVersion;
-      },
-    });
-    this.owner.register('service:iliosConfig', iliosConfigMock);
+      }
+    }
+    this.owner.register('service:iliosConfig', IliosConfigMock);
     const service = this.owner.lookup('service:api-version');
     const versionMismatch = await service.getIsMismatched();
     assert.notOk(versionMismatch);
   });
 
   test('returns true on version mismatch', async function (assert) {
-    const iliosConfigMock = Service.extend({
+    class IliosConfigMock extends Service {
       async getApiVersion() {
         return '1.0.0';
-      },
-    });
-    this.owner.register('service:iliosConfig', iliosConfigMock);
+      }
+    }
+    this.owner.register('service:iliosConfig', IliosConfigMock);
     const service = this.owner.lookup('service:api-version');
     const versionMismatch = await service.getIsMismatched();
     assert.ok(versionMismatch);

--- a/packages/test-app/tests/unit/services/data-loader-test.js
+++ b/packages/test-app/tests/unit/services/data-loader-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Service | data-loader', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const service = this.owner.lookup('service:data-loader');
     assert.ok(service);

--- a/packages/test-app/tests/unit/services/fetch-test.js
+++ b/packages/test-app/tests/unit/services/fetch-test.js
@@ -9,10 +9,10 @@ module('Unit | Service | fetch', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const iliosConfigMock = Service.extend({
-      apiHost: '',
-    });
-    this.owner.register('service:iliosConfig', iliosConfigMock);
+    class IliosConfigMock extends Service {
+      apiHost = '';
+    }
+    this.owner.register('service:iliosConfig', IliosConfigMock);
   });
 
   test('getJsonFromApiHost works', async function (assert) {

--- a/packages/test-app/tests/unit/services/permission-checker-test.js
+++ b/packages/test-app/tests/unit/services/permission-checker-test.js
@@ -7,7 +7,6 @@ module('Unit | Service | permission-checker', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const service = this.owner.lookup('service:permission-checker');
     assert.ok(service);
@@ -17,38 +16,38 @@ module('Unit | Service | permission-checker', function (hooks) {
     assert.expect(7);
     const school = { id: 1 };
 
-    const apiVersionMock = Service.extend({
+    class ApiVersionMock extends Service {
       async getIsMismatched() {
         return false;
-      },
-    });
-    this.owner.register('service:apiVersion', apiVersionMock);
+      }
+    }
+    this.owner.register('service:apiVersion', ApiVersionMock);
 
-    const currentUserMock = Service.extend({
-      isRoot: false,
+    class CurrentUserMock extends Service {
+      isRoot = false;
       async getRolesInSchool(sch) {
         assert.strictEqual(sch, school);
         return ['ADMIN'];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
-    const permissionMatrixMock = Service.extend({
+    class PermissionMatrixMock extends Service {
       getPermittedRoles(sch, cap) {
         assert.strictEqual(sch, school);
         assert.strictEqual(cap, 'GO_FORTH');
 
         return ['ADMIN'];
-      },
+      }
       hasPermission(sch, cap, roles) {
         assert.strictEqual(sch, school);
         assert.strictEqual(cap, 'GO_FORTH');
         assert.deepEqual(roles, ['ADMIN']);
 
         return ['ADMIN'];
-      },
-    });
-    this.owner.register('service:permissionMatrix', permissionMatrixMock);
+      }
+    }
+    this.owner.register('service:permissionMatrix', PermissionMatrixMock);
 
     const service = this.owner.lookup('service:permission-checker');
     const canChangeInSchool = await service.canChangeInSchool(school, 'GO_FORTH');
@@ -59,18 +58,17 @@ module('Unit | Service | permission-checker', function (hooks) {
     assert.expect(2);
     const school = { id: 1 };
 
-    const apiVersionMock = Service.extend({
+    class ApiVersionMock extends Service {
       async getIsMismatched() {
         assert.ok(true);
         return true;
-      },
-    });
-    const currentUserMock = Service.extend({
-      isRoot: true,
-    });
-    this.owner.register('service:currentUser', currentUserMock);
-
-    this.owner.register('service:apiVersion', apiVersionMock);
+      }
+    }
+    class CurrentUserMock extends Service {
+      isRoot = true;
+    }
+    this.owner.register('service:apiVersion', ApiVersionMock);
+    this.owner.register('service:currentUser', CurrentUserMock);
     const service = this.owner.lookup('service:permission-checker');
     const canChangeInSchool = await service.canChangeInSchool(school, 'GO_FORTH');
     assert.notOk(canChangeInSchool);
@@ -80,20 +78,20 @@ module('Unit | Service | permission-checker', function (hooks) {
     assert.expect(2);
     const school = { id: 1 };
 
-    const apiVersionMock = Service.extend({
+    class ApiVersionMock extends Service {
       async getIsMismatched() {
         return false;
-      },
-    });
-    this.owner.register('service:apiVersion', apiVersionMock);
+      }
+    }
+    this.owner.register('service:apiVersion', ApiVersionMock);
 
-    const currentUserMock = Service.extend({
+    class CurrentUserMock extends Service {
       get isRoot() {
         assert.ok(true);
         return true;
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     const service = this.owner.lookup('service:permission-checker');
     const canChangeInSchool = await service.canChangeInSchool(school, 'GO_FORTH');
@@ -109,14 +107,14 @@ module('Unit | Service | permission-checker', function (hooks) {
     const group = this.server.create('learner-group', { cohort });
     const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
-    const currentUserMock = Service.extend({
-      isRoot: false,
+    class CurrentUserMock extends Service {
+      isRoot = false;
       async getRolesInSchool(sch) {
         assert.strictEqual(sch.id, school.id);
         return ['SCHOOL_ADMINISTRATOR'];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     const service = this.owner.lookup('service:permission-checker');
     const canUpdateLearnerGroup = await service.canUpdateLearnerGroup(model);
@@ -132,14 +130,14 @@ module('Unit | Service | permission-checker', function (hooks) {
     const group = this.server.create('learner-group', { cohort });
     const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
-    const currentUserMock = Service.extend({
-      isRoot: false,
+    class CurrentUserMock extends Service {
+      isRoot = false;
       async getRolesInSchool(sch) {
         assert.strictEqual(sch.id, school.id);
         return ['SCHOOL_ADMINISTRATOR'];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     const service = this.owner.lookup('service:permission-checker');
     const canDeleteLearnerGroup = await service.canUpdateLearnerGroup(model);
@@ -155,14 +153,14 @@ module('Unit | Service | permission-checker', function (hooks) {
     const group = this.server.create('learner-group', { cohort });
     const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
-    const currentUserMock = Service.extend({
-      isRoot: false,
+    class CurrentUserMock extends Service {
+      isRoot = false;
       async getRolesInSchool(sch) {
         assert.strictEqual(sch.id, school.id);
         return [];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     const service = this.owner.lookup('service:permission-checker');
     const canUpdateLearnerGroup = await service.canUpdateLearnerGroup(model);
@@ -178,14 +176,14 @@ module('Unit | Service | permission-checker', function (hooks) {
     const group = this.server.create('learner-group', { cohort });
     const model = await this.owner.lookup('service:store').findRecord('learner-group', group.id);
 
-    const currentUserMock = Service.extend({
-      isRoot: false,
+    class CurrentUserMock extends Service {
+      isRoot = false;
       async getRolesInSchool(sch) {
         assert.strictEqual(sch.id, school.id);
         return [];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     const service = this.owner.lookup('service:permission-checker');
     const canDeleteLearnerGroup = await service.canUpdateLearnerGroup(model);
@@ -201,14 +199,14 @@ module('Unit | Service | permission-checker', function (hooks) {
       .lookup('service:store')
       .findRecord('curriculum-inventory-report', report.id);
 
-    const currentUserMock = Service.extend({
-      isRoot: false,
+    class CurrentUserMock extends Service {
+      isRoot = false;
       async getRolesInSchool(sch) {
         assert.strictEqual(sch.id, school.id);
         return ['SCHOOL_ADMINISTRATOR'];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     const service = this.owner.lookup('service:permission-checker');
     const canDeleteCurriculumInventoryReport =
@@ -225,18 +223,18 @@ module('Unit | Service | permission-checker', function (hooks) {
       .lookup('service:store')
       .findRecord('curriculum-inventory-report', report.id);
 
-    const currentUserMock = Service.extend({
-      isRoot: false,
+    class CurrentUserMock extends Service {
+      isRoot = false;
       async getRolesInSchool(sch) {
         assert.strictEqual(sch.id, school.id);
         return [];
-      },
+      }
       async getRolesInCurriculumInventoryReport(rpt) {
         assert.strictEqual(rpt.id, model.id);
         return ['CURRICULUM_INVENTORY_REPORT_ADMINISTRATOR'];
-      },
-    });
-    this.owner.register('service:currentUser', currentUserMock);
+      }
+    }
+    this.owner.register('service:currentUser', CurrentUserMock);
 
     const service = this.owner.lookup('service:permission-checker');
     const canDeleteCurriculumInventoryReport =

--- a/packages/test-app/tests/unit/services/permission-matrix-test.js
+++ b/packages/test-app/tests/unit/services/permission-matrix-test.js
@@ -4,7 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Service | permission-matrix', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function (assert) {
     const service = this.owner.lookup('service:permission-matrix');
     assert.ok(service);

--- a/packages/test-app/tests/unit/utils/as-array-test.js
+++ b/packages/test-app/tests/unit/utils/as-array-test.js
@@ -107,6 +107,7 @@ module('Unit | Utility | as-array', function () {
   });
 
   test('it works for ember object with toArray property [EmberObject]', function (assert) {
+    // eslint-disable-next-line ember/no-classic-classes
     const item = EmberObject.extend({
       toArray() {
         return [1, 2, 3];
@@ -157,6 +158,7 @@ module('Unit | Utility | as-array', function () {
   test('it not works for EmberObject as array', function (assert) {
     assert.expect(1);
     try {
+      // eslint-disable-next-line ember/no-classic-classes
       const item = EmberObject.extend({}).create();
       asArray(item);
     } catch (e) {

--- a/packages/test-app/tests/unit/utils/is-equal-test.js
+++ b/packages/test-app/tests/unit/utils/is-equal-test.js
@@ -42,6 +42,7 @@ module('Unit | Utility | is equal', function () {
     },
     {
       label: 'Ember.isEqual applied to firstValue',
+      // eslint-disable-next-line ember/no-classic-classes
       firstValue: EmberObject.extend({
         isEqual(value) {
           return this.get('value') === value;
@@ -54,6 +55,7 @@ module('Unit | Utility | is equal', function () {
     {
       label: 'Ember.isEqual applied to secondValue',
       firstValue: 10,
+      // eslint-disable-next-line ember/no-classic-classes
       secondValue: EmberObject.extend({
         isEqual(value) {
           return this.get('value') === value;


### PR DESCRIPTION
We had this linting exception in place for tests where we were still using this old pattern. Removed the exception and cleaned up the invocations. I also removed a comment that keeps bugging me and I never remember to remove. Little bonus!