### PR TITLE
Stricter Peers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         run: pnpm install
       - name: Lint
         run: pnpm run lint
+      - name: Test Dependency Installation
+        run: pnpm install --resolution-only --no-frozen-lockfile
 
   test:
     name: Test

--- a/.npmrc
+++ b/.npmrc
@@ -6,4 +6,7 @@
 
 # we want true isolation,
 # if a dependency is not declared, we want an error
-# resolve-peers-from-workspace-root=false
+resolve-peers-from-workspace-root=false
+
+# fail when peers are not met
+strict-peer-dependencies=true


### PR DESCRIPTION
Adding some pnpm configuration to improve our peer dependencies. This will cause the build to fail when peers requirements aren't met.