### PR TITLE
use Yup for form validation in curriculum-inventory/report-header component

### DIFF
--- a/packages/frontend/app/components/curriculum-inventory/report-header.hbs
+++ b/packages/frontend/app/components/curriculum-inventory/report-header.hbs
@@ -19,9 +19,13 @@
           value={{this.name}}
           disabled={{isSaving}}
           {{on "input" (pick "target.value" (set this "name"))}}
-          {{on "keyup" (fn this.addErrorDisplayFor "name")}}
+          {{this.validations.attach "name"}}
         />
-        <ValidationError @validatable={{this}} @property="name" />
+        <YupValidationMessage
+          @description={{t "general.name"}}
+          @validationErrors={{this.validations.errors.name}}
+          data-test-name-validation-error-message
+        />
       </EditableField>
     {{else}}
       <h2 data-test-locked-name>

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-header-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-header-test.js
@@ -78,20 +78,6 @@ module('Integration | Component | curriculum-inventory/report-header', function 
     assert.ok(component.name.hasError);
   });
 
-  test('change name fails if name is too short', async function (assert) {
-    this.set('report', this.report);
-    await render(hbs`<CurriculumInventory::ReportHeader
-  @report={{this.report}}
-  @canUpdate={{true}}
-  @finalize={{(noop)}}
-/>`);
-    await component.name.edit();
-    assert.notOk(component.name.hasError);
-    await component.name.set('ab');
-    await component.name.save();
-    assert.ok(component.name.hasError);
-  });
-
   test('change name fails if name is too long', async function (assert) {
     this.set('report', this.report);
     await render(hbs`<CurriculumInventory::ReportHeader

--- a/packages/frontend/tests/pages/components/curriculum-inventory/report-header.js
+++ b/packages/frontend/tests/pages/components/curriculum-inventory/report-header.js
@@ -3,6 +3,7 @@ import {
   clickable,
   create,
   fillable,
+  isPresent,
   isVisible,
   property,
   text,
@@ -19,7 +20,7 @@ const definition = {
     set: fillable('input'),
     edit: clickable('[data-test-edit]'),
     save: clickable('.done'),
-    hasError: isVisible('.validation-error-message'),
+    hasError: isPresent('[data-test-name-validation-error-message]'),
   },
   downloadLink: {
     scope: '[data-test-download]',


### PR DESCRIPTION
this changes the min char requirement for report name from 3 to 1 chars. which aligns it with how form validation for this attribute works in report-rollover and new-report component.

refs https://github.com/ilios/ilios/issues/6055