### PR TITLE
Replace Last Update

### DIFF
--- a/packages/frontend/tests/acceptance/course/session/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/session/overview-test.js
@@ -224,24 +224,32 @@ module('Acceptance | Session - Overview', function (hooks) {
       },
       true,
     );
+    const updatedAt = DateTime.fromObject({
+      year: 2019,
+      month: 7,
+      day: 9,
+      hour: 17,
+      minute: 0,
+      second: 0,
+    }).toJSDate();
     this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
-      updatedAt: DateTime.fromObject({
-        year: 2019,
-        month: 7,
-        day: 9,
-        hour: 17,
-        minute: 0,
-        second: 0,
-      }).toJSDate(),
+      updatedAt,
     });
     await page.visit({ courseId: 1, sessionId: 1 });
+    const updatedAtString = this.intl.formatDate(updatedAt, {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
 
     assert.strictEqual(currentRouteName(), 'session.index');
     assert.strictEqual(
       page.details.overview.lastUpdated,
-      'Last Update Last Update: 7/9/2019 5:00 PM',
+      `Last Update Last Update: ${updatedAtString}`,
     );
   });
 

--- a/packages/frontend/tests/acceptance/course/sessionlist-test.js
+++ b/packages/frontend/tests/acceptance/course/sessionlist-test.js
@@ -215,10 +215,14 @@ module('Acceptance | Course - Session List', function (hooks) {
     await page.visit({ courseId: this.course.id, details: true });
     const { sessions, expandedSessions } = page.courseSessions.sessionsGrid;
     await sessions[0].row.expand();
-    assert.strictEqual(
-      expandedSessions[0].lastUpdated,
-      'Last Update Last Update: 07/09/2019, 05:00 PM',
-    );
+    const updatedAt = this.intl.formatDate(this.session1.updatedAt, {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+    assert.strictEqual(expandedSessions[0].lastUpdated, `Last Update Last Update: ${updatedAt}`);
   });
 
   test('expand all sessions', async function (assert) {

--- a/packages/ilios-common/addon/components/session/overview.hbs
+++ b/packages/ilios-common/addon/components/session/overview.hbs
@@ -7,7 +7,7 @@
         <div class="last-update" data-test-last-update>
           <FaIcon @icon="clock-rotate-left" @title={{t "general.lastUpdate"}} />
           {{t "general.lastUpdate"}}:
-          {{this.updatedAt}}
+          {{format-date @session.updatedAt month="2-digit" day="2-digit" year="numeric" hour="2-digit" minute="2-digit"}}
         </div>
 
         <div class="session-overview-header">

--- a/packages/ilios-common/addon/components/session/overview.js
+++ b/packages/ilios-common/addon/components/session/overview.js
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import { task } from 'ember-concurrency';
-import { DateTime } from 'luxon';
 import { findById, sortBy } from 'ilios-common/utils/array-helpers';
 import { TrackedAsyncData } from 'ember-async-data';
 import YupValidations from 'ilios-common/classes/yup-validations';
@@ -181,10 +180,6 @@ export default class SessionOverview extends Component {
       return this.sessionTypeData.isResolved ? this.sessionTypeData.value : null;
     }
     return this.localSessionType;
-  }
-
-  get updatedAt() {
-    return DateTime.fromJSDate(this.args.session.updatedAt).toFormat('D t');
   }
 
   get isLoaded() {


### PR DESCRIPTION
Tests for this value have been flaky because we were passing through different internationalization layers. Now everything goes through ember-intl and we should get consistent output.

Minor visual change in Session Overview, there is now a comma in this value:
old: `Last Update: 10/31/2024 11:34 AM`
new: `Last Update: 10/31/2024, 11:34 AM`