### PR TITLE
fix Subject Report title wrapping

### DIFF
--- a/packages/frontend/app/components/reports/table-row.hbs
+++ b/packages/frontend/app/components/reports/table-row.hbs
@@ -2,14 +2,14 @@
   class="reports-table-row{{if this.showRemoveConfirmation ' confirm-removal'}}"
   data-test-reports-table-row
 >
-  <td class="text-left" data-test-report-title>
+  <td class="text-left" colspan="11" data-test-report-title>
     {{#if this.isSubjectReport}}
       <LinkTo @route="reports.subject" @model={{@decoratedReport.report}}>
         {{@decoratedReport.title}}
       </LinkTo>
     {{/if}}
   </td>
-  <td class="text-right" data-test-status>
+  <td class="text-right" colspan="1" data-test-status>
     <button
       type="button"
       class="link-button"

--- a/packages/frontend/app/components/reports/table-row.hbs
+++ b/packages/frontend/app/components/reports/table-row.hbs
@@ -1,10 +1,9 @@
 <tr
-  class="reports-table-row
-    {{if (includes @decoratedReport.report.id @reportsForRemovalConfirmation) 'confirm-removal'}}"
+  class="reports-table-row{{if this.showRemoveConfirmation ' confirm-removal'}}"
   data-test-reports-table-row
 >
   <td class="text-left" data-test-report-title>
-    {{#if (eq @decoratedReport.type "subject")}}
+    {{#if this.isSubjectReport}}
       <LinkTo @route="reports.subject" @model={{@decoratedReport.report}}>
         {{@decoratedReport.title}}
       </LinkTo>

--- a/packages/frontend/app/components/reports/table-row.js
+++ b/packages/frontend/app/components/reports/table-row.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class ReportsListRowComponent extends Component {
+  get showRemoveConfirmation() {
+    return this.args.reportsForRemovalConfirmation.includes(this.args.decoratedReport.report.id);
+  }
+
+  get isSubjectReport() {
+    return this.args.decoratedReport.type === 'subject';
+  }
+}

--- a/packages/frontend/app/components/reports/table.hbs
+++ b/packages/frontend/app/components/reports/table.hbs
@@ -5,11 +5,12 @@
         data-test-report-title-heading
         @sortedAscending={{this.sortedAscending}}
         @sortedBy={{or (eq @sortBy "title") (eq @sortBy "title:desc")}}
+        @colspan="11"
         @onClick={{fn this.setSortBy "title"}}
       >
         {{t "general.title"}}
       </SortableTh>
-      <th class="text-right">{{t "general.actions"}}</th>
+      <th class="text-right" colspan="1">{{t "general.actions"}}</th>
     </tr>
   </thead>
   <tbody data-test-reports>

--- a/packages/frontend/app/components/reports/table.hbs
+++ b/packages/frontend/app/components/reports/table.hbs
@@ -22,7 +22,7 @@
       />
       {{#if (includes decoratedReport.report.id this.reportsForRemovalConfirmation)}}
         <tr class="confirm-removal">
-          <td colspan="2">
+          <td colspan="12">
             <div class="confirm-message">
               {{t "general.reportConfirmRemove"}}
               <br />

--- a/packages/frontend/tests/integration/components/reports/table-row-test.js
+++ b/packages/frontend/tests/integration/components/reports/table-row-test.js
@@ -30,7 +30,7 @@ module('Integration | Component | reports/table-row', function (hooks) {
     });
 
     await render(
-      hbs`<Reports::TableRow @decoratedReport={{this.decoratedReport}} @confirmRemoval={{(noop)}} />`,
+      hbs`<Reports::TableRow @decoratedReport={{this.decoratedReport}} @reportsForRemovalConfirmation={{(array)}} @confirmRemoval={{(noop)}} />`,
     );
 
     assert.strictEqual(component.title, 'this report');


### PR DESCRIPTION
Fixes ilios/ilios#5240

Added some `colspan` values to Subject Reports list so long titles don't get wrapped early.