### PR TITLE
prevent contents in removable tag list item from running together by removing flex display.

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -108,8 +108,6 @@
 
   li {
     cursor: pointer;
-    display: flex;
-
     .remove,
     .info {
       margin-left: 0.5em;


### PR DESCRIPTION
during review, please check percy output.

fixes https://github.com/ilios/ilios/issues/6047