### PR TITLE
adds wrapper element around validation error messages 

### DIFF
--- a/packages/ilios-common/addon/components/yup-validation-message.gjs
+++ b/packages/ilios-common/addon/components/yup-validation-message.gjs
@@ -27,10 +27,14 @@ export default class YupValidationMessage extends Component {
     return [];
   }
   <template>
-    {{#each this.messages as |m|}}
-      <span class="validation-error-message" data-test-validation-error-message ...attributes>
-        {{m}}
+    {{#if this.messages.length}}
+      <span ...attributes>
+        {{#each this.messages as |m|}}
+          <span class="validation-error-message" data-test-validation-error-message>
+            {{m}}
+          </span>
+        {{/each}}
       </span>
-    {{/each}}
+    {{/if}}
   </template>
 }


### PR DESCRIPTION
… , and target it with splattributes.

we need to do this dance in order to assign an element id to a block of messages.
having the ability to assign an id allows us to tether form inputs to their corresponding validation error messages in an accessible manner, via "aria-errormessage" attribute.

for reference please see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-errormessage

refs https://github.com/ilios/frontend/pull/8635