### PR TITLE
Use npm in Check

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,9 +15,8 @@ jobs:
         uses: dependabot/fetch-metadata@v2.3.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: pnpm/action-setup@v4
       - run: >
-          pnpm dlx in-string-list ${{ steps.metadata.outputs.dependency-names }} ${{ env.SAFE_DEPENDENCIES }}
+          npx in-string-list ${{ steps.metadata.outputs.dependency-names }} ${{ env.SAFE_DEPENDENCIES }}
           && echo "isSafe=yes" >> "$GITHUB_ENV"
           || echo "Not marked as safe"
       - run: >


### PR DESCRIPTION
Because we're not doing a checkout pnpm doesn't know what version of itself to install here (now that we're using corepack). Instead use whatever version of npm is pre-installed and run it that way.