### PR TITLE
clear form validation errors on cancel.

### DIFF
--- a/packages/frontend/app/components/curriculum-inventory/report-header.js
+++ b/packages/frontend/app/components/curriculum-inventory/report-header.js
@@ -18,12 +18,12 @@ export default class CurriculumInventoryReportHeaderComponent extends Component 
   });
 
   saveName = restartableTask(async () => {
-    this.validations.addErrorDisplayForAllFields();
+    this.validations.addErrorDisplayFor('name');
     const isValid = await this.validations.isValid();
     if (!isValid) {
       return false;
     }
-    this.validations.clearErrorDisplay();
+    this.validations.clearErrorDisplay('name');
     this.args.report.set('name', this.name);
     await this.args.report.save();
     this.name = this.args.report.name;
@@ -31,6 +31,7 @@ export default class CurriculumInventoryReportHeaderComponent extends Component 
 
   @action
   revertNameChanges() {
+    this.validations.clearErrorDisplay('name');
     this.name = this.args.report.name;
   }
 }

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-header-test.js
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-header-test.js
@@ -76,6 +76,8 @@ module('Integration | Component | curriculum-inventory/report-header', function 
     await component.name.set('');
     await component.name.save();
     assert.ok(component.name.hasError);
+    await component.name.cancel();
+    assert.notOk(component.name.hasError);
   });
 
   test('change name fails if name is too long', async function (assert) {

--- a/packages/frontend/tests/pages/components/curriculum-inventory/report-header.js
+++ b/packages/frontend/tests/pages/components/curriculum-inventory/report-header.js
@@ -20,6 +20,7 @@ const definition = {
     set: fillable('input'),
     edit: clickable('[data-test-edit]'),
     save: clickable('.done'),
+    cancel: clickable('.cancel'),
     hasError: isPresent('[data-test-name-validation-error-message]'),
   },
   downloadLink: {


### PR DESCRIPTION
while at it, appropriately scope down validation function calls to name attribute when saving name changes.

companion to https://github.com/ilios/frontend/pull/8532