### PR TITLE
Fully Engage a11y Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [lint]
-
+    env:
+      ENABLE_A11Y_AUDIT: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,23 +30,3 @@ jobs:
         run: pnpm --filter ${{ matrix.workspace }} exec percy exec -- ember test --filter="Acceptance"
         env:
           PERCY_TOKEN: "web_1899a9764a4891f3a19b87e52aa1ae038359e28ba550daa6bad00d0e0a230a33"
-  a11y:
-    name: Run Accessibility Tests
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        workspace:
-          - frontend
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install
-      - name: Run Tests With Accessibility A11y Audit
-        run: pnpm run test:frontend
-        env:
-          ENABLE_A11Y_AUDIT: true


### PR DESCRIPTION
Added the configuration to the test-app and activated these tests in CI.

Fixes ilios/ilios#6322

Todo:
- [x] Ensure we get tests failures, not everything is fixed yet
- [x] Fix remaining tests and rebase
- [x] Party!