### PR TITLE
Fix Dashboard->Event->LM note alignment

### DIFF
--- a/packages/ilios-common/addon/components/week-glance/learning-material-list-item.gjs
+++ b/packages/ilios-common/addon/components/week-glance/learning-material-list-item.gjs
@@ -94,6 +94,7 @@ import TimedReleaseSchedule from 'ilios-common/components/timed-release-schedule
       {{/if}}
       {{#if @lm.publicNotes}}
         <p class="public-notes" data-test-public-notes>
+          -
           <TruncateText @text={{@lm.publicNotes}} @length={{50}} />
         </p>
       {{/if}}

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance/learning-materials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance/learning-materials.scss
@@ -23,7 +23,7 @@
     }
 
     .public-notes {
-      padding-left: 2em;
+      padding-left: 0.3em;
     }
 
     .timed-release-info {
@@ -31,6 +31,7 @@
     }
 
     .week-glance-learning-material-list-item {
+      align-items: center;
       display: flex;
 
       &.fa-download {

--- a/packages/test-app/tests/integration/components/week-glance-event-test.gjs
+++ b/packages/test-app/tests/integration/components/week-glance-event-test.gjs
@@ -74,7 +74,7 @@ module('Integration | Component | week-glance-event', function (hooks) {
     assert.ok(component.learningMaterials.materials[0].hasCitation);
     assert.strictEqual(component.learningMaterials.materials[0].citation, 'citationtext');
     assert.ok(component.learningMaterials.materials[0].hasPublicNotes);
-    assert.strictEqual(component.learningMaterials.materials[0].publicNotes, 'This is cool.');
+    assert.strictEqual(component.learningMaterials.materials[0].publicNotes, '- This is cool.');
 
     assert.strictEqual(component.learningMaterials.materials[1].title, 'Link LM');
     assert.ok(component.learningMaterials.materials[1].typeIcon.isPresent);
@@ -141,7 +141,7 @@ module('Integration | Component | week-glance-event', function (hooks) {
     assert.ok(component.learningMaterials.materials[0].typeIcon.isPdf);
     assert.notOk(component.learningMaterials.materials[0].hasCitation);
     assert.ok(component.learningMaterials.materials[0].hasPublicNotes);
-    assert.strictEqual(component.learningMaterials.materials[0].publicNotes, 'slide notes');
+    assert.strictEqual(component.learningMaterials.materials[0].publicNotes, '- slide notes');
     assert.strictEqual(
       component.learningMaterials.materials[0].url,
       'http://myhost.com/url1?inline',


### PR DESCRIPTION
Fixes ilios/ilios#5372

Fixed alignment and spacing between link and note (with a `-` for better distinction)