### PR TITLE
Curriculum Report: add a deselect button when courses are selected

### DIFF
--- a/packages/frontend/app/components/reports/curriculum.hbs
+++ b/packages/frontend/app/components/reports/curriculum.hbs
@@ -15,6 +15,7 @@
       @schools={{@schools}}
       @add={{this.pickCourse}}
       @remove={{this.removeCourse}}
+      @removeAll={{this.removeAll}}
     />
   {{/if}}
 </div>

--- a/packages/frontend/app/components/reports/curriculum.js
+++ b/packages/frontend/app/components/reports/curriculum.js
@@ -61,6 +61,10 @@ export default class ReportsCurriculumComponent extends Component {
     this.args.setSelectedCourseIds(this.passedCourseIds.filter((i) => i !== Number(id)).sort());
   };
 
+  removeAll = () => {
+    this.args.setSelectedCourseIds();
+  };
+
   changeSelectedReport = (value) => {
     this.args.stop();
     this.args.setReport(value);

--- a/packages/frontend/app/components/reports/curriculum.js
+++ b/packages/frontend/app/components/reports/curriculum.js
@@ -62,6 +62,7 @@ export default class ReportsCurriculumComponent extends Component {
   };
 
   removeAll = () => {
+    this.args.stop();
     this.args.setSelectedCourseIds();
   };
 

--- a/packages/frontend/app/components/reports/curriculum/choose-course.hbs
+++ b/packages/frontend/app/components/reports/curriculum/choose-course.hbs
@@ -15,6 +15,17 @@
     {{else}}
       {{this.selectedSchool.title}}
     {{/if}}
+    {{#if @selectedCourseIds.length}}
+      <button
+        type="button"
+        aria-label={{t "general.deselectAllCourses"}}
+        class="deselect-all"
+        {{on "click" @removeAll}}
+        data-test-deselect-all
+      >
+        {{t "general.deselectAllCourses"}}
+      </button>
+    {{/if}}
   </div>
   {{#each this.selectedSchoolYears as |y|}}
     <ul class="year {{if y.isExpanded 'expanded' 'collapsed'}}" data-test-year>

--- a/packages/frontend/app/styles/components/reports/choose-course.scss
+++ b/packages/frontend/app/styles/components/reports/choose-course.scss
@@ -1,3 +1,4 @@
+@use "../../ilios-common/colors" as c;
 @use "../../ilios-common/mixins" as cm;
 
 .reports-choose-course {
@@ -19,6 +20,12 @@
     ul {
       margin-top: 0.5rem;
     }
+  }
+
+  .deselect-all {
+    @include cm.ilios-button-reset;
+    @include cm.font-size("small");
+    color: c.$blueMunsell;
   }
 
   .select-all {

--- a/packages/frontend/tests/pages/components/reports/curriculum/choose-course.js
+++ b/packages/frontend/tests/pages/components/reports/curriculum/choose-course.js
@@ -3,6 +3,7 @@ import {
   create,
   collection,
   isPresent,
+  isVisible,
   fillable,
   property,
   text,
@@ -30,6 +31,11 @@ const definition = {
     isFullySelected: property('checked', '[data-test-toggle-all]'),
     toggleAll: clickable('[data-test-toggle-all]'),
   }),
+  deselectAll: {
+    scope: '[data-test-deselect-all]',
+    visible: isVisible(),
+    click: clickable(),
+  },
 };
 
 export default definition;

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -110,6 +110,7 @@ general:
   delete: Delete
   deleteCourse: Delete Course
   departments: Departments
+  deselectAllCourses: Deselect All Courses
   deselectUser: Deselect User
   details: Course Details
   developer: Developer

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -110,6 +110,7 @@ general:
   delete: Eliminar
   deleteCourse: Eliminar el curso
   departments: Departmentos
+  deselectAllCourses: Deseleccionen Todos Cursos
   deselectUser: Deseleccione usuario
   details: Detalles de Curso
   developer: Desarrollador

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -110,6 +110,7 @@ general:
   delete: Supprimer
   deleteCourse: Supprimer le cours
   departments: Facultés
+  deselectAllCourses: "Désélectionner tous les cours"
   deselectUser: "Désélectionner l'utilisateur "
   details: Détails de Cours
   developer: Administrateur


### PR DESCRIPTION
Fixes ilios/ilios#6031

Using the Dashboard::Calendar "Clear Filters" methodology, I have added a "Deselect All Courses" button to deselect all courses and reset your Curriculum Report course selection journey back to its origin.