### PR TITLE
Enable staticEmberSource Option

### DIFF
--- a/packages/frontend/ember-cli-build.js
+++ b/packages/frontend/ember-cli-build.js
@@ -70,6 +70,7 @@ module.exports = async function (defaults) {
     staticAddonTestSupportTrees: true,
     staticAddonTrees: true,
     staticInvokables: true,
+    staticEmberSource: true,
     // splitAtRoutes: [], disabled until https://github.com/embroider-build/embroider/issues/231 once again allows our loading routes to work
     packagerOptions: {
       webpackConfig: {

--- a/packages/lti-course-manager/ember-cli-build.js
+++ b/packages/lti-course-manager/ember-cli-build.js
@@ -39,5 +39,6 @@ module.exports = async function (defaults) {
     staticAddonTrees: true,
     staticHelpers: true,
     staticComponents: true,
+    staticEmberSource: true,
   });
 };

--- a/packages/lti-dashboard/ember-cli-build.js
+++ b/packages/lti-dashboard/ember-cli-build.js
@@ -40,5 +40,6 @@ module.exports = async function (defaults) {
     staticAddonTrees: true,
     staticHelpers: true,
     staticComponents: true,
+    staticEmberSource: true,
   });
 };

--- a/packages/test-app/ember-cli-build.js
+++ b/packages/test-app/ember-cli-build.js
@@ -37,5 +37,6 @@ module.exports = async function (defaults) {
     staticAddonTestSupportTrees: true,
     staticAddonTrees: true,
     staticInvokables: true,
+    staticEmberSource: true,
   });
 };


### PR DESCRIPTION
This will default to true in the next embroider release, adding it now stops the console message on boot and ensures we're compatible.