### PR TITLE
Add labels for course visualizations that don't have data (yet)

### DIFF
--- a/packages/ilios-common/addon/components/course/visualizations.hbs
+++ b/packages/ilios-common/addon/components/course/visualizations.hbs
@@ -35,6 +35,7 @@
             @isIcon={{true}}
             @course={{@model}}
             @showDataTable={{false}}
+            @showNoChartDataError={{true}}
           />
         </LinkTo>
       </div>
@@ -43,7 +44,11 @@
           <h4>
             {{t "general.sessionTypes"}}
           </h4>
-          <Course::VisualizeSessionTypesGraph @isIcon={{true}} @course={{@model}} />
+          <Course::VisualizeSessionTypesGraph
+            @isIcon={{true}}
+            @course={{@model}}
+            @showNoChartDataError={{true}}
+          />
         </LinkTo>
       </div>
       <div data-test-visualize-vocabularies>
@@ -55,6 +60,7 @@
             @isIcon={{true}}
             @course={{@model}}
             @showDataTable={{false}}
+            @showNoChartDataError={{true}}
           />
         </LinkTo>
       </div>
@@ -63,7 +69,11 @@
           <h4>
             {{t "general.instructors"}}
           </h4>
-          <Course::VisualizeInstructorsGraph @isIcon={{true}} @course={{@model}} />
+          <Course::VisualizeInstructorsGraph
+            @isIcon={{true}}
+            @course={{@model}}
+            @showNoChartDataError={{true}}
+          />
         </LinkTo>
       </div>
     </div>

