### PR TITLE
Silence Remaining Build Scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   },
   "pnpm": {
     "ignoredBuiltDependencies": [
-      "@percy/core"
+      "@parcel/watcher",
+      "@percy/core",
+      "core-js"
     ],
     "onlyBuiltDependencies": [
       "aws-sdk",


### PR DESCRIPTION
Not sure why only built doesn't silence the others, but we seem to need to list them all. So... I've done that.