### PR TITLE
for vocabulary selection, filter out vocabularies where all top-level terms are inactive.

### DIFF
--- a/packages/ilios-common/addon/components/taxonomy-manager.js
+++ b/packages/ilios-common/addon/components/taxonomy-manager.js
@@ -55,8 +55,23 @@ export default class TaxonomyManager extends Component {
     }
   }
 
+  @cached
+  get assignableVocabulariesData() {
+    return new TrackedAsyncData(this.getAssignableVocabularies(this.nonEmptyVocabularies));
+  }
+
   get assignableVocabularies() {
-    return this.nonEmptyVocabularies.filter((vocab) => vocab.active);
+    return this.assignableVocabulariesData.isResolved ? this.assignableVocabulariesData.value : [];
+  }
+
+  async getAssignableVocabularies(vocabularies) {
+    // Filter out inactive vocabularies.
+    const activeVocabularies = vocabularies.filter((vocab) => vocab.active);
+    // Filter out vocabularies where all top-level terms are inactive.
+    return filter(activeVocabularies, async (vocabulary) => {
+      const topLevelTerms = await vocabulary.getTopLevelTerms();
+      return !topLevelTerms.every((term) => !term.active);
+    });
   }
 
   get listableVocabularies() {

--- a/packages/test-app/tests/integration/components/taxonomy-manager-test.js
+++ b/packages/test-app/tests/integration/components/taxonomy-manager-test.js
@@ -229,4 +229,19 @@ module('Integration | Component | taxonomy manager', function (hooks) {
     assert.strictEqual(component.availableTerms.length, 1);
     assert.strictEqual(component.availableTerms[0].name, 'Gamma');
   });
+
+  test('vocabulary without active top-level terms is not assignable', async function (assert) {
+    // deactivate all top-level terms in vocabulary 1
+    this.termModel1.set('active', false);
+    this.termModel2.set('active', false);
+
+    this.set('assignableVocabularies', [this.vocabModel1]);
+    await render(hbs`<TaxonomyManager
+  @vocabularies={{this.assignableVocabularies}}
+  @selectedTerms={{(array)}}
+  @add={{(noop)}}
+  @remove={{(noop)}}
+/>`);
+    assert.strictEqual(component.vocabulary.options.length, 0);
+  });
 });


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/6033