### PR TITLE
Hide Empty Materials Lists

### DIFF
--- a/packages/ilios-common/addon/components/week-glance/learning-material-list.gjs
+++ b/packages/ilios-common/addon/components/week-glance/learning-material-list.gjs
@@ -12,31 +12,35 @@ import LearningMaterialListItem from 'ilios-common/components/week-glance/learni
             <LinkTo @route="events" @model={{event.slug}}>
               {{event.name}}
             </LinkTo>
-            <ul>
-              {{#each event.learningMaterials as |lm index|}}
-                <LearningMaterialListItem
-                  @event={{@event}}
-                  @lm={{lm}}
-                  @index={{index}}
-                  @showLink={{false}}
-                  data-test-prework-learning-material
-                />
-              {{/each}}
-            </ul>
+            {{#if event.learningMaterials}}
+              <ul>
+                {{#each event.learningMaterials as |lm index|}}
+                  <LearningMaterialListItem
+                    @event={{@event}}
+                    @lm={{lm}}
+                    @index={{index}}
+                    @showLink={{false}}
+                    data-test-prework-learning-material
+                  />
+                {{/each}}
+              </ul>
+            {{/if}}
           </li>
         {{/each}}
       </ul>
     {{/if}}
-    <ul>
-      {{#each @learningMaterials as |lm index|}}
-        <LearningMaterialListItem
-          @event={{@event}}
-          @lm={{lm}}
-          @index={{index}}
-          @showLink={{true}}
-          data-test-learning-material
-        />
-      {{/each}}
-    </ul>
+    {{#if @learningMaterials}}
+      <ul>
+        {{#each @learningMaterials as |lm index|}}
+          <LearningMaterialListItem
+            @event={{@event}}
+            @lm={{lm}}
+            @index={{index}}
+            @showLink={{true}}
+            data-test-learning-material
+          />
+        {{/each}}
+      </ul>
+    {{/if}}
   </div>
 </template>


### PR DESCRIPTION
For a11y we shouldn't output an empty list, check to be sure there is content first.