### PR TITLE
prevent redundant form validation error messages to show when instructor-group title is blank.

### DIFF
--- a/packages/frontend/app/components/instructor-group/header.gjs
+++ b/packages/frontend/app/components/instructor-group/header.gjs
@@ -25,7 +25,7 @@ export default class InstructorGroupHeaderComponent extends Component {
   }
 
   validations = new YupValidations(this, {
-    title: string().required().min(3).max(60),
+    title: string().ensure().trim().min(3).max(60),
   });
 
   changeTitle = dropTask(async () => {

--- a/packages/frontend/tests/integration/components/instructor-group/header-test.gjs
+++ b/packages/frontend/tests/integration/components/instructor-group/header-test.gjs
@@ -80,7 +80,7 @@ module('Integration | Component | instructor-group/header', function (hooks) {
     assert.strictEqual(component.title.text, 'foo bar');
   });
 
-  test('changing title fails if new title is too long', async function (assert) {
+  test('validation fails if title is too long', async function (assert) {
     this.set('instructorGroup', this.instructorGroup);
     this.set('canUpdate', true);
 
@@ -92,14 +92,14 @@ module('Integration | Component | instructor-group/header', function (hooks) {
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
     await component.title.edit();
-    assert.strictEqual(component.title.errors.length, 0);
+    assert.notOk(component.title.hasError);
     assert.strictEqual(component.title.value, 'lorem ipsum');
-    await component.title.set('01234567890'.repeat(1000));
+    await component.title.set('a'.repeat(61));
     await component.title.save();
-    assert.strictEqual(component.title.errors.length, 1);
+    assert.strictEqual(component.title.error, 'Title is too long (maximum is 60 characters)');
   });
 
-  test('changing title fails if new title is too short', async function (assert) {
+  test('validation fails if title is too short', async function (assert) {
     this.set('instructorGroup', this.instructorGroup);
     this.set('canUpdate', true);
 
@@ -111,14 +111,14 @@ module('Integration | Component | instructor-group/header', function (hooks) {
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
     await component.title.edit();
-    assert.strictEqual(component.title.errors.length, 0);
+    assert.notOk(component.title.hasError);
     assert.strictEqual(component.title.value, 'lorem ipsum');
     await component.title.set('AB');
     await component.title.save();
-    assert.strictEqual(component.title.errors.length, 1);
+    assert.strictEqual(component.title.error, 'Title is too short (minimum is 3 characters)');
   });
 
-  test('changing title fails if title is blank', async function (assert) {
+  test('validation fails if title is blank', async function (assert) {
     this.set('instructorGroup', this.instructorGroup);
     this.set('canUpdate', true);
 
@@ -130,11 +130,11 @@ module('Integration | Component | instructor-group/header', function (hooks) {
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
     await component.title.edit();
-    assert.strictEqual(component.title.errors.length, 0);
+    assert.notOk(component.title.hasError);
     assert.strictEqual(component.title.value, 'lorem ipsum');
     await component.title.set('');
     await component.title.save();
-    assert.strictEqual(component.title.errors.length, 2);
+    assert.strictEqual(component.title.error, 'Title is too short (minimum is 3 characters)');
   });
 
   test('cancel title changes', async function (assert) {
@@ -149,7 +149,7 @@ module('Integration | Component | instructor-group/header', function (hooks) {
 
     assert.strictEqual(component.title.text, 'lorem ipsum');
     await component.title.edit();
-    assert.strictEqual(component.title.errors.length, 0);
+    assert.notOk(component.title.hasError);
     assert.strictEqual(component.title.value, 'lorem ipsum');
     await component.title.set('foo bar');
     await component.title.cancel();

--- a/packages/frontend/tests/pages/components/instructor-group/header.js
+++ b/packages/frontend/tests/pages/components/instructor-group/header.js
@@ -4,6 +4,7 @@ import {
   create,
   fillable,
   hasClass,
+  isPresent,
   text,
   value,
 } from 'ember-cli-page-object';
@@ -15,7 +16,8 @@ const definition = {
     edit: clickable('[data-test-edit]'),
     set: fillable('input'),
     value: value('input'),
-    errors: collection('[data-test-title-validation-error-message]'),
+    hasError: isPresent('[data-test-title-validation-error-message]'),
+    error: text('[data-test-title-validation-error-message]'),
     cancel: clickable('.cancel'),
     save: clickable('.done'),
     isEditable: hasClass('editinplace'),


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/6180