### PR TITLE
check if user is authenticated in session before checking user permissions.

### DIFF
--- a/packages/frontend/app/routes/courses.js
+++ b/packages/frontend/app/routes/courses.js
@@ -17,7 +17,7 @@ export default class CoursesRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       // Slash on the route name is necessary here due to this bug:
       // https://github.com/emberjs/ember.js/issues/12945
       this.router.replaceWith('/four-oh-four');

--- a/packages/frontend/app/routes/courses.js
+++ b/packages/frontend/app/routes/courses.js
@@ -16,12 +16,7 @@ export default class CoursesRoute extends Route {
   };
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      // Slash on the route name is necessary here due to this bug:
-      // https://github.com/emberjs/ember.js/issues/12945
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 
   async model() {

--- a/packages/frontend/app/routes/reports.js
+++ b/packages/frontend/app/routes/reports.js
@@ -8,7 +8,7 @@ export default class ReportsRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       // Slash on the route name is necessary here due to this bug:
       // https://github.com/emberjs/ember.js/issues/12945
       this.router.replaceWith('/four-oh-four');

--- a/packages/frontend/app/routes/reports.js
+++ b/packages/frontend/app/routes/reports.js
@@ -7,11 +7,6 @@ export default class ReportsRoute extends Route {
   @service session;
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      // Slash on the route name is necessary here due to this bug:
-      // https://github.com/emberjs/ember.js/issues/12945
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/frontend/app/routes/reports/curriculum.js
+++ b/packages/frontend/app/routes/reports/curriculum.js
@@ -16,12 +16,7 @@ export default class ReportsCurriculumRoute extends Route {
   };
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      // Slash on the route name is necessary here due to this bug:
-      // https://github.com/emberjs/ember.js/issues/12945
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 
   async model() {

--- a/packages/frontend/app/routes/reports/curriculum.js
+++ b/packages/frontend/app/routes/reports/curriculum.js
@@ -17,7 +17,7 @@ export default class ReportsCurriculumRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       // Slash on the route name is necessary here due to this bug:
       // https://github.com/emberjs/ember.js/issues/12945
       this.router.replaceWith('/four-oh-four');

--- a/packages/frontend/app/routes/reports/index.js
+++ b/packages/frontend/app/routes/reports/index.js
@@ -8,7 +8,7 @@ export default class ReportsIndexRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       // Slash on the route name is necessary here due to this bug:
       // https://github.com/emberjs/ember.js/issues/12945
       this.router.replaceWith('/four-oh-four');

--- a/packages/frontend/app/routes/reports/index.js
+++ b/packages/frontend/app/routes/reports/index.js
@@ -7,12 +7,8 @@ export default class ReportsIndexRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      // Slash on the route name is necessary here due to this bug:
-      // https://github.com/emberjs/ember.js/issues/12945
-      this.router.replaceWith('/four-oh-four');
+    if (this.currentUser.requireNonLearner(transition)) {
+      this.router.replaceWith('reports.subjects');
     }
-    this.router.replaceWith('reports.subjects');
   }
 }

--- a/packages/frontend/app/routes/reports/subject.js
+++ b/packages/frontend/app/routes/reports/subject.js
@@ -9,12 +9,7 @@ export default class ReportsSubjectRoute extends Route {
   @service store;
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      // Slash on the route name is necessary here due to this bug:
-      // https://github.com/emberjs/ember.js/issues/12945
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 
   model(params) {

--- a/packages/frontend/app/routes/reports/subject.js
+++ b/packages/frontend/app/routes/reports/subject.js
@@ -10,7 +10,7 @@ export default class ReportsSubjectRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       // Slash on the route name is necessary here due to this bug:
       // https://github.com/emberjs/ember.js/issues/12945
       this.router.replaceWith('/four-oh-four');

--- a/packages/frontend/app/routes/reports/subjects.js
+++ b/packages/frontend/app/routes/reports/subjects.js
@@ -7,11 +7,6 @@ export default class ReportsSubjectsRoute extends Route {
   @service session;
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      // Slash on the route name is necessary here due to this bug:
-      // https://github.com/emberjs/ember.js/issues/12945
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/frontend/app/routes/reports/subjects.js
+++ b/packages/frontend/app/routes/reports/subjects.js
@@ -8,7 +8,7 @@ export default class ReportsSubjectsRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       // Slash on the route name is necessary here due to this bug:
       // https://github.com/emberjs/ember.js/issues/12945
       this.router.replaceWith('/four-oh-four');

--- a/packages/ilios-common/addon/routes/course-materials.js
+++ b/packages/ilios-common/addon/routes/course-materials.js
@@ -24,7 +24,7 @@ export default class CourseMaterialsRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course-materials.js
+++ b/packages/ilios-common/addon/routes/course-materials.js
@@ -23,10 +23,7 @@ export default class CourseMaterialsRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 
   async loadCourseLearningMaterials(course) {

--- a/packages/ilios-common/addon/routes/course-visualizations.js
+++ b/packages/ilios-common/addon/routes/course-visualizations.js
@@ -60,9 +60,6 @@ export default class CourseVisualizationsRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualizations.js
+++ b/packages/ilios-common/addon/routes/course-visualizations.js
@@ -61,7 +61,7 @@ export default class CourseVisualizationsRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course-visualize-instructor.js
+++ b/packages/ilios-common/addon/routes/course-visualize-instructor.js
@@ -22,7 +22,7 @@ export default class CourseVisualizeInstructorRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course-visualize-instructor.js
+++ b/packages/ilios-common/addon/routes/course-visualize-instructor.js
@@ -21,9 +21,6 @@ export default class CourseVisualizeInstructorRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-instructors.js
+++ b/packages/ilios-common/addon/routes/course-visualize-instructors.js
@@ -25,9 +25,6 @@ export default class CourseVisualizeInstructorsRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-instructors.js
+++ b/packages/ilios-common/addon/routes/course-visualize-instructors.js
@@ -26,7 +26,7 @@ export default class CourseVisualizeInstructorsRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course-visualize-objectives.js
+++ b/packages/ilios-common/addon/routes/course-visualize-objectives.js
@@ -21,9 +21,6 @@ export default class CourseVisualizeObjectivesRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-objectives.js
+++ b/packages/ilios-common/addon/routes/course-visualize-objectives.js
@@ -22,7 +22,7 @@ export default class CourseVisualizeObjectivesRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course-visualize-session-type.js
+++ b/packages/ilios-common/addon/routes/course-visualize-session-type.js
@@ -28,7 +28,7 @@ export default class CourseVisualizeSessionTypeRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course-visualize-session-type.js
+++ b/packages/ilios-common/addon/routes/course-visualize-session-type.js
@@ -27,9 +27,6 @@ export default class CourseVisualizeSessionTypeRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-session-types.js
+++ b/packages/ilios-common/addon/routes/course-visualize-session-types.js
@@ -22,7 +22,7 @@ export default class CourseVisualizeSessionTypesRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course-visualize-session-types.js
+++ b/packages/ilios-common/addon/routes/course-visualize-session-types.js
@@ -21,9 +21,6 @@ export default class CourseVisualizeSessionTypesRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-term.js
+++ b/packages/ilios-common/addon/routes/course-visualize-term.js
@@ -27,9 +27,6 @@ export default class CourseVisualizeTermRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-term.js
+++ b/packages/ilios-common/addon/routes/course-visualize-term.js
@@ -28,7 +28,7 @@ export default class CourseVisualizeTermRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course-visualize-vocabularies.js
+++ b/packages/ilios-common/addon/routes/course-visualize-vocabularies.js
@@ -21,9 +21,6 @@ export default class CourseVisualizeVocabulariesRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course-visualize-vocabularies.js
+++ b/packages/ilios-common/addon/routes/course-visualize-vocabularies.js
@@ -22,7 +22,7 @@ export default class CourseVisualizeVocabulariesRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course-visualize-vocabulary.js
+++ b/packages/ilios-common/addon/routes/course-visualize-vocabulary.js
@@ -25,7 +25,7 @@ export default class CourseVisualizeVocabularyRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course-visualize-vocabulary.js
+++ b/packages/ilios-common/addon/routes/course-visualize-vocabulary.js
@@ -24,9 +24,6 @@ export default class CourseVisualizeVocabularyRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course.js
+++ b/packages/ilios-common/addon/routes/course.js
@@ -15,12 +15,7 @@ export default class CourseRoute extends Route {
   #preloadTopLevel = null;
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      // Slash on the route name is necessary here due to this bug:
-      // https://github.com/emberjs/ember.js/issues/12945
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 
   async model(params) {

--- a/packages/ilios-common/addon/routes/course.js
+++ b/packages/ilios-common/addon/routes/course.js
@@ -16,7 +16,7 @@ export default class CourseRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       // Slash on the route name is necessary here due to this bug:
       // https://github.com/emberjs/ember.js/issues/12945
       this.router.replaceWith('/four-oh-four');

--- a/packages/ilios-common/addon/routes/course/index.js
+++ b/packages/ilios-common/addon/routes/course/index.js
@@ -21,7 +21,7 @@ export default class CourseIndexRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course/index.js
+++ b/packages/ilios-common/addon/routes/course/index.js
@@ -20,10 +20,7 @@ export default class CourseIndexRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 
   setupController(controller, model) {

--- a/packages/ilios-common/addon/routes/course/publication-check.js
+++ b/packages/ilios-common/addon/routes/course/publication-check.js
@@ -7,9 +7,6 @@ export default class CoursePublicationCheckRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course/publication-check.js
+++ b/packages/ilios-common/addon/routes/course/publication-check.js
@@ -8,7 +8,7 @@ export default class CoursePublicationCheckRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course/publishall.js
+++ b/packages/ilios-common/addon/routes/course/publishall.js
@@ -7,9 +7,6 @@ export default class CoursePublishallRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course/publishall.js
+++ b/packages/ilios-common/addon/routes/course/publishall.js
@@ -8,7 +8,7 @@ export default class CoursePublishallRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/course/rollover.js
+++ b/packages/ilios-common/addon/routes/course/rollover.js
@@ -7,9 +7,6 @@ export default class CourseRolloverRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/course/rollover.js
+++ b/packages/ilios-common/addon/routes/course/rollover.js
@@ -8,7 +8,7 @@ export default class CourseRolloverRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/print-course.js
+++ b/packages/ilios-common/addon/routes/print-course.js
@@ -34,7 +34,7 @@ export default class PrintCourseRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/print-course.js
+++ b/packages/ilios-common/addon/routes/print-course.js
@@ -33,9 +33,6 @@ export default class PrintCourseRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/session.js
+++ b/packages/ilios-common/addon/routes/session.js
@@ -16,9 +16,6 @@ export default class SessionRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/session.js
+++ b/packages/ilios-common/addon/routes/session.js
@@ -17,7 +17,7 @@ export default class SessionRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/session/copy.js
+++ b/packages/ilios-common/addon/routes/session/copy.js
@@ -15,7 +15,7 @@ export default class SessionCopyRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/session/copy.js
+++ b/packages/ilios-common/addon/routes/session/copy.js
@@ -14,10 +14,7 @@ export default class SessionCopyRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 
   setupController(controller, model) {

--- a/packages/ilios-common/addon/routes/session/index.js
+++ b/packages/ilios-common/addon/routes/session/index.js
@@ -16,7 +16,7 @@ export default class SessionIndexRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/ilios-common/addon/routes/session/index.js
+++ b/packages/ilios-common/addon/routes/session/index.js
@@ -15,10 +15,7 @@ export default class SessionIndexRoute extends Route {
   }
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 
   setupController(controller, model) {

--- a/packages/ilios-common/addon/routes/session/publication-check.js
+++ b/packages/ilios-common/addon/routes/session/publication-check.js
@@ -7,9 +7,6 @@ export default class SessionPublicationCheckRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    this.session.requireAuthentication(transition, 'login');
-    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
-      this.router.replaceWith('/four-oh-four');
-    }
+    this.currentUser.requireNonLearner(transition);
   }
 }

--- a/packages/ilios-common/addon/routes/session/publication-check.js
+++ b/packages/ilios-common/addon/routes/session/publication-check.js
@@ -8,7 +8,7 @@ export default class SessionPublicationCheckRoute extends Route {
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
-    if (!this.currentUser.performsNonLearnerFunction) {
+    if (this.session.isAuthenticated && !this.currentUser.performsNonLearnerFunction) {
       this.router.replaceWith('/four-oh-four');
     }
   }

--- a/packages/test-app/tests/integration/services/current-user-test.js
+++ b/packages/test-app/tests/integration/services/current-user-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, todo } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { setupMirage } from 'test-app/tests/test-support/mirage';
 import { authenticateSession, invalidateSession } from 'ember-simple-auth/test-support';
@@ -266,5 +266,9 @@ module('Integration | Service | Current User', function (hooks) {
     const isTeachingSession2 = await subject.isTeachingSession(sessionModel2);
     assert.ok(isTeachingSession1);
     assert.notOk(isTeachingSession2);
+  });
+
+  todo('requireNonLearner', function (assert) {
+    assert.ok(true, 'to be implemented');
   });
 });

--- a/packages/test-app/tests/integration/services/current-user-test.js
+++ b/packages/test-app/tests/integration/services/current-user-test.js
@@ -268,7 +268,7 @@ module('Integration | Service | Current User', function (hooks) {
     assert.notOk(isTeachingSession2);
   });
 
-  todo('requireNonLearner', function (assert) {
-    assert.ok(true, 'to be implemented');
+  todo('requireNonLearner', function (/* assert */) {
+    // TODO: implement.
   });
 });


### PR DESCRIPTION
turns out that invoking `this.session.requireAuthentication(transition, 'login');` in `Route::beforeModel()` doesn't immediately bounce the user to the login page if they're not logged in.
So we must check that the user is authenticated before doing any permissions check on the user, to prevent the perms check from running on unauthenticated requests.

fixes https://github.com/ilios/ilios/issues/6355


how to test 
1. using the netlify build, as an unauthenticated user, access the route `/courses/2327/sessions/87227`
2. observe that you're taken to the login page. log in as demo developer 1.
3. behold that you're now taken to the course/session management page.
4. log out
5. access the same route as described in 1.
6. observe that you're on the login page again. this time, log in as demo student 2.
7. behold that you're now on the rats/404 page.