### PR TITLE
Drop @embroider/router

### DIFF
--- a/packages/frontend/app/router.js
+++ b/packages/frontend/app/router.js
@@ -1,4 +1,4 @@
-import EmberRouter from '@embroider/router';
+import EmberRouter from '@ember/routing/router';
 import config from 'frontend/config/environment';
 import { courseRoutes, dashboardRoutes } from 'ilios-common/common-routes';
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -45,7 +45,6 @@
     "@embroider/compat": "~3.8.0",
     "@embroider/core": "~3.5.0",
     "@embroider/macros": "^1.16.12",
-    "@embroider/router": "^2.1.8",
     "@embroider/webpack": "~4.1.0",
     "@eslint/js": "^9.23.0",
     "@glimmer/component": "^2.0.0",

--- a/packages/lti-course-manager/app/router.js
+++ b/packages/lti-course-manager/app/router.js
@@ -1,4 +1,4 @@
-import EmberRouter from '@embroider/router';
+import EmberRouter from '@ember/routing/router';
 import config from 'lti-course-manager/config/environment';
 
 export default class Router extends EmberRouter {

--- a/packages/lti-course-manager/package.json
+++ b/packages/lti-course-manager/package.json
@@ -43,7 +43,6 @@
     "@embroider/compat": "~3.8.0",
     "@embroider/core": "~3.5.0",
     "@embroider/macros": "^1.16.12",
-    "@embroider/router": "^2.1.8",
     "@embroider/webpack": "~4.1.0",
     "@eslint/js": "^9.23.0",
     "@glimmer/component": "^2.0.0",

--- a/packages/lti-dashboard/app/router.js
+++ b/packages/lti-dashboard/app/router.js
@@ -1,4 +1,4 @@
-import EmberRouter from '@embroider/router';
+import EmberRouter from '@ember/routing/router';
 import config from 'lti-dashboard/config/environment';
 
 export default class Router extends EmberRouter {

--- a/packages/lti-dashboard/package.json
+++ b/packages/lti-dashboard/package.json
@@ -43,7 +43,6 @@
     "@ember/test-waiters": "^3.1.0",
     "@embroider/compat": "~3.8.0",
     "@embroider/macros": "^1.16.12",
-    "@embroider/router": "^2.1.8",
     "@embroider/webpack": "~4.1.0",
     "@eslint/js": "^9.23.0",
     "@glimmer/component": "^2.0.0",

--- a/packages/test-app/app/router.js
+++ b/packages/test-app/app/router.js
@@ -1,4 +1,4 @@
-import EmberRouter from '@embroider/router';
+import EmberRouter from '@ember/routing/router';
 import config from 'test-app/config/environment';
 import { courseRoutes, dashboardRoutes } from 'ilios-common/common-routes';
 

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -40,7 +40,6 @@
     "@ember/test-waiters": "^3.1.0",
     "@embroider/compat": "^3.8.0",
     "@embroider/macros": "^1.16.12",
-    "@embroider/router": "^2.1.8",
     "@embroider/test-setup": "^4.0.0",
     "@embroider/webpack": "~4.1.0",
     "@eslint/js": "^9.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       '@embroider/macros':
         specifier: ^1.16.12
         version: 1.17.2
-      '@embroider/router':
-        specifier: ^2.1.8
-        version: 2.1.8(@embroider/core@3.5.6)
       '@embroider/webpack':
         specifier: ~4.1.0
         version: 4.1.0(@embroider/core@3.5.6)(webpack@5.99.6)
@@ -706,9 +703,6 @@ importers:
       '@embroider/macros':
         specifier: ^1.16.12
         version: 1.17.2
-      '@embroider/router':
-        specifier: ^2.1.8
-        version: 2.1.8(@embroider/core@3.5.6)
       '@embroider/webpack':
         specifier: ~4.1.0
         version: 4.1.0(@embroider/core@3.5.6)(webpack@5.99.6)
@@ -940,9 +934,6 @@ importers:
       '@embroider/macros':
         specifier: ^1.16.12
         version: 1.17.2
-      '@embroider/router':
-        specifier: ^2.1.8
-        version: 2.1.8(@embroider/core@3.5.6)
       '@embroider/webpack':
         specifier: ~4.1.0
         version: 4.1.0(@embroider/core@3.5.6)(webpack@5.99.6)
@@ -1174,9 +1165,6 @@ importers:
       '@embroider/macros':
         specifier: ^1.16.12
         version: 1.17.2
-      '@embroider/router':
-        specifier: ^2.1.8
-        version: 2.1.8(@embroider/core@3.5.6)
       '@embroider/test-setup':
         specifier: ^4.0.0
         version: 4.0.0(@embroider/compat@3.8.5(@embroider/core@3.5.6))(@embroider/core@3.5.6)(@embroider/webpack@4.1.0(@embroider/core@3.5.6)(webpack@5.99.6))
@@ -2321,14 +2309,6 @@ packages:
       '@glint/template': ^1.0.0
     peerDependenciesMeta:
       '@glint/template':
-        optional: true
-
-  '@embroider/router@2.1.8':
-    resolution: {integrity: sha512-Dvp8YdqAWT6T0yzBZfUe6SyaVNH7xoXBlrxF1LbqoF/Q2buNzDy9oAQ5tTnbX1x+5KOrM0ryOjfeF0GoqkfobA==}
-    peerDependencies:
-      '@embroider/core': ^2.0.0||^3.0.0
-    peerDependenciesMeta:
-      '@embroider/core':
         optional: true
 
   '@embroider/shared-internals@1.8.3':
@@ -11652,15 +11632,6 @@ snapshots:
       lodash: 4.17.21
       resolve: 1.22.10
       semver: 7.7.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@embroider/router@2.1.8(@embroider/core@3.5.6)':
-    dependencies:
-      '@ember/test-waiters': 3.1.0
-      '@embroider/addon-shim': 1.10.0
-    optionalDependencies:
-      '@embroider/core': 3.5.6
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
We don't need this anymore as we've disabled splitAtRoutes. Will add it again when we re-enable this feature.