### PR TITLE
render the name of the current learner group, not its top-level parent, in the component title.

### DIFF
--- a/packages/frontend/app/components/learner-group/cohort-user-manager.gjs
+++ b/packages/frontend/app/components/learner-group/cohort-user-manager.gjs
@@ -103,7 +103,7 @@ export default class LearnerGroupCohortUserManagerComponent extends Component {
       >
         <div class="learner-group-cohort-user-manager-header">
           <div class="title" data-test-title>
-            {{t "general.cohortMembersNotInGroup" groupTitle=@topLevelGroupTitle}}
+            {{t "general.cohortMembersNotInGroup" groupTitle=@learnerGroupTitle}}
             ({{@users.length}})
           </div>
           <div class="actions">

--- a/packages/frontend/app/components/learner-group/root.gjs
+++ b/packages/frontend/app/components/learner-group/root.gjs
@@ -816,7 +816,6 @@ export default class LearnerGroupRootComponent extends Component {
               @users={{this.usersForCohortManager}}
               @canUpdate={{@canUpdate}}
               @learnerGroupTitle={{this.learnerGroupTitle}}
-              @topLevelGroupTitle={{this.topLevelGroupTitle}}
               @sortBy={{this.sortUsersBy}}
               @setSortBy={{@setSortUsersBy}}
               @addUserToGroup={{perform this.addUserToGroup}}

--- a/packages/frontend/tests/integration/components/learner-group/cohort-user-manager-test.gjs
+++ b/packages/frontend/tests/integration/components/learner-group/cohort-user-manager-test.gjs
@@ -36,7 +36,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="lastName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{(noop)}}
@@ -45,7 +44,7 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
       </template>,
     );
 
-    assert.strictEqual(component.title, 'Cohort Members NOT assigned to top level group (2)');
+    assert.strictEqual(component.title, 'Cohort Members NOT assigned to this group (2)');
     assert.strictEqual(component.users.length, 2);
     assert.strictEqual(component.users[0].name.userNameInfo.fullName, 'Jasper M. Dog');
     assert.notOk(component.users[0].name.userStatus.accountIsDisabled);
@@ -79,7 +78,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="fullName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{(noop)}}
@@ -111,7 +109,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="firstName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{(noop)}}
@@ -145,7 +142,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="firstName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{this.addOne}}
@@ -171,7 +167,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="firstName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{(noop)}}
@@ -205,7 +200,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="firstName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{(noop)}}
@@ -237,7 +231,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="firstName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{(noop)}}
@@ -279,7 +272,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="firstName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{(noop)}}
@@ -375,7 +367,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="lastName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{(noop)}}
@@ -408,7 +399,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="firstName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{(noop)}}
@@ -431,7 +421,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="firstName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{(noop)}}
@@ -454,7 +443,6 @@ module('Integration | Component | learner-group/cohort-user-manager', function (
           @users={{this.users}}
           @canUpdate={{true}}
           @learnerGroupTitle="this group"
-          @topLevelGroupTitle="top level group"
           @sortBy="firstName"
           @setSortBy={{(noop)}}
           @addUserToGroup={{(noop)}}


### PR DESCRIPTION
the current learner group is the correct context to put on the screen.

fixes https://github.com/ilios/ilios/issues/6210