### PR TITLE
Add FadeText short-circuiting

### DIFF
--- a/packages/ilios-common/addon/components/fade-text.gjs
+++ b/packages/ilios-common/addon/components/fade-text.gjs
@@ -42,6 +42,10 @@ export default class FadeTextComponent extends Component {
   }
 
   get shouldFade() {
+    // short-circuit fading if no tracked property passed (i.e. doesn't make sense to use it)
+    if (!this.args.expanded) {
+      return false;
+    }
     if (this.expanded !== undefined) {
       return this.expanded ? false : this.exceedsHeight;
     }
@@ -63,6 +67,10 @@ export default class FadeTextComponent extends Component {
 
   @action
   collapse(event) {
+    // short-circuit fading if no method passed (i.e. doesn't make sense to use it)
+    if (!this.args.onExpandAll) {
+      return false;
+    }
     if (event) {
       event.stopPropagation();
     }

--- a/packages/ilios-common/addon/components/fade-text.gjs
+++ b/packages/ilios-common/addon/components/fade-text.gjs
@@ -42,6 +42,10 @@ export default class FadeTextComponent extends Component {
   }
 
   get shouldFade() {
+    // short-circuit fading if no tracked property passed (i.e. doesn't make sense to fade text)
+    if (this.args.expanded === undefined) {
+      return false;
+    }
     if (this.expanded !== undefined) {
       return this.expanded ? false : this.exceedsHeight;
     }
@@ -50,10 +54,6 @@ export default class FadeTextComponent extends Component {
   }
 
   get expanded() {
-    // short-circuit fading if no tracked property passed (i.e. doesn't make sense to fade text)
-    if (!this.args.expanded) {
-      return false;
-    }
     return this.args.expanded && this.exceedsHeight;
   }
 
@@ -67,10 +67,6 @@ export default class FadeTextComponent extends Component {
 
   @action
   collapse(event) {
-    // short-circuit fading if no method passed (i.e. doesn't make sense to fade text)
-    if (!this.args.onExpandAll) {
-      return false;
-    }
     if (event) {
       event.stopPropagation();
     }

--- a/packages/ilios-common/addon/components/fade-text.gjs
+++ b/packages/ilios-common/addon/components/fade-text.gjs
@@ -42,10 +42,6 @@ export default class FadeTextComponent extends Component {
   }
 
   get shouldFade() {
-    // short-circuit fading if no tracked property passed (i.e. doesn't make sense to use it)
-    if (!this.args.expanded) {
-      return false;
-    }
     if (this.expanded !== undefined) {
       return this.expanded ? false : this.exceedsHeight;
     }
@@ -54,6 +50,10 @@ export default class FadeTextComponent extends Component {
   }
 
   get expanded() {
+    // short-circuit fading if no tracked property passed (i.e. doesn't make sense to fade text)
+    if (!this.args.expanded) {
+      return false;
+    }
     return this.args.expanded && this.exceedsHeight;
   }
 
@@ -67,7 +67,7 @@ export default class FadeTextComponent extends Component {
 
   @action
   collapse(event) {
-    // short-circuit fading if no method passed (i.e. doesn't make sense to use it)
+    // short-circuit fading if no method passed (i.e. doesn't make sense to fade text)
     if (!this.args.onExpandAll) {
       return false;
     }

--- a/packages/test-app/tests/integration/components/fade-text-test.gjs
+++ b/packages/test-app/tests/integration/components/fade-text-test.gjs
@@ -55,6 +55,19 @@ module('Integration | Component | fade-text', function (hooks) {
     assert.dom(this.element).hasText(shortText);
   });
 
+  test('it ignores fading behavior on tall text if tracking variable is missing', async function (assert) {
+    this.set('longHtml', this.longHtml);
+
+    this.set('expanded', false);
+    this.set('onExpandAll', (isExpanded) => {
+      this.set('expanded', isExpanded);
+    });
+    await render(<template><FadeText @text={{this.longHtml}} /></template>);
+
+    assert.dom('.display-text-wrapper', this.element).doesNotHaveClass(this.fadedClass);
+    assert.notOk(component.control.expand.isVisible, 'expand button is not visible');
+  });
+
   test('it fades tall text given as component argument', async function (assert) {
     this.set('longHtml', this.longHtml);
 
@@ -75,7 +88,7 @@ module('Integration | Component | fade-text', function (hooks) {
     // slight delay to allow for proper loading of component
     await waitFor(this.fadedSelector);
 
-    assert.false(this.expanded);
+    assert.false(this.expanded, 'text is not expanded');
     assert.dom('.display-text-wrapper', this.element).hasClass(this.fadedClass);
 
     await component.control.expand.click();


### PR DESCRIPTION
Fixes ilios/ilios#6212

There are many instances of `<EditableText>` that don't need to have any fading done, so I added a simple short-circuit mechanism that removes any fading behavior, which, in effect, also fixes any other potential `no this.args.onExpandAll method found` bugs