### PR TITLE
Creating new Session Type now displays 'saved-result' notification

### DIFF
--- a/packages/frontend/app/components/school-manager.hbs
+++ b/packages/frontend/app/components/school-manager.hbs
@@ -112,6 +112,8 @@
           @setSchoolManagedSessionType={{@setSchoolManagedSessionType}}
           @schoolNewSessionType={{@schoolNewSessionType}}
           @setSchoolNewSessionType={{@setSchoolNewSessionType}}
+          @newSavedSessionType={{this.newSavedSessionType}}
+          @setNewSavedSessionType={{this.setNewSavedSessionType}}
         />
       {{else}}
         <SchoolSessionTypesCollapsed

--- a/packages/frontend/app/components/school-manager.js
+++ b/packages/frontend/app/components/school-manager.js
@@ -10,6 +10,7 @@ import { string } from 'yup';
 export default class SchoolManagerComponent extends Component {
   @service flashMessages;
   @tracked title;
+  @tracked newSavedSessionType;
 
   constructor() {
     super(...arguments);
@@ -58,6 +59,11 @@ export default class SchoolManagerComponent extends Component {
     this.newSchool = await this.args.school.save();
     this.flashMessages.success('general.savedSuccessfully');
   });
+
+  @action
+  setNewSavedSessionType(sessionType) {
+    this.newSavedSessionType = sessionType;
+  }
 
   @action
   revertTitleChanges() {

--- a/packages/frontend/app/components/school-session-type-form.hbs
+++ b/packages/frontend/app/components/school-session-type-form.hbs
@@ -10,6 +10,7 @@
             id="title-{{templateId}}"
             type="text"
             value={{this.title}}
+            placeholder={{t "general.sessionTypeTitlePlaceholder"}}
             {{on "input" (pick "target.value" (set this "title"))}}
             {{on "keyup" (queue (fn this.addErrorDisplayFor "title") (perform this.saveOrCancel))}}
           />

--- a/packages/frontend/app/components/school-session-types-expanded.hbs
+++ b/packages/frontend/app/components/school-session-types-expanded.hbs
@@ -47,7 +47,22 @@
         @canUpdate={{true}}
         @save={{perform this.save}}
         @close={{fn @setSchoolNewSessionType false}}
+        @newSavedSessionType={{@newSavedSessionType}}
+        @setNewSavedSessionType={{@setNewSavedSessionType}}
       />
+    {{/if}}
+    {{#if @newSavedSessionType}}
+      <div class="saved-result">
+        <button
+          class="link-button"
+          type="button"
+          {{on "click" (fn @setSchoolManagedSessionType @newSavedSessionType.id)}}
+        >
+          <FaIcon @icon="square-up-right" />
+          {{@newSavedSessionType.title}}
+        </button>
+        {{t "general.savedSuccessfully"}}
+      </div>
     {{/if}}
     {{#if this.managedSessionType}}
       <SchoolSessionTypeManager

--- a/packages/frontend/app/components/school-session-types-expanded.hbs
+++ b/packages/frontend/app/components/school-session-types-expanded.hbs
@@ -52,7 +52,7 @@
       />
     {{/if}}
     {{#if @newSavedSessionType}}
-      <div class="saved-result">
+      <div class="saved-result" data-test-saved-result>
         <button
           class="link-button"
           type="button"

--- a/packages/frontend/app/components/school-session-types-expanded.js
+++ b/packages/frontend/app/components/school-session-types-expanded.js
@@ -62,6 +62,8 @@ export default class SchoolSessionTypesExpandedComponent extends Component {
         active: isActive,
       });
 
+      this.args.setNewSavedSessionType(sessionType);
+
       await sessionType.save();
     },
   );

--- a/packages/frontend/app/styles/components/school-session-type-form.scss
+++ b/packages/frontend/app/styles/components/school-session-type-form.scss
@@ -4,7 +4,10 @@
 .school-session-type-form {
   .form {
     @include m.ilios-form;
-    width: 80%;
+    background-color: c.$slightWhite;
+    border: 1px solid c.$culturedGrey;
+    margin: 0.5rem 0;
+    padding: 1rem;
 
     .item {
       @include m.ilios-form-item;

--- a/packages/frontend/app/styles/components/school-session-type-form.scss
+++ b/packages/frontend/app/styles/components/school-session-type-form.scss
@@ -4,7 +4,6 @@
 .school-session-type-form {
   .form {
     @include m.ilios-form;
-    display: block;
     width: 80%;
 
     .item {

--- a/packages/frontend/app/styles/components/school-session-type-manager.scss
+++ b/packages/frontend/app/styles/components/school-session-type-manager.scss
@@ -6,6 +6,6 @@
   }
 
   .school-session-type-form {
-    margin-left: 6rem;
+    margin-left: 0;
   }
 }

--- a/packages/frontend/app/styles/components/school-session-types-expanded.scss
+++ b/packages/frontend/app/styles/components/school-session-types-expanded.scss
@@ -19,6 +19,10 @@
   .school-session-types-expanded-content {
     @include m.detail-container-content;
 
+    .saved-result {
+      @include m.main-list-saved-new;
+    }
+
     table {
       @include m.ilios-table-structure;
       @include m.ilios-table-colors;

--- a/packages/frontend/tests/acceptance/school/session-types-test.js
+++ b/packages/frontend/tests/acceptance/school/session-types-test.js
@@ -102,7 +102,7 @@ module('Acceptance | School - Session Types', function (hooks) {
   });
 
   test('new session type', async function (assert) {
-    assert.expect(8);
+    assert.expect(9);
     this.server.create('aamc-method', { id: 'IM001', active: true });
     this.server.create('aamc-method', { id: 'IM002', active: true });
     this.server.create('aamc-method', { id: 'AM001', active: true });
@@ -124,10 +124,11 @@ module('Acceptance | School - Session Types', function (hooks) {
     assert.notOk(e.list.sessionTypes[0].isAssessment);
     assert.strictEqual(e.list.sessionTypes[0].aamcMethod, 'aamc method 1');
     assert.strictEqual(e.list.sessionTypes[0].calendarColor, 'background-color: #cc6699');
+    assert.strictEqual(e.savedResult, 'lorem ipsum Saved Successfully');
   });
 
   test('new session type - assessment', async function (assert) {
-    assert.expect(9);
+    assert.expect(10);
     this.server.create('aamc-method', { id: 'IM001', active: true });
     this.server.create('aamc-method', { id: 'IM002', active: true });
     this.server.create('aamc-method', { id: 'AM001', active: true });
@@ -152,5 +153,6 @@ module('Acceptance | School - Session Types', function (hooks) {
     assert.strictEqual(e.list.sessionTypes[0].assessmentOption, 'summative');
     assert.strictEqual(e.list.sessionTypes[0].aamcMethod, 'aamc method 3');
     assert.strictEqual(e.list.sessionTypes[0].calendarColor, 'background-color: #ccff00');
+    assert.strictEqual(e.savedResult, 'lorem ipsum Saved Successfully');
   });
 });

--- a/packages/frontend/tests/pages/components/school-session-types-expanded.js
+++ b/packages/frontend/tests/pages/components/school-session-types-expanded.js
@@ -8,6 +8,7 @@ const definition = {
   collapse: clickable('[data-test-header] [data-test-title]'),
   title: text('[data-test-header] [data-test-title]'),
   createNew: clickable('[data-test-expand-collapse-button] button'),
+  savedResult: text('[data-test-saved-result]'),
   newSessionType,
   manager,
   list,

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -391,6 +391,7 @@ general:
   sessionObjectivesReportSummary: "report for {courseCount, plural, one {one course} other {# courses}}. Each session objective is listed along with instructors and course data."
   sessionTitlePlaceholder: Enter a title for this session
   sessionTypeConfirmRemoval: Are you sure you want to delete this session type? This action cannot be undone.
+  sessionTypeTitlePlaceholder: Enter a title for this session type
   showResultsFor: Show Results For
   showRolesInCourses: Show roles in courses
   showRolesInPrograms: Show roles in programs

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -391,6 +391,7 @@ general:
   sessionObjectivesReportSummary: "informe para {courseCount, plural, one {un curso} other {# cursos}}. Se enumera el objetivo de cada sesión junto con los instructores y los datos del curso."
   sessionTitlePlaceholder: Entre en un titulo para esta sesión
   sessionTypeConfirmRemoval: ¿Está seguro de que desea eliminar este tipo de sesión? Esta acción no se puede deshacer.
+  sessionTypeTitlePlaceholder: Entre en un titulo para este tipo de sesión
   showResultsFor: Mostrar Resultados Para
   showRolesInCourses: Mostrar roles en cursos
   showRolesInPrograms: Mostrar roles en programas

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -392,6 +392,7 @@ general:
   sessionObjectivesReportSummary: "Rapport de {courseCount, plural, one {one course} other {# courses}}. Chaque objectif de séance est listée avec des instructeurs et cours données."
   sessionTitlePlaceholder: Ajoutez un titre pour ce session
   sessionTypeConfirmRemoval: "Voulez-vous vraiment supprimer ce type de session ? Cette action ne peut pas être annulée."
+  sessionTypeTitlePlaceholder: Ajoutez un titre pour ce type de session
   showResultsFor: Afficher les résultats pour
   showRolesInCourses: Afficher les rôles dans les cours
   showRolesInPrograms: Afficher les rôles dans les programmes


### PR DESCRIPTION
Fixes ilios/ilios#4340

Creating a new Session Type now shows a "foo Successfully Created" notification on the screen above the list of Session Types, just like, for example, Programs.

While in the code, I also improved the form, giving it normalized margins, fixing a CSS display bug, and adding the usual New Thing background color/border CSS stuff.