### PR TITLE
Remove Get

### DIFF
--- a/packages/ilios-common/addon/authenticators/ilios-jwt.js
+++ b/packages/ilios-common/addon/authenticators/ilios-jwt.js
@@ -1,4 +1,3 @@
-import { get } from '@ember/object';
 import { service } from '@ember/service';
 import Base from 'ember-simple-auth/authenticators/base';
 import jwtDecode from 'ilios-common/utils/jwt-decode';
@@ -28,8 +27,7 @@ export default class IliosJWT extends Base {
 
   async restore(data) {
     const now = DateTime.now().toUnixInteger();
-    const jwt = get(data, 'jwt');
-    let exp = get(data, 'exp');
+    let { jwt, exp } = data;
 
     if (!exp) {
       // Fetch the expiration time from the token data since `exp` wasn't included in the data object that was passed in.

--- a/packages/ilios-common/addon/serializers/learning-material.js
+++ b/packages/ilios-common/addon/serializers/learning-material.js
@@ -1,11 +1,10 @@
 import IliosSerializer from './ilios';
-import { get } from '@ember/object';
 
 export default class LearningMaterialSerializer extends IliosSerializer {
   serialize(snapshot, options) {
     const json = super.serialize(snapshot, options);
     //When POSTing new file learningMaterials we need to include the file hash
-    const fileHash = get(snapshot.record, 'fileHash');
+    const fileHash = snapshot.record?.fileHash;
     if (fileHash) {
       json.data.attributes.fileHash = fileHash;
     }

--- a/packages/ilios-common/addon/services/current-user.js
+++ b/packages/ilios-common/addon/services/current-user.js
@@ -21,7 +21,7 @@ export default class CurrentUserService extends Service {
     }
     const obj = jwtDecode(this.session.data.authenticated.jwt);
 
-    return get(obj, 'user_id');
+    return obj?.user_id;
   }
 
   async getModel() {

--- a/packages/ilios-common/addon/utils/as-array.js
+++ b/packages/ilios-common/addon/utils/as-array.js
@@ -1,5 +1,5 @@
 // taken from Ember Composable Helpers (https://github.com/DockYard/ember-composable-helpers), then modified.
-import EmberObject, { get } from '@ember/object';
+import EmberObject from '@ember/object';
 
 function isIterable(value) {
   return Symbol.iterator in Object(value);
@@ -55,7 +55,7 @@ function _asArray(maybeArray) {
   }
   if (typeof maybeArray === 'object') {
     if (isPromiseProxyLike(maybeArray)) {
-      const content = get(maybeArray, 'content');
+      const { content } = maybeArray;
       if (typeof content !== 'object' || content === null) {
         throw new Error('Unknown content type in array-like object [ilios-common]');
       }

--- a/packages/ilios-common/eslint.config.mjs
+++ b/packages/ilios-common/eslint.config.mjs
@@ -51,7 +51,6 @@ export default [
       reportUnusedDisableDirectives: 'error',
     },
     rules: {
-      'ember/no-get': 'off',
       'no-duplicate-imports': 'error',
     },
   },


### PR DESCRIPTION
Using this utility from ember is now linted against. The functionality it used to provide is either unnecessary or replaced with optional chaining.