### PR TITLE
Replace render modifiers in course rollover component

### DIFF
--- a/packages/ilios-common/.lint-todo
+++ b/packages/ilios-common/.lint-todo
@@ -4,7 +4,3 @@ add|ember-template-lint|no-at-ember-render-modifiers|3|2|3|2|1fb6f249958ee245e6a
 add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|856162ce473b112534763bb641aae7a4422d8e2e|1731542400000|1762646400000|1793750400000|addon/components/session-copy.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|3|2|3|2|23cd787c79c34a628dadb6e96dd4004d42eebb79|1731542400000|1762646400000|1793750400000|addon/components/session-offerings-list.hbs
 add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|60333f2ba463ca3d2ba17a04d799c8d66d8b99e2|1731542400000|1762646400000|1793750400000|addon/components/session-offerings-list.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|2bbf15957242a9a3c1e26e14e5d022c858199fde|1731542400000|1762646400000|1793750400000|addon/components/course/rollover-date-picker.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|5|2|5|2|167e8d9ede488c7f199cb748e81bc09b97617e71|1731542400000|1762646400000|1793750400000|addon/components/course/rollover-date-picker.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|3|2|3|2|1009d3843f6aed52099f0e7fbd4eebb52bc176e5|1731542400000|1762646400000|1793750400000|addon/components/course/rollover.hbs
-add|ember-template-lint|no-at-ember-render-modifiers|4|2|4|2|84076f8cf85c554eaf0d9fdec26154bae5bceeb2|1731542400000|1762646400000|1793750400000|addon/components/course/rollover.hbs

--- a/packages/ilios-common/addon/components/course/rollover.hbs
+++ b/packages/ilios-common/addon/components/course/rollover.hbs
@@ -82,7 +82,7 @@
             @value={{this.startDate}}
             @allowedWeekdays={{this.allowedWeekdays}}
             @minDate={{@course.startDate}}
-            @onChange={{this.updateStartDate}}
+            @onChange={{this.changeStartDate}}
           />
         </div>
         <div class="included">

