### PR TITLE
 display courses associated with instructor groups in new component

### DIFF
--- a/packages/frontend/app/components/instructor-group/course-associations.gjs
+++ b/packages/frontend/app/components/instructor-group/course-associations.gjs
@@ -1,0 +1,228 @@
+import Component from '@glimmer/component';
+import { cached, tracked } from '@glimmer/tracking';
+import { array, fn, uniqueId } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
+import { TrackedAsyncData } from 'ember-async-data';
+import t from 'ember-intl/helpers/t';
+import add from 'ember-math-helpers/helpers/add';
+import eq from 'ember-truth-helpers/helpers/eq';
+import or from 'ember-truth-helpers/helpers/or';
+import FaIcon from 'ilios-common/components/fa-icon';
+import SortableTh from 'ilios-common/components/sortable-th';
+import sortBy from 'ilios-common/helpers/sort-by';
+import { mapBy, uniqueValues } from 'ilios-common/utils/array-helpers';
+
+export default class InstructorGroupCourseAssociationsComponent extends Component {
+  @service iliosConfig;
+  @service intl;
+  @tracked sortBy = 'school';
+
+  crossesBoundaryConfig = new TrackedAsyncData(
+    this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
+  );
+
+  @cached
+  get academicYearCrossesCalendarYearBoundaries() {
+    return this.crossesBoundaryConfig.isResolved ? this.crossesBoundaryConfig.value : false;
+  }
+
+  get sortedAscending() {
+    return !this.sortBy.includes(':desc');
+  }
+
+  @action
+  setSortBy(what) {
+    if (this.sortBy === what) {
+      what += ':desc';
+    }
+    this.sortBy = what;
+  }
+
+  @action
+  sortAssociations(a, b) {
+    const locale = this.intl.get('primaryLocale');
+    switch (this.sortBy) {
+      case 'school':
+        return a.school.title.localeCompare(b.school.title, locale);
+      case 'school:desc':
+        return b.school.title.localeCompare(a.school.title, locale);
+      case 'course':
+        return a.course.title.localeCompare(b.course.title, locale);
+      case 'course:desc':
+        return b.course.title.localeCompare(a.course.title, locale);
+    }
+    return 0;
+  }
+
+  @cached
+  get associationsData() {
+    return new TrackedAsyncData(this.getAssociations(this.args.instructorGroup));
+  }
+
+  get associations() {
+    return this.associationsData.isResolved ? this.associationsData.value : [];
+  }
+
+  get hasAssociations() {
+    return !!this.associations.length;
+  }
+
+  get isLoaded() {
+    return this.associationsData.isResolved;
+  }
+
+  async getAssociations(instructorGroup) {
+    // get sessions from the offerings and ILMs associated with the given instructor group.
+    const offerings = await instructorGroup.offerings;
+    const ilms = await instructorGroup.ilmSessions;
+    const arr = [...offerings, ...ilms];
+    const sessions = await Promise.all(mapBy(arr, 'session'));
+    const uniqueSessions = uniqueValues(sessions);
+
+    // add owning courses and school to their sessions
+    const sessionsWithCourseAndSchool = await Promise.all(
+      uniqueSessions.map(async (session) => {
+        const course = await session.course;
+        const school = await course.school;
+        return { session, course, school };
+      }),
+    );
+    // group these sessions by their owning courses
+    const map = new Map();
+    sessionsWithCourseAndSchool.forEach(({ session, course, school }) => {
+      if (!map.has(course.id)) {
+        map.set(course.id, {
+          course,
+          school,
+          sessions: [],
+        });
+      }
+      map.get(course.id).sessions.push(session);
+    });
+    // convert map into an array.
+    const rhett = [...map.values()];
+
+    // sort sessions by title in each data object, then return the list of objects.
+    const locale = this.intl.get('primaryLocale');
+    return rhett.map((obj) => {
+      obj.sessions.sort((a, b) => {
+        return a.title.localeCompare(b.title, locale);
+      });
+      return obj;
+    });
+  }
+
+  <template>
+    {{#let (uniqueId) as |templateId|}}
+      <section
+        class="instructor-group-course-associations"
+        data-test-instructor-group-course-associations
+      >
+        {{#if this.isLoaded}}
+          <div class="header" data-test-header>
+            <h2 class="title" data-test-title>
+              {{#if this.hasAssociations}}
+                {{#if @isExpanded}}
+                  <button
+                    class="title link-button"
+                    type="button"
+                    aria-expanded="true"
+                    aria-controls="content-{{templateId}}"
+                    aria-label={{t "general.hideAssociatedCourses"}}
+                    data-test-toggle
+                    {{on "click" (fn @setIsExpanded false)}}
+                  >
+                    {{t "general.associatedCourses"}}
+                    ({{this.associations.length}})
+                    <FaIcon @icon="caret-down" />
+                  </button>
+                {{else}}
+                  <button
+                    class="title link-button"
+                    type="button"
+                    aria-expanded="false"
+                    aria-controls="content-{{templateId}}"
+                    aria-label={{t "general.showAssociatedCourses"}}
+                    data-test-toggle
+                    {{on "click" (fn @setIsExpanded true)}}
+                  >
+                    {{t "general.associatedCourses"}}
+                    ({{this.associations.length}})
+                    <FaIcon @icon="caret-right" />
+                  </button>
+                {{/if}}
+              {{else}}
+                {{t "general.associatedCourses"}}
+                ({{this.associations.length}})
+              {{/if}}
+            </h2>
+          </div>
+          {{#if this.hasAssociations}}
+            <div
+              id="content-{{templateId}}"
+              class="content{{if @isExpanded '' ' hidden'}}"
+              data-test-content
+              hidden={{@isExpanded}}
+            >
+              <table data-test-associations>
+                <thead>
+                  <tr>
+                    <SortableTh
+                      @sortedAscending={{this.sortedAscending}}
+                      @onClick={{fn this.setSortBy "school"}}
+                      @sortedBy={{or (eq this.sortBy "school") (eq this.sortBy "school:desc")}}
+                    >
+                      {{t "general.school"}}
+                    </SortableTh>
+                    <SortableTh
+                      colspan="3"
+                      @sortedAscending={{this.sortedAscending}}
+                      @onClick={{fn this.setSortBy "course"}}
+                      @sortedBy={{or (eq this.sortBy "course") (eq this.sortBy "course:desc")}}
+                    >
+                      {{t "general.course"}}
+                    </SortableTh>
+                    <th colspan="3">{{t "general.sessions"}}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {{#each (sortBy this.sortAssociations this.associations) as |association|}}
+                    <tr>
+                      <td>{{association.school.title}}</td>
+                      <td colspan="3">
+                        <LinkTo @route="course" @model={{association.course}}>
+                          {{association.course.title}}
+                          {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                            ({{association.course.year}}
+                            -
+                            {{add association.course.year 1}})
+                          {{else}}
+                            ({{association.course.year}})
+                          {{/if}}
+                        </LinkTo>
+                      </td>
+                      <td colspan="3">
+                        <ul class="sessions-list">
+                          {{#each association.sessions as |session|}}
+                            <li data-test-session>
+                              <LinkTo @route="session" @models={{array session.course session}}>
+                                {{session.title}}
+                              </LinkTo>
+                            </li>
+                          {{/each}}
+                        </ul>
+                      </td>
+                    </tr>
+                  {{/each}}
+                </tbody>
+              </table>
+            </div>
+          {{/if}}
+        {{/if}}
+      </section>
+    {{/let}}
+  </template>
+}

--- a/packages/frontend/app/styles/components.scss
+++ b/packages/frontend/app/styles/components.scss
@@ -86,6 +86,7 @@
 @forward "components/learner-groups/loading";
 
 @forward "components/instructor-group/courses";
+@forward "components/instructor-group/course-associations";
 @forward "components/instructor-group/header";
 @forward "components/instructor-group/instructor-manager";
 @forward "components/instructor-group/root";

--- a/packages/frontend/app/styles/components/instructor-group/course-associations.scss
+++ b/packages/frontend/app/styles/components/instructor-group/course-associations.scss
@@ -1,0 +1,33 @@
+@use "../../ilios-common/colors" as c;
+@use "../../ilios-common/mixins" as m;
+
+.instructor-group-course-associations {
+  @include m.detail-container-content;
+  border-top: 1px dotted (var(--orange));
+
+  .header {
+    @include m.detail-container-header;
+
+    .title {
+      @include m.collapsed-container-title;
+    }
+  }
+
+  .content {
+    @include m.main-list-box-table;
+
+    &.hidden {
+      display: none;
+    }
+
+    .sessions-list {
+      @include m.ilios-list-reset;
+    }
+
+    tbody {
+      td {
+        vertical-align: top;
+      }
+    }
+  }
+}

--- a/packages/frontend/tests/integration/components/instructor-group/course-associations-test.gjs
+++ b/packages/frontend/tests/integration/components/instructor-group/course-associations-test.gjs
@@ -1,0 +1,324 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend/tests/helpers';
+import { setupMirage } from 'frontend/tests/test-support/mirage';
+import { render } from '@ember/test-helpers';
+import { component } from 'frontend/tests/pages/components/instructor-group/course-associations';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import CourseAssociations from 'frontend/components/instructor-group/course-associations';
+import noop from 'ilios-common/helpers/noop';
+
+module('Integration | Component | instructor-group/course-associations', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    this.instructorGroup = this.server.create('instructor-group');
+  });
+
+  test('it renders expanded with data', async function (assert) {
+    const schools = this.server.createList('school', 2);
+    const coursesInSchool1 = this.server.createList('course', 2, {
+      school: schools[0],
+      year: 2025,
+    });
+    const courseInSchool2 = this.server.create('course', { school: schools[1], year: 2025 });
+    const sessionInCourse1 = this.server.create('session', { course: coursesInSchool1[0] });
+    const sessionsInCourse2 = this.server.createList('session', 2, { course: coursesInSchool1[1] });
+    const sessionInCourse3 = this.server.create('session', { course: courseInSchool2 });
+    this.server.create('ilmSession', {
+      session: sessionsInCourse2[0],
+      instructorGroups: [this.instructorGroup],
+    });
+    this.server.create('ilmSession', {
+      session: sessionInCourse3,
+      instructorGroups: [this.instructorGroup],
+    });
+    this.server.createList('offering', 2, {
+      session: sessionsInCourse2[0],
+      instructorGroups: [this.instructorGroup],
+    });
+    this.server.createList('offering', 2, {
+      session: sessionsInCourse2[1],
+      instructorGroups: [this.instructorGroup],
+    });
+    this.server.createList('offering', 2, {
+      session: sessionInCourse1,
+      instructorGroups: [this.instructorGroup],
+    });
+
+    const instructorGroup = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', this.instructorGroup.id);
+    this.set('instructorGroup', instructorGroup);
+    await render(
+      <template>
+        <CourseAssociations
+          @instructorGroup={{this.instructorGroup}}
+          @isExpanded={{true}}
+          @setIsExpanded={{(noop)}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(component.header.toggle.ariaControls, component.content.id);
+    assert.notOk(component.header.toggle.isCollapsed);
+    assert.ok(component.header.toggle.isExpanded);
+    assert.strictEqual(component.header.toggle.ariaExpanded, 'true');
+    assert.strictEqual(component.header.toggle.ariaLabel, 'Hide associated courses');
+    assert.notOk(component.content.isHidden);
+    assert.strictEqual(component.header.title, 'Associated Courses (3)');
+
+    assert.strictEqual(component.content.headers.school.text, 'School');
+    assert.strictEqual(component.content.headers.course.text, 'Course');
+    assert.strictEqual(component.content.headers.sessions.text, 'Sessions');
+
+    assert.strictEqual(component.content.associations.length, 3);
+    assert.strictEqual(component.content.associations[0].school, 'school 0');
+    assert.strictEqual(component.content.associations[0].course.text, 'course 1 (2025)');
+    assert.strictEqual(component.content.associations[0].course.link, '/courses/2');
+    assert.strictEqual(component.content.associations[0].sessions.length, 2);
+    assert.strictEqual(component.content.associations[0].sessions[0].text, 'session 1');
+    assert.strictEqual(component.content.associations[0].sessions[0].link, '/courses/2/sessions/2');
+    assert.strictEqual(component.content.associations[0].sessions[1].text, 'session 2');
+    assert.strictEqual(component.content.associations[0].sessions[1].link, '/courses/2/sessions/3');
+    assert.strictEqual(component.content.associations[1].school, 'school 0');
+    assert.strictEqual(component.content.associations[1].course.text, 'course 0 (2025)');
+    assert.strictEqual(component.content.associations[1].course.link, '/courses/1');
+    assert.strictEqual(component.content.associations[1].sessions.length, 1);
+    assert.strictEqual(component.content.associations[1].sessions[0].text, 'session 0');
+    assert.strictEqual(component.content.associations[1].sessions[0].link, '/courses/1/sessions/1');
+    assert.strictEqual(component.content.associations[2].school, 'school 1');
+    assert.strictEqual(component.content.associations[2].course.text, 'course 2 (2025)');
+    assert.strictEqual(component.content.associations[2].course.link, '/courses/3');
+    assert.strictEqual(component.content.associations[2].sessions.length, 1);
+    assert.strictEqual(component.content.associations[2].sessions[0].text, 'session 3');
+    assert.strictEqual(component.content.associations[2].sessions[0].link, '/courses/3/sessions/4');
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders collapsed with data', async function (assert) {
+    const schools = this.server.createList('school', 2);
+    const coursesInSchool1 = this.server.createList('course', 2, {
+      school: schools[0],
+      year: 2025,
+    });
+    const courseInSchool2 = this.server.create('course', { school: schools[1], year: 2025 });
+    const sessionInCourse1 = this.server.create('session', { course: coursesInSchool1[0] });
+    const sessionsInCourse2 = this.server.createList('session', 2, { course: coursesInSchool1[1] });
+    const sessionInCourse3 = this.server.create('session', { course: courseInSchool2 });
+    this.server.create('ilmSession', {
+      session: sessionsInCourse2[0],
+      instructorGroups: [this.instructorGroup],
+    });
+    this.server.create('ilmSession', {
+      session: sessionInCourse3,
+      instructorGroups: [this.instructorGroup],
+    });
+    this.server.createList('offering', 2, {
+      session: sessionsInCourse2[0],
+      instructorGroups: [this.instructorGroup],
+    });
+    this.server.createList('offering', 2, {
+      session: sessionsInCourse2[1],
+      instructorGroups: [this.instructorGroup],
+    });
+    this.server.createList('offering', 2, {
+      session: sessionInCourse1,
+      instructorGroups: [this.instructorGroup],
+    });
+
+    const instructorGroup = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', this.instructorGroup.id);
+    this.set('instructorGroup', instructorGroup);
+    await render(
+      <template>
+        <CourseAssociations
+          @instructorGroup={{this.instructorGroup}}
+          @isExpanded={{false}}
+          @setIsExpanded={{(noop)}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(component.header.toggle.ariaControls, component.content.id);
+    assert.ok(component.header.toggle.isCollapsed);
+    assert.notOk(component.header.toggle.isExpanded);
+    assert.strictEqual(component.header.toggle.ariaExpanded, 'false');
+    assert.strictEqual(component.header.toggle.ariaLabel, 'Show associated courses');
+    assert.ok(component.content.isHidden);
+    assert.strictEqual(component.header.title, 'Associated Courses (3)');
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders without data', async function (assert) {
+    const instructorGroup = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', this.instructorGroup.id);
+    this.set('instructorGroup', instructorGroup);
+    await render(
+      <template><CourseAssociations @instructorGroup={{this.instructorGroup}} /></template>,
+    );
+
+    assert.notOk(component.header.toggle.isPresent);
+    assert.strictEqual(component.header.title, 'Associated Courses (0)');
+    assert.notOk(component.content.isPresent);
+  });
+
+  test('sorting works', async function (assert) {
+    const schools = this.server.createList('school', 2);
+    const course1 = this.server.create('course', { school: schools[0], year: 2025 });
+    const course2 = this.server.create('course', { school: schools[1], year: 2025 });
+    const session1 = this.server.create('session', { course: course1 });
+    const session2 = this.server.create('session', { course: course2 });
+    this.server.create('offering', { session: session1, instructorGroups: [this.instructorGroup] });
+    this.server.create('offering', { session: session2, instructorGroups: [this.instructorGroup] });
+    const instructorGroup = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', this.instructorGroup.id);
+    this.set('instructorGroup', instructorGroup);
+    await render(
+      <template>
+        <CourseAssociations
+          @instructorGroup={{this.instructorGroup}}
+          @isExpanded={{true}}
+          @setIsExpanded={{(noop)}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(component.content.associations.length, 2);
+    assert.ok(component.content.headers.school.isSortedAscending);
+    assert.ok(component.content.headers.course.isNotSorted);
+    assert.strictEqual(component.content.associations[0].school, 'school 0');
+    assert.strictEqual(component.content.associations[0].course.text, 'course 0 (2025)');
+    assert.strictEqual(component.content.associations[1].school, 'school 1');
+    assert.strictEqual(component.content.associations[1].course.text, 'course 1 (2025)');
+
+    await component.content.headers.school.sort();
+    assert.ok(component.content.headers.school.isSortedDescending);
+    assert.ok(component.content.headers.course.isNotSorted);
+    assert.strictEqual(component.content.associations[0].school, 'school 1');
+    assert.strictEqual(component.content.associations[0].course.text, 'course 1 (2025)');
+    assert.strictEqual(component.content.associations[1].school, 'school 0');
+    assert.strictEqual(component.content.associations[1].course.text, 'course 0 (2025)');
+
+    await component.content.headers.school.sort();
+    assert.ok(component.content.headers.school.isSortedAscending);
+    assert.ok(component.content.headers.course.isNotSorted);
+    assert.strictEqual(component.content.associations[0].school, 'school 0');
+    assert.strictEqual(component.content.associations[0].course.text, 'course 0 (2025)');
+    assert.strictEqual(component.content.associations[1].school, 'school 1');
+    assert.strictEqual(component.content.associations[1].course.text, 'course 1 (2025)');
+
+    await component.content.headers.course.sort();
+    assert.ok(component.content.headers.school.isNotSorted);
+    assert.ok(component.content.headers.course.isSortedAscending);
+    assert.strictEqual(component.content.associations[0].school, 'school 0');
+    assert.strictEqual(component.content.associations[0].course.text, 'course 0 (2025)');
+    assert.strictEqual(component.content.associations[1].school, 'school 1');
+    assert.strictEqual(component.content.associations[1].course.text, 'course 1 (2025)');
+
+    await component.content.headers.course.sort();
+    assert.ok(component.content.headers.school.isNotSorted);
+    assert.ok(component.content.headers.course.isSortedDescending);
+    assert.strictEqual(component.content.associations[0].school, 'school 1');
+    assert.strictEqual(component.content.associations[0].course.text, 'course 1 (2025)');
+    assert.strictEqual(component.content.associations[1].school, 'school 0');
+    assert.strictEqual(component.content.associations[1].course.text, 'course 0 (2025)');
+
+    await component.content.headers.course.sort();
+    assert.ok(component.content.headers.school.isNotSorted);
+    assert.ok(component.content.headers.course.isSortedAscending);
+    assert.strictEqual(component.content.associations[0].school, 'school 0');
+    assert.strictEqual(component.content.associations[0].course.text, 'course 0 (2025)');
+    assert.strictEqual(component.content.associations[1].school, 'school 1');
+    assert.strictEqual(component.content.associations[1].course.text, 'course 1 (2025)');
+  });
+
+  test('crossing academic year boundaries is correctly reflected', async function (assert) {
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school, year: 2025 });
+    const session = this.server.create('session', { course });
+    this.server.create('offering', { session, instructorGroups: [this.instructorGroup] });
+    const instructorGroup = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', this.instructorGroup.id);
+    this.set('instructorGroup', instructorGroup);
+    const { apiVersion } = this.owner.resolveRegistration('config:environment');
+    this.server.get('application/config', function () {
+      return {
+        config: {
+          academicYearCrossesCalendarYearBoundaries: true,
+          apiVersion,
+        },
+      };
+    });
+    await render(
+      <template>
+        <CourseAssociations
+          @instructorGroup={{this.instructorGroup}}
+          @isExpanded={{true}}
+          @setIsExpanded={{(noop)}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(component.content.associations.length, 1);
+    assert.strictEqual(component.content.associations[0].course.text, 'course 0 (2025 - 2026)');
+  });
+
+  test('collapse action fires', async function (assert) {
+    assert.expect(1);
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school, year: 2025 });
+    const session = this.server.create('session', { course });
+    this.server.create('offering', { session, instructorGroups: [this.instructorGroup] });
+    const instructorGroup = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', this.instructorGroup.id);
+    this.set('instructorGroup', instructorGroup);
+    this.set('setIsExpanded', (value) => {
+      assert.notOk(value);
+    });
+    await render(
+      <template>
+        <CourseAssociations
+          @instructorGroup={{this.instructorGroup}}
+          @isExpanded={{true}}
+          @setIsExpanded={{this.setIsExpanded}}
+        />
+      </template>,
+    );
+
+    await component.header.toggle.click();
+  });
+
+  test('expand action fires', async function (assert) {
+    assert.expect(1);
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school, year: 2025 });
+    const session = this.server.create('session', { course });
+    this.server.create('offering', { session, instructorGroups: [this.instructorGroup] });
+    const instructorGroup = await this.owner
+      .lookup('service:store')
+      .findRecord('instructor-group', this.instructorGroup.id);
+    this.set('instructorGroup', instructorGroup);
+    this.set('setIsExpanded', (value) => {
+      assert.ok(value);
+    });
+    await render(
+      <template>
+        <CourseAssociations
+          @instructorGroup={{this.instructorGroup}}
+          @isExpanded={{false}}
+          @setIsExpanded={{this.setIsExpanded}}
+        />
+      </template>,
+    );
+
+    await component.header.toggle.click();
+  });
+});

--- a/packages/frontend/tests/pages/components/instructor-group/course-associations.js
+++ b/packages/frontend/tests/pages/components/instructor-group/course-associations.js
@@ -1,0 +1,63 @@
+import {
+  attribute,
+  clickable,
+  collection,
+  create,
+  hasClass,
+  isPresent,
+  text,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-instructor-group-course-associations]',
+  header: {
+    scope: '[data-test-header]',
+    title: text('[data-test-title]'),
+    toggle: {
+      scope: '[data-test-toggle]',
+      isCollapsed: isPresent('[data-icon="caret-right"]'),
+      isExpanded: isPresent('[data-icon="caret-down"]'),
+      ariaExpanded: attribute('aria-expanded'),
+      ariaControls: attribute('aria-controls'),
+      ariaLabel: attribute('aria-label'),
+    },
+  },
+  content: {
+    scope: '[data-test-content]',
+    id: attribute('id'),
+    isHidden: hasClass('hidden'),
+    headers: {
+      scope: '[data-test-associations] thead tr:nth-of-type(1)',
+      school: {
+        scope: 'th:nth-of-type(1)',
+        isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
+        isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
+        isNotSorted: hasClass('fa-sort', 'svg'),
+        sort: clickable('button'),
+      },
+      course: {
+        scope: 'th:nth-of-type(2)',
+        isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
+        isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
+        isNotSorted: hasClass('fa-sort', 'svg'),
+        sort: clickable('button'),
+      },
+      sessions: {
+        scope: 'th:nth-of-type(3)',
+      },
+    },
+    associations: collection('[data-test-associations] tbody tr', {
+      school: text('td:nth-of-type(1)'),
+      course: {
+        scope: 'td:nth-of-type(2)',
+        link: attribute('href', 'a'),
+      },
+      sessions: collection('td:nth-of-type(3) [data-test-session]', {
+        link: attribute('href', 'a'),
+      }),
+    }),
+  },
+};
+
+export default definition;
+export const component = create(definition);


### PR DESCRIPTION
replaces the current component that lists associated courses with a new one that's modeled after the one used for learner group management.

refs https://github.com/ilios/frontend/pull/8644