### PR TITLE
Remove ember-event-helpers Addon

### DIFF
--- a/packages/ilios-common/addon/components/back-link.hbs
+++ b/packages/ilios-common/addon/components/back-link.hbs
@@ -2,7 +2,7 @@
   title={{t "general.returnToPreviousPage"}}
   class="back-link"
   href="#"
-  {{on "click" (prevent-default this.back)}}
+  {{on "click" this.back}}
   data-test-back-link
 >
   <FaIcon @icon="angles-left" />

--- a/packages/ilios-common/addon/components/back-link.js
+++ b/packages/ilios-common/addon/components/back-link.js
@@ -3,7 +3,8 @@ import Component from '@glimmer/component';
 
 export default class BackLinkComponent extends Component {
   @service intl;
-  back() {
+  back(event) {
+    event.preventDefault();
     window.history.back();
   }
 }

--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -42,7 +42,6 @@
     "ember-cli-page-object": "^2.3.0",
     "ember-click-outside": "^6.0.0",
     "ember-concurrency": "^4.0.2",
-    "ember-event-helpers": "^0.1.0",
     "ember-file-upload": "^9.0.0",
     "ember-focus-trap": "^1.0.0",
     "ember-in-element-polyfill": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,9 +423,6 @@ importers:
       ember-concurrency:
         specifier: ^4.0.2
         version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(ember-source@6.3.0(@glimmer/component@2.0.0)(rsvp@4.8.5)(webpack@5.98.0))
-      ember-event-helpers:
-        specifier: ^0.1.0
-        version: 0.1.1
       ember-file-upload:
         specifier: ^9.0.0
         version: 9.3.0(@ember/test-helpers@5.2.1(@babel/core@7.26.10)(ember-source@6.3.0(@glimmer/component@2.0.0)(rsvp@4.8.5)(webpack@5.98.0)))(@glimmer/component@2.0.0)(@glimmer/tracking@1.1.2)(ember-modifier@4.2.0(@babel/core@7.26.10)(ember-source@6.3.0(@glimmer/component@2.0.0)(rsvp@4.8.5)(webpack@5.98.0)))(miragejs@0.1.48)(tracked-built-ins@3.4.0(@babel/core@7.26.10))(webpack@5.98.0)
@@ -5346,10 +5343,6 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
-
-  ember-event-helpers@0.1.1:
-    resolution: {integrity: sha512-fWcbWd4W4nRv8bbato8JB6oGRpATkR+oGYxMIqnfgTgPWaCS0ww7CuUVNpwg1TulojKMCuTXi8Fem2b1NSF1ZQ==}
-    engines: {node: 8.* || >= 10.*}
 
   ember-exam@9.1.0:
     resolution: {integrity: sha512-POqCgZ1jjQEvIARnDVDFoag3KZaNRU7XTGIzL/enVsilzPA0xTomOlCpc2lZNh/hXOZSfB69fHwygYshxMf3+A==}
@@ -15974,12 +15967,6 @@ snapshots:
       svg-tags: 1.0.0
     transitivePeerDependencies:
       - eslint
-
-  ember-event-helpers@0.1.1:
-    dependencies:
-      ember-cli-babel: 7.26.11
-    transitivePeerDependencies:
-      - supports-color
 
   ember-exam@9.1.0(ember-qunit@9.0.2(@ember/test-helpers@5.2.1(@babel/core@7.26.10)(ember-source@6.3.0(@glimmer/component@2.0.0)(rsvp@4.8.5)(webpack@5.98.0)))(ember-source@6.3.0(@glimmer/component@2.0.0)(rsvp@4.8.5)(webpack@5.98.0))(qunit@2.24.1))(ember-source@6.3.0(@glimmer/component@2.0.0)(rsvp@4.8.5)(webpack@5.98.0))(qunit@2.24.1)(webpack@5.98.0):
     dependencies:


### PR DESCRIPTION
We're only using this in one place. It's a perfectly nice addon, but ancient and never going to be updated. Much easier to reach for the event itself and not add this complication.