### PR TITLE
Log Invisible Validation Errors

### DIFF
--- a/packages/ilios-common/addon/classes/yup-validations.js
+++ b/packages/ilios-common/addon/classes/yup-validations.js
@@ -24,7 +24,13 @@ export default class YupValidations {
     this.context = context;
     this.shape = shape;
     this.schema = object().shape(shape);
-    this.intl = getOwner(context).lookup('service:intl');
+    const owner = context.owner ?? getOwner(context);
+    if (!owner) {
+      throw new Error(
+        'No owner found for YupValidations. Either the context does not have an owner or the owner is not set.',
+      );
+    }
+    this.intl = owner.lookup('service:intl');
   }
 
   get errorsByKey() {

--- a/packages/ilios-common/addon/classes/yup-validations.js
+++ b/packages/ilios-common/addon/classes/yup-validations.js
@@ -3,6 +3,7 @@ import { getProperties } from '@ember/object';
 import { object, setLocale } from 'yup';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { modifier } from 'ember-modifier';
+import { getOwner } from '@ember/application';
 
 const DEBOUNCE_MS = 100;
 
@@ -13,6 +14,7 @@ export default class YupValidations {
   context;
   schema;
   shape;
+  intl;
 
   @tracked error;
   @tracked showAllErrors = false;
@@ -22,6 +24,7 @@ export default class YupValidations {
     this.context = context;
     this.shape = shape;
     this.schema = object().shape(shape);
+    this.intl = getOwner(context).lookup('service:intl');
   }
 
   get errorsByKey() {
@@ -86,7 +89,26 @@ export default class YupValidations {
   }
 
   async isValid() {
-    return (await this.#validate()) === true;
+    const isValid = await this.#validate();
+    if (isValid === true) {
+      return true;
+    }
+    //find errors that are not visible and log them
+    //this makes it easier to find invisible errors when debugging
+    const invisibleErrors = Object.keys(this.errorsByKey).filter(
+      (key) => !this.visibleErrors.includes(key),
+    );
+    if (invisibleErrors.length) {
+      invisibleErrors.forEach((key) => {
+        const errors = this.errorsByKey[key].map(({ messageKey, values }) => {
+          values.description = key;
+          return this.intl.t(messageKey, values);
+        });
+        console.warn('Invisible errors prevented validation:\n  ' + errors.join('\n  '));
+      });
+    }
+
+    return false;
   }
 
   addErrorDisplaysFor = (fields) => {

--- a/packages/ilios-common/addon/classes/yup-validations.js
+++ b/packages/ilios-common/addon/classes/yup-validations.js
@@ -101,6 +101,9 @@ export default class YupValidations {
     if (invisibleErrors.length) {
       invisibleErrors.forEach((key) => {
         const errors = this.errorsByKey[key].map(({ messageKey, values }) => {
+          if (!values) {
+            values = {};
+          }
           values.description = key;
           return this.intl.t(messageKey, values);
         });
@@ -212,7 +215,7 @@ function isEmail() {
     return {
       path: validationParams.path,
       messageKey: 'errors.email',
-      values: [],
+      values: {},
     };
   };
 }
@@ -222,7 +225,7 @@ function isURL() {
     return {
       path: validationParams.path,
       messageKey: 'errors.url',
-      values: [],
+      values: {},
     };
   };
 }
@@ -230,7 +233,7 @@ function isURL() {
 function notType() {
   return ({ type, path }) => {
     let messageKey,
-      values = [];
+      values = {};
     switch (type) {
       case 'number':
         messageKey = 'errors.notANumber';


### PR DESCRIPTION
To prevent bugs such as we had with validating the session overview (#8492), where an error in a field that isn't currently open or showing errors prevents validation, this now logs those errors to the console. This isn't visible much to users, as it's in the console, but I used the intl service to translate them into nice errors anyway.