### PR TITLE
Hide Ilios error overlay when testing

### DIFF
--- a/packages/frontend/public/assets/test-support.css
+++ b/packages/frontend/public/assets/test-support.css
@@ -1,0 +1,4 @@
+/* add styles here specifically for testing */
+#ilios-loading-error {
+  display: none !important;
+}

--- a/packages/frontend/tests/index.html
+++ b/packages/frontend/tests/index.html
@@ -11,6 +11,7 @@
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/frontend.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     <!-- Ilios variables set  by the web server -->
     {{content-for 'server-variables'}}


### PR DESCRIPTION
While [improving](https://github.com/ilios/frontend/pull/8277) the rarely-seen-if-everything-is-going-fine `ilios-loading-error` overlay dialog was _good_ (it can't be ignored, and it usually means BAD THING HAPPEN), it can be a hindrance when running tests in the browser, as it just...sits there, obscuring the test information. This change adds CSS support back to the testing area and hides it. Errors still appear in the dev console, but the overlay won't hinder things anymore.