### PR TITLE
Use a Modifier for Validation

### DIFF
--- a/packages/ilios-common/addon/classes/yup-validations.js
+++ b/packages/ilios-common/addon/classes/yup-validations.js
@@ -2,6 +2,7 @@ import { tracked } from '@glimmer/tracking';
 import { getProperties } from '@ember/object';
 import { object, setLocale } from 'yup';
 import { restartableTask, timeout } from 'ember-concurrency';
+import { modifier } from 'ember-modifier';
 
 const DEBOUNCE_MS = 100;
 
@@ -105,6 +106,23 @@ export default class YupValidations {
   #validationProperties() {
     return getProperties(this.context, ...Object.keys(this.shape));
   }
+
+  attach = modifier((element, [field]) => {
+    element.addEventListener(
+      'focusout',
+      () => {
+        this.addErrorDisplayFor(field);
+      },
+      { passive: true },
+    );
+    element.addEventListener(
+      'input',
+      () => {
+        this.runValidator.perform();
+      },
+      { passive: true },
+    );
+  });
 }
 //call this function to set the error messages and their locale one time when this file is loaded
 setupErrorMessages();

--- a/packages/ilios-common/addon/components/course/rollover.hbs
+++ b/packages/ilios-common/addon/components/course/rollover.hbs
@@ -26,7 +26,7 @@
           type="text"
           value={{this.title}}
           {{on "input" (pick "target.value" (set this "newTitle"))}}
-          {{on "input" (fn this.validations.addErrorDisplayFor "title")}}
+          {{this.validations.attach "title"}}
           disabled={{this.save.isRunning}}
           placeholder={{t "general.courseTitlePlaceholder"}}
           data-test-title

--- a/packages/ilios-common/addon/components/learningmaterial-manager.hbs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.hbs
@@ -11,7 +11,7 @@
             type="text"
             value={{this.title}}
             disabled={{this.save.isRunning}}
-            {{on "keyup" (fn this.validations.addErrorDisplayFor "title")}}
+            {{this.validations.attach "title"}}
             {{on "input" (pick "target.value" (set this "title"))}}
           />
           <YupValidationMessage

--- a/packages/ilios-common/addon/components/new-session.hbs
+++ b/packages/ilios-common/addon/components/new-session.hbs
@@ -14,10 +14,9 @@
           id="title-{{templateId}}"
           type="text"
           value={{this.title}}
-          {{on "focusout" (fn this.validations.addErrorDisplayFor "title")}}
           {{on "input" this.changeTitle}}
-          {{on "keyup" (fn this.validations.addErrorDisplayFor "title")}}
           {{on "keyup" this.keyboard}}
+          {{this.validations.attach "title"}}
           class={{if this.validations.errors.title "has-error"}}
           disabled={{this.saveNewSession.isRunning}}
           data-test-title

--- a/packages/ilios-common/addon/components/session/header.hbs
+++ b/packages/ilios-common/addon/components/session/header.hbs
@@ -14,8 +14,7 @@
           type="text"
           value={{this.title}}
           {{on "input" (pick "target.value" (set this "title"))}}
-          {{on "focusout" (fn this.validations.addErrorDisplayFor "title")}}
-          {{on "keyup" (fn this.validations.addErrorDisplayFor "title")}}
+          {{this.validations.attach "title"}}
         >
         <YupValidationMessage
           @description={{t 'general.title'}}

--- a/packages/ilios-common/addon/components/session/ilm.hbs
+++ b/packages/ilios-common/addon/components/session/ilm.hbs
@@ -30,8 +30,7 @@
             disabled={{isSaving}}
             type="text"
             value={{this.hours}}
-            {{on "key-press" (fn this.validations.addErrorDisplayFor "hours")}}
-            {{on "focusout" (fn this.validations.addErrorDisplayFor "hours")}}
+            {{this.validations.attach "hours"}}
             {{on "input" (pick "target.value" (set this "localHours"))}}
           >
           <YupValidationMessage

--- a/packages/test-app/tests/integration/components/course/rollover-test.js
+++ b/packages/test-app/tests/integration/components/course/rollover-test.js
@@ -468,6 +468,7 @@ module('Integration | Component | course/rollover', function (hooks) {
     const input = `${title} input`;
 
     await fillIn(input, '');
+    await emberBlur(input);
     assert.dom('.validation-error-message').exists({ count: 1 });
     assert.ok(find('.validation-error-message').textContent.includes('too short'));
   });


### PR DESCRIPTION
We had several different patterns here to both start showing the error message and to ensure that the message gets updated when the value changes. I've replaced them all with a modifier on the validation class that doesn't show any errors until the user focuses out of the input, but does re-run the validations anytime the value changes.

Refs ilios/ilios#6055