### PR TITLE
Subject Reports now remember school, subject, and object

### DIFF
--- a/packages/frontend/app/components/reports/new-subject.hbs
+++ b/packages/frontend/app/components/reports/new-subject.hbs
@@ -74,7 +74,7 @@
         @school={{this.currentSchool}}
         @templateId={{templateId}}
         @currentId={{this.prepositionalObjectId}}
-        @changeId={{set this "selectedPrepositionalObjectId"}}
+        @changeId={{@setSelectedPrepositionalObjectId}}
       />
       <div class="input-buttons">
         <ValidationError

--- a/packages/frontend/app/components/reports/new-subject.js
+++ b/packages/frontend/app/components/reports/new-subject.js
@@ -28,7 +28,6 @@ export default class ReportsNewSubjectComponent extends Component {
   @service dataLoader;
 
   @tracked selectedPrepositionalObject;
-  @tracked selectedSubject;
   @tracked selectedPrepositionalObjectId;
   @tracked selectedTitle;
 
@@ -54,7 +53,7 @@ export default class ReportsNewSubjectComponent extends Component {
   }
 
   get subject() {
-    return this.selectedSubject ?? this.args.report?.subject ?? 'course';
+    return this.args.selectedSubject ?? this.args.report?.subject ?? 'course';
   }
 
   @Length(1, 240)
@@ -283,7 +282,7 @@ export default class ReportsNewSubjectComponent extends Component {
 
   @action
   changeSubject(subject) {
-    this.selectedSubject = subject;
+    this.args.setSelectedSubject(subject);
 
     if (this.includeAnythingObject) {
       this.changePrepositionalObject(null);

--- a/packages/frontend/app/components/reports/new-subject.js
+++ b/packages/frontend/app/components/reports/new-subject.js
@@ -27,25 +27,21 @@ export default class ReportsNewSubjectComponent extends Component {
   @service store;
   @service dataLoader;
 
-  @tracked selectedPrepositionalObject;
-  @tracked selectedPrepositionalObjectId;
   @tracked selectedTitle;
 
   @tracked isSaving = false;
   @tracked schoolChanged = false;
 
-  get selectedSchoolId() {
-    return this.args.selectedSchoolId ?? null;
-  }
-
   @Custom('validatePrepositionalObjectCallback', 'validatePrepositionalObjectMessageCallback')
   get prepositionalObject() {
-    return this.selectedPrepositionalObject ?? this.args.report?.prepositionalObject;
+    return this.args.selectedPrepositionalObject ?? this.args.report?.prepositionalObject;
   }
 
   @Custom('validatePrepositionalObjectIdCallback', 'validatePrepositionalObjectIdMessageCallback')
   get prepositionalObjectId() {
-    return this.selectedPrepositionalObjectId ?? this.args.report?.prepositionalObjectTableRowId;
+    return (
+      this.args.selectedPrepositionalObjectId ?? this.args.report?.prepositionalObjectTableRowId
+    );
   }
 
   get prepositionalObjectIdMissing() {
@@ -275,34 +271,13 @@ export default class ReportsNewSubjectComponent extends Component {
     return this.usersPrimarySchool;
   }
 
+  get selectedSchoolId() {
+    return this.args.selectedSchoolId ?? null;
+  }
+
   get includeAnythingObject() {
     const exceptedSubjects = ['instructor', 'mesh term'];
     return !exceptedSubjects.includes(this.subject);
-  }
-
-  @action
-  changeSubject(subject) {
-    this.args.setSelectedSubject(subject);
-
-    if (this.includeAnythingObject) {
-      this.changePrepositionalObject(null);
-    } else {
-      const firstPrepositionalObjectLabel = Object.values(this.prepositionalObjectList)
-        .map((item) => item.label)
-        .sort()[0];
-      const firstPrepositionalObject = this.fullPrepositionalObjectList.filter(
-        (item) => item.label === firstPrepositionalObjectLabel,
-      )[0].value;
-
-      this.changePrepositionalObject(firstPrepositionalObject);
-    }
-  }
-
-  @action
-  changePrepositionalObject(object, id = null) {
-    this.selectedPrepositionalObject = object;
-    this.selectedPrepositionalObjectId = id;
-    this.clearErrorDisplay();
   }
 
   keyUp(event) {
@@ -373,6 +348,31 @@ export default class ReportsNewSubjectComponent extends Component {
   changeSchool(schoolId) {
     this.args.setSelectedSchoolId(schoolId);
     this.schoolChanged = true;
+  }
+
+  @action
+  changeSubject(subject) {
+    this.args.setSelectedSubject(subject);
+
+    if (this.includeAnythingObject) {
+      this.changePrepositionalObject(null);
+    } else {
+      const firstPrepositionalObjectLabel = Object.values(this.prepositionalObjectList)
+        .map((item) => item.label)
+        .sort()[0];
+      const firstPrepositionalObject = this.fullPrepositionalObjectList.filter(
+        (item) => item.label === firstPrepositionalObjectLabel,
+      )[0].value;
+
+      this.changePrepositionalObject(firstPrepositionalObject);
+    }
+  }
+
+  @action
+  changePrepositionalObject(object, id = null) {
+    this.args.setSelectedPrepositionalObject(object);
+    this.args.setSelectedPrepositionalObjectId(id);
+    this.clearErrorDisplay();
   }
 
   @action

--- a/packages/frontend/app/components/reports/new-subject.js
+++ b/packages/frontend/app/components/reports/new-subject.js
@@ -33,8 +33,11 @@ export default class ReportsNewSubjectComponent extends Component {
   @tracked selectedTitle;
 
   @tracked isSaving = false;
-  @tracked selectedSchool = null;
   @tracked schoolChanged = false;
+
+  get selectedSchoolId() {
+    return this.args.selectedSchoolId ?? null;
+  }
 
   @Custom('validatePrepositionalObjectCallback', 'validatePrepositionalObjectMessageCallback')
   get prepositionalObject() {
@@ -261,8 +264,8 @@ export default class ReportsNewSubjectComponent extends Component {
   }
 
   get currentSchool() {
-    if (this.selectedSchool) {
-      return this.selectedSchool;
+    if (this.selectedSchoolId) {
+      return findById(this.allSchools, this.selectedSchoolId);
     }
 
     //if the school has been set to null intentionally
@@ -369,7 +372,7 @@ export default class ReportsNewSubjectComponent extends Component {
 
   @action
   changeSchool(schoolId) {
-    this.selectedSchool = findById(this.allSchools, schoolId);
+    this.args.setSelectedSchoolId(schoolId);
     this.schoolChanged = true;
   }
 

--- a/packages/frontend/app/components/reports/subjects-list.hbs
+++ b/packages/frontend/app/components/reports/subjects-list.hbs
@@ -33,6 +33,8 @@
           @run={{perform this.runSubjectReport}}
           @selectedSchoolId={{@selectedSchoolId}}
           @setSelectedSchoolId={{@setSelectedSchoolId}}
+          @selectedSubject={{@selectedSubject}}
+          @setSelectedSubject={{@setSelectedSubject}}
         />
       {{/if}}
       {{#if this.newReport}}

--- a/packages/frontend/app/components/reports/subjects-list.hbs
+++ b/packages/frontend/app/components/reports/subjects-list.hbs
@@ -31,6 +31,8 @@
           @save={{perform this.saveNewSubjectReport}}
           @close={{@toggleNewReportForm}}
           @run={{perform this.runSubjectReport}}
+          @selectedSchoolId={{@selectedSchoolId}}
+          @setSelectedSchoolId={{@setSelectedSchoolId}}
         />
       {{/if}}
       {{#if this.newReport}}

--- a/packages/frontend/app/components/reports/subjects-list.hbs
+++ b/packages/frontend/app/components/reports/subjects-list.hbs
@@ -35,6 +35,10 @@
           @setSelectedSchoolId={{@setSelectedSchoolId}}
           @selectedSubject={{@selectedSubject}}
           @setSelectedSubject={{@setSelectedSubject}}
+          @selectedPrepositionalObject={{@selectedPrepositionalObject}}
+          @setSelectedPrepositionalObject={{@setSelectedPrepositionalObject}}
+          @selectedPrepositionalObjectId={{@selectedPrepositionalObjectId}}
+          @setSelectedPrepositionalObjectId={{@setSelectedPrepositionalObjectId}}
         />
       {{/if}}
       {{#if this.newReport}}

--- a/packages/frontend/app/controllers/reports/subjects.js
+++ b/packages/frontend/app/controllers/reports/subjects.js
@@ -8,11 +8,13 @@ export default class ReportsSubjectsController extends Controller {
     { sortReportsBy: 'sortBy' },
     { titleFilter: 'filter' },
     { showNewReportForm: 'showNewReportForm' },
+    { selectedSchoolId: 'selectedSchoolId' },
   ];
 
   @tracked sortReportsBy = 'title';
   @tracked titleFilter = null;
   @tracked showNewReportForm = false;
+  @tracked selectedSchoolId = null;
   @tracked runningSubjectReport = null;
 
   changeTitleFilter = restartableTask(async (value) => {

--- a/packages/frontend/app/controllers/reports/subjects.js
+++ b/packages/frontend/app/controllers/reports/subjects.js
@@ -9,12 +9,14 @@ export default class ReportsSubjectsController extends Controller {
     { titleFilter: 'filter' },
     { showNewReportForm: 'showNewReportForm' },
     { selectedSchoolId: 'selectedSchoolId' },
+    { selectedSubject: 'selectedSubject' },
   ];
 
   @tracked sortReportsBy = 'title';
   @tracked titleFilter = null;
   @tracked showNewReportForm = false;
   @tracked selectedSchoolId = null;
+  @tracked selectedSubject = null;
   @tracked runningSubjectReport = null;
 
   changeTitleFilter = restartableTask(async (value) => {

--- a/packages/frontend/app/controllers/reports/subjects.js
+++ b/packages/frontend/app/controllers/reports/subjects.js
@@ -10,6 +10,8 @@ export default class ReportsSubjectsController extends Controller {
     { showNewReportForm: 'showNewReportForm' },
     { selectedSchoolId: 'selectedSchoolId' },
     { selectedSubject: 'selectedSubject' },
+    { selectedPrepositionalObject: 'selectedPrepositionalObject' },
+    { selectedPrepositionalObjectId: 'selectedPrepositionalObjectId' },
   ];
 
   @tracked sortReportsBy = 'title';
@@ -17,6 +19,8 @@ export default class ReportsSubjectsController extends Controller {
   @tracked showNewReportForm = false;
   @tracked selectedSchoolId = null;
   @tracked selectedSubject = null;
+  @tracked selectedPrepositionalObject = null;
+  @tracked selectedPrepositionalObjectId = null;
   @tracked runningSubjectReport = null;
 
   changeTitleFilter = restartableTask(async (value) => {

--- a/packages/frontend/app/controllers/reports/subjects.js
+++ b/packages/frontend/app/controllers/reports/subjects.js
@@ -37,6 +37,10 @@ export default class ReportsSubjectsController extends Controller {
   @action
   toggleNewReportForm() {
     this.runningSubjectReport = null;
+    this.selectedSchoolId = null;
+    this.selectedSubject = null;
+    this.selectedPrepositionalObject = null;
+    this.selectedPrepositionalObjectId = null;
     this.showNewReportForm = !this.showNewReportForm;
   }
 }

--- a/packages/frontend/app/templates/reports/subjects.hbs
+++ b/packages/frontend/app/templates/reports/subjects.hbs
@@ -9,6 +9,10 @@
   @setSelectedSchoolId={{set this "selectedSchoolId"}}
   @selectedSubject={{this.selectedSubject}}
   @setSelectedSubject={{set this "selectedSubject"}}
+  @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+  @setSelectedPrepositionalObject={{set this "selectedPrepositionalObject"}}
+  @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
+  @setSelectedPrepositionalObjectId={{set this "selectedPrepositionalObjectId"}}
   @toggleNewReportForm={{this.toggleNewReportForm}}
   @runningSubjectReport={{this.runningSubjectReport}}
   @setRunningSubjectReport={{this.setRunningSubjectReport}}

--- a/packages/frontend/app/templates/reports/subjects.hbs
+++ b/packages/frontend/app/templates/reports/subjects.hbs
@@ -7,6 +7,8 @@
   @showNewReportForm={{this.showNewReportForm}}
   @selectedSchoolId={{this.selectedSchoolId}}
   @setSelectedSchoolId={{set this "selectedSchoolId"}}
+  @selectedSubject={{this.selectedSubject}}
+  @setSelectedSubject={{set this "selectedSubject"}}
   @toggleNewReportForm={{this.toggleNewReportForm}}
   @runningSubjectReport={{this.runningSubjectReport}}
   @setRunningSubjectReport={{this.setRunningSubjectReport}}

--- a/packages/frontend/app/templates/reports/subjects.hbs
+++ b/packages/frontend/app/templates/reports/subjects.hbs
@@ -5,6 +5,8 @@
   @titleFilter={{this.titleFilter}}
   @changeTitleFilter={{perform this.changeTitleFilter}}
   @showNewReportForm={{this.showNewReportForm}}
+  @selectedSchoolId={{this.selectedSchoolId}}
+  @setSelectedSchoolId={{set this "selectedSchoolId"}}
   @toggleNewReportForm={{this.toggleNewReportForm}}
   @runningSubjectReport={{this.runningSubjectReport}}
   @setRunningSubjectReport={{this.setRunningSubjectReport}}

--- a/packages/frontend/tests/acceptance/reports/subjects-test.js
+++ b/packages/frontend/tests/acceptance/reports/subjects-test.js
@@ -403,7 +403,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
     });
     await page.subjects.list.newSubject.run();
     await percySnapshot(assert);
-    assert.strictEqual(currentURL(), '/reports/subjects?showNewReportForm=true');
+    assert.strictEqual(currentURL(), '/reports/subjects?selectedSchoolId=1&showNewReportForm=true');
     assert.strictEqual(
       page.subjects.results.description,
       'This report shows all Sessions associated with Course "course 0" (2015) in school 0. (1)',

--- a/packages/frontend/tests/acceptance/reports/subjects-test.js
+++ b/packages/frontend/tests/acceptance/reports/subjects-test.js
@@ -405,7 +405,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
     await percySnapshot(assert);
     assert.strictEqual(
       currentURL(),
-      '/reports/subjects?selectedSchoolId=1&selectedSubject=session&showNewReportForm=true',
+      '/reports/subjects?selectedPrepositionalObject=course&selectedPrepositionalObjectId=1&selectedSchoolId=1&selectedSubject=session&showNewReportForm=true',
     );
     assert.strictEqual(
       page.subjects.results.description,

--- a/packages/frontend/tests/acceptance/reports/subjects-test.js
+++ b/packages/frontend/tests/acceptance/reports/subjects-test.js
@@ -403,7 +403,10 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
     });
     await page.subjects.list.newSubject.run();
     await percySnapshot(assert);
-    assert.strictEqual(currentURL(), '/reports/subjects?selectedSchoolId=1&showNewReportForm=true');
+    assert.strictEqual(
+      currentURL(),
+      '/reports/subjects?selectedSchoolId=1&selectedSubject=session&showNewReportForm=true',
+    );
     assert.strictEqual(
       page.subjects.results.description,
       'This report shows all Sessions associated with Course "course 0" (2015) in school 0. (1)',

--- a/packages/frontend/tests/integration/components/reports/new-subject-test.js
+++ b/packages/frontend/tests/integration/components/reports/new-subject-test.js
@@ -18,14 +18,25 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     context.set('selectedSubject', null);
     context.set('setSelectedSubject', (subject) => {
       context.set('selectedSubject', subject);
+      assert.strictEqual(context.selectedSubject, subject, 'selected subject is correct');
     });
     context.set('selectedPrepositionalObject', null);
     context.set('setSelectedPrepositionalObject', (object) => {
       context.set('selectedPrepositionalObject', object);
+      assert.strictEqual(
+        context.selectedPrepositionalObject,
+        object,
+        'selected prepositional object is correct',
+      );
     });
     context.set('selectedPrepositionalObjectId', null);
     context.set('setSelectedPrepositionalObjectId', (id) => {
       context.set('selectedPrepositionalObjectId', id);
+      assert.strictEqual(
+        context.selectedPrepositionalObjectId,
+        id,
+        'selected prepositional object id is correct',
+      );
     });
 
     class CurrentUserMock extends Service {
@@ -141,10 +152,20 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     this.set('selectedPrepositionalObject', null);
     this.set('setSelectedPrepositionalObject', (object) => {
       this.set('selectedPrepositionalObject', object);
+      assert.strictEqual(
+        this.selectedPrepositionalObject,
+        object,
+        'prepositional object is correct',
+      );
     });
     this.set('selectedPrepositionalObjectId', null);
     this.set('setSelectedPrepositionalObjectId', (id) => {
       this.set('selectedPrepositionalObjectId', id);
+      assert.strictEqual(
+        this.selectedPrepositionalObjectId,
+        id,
+        'prepositional object id is correct',
+      );
     });
     await render(hbs`<Reports::NewSubject
   @close={{(noop)}}
@@ -154,12 +175,16 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}}
 />`);
     await component.objects.choose('mesh term');
-    assert.notOk(component.meshTerm.hasSelectedTerm);
+    assert.notOk(component.meshTerm.hasSelectedTerm, 'no mesh term selected');
     await component.meshTerm.meshManager.search.set('descriptor 0');
     await component.meshTerm.meshManager.searchResults[0].add();
-    assert.strictEqual(component.meshTerm.selectedTerm, 'descriptor 0');
+    assert.strictEqual(
+      component.meshTerm.selectedTerm,
+      'descriptor 0',
+      'selected mesh term is correct',
+    );
     await component.meshTerm.removeSelectedTerm();
-    assert.notOk(component.meshTerm.hasSelectedTerm);
+    assert.notOk(component.meshTerm.hasSelectedTerm, 'no mesh term selected');
   });
 
   test('selecting and de-selecting an instructor as prepositional object', async function (assert) {
@@ -167,10 +192,20 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     this.set('selectedPrepositionalObject', null);
     this.set('setSelectedPrepositionalObject', (object) => {
       this.set('selectedPrepositionalObject', object);
+      assert.strictEqual(
+        this.selectedPrepositionalObject,
+        object,
+        'prepositional object is correct',
+      );
     });
     this.set('selectedPrepositionalObjectId', null);
     this.set('setSelectedPrepositionalObjectId', (id) => {
       this.set('selectedPrepositionalObjectId', id);
+      assert.strictEqual(
+        this.selectedPrepositionalObjectId,
+        id,
+        'prepositional object id is correct',
+      );
     });
     await render(hbs`<Reports::NewSubject
   @close={{(noop)}}
@@ -190,7 +225,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing course selects correct objects', function (assert) {
-    assert.expect(10);
+    assert.expect(15);
     return checkObjects(this, assert, 0, 'course', [
       'academic year',
       'competency',
@@ -204,7 +239,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing session selects correct objects', function (assert) {
-    assert.expect(11);
+    assert.expect(16);
     return checkObjects(this, assert, 1, 'session', [
       'academic year',
       'competency',
@@ -219,17 +254,17 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing programs selects correct objects', function (assert) {
-    assert.expect(4);
+    assert.expect(9);
     return checkObjects(this, assert, 2, 'program', ['course', 'session']);
   });
 
   test('choosing program years selects correct objects', function (assert) {
-    assert.expect(4);
+    assert.expect(9);
     return checkObjects(this, assert, 3, 'program year', ['course', 'session']);
   });
 
   test('choosing instructor selects correct objects', function (assert) {
-    assert.expect(7);
+    assert.expect(12);
     return checkObjects(this, assert, 4, 'instructor', [
       'academic year',
       'course',
@@ -241,7 +276,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing instructor group selects correct objects', function (assert) {
-    assert.expect(8);
+    assert.expect(13);
     return checkObjects(this, assert, 5, 'instructor group', [
       'academic year',
       'course',
@@ -253,7 +288,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing learning material selects correct objects', function (assert) {
-    assert.expect(8);
+    assert.expect(13);
     return checkObjects(this, assert, 6, 'learning material', [
       'course',
       'instructor',
@@ -265,7 +300,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing competency selects correct objects', function (assert) {
-    assert.expect(6);
+    assert.expect(11);
     return checkObjects(this, assert, 7, 'competency', [
       'academic year',
       'course',
@@ -275,7 +310,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing mesh term selects correct objects', function (assert) {
-    assert.expect(5);
+    assert.expect(10);
     return checkObjects(this, assert, 8, 'mesh term', [
       'course',
       'learning material',
@@ -285,7 +320,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing term selects correct objects', function (assert) {
-    assert.expect(10);
+    assert.expect(15);
     return checkObjects(this, assert, 9, 'term', [
       'academic year',
       'competency',
@@ -299,7 +334,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
   });
 
   test('choosing session type selects correct objects', function (assert) {
-    assert.expect(11);
+    assert.expect(16);
     return checkObjects(this, assert, 10, 'session type', [
       'academic year',
       'competency',
@@ -333,10 +368,20 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     this.set('selectedPrepositionalObject', null);
     this.set('setSelectedPrepositionalObject', (object) => {
       this.set('selectedPrepositionalObject', object);
+      assert.strictEqual(
+        this.selectedPrepositionalObject,
+        object,
+        'prepositional object is correct',
+      );
     });
     this.set('selectedPrepositionalObjectId', null);
     this.set('setSelectedPrepositionalObjectId', (id) => {
       this.set('selectedPrepositionalObjectId', id);
+      assert.strictEqual(
+        this.selectedPrepositionalObjectId,
+        id,
+        'prepositional object id is correct',
+      );
     });
     await render(hbs`<Reports::NewSubject
   @close={{(noop)}}
@@ -424,10 +469,20 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     this.set('selectedPrepositionalObject', null);
     this.set('setSelectedPrepositionalObject', (object) => {
       this.set('selectedPrepositionalObject', object);
+      assert.strictEqual(
+        this.selectedPrepositionalObject,
+        object,
+        'prepositional object is correct',
+      );
     });
     this.set('selectedPrepositionalObjectId', null);
     this.set('setSelectedPrepositionalObjectId', (id) => {
       this.set('selectedPrepositionalObjectId', id);
+      assert.strictEqual(
+        this.selectedPrepositionalObjectId,
+        id,
+        'prepositional object id is correct',
+      );
     });
     await render(hbs`<Reports::NewSubject
   @close={{(noop)}}
@@ -456,10 +511,20 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     this.set('selectedPrepositionalObject', null);
     this.set('setSelectedPrepositionalObject', (object) => {
       this.set('selectedPrepositionalObject', object);
+      assert.strictEqual(
+        this.selectedPrepositionalObject,
+        object,
+        'prepositional object is correct',
+      );
     });
     this.set('selectedPrepositionalObjectId', null);
     this.set('setSelectedPrepositionalObjectId', (id) => {
       this.set('selectedPrepositionalObjectId', id);
+      assert.strictEqual(
+        this.selectedPrepositionalObjectId,
+        id,
+        'prepositional object id is correct',
+      );
     });
     await render(hbs`<Reports::NewSubject
   @close={{(noop)}}

--- a/packages/frontend/tests/integration/components/reports/new-subject-test.js
+++ b/packages/frontend/tests/integration/components/reports/new-subject-test.js
@@ -273,7 +273,8 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       email: 'test@example.com',
       displayName: 'Aardvark',
     });
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
+    await render(hbs`<Reports::NewSubject @close={{(noop)}}
+          @setSelectedSchoolId={{(noop)}} />`);
     assert.notOk(component.instructor.userSearch.isVisible);
     assert.notOk(component.instructor.hasSelectedInstructor);
     await component.schools.choose('null');

--- a/packages/frontend/tests/integration/components/reports/new-subject-test.js
+++ b/packages/frontend/tests/integration/components/reports/new-subject-test.js
@@ -19,6 +19,14 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     context.set('setSelectedSubject', (subject) => {
       context.set('selectedSubject', subject);
     });
+    context.set('selectedPrepositionalObject', null);
+    context.set('setSelectedPrepositionalObject', (object) => {
+      context.set('selectedPrepositionalObject', object);
+    });
+    context.set('selectedPrepositionalObjectId', null);
+    context.set('setSelectedPrepositionalObjectId', (id) => {
+      context.set('selectedPrepositionalObjectId', id);
+    });
 
     class CurrentUserMock extends Service {
       async getModel() {
@@ -31,7 +39,11 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       hbs`<Reports::NewSubject @close={{(noop)}}
   @setSelectedSchoolId={{(noop)}}
   @selectedSubject={{this.selectedSubject}}
-  @setSelectedSubject={{this.setSelectedSubject}} />`,
+  @setSelectedSubject={{this.setSelectedSubject}}
+  @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+  @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
+  @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`,
     );
     assert.strictEqual(
       component.subjects.items[subjectNum].value,
@@ -126,7 +138,20 @@ module('Integration | Component | reports/new-subject', function (hooks) {
 
   test('selecting and de-selecting a MeSH term as prepositional object', async function (assert) {
     this.server.create('mesh-descriptor');
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
+    this.set('selectedPrepositionalObject', null);
+    this.set('setSelectedPrepositionalObject', (object) => {
+      this.set('selectedPrepositionalObject', object);
+    });
+    this.set('selectedPrepositionalObjectId', null);
+    this.set('setSelectedPrepositionalObjectId', (id) => {
+      this.set('selectedPrepositionalObjectId', id);
+    });
+    await render(hbs`<Reports::NewSubject
+      @close={{(noop)}}
+      @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+  @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
+  @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`);
     await component.objects.choose('mesh term');
     assert.notOk(component.meshTerm.hasSelectedTerm);
     await component.meshTerm.meshManager.search.set('descriptor 0');
@@ -138,7 +163,20 @@ module('Integration | Component | reports/new-subject', function (hooks) {
 
   test('selecting and de-selecting an instructor as prepositional object', async function (assert) {
     this.server.create('user', { firstName: 'Rusty' });
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
+    this.set('selectedPrepositionalObject', null);
+    this.set('setSelectedPrepositionalObject', (object) => {
+      this.set('selectedPrepositionalObject', object);
+    });
+    this.set('selectedPrepositionalObjectId', null);
+    this.set('setSelectedPrepositionalObjectId', (id) => {
+      this.set('selectedPrepositionalObjectId', id);
+    });
+    await render(hbs`<Reports::NewSubject
+      @close={{(noop)}}
+      @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+  @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
+  @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`);
 
     await component.objects.choose('instructor');
     assert.notOk(component.instructor.hasSelectedInstructor);
@@ -290,8 +328,19 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       email: 'test@example.com',
       displayName: 'Aardvark',
     });
+    this.set('selectedPrepositionalObject', null);
+    this.set('setSelectedPrepositionalObject', (object) => {
+      this.set('selectedPrepositionalObject', object);
+    });
+    this.set('selectedPrepositionalObjectId', null);
+    this.set('setSelectedPrepositionalObjectId', (id) => {
+      this.set('selectedPrepositionalObjectId', id);
+    });
     await render(hbs`<Reports::NewSubject @close={{(noop)}}
-          @setSelectedSchoolId={{(noop)}} @setSelectedSchool={{(noop)}} />`);
+          @setSelectedSchoolId={{(noop)}} @setSelectedSchool={{(noop)}} @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+  @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
+  @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`);
     assert.notOk(component.instructor.userSearch.isVisible);
     assert.notOk(component.instructor.hasSelectedInstructor);
     await component.schools.choose('null');
@@ -366,7 +415,18 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       }
     }
     this.owner.register('service:current-user', CurrentUserMock);
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
+    this.set('selectedPrepositionalObject', null);
+    this.set('setSelectedPrepositionalObject', (object) => {
+      this.set('selectedPrepositionalObject', object);
+    });
+    this.set('selectedPrepositionalObjectId', null);
+    this.set('setSelectedPrepositionalObjectId', (id) => {
+      this.set('selectedPrepositionalObjectId', id);
+    });
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+  @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
+  @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`);
     await component.objects.choose('instructor');
     assert.strictEqual(component.errors.length, 0);
     await component.save();
@@ -384,7 +444,18 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       }
     }
     this.owner.register('service:current-user', CurrentUserMock);
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
+    this.set('selectedPrepositionalObject', null);
+    this.set('setSelectedPrepositionalObject', (object) => {
+      this.set('selectedPrepositionalObject', object);
+    });
+    this.set('selectedPrepositionalObjectId', null);
+    this.set('setSelectedPrepositionalObjectId', (id) => {
+      this.set('selectedPrepositionalObjectId', id);
+    });
+    await render(hbs`<Reports::NewSubject @close={{(noop)}} @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+  @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
+  @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`);
     await component.objects.choose('mesh term');
     assert.strictEqual(component.errors.length, 0);
     await component.save();

--- a/packages/frontend/tests/integration/components/reports/new-subject-test.js
+++ b/packages/frontend/tests/integration/components/reports/new-subject-test.js
@@ -15,6 +15,10 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     const user = context.server.create('user', { school });
     const userModel = await context.owner.lookup('service:store').findRecord('user', user.id);
     const exceptedSubjects = ['instructor', 'mesh term'];
+    context.set('selectedSubject', null);
+    context.set('setSelectedSubject', (subject) => {
+      context.set('selectedSubject', subject);
+    });
 
     class CurrentUserMock extends Service {
       async getModel() {
@@ -23,18 +27,31 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     }
 
     context.owner.register('service:current-user', CurrentUserMock);
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} />`);
-    assert.strictEqual(component.subjects.items[subjectNum].value, subjectVal);
+    await render(
+      hbs`<Reports::NewSubject @close={{(noop)}}
+  @setSelectedSchoolId={{(noop)}}
+  @selectedSubject={{this.selectedSubject}}
+  @setSelectedSubject={{this.setSelectedSubject}} />`,
+    );
+    assert.strictEqual(
+      component.subjects.items[subjectNum].value,
+      subjectVal,
+      'subject dropdown value is correct',
+    );
     await component.subjects.choose(subjectVal);
     await component.objects.choose('null');
     if (!exceptedSubjects.includes(subjectVal)) {
       assert.strictEqual(component.objects.items[0].value, '', '"Anything" is first object option');
       expectedObjects.forEach((val, i) => {
-        assert.strictEqual(component.objects.items[i + 1].value, val, `${val} is object option`);
+        assert.strictEqual(
+          component.objects.items[i + 1].value,
+          val,
+          `${val} is next object option`,
+        );
       });
     } else {
       expectedObjects.forEach((val, i) => {
-        assert.strictEqual(component.objects.items[i].value, val, `${val} is object option`);
+        assert.strictEqual(component.objects.items[i].value, val, `${val} is next object option`);
       });
     }
   };
@@ -274,7 +291,7 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       displayName: 'Aardvark',
     });
     await render(hbs`<Reports::NewSubject @close={{(noop)}}
-          @setSelectedSchoolId={{(noop)}} />`);
+          @setSelectedSchoolId={{(noop)}} @setSelectedSchool={{(noop)}} />`);
     assert.notOk(component.instructor.userSearch.isVisible);
     assert.notOk(component.instructor.hasSelectedInstructor);
     await component.schools.choose('null');

--- a/packages/frontend/tests/integration/components/reports/new-subject-test.js
+++ b/packages/frontend/tests/integration/components/reports/new-subject-test.js
@@ -35,16 +35,16 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     }
 
     context.owner.register('service:current-user', CurrentUserMock);
-    await render(
-      hbs`<Reports::NewSubject @close={{(noop)}}
+    await render(hbs`<Reports::NewSubject
+  @close={{(noop)}}
   @setSelectedSchoolId={{(noop)}}
   @selectedSubject={{this.selectedSubject}}
   @setSelectedSubject={{this.setSelectedSubject}}
   @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
   @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
   @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
-  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`,
-    );
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}}
+/>`);
     assert.strictEqual(
       component.subjects.items[subjectNum].value,
       subjectVal,
@@ -147,11 +147,12 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       this.set('selectedPrepositionalObjectId', id);
     });
     await render(hbs`<Reports::NewSubject
-      @close={{(noop)}}
-      @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+  @close={{(noop)}}
+  @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
   @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
   @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
-  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`);
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}}
+/>`);
     await component.objects.choose('mesh term');
     assert.notOk(component.meshTerm.hasSelectedTerm);
     await component.meshTerm.meshManager.search.set('descriptor 0');
@@ -172,11 +173,12 @@ module('Integration | Component | reports/new-subject', function (hooks) {
       this.set('selectedPrepositionalObjectId', id);
     });
     await render(hbs`<Reports::NewSubject
-      @close={{(noop)}}
-      @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+  @close={{(noop)}}
+  @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
   @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
   @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
-  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`);
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}}
+/>`);
 
     await component.objects.choose('instructor');
     assert.notOk(component.instructor.hasSelectedInstructor);
@@ -336,11 +338,15 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     this.set('setSelectedPrepositionalObjectId', (id) => {
       this.set('selectedPrepositionalObjectId', id);
     });
-    await render(hbs`<Reports::NewSubject @close={{(noop)}}
-          @setSelectedSchoolId={{(noop)}} @setSelectedSchool={{(noop)}} @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+    await render(hbs`<Reports::NewSubject
+  @close={{(noop)}}
+  @setSelectedSchoolId={{(noop)}}
+  @setSelectedSchool={{(noop)}}
+  @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
   @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
   @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
-  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`);
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}}
+/>`);
     assert.notOk(component.instructor.userSearch.isVisible);
     assert.notOk(component.instructor.hasSelectedInstructor);
     await component.schools.choose('null');
@@ -423,10 +429,13 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     this.set('setSelectedPrepositionalObjectId', (id) => {
       this.set('selectedPrepositionalObjectId', id);
     });
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+    await render(hbs`<Reports::NewSubject
+  @close={{(noop)}}
+  @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
   @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
   @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
-  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`);
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}}
+/>`);
     await component.objects.choose('instructor');
     assert.strictEqual(component.errors.length, 0);
     await component.save();
@@ -452,10 +461,13 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     this.set('setSelectedPrepositionalObjectId', (id) => {
       this.set('selectedPrepositionalObjectId', id);
     });
-    await render(hbs`<Reports::NewSubject @close={{(noop)}} @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
+    await render(hbs`<Reports::NewSubject
+  @close={{(noop)}}
+  @selectedPrepositionalObject={{this.selectedPrepositionalObject}}
   @setSelectedPrepositionalObject={{this.setSelectedPrepositionalObject}}
   @selectedPrepositionalObjectId={{this.selectedPrepositionalObjectId}}
-  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}} />`);
+  @setSelectedPrepositionalObjectId={{this.setSelectedPrepositionalObjectId}}
+/>`);
     await component.objects.choose('mesh term');
     assert.strictEqual(component.errors.length, 0);
     await component.save();


### PR DESCRIPTION
Fixes https://github.com/ilios/ilios/issues/6079

Changing the school, subject, object, or object id will add to the queryString and remember if you navigate away.