### PR TITLE
Fix reporting double-<title> bug

### DIFF
--- a/packages/frontend/app/services/page-title.js
+++ b/packages/frontend/app/services/page-title.js
@@ -10,11 +10,6 @@ export default class HeaderTitleService extends EmberPageTitleService {
   @tracked title = '';
 
   titleDidUpdate(title) {
-    // exception to avoid double-titling in reports
-    if (title == 'Ilios Curriculum Reports Subject Reports') {
-      this.title = 'Ilios Curriculum Reports';
-    } else {
-      this.title = title;
-    }
+    this.title = title;
   }
 }

--- a/packages/frontend/app/services/page-title.js
+++ b/packages/frontend/app/services/page-title.js
@@ -10,6 +10,11 @@ export default class HeaderTitleService extends EmberPageTitleService {
   @tracked title = '';
 
   titleDidUpdate(title) {
-    this.title = title;
+    // exception to avoid double-titling in reports
+    if (title == 'Ilios Curriculum Reports Subject Reports') {
+      this.title = 'Ilios Curriculum Reports';
+    } else {
+      this.title = title;
+    }
   }
 }

--- a/packages/frontend/app/templates/reports.hbs
+++ b/packages/frontend/app/templates/reports.hbs
@@ -1,3 +1,2 @@
-{{page-title (t "general.subjectReports")}}
 <Reports::Switcher />
 {{outlet}}

--- a/packages/frontend/app/templates/reports.hbs
+++ b/packages/frontend/app/templates/reports.hbs
@@ -1,3 +1,3 @@
-{{page-title (t "general.reports")}}
+{{page-title (t "general.subjectReports")}}
 <Reports::Switcher />
 {{outlet}}

--- a/packages/frontend/app/templates/reports/curriculum.hbs
+++ b/packages/frontend/app/templates/reports/curriculum.hbs
@@ -1,4 +1,5 @@
-{{page-title (t "general.curriculumReports")}}
+{{page-title (t "general.curriculumReports") replace=true}}
+{{page-title (t "general.ilios")}}
 <Reports::Curriculum
   @selectedCourseIds={{this.selectedCourseIds}}
   @setSelectedCourseIds={{this.setSelectedCourseIds}}

--- a/packages/frontend/app/templates/reports/curriculum.hbs
+++ b/packages/frontend/app/templates/reports/curriculum.hbs
@@ -1,3 +1,4 @@
+{{page-title (t "general.curriculumReports")}}
 <Reports::Curriculum
   @selectedCourseIds={{this.selectedCourseIds}}
   @setSelectedCourseIds={{this.setSelectedCourseIds}}

--- a/packages/frontend/app/templates/reports/curriculum.hbs
+++ b/packages/frontend/app/templates/reports/curriculum.hbs
@@ -1,5 +1,4 @@
-{{page-title (t "general.curriculumReports") replace=true}}
-{{page-title (t "general.ilios")}}
+{{page-title (t "general.curriculumReports")}}
 <Reports::Curriculum
   @selectedCourseIds={{this.selectedCourseIds}}
   @setSelectedCourseIds={{this.setSelectedCourseIds}}

--- a/packages/frontend/app/templates/reports/subject.hbs
+++ b/packages/frontend/app/templates/reports/subject.hbs
@@ -1,3 +1,4 @@
+{{page-title (t "general.subjectReports")}}
 <Reports::Subject
   @report={{this.model}}
   @year={{this.reportYear}}

--- a/packages/frontend/app/templates/reports/subject.hbs
+++ b/packages/frontend/app/templates/reports/subject.hbs
@@ -1,4 +1,3 @@
-{{page-title (t "general.reports")}}
 <Reports::Subject
   @report={{this.model}}
   @year={{this.reportYear}}

--- a/packages/frontend/app/templates/reports/subjects.hbs
+++ b/packages/frontend/app/templates/reports/subjects.hbs
@@ -1,3 +1,4 @@
+{{page-title (t "general.subjectReports")}}
 <Reports::SubjectsList
   @sortReportsBy={{this.sortReportsBy}}
   @setSortReportsBy={{set this "sortReportsBy"}}


### PR DESCRIPTION
Fixes ilios/ilios#6078

The reporting area has an exception where it tries to set the page title twice due to the new Subject/Curriculum Reports switching. I fixed the `{{page-title}}` directives and added an exception to avoid a bug in how the `<title>` gets set.