### PR TITLE
rm unused mixin.

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -145,18 +145,6 @@
   }
 }
 
-@mixin ilios-list-badges() {
-  @include ilios-removable-list;
-
-  li {
-    background-color: c.$culturedGrey;
-    border-radius: 4px;
-    font-weight: bold;
-    margin-top: 0.5rem;
-    padding: 1rem;
-  }
-}
-
 @mixin ilios-list-tree() {
   @include ilios-list-reset;
 


### PR DESCRIPTION
spotted this in passing.

```bash
stefan@nichtsnutz: ~/dev/projects/frontend on master[$]
$ grep -r 'ilios-list-badges' packages --exclude-dir=dist --exclude-dir=node_modules
packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss:@mixin ilios-list-badges() {
```