### PR TITLE
Correct for Empty Notes and Description

### DIFF
--- a/packages/ilios-common/addon/components/session/overview.js
+++ b/packages/ilios-common/addon/components/session/overview.js
@@ -162,17 +162,25 @@ export default class SessionOverview extends Component {
   }
 
   get instructionalNotes() {
-    if (this.localInstructionalNotes === undefined) {
-      return this.args.session.instructionalNotes;
+    const instructionalNotes =
+      this.localInstructionalNotes === undefined
+        ? this.args.session.instructionalNotes
+        : this.localInstructionalNotes;
+    if (instructionalNotes === '') {
+      return null;
     }
-    return this.localInstructionalNotes;
+
+    return instructionalNotes;
   }
 
   get description() {
-    if (this.localDescription === undefined) {
-      return this.args.session.description;
+    const description =
+      this.localDescription === undefined ? this.args.session.description : this.localDescription;
+    if (description === '') {
+      return null;
     }
-    return this.localDescription;
+
+    return description;
   }
 
   get sessionType() {


### PR DESCRIPTION
When either the instructional notes or the description on a session are an empty string validation would fail making it impossible to save. While the data shouldn't be saveable like this we have many examples in our data that say it is. Handle this state gracefully in our code.