### PR TITLE
Format Code in Tagging Workflow

### DIFF
--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -20,28 +20,32 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.ZORGBORT_TOKEN }}
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: pnpm
+      - run: pnpm install
       - name: Validate releaseType
-        run: npx in-string-list ${{ github.event.inputs.releaseType }} major,minor,patch
+        run: pnpx in-string-list ${{ github.event.inputs.releaseType }} major,minor,patch
       - name: Setup Git
         run: |
           git config user.name Zorgbort
           git config user.email info@iliosproject.org
-      - name: Increment Frontend Version
-        working-directory: ./packages/frontend
-        run: npx versionup --level ${{ github.event.inputs.releaseType }}
-      - name: Increment LTI Dashboard Version
-        working-directory: ./packages/lti-dashboard
-        run: npx versionup --level ${{ github.event.inputs.releaseType }}
+      - name: Increment Package Versions
+        run: |
+          pnpx versionup --level ${{ github.event.inputs.releaseType }} --path packages/frontend
+          pnpx versionup --level ${{ github.event.inputs.releaseType }} --path packages/lti-dashboard
+      - name: Format Package JSON
+        run: pnpm format
       - run: |
           NEW_TAG=`node -p "require('./packages/frontend/package.json').version"`
           echo ${NEW_TAG}
           echo "new_tag=${NEW_TAG}" >> $GITHUB_ENV
       - name: Tag Version
         run: |
-          git commit -a -m "${{env.new_tag}}"
+          git add packages/frontend/package.json packages/lti-dashboard/package.json
+          git commit -m "${{env.new_tag}}"
           git tag v${{env.new_tag}} -m "Tagging the v${{env.new_tag}} ${{ github.event.inputs.releaseType }} release"
       - name: Push Changes
         run: git push --follow-tags


### PR DESCRIPTION
When we tag the newline in the package.json files gets dropped, adding a step to run prettier and format these again. This requires installing pnpm and our packages. Just in case other stuff gets formatted and we don't want it as part of the commit I'm only adding and committing the two files we expect to change.