### PR TITLE
show inactive label on terms regardless of edit or view mode.

### DIFF
--- a/packages/frontend/tests/acceptance/course/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivelist-test.js
@@ -26,7 +26,7 @@ module('Acceptance | Course - Objective List', function (hooks) {
       competency: competencies[0],
     });
     const programYearObjectiveWithoutCompetency = this.server.create('program-year-objective');
-    const term1 = this.server.create('term', { vocabulary });
+    const term1 = this.server.create('term', { vocabulary, active: true });
     const term2 = this.server.create('term', { vocabulary });
     const course = this.server.create('course', {
       year: 2013,
@@ -124,7 +124,7 @@ module('Acceptance | Course - Objective List', function (hooks) {
     );
     assert.strictEqual(
       page.details.objectives.objectiveList.objectives[1].selectedTerms.list[0].terms[0].name,
-      'term 1',
+      'term 1 (inactive)',
     );
 
     for (let i = 2; i <= 12; i++) {

--- a/packages/frontend/tests/acceptance/course/printcourse-test.js
+++ b/packages/frontend/tests/acceptance/course/printcourse-test.js
@@ -166,7 +166,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
     const vocabulary = this.server.create('vocabulary', {
       school: this.school,
     });
-    const term = this.server.create('term', { vocabulary });
+    const term = this.server.create('term', { vocabulary, active: true });
     const sessionObjective = this.server.create('session-objective', {
       session,
       title: 'Session Objective 1',
@@ -213,7 +213,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
     const vocabulary = this.server.create('vocabulary', {
       school: this.school,
     });
-    const term = this.server.create('term', { vocabulary });
+    const term = this.server.create('term', { vocabulary, active: true });
     const courseObjective = this.server.create('course-objective', {
       course: this.course,
       title: 'Course Objective 1',
@@ -286,10 +286,12 @@ module('Acceptance | Course - Print Course', function (hooks) {
     this.server.createList('term', 3, {
       vocabulary: vocabulary1,
       sessions: [session],
+      active: true,
     });
     this.server.createList('term', 2, {
       vocabulary: vocabulary2,
       sessions: [session],
+      active: true,
     });
 
     await visit('/course/1/print');

--- a/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
@@ -30,18 +30,19 @@ module('Acceptance | Session - Objective List', function (hooks) {
     });
     const courseObjectives = this.server.createList('course-objective', 2);
     const meshDescriptors = this.server.createList('mesh-descriptor', 3);
-    const terms = this.server.createList('term', 2, { vocabulary });
+    const term1 = this.server.create('term', { vocabulary, active: true });
+    const term2 = this.server.create('term', { vocabulary });
     this.server.create('session-objective', {
       session,
       courseObjectives: [courseObjectives.shift()],
       meshDescriptors: [meshDescriptors.shift()],
-      terms: [terms.shift()],
+      terms: [term1],
     });
     this.server.create('session-objective', {
       session,
       courseObjectives,
       meshDescriptors,
-      terms: terms,
+      terms: [term2],
     });
     this.server.createList('session-objective', 11, { session });
     await page.visit({
@@ -121,7 +122,7 @@ module('Acceptance | Session - Objective List', function (hooks) {
     );
     assert.strictEqual(
       page.details.objectives.objectiveList.objectives[1].selectedTerms.list[0].terms[0].name,
-      'term 1',
+      'term 1 (inactive)',
     );
 
     for (let i = 2; i <= 12; i++) {

--- a/packages/frontend/tests/acceptance/program-year/objectives-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectives-test.js
@@ -14,7 +14,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
       school: this.school,
     });
     const vocabulary = this.server.create('vocabulary', { school: this.school });
-    const term1 = this.server.create('term', { vocabulary });
+    const term1 = this.server.create('term', { vocabulary, active: true });
     const term2 = this.server.create('term', { vocabulary });
     const programYear = this.server.create('program-year', {
       program,
@@ -132,7 +132,7 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     );
     assert.strictEqual(
       page.details.objectives.objectiveList.objectives[1].selectedTerms.list[0].terms[0].name,
-      'term 1',
+      'term 1 (inactive)',
     );
 
     assert.strictEqual(

--- a/packages/frontend/tests/integration/components/program-year/objective-list-test.js
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
     const program = this.server.create('program', { school });
     const programYear = this.server.create('program-year', { program });
     const vocabulary = this.server.create('vocabulary', { school });
-    const term1 = this.server.create('term', { vocabulary });
+    const term1 = this.server.create('term', { vocabulary, active: true });
     const term2 = this.server.create('term', { vocabulary });
     this.server.create('program-year-objective', {
       programYear,
@@ -50,7 +50,10 @@ module('Integration | Component | program-year/objective-list', function (hooks)
       component.objectives[0].selectedTerms.list[0].title,
       'Vocabulary 1 (school 0)',
     );
-    assert.strictEqual(component.objectives[0].selectedTerms.list[0].terms[0].name, 'term 1');
+    assert.strictEqual(
+      component.objectives[0].selectedTerms.list[0].terms[0].name,
+      'term 1 (inactive)',
+    );
     assert.strictEqual(component.objectives[1].description.text, 'Objective A');
     assert.strictEqual(
       component.objectives[1].selectedTerms.list[0].title,

--- a/packages/ilios-common/addon/components/detail-terms-list-item.hbs
+++ b/packages/ilios-common/addon/components/detail-terms-list-item.hbs
@@ -23,11 +23,11 @@
     {{/each}}
     {{@term.title}}
   {{/if}}
-  {{#if (and @canEdit (not @term.active))}}
+  {{#unless @term.active}}
     <span class="inactive">
       ({{t "general.inactive"}})
     </span>
-  {{/if}}
+  {{/unless}}
   {{#if @canEdit}}
     <FaIcon @icon="xmark" class="remove" />
   {{/if}}

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
@@ -7,7 +7,7 @@
   margin-bottom: 1rem;
 
   .inactive {
-    font-style: italic;
+    color: c.$crimson;
   }
 
   .selected-taxonomy-terms {

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
@@ -7,8 +7,7 @@
   margin-bottom: 1rem;
 
   .inactive {
-    color: c.$crimson;
-    font-weight: bolder;
+    font-style: italic;
   }
 
   .selected-taxonomy-terms {

--- a/packages/test-app/tests/integration/components/course/objective-list-test.js
+++ b/packages/test-app/tests/integration/components/course/objective-list-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | course/objective-list', function (hooks) {
     const school = this.server.create('school');
     const course = this.server.create('course');
     const vocabulary = this.server.create('vocabulary', { school });
-    const term1 = this.server.create('term', { vocabulary });
+    const term1 = this.server.create('term', { vocabulary, active: true });
     const term2 = this.server.create('term', { vocabulary });
     this.server.create('course-objective', {
       course,
@@ -46,7 +46,10 @@ module('Integration | Component | course/objective-list', function (hooks) {
       component.objectives[0].selectedTerms.list[0].title,
       'Vocabulary 1 (school 0)',
     );
-    assert.strictEqual(component.objectives[0].selectedTerms.list[0].terms[0].name, 'term 1');
+    assert.strictEqual(
+      component.objectives[0].selectedTerms.list[0].terms[0].name,
+      'term 1 (inactive)',
+    );
     assert.strictEqual(component.objectives[1].description.text, 'Objective A');
     assert.strictEqual(
       component.objectives[1].selectedTerms.list[0].title,

--- a/packages/test-app/tests/integration/components/detail-terms-list-item-test.js
+++ b/packages/test-app/tests/integration/components/detail-terms-list-item-test.js
@@ -86,7 +86,7 @@ module('Integration | Component | detail terms list item', function (hooks) {
     const termModel = await this.owner.lookup('service:store').findRecord('term', term.id);
     this.set('term', termModel);
     await render(hbs`<DetailTermsListItem @term={{this.term}} @canEdit={{false}} />`);
-    assert.dom('.inactive').doesNotExist();
+    assert.dom('.inactive').exists();
     assert.dom('.fa-xmark').doesNotExist();
   });
 });

--- a/packages/test-app/tests/integration/components/detail-terms-list-test.js
+++ b/packages/test-app/tests/integration/components/detail-terms-list-test.js
@@ -30,6 +30,7 @@ module('Integration | Component | detail terms list', function (hooks) {
     });
     this.server.create('term', {
       title: 'bar',
+      active: true,
       vocabulary,
     });
     this.server.create('term', {
@@ -54,7 +55,7 @@ module('Integration | Component | detail terms list', function (hooks) {
     assert.strictEqual(component.vocabularyName, 'Topics');
     assert.strictEqual(component.terms.length, 2);
     assert.strictEqual(component.terms[0].name, 'bar');
-    assert.strictEqual(component.terms[1].name, 'foo');
+    assert.strictEqual(component.terms[1].name, 'foo (inactive)');
   });
 
   test('empty list', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/objective-list-test.js
+++ b/packages/test-app/tests/integration/components/session/objective-list-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | session/objective-list', function (hooks) {
     const course = this.server.create('course');
     const session = this.server.create('session', { course });
     const vocabulary = this.server.create('vocabulary', { school });
-    const term1 = this.server.create('term', { vocabulary });
+    const term1 = this.server.create('term', { vocabulary, active: true });
     const term2 = this.server.create('term', { vocabulary });
     this.server.create('session-objective', {
       session,
@@ -46,7 +46,10 @@ module('Integration | Component | session/objective-list', function (hooks) {
       component.objectives[0].selectedTerms.list[0].title,
       'Vocabulary 1 (school 0)',
     );
-    assert.strictEqual(component.objectives[0].selectedTerms.list[0].terms[0].name, 'term 1');
+    assert.strictEqual(
+      component.objectives[0].selectedTerms.list[0].terms[0].name,
+      'term 1 (inactive)',
+    );
     assert.strictEqual(component.objectives[1].description.text, 'Objective A');
     assert.strictEqual(
       component.objectives[1].selectedTerms.list[0].title,


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/6048

this changes the output in a couple of places, if applicable:

in course/session objectives management:

![image](https://github.com/user-attachments/assets/d126c471-9e65-44e4-b02d-6431718e0865)

in program year objectives management: 

![image](https://github.com/user-attachments/assets/fd895aef-4c42-43b2-9182-de42a574780f)

in program year details:

![image](https://github.com/user-attachments/assets/e09455ef-0694-46ed-894e-a17f28706999)

in course details:

![image](https://github.com/user-attachments/assets/785c37b1-ad10-4ec1-b601-5471a74e6979)

in session details:

![image](https://github.com/user-attachments/assets/6c2df8c0-fdf3-47fa-aefe-b8aa08717697)

in course print view:

![image](https://github.com/user-attachments/assets/24654b9c-2848-4999-bfc1-988161a57d63)

