### PR TITLE
Limit Integration a11y Tests

### DIFF
--- a/packages/frontend/tests/helpers/index.js
+++ b/packages/frontend/tests/helpers/index.js
@@ -5,6 +5,7 @@ import {
 } from 'ember-qunit';
 import { setupMirage } from 'frontend/tests/test-support/mirage';
 import { setupIntl } from 'ember-intl/test-support';
+import { setRunOptions } from 'ember-a11y-testing/test-support';
 
 // This file exists to provide wrappers around ember-qunit's
 // test setup functions. This way, you can easily extend the setup that is
@@ -34,6 +35,13 @@ function setupRenderingTest(hooks, options) {
   setupIntl(hooks, 'en-us'); // ember-intl
 
   // Additional setup for rendering tests can be done here.
+
+  setRunOptions({
+    rules: {
+      //disable color-contrast check on integration tests as we don't have a full background or styles
+      'color-contrast': { enabled: false },
+    },
+  });
 }
 
 function setupTest(hooks, options) {


### PR DESCRIPTION
Setting a global run option for all integration tests to disable this color contrast check. For many of our components they're styled in place within the context of other components and inherit those styles and background. This makes tests of the color contrast here fail, we'll rely on acceptance tests to catch this issue.

Refs ilios/ilios#6322