### PR TITLE
respond intelligently to escape key on ManageUsersSummary search box

### DIFF
--- a/packages/frontend/app/components/manage-users-summary.hbs
+++ b/packages/frontend/app/components/manage-users-summary.hbs
@@ -41,7 +41,8 @@
       aria-label={{t "general.searchForIliosUsers"}}
       incremental="true"
       {{on "search" (perform this.searchForUsers)}}
-      {{on "keyup" (perform this.searchForUsers)}}
+      {{!-- {{on "keyup" (perform this.searchForUsers)}} --}}
+      {{on "keyup" this.keyboard}}
     />
     <ul
       class="results

--- a/packages/frontend/app/components/manage-users-summary.hbs
+++ b/packages/frontend/app/components/manage-users-summary.hbs
@@ -41,7 +41,6 @@
       aria-label={{t "general.searchForIliosUsers"}}
       incremental="true"
       {{on "search" (perform this.searchForUsers)}}
-      {{!-- {{on "keyup" (perform this.searchForUsers)}} --}}
       {{on "keyup" this.keyboard}}
     />
     <ul

--- a/packages/frontend/app/components/manage-users-summary.js
+++ b/packages/frontend/app/components/manage-users-summary.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import Ember from 'ember';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { dropTask, restartableTask, timeout } from 'ember-concurrency';
 import { cleanQuery } from 'ilios-common/utils/query-utils';
@@ -49,6 +50,27 @@ export default class ManageUsersSummaryComponent extends Component {
     const { users } = await this.search.forUsers(q);
 
     return users;
+  }
+
+  @action
+  keyboard(event) {
+    event.preventDefault();
+
+    const { keyCode } = event;
+
+    if (this.isEscapeKey(keyCode)) {
+      this.clear();
+    }
+
+    this.searchForUsers.perform();
+  }
+
+  clear() {
+    this.searchValue = null;
+  }
+
+  isEscapeKey(keyCode) {
+    return keyCode === 27;
   }
 
   searchForUsers = restartableTask(async () => {

--- a/packages/frontend/tests/integration/components/manage-users-summary-test.js
+++ b/packages/frontend/tests/integration/components/manage-users-summary-test.js
@@ -1,6 +1,6 @@
 import { module, skip, test } from 'qunit';
 import { setupRenderingTest } from 'frontend/tests/helpers';
-import { render, findAll, find, fillIn, triggerEvent } from '@ember/test-helpers';
+import { render, findAll, find, fillIn, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
@@ -28,6 +28,36 @@ module('Integration | Component | manage users summary', function (hooks) {
     assert.dom(findAll('a')[2]).hasText('Upload Multiple Users');
   });
 
+  test('show more input prompt', async function (assert) {
+    await render(hbs`<ManageUsersSummary />`);
+
+    const userSearch = '.user-search input';
+    const results = '.user-search .results li';
+
+    await fillIn(userSearch, '12');
+    await triggerEvent(userSearch, 'keyup');
+
+    assert.dom(results).exists({ count: 1 });
+    assert.dom(results).hasText('keep typing...');
+  });
+
+  test('escape key clears input and results', async function (assert) {
+    await render(hbs`<ManageUsersSummary />`);
+
+    const userSearch = '.user-search input';
+    const results = '.user-search .results li';
+
+    await fillIn(userSearch, '12');
+    await triggerEvent(userSearch, 'keyup');
+    assert.dom(results).exists({ count: 1 });
+    assert.dom(results).hasText('keep typing...');
+
+    await triggerKeyEvent(userSearch, 'keyup', 'Escape');
+
+    assert.dom(userSearch).hasText('');
+    assert.dom(results).exists({ count: 0 });
+  });
+
   /**
    * @todo Move the URL tests to an acceptance test so we don't
    * have to inject a working router which blows up ember-simple-auth
@@ -47,18 +77,5 @@ module('Integration | Component | manage users summary', function (hooks) {
       -1,
       `${findAll('a')[2].href} links to /users?addUsers=true`,
     );
-  });
-
-  test('show more input prompt', async function (assert) {
-    await render(hbs`<ManageUsersSummary />`);
-
-    const userSearch = '.user-search input';
-    const results = '.user-search .results li';
-
-    await fillIn(userSearch, '12');
-    await triggerEvent(userSearch, 'keyup');
-
-    assert.dom(results).exists({ count: 1 });
-    assert.dom(results).hasText('keep typing...');
   });
 });


### PR DESCRIPTION
Fixed ilios/ilios#6044

Cribbed a minimal bit of logic from `GlobalSearchBox` (making the arrow keys cycle through search results is still an issue, but it works substantially differently so that's another PR) to make the escape key work like it should across browsers.