### PR TITLE
Replace Term Picker Interaction

### DIFF
--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-terms-list.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-terms-list.js
@@ -7,7 +7,7 @@ const definition = {
   manage: clickable('[data-test-manage]'),
   terms: collection('.selected-taxonomy-terms li', {
     name: text(),
-    remove: clickable(),
+    remove: clickable('button'),
     isSelected: hasClass('selected'),
     hasDeleteIcon: isPresent('.fa-xmark'),
   }),

--- a/packages/ilios-common/addon/components/detail-terms-list-item.gjs
+++ b/packages/ilios-common/addon/components/detail-terms-list-item.gjs
@@ -4,7 +4,6 @@ import { TrackedAsyncData } from 'ember-async-data';
 import { guidFor } from '@ember/object/internals';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
-import noop from 'ilios-common/helpers/noop';
 import mouseHoverToggle from 'ilios-common/modifiers/mouse-hover-toggle';
 import set from 'ember-set-helper/helpers/set';
 import IliosTooltip from 'ilios-common/components/ilios-tooltip';
@@ -52,37 +51,54 @@ export default class DetailTermsListItem extends Component {
   }
   <template>
     <li
-      {{! template-lint-disable no-invalid-interactive }}
       class="detail-terms-list-item"
-      role={{if @canEdit "button"}}
-      {{on "click" (fn (if @canEdit @remove (noop)) @term)}}
-      {{mouseHoverToggle (set this "isHovering")}}
       id={{this.detailTermsListItemId}}
+      {{mouseHoverToggle (set this "isHovering")}}
     >
-      {{#if this.showTooltip}}
-        <IliosTooltip @target={{this.detailTermsListItemElement}}>
-          {{@term.description}}
-        </IliosTooltip>
-      {{/if}}
-      {{#if @term.isTopLevel}}
-        {{@term.title}}
-      {{else}}
-        {{#each this.allParentTitles as |title|}}
-          {{! template-lint-disable no-bare-strings}}
-          <span class="muted">
-            {{title}}
-            &raquo;&nbsp;
-          </span>
-        {{/each}}
-        {{@term.title}}
-      {{/if}}
-      {{#unless @term.active}}
-        <span class="inactive">
-          ({{t "general.inactive"}})
-        </span>
-      {{/unless}}
       {{#if @canEdit}}
-        <FaIcon @icon="xmark" class="remove" />
+        {{#if this.showTooltip}}
+          <IliosTooltip @target={{this.detailTermsListItemElement}}>
+            {{@term.description}}
+          </IliosTooltip>
+        {{/if}}
+        <button type="button" {{on "click" (fn @remove @term)}}>
+          {{#if @term.isTopLevel}}
+            {{@term.title}}
+          {{else}}
+            {{#each this.allParentTitles as |title|}}
+              {{! template-lint-disable no-bare-strings}}
+              <span class="muted">
+                {{title}}
+                &raquo;&nbsp;
+              </span>
+            {{/each}}
+            {{@term.title}}
+          {{/if}}
+          {{#unless @term.active}}
+            <span class="inactive">
+              ({{t "general.inactive"}})
+            </span>
+          {{/unless}}
+          <FaIcon @icon="xmark" class="remove" />
+        </button>
+      {{else}}
+        {{#if @term.isTopLevel}}
+          {{@term.title}}
+        {{else}}
+          {{#each this.allParentTitles as |title|}}
+            {{! template-lint-disable no-bare-strings}}
+            <span class="muted">
+              {{title}}
+              &raquo;&nbsp;
+            </span>
+          {{/each}}
+          {{@term.title}}
+        {{/if}}
+        {{#unless @term.active}}
+          <span class="inactive">
+            ({{t "general.inactive"}})
+          </span>
+        {{/unless}}
       {{/if}}
     </li>
   </template>

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
@@ -1,5 +1,6 @@
 @use "../colors" as c;
 @use "../mixins" as m;
+@use "../constants" as constants;
 
 @use "sass:color";
 
@@ -16,10 +17,16 @@
     button {
       background-color: c.$culturedGrey;
       color: c.$raisinBlack;
+      padding: calc(constants.$golden-ratio-small * 0.5rem)
+        calc(constants.$golden-ratio-large * 0.5rem);
     }
 
     &.removable-list {
       @include m.ilios-removable-list;
+
+      li {
+        padding: 0;
+      }
     }
 
     .muted {


### PR DESCRIPTION
Tying a click to a list item isn't a good idea, replaced everything with buttons more suited to the purpose.