### PR TITLE
Detect Non Learner Functions in Test Setup

### DIFF
--- a/packages/ilios-common/addon-test-support/ilios-common/helpers/setup-authentication.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/helpers/setup-authentication.js
@@ -11,7 +11,24 @@ export default async function (
   const jwtObject = {
     user_id: userId,
   };
-  if (performsNonLearnerFunction) {
+  const nonLearnerFunctions = [
+    'directedCourses',
+    'administeredCourses',
+    'administeredSessions',
+    'instructorGroups',
+    'instructedOfferings',
+    'instructorIlmSessions',
+    'instructedLearnerGroups',
+    'directedPrograms',
+    'programYears',
+    'administeredCurriculumInventoryReports',
+    'directedSchools',
+    'administeredSchools',
+  ];
+  const hasNonLearnerFunctionInPassedData = nonLearnerFunctions.some((key) => {
+    return key in userObject && Array.isArray(userObject[key]) && userObject[key].length > 0;
+  });
+  if (performsNonLearnerFunction || hasNonLearnerFunctionInPassedData) {
     jwtObject['performs_non_learner_function'] = true;
   }
   const encodedData = window.btoa('') + '.' + window.btoa(JSON.stringify(jwtObject)) + '.';


### PR DESCRIPTION
While it is possible to pass this in as an option we don't reliably do this in our tests. In addition to sending the data we can also look at what has been setup and determine if we should include this attribute.

My hope is that this improves some of the variability @dartajax reported in Percy tests, but initially it will probably result in a lot of Percy failures.