### PR TITLE
Import and Use Refocus Styles

### DIFF
--- a/packages/frontend/app/styles/app.scss
+++ b/packages/frontend/app/styles/app.scss
@@ -2,3 +2,4 @@
 @use "layout/noscript";
 @use "components";
 @use "layout/layout";
+@use "navigation-narrator.css"; //ember-a11y-refocus

--- a/packages/frontend/ember-cli-build.js
+++ b/packages/frontend/ember-cli-build.js
@@ -50,6 +50,7 @@ module.exports = async function (defaults) {
     },
     sassOptions: {
       silenceDeprecations: ['mixed-decls'],
+      includePaths: ['node_modules/ember-a11y-refocus/dist/styles'],
     },
   };
 


### PR DESCRIPTION
In the update to v5.x in #8627 this addon now requires these styles be imported by the app directly.

Refs 