### PR TITLE
clear search input in new directory user form as appropriate

### DIFF
--- a/packages/frontend/app/components/ilios-users.gjs
+++ b/packages/frontend/app/components/ilios-users.gjs
@@ -90,6 +90,12 @@ export default class IliosUsersComponent extends Component {
     this.args.setOffset(offset);
     this.searchForUsers.perform();
   }
+
+  @action
+  closeNewUserForm() {
+    this.args.setSearchTerms('');
+    this.args.setShowNewUserForm(false);
+  }
   <template>
     <div class="ilios-users" data-test-ilios-users ...attributes>
       <div class="filters" data-test-filters>
@@ -116,11 +122,7 @@ export default class IliosUsersComponent extends Component {
                   type="button"
                   {{on
                     "click"
-                    (if
-                      @showNewUserForm
-                      (fn @setShowNewUserForm false)
-                      (fn @setShowBulkNewUserForm false)
-                    )
+                    (if @showNewUserForm this.closeNewUserForm (fn @setShowBulkNewUserForm false))
                   }}
                   data-test-collapse
                 >

--- a/packages/frontend/app/components/new-directory-user.gjs
+++ b/packages/frontend/app/components/new-directory-user.gjs
@@ -304,6 +304,7 @@ export default class NewDirectoryUserComponent extends Component {
     });
     await authentication.save();
     this.validations.clearErrorDisplay();
+    this.args.setSearchTerms('');
     this.flashMessages.success('general.saved');
     this.args.transitionToUser(user.id);
   });

--- a/packages/frontend/app/components/new-directory-user.gjs
+++ b/packages/frontend/app/components/new-directory-user.gjs
@@ -241,7 +241,7 @@ export default class NewDirectoryUserComponent extends Component {
       }
 
       if (27 === keyCode) {
-        this.searchTerms = '';
+        this.args.setSearchTerms('');
       }
     }
   }

--- a/packages/frontend/tests/integration/components/new-directory-user-test.gjs
+++ b/packages/frontend/tests/integration/components/new-directory-user-test.gjs
@@ -8,7 +8,7 @@ import { component } from 'frontend/tests/pages/components/new-directory-user';
 import NewDirectoryUser from 'frontend/components/new-directory-user';
 import noop from 'ilios-common/helpers/noop';
 
-module('Integration | Component | new directory user', function (hooks) {
+module('Integration | Component | new-directory-user', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
@@ -85,6 +85,31 @@ module('Integration | Component | new directory user', function (hooks) {
       </template>,
     );
     assert.strictEqual(component.search.value, startingSearchTerms);
+  });
+
+  test('pressing escape in search box clears search term', async function (assert) {
+    assert.expect(2);
+    const startingSearchTerms = 'start here';
+    this.server.get(`/application/directory/search`, () => {
+      return {
+        results: [],
+      };
+    });
+    this.set('startingSearchTerms', startingSearchTerms);
+    this.set('setSearchTerms', (what) => {
+      assert.strictEqual(what, '');
+    });
+    await render(
+      <template>
+        <NewDirectoryUser
+          @close={{(noop)}}
+          @setSearchTerms={{this.setSearchTerms}}
+          @searchTerms={{this.startingSearchTerms}}
+        />
+      </template>,
+    );
+    assert.strictEqual(component.search.value, startingSearchTerms);
+    await component.search.clearOnEscape();
   });
 
   test('create new user', async function (assert) {

--- a/packages/frontend/tests/integration/components/new-directory-user-test.gjs
+++ b/packages/frontend/tests/integration/components/new-directory-user-test.gjs
@@ -433,6 +433,7 @@ module('Integration | Component | new-directory-user', function (hooks) {
   });
 
   test('save with custom username and password', async function (assert) {
+    assert.expect(8);
     this.server.create('user-role', {
       id: 4,
       title: 'Student',
@@ -462,11 +463,14 @@ module('Integration | Component | new-directory-user', function (hooks) {
         ],
       };
     });
+    this.set('setSearchTerms', (what) => {
+      assert.strictEqual(what, '');
+    });
     await render(
       <template>
         <NewDirectoryUser
           @close={{(noop)}}
-          @setSearchTerms={{(noop)}}
+          @setSearchTerms={{this.setSearchTerms}}
           @transitionToUser={{(noop)}}
           @searchTerms="searchterm"
         />

--- a/packages/frontend/tests/pages/components/new-directory-user.js
+++ b/packages/frontend/tests/pages/components/new-directory-user.js
@@ -23,6 +23,9 @@ const definition = {
     submitOnEnter: triggerable('keyup', 'input[type="search"]', {
       eventProperties: { key: 'Enter' },
     }),
+    clearOnEscape: triggerable('keyup', 'input[type="search"]', {
+      eventProperties: { key: 'Escape' },
+    }),
   },
   searchResults: collection('[data-test-search-result]', {
     addUser: clickable('[data-test-add]'),


### PR DESCRIPTION
user search is reset when

1. the user presses the ESCAPE key in the directory search input

![image](https://github.com/user-attachments/assets/699ee6aa-8286-46e6-a05a-67cd8d3ee1e0)

2. the user closes the form

![image](https://github.com/user-attachments/assets/8bc5c01a-dec1-401e-9df3-761453662333)

3. after a new directory user has successfully been imported (not pictured here - use the power of your imagination instead, or click-test it yourself)