--- a/packages/ilios-common/addon/components/course/visualize-instructors-graph.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-instructors-graph.hbs
@@ -5,21 +5,27 @@
 >
   {{#if this.isLoaded}}
     {{#if (or @isIcon this.hasChartData)}}
-      <SimpleChart
-        @name="horz-bar"
-        @isIcon={{@isIcon}}
-        @data={{this.filteredChartData}}
-        @onClick={{this.barClick}}
-        @hover={{perform this.barHover}}
-        @leave={{perform this.barHover}}
-        as |chart|
-      >
-        {{#if this.tooltipContent}}
-          <chart.tooltip @title={{this.tooltipTitle}}>
-            {{this.tooltipContent}}
-          </chart.tooltip>
-        {{/if}}
-      </SimpleChart>
+      {{#if this.hasChartData}}
+        <SimpleChart
+          @name="horz-bar"
+          @isIcon={{@isIcon}}
+          @data={{this.filteredChartData}}
+          @onClick={{this.barClick}}
+          @hover={{perform this.barHover}}
+          @leave={{perform this.barHover}}
+          as |chart|
+        >
+          {{#if this.tooltipContent}}
+            <chart.tooltip @title={{this.tooltipTitle}}>
+              {{this.tooltipContent}}
+            </chart.tooltip>
+          {{/if}}
+        </SimpleChart>
+      {{else}}
+        <div class="no-data" data-test-no-data>
+          {{t "general.courseVisualizationsInstructorsGraphNoData"}}
+        </div>
+      {{/if}}
     {{/if}}
     {{#if (and (not @isIcon) (not this.hasData))}}
       <div class="no-data" data-test-no-data>

--- a/packages/ilios-common/addon/components/course/visualize-instructors-graph.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-instructors-graph.hbs
@@ -22,9 +22,11 @@
           {{/if}}
         </SimpleChart>
       {{else}}
-        <div class="no-data" data-test-no-data>
-          {{t "general.courseVisualizationsInstructorsGraphNoData"}}
-        </div>
+        {{#if @showNoChartDataError}}
+          <div class="no-data" data-test-no-data>
+            {{t "general.courseVisualizationsInstructorsGraphNoData"}}
+          </div>
+        {{/if}}
       {{/if}}
     {{/if}}
     {{#if (and (not @isIcon) (not this.hasData))}}

--- a/packages/ilios-common/addon/components/course/visualize-instructors.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-instructors.hbs
@@ -30,16 +30,18 @@
         {{/if}}
       </LinkTo>
     </h3>
-    <div class="filter" data-test-filter>
-      <input
-        aria-label={{t "general.filterChartPlaceholder"}}
-        autocomplete="off"
-        type="search"
-        value={{this.name}}
-        placeholder={{t "general.filterPlaceholder"}}
-        {{on "input" (pick "target.value" (set this "name"))}}
-      />
-    </div>
+    {{#if @model.sessions.length}}
+      <div class="filter" data-test-filter>
+        <input
+          aria-label={{t "general.filterChartPlaceholder"}}
+          autocomplete="off"
+          type="search"
+          value={{this.name}}
+          placeholder={{t "general.filterPlaceholder"}}
+          {{on "input" (pick "target.value" (set this "name"))}}
+        />
+      </div>
+    {{/if}}
     <div class="visualizations">
       <Course::VisualizeInstructorsGraph
         @filter={{this.name}}

--- a/packages/ilios-common/addon/components/course/visualize-instructors.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-instructors.hbs
@@ -47,6 +47,7 @@
         @filter={{this.name}}
         @course={{@model}}
         @showDataTable={{true}}
+        @showNoChartDataError={{true}}
       />
     </div>
   {{/if}}

--- a/packages/ilios-common/addon/components/course/visualize-objectives-graph.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-objectives-graph.hbs
@@ -5,26 +5,20 @@
 >
   {{#if this.isLoaded}}
     {{#if (or @isIcon this.objectiveWithMinutes.length)}}
-      {{#if this.objectiveWithMinutes.length}}
-        <SimpleChart
-          @name="donut"
-          @isIcon={{@isIcon}}
-          @data={{this.objectiveWithMinutes}}
-          @hover={{perform this.donutHover}}
-          @leave={{perform this.donutHover}}
-          as |chart|
-        >
-          {{#if this.tooltipContent}}
-            <chart.tooltip @title={{this.tooltipTitle}}>
-              {{this.tooltipContent}}
-            </chart.tooltip>
-          {{/if}}
-        </SimpleChart>
-      {{else}}
-        <div class="no-data" data-test-no-data>
-          {{t "general.objectivesWithNoLink"}}
-        </div>
-      {{/if}}
+      <SimpleChart
+        @name="donut"
+        @isIcon={{@isIcon}}
+        @data={{this.objectiveWithMinutes}}
+        @hover={{perform this.donutHover}}
+        @leave={{perform this.donutHover}}
+        as |chart|
+      >
+        {{#if this.tooltipContent}}
+          <chart.tooltip @title={{this.tooltipTitle}}>
+            {{this.tooltipContent}}
+          </chart.tooltip>
+        {{/if}}
+      </SimpleChart>
     {{else}}
       <div class="with-hours" data-test-with-hours>
         <p>

--- a/packages/ilios-common/addon/components/course/visualize-objectives-graph.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-objectives-graph.hbs
@@ -5,20 +5,26 @@
 >
   {{#if this.isLoaded}}
     {{#if (or @isIcon this.objectiveWithMinutes.length)}}
-      <SimpleChart
-        @name="donut"
-        @isIcon={{@isIcon}}
-        @data={{this.objectiveWithMinutes}}
-        @hover={{perform this.donutHover}}
-        @leave={{perform this.donutHover}}
-        as |chart|
-      >
-        {{#if this.tooltipContent}}
-          <chart.tooltip @title={{this.tooltipTitle}}>
-            {{this.tooltipContent}}
-          </chart.tooltip>
-        {{/if}}
-      </SimpleChart>
+      {{#if this.objectiveWithMinutes.length}}
+        <SimpleChart
+          @name="donut"
+          @isIcon={{@isIcon}}
+          @data={{this.objectiveWithMinutes}}
+          @hover={{perform this.donutHover}}
+          @leave={{perform this.donutHover}}
+          as |chart|
+        >
+          {{#if this.tooltipContent}}
+            <chart.tooltip @title={{this.tooltipTitle}}>
+              {{this.tooltipContent}}
+            </chart.tooltip>
+          {{/if}}
+        </SimpleChart>
+      {{else}}
+        <div class="no-data" data-test-no-data>
+          {{t "general.objectivesWithNoLink"}}
+        </div>
+      {{/if}}
     {{else}}
       <div class="with-hours" data-test-with-hours>
         <p>

--- a/packages/ilios-common/addon/components/course/visualize-objectives-graph.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-objectives-graph.hbs
@@ -4,30 +4,60 @@
   ...attributes
 >
   {{#if this.isLoaded}}
-    {{#if (or @isIcon this.objectiveWithMinutes.length)}}
-      <SimpleChart
-        @name="donut"
-        @isIcon={{@isIcon}}
-        @data={{this.objectiveWithMinutes}}
-        @hover={{perform this.donutHover}}
-        @leave={{perform this.donutHover}}
-        as |chart|
-      >
-        {{#if this.tooltipContent}}
-          <chart.tooltip @title={{this.tooltipTitle}}>
-            {{this.tooltipContent}}
-          </chart.tooltip>
+    {{#if @isIcon}}
+      {{#if this.objectiveWithMinutes.length}}
+        <SimpleChart
+          @name="donut"
+          @isIcon={{@isIcon}}
+          @data={{this.objectiveWithMinutes}}
+          @hover={{perform this.donutHover}}
+          @leave={{perform this.donutHover}}
+          as |chart|
+        >
+          {{#if this.tooltipContent}}
+            <chart.tooltip @title={{this.tooltipTitle}}>
+              {{this.tooltipContent}}
+            </chart.tooltip>
+          {{/if}}
+        </SimpleChart>
+      {{else}}
+        {{#if @showNoChartDataError}}
+          <div class="with-hours" data-test-with-hours>
+            <p>
+              {{t "general.objectivesWithNoLink"}}
+            </p>
+            <h4>
+              <FaIcon @icon="meh" class="meh-o" />
+            </h4>
+          </div>
         {{/if}}
-      </SimpleChart>
+      {{/if}}
     {{else}}
-      <div class="with-hours" data-test-with-hours>
-        <p>
-          {{t "general.objectivesWithNoLink"}}
-        </p>
-        <h4>
-          <FaIcon @icon="meh" class="meh-o" />
-        </h4>
-      </div>
+      {{#if this.objectiveWithMinutes.length}}
+        <SimpleChart
+          @name="donut"
+          @isIcon={{@isIcon}}
+          @data={{this.objectiveWithMinutes}}
+          @hover={{perform this.donutHover}}
+          @leave={{perform this.donutHover}}
+          as |chart|
+        >
+          {{#if this.tooltipContent}}
+            <chart.tooltip @title={{this.tooltipTitle}}>
+              {{this.tooltipContent}}
+            </chart.tooltip>
+          {{/if}}
+        </SimpleChart>
+      {{else}}
+        <div class="with-hours" data-test-with-hours>
+          <p>
+            {{t "general.objectivesWithNoLink"}}
+          </p>
+          <h4>
+            <FaIcon @icon="meh" class="meh-o" />
+          </h4>
+        </div>
+      {{/if}}
     {{/if}}
     {{#if (and (not @isIcon) this.objectiveWithoutMinutes.length)}}
       <div class="zero-hours" data-test-zero-hours>

--- a/packages/ilios-common/addon/components/course/visualize-objectives.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-objectives.hbs
@@ -30,6 +30,10 @@
     </LinkTo>
   </h3>
   <div class="visualizations">
-    <Course::VisualizeObjectivesGraph @course={{@model}} @showDataTable={{true}} />
+    <Course::VisualizeObjectivesGraph
+      @course={{@model}}
+      @showDataTable={{true}}
+      @showNoChartDataError={{true}}
+    />
   </div>
 </section>

--- a/packages/ilios-common/addon/components/course/visualize-session-types-graph.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-session-types-graph.hbs
@@ -22,9 +22,11 @@
           {{/if}}
         </SimpleChart>
       {{else}}
-        <div class="no-data" data-test-no-data>
-          {{t "general.courseVisualizationsNoSessions"}}
-        </div>
+        {{#if @showNoChartDataError}}
+          <div class="no-data" data-test-no-data>
+            {{t "general.courseVisualizationsNoSessions"}}
+          </div>
+        {{/if}}
       {{/if}}
     {{/if}}
     {{#if (and (not @isIcon) (not this.hasData))}}

--- a/packages/ilios-common/addon/components/course/visualize-session-types-graph.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-session-types-graph.hbs
@@ -5,21 +5,27 @@
 >
   {{#if this.isLoaded}}
     {{#if (or @isIcon this.hasChartData)}}
-      <SimpleChart
-        @name="horz-bar"
-        @isIcon={{@isIcon}}
-        @data={{this.filteredChartData}}
-        @onClick={{this.barClick}}
-        @hover={{perform this.barHover}}
-        @leave={{perform this.barHover}}
-        as |chart|
-      >
-        {{#if this.tooltipContent}}
-          <chart.tooltip @title={{this.tooltipTitle}}>
-            {{this.tooltipContent}}
-          </chart.tooltip>
-        {{/if}}
-      </SimpleChart>
+      {{#if this.hasChartData}}
+        <SimpleChart
+          @name="horz-bar"
+          @isIcon={{@isIcon}}
+          @data={{this.filteredChartData}}
+          @onClick={{this.barClick}}
+          @hover={{perform this.barHover}}
+          @leave={{perform this.barHover}}
+          as |chart|
+        >
+          {{#if this.tooltipContent}}
+            <chart.tooltip @title={{this.tooltipTitle}}>
+              {{this.tooltipContent}}
+            </chart.tooltip>
+          {{/if}}
+        </SimpleChart>
+      {{else}}
+        <div class="no-data" data-test-no-data>
+          {{t "general.courseVisualizationsNoSessions"}}
+        </div>
+      {{/if}}
     {{/if}}
     {{#if (and (not @isIcon) (not this.hasData))}}
       <div class="no-data" data-test-no-data>

--- a/packages/ilios-common/addon/components/course/visualize-session-types.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-session-types.hbs
@@ -29,16 +29,18 @@
       {{/if}}
     </LinkTo>
   </h3>
-  <div class="filter" data-test-filter>
-    <input
-      aria-label={{t "general.filterChartPlaceholder"}}
-      autocomplete="off"
-      type="search"
-      value={{this.title}}
-      placeholder={{t "general.filterPlaceholder"}}
-      {{on "input" (pick "target.value" (set this "title"))}}
-    />
-  </div>
+  {{#if @model.sessions.length}}
+    <div class="filter" data-test-filter>
+      <input
+        aria-label={{t "general.filterChartPlaceholder"}}
+        autocomplete="off"
+        type="search"
+        value={{this.title}}
+        placeholder={{t "general.filterPlaceholder"}}
+        {{on "input" (pick "target.value" (set this "title"))}}
+      />
+    </div>
+  {{/if}}
   <div class="visualizations">
     <Course::VisualizeSessionTypesGraph
       @filter={{this.title}}

--- a/packages/ilios-common/addon/components/course/visualize-session-types.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-session-types.hbs
@@ -46,6 +46,7 @@
       @filter={{this.title}}
       @course={{@model}}
       @showDataTable={{true}}
+      @showNoChartDataError={{true}}
     />
   </div>
 </section>

--- a/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.hbs
@@ -22,9 +22,11 @@
           {{/if}}
         </SimpleChart>
       {{else}}
-        <div class="no-data" data-test-no-data>
-          {{t "general.courseVisualizationsNoSessions"}}
-        </div>
+        {{#if @showNoChartDataError}}
+          <div class="no-data" data-test-no-data>
+            {{t "general.courseVisualizationsNoSessionsVocabularyData"}}
+          </div>
+        {{/if}}
       {{/if}}
     {{/if}}
     {{#if (and (not @isIcon) (not this.hasData))}}

--- a/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.hbs
@@ -24,14 +24,14 @@
       {{else}}
         {{#if @showNoChartDataError}}
           <div class="no-data" data-test-no-data>
-            {{t "general.courseVisualizationsNoSessionsVocabularyData"}}
+            {{t "general.courseVisualizationsNoSessionVocabularyTerms"}}
           </div>
         {{/if}}
       {{/if}}
     {{/if}}
     {{#if (and (not @isIcon) (not this.hasData))}}
       <div class="no-data" data-test-no-data>
-        {{t "general.courseVisualizationsNoSessions"}}
+        {{t "general.courseVisualizationsNoSessionVocabularyTerms"}}
       </div>
     {{/if}}
     {{#if (and (not @isIcon) this.hasData @showDataTable)}}

--- a/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.hbs
@@ -5,21 +5,27 @@
 >
   {{#if this.isLoaded}}
     {{#if (or @isIcon this.hasChartData)}}
-      <SimpleChart
-        @name="horz-bar"
-        @isIcon={{@isIcon}}
-        @data={{this.chartData}}
-        @onClick={{this.barClick}}
-        @hover={{perform this.barHover}}
-        @leave={{perform this.barHover}}
-        as |chart|
-      >
-        {{#if this.tooltipContent}}
-          <chart.tooltip @title={{this.tooltipTitle}}>
-            {{this.tooltipContent}}
-          </chart.tooltip>
-        {{/if}}
-      </SimpleChart>
+      {{#if this.hasChartData}}
+        <SimpleChart
+          @name="horz-bar"
+          @isIcon={{@isIcon}}
+          @data={{this.chartData}}
+          @onClick={{this.barClick}}
+          @hover={{perform this.barHover}}
+          @leave={{perform this.barHover}}
+          as |chart|
+        >
+          {{#if this.tooltipContent}}
+            <chart.tooltip @title={{this.tooltipTitle}}>
+              {{this.tooltipContent}}
+            </chart.tooltip>
+          {{/if}}
+        </SimpleChart>
+      {{else}}
+        <div class="no-data" data-test-no-data>
+          {{t "general.courseVisualizationsNoSessions"}}
+        </div>
+      {{/if}}
     {{/if}}
     {{#if (and (not @isIcon) (not this.hasData))}}
       <div class="no-data" data-test-no-data>

--- a/packages/ilios-common/addon/components/course/visualize-vocabularies.hbs
+++ b/packages/ilios-common/addon/components/course/visualize-vocabularies.hbs
@@ -34,6 +34,10 @@
     </LinkTo>
   </h3>
   <div class="visualizations">
-    <Course::VisualizeVocabulariesGraph @course={{@model}} @showDataTable={{true}} />
+    <Course::VisualizeVocabulariesGraph
+      @course={{@model}}
+      @showDataTable={{true}}
+      @showNoChartDataError={{true}}
+    />
   </div>
 </section>

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -89,7 +89,7 @@ general:
   courseTitlePlaceholder: Enter a title for this course
   courseVisualizations: Course Visualizations
   courseVisualizationsNoSessions: "This course has no sessions."
-  courseVisualizationsNoSessionVocabularyTerms: "This course has no session vocabulary terms."
+  courseVisualizationsNoSessionVocabularyTerms: No vocabularies have been linked to any sessions in this course.
   courseVisualizationsInstructorNoData: "{instructor} is not instructing any sessions in this this course."
   courseVisualizationsInstructorsGraphNoData: No instructors have been linked to any sessions in this course.
   courseVisualizationsSessionTypeGraphNoData: "No vocabulary terms have been linked to any {sessionType} sessions in this course."

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -89,6 +89,7 @@ general:
   courseTitlePlaceholder: Enter a title for this course
   courseVisualizations: Course Visualizations
   courseVisualizationsNoSessions: "This course has no sessions."
+  courseVisualizationsNoSessionVocabularyTerms: "This course has no session vocabulary terms."
   courseVisualizationsInstructorNoData: "{instructor} is not instructing any sessions in this this course."
   courseVisualizationsInstructorsGraphNoData: No instructors have been linked to any sessions in this course.
   courseVisualizationsSessionTypeGraphNoData: "No vocabulary terms have been linked to any {sessionType} sessions in this course."

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -255,7 +255,7 @@ general:
   objectiveParentTitleSingular: Select Parent Objective
   objectives: Objectives
   objectivesWithNoHours: "The following course objectives are either not linked to any session, or only linked to sessions without offering or duration data."
-  objectivesWithNoLink: No Course Objectives Currently Linked to Instructional Time.
+  objectivesWithNoLink: No course objectives currently linked to instructional time.
   offering: Offering
   offerings: Offerings
   otherVisualizations: Other Visualizations

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -89,7 +89,7 @@ general:
   courseTitlePlaceholder: Entre en un título para este curso
   courseVisualizations: Visualizaciones de Cursos
   courseVisualizationsNoSessions: Este curso no tiene sesiones.
-  courseVisualizationsNoSessionVocabularyTerms: "Este curso no tiene términos de vocabulario de sesión."
+  courseVisualizationsNoSessionVocabularyTerms: No se han vinculado vocabularios a ninguna sesión de este curso.
   courseVisualizationsInstructorNoData: "{instructor} no está impartiendo ninguna sesión en este curso."
   courseVisualizationsInstructorsGraphNoData: No se han vinculado instructores a ninguna sesión de este curso.
   courseVisualizationsSessionTypeGraphNoData: "No se han vinculado términos de vocabulario a ninguna sesión {sessionType} en este curso."

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -89,6 +89,7 @@ general:
   courseTitlePlaceholder: Entre en un título para este curso
   courseVisualizations: Visualizaciones de Cursos
   courseVisualizationsNoSessions: Este curso no tiene sesiones.
+  courseVisualizationsNoSessionVocabularyTerms: "Este curso no tiene términos de vocabulario de sesión."
   courseVisualizationsInstructorNoData: "{instructor} no está impartiendo ninguna sesión en este curso."
   courseVisualizationsInstructorsGraphNoData: No se han vinculado instructores a ninguna sesión de este curso.
   courseVisualizationsSessionTypeGraphNoData: "No se han vinculado términos de vocabulario a ninguna sesión {sessionType} en este curso."

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -89,6 +89,7 @@ general:
   courseTitlePlaceholder: Ajoutez titre par ce cours
   courseVisualizations: Cours Visualisations
   courseVisualizationsNoSessions: Ce cours n'a pas de séances.
+  courseVisualizationsNoSessionVocabularyTerms: "Ce cours n'a pas de termes de vocabulaire de session."
   courseVisualizationsInstructorNoData: "{instructor} n'enseigne aucune séance dans ce cours."
   courseVisualizationsInstructorsGraphNoData: Aucun instructeur n'a été lié à aucune session de ce cours.
   courseVisualizationsSessionTypeGraphNoData: "Aucun terme de vocabulaire n'a été lié à une session {sessionType} dans ce cours."

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -89,7 +89,7 @@ general:
   courseTitlePlaceholder: Ajoutez titre par ce cours
   courseVisualizations: Cours Visualisations
   courseVisualizationsNoSessions: Ce cours n'a pas de séances.
-  courseVisualizationsNoSessionVocabularyTerms: "Ce cours n'a pas de termes de vocabulaire de session."
+  courseVisualizationsNoSessionVocabularyTerms: "Aucun vocabulaires n'a été lié à aucune session de ce cours."
   courseVisualizationsInstructorNoData: "{instructor} n'enseigne aucune séance dans ce cours."
   courseVisualizationsInstructorsGraphNoData: Aucun instructeur n'a été lié à aucune session de ce cours.
   courseVisualizationsSessionTypeGraphNoData: "Aucun terme de vocabulaire n'a été lié à une session {sessionType} dans ce cours."

--- a/packages/test-app/tests/integration/components/course/visualize-objectives-graph-test.js
+++ b/packages/test-app/tests/integration/components/course/visualize-objectives-graph-test.js
@@ -317,7 +317,7 @@ module('Integration | Component | course/visualize-objectives-graph', function (
     assert.ok(component.unlinkedObjectives.isPresent);
     assert.strictEqual(
       component.unlinkedObjectives.text,
-      'No Course Objectives Currently Linked to Instructional Time.',
+      'No course objectives currently linked to instructional time.',
     );
   });
 

--- a/packages/test-app/tests/integration/components/course/visualize-vocabularies-graph-test.js
+++ b/packages/test-app/tests/integration/components/course/visualize-vocabularies-graph-test.js
@@ -205,7 +205,7 @@ module('Integration | Component | course/visualize-vocabularies-graph', function
     );
     assert.notOk(component.chart.isVisible);
     assert.notOk(component.dataTable.isVisible);
-    assert.strictEqual(component.noData.text, 'This course has no sessions.');
+    assert.strictEqual(component.noData.text, 'This course has no session vocabulary terms.');
   });
 
   test('only zero time data', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/visualize-vocabularies-graph-test.js
+++ b/packages/test-app/tests/integration/components/course/visualize-vocabularies-graph-test.js
@@ -205,7 +205,10 @@ module('Integration | Component | course/visualize-vocabularies-graph', function
     );
     assert.notOk(component.chart.isVisible);
     assert.notOk(component.dataTable.isVisible);
-    assert.strictEqual(component.noData.text, 'This course has no session vocabulary terms.');
+    assert.strictEqual(
+      component.noData.text,
+      'No vocabularies have been linked to any sessions in this course.',
+    );
   });
 
   test('only zero time data', async function (assert) {


### PR DESCRIPTION
Fixes ilios/ilios#4328

Added some display labels when data isn't present for course visualizations.