### PR TITLE
removes unnecessary spacing between text and icons in removable tag list items.

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -108,10 +108,6 @@
 
   li {
     cursor: pointer;
-    .remove,
-    .info {
-      margin-left: 0.5em;
-    }
   }
 }
 


### PR DESCRIPTION
as requested by @dartajax in the Ilios standup last week.

follows https://github.com/ilios/frontend/pull/8437

component stylesheets that use the modified mixin:

```
stefan@nichtsnutz: ~/dev/projects/frontend on removable-tag-list-icon-spacing[!$]
$ grep -r 'ilios-removable-list' . --include=*.scss --exclude-dir=node_modules
./packages/ilios-common/app/styles/ilios-common/components/selected-learners.scss:    @include m.ilios-removable-list;
./packages/ilios-common/app/styles/ilios-common/components/selected-instructors.scss:    @include m.ilios-removable-list;
./packages/ilios-common/app/styles/ilios-common/components/detail-cohort-manager.scss:    @include m.ilios-removable-list;
./packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss:      @include m.ilios-removable-list;
./packages/ilios-common/app/styles/ilios-common/components/detail-learnergroups-list.scss:      @include m.ilios-removable-list;
./packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss:@mixin ilios-removable-list {
./packages/frontend/app/styles/components/learner-group/instructor-manager.scss:      @include m.ilios-removable-list;
./packages/frontend/app/styles/components/instructor-group/instructor-manager.scss:    @include m.ilios-removable-list;
./packages/frontend/app/styles/components/course-director-manager.scss:      @include m.ilios-removable-list;
./packages/frontend/app/styles/components/programyear-overview.scss:      @include m.ilios-removable-list;
```

for comparison:

before:
![image](https://github.com/user-attachments/assets/8788afd2-97cb-4a12-b3a3-22dc3a3cacaa)

after:

![image](https://github.com/user-attachments/assets/a7c1ccc0-e6a1-4e53-9934-bd279dbdb671)


