### PR TITLE
Yupdate CourseHeader validation

### DIFF
--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/header.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/header.js
@@ -4,7 +4,7 @@ import {
   clickable,
   fillable,
   text,
-  isVisible,
+  isPresent,
   value,
 } from 'ember-cli-page-object';
 import publicationMenu from './publication-menu';
@@ -20,7 +20,7 @@ const definition = {
     cancel: clickable('.cancel'),
     inputValue: value('input'),
     blur: blurrable('input'),
-    hasError: isVisible('.validation-error-message'),
+    hasError: isPresent('[data-test-title-validation-error-message]'),
   },
   academicYear: text('[data-test-academic-year]'),
   publicationMenu,

--- a/packages/ilios-common/addon/classes/yup-validations.js
+++ b/packages/ilios-common/addon/classes/yup-validations.js
@@ -13,17 +13,15 @@ export default class YupValidations {
   context;
   schema;
   shape;
-  options;
 
   @tracked error;
   @tracked showAllErrors = false;
   @tracked visibleErrors = [];
 
-  constructor(context, shape, options) {
+  constructor(context, shape) {
     this.context = context;
     this.shape = shape;
     this.schema = object().shape(shape);
-    this.options = options;
   }
 
   get errorsByKey() {
@@ -76,7 +74,7 @@ export default class YupValidations {
   async #validate() {
     try {
       await this.schema.validate(this.#validationProperties(), {
-        abortEarly: this.options?.abortEarly ?? false,
+        abortEarly: false,
         context: this.context,
       });
       this.error = null;

--- a/packages/ilios-common/addon/classes/yup-validations.js
+++ b/packages/ilios-common/addon/classes/yup-validations.js
@@ -13,15 +13,17 @@ export default class YupValidations {
   context;
   schema;
   shape;
+  options;
 
   @tracked error;
   @tracked showAllErrors = false;
   @tracked visibleErrors = [];
 
-  constructor(context, shape) {
+  constructor(context, shape, options) {
     this.context = context;
     this.shape = shape;
     this.schema = object().shape(shape);
+    this.options = options;
   }
 
   get errorsByKey() {
@@ -74,7 +76,7 @@ export default class YupValidations {
   async #validate() {
     try {
       await this.schema.validate(this.#validationProperties(), {
-        abortEarly: false,
+        abortEarly: this.options?.abortEarly ?? false,
         context: this.context,
       });
       this.error = null;

--- a/packages/ilios-common/addon/components/course/header.gjs
+++ b/packages/ilios-common/addon/components/course/header.gjs
@@ -31,9 +31,13 @@ export default class CourseHeaderComponent extends Component {
     this.courseTitle = this.args.course.title;
   }
 
-  validations = new YupValidations(this, {
-    courseTitle: string().trim().required().min(3).max(200),
-  });
+  validations = new YupValidations(
+    this,
+    {
+      courseTitle: string().trim().required().min(3).max(200),
+    },
+    { abortEarly: true },
+  );
 
   @cached
   get academicYearCrossesCalendarYearBoundariesData() {

--- a/packages/ilios-common/addon/components/course/header.gjs
+++ b/packages/ilios-common/addon/components/course/header.gjs
@@ -59,7 +59,7 @@ export default class CourseHeaderComponent extends Component {
     if (!isValid) {
       return false;
     }
-    this.validations.clearErrorForDisplay();
+    this.validations.clearErrorDisplay('courseTitle');
     this.args.course.set('title', this.courseTitle);
     await this.args.course.save();
   });
@@ -67,6 +67,7 @@ export default class CourseHeaderComponent extends Component {
   @action
   revertTitleChanges() {
     this.courseTitle = this.args.course.title;
+    this.validations.clearErrorDisplay('courseTitle');
   }
   <template>
     <div class="course-header" data-test-course-header>

--- a/packages/ilios-common/addon/components/course/header.gjs
+++ b/packages/ilios-common/addon/components/course/header.gjs
@@ -31,13 +31,9 @@ export default class CourseHeaderComponent extends Component {
     this.courseTitle = this.args.course.title;
   }
 
-  validations = new YupValidations(
-    this,
-    {
-      courseTitle: string().trim().required().min(3).max(200),
-    },
-    { abortEarly: true },
-  );
+  validations = new YupValidations(this, {
+    courseTitle: string().ensure().trim().min(3).max(200),
+  });
 
   @cached
   get academicYearCrossesCalendarYearBoundariesData() {

--- a/packages/ilios-common/addon/components/course/header.gjs
+++ b/packages/ilios-common/addon/components/course/header.gjs
@@ -2,17 +2,18 @@ import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency';
-import { validatable, Length, NotBlank } from 'ilios-common/decorators/validation';
+import { validatable } from 'ilios-common/decorators/validation';
 import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
+import YupValidations from 'ilios-common/classes/yup-validations';
+import YupValidationMessage from 'ilios-common/components/yup-validation-message';
+import { string } from 'yup';
 import EditableField from 'ilios-common/components/editable-field';
 import perform from 'ember-concurrency/helpers/perform';
 import set from 'ember-set-helper/helpers/set';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import pick from 'ilios-common/helpers/pick';
-import { fn } from '@ember/helper';
-import ValidationError from 'ilios-common/components/validation-error';
 import FaIcon from 'ilios-common/components/fa-icon';
 import add from 'ember-math-helpers/helpers/add';
 import PublicationMenu from 'ilios-common/components/course/publication-menu';
@@ -22,13 +23,17 @@ import PublicationStatus from 'ilios-common/components/publication-status';
 export default class CourseHeaderComponent extends Component {
   @service iliosConfig;
 
-  @Length(3, 200) @NotBlank() @tracked courseTitle;
+  @tracked courseTitle;
   @tracked isEditingTitle = false;
 
   constructor() {
     super(...arguments);
     this.courseTitle = this.args.course.title;
   }
+
+  validations = new YupValidations(this, {
+    courseTitle: string().trim().required().min(3).max(200),
+  });
 
   @cached
   get academicYearCrossesCalendarYearBoundariesData() {
@@ -45,12 +50,12 @@ export default class CourseHeaderComponent extends Component {
 
   changeTitle = restartableTask(async () => {
     this.courseTitle = this.courseTitle.trim();
-    this.addErrorDisplayFor('courseTitle');
-    const isValid = await this.isValid('courseTitle');
+    this.validations.addErrorDisplayForAllFields();
+    const isValid = await this.validations.isValid();
     if (!isValid) {
       return false;
     }
-    this.removeErrorDisplayFor('courseTitle');
+    this.validations.clearErrorForDisplay();
     this.args.course.set('title', this.courseTitle);
     await this.args.course.save();
   });
@@ -78,9 +83,13 @@ export default class CourseHeaderComponent extends Component {
               type="text"
               value={{this.courseTitle}}
               {{on "input" (pick "target.value" (set this "courseTitle"))}}
-              {{on "keypress" (fn this.addErrorDisplayFor "courseTitle")}}
+              {{this.validations.attach "courseTitle"}}
             />
-            <ValidationError @validatable={{this}} @property="courseTitle" />
+            <YupValidationMessage
+              @description={{t "general.title"}}
+              @validationErrors={{this.validations.errors.courseTitle}}
+              data-test-title-validation-error-message
+            />
           </EditableField>
         {{else}}
           <h2>

--- a/packages/ilios-common/addon/components/course/header.gjs
+++ b/packages/ilios-common/addon/components/course/header.gjs
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency';
-import { validatable } from 'ilios-common/decorators/validation';
 import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import YupValidations from 'ilios-common/classes/yup-validations';
@@ -19,7 +18,6 @@ import add from 'ember-math-helpers/helpers/add';
 import PublicationMenu from 'ilios-common/components/course/publication-menu';
 import PublicationStatus from 'ilios-common/components/publication-status';
 
-@validatable
 export default class CourseHeaderComponent extends Component {
   @service iliosConfig;
 

--- a/packages/test-app/tests/integration/components/course/header-test.gjs
+++ b/packages/test-app/tests/integration/components/course/header-test.gjs
@@ -56,13 +56,13 @@ module('Integration | Component | course/header', function (hooks) {
     const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(<template><Header @course={{this.course}} @editable={{true}} /></template>);
-    assert.ok(component.title.isVisible);
-    assert.strictEqual(component.title.value);
+    assert.ok(component.title.isVisible, 'course title is visible');
+    assert.strictEqual(component.title.value, 'course 0', 'course title is correct');
     await component.title.edit();
-    assert.notOk(component.title.hasError);
+    assert.notOk(component.title.hasError, 'no error message displayed');
     await component.title.set('a');
     await component.title.save();
-    assert.ok(component.title.hasError);
+    assert.ok(component.title.hasError, 'error message displayed');
   });
 
   test('course title validation fails if value is too long', async function (assert) {

--- a/packages/test-app/tests/integration/components/course/header-test.gjs
+++ b/packages/test-app/tests/integration/components/course/header-test.gjs
@@ -42,13 +42,13 @@ module('Integration | Component | course/header', function (hooks) {
     this.set('course', courseModel);
     await render(<template><Header @course={{this.course}} @editable={{true}} /></template>);
 
-    assert.ok(component.title.isVisible);
-    assert.strictEqual(component.title.value, 'course 0');
+    assert.ok(component.title.isVisible, 'course title is visible');
+    assert.strictEqual(component.title.value, 'course 0', 'course title is correct');
     await component.title.edit();
-    assert.notOk(component.title.hasError);
+    assert.notOk(component.title.hasError, 'no error message displayed');
     await component.title.set('');
     await component.title.save();
-    assert.ok(component.title.hasError);
+    assert.ok(component.title.hasError, 'error message is displayed');
   });
 
   test('course title validation fails if value is too short', async function (assert) {
@@ -56,9 +56,8 @@ module('Integration | Component | course/header', function (hooks) {
     const courseModel = await this.store.findRecord('course', course.id);
     this.set('course', courseModel);
     await render(<template><Header @course={{this.course}} @editable={{true}} /></template>);
-
     assert.ok(component.title.isVisible);
-    assert.strictEqual(component.title.value, 'course 0');
+    assert.strictEqual(component.title.value);
     await component.title.edit();
     assert.notOk(component.title.hasError);
     await component.title.set('a');


### PR DESCRIPTION
Refs ilios/ilios#6055

In order to avoid multiple error messages, I removed an obvious `required()` validator and used a `min().max()` approach that would still make it required and the correct length.