--- a/packages/ilios-common/addon/components/course/rollover.hbs
+++ b/packages/ilios-common/addon/components/course/rollover.hbs
@@ -1,8 +1,4 @@
-<div
-  class="course-rollover"
-  {{did-insert (perform this.load) @course}}
-  {{did-update (perform this.load) @course}}
->
+<div class="course-rollover">
   {{#if this.save.isRunning}}
     <WaitSaving
       @showProgress={{false}}

--- a/packages/ilios-common/addon/components/course/rollover.hbs
+++ b/packages/ilios-common/addon/components/course/rollover.hbs
@@ -51,7 +51,7 @@
               <option
                 disabled={{includes year this.unavailableYears}}
                 value={{year}}
-                selected={{is-equal year this.selectedYear}}
+                selected={{is-equal year this.year}}
               >
                 {{#if this.academicYearCrossesCalendarYearBoundaries}}
                   {{year}} - {{add year 1}}
@@ -119,8 +119,8 @@
           type="button"
           disabled={{if
             (or
-              (not this.selectedYear)
-              (includes this.selectedYear this.unavailableYears)
+              (not this.year)
+              (includes this.year this.unavailableYears)
             )
             true
           }}

--- a/packages/ilios-common/addon/components/course/rollover.hbs
+++ b/packages/ilios-common/addon/components/course/rollover.hbs
@@ -26,12 +26,15 @@
           type="text"
           value={{this.title}}
           {{on "input" (pick "target.value" (set this "newTitle"))}}
-          {{on "input" (fn this.addErrorDisplayFor "newTitle")}}
+          {{on "input" (fn this.validations.addErrorDisplayFor "title")}}
           disabled={{this.save.isRunning}}
           placeholder={{t "general.courseTitlePlaceholder"}}
           data-test-title
         >
-        <ValidationError @validatable={{this}} @property="newTitle" />
+        <YupValidationMessage
+          @description={{t 'general.title'}}
+          @validationErrors={{this.validations.errors.title}}
+        />
       </div>
       <div class="item year-select">
         <label for="year-{{templateId}}">
@@ -63,7 +66,10 @@
         {{else}}
           <LoadingSpinner />
         {{/if}}
-        <ValidationError @validatable={{this}} @property="selectedYear" />
+        <YupValidationMessage
+          @description={{t 'general.year'}}
+          @validationErrors={{this.validations.errors.year}}
+        />
       </div>
       <div class="advanced-options">
         <div class="item">

--- a/packages/ilios-common/addon/components/course/rollover.hbs
+++ b/packages/ilios-common/addon/components/course/rollover.hbs
@@ -29,13 +29,13 @@
           id="title-{{templateId}}"
           type="text"
           value={{this.title}}
-          {{on "input" (pick "target.value" (set this "title"))}}
-          {{on "input" (fn this.addErrorDisplayFor "title")}}
+          {{on "input" (pick "target.value" (set this "newTitle"))}}
+          {{on "input" (fn this.addErrorDisplayFor "newTitle")}}
           disabled={{this.save.isRunning}}
           placeholder={{t "general.courseTitlePlaceholder"}}
           data-test-title
         >
-        <ValidationError @validatable={{this}} @property="title" />
+        <ValidationError @validatable={{this}} @property="newTitle" />
       </div>
       <div class="item year-select">
         <label for="year-{{templateId}}">

--- a/packages/ilios-common/addon/components/course/rollover.js
+++ b/packages/ilios-common/addon/components/course/rollover.js
@@ -72,7 +72,7 @@ export default class CourseRolloverComponent extends Component {
   }
 
   get startDate() {
-    return this.isStartDateSet ? this.startDate : this.args.course.startDate;
+    return this.isStartDateSet ? this.selectedStartDate : this.args.course.startDate;
   }
 
   get allowedWeekdays() {

--- a/packages/ilios-common/addon/components/course/rollover.js
+++ b/packages/ilios-common/addon/components/course/rollover.js
@@ -117,9 +117,13 @@ export default class CourseRolloverComponent extends Component {
 
   save = dropTask(async () => {
     await timeout(1);
-    // if the user hasn't set a new title, then we do this on their behalf now.
+    // if the user hasn't set a new title, then do this now on their behalf.
     if (!this.isNewTitleSet) {
       this.changeTitle(this.args.course.title);
+    }
+    // if the user hasn't set a start date, then do this now on their behalf.
+    if (!this.isStartDateSet) {
+      this.updateStartDate(this.args.course.startDate);
     }
     this.addErrorDisplayForAllFields();
     const isValid = await this.isValid();

--- a/packages/ilios-common/addon/components/course/rollover.js
+++ b/packages/ilios-common/addon/components/course/rollover.js
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import { cached, tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { validatable, Length, NotBlank } from 'ilios-common/decorators/validation';
-import { dropTask, restartableTask, timeout } from 'ember-concurrency';
+import { dropTask, timeout } from 'ember-concurrency';
 import { DateTime } from 'luxon';
 import { filterBy, mapBy } from 'ilios-common/utils/array-helpers';
 import { TrackedAsyncData } from 'ember-async-data';
@@ -96,15 +96,6 @@ export default class CourseRolloverComponent extends Component {
       },
     });
   }
-
-  load = restartableTask(async (event, [course]) => {
-    if (!course) {
-      return;
-    }
-    // set selectedYear to next valid year (or current if none found)
-    const validYear = this.years.find((year) => !this.unavailableYears.includes(year));
-    this.changeSelectedYear(validYear || this.years[0]);
-  });
 
   @action
   changeTitle(newTitle) {

--- a/packages/ilios-common/addon/components/course/rollover.js
+++ b/packages/ilios-common/addon/components/course/rollover.js
@@ -37,7 +37,7 @@ export default class CourseRolloverComponent extends Component {
   }
 
   get isNewTitleSet() {
-    return typeof this.newTitle !== 'undefined';
+    return this.newTitle !== undefined;
   }
 
   get title() {

--- a/packages/ilios-common/addon/components/course/rollover.js
+++ b/packages/ilios-common/addon/components/course/rollover.js
@@ -44,6 +44,16 @@ export default class CourseRolloverComponent extends Component {
     return this.isNewTitleSet ? this.newTitle : this.args.course.title;
   }
 
+  get isYearSet() {
+    return this.selectedYear !== undefined;
+  }
+
+  get year() {
+    return this.isYearSet
+      ? this.selectedYear
+      : (this.years.find((year) => !this.unavailableYears.includes(year)) ?? this.years[0]);
+  }
+
   @cached
   get academicYearCrossesCalendarYearBoundariesData() {
     return new TrackedAsyncData(
@@ -119,11 +129,15 @@ export default class CourseRolloverComponent extends Component {
     await timeout(1);
     // if the user hasn't set a new title, then do this now on their behalf.
     if (!this.isNewTitleSet) {
-      this.changeTitle(this.args.course.title);
+      this.changeTitle(this.title);
     }
-    // if the user hasn't set a start date, then do this now on their behalf.
+    // if the user hasn't selected a new year, then do this now on their behalf.
+    if (!this.isYearSet) {
+      this.changeSelectedYear(this.year);
+    }
+    // if the user hasn't selected a start date, then do this now on their behalf.
     if (!this.isStartDateSet) {
-      this.updateStartDate(this.args.course.startDate);
+      this.changeStartDate(this.startDate);
     }
     this.addErrorDisplayForAllFields();
     const isValid = await this.isValid();
@@ -135,7 +149,7 @@ export default class CourseRolloverComponent extends Component {
     const selectedCohortIds = mapBy(this.selectedCohorts, 'id');
 
     const data = {
-      year: this.selectedYear,
+      year: this.year,
       newCourseTitle: this.title,
     };
     if (this.selectedStartDate) {

--- a/packages/ilios-common/addon/components/course/rollover.js
+++ b/packages/ilios-common/addon/components/course/rollover.js
@@ -18,7 +18,6 @@ export default class CourseRolloverComponent extends Component {
   @Length(3, 200) @NotBlank() @tracked newTitle;
   @NotBlank() @tracked selectedYear;
   @tracked years;
-  @tracked course;
   @tracked selectedStartDate;
   @tracked skipOfferings = false;
   @tracked selectedCohorts = [];

--- a/packages/ilios-common/addon/components/course/rollover.js
+++ b/packages/ilios-common/addon/components/course/rollover.js
@@ -170,15 +170,14 @@ export default class CourseRolloverComponent extends Component {
   @action
   changeSelectedYear(selectedYear) {
     this.selectedYear = Number(selectedYear);
-
     const from = DateTime.fromJSDate(this.args.course.startDate);
-
-    this.selectedStartDate = DateTime.fromObject({
+    const startDate = DateTime.fromObject({
       hour: 0,
       minute: 0,
       weekYear: Number(selectedYear),
       weekNumber: from.weekNumber,
       weekday: from.weekday,
     }).toJSDate();
+    this.changeStartDate(startDate);
   }
 }

--- a/packages/ilios-common/addon/components/course/rollover.js
+++ b/packages/ilios-common/addon/components/course/rollover.js
@@ -110,7 +110,7 @@ export default class CourseRolloverComponent extends Component {
   }
 
   @action
-  updateStartDate(newStartDate) {
+  changeStartDate(newStartDate) {
     // if a date is forced that isn't allowed
     this.selectedStartDate = newStartDate ? newStartDate : this.args.course.startDate;
   }

--- a/packages/ilios-common/addon/components/course/rollover.js
+++ b/packages/ilios-common/addon/components/course/rollover.js
@@ -57,8 +57,12 @@ export default class CourseRolloverComponent extends Component {
       : false;
   }
 
+  get isStartDateSet() {
+    return this.selectedStartDate !== undefined;
+  }
+
   get startDate() {
-    return this.selectedStartDate ?? this.args.course.startDate;
+    return this.isStartDateSet ? this.startDate : this.args.course.startDate;
   }
 
   get allowedWeekdays() {

--- a/packages/ilios-common/addon/components/course/rollover.js
+++ b/packages/ilios-common/addon/components/course/rollover.js
@@ -142,10 +142,9 @@ export default class CourseRolloverComponent extends Component {
     const data = {
       year: this.year,
       newCourseTitle: this.title,
+      newStartDate: DateTime.fromJSDate(this.selectedStartDate).toFormat('yyyy-LL-dd'),
     };
-    if (this.selectedStartDate) {
-      data.newStartDate = DateTime.fromJSDate(this.selectedStartDate).toFormat('yyyy-LL-dd');
-    }
+
     if (this.skipOfferings) {
       data.skipOfferings = true;
     }

--- a/packages/test-app/tests/integration/components/course/rollover-test.js
+++ b/packages/test-app/tests/integration/components/course/rollover-test.js
@@ -469,7 +469,7 @@ module('Integration | Component | course/rollover', function (hooks) {
 
     await fillIn(input, '');
     assert.dom('.validation-error-message').exists({ count: 1 });
-    assert.ok(find('.validation-error-message').textContent.includes('blank'));
+    assert.ok(find('.validation-error-message').textContent.includes('too short'));
   });
 
   test('rollover course with cohorts', async function (assert) {


### PR DESCRIPTION
refs https://github.com/ilios/ilios/issues/5374

i'm still a bit iffy by setting tracked props in the `save()` task, but don't see another way to shoe-horn these in if the user hasn't changed the defaults _before_ form validation runs.