### PR TITLE
Only Approve New PRs

### DIFF
--- a/.github/workflows/update-pnpm-version.yml
+++ b/.github/workflows/update-pnpm-version.yml
@@ -37,6 +37,7 @@ jobs:
           branch: update-pnpm-version
           labels: dependencies
       - name: Approve Pull Request
+        if: steps.cpr.outputs.pull-request-operation == 'created'
         run: gh pr review --approve -b "Auto Approved" ${{ steps.cpr.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When we update `pnpm` we shouldn't attempt to approve if no PR was created. This check was only on the automerge and label step, need it on both.