### PR TITLE
Avoid Empty Competency List

### DIFF
--- a/packages/ilios-common/addon/components/detail-competencies.gjs
+++ b/packages/ilios-common/addon/components/detail-competencies.gjs
@@ -48,13 +48,15 @@ export default class DetailCompetenciesComponent extends Component {
             {{#each @course.domainsWithSubcompetencies as |domain|}}
               <li data-test-domain>
                 {{domain.title}}
-                <ul>
-                  {{#each domain.subCompetencies as |competency|}}
-                    <li data-test-competency>
-                      {{competency.title}}
-                    </li>
-                  {{/each}}
-                </ul>
+                {{#if domain.subCompetencies}}
+                  <ul>
+                    {{#each domain.subCompetencies as |competency|}}
+                      <li data-test-competency>
+                        {{competency.title}}
+                      </li>
+                    {{/each}}
+                  </ul>
+                {{/if}}
               </li>
             {{/each}}
           </ul>

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -189,13 +189,15 @@ export default class PrintCourseComponent extends Component {
               {{#each @course.domainsWithSubcompetencies as |domain|}}
                 <li>
                   {{domain.title}}
-                  <ul>
-                    {{#each domain.subCompetencies as |competency|}}
-                      <li>
-                        {{competency.title}}
-                      </li>
-                    {{/each}}
-                  </ul>
+                  {{#if domain.subCompetencies}}
+                    <ul>
+                      {{#each domain.subCompetencies as |competency|}}
+                        <li>
+                          {{competency.title}}
+                        </li>
+                      {{/each}}
+                    </ul>
+                  {{/if}}
                 </li>
               {{/each}}
             </ul>


### PR DESCRIPTION
For a11y we don't want lists with no elements so check for on competencies if we need to create the ul element at all.