### PR TITLE
V2 Search API

### DIFF
--- a/packages/frontend/app/components/global-search-box.gjs
+++ b/packages/frontend/app/components/global-search-box.gjs
@@ -2,43 +2,22 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { isBlank } from '@ember/utils';
-import { findBy } from 'ilios-common/utils/array-helpers';
 import { cleanQuery } from 'ilios-common/utils/query-utils';
-import { restartableTask, timeout } from 'ember-concurrency';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import queue from 'ilios-common/helpers/queue';
 import pick from 'ilios-common/helpers/pick';
 import set from 'ember-set-helper/helpers/set';
-import perform from 'ember-concurrency/helpers/perform';
 import onKey from 'ember-keyboard/modifiers/on-key';
 import FaIcon from 'ilios-common/components/fa-icon';
-import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
-import { fn } from '@ember/helper';
 
-const DEBOUNCE_MS = 250;
 const MIN_INPUT = 3;
 
 export default class GlobalSearchBox extends Component {
-  @service iliosConfig;
-  @service('search') iliosSearch;
-  @service intl;
   @service router;
 
-  @tracked autocompleteCache = [];
-  @tracked autocompleteSelectedQuery;
   @tracked internalQuery;
-  @tracked results = null;
-
-  get hasResults() {
-    return !!this.results?.length;
-  }
 
   get computedQuery() {
-    if (typeof this.autocompleteSelectedQuery === 'string') {
-      return this.autocompleteSelectedQuery;
-    }
     if (typeof this.internalQuery === 'string') {
       return this.internalQuery;
     }
@@ -50,13 +29,6 @@ export default class GlobalSearchBox extends Component {
     const searchInputElement =
       event.currentTarget.parentElement.getElementsByClassName('global-search-input')[0];
     searchInputElement.focus();
-    this.search();
-  }
-
-  @action
-  searchFromResult(result) {
-    this.autocompleteSelectedQuery = null;
-    this.internalQuery = result.text;
     this.search();
   }
 
@@ -84,21 +56,6 @@ export default class GlobalSearchBox extends Component {
     }
   }
 
-  @action
-  onArrowKey(event) {
-    const { keyCode, target } = event;
-
-    const container = target.parentElement.parentElement;
-    const list = container.getElementsByClassName('autocomplete-row');
-    const listArray = Array.from(list);
-
-    const isValid = listArray.length > 0;
-
-    if (isValid) {
-      this.verticalKeyAction(keyCode, listArray, container);
-    }
-  }
-
   /**
    * Clear all the caches and query local copies
    * This component is complicated by the many types of user interaction
@@ -106,150 +63,18 @@ export default class GlobalSearchBox extends Component {
    * several things to clear
    */
   clear() {
-    this.autocompleteCache = [];
     this.internalQuery = null;
-    this.autocompleteSelectedQuery = null;
-    this.autocomplete.perform();
   }
 
-  verticalKeyAction(keyCode, listArray, container) {
-    if (this.listHasFocus(listArray)) {
-      this.resultListAction(listArray, keyCode);
-    } else {
-      const selector = keyCode === 40 ? 'first' : 'last';
-      const option = container.querySelector(`.autocomplete-row:${selector}-child`);
-      option.classList.add('active');
-      this.autocompleteSelectedQuery = option.innerText.trim();
-    }
-  }
-
-  resultListAction(listArray, keyCode) {
-    if (this.hasFocusOnEdge(listArray, keyCode === 40)) {
-      this.removeActiveClass(listArray);
-      this.autocompleteSelectedQuery = null;
-    } else {
-      this.addClassToNext(listArray, keyCode === 38);
-    }
-  }
-
-  listHasFocus(listArray) {
-    return Boolean(listArray.find((element) => element.classList.contains('active')));
-  }
-
-  hasFocusOnEdge(listArray, shouldReverse) {
-    const list = shouldReverse ? listArray.slice().reverse() : listArray;
-    return list[0].classList.contains('active');
-  }
-
-  removeActiveClass(listArray) {
-    listArray.forEach(({ classList }) => classList.remove('active'));
-  }
-
-  addClassToNext(listArray, shouldReverse) {
-    const list = shouldReverse ? listArray.slice().reverse() : listArray;
-    let shouldAddClass = false;
-    list.forEach((element) => {
-      const { classList } = element;
-
-      if (classList.contains('active')) {
-        shouldAddClass = true;
-        classList.remove('active');
-      } else if (shouldAddClass) {
-        classList.add('active');
-        shouldAddClass = false;
-        this.autocompleteSelectedQuery = element.innerText.trim();
-      }
-    });
-  }
-
-  /**
-   * Discover previously cached autocomplete suggestions
-   * @param {string} q
-   *
-   * @returns {array}
-   */
-  findCachedAutocomplete(q) {
-    const exactMatch = findBy(this.autocompleteCache, 'q', q);
-    if (exactMatch) {
-      return exactMatch.autocomplete;
-    }
-    const possibleKeys = [];
-    for (let i = q.length; i > MIN_INPUT; i--) {
-      possibleKeys.push(q.substring(0, i));
-    }
-
-    const allMatches = possibleKeys.reduce((set, q) => {
-      const removedChar = q.substring(q.length - 1);
-      const newQuery = q.substring(0, q.length - 1);
-      const possibleMatches = findBy(this.autocompleteCache, 'q', newQuery);
-
-      if (possibleMatches) {
-        const matches = possibleMatches.autocomplete.filter((text) => {
-          return text.substring(newQuery.length, newQuery.length + 1) === removedChar;
-        });
-
-        set = [...set, ...matches];
-      }
-
-      return set;
-    }, []);
-
-    return allMatches.filter((text) => text.indexOf(q) === 0);
-  }
-
-  autocomplete = restartableTask(async () => {
-    const q = cleanQuery(this.internalQuery);
-
-    if (isBlank(q)) {
-      this.results = [];
-      return [];
-    }
-
-    if (q.length < MIN_INPUT) {
-      this.results = [
-        {
-          text: this.intl.t('general.moreInputRequiredPrompt'),
-        },
-      ];
-
-      return this.results;
-    }
-
-    const cachedResults = this.findCachedAutocomplete(this.internalQuery);
-    if (cachedResults.length) {
-      this.results = cachedResults.map((text) => {
-        return { text };
-      });
-      return this.results;
-    }
-
-    await timeout(DEBOUNCE_MS);
-
-    const { autocomplete } = await this.iliosSearch.forCurriculum(this.internalQuery, true);
-    this.autocompleteCache = [...this.autocompleteCache, { q: this.internalQuery, autocomplete }];
-
-    this.results = autocomplete.map((text) => {
-      return { text };
-    });
-    return this.results;
-  });
   <template>
     <div class="global-search-box" data-test-global-search-box>
       <input
         aria-label={{t "general.searchTheCurriculum"}}
-        autocomplete="name"
         class="global-search-input"
         data-test-input
         type="search"
         value={{this.computedQuery}}
-        {{on
-          "input"
-          (queue
-            (pick "target.value" (set this "internalQuery"))
-            (set this "autocompleteSelectedQuery" null)
-            (perform this.autocomplete)
-          )
-        }}
+        {{on "input" (pick "target.value" (set this "internalQuery"))}}
         {{onKey "Escape" this.onEscapeKey}}
         {{onKey "Enter" this.onEnterKey}}
         {{onKey "ArrowUp" this.onArrowKey}}
@@ -264,23 +89,6 @@ export default class GlobalSearchBox extends Component {
       >
         <FaIcon @icon="magnifying-glass" />
       </button>
-      {{#if this.hasResults}}
-        <div {{onClickOutside (set this "results" null)}}>
-          <div class="autocomplete" data-test-autocomplete>
-            {{#each this.results as |result|}}
-              <button
-                type="button"
-                class="autocomplete-row"
-                data-test-autocomplete-row
-                {{on "click" (fn this.searchFromResult result)}}
-              >
-                <FaIcon @icon="magnifying-glass" />
-                {{result.text}}
-              </button>
-            {{/each}}
-          </div>
-        </div>
-      {{/if}}
     </div>
   </template>
 }

--- a/packages/frontend/app/components/global-search.gjs
+++ b/packages/frontend/app/components/global-search.gjs
@@ -1,24 +1,21 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
-import { findBy, findById, mapBy, sortBy, uniqueValues } from 'ilios-common/utils/array-helpers';
-import { action } from '@ember/object';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 import GlobalSearchBox from 'frontend/components/global-search-box';
 import and from 'ember-truth-helpers/helpers/and';
 import not from 'ember-truth-helpers/helpers/not';
+import gt from 'ember-truth-helpers/helpers/gt';
 import FaIcon from 'ilios-common/components/fa-icon';
 import t from 'ember-intl/helpers/t';
 import CourseSearchResult from 'frontend/components/course-search-result';
 import { on } from '@ember/modifier';
-import pick from 'ilios-common/helpers/pick';
-import eq from 'ember-truth-helpers/helpers/eq';
 import add from 'ember-math-helpers/helpers/add';
-import gt from 'ember-truth-helpers/helpers/gt';
-import { get, fn } from '@ember/helper';
-import or from 'ember-truth-helpers/helpers/or';
+import { fn } from '@ember/helper';
 import includes from 'ilios-common/helpers/includes';
 import PaginationLinks from 'frontend/components/pagination-links';
+
+const COURSES_PER_PAGE = 10;
 
 export default class GlobalSearchComponent extends Component {
   @service iliosConfig;
@@ -26,13 +23,17 @@ export default class GlobalSearchComponent extends Component {
   @service('search') iliosSearch;
   @service store;
 
-  size = 10;
-
   @cached
   get resultsData() {
     return new TrackedAsyncData(
       this.args.query
-        ? this.iliosSearch.forCurriculum(this.args.query, false, this.size, this.from)
+        ? this.iliosSearch.forCurriculum(
+            this.args.query,
+            COURSES_PER_PAGE,
+            this.from,
+            this.args.selectedSchools,
+            this.args.selectedYears,
+          )
         : null,
     );
   }
@@ -42,8 +43,33 @@ export default class GlobalSearchComponent extends Component {
     return new TrackedAsyncData(this.store.findAll('school'));
   }
 
+  @cached
+  get academicYearData() {
+    return new TrackedAsyncData(this.store.findAll('academic-year'));
+  }
+
+  crossesBoundaryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
+  }
+
+  get visibleAcademicYears() {
+    if (!this.academicYearData.isResolved) {
+      return [];
+    }
+
+    return this.academicYearData.value
+      .map((year) => Number(year.id))
+      .sort()
+      .reverse();
+  }
+
   get from() {
-    return (this.args.page - 1) * this.size;
+    return (this.args.page - 1) * COURSES_PER_PAGE;
   }
 
   get results() {
@@ -75,77 +101,22 @@ export default class GlobalSearchComponent extends Component {
     return this.schoolData.value;
   }
 
-  get ignoredSchoolTitles() {
-    if (!this.args.ignoredSchoolIds) {
-      return [];
-    }
-    return this.args.ignoredSchoolIds.map((id) => {
-      const school = findById(this.schools, id);
-      return school ? school.title : '';
-    });
-  }
-
-  get yearFilteredResults() {
-    if (!this.args.selectedYear) {
-      return this.results;
-    }
-
-    return this.results.filter((course) => course.year === Number(this.args.selectedYear));
-  }
-
-  get filteredResults() {
-    return this.yearFilteredResults.filter(
-      (course) => !this.ignoredSchoolTitles.includes(course.school),
-    );
-  }
-
-  get schoolOptions() {
-    if (this.yearFilteredResults.length && this.schools.length) {
-      const emptySchools = sortBy(
-        this.schools.map(({ id, title }) => {
-          return {
-            id,
-            title,
-            results: 0,
-          };
-        }),
-        'title',
-      );
-      const options = this.yearFilteredResults.reduce((set, course) => {
-        const schoolOption = findBy(set, 'title', course.school);
-        schoolOption.results++;
-
-        return set;
-      }, emptySchools);
-      return options;
-    }
-
-    return [];
-  }
-
-  get yearOptions() {
-    return uniqueValues(mapBy(this.results, 'year')).sort().reverse();
-  }
-
-  @action
-  setSelectedYear(year) {
-    this.args.setSelectedYear(year ? Number(year) : null);
-    this.args.onSelectPage(1);
-  }
-
-  @action
-  toggleSchoolSelection(id) {
-    const ignoredSchoolIds = this.args.ignoredSchoolIds ? [...this.args.ignoredSchoolIds] : [];
-
-    if (ignoredSchoolIds.includes(id)) {
-      ignoredSchoolIds.splice(ignoredSchoolIds.indexOf(id), 1);
+  toggleSchoolSelection = (id) => {
+    if (this.args.selectedSchools.includes(id)) {
+      this.args.setSchools(this.args.selectedSchools.filter((schoolId) => schoolId !== id));
     } else {
-      ignoredSchoolIds.push(id);
+      this.args.setSchools([...this.args.selectedSchools, id]);
     }
+  };
 
-    this.args.onSelectPage(1);
-    this.args.setIgnoredSchoolIds(ignoredSchoolIds);
-  }
+  toggleYearSelection = (year) => {
+    if (this.args.selectedYears.includes(year)) {
+      this.args.setYears(this.args.selectedYears.filter((y) => y !== year));
+    } else {
+      this.args.setYears([...this.args.selectedYears, year]);
+    }
+  };
+
   <template>
     <div class="global-search" data-test-global-search ...attributes>
       <GlobalSearchBox @query={{@query}} @search={{@setQuery}} />
@@ -168,55 +139,52 @@ export default class GlobalSearchComponent extends Component {
           {{/each}}
         {{/if}}
       </ul>
-      {{#if this.hasResults}}
-        <fieldset class="filters">
-          <legend>
-            {{t "general.showResultsFor"}}
-          </legend>
-          <div class="year-filters">
-            <select
-              aria-label={{t "general.year"}}
-              data-test-academic-year-filter
-              {{on "change" (pick "target.value" this.setSelectedYear)}}
-            >
-              <option selected={{eq null @selectedYear}} value>
-                {{t "general.allAcademicYears"}}
-              </option>
-              {{#each this.yearOptions as |year|}}
-                <option selected={{eq year @selectedYear}} value={{year}}>
+      <fieldset class="filters">
+        {{#if (gt this.schools.length 1)}}
+          <div class="school-filters" data-test-school-filters>
+            {{#each this.schools as |school index|}}
+              <span class="filter" data-test-school-filter>
+                <input
+                  id="school={{index}}"
+                  type="checkbox"
+                  checked={{includes school.id @selectedSchools}}
+                  {{on "click" (fn this.toggleSchoolSelection school.id)}}
+                />
+                <label for="school={{index}}">
+                  {{school.title}}
+                </label>
+              </span>
+            {{/each}}
+          </div>
+        {{/if}}
+        <div class="year-filters" data-test-year-filters>
+          {{#each this.visibleAcademicYears as |year index|}}
+            <span class="filter" data-test-year-filter>
+              <input
+                id="year={{index}}"
+                type="checkbox"
+                checked={{includes year @selectedYears}}
+                {{on "click" (fn this.toggleYearSelection year)}}
+              />
+              <label for="year={{index}}">
+                {{#if this.academicYearCrossesCalendarYearBoundaries}}
                   {{year}}
                   -
                   {{add year 1}}
-                </option>
-              {{/each}}
-            </select>
-          </div>
-          {{#if (gt (get this.schools "length") 1)}}
-            <div class="school-filters" data-test-school-filters>
-              {{#each this.schoolOptions as |obj index|}}
-                <span class="filter" data-test-school-filter>
-                  <input
-                    id="school={{index}}"
-                    type="checkbox"
-                    checked={{or (eq obj.results 0) (not (includes obj.id @ignoredSchoolIds))}}
-                    {{on "click" (fn this.toggleSchoolSelection obj.id)}}
-                    disabled={{eq obj.results 0}}
-                  />
-                  <label for="school={{index}}">
-                    {{obj.title}}
-                  </label>
-                </span>
-              {{/each}}
-            </div>
-          {{/if}}
-        </fieldset>
-      {{/if}}
+                {{else}}
+                  {{year}}
+                {{/if}}
+              </label>
+            </span>
+          {{/each}}
+        </div>
+      </fieldset>
     </div>
     <PaginationLinks
       @page={{@page}}
       @results={{this.totalResults}}
-      @size={{this.size}}
-      @onSelectPage={{@onSelectPage}}
+      @size={{COURSES_PER_PAGE}}
+      @onSelectPage={{@setPage}}
     />
   </template>
 }

--- a/packages/frontend/app/components/ilios-header.gjs
+++ b/packages/frontend/app/components/ilios-header.gjs
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { defaultValidator } from 'ember-a11y-refocus';
 import NavigationNarrator from 'ember-a11y-refocus/components/navigation-narrator';
 import t from 'ember-intl/helpers/t';
@@ -10,6 +9,7 @@ import GlobalSearchBox from 'frontend/components/global-search-box';
 import LocaleChooser from 'frontend/components/locale-chooser';
 import UserMenu from 'frontend/components/user-menu';
 import UserGuideLink from 'frontend/components/user-guide-link';
+import currentAcademicYear from 'ilios-common/utils/current-academic-year';
 
 export default class IliosHeaderComponent extends Component {
   @service currentUser;
@@ -24,21 +24,44 @@ export default class IliosHeaderComponent extends Component {
     return this.searchConfig.isResolved ? this.searchConfig.value : false;
   }
 
+  @cached
+  get userModelData() {
+    return new TrackedAsyncData(this.currentUser.getModel());
+  }
+
+  @cached
+  get primarySchoolData() {
+    return new TrackedAsyncData(this.userModel?.school);
+  }
+
+  get userModel() {
+    return this.userModelData.isResolved ? this.userModelData.value : null;
+  }
+
+  get primarySchool() {
+    return this.primarySchoolData.isResolved ? this.primarySchoolData.value : null;
+  }
+
   get showSearch() {
     return (
       this.searchEnabled &&
       this.session.isAuthenticated &&
       this.router.currentRouteName !== 'search' &&
-      this.currentUser.performsNonLearnerFunction
+      this.currentUser.performsNonLearnerFunction &&
+      this.userModelData.isResolved &&
+      this.primarySchoolData.isResolved
     );
   }
 
-  @action
-  search(q) {
+  search = (q) => {
     this.router.transitionTo('search', {
-      queryParams: { q },
+      queryParams: {
+        q,
+        schools: this.primarySchool.id,
+        years: `${currentAcademicYear()}-${currentAcademicYear() - 1}`,
+      },
     });
-  }
+  };
 
   checkRouteChange(transition) {
     if (transition.from?.name === transition.to?.name) {

--- a/packages/frontend/app/controllers/search.js
+++ b/packages/frontend/app/controllers/search.js
@@ -1,55 +1,44 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import currentAcademicYear from 'ilios-common/utils/current-academic-year';
 
 export default class SearchController extends Controller {
   queryParams = [
     {
       page: 'page',
       query: 'q',
-      ignoredSchoolIds: 'ignoredSchools',
-      selectedYear: 'year',
+      schools: 'schools',
+      years: 'years',
     },
   ];
 
   @tracked page = 1;
   @tracked query = '';
-  @tracked ignoredSchoolIds = null;
-  @tracked selectedYear = currentAcademicYear();
+  @tracked schools = null;
+  @tracked years = null;
 
-  get ignoredSchoolIdsArray() {
-    return this.ignoredSchoolIds ? this.ignoredSchoolIds.split('-') : [];
+  get schoolIdsArray() {
+    return this.schools ? this.schools.split('-') : [];
   }
 
-  get selectedYearInt() {
-    return this.selectedYear ? parseInt(this.selectedYear, 10) : null;
+  get selectedYearsArray() {
+    return this.years ? this.years.split('-').map(Number) : [];
   }
 
-  @action
-  setQuery(query) {
+  setQuery = (query) => {
     // don't reset the page when returning back to the same query
     if (query !== this.query) {
       this.page = 1;
       this.query = query;
-      this.ignoredSchoolIds = null;
-      this.selectedYear = null;
     }
-  }
+  };
 
-  @action
-  setIgnoredSchools(schools) {
+  setSchools = (schools) => {
     const str = schools.length ? schools.join('-') : null;
-    this.ignoredSchoolIds = str;
-  }
+    this.schools = str;
+  };
 
-  @action
-  setSelectedYear(year) {
-    this.selectedYear = year;
-  }
-
-  @action
-  setPage(page) {
-    this.page = page;
-  }
+  setYears = (years) => {
+    const str = years.length ? years.join('-') : null;
+    this.years = str;
+  };
 }

--- a/packages/frontend/app/styles/components/global-search.scss
+++ b/packages/frontend/app/styles/components/global-search.scss
@@ -35,14 +35,11 @@
       padding: 0 0 0 0.5rem;
     }
 
-    .year-filters,
-    .school-filters {
-      margin-left: 1rem;
-    }
-
-    .school-filters {
+    .school-filters,
+    .year-filters {
       display: flex;
       justify-content: flex-start;
+      margin-left: 1rem;
       margin-top: 0.5rem;
       flex-direction: column;
 

--- a/packages/frontend/app/templates/search.hbs
+++ b/packages/frontend/app/templates/search.hbs
@@ -3,9 +3,9 @@
   @page={{this.page}}
   @query={{this.query}}
   @setQuery={{this.setQuery}}
-  @onSelectPage={{this.setPage}}
-  @ignoredSchoolIds={{this.ignoredSchoolIdsArray}}
-  @setIgnoredSchoolIds={{this.setIgnoredSchools}}
-  @selectedYear={{this.selectedYearInt}}
-  @setSelectedYear={{this.setSelectedYear}}
+  @setPage={{set this "page"}}
+  @selectedSchools={{this.schoolIdsArray}}
+  @setSchools={{this.setSchools}}
+  @selectedYears={{this.selectedYearsArray}}
+  @setYears={{this.setYears}}
 />

--- a/packages/frontend/tests/pages/components/global-search-box.js
+++ b/packages/frontend/tests/pages/components/global-search-box.js
@@ -1,12 +1,4 @@
-import {
-  clickable,
-  create,
-  collection,
-  fillable,
-  hasClass,
-  triggerable,
-  value,
-} from 'ember-cli-page-object';
+import { clickable, create, fillable, triggerable, value } from 'ember-cli-page-object';
 import { hasFocus } from 'ilios-common';
 
 const definition = {
@@ -16,15 +8,9 @@ const definition = {
   inputHasFocus: hasFocus('input'),
   triggerInput: triggerable('keyup', 'input'),
   clickIcon: clickable('[data-test-search-icon]'),
-  autocompleteResults: collection('[data-test-autocomplete-row]'),
-  resultsRow1HasActiveClass: hasClass('active', '[data-test-autocomplete-row]:nth-of-type(1)'),
-  resultsRow2HasActiveClass: hasClass('active', '[data-test-autocomplete-row]:nth-of-type(2)'),
-  resultsRow3HasActiveClass: hasClass('active', '[data-test-autocomplete-row]:nth-of-type(3)'),
   keyDown: {
     scope: '[data-test-input]',
     enter: triggerable('keydown', '', { eventProperties: { key: 'Enter' } }),
-    down: triggerable('keydown', '', { eventProperties: { key: 'ArrowDown' } }),
-    up: triggerable('keydown', '', { eventProperties: { key: 'ArrowUp' } }),
     escape: triggerable('keydown', '', { eventProperties: { key: 'Escape' } }),
   },
 };

--- a/packages/frontend/tests/pages/components/global-search.js
+++ b/packages/frontend/tests/pages/components/global-search.js
@@ -1,13 +1,4 @@
-import {
-  clickable,
-  collection,
-  create,
-  fillable,
-  isVisible,
-  property,
-  text,
-  value,
-} from 'ember-cli-page-object';
+import { clickable, collection, create, isVisible, property, text } from 'ember-cli-page-object';
 
 import courseSearchResult from './course-search-result';
 import searchBox from './global-search-box';
@@ -16,14 +7,17 @@ const definition = {
   scope: '[data-test-global-search]',
   searchBox,
   noResultsIsVisible: isVisible('.no-results'),
-  academicYear: value('[data-test-academic-year-filter]'),
-  academicYearOptions: text('[data-test-academic-year-filter]'),
   courseTitleLinks: collection('.course-title-link'),
-  selectAcademicYear: fillable('[data-test-academic-year-filter]'),
   schoolFilters: collection('[data-test-school-filters] [data-test-school-filter]', {
     isSelected: property('checked', 'input'),
     isDisabled: property('disabled', 'input'),
     school: text('label'),
+    toggle: clickable('label'),
+  }),
+  yearFilters: collection('[data-test-year-filters] [data-test-year-filter]', {
+    isSelected: property('checked', 'input'),
+    isDisabled: property('disabled', 'input'),
+    year: text('label'),
     toggle: clickable('label'),
   }),
   searchResults: collection('[data-test-course-search-result]', courseSearchResult),

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -403,7 +403,6 @@ general:
   sessionTypeConfirmRemoval: Are you sure you want to delete this session type? This action cannot be undone.
   sessionTypeTitlePlaceholder: Enter a title for this session type
   showAssociatedCourses: Show associated courses
-  showResultsFor: Show Results For
   showRolesInCourses: Show roles in courses
   showRolesInPrograms: Show roles in programs
   showRolesInProgramYears: Show roles in program years

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -403,7 +403,6 @@ general:
   sessionTypeConfirmRemoval: ¿Está seguro de que desea eliminar este tipo de sesión? Esta acción no se puede deshacer.
   sessionTypeTitlePlaceholder: Entre en un titulo para este tipo de sesión
   showAssociatedCourses: Mostrar cursos asociados
-  showResultsFor: Mostrar Resultados Para
   showRolesInCourses: Mostrar roles en cursos
   showRolesInPrograms: Mostrar roles en programas
   showRolesInProgramYears: Mostrar roles en años de programa

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -404,7 +404,6 @@ general:
   sessionTypeConfirmRemoval: "Voulez-vous vraiment supprimer ce type de session ? Cette action ne peut pas être annulée."
   sessionTypeTitlePlaceholder: Ajoutez un titre pour ce type de session
   showAssociatedCourses: Afficher les cours associés
-  showResultsFor: Afficher les résultats pour
   showRolesInCourses: Afficher les rôles dans les cours
   showRolesInPrograms: Afficher les rôles dans les programmes
   showRolesInProgramYears: Afficher les rôles dans les années du programme

--- a/packages/ilios-common/addon/services/search.js
+++ b/packages/ilios-common/addon/services/search.js
@@ -24,32 +24,11 @@ export default class SearchService extends Service {
 
   /**
    * Find courses
-   * @param {string} q
    */
-  async forCurriculum(q, onlySuggestEnabled = false, size = 25, from = 0) {
-    return this.search('curriculum', q, onlySuggestEnabled, size, from);
-  }
-
-  /**
-   * Find users
-   * @param {string} q
-   * @param {number} size
-   */
-  async forUsers(q, size = 100, from = 0, onlySuggestEnabled = false) {
-    const { users, autocomplete } = await this.search('users', q, onlySuggestEnabled, size, from);
-
-    const mappedUsers = users.map((user) => {
-      user.fullName = this.getUserFullName(user);
-
-      return user;
-    });
-
-    return { autocomplete, users: mappedUsers };
-  }
-
-  async search(type, q, onlySuggestEnabled, size, from) {
-    const onlySuggest = onlySuggestEnabled ? '&onlySuggest=true' : '';
-    const url = `${this.host}/api/search/v1/${type}?q=${q}&size=${size}&from=${from}${onlySuggest}`;
+  async forCurriculum(q, size, from, schools, years) {
+    const schoolQuery = schools ? `&schools=${schools.join('-')}` : '';
+    const yearQuery = years ? `&years=${years.join('-')}` : '';
+    const url = `${this.host}/api/search/v2/curriculum?q=${q}&size=${size}&from=${from}${schoolQuery}${yearQuery}`;
 
     const response = await waitForPromise(
       fetch(url, {
@@ -59,6 +38,31 @@ export default class SearchService extends Service {
     const { results } = await response.json();
 
     return results;
+  }
+
+  /**
+   * Find users
+   */
+  async forUsers(q, size = 100, onlySuggestEnabled = false) {
+    const onlySuggest = onlySuggestEnabled ? '&onlySuggest=true' : '';
+    const url = `${this.host}/api/search/v1/users?q=${q}&size=${size}${onlySuggest}`;
+
+    const response = await waitForPromise(
+      fetch(url, {
+        headers: this.authHeaders,
+      }),
+    );
+    const { results } = await response.json();
+
+    const { users, autocomplete } = results;
+
+    const mappedUsers = users.map((user) => {
+      user.fullName = this.getUserFullName(user);
+
+      return user;
+    });
+
+    return { autocomplete, users: mappedUsers };
   }
 
   getUserFullName(user) {

--- a/packages/ilios-common/addon/services/search.js
+++ b/packages/ilios-common/addon/services/search.js
@@ -26,8 +26,8 @@ export default class SearchService extends Service {
    * Find courses
    * @param {string} q
    */
-  async forCurriculum(q, onlySuggestEnabled = false) {
-    return this.search('curriculum', q, 1000, onlySuggestEnabled);
+  async forCurriculum(q, onlySuggestEnabled = false, size = 25, from = 0) {
+    return this.search('curriculum', q, onlySuggestEnabled, size, from);
   }
 
   /**
@@ -35,8 +35,8 @@ export default class SearchService extends Service {
    * @param {string} q
    * @param {number} size
    */
-  async forUsers(q, size = 100, onlySuggestEnabled = false) {
-    const { users, autocomplete } = await this.search('users', q, size, onlySuggestEnabled);
+  async forUsers(q, size = 100, from = 0, onlySuggestEnabled = false) {
+    const { users, autocomplete } = await this.search('users', q, onlySuggestEnabled, size, from);
 
     const mappedUsers = users.map((user) => {
       user.fullName = this.getUserFullName(user);
@@ -47,9 +47,9 @@ export default class SearchService extends Service {
     return { autocomplete, users: mappedUsers };
   }
 
-  async search(type, q, size, onlySuggestEnabled) {
+  async search(type, q, onlySuggestEnabled, size, from) {
     const onlySuggest = onlySuggestEnabled ? '&onlySuggest=true' : '';
-    const url = `${this.host}/api/search/v1/${type}?q=${q}&size=${size}${onlySuggest}`;
+    const url = `${this.host}/api/search/v1/${type}?q=${q}&size=${size}&from=${from}${onlySuggest}`;
 
     const response = await waitForPromise(
       fetch(url, {

--- a/packages/ilios-common/config/api-version.js
+++ b/packages/ilios-common/config/api-version.js
@@ -1,3 +1,3 @@
 /* eslint-env node */
 
-module.exports = 'v3.12';
+module.exports = 'v3.13';

--- a/packages/test-app/tests/unit/services/search-test.js
+++ b/packages/test-app/tests/unit/services/search-test.js
@@ -12,12 +12,15 @@ module('Unit | Service | search', function (hooks) {
   });
 
   test('test search for curriculum', async function (assert) {
-    assert.expect(3);
+    assert.expect(6);
     const courses = [{ id: 1, title: 'Sweet', sessions: [] }];
     const autocomplete = ['one', 'two'];
-    this.server.get('api/search/v1/curriculum', (schema, { queryParams }) => {
+    this.server.get('api/search/v2/curriculum', (schema, { queryParams }) => {
       assert.strictEqual(queryParams.q, 'codejam');
-      assert.strictEqual(parseInt(queryParams.size, 10), 1000);
+      assert.strictEqual(Number(queryParams.size), 10);
+      assert.strictEqual(Number(queryParams.from), 11);
+      assert.strictEqual(queryParams.schools, '1-2');
+      assert.strictEqual(queryParams.years, '2021-2028');
       return {
         results: {
           courses,
@@ -26,7 +29,7 @@ module('Unit | Service | search', function (hooks) {
       };
     });
     const service = this.owner.lookup('service:search');
-    const results = await service.forCurriculum('codejam');
+    const results = await service.forCurriculum('codejam', 10, 11, [1, 2], [2021, 2028]);
     assert.deepEqual(results, { courses, autocomplete });
   });
 
@@ -88,7 +91,7 @@ module('Unit | Service | search', function (hooks) {
     assert.expect(3);
     this.server.get('api/search/v1/users', (schema, { queryParams }) => {
       assert.strictEqual(queryParams.q, 'codejam');
-      assert.strictEqual(parseInt(queryParams.size, 10), 19);
+      assert.strictEqual(Number(queryParams.size), 19);
       assert.strictEqual(queryParams.onlySuggest, 'true');
       return {
         results: {
@@ -99,22 +102,5 @@ module('Unit | Service | search', function (hooks) {
     });
     const service = this.owner.lookup('service:search');
     await service.forUsers('codejam', 19, true);
-  });
-
-  test('test search for curriculum with onlySuggest parameters', async function (assert) {
-    assert.expect(3);
-    this.server.get('api/search/v1/curriculum', (schema, { queryParams }) => {
-      assert.strictEqual(queryParams.q, 'codejam');
-      assert.strictEqual(parseInt(queryParams.size, 10), 1000);
-      assert.strictEqual(queryParams.onlySuggest, 'true');
-      return {
-        results: {
-          courses: [],
-          autocomplete: ['one', 'two'],
-        },
-      };
-    });
-    const service = this.owner.lookup('service:search');
-    await service.forCurriculum('codejam', true);
   });
 });


### PR DESCRIPTION
Align our UI with the new search API in https://github.com/ilios/ilios/pull/6295 where schools and years are part of filtering on the server and not on the frontend, autocomplete is removed, and the API version is bumped.

With this new interface we get much faster search results at a significant performance improvement on Opensearch and much better pagination.