### PR TITLE
Realign Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: "monday"
+      day: "tuesday"
     open-pull-requests-limit: 10
     groups:
       embroider:
@@ -24,8 +24,7 @@ updates:
       - dependency-name: "@babel/eslint-parser"
       - dependency-name: "@babel/plugin-proposal-decorators"
       - dependency-name: "@ember/optional-features"
-      - dependency-name: "@ember/test-helpers"
-      - dependency-name: "@embroider/test-setup"
+      - dependency-name: "@eslint/js"
       - dependency-name: "@glimmer/component"
       - dependency-name: "@glimmer/tracking"
       - dependency-name: broccoli-asset-rev
@@ -34,9 +33,11 @@ updates:
       - dependency-name: ember-cli
       - dependency-name: ember-cli-app-version
       - dependency-name: ember-cli-babel
+      - dependency-name: ember-cli-clean-css
       - dependency-name: ember-cli-dependency-checker
       - dependency-name: ember-cli-htmlbars
       - dependency-name: ember-cli-inject-live-reload
+      - dependency-name: ember-cli-sri
       - dependency-name: ember-cli-terser
       - dependency-name: ember-fetch
       - dependency-name: ember-load-initializers
@@ -46,6 +47,7 @@ updates:
       - dependency-name: ember-resolver
       - dependency-name: ember-source
       - dependency-name: ember-source-channel-url
+      - dependency-name: ember-template-imports
       - dependency-name: ember-template-lint
       - dependency-name: ember-try
       - dependency-name: ember-welcome-page
@@ -55,8 +57,10 @@ updates:
       - dependency-name: eslint-plugin-n
       - dependency-name: eslint-plugin-prettier
       - dependency-name: eslint-plugin-qunit
-      - dependency-name: loader.js
+      - dependency-name: globals
+      - dependency-name: loader
       - dependency-name: prettier
+      - dependency-name: prettier-plugin-ember-template-tag
       - dependency-name: qunit
       - dependency-name: qunit-dom
       - dependency-name: stylelint


### PR DESCRIPTION
Aligning our ignored updates with the latest output from ember-cli for apps and addons. I also moved our update day to Tuesday to give us time to resolve issues with the transitive update job before we get a bunch of minor update PRs.