### PR TITLE
improve table layout and spacing in learner group management ui.

### DIFF
--- a/packages/frontend/app/components/learner-group/cohort-user-manager.gjs
+++ b/packages/frontend/app/components/learner-group/cohort-user-manager.gjs
@@ -171,14 +171,6 @@ export default class LearnerGroupCohortUserManagerComponent extends Component {
                           {{on "click" (fn this.toggleUserSelection user)}}
                         />
                       {{/if}}
-                      {{#unless user.enabled}}
-                        <FaIcon
-                          @icon="user-xmark"
-                          @title={{t "general.disabled"}}
-                          class="disabled-user"
-                          data-test-is-disabled
-                        />
-                      {{/unless}}
                     </td>
                     <td class="text-left" colspan="4">
                       {{#if @canUpdate}}
@@ -188,6 +180,14 @@ export default class LearnerGroupCohortUserManagerComponent extends Component {
                           {{on "click" (fn this.toggleUserSelection user)}}
                         >
                           <UserNameInfo id="username-{{index}}-{{templateId}}" @user={{user}} />
+                          {{#unless user.enabled}}
+                            <FaIcon
+                              @icon="user-xmark"
+                              @title={{t "general.disabled"}}
+                              class="disabled-user"
+                              data-test-is-disabled
+                            />
+                          {{/unless}}
                         </button>
                       {{else}}
                         <UserNameInfo id="username-{{index}}-{{templateId}}" @user={{user}} />

--- a/packages/frontend/app/components/learner-group/members.gjs
+++ b/packages/frontend/app/components/learner-group/members.gjs
@@ -77,8 +77,6 @@ export default class LearnerGroupUserMembersComponent extends Component {
               <table>
                 <thead>
                   <tr>
-                    <th class="text-left" colspan="1">
-                    </th>
                     <SortableTh
                       @colspan={{4}}
                       @onClick={{fn this.setSortBy "fullName"}}
@@ -98,7 +96,11 @@ export default class LearnerGroupUserMembersComponent extends Component {
                 <tbody>
                   {{#each (sortBy @sortBy this.filteredUsers) as |user index|}}
                     <tr class={{unless user.enabled "disabled-user-account" ""}}>
-                      <td class="text-left" colspan="1">
+                      <td class="text-left" colspan="4">
+                        <UserNameInfo
+                          id="selected-username-{{index}}-{{templateId}}"
+                          @user={{user}}
+                        />
                         {{#unless user.enabled}}
                           <FaIcon
                             @icon="user-xmark"
@@ -107,12 +109,6 @@ export default class LearnerGroupUserMembersComponent extends Component {
                             data-test-is-disabled
                           />
                         {{/unless}}
-                      </td>
-                      <td class="text-left" colspan="4">
-                        <UserNameInfo
-                          id="selected-username-{{index}}-{{templateId}}"
-                          @user={{user}}
-                        />
                       </td>
                       <td class="text-left" colspan="2">
                         {{user.campusId}}

--- a/packages/frontend/app/components/learner-group/user-manager.gjs
+++ b/packages/frontend/app/components/learner-group/user-manager.gjs
@@ -284,14 +284,6 @@ export default class LearnerGroupUserManagerComponent extends Component {
                           checked={{includes user.content this.selectedGroupUsers}}
                           {{on "click" (fn this.toggleGroupUserSelection user.content)}}
                         />
-                        {{#unless user.enabled}}
-                          <FaIcon
-                            @icon="user-xmark"
-                            @title={{t "general.disabled"}}
-                            class="disabled-user"
-                            data-test-is-disabled
-                          />
-                        {{/unless}}
                       </td>
                       <td class="text-left" colspan="4">
                         <button
@@ -303,6 +295,14 @@ export default class LearnerGroupUserManagerComponent extends Component {
                             id="selected-username-{{index}}-{{templateId}}"
                             @user={{user}}
                           />
+                          {{#unless user.enabled}}
+                            <FaIcon
+                              @icon="user-xmark"
+                              @title={{t "general.disabled"}}
+                              class="disabled-user"
+                              data-test-is-disabled
+                            />
+                          {{/unless}}
                         </button>
                       </td>
                       <td class="text-left" colspan="2">
@@ -438,6 +438,14 @@ export default class LearnerGroupUserManagerComponent extends Component {
                             id="cohort-username-{{index}}-{{templateId}}"
                             @user={{user}}
                           />
+                          {{#unless user.enabled}}
+                            <FaIcon
+                              @icon="user-xmark"
+                              @title={{t "general.disabled"}}
+                              class="disabled-user"
+                              data-test-is-disabled
+                            />
+                          {{/unless}}
                         </button>
                       </td>
                       <td class="text-left" colspan="2">

--- a/packages/frontend/app/styles/components/learner-group/cohort-user-manager.scss
+++ b/packages/frontend/app/styles/components/learner-group/cohort-user-manager.scss
@@ -29,6 +29,10 @@
       @include m.main-list-box-table;
       max-height: 360px;
       overflow: auto;
+
+      th:nth-child(1) {
+        width: 1.5rem;
+      }
     }
   }
 

--- a/packages/frontend/app/styles/components/learner-group/user-manager.scss
+++ b/packages/frontend/app/styles/components/learner-group/user-manager.scss
@@ -28,6 +28,10 @@
       grid-column: 1 / -1;
       max-height: 540px;
       overflow: auto;
+
+      th:nth-child(1) {
+        width: 1.5rem;
+      }
     }
   }
 

--- a/packages/frontend/tests/integration/components/learner-group/members-test.gjs
+++ b/packages/frontend/tests/integration/components/learner-group/members-test.gjs
@@ -63,9 +63,11 @@ module('Integration | Component | learner-group/members', function (hooks) {
     assert.strictEqual(component.users[0].name.userNameInfo.fullName, 'Jasper M. Dog');
     assert.strictEqual(component.users[0].campusId.text, '1234');
     assert.strictEqual(component.users[0].email.text, 'testemail');
+    assert.notOk(component.users[0].name.isDisabled);
     assert.strictEqual(component.users[1].name.userNameInfo.fullName, 'Jackson M. Doggy');
     assert.strictEqual(component.users[1].campusId.text, '123');
     assert.strictEqual(component.users[1].email.text, 'testemail2');
+    assert.ok(component.users[1].name.isDisabled);
   });
 
   test('filtering', async function (assert) {

--- a/packages/frontend/tests/pages/components/learner-group/cohort-user-manager.js
+++ b/packages/frontend/tests/pages/components/learner-group/cohort-user-manager.js
@@ -39,7 +39,7 @@ const definition = {
       isClickable: isPresent('button'),
       click: clickable('button'),
     },
-    isDisabled: isPresent('td:nth-of-type(1) [data-test-is-disabled]'),
+    isDisabled: isPresent('td:nth-of-type(2) [data-test-is-disabled]'),
     add: clickable('[data-test-add-user]'),
     canBeAdded: isPresent('[data-test-add-user]'),
   }),

--- a/packages/frontend/tests/pages/components/learner-group/members.js
+++ b/packages/frontend/tests/pages/components/learner-group/members.js
@@ -1,33 +1,24 @@
-import {
-  clickable,
-  collection,
-  create,
-  fillable,
-  isPresent,
-  property,
-} from 'ember-cli-page-object';
+import { clickable, collection, create, fillable, isPresent } from 'ember-cli-page-object';
 import userNameInfo from 'ilios-common/page-objects/components/user-name-info';
 
 const definition = {
   scope: '[data-test-learner-group-members]',
   filter: fillable('[data-test-filter]'),
   users: collection('table tbody tr', {
-    isSelected: property('checked', 'td:eq(0) input'),
-    canBeSelected: isPresent('td:eq(0) input'),
-    select: clickable('td:eq(0) input'),
     name: {
-      scope: 'td:eq(1)',
+      scope: 'td:eq(0)',
       isClickable: isPresent('button'),
       click: clickable('button'),
+      isDisabled: isPresent('[data-test-is-disabled]'),
       userNameInfo,
     },
     campusId: {
-      scope: 'td:eq(2)',
+      scope: 'td:eq(1)',
       isClickable: isPresent('button'),
       click: clickable('button'),
     },
     email: {
-      scope: 'td:eq(3)',
+      scope: 'td:eq(2)',
       isClickable: isPresent('button'),
       click: clickable('button'),
     },

--- a/packages/frontend/tests/pages/components/learner-group/user-manager.js
+++ b/packages/frontend/tests/pages/components/learner-group/user-manager.js
@@ -52,7 +52,7 @@ const definition = {
       linkTitle: attribute('title', 'a'),
       linkAriaLabel: attribute('aria-label', 'a'),
     },
-    isDisabled: isPresent('td:nth-of-type(1) [data-test-is-disabled]'),
+    isDisabled: isPresent('td:nth-of-type(2) [data-test-is-disabled]'),
     remove: clickable('[data-test-remove-user]'),
     canBeRemoved: isPresent('[data-test-remove-user]'),
   }),


### PR DESCRIPTION
this moves the "disabled user account" indicator into the "name" column, and reduces the width of the checkbox column.

fixes https://github.com/ilios/ilios/issues/6242

