### PR TITLE
Adjust Course Year Header Level

### DIFF
--- a/packages/ilios-common/addon/components/course/header.gjs
+++ b/packages/ilios-common/addon/components/course/header.gjs
@@ -84,9 +84,9 @@ export default class CourseHeaderComponent extends Component {
           </h2>
         {{/if}}
         {{#unless this.isEditingTitle}}
-          <h3 class="academic-year" data-test-academic-year>
+          <h2 class="academic-year" data-test-academic-year>
             {{@academicYear}}
-          </h3>
+          </h2>
         {{/unless}}
       </span>
       <div class="course-publication">

--- a/packages/ilios-common/app/styles/ilios-common/mixins/course/header.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/course/header.scss
@@ -18,8 +18,7 @@
     height: 2rem;
   }
 
-  h2,
-  h3 {
+  h2 {
     @include ilios-heading.ilios-heading-h4;
     @include font-size.text-align-bottom;
   }


### PR DESCRIPTION
When the course is editable we lose the h2 for the course title and end up with a span. This probably requires a complete re-write of editable field to fix well, but for now upping the year to also be an h2 ensures we don't skip a header level.