### PR TITLE
Color Palette Adjustments

### DIFF
--- a/packages/frontend/app/styles/components/bulk-new-users.scss
+++ b/packages/frontend/app/styles/components/bulk-new-users.scss
@@ -52,8 +52,8 @@
       overflow-y: scroll;
 
       .error {
-        border: 1px solid var(--red);
-        color: var(--red);
+        border: 1px solid var(--light-red);
+        color: var(--light-red);
       }
 
       table {
@@ -72,13 +72,13 @@
 
   .saving-user-errors,
   .saving-authentication-errors {
-    border: 1px solid var(--red);
-    border-top: 10px solid var(--red);
+    border: 1px solid var(--light-red);
+    border-top: 10px solid var(--light-red);
     margin: 1rem 4rem;
     padding: 0 1rem 1rem;
 
     p {
-      color: var(--red);
+      color: var(--light-red);
     }
 
     li {

--- a/packages/frontend/app/styles/components/bulk-new-users.scss
+++ b/packages/frontend/app/styles/components/bulk-new-users.scss
@@ -52,8 +52,8 @@
       overflow-y: scroll;
 
       .error {
-        border: 1px solid var(--crimson);
-        color: var(--crimson);
+        border: 1px solid var(--red);
+        color: var(--red);
       }
 
       table {
@@ -72,13 +72,13 @@
 
   .saving-user-errors,
   .saving-authentication-errors {
-    border: 1px solid var(--crimson);
-    border-top: 10px solid var(--crimson);
+    border: 1px solid var(--red);
+    border-top: 10px solid var(--red);
     margin: 1rem 4rem;
     padding: 0 1rem 1rem;
 
     p {
-      color: var(--crimson);
+      color: var(--red);
     }
 
     li {

--- a/packages/frontend/app/styles/components/connection-status.scss
+++ b/packages/frontend/app/styles/components/connection-status.scss
@@ -3,7 +3,7 @@
 
 .connection-status {
   $height: 2.5rem;
-  @include m.critical-notice(var(--gold), var(--black), $height);
+  @include m.critical-notice(var(--dark-yellow), var(--black), $height);
 
   display: none;
 

--- a/packages/frontend/app/styles/components/connection-status.scss
+++ b/packages/frontend/app/styles/components/connection-status.scss
@@ -3,7 +3,7 @@
 
 .connection-status {
   $height: 2.5rem;
-  @include m.critical-notice(var(--gold), var(--raisin-black), $height);
+  @include m.critical-notice(var(--gold), var(--black), $height);
 
   display: none;
 
@@ -20,7 +20,7 @@
     height: $height;
 
     button {
-      background-color: var(--raisin-black);
+      background-color: var(--black);
       border: 0;
       color: var(--white);
       display: inline-block;

--- a/packages/frontend/app/styles/components/course-director-manager.scss
+++ b/packages/frontend/app/styles/components/course-director-manager.scss
@@ -13,7 +13,7 @@
     }
 
     .bigcancel {
-      background-color: var(--darker-red);
+      background-color: var(--red);
       color: var(--white);
     }
   }

--- a/packages/frontend/app/styles/components/course-director-manager.scss
+++ b/packages/frontend/app/styles/components/course-director-manager.scss
@@ -13,7 +13,7 @@
     }
 
     .bigcancel {
-      background-color: var(--crimson);
+      background-color: var(--red);
       color: var(--white);
     }
   }

--- a/packages/frontend/app/styles/components/course-director-manager.scss
+++ b/packages/frontend/app/styles/components/course-director-manager.scss
@@ -13,7 +13,7 @@
     }
 
     .bigcancel {
-      background-color: var(--red);
+      background-color: var(--darker-red);
       color: var(--white);
     }
   }

--- a/packages/frontend/app/styles/components/course-director-manager.scss
+++ b/packages/frontend/app/styles/components/course-director-manager.scss
@@ -7,7 +7,7 @@
     justify-content: flex-end;
 
     .bigadd {
-      background-color: var(--fern-green);
+      background-color: var(--green);
       color: var(--white);
       margin-right: 0.25rem;
     }

--- a/packages/frontend/app/styles/components/course-search-result.scss
+++ b/packages/frontend/app/styles/components/course-search-result.scss
@@ -6,7 +6,7 @@
   padding: 0.5rem 0;
 
   .course-flag {
-    background: var(--fern-green);
+    background: var(--green);
     border-radius: 2px;
     bottom: 2px;
     color: var(--white);
@@ -17,7 +17,7 @@
   }
 
   .school-flag {
-    background: var(--fern-green);
+    background: var(--green);
     border-radius: 2px;
     bottom: 2px;
     color: var(--white);

--- a/packages/frontend/app/styles/components/course-search-result.scss
+++ b/packages/frontend/app/styles/components/course-search-result.scss
@@ -58,7 +58,7 @@
     overflow: hidden;
 
     .global-search-tag {
-      background: var(--slight-white);
+      background: var(--white);
       border: 1px solid var(--davys-grey);
       border-radius: 0.125rem;
       color: var(--raisin-black);

--- a/packages/frontend/app/styles/components/course-search-result.scss
+++ b/packages/frontend/app/styles/components/course-search-result.scss
@@ -32,7 +32,7 @@
     padding: 0.25rem 0.75rem 0;
 
     .sessions {
-      color: var(--davys-grey);
+      color: var(--grey);
       @include m.font-size("small");
     }
   }
@@ -59,7 +59,7 @@
 
     .global-search-tag {
       background: var(--white);
-      border: 1px solid var(--davys-grey);
+      border: 1px solid var(--grey);
       border-radius: 0.125rem;
       color: var(--black);
       display: inline-block;

--- a/packages/frontend/app/styles/components/course-search-result.scss
+++ b/packages/frontend/app/styles/components/course-search-result.scss
@@ -61,7 +61,7 @@
       background: var(--white);
       border: 1px solid var(--davys-grey);
       border-radius: 0.125rem;
-      color: var(--raisin-black);
+      color: var(--black);
       display: inline-block;
       @include m.font-size("smallest");
       margin-right: 0.375rem;

--- a/packages/frontend/app/styles/components/courses/loading.scss
+++ b/packages/frontend/app/styles/components/courses/loading.scss
@@ -5,6 +5,6 @@
   .toggle-mycourses .toggle-buttons label {
     @include cm.loading-text;
     cursor: default;
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
   }
 }

--- a/packages/frontend/app/styles/components/courses/new.scss
+++ b/packages/frontend/app/styles/components/courses/new.scss
@@ -3,7 +3,7 @@
 
 .courses-new {
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/courses/new.scss
+++ b/packages/frontend/app/styles/components/courses/new.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .courses-new {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/curriculum-inventory/new-report.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/new-report.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .curriculum-inventory-new-report {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/curriculum-inventory/new-report.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/new-report.scss
@@ -3,7 +3,7 @@
 
 .curriculum-inventory-new-report {
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/curriculum-inventory/new-sequence-block.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/new-sequence-block.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .curriculum-inventory-new-sequence-block {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/curriculum-inventory/new-sequence-block.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/new-sequence-block.scss
@@ -3,7 +3,7 @@
 
 .curriculum-inventory-new-sequence-block {
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
@@ -13,7 +13,7 @@
     background-color: var(--lightest-red);
 
     .confirm-message {
-      color: var(--darker-red);
+      color: var(--red);
       font-weight: bold;
       padding: 1rem 10%;
       text-align: center;
@@ -25,10 +25,10 @@
 
     .finalize {
       background-color: var(--white);
-      color: var(--darker-red);
+      color: var(--red);
 
       &:hover {
-        background-color: var(--red);
+        background-color: var(--light-red);
         color: var(--white);
       }
     }

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
@@ -28,7 +28,7 @@
       color: var(--rosewood);
 
       &:hover {
-        background-color: var(--crimson);
+        background-color: var(--red);
         color: var(--white);
       }
     }

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
@@ -13,7 +13,7 @@
     background-color: var(--lavender-blush);
 
     .confirm-message {
-      color: var(--rosewood);
+      color: var(--darker-red);
       font-weight: bold;
       padding: 1rem 10%;
       text-align: center;
@@ -25,7 +25,7 @@
 
     .finalize {
       background-color: var(--white);
-      color: var(--rosewood);
+      color: var(--darker-red);
 
       &:hover {
         background-color: var(--red);

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
@@ -10,7 +10,7 @@
   }
 
   .confirm-finalize {
-    background-color: var(--lavender-blush);
+    background-color: var(--lightest-red);
 
     .confirm-message {
       color: var(--darker-red);

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-header.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-header.scss
@@ -16,7 +16,7 @@
 
   button:disabled {
     cursor: default;
-    background-color: var(--davys-grey);
+    background-color: var(--grey);
   }
 
   .actions {

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-header.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-header.scss
@@ -3,7 +3,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .curriculum-inventory-report-header {
-  border-bottom: 1px solid var(--cultured-grey);
+  border-bottom: 1px solid var(--lightest-grey);
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-overview.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-overview.scss
@@ -18,7 +18,7 @@
 
       a,
       span {
-        color: var(--blue-munsell);
+        color: var(--light-blue);
         @include m.font-size("medium");
         margin-right: 0.5rem;
       }

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-rollover.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-rollover.scss
@@ -9,7 +9,7 @@
 
   .rollover-form {
     @include m.ilios-form;
-    border: 1px solid var(--blue-munsell);
+    border: 1px solid var(--light-blue);
     display: block;
     margin-top: 1rem;
     padding: 1rem;

--- a/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-header.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-header.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .curriculum-inventory-sequence-block-header {
-  border-bottom: 1px solid var(--cultured-grey);
+  border-bottom: 1px solid var(--lightest-grey);
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-header.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-header.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .curriculum-inventory-verification-preview-header {
-  background-color: var(--cultured-grey);
+  background-color: var(--lightest-grey);
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/packages/frontend/app/styles/components/dashboard-loading.scss
+++ b/packages/frontend/app/styles/components/dashboard-loading.scss
@@ -8,7 +8,7 @@
 
   .main-box {
     .controls {
-      border-bottom: 1px dotted var(--davys-grey);
+      border-bottom: 1px dotted var(--grey);
       height: 2rem;
       padding: 0.25rem;
     }

--- a/packages/frontend/app/styles/components/filter-tools.scss
+++ b/packages/frontend/app/styles/components/filter-tools.scss
@@ -3,7 +3,7 @@
 @use "../mixins" as m;
 
 .filter-tools {
-  $filter-tools-border-color: var(--cultured-grey);
+  $filter-tools-border-color: var(--lightest-grey);
 
   @include m.clearfix;
   border-radius: 3px;

--- a/packages/frontend/app/styles/components/flash-messages.scss
+++ b/packages/frontend/app/styles/components/flash-messages.scss
@@ -40,7 +40,7 @@
   }
 
   .alert-warning {
-    @include flash(var(--gold));
+    @include flash(var(--dark-yellow));
   }
 
   .alert-info {

--- a/packages/frontend/app/styles/components/flash-messages.scss
+++ b/packages/frontend/app/styles/components/flash-messages.scss
@@ -44,7 +44,7 @@
   }
 
   .alert-info {
-    @include flash(var(--blue-munsell));
+    @include flash(var(--light-blue));
   }
 
   .alert-alert {

--- a/packages/frontend/app/styles/components/flash-messages.scss
+++ b/packages/frontend/app/styles/components/flash-messages.scss
@@ -58,7 +58,7 @@
   }
 
   .alert-alert {
-    @include flash(var(--red));
+    @include flash(var(--light-red));
   }
 
   .alert:last-of-type {

--- a/packages/frontend/app/styles/components/flash-messages.scss
+++ b/packages/frontend/app/styles/components/flash-messages.scss
@@ -36,7 +36,7 @@
   }
 
   .alert-success {
-    @include flash(var(--fern-green));
+    @include flash(var(--green));
   }
 
   .alert-warning {

--- a/packages/frontend/app/styles/components/flash-messages.scss
+++ b/packages/frontend/app/styles/components/flash-messages.scss
@@ -48,7 +48,7 @@
   }
 
   .alert-alert {
-    @include flash(var(--crimson));
+    @include flash(var(--red));
   }
 
   .alert:last-of-type {

--- a/packages/frontend/app/styles/components/flash-messages.scss
+++ b/packages/frontend/app/styles/components/flash-messages.scss
@@ -22,11 +22,21 @@
 
     a {
       color: hsl(from $color h s calc(l + 40));
+
+      //Support for Safari < 18.x
+      @supports (color: hsl(from orange h s calc(l + 15%))) {
+        color: hsl(from $color h s calc(l + 40%));
+      }
       text-decoration: underline;
 
       &:focus,
       &:hover {
         color: hsl(from $color h s calc(l + 90));
+
+        //Support for Safari < 18.x
+        @supports (color: hsl(from orange h s calc(l + 15%))) {
+          color: hsl(from $color h s calc(l + 90));
+        }
       }
     }
 

--- a/packages/frontend/app/styles/components/global-search-box.scss
+++ b/packages/frontend/app/styles/components/global-search-box.scss
@@ -11,7 +11,7 @@
   flex-direction: row-reverse;
 
   &:focus-within {
-    outline: 2px solid var(--blue-munsell);
+    outline: 2px solid var(--light-blue);
   }
 
   button {
@@ -20,7 +20,7 @@
     background-color: var(--white);
     border: 0;
     border-radius: 3px 0 0 3px;
-    color: var(--blue-munsell);
+    color: var(--light-blue);
     cursor: pointer;
     display: flex;
     height: 100%;

--- a/packages/frontend/app/styles/components/global-search.scss
+++ b/packages/frontend/app/styles/components/global-search.scss
@@ -56,7 +56,7 @@
   }
 
   .results {
-    border-right: 1px solid var(--raisin-black);
+    border-right: 1px solid var(--black);
     grid-area: results;
     list-style-type: none;
     padding: 0 2rem;

--- a/packages/frontend/app/styles/components/ilios-footer.scss
+++ b/packages/frontend/app/styles/components/ilios-footer.scss
@@ -16,7 +16,7 @@
     background-color: hsl(from var(--white) h s calc(l - 3));
     border: 1px solid m.$header-menu-background-color;
     border-radius: 0.2rem;
-    color: var(--raisin-black);
+    color: var(--black);
     display: flex;
     @include cm.font-size("smallest");
     font-weight: 100;

--- a/packages/frontend/app/styles/components/ilios-footer.scss
+++ b/packages/frontend/app/styles/components/ilios-footer.scss
@@ -13,7 +13,7 @@
 
   .version {
     align-items: center;
-    background-color: hsl(from var(--slight-white) h s calc(l - 3));
+    background-color: hsl(from var(--white) h s calc(l - 3));
     border: 1px solid m.$header-menu-background-color;
     border-radius: 0.2rem;
     color: var(--raisin-black);

--- a/packages/frontend/app/styles/components/ilios-footer.scss
+++ b/packages/frontend/app/styles/components/ilios-footer.scss
@@ -13,8 +13,8 @@
 
   .version {
     align-items: center;
-    background-color: hsl(from var(--white) h s calc(l - 3));
-    border: 1px solid m.$header-menu-background-color;
+    background-color: var(--super-light-grey);
+    border: 1px solid var(--super-light-grey);
     border-radius: 0.2rem;
     color: var(--black);
     display: flex;

--- a/packages/frontend/app/styles/components/ilios-navigation.scss
+++ b/packages/frontend/app/styles/components/ilios-navigation.scss
@@ -52,7 +52,7 @@
       justify-content: center;
 
       .expander {
-        color: var(--slight-white);
+        color: var(--white);
 
         &:hover {
           background-color: var(--blue-munsell);

--- a/packages/frontend/app/styles/components/ilios-navigation.scss
+++ b/packages/frontend/app/styles/components/ilios-navigation.scss
@@ -5,7 +5,7 @@
 /* stylelint-disable property-disallowed-list */
 @use "sass:color";
 .ilios-navigation {
-  background-color: var(--davys-grey);
+  background-color: var(--grey);
   display: grid;
   grid-auto-flow: column;
   grid-template-columns: 2rem auto;
@@ -33,7 +33,7 @@
 
         &:first-of-type {
           padding-top: 2px;
-          border-top: 2px solid var(--davys-grey);
+          border-top: 2px solid var(--grey);
         }
       }
     }

--- a/packages/frontend/app/styles/components/ilios-navigation.scss
+++ b/packages/frontend/app/styles/components/ilios-navigation.scss
@@ -55,7 +55,7 @@
         color: var(--white);
 
         &:hover {
-          background-color: var(--blue-munsell);
+          background-color: var(--light-blue);
         }
       }
     }
@@ -85,7 +85,7 @@
 
   @include m.for-smaller-than-laptop {
     a.active {
-      background-color: var(--blue-munsell);
+      background-color: var(--light-blue);
     }
   }
 
@@ -133,7 +133,7 @@
       }
 
       .if-active {
-        color: var(--blue-munsell);
+        color: var(--light-blue);
         justify-self: end;
         font-weight: bold;
       }
@@ -142,7 +142,7 @@
         .if-active {
           display: inline;
         }
-        color: var(--blue-munsell);
+        color: var(--light-blue);
 
         .text {
           color: hsl(0, 0%, 92%);
@@ -151,7 +151,7 @@
     }
 
     &:hover {
-      background-color: var(--blue-munsell);
+      background-color: var(--light-blue);
       color: hsl(0, 0%, 92%);
 
       .if-active {

--- a/packages/frontend/app/styles/components/instructor-group/header.scss
+++ b/packages/frontend/app/styles/components/instructor-group/header.scss
@@ -4,7 +4,7 @@
 
 .instructor-group-header {
   .header-bar {
-    border-bottom: 1px solid var(--cultured-grey);
+    border-bottom: 1px solid var(--lightest-grey);
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/packages/frontend/app/styles/components/instructor-groups/new.scss
+++ b/packages/frontend/app/styles/components/instructor-groups/new.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-instructor-group {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/instructor-groups/new.scss
+++ b/packages/frontend/app/styles/components/instructor-groups/new.scss
@@ -3,7 +3,7 @@
 
 .new-instructor-group {
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
+++ b/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
@@ -53,7 +53,7 @@
       }
 
       &.not-matched {
-        background-color: hsl(from var(--dark-yellow) h s calc(l + 15));
+        background-color: var(--yellow);
       }
     }
   }

--- a/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
+++ b/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
@@ -24,13 +24,13 @@
     }
 
     .issue {
-      color: var(--davys-grey);
+      color: var(--grey);
       margin-left: 1rem;
     }
   }
 
   .group-matcher {
-    border: 1px solid var(--davys-grey);
+    border: 1px solid var(--grey);
 
     th:nth-child(1),
     td:nth-child(1) {
@@ -42,7 +42,7 @@
     }
 
     .learner-group-bulk-group-matcher {
-      border: 1px solid var(--davys-grey);
+      border: 1px solid var(--grey);
 
       select {
         width: 100%;

--- a/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
+++ b/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
@@ -49,7 +49,7 @@
       }
 
       &.matched {
-        background-color: hsl(from var(--green) h s calc(l + 15));
+        background-color: var(--transparent-green);
       }
 
       &.not-matched {

--- a/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
+++ b/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
@@ -53,7 +53,7 @@
       }
 
       &.not-matched {
-        background-color: hsl(from var(--gold) h s calc(l + 15));
+        background-color: hsl(from var(--dark-yellow) h s calc(l + 15));
       }
     }
   }

--- a/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
+++ b/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
@@ -49,7 +49,7 @@
       }
 
       &.matched {
-        background-color: hsl(from var(--fern-green) h s calc(l + 15));
+        background-color: hsl(from var(--green) h s calc(l + 15));
       }
 
       &.not-matched {

--- a/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
+++ b/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
@@ -15,7 +15,7 @@
       width: 100%;
 
       i {
-        color: var(--blue-munsell);
+        color: var(--light-blue);
         @include m.font-size("xxl");
         font-weight: 600;
         margin: 0;

--- a/packages/frontend/app/styles/components/learner-group/cohort-user-manager.scss
+++ b/packages/frontend/app/styles/components/learner-group/cohort-user-manager.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .learner-group-cohort-user-manager {
-  @include m.detail-container(var(--teal-blue));
+  @include m.detail-container(var(--blue));
   border-bottom: 0;
   border-top: 1px dotted var(--orange);
   padding-left: 0;

--- a/packages/frontend/app/styles/components/learner-group/header.scss
+++ b/packages/frontend/app/styles/components/learner-group/header.scss
@@ -4,7 +4,7 @@
 
 .learner-group-header {
   .header-bar {
-    border-bottom: 1px solid var(--cultured-grey);
+    border-bottom: 1px solid var(--lightest-grey);
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/packages/frontend/app/styles/components/learner-group/instructor-manager.scss
+++ b/packages/frontend/app/styles/components/learner-group/instructor-manager.scss
@@ -35,7 +35,7 @@
 
     .removable-instructor-group {
       & > span {
-        background-color: var(--cultured-grey);
+        background-color: var(--lightest-grey);
         border-radius: 4px;
         cursor: pointer;
         font-weight: bold;

--- a/packages/frontend/app/styles/components/learner-group/members.scss
+++ b/packages/frontend/app/styles/components/learner-group/members.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .learner-group-members {
-  @include m.detail-container(var(--teal-blue));
+  @include m.detail-container(var(--blue));
   border-bottom: 0;
   display: grid;
   grid-template-columns: 3fr 1fr;

--- a/packages/frontend/app/styles/components/learner-group/new.scss
+++ b/packages/frontend/app/styles/components/learner-group/new.scss
@@ -3,7 +3,7 @@
 
 .new-learner-group {
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/learner-group/new.scss
+++ b/packages/frontend/app/styles/components/learner-group/new.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-learner-group {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/learner-group/root.scss
+++ b/packages/frontend/app/styles/components/learner-group/root.scss
@@ -70,8 +70,8 @@
       .confirm-copy,
       .confirm-copy:nth-child(even),
       .confirm-copy:nth-child(odd) {
-        background-color: hsl(from var(--blue-munsell) h s calc(l + 60));
-        border: 2px solid var(--blue-munsell);
+        background-color: hsl(from var(--light-blue) h s calc(l + 60));
+        border: 2px solid var(--light-blue);
 
         &.actions-row {
           border-top: 0;

--- a/packages/frontend/app/styles/components/learner-group/root.scss
+++ b/packages/frontend/app/styles/components/learner-group/root.scss
@@ -70,7 +70,7 @@
       .confirm-copy,
       .confirm-copy:nth-child(even),
       .confirm-copy:nth-child(odd) {
-        background-color: hsl(from var(--light-blue) h s calc(l + 60));
+        background-color: var(--lightest-blue);
         border: 2px solid var(--light-blue);
 
         &.actions-row {

--- a/packages/frontend/app/styles/components/learner-group/user-manager.scss
+++ b/packages/frontend/app/styles/components/learner-group/user-manager.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .learner-group-user-manager {
-  @include m.detail-container(var(--teal-blue));
+  @include m.detail-container(var(--blue));
   border-bottom: 0;
   display: grid;
   grid-template-columns: 3fr 1fr;

--- a/packages/frontend/app/styles/components/learner-groups/root.scss
+++ b/packages/frontend/app/styles/components/learner-groups/root.scss
@@ -47,7 +47,7 @@
       .confirm-copy,
       .confirm-copy:nth-child(even),
       .confirm-copy:nth-child(odd) {
-        background-color: hsl(from var(--light-blue) h s calc(l + 60));
+        background-color: var(--lightest-blue);
         border: 2px solid var(--light-blue);
 
         &.actions-row {

--- a/packages/frontend/app/styles/components/learner-groups/root.scss
+++ b/packages/frontend/app/styles/components/learner-groups/root.scss
@@ -47,8 +47,8 @@
       .confirm-copy,
       .confirm-copy:nth-child(even),
       .confirm-copy:nth-child(odd) {
-        background-color: hsl(from var(--blue-munsell) h s calc(l + 60));
-        border: 2px solid var(--blue-munsell);
+        background-color: hsl(from var(--light-blue) h s calc(l + 60));
+        border: 2px solid var(--light-blue);
 
         &.actions-row {
           border-top: 0;

--- a/packages/frontend/app/styles/components/manage-users-summary.scss
+++ b/packages/frontend/app/styles/components/manage-users-summary.scss
@@ -57,8 +57,8 @@
       }
 
       button:active {
-        background-color: var(--cultured-grey);
-        border-bottom: 1px solid var(--cultured-grey);
+        background-color: var(--lightest-grey);
+        border-bottom: 1px solid var(--lightest-grey);
       }
     }
   }

--- a/packages/frontend/app/styles/components/manage-users-summary.scss
+++ b/packages/frontend/app/styles/components/manage-users-summary.scss
@@ -43,7 +43,7 @@
 
     input[type="search"] {
       background-color: var(--white);
-      border: 1px solid var(--teal-blue);
+      border: 1px solid var(--blue);
       border-radius: 3px;
       height: 2rem;
       width: 100%;

--- a/packages/frontend/app/styles/components/my-profile.scss
+++ b/packages/frontend/app/styles/components/my-profile.scss
@@ -11,7 +11,7 @@
   }
 
   .is-student {
-    color: var(--fern-green);
+    color: var(--green);
     display: block;
     text-align: center;
     width: 100%;

--- a/packages/frontend/app/styles/components/new-directory-user.scss
+++ b/packages/frontend/app/styles/components/new-directory-user.scss
@@ -2,7 +2,7 @@
 @use "../ilios-common/mixins" as m;
 
 .new-directory-user {
-  border-bottom: 1px solid var(--cultured-grey);
+  border-bottom: 1px solid var(--lightest-grey);
   margin: 0.5rem;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/new-user.scss
+++ b/packages/frontend/app/styles/components/new-user.scss
@@ -3,7 +3,7 @@
 
 .new-user {
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/new-user.scss
+++ b/packages/frontend/app/styles/components/new-user.scss
@@ -2,7 +2,7 @@
 @use "../ilios-common/mixins" as m;
 
 .new-user {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/pagination-links.scss
+++ b/packages/frontend/app/styles/components/pagination-links.scss
@@ -2,7 +2,7 @@
 @use "../ilios-common/mixins" as m;
 
 .pagination-links {
-  color: var(--raisin-black);
+  color: var(--black);
   margin: 2rem 0;
   text-align: center;
 
@@ -59,7 +59,7 @@
     &:disabled {
       background: var(--white);
       border: none;
-      color: var(--raisin-black);
+      color: var(--black);
       cursor: default;
     }
   }

--- a/packages/frontend/app/styles/components/pagination-links.scss
+++ b/packages/frontend/app/styles/components/pagination-links.scss
@@ -38,7 +38,7 @@
   }
 
   .page-button {
-    background: var(--slight-white);
+    background: var(--white);
     border: 1px solid var(--davys-grey);
     color: var(--davys-grey);
     display: inline-block;

--- a/packages/frontend/app/styles/components/pagination-links.scss
+++ b/packages/frontend/app/styles/components/pagination-links.scss
@@ -11,7 +11,7 @@
     text-transform: uppercase;
 
     &:disabled {
-      color: var(--davys-grey);
+      color: var(--grey);
       cursor: default;
     }
 
@@ -39,8 +39,8 @@
 
   .page-button {
     background: var(--white);
-    border: 1px solid var(--davys-grey);
-    color: var(--davys-grey);
+    border: 1px solid var(--grey);
+    color: var(--grey);
     display: inline-block;
     min-width: 2rem;
     outline: none;

--- a/packages/frontend/app/styles/components/program-overview.scss
+++ b/packages/frontend/app/styles/components/program-overview.scss
@@ -2,7 +2,7 @@
 @use "../ilios-common/mixins" as m;
 
 .program-overview {
-  @include m.ilios-overview(var(--cultured-grey));
+  @include m.ilios-overview(var(--lightest-grey));
 
   h2 {
     @include m.ilios-overview-title;

--- a/packages/frontend/app/styles/components/program-year/competencies.scss
+++ b/packages/frontend/app/styles/components/program-year/competencies.scss
@@ -23,7 +23,7 @@
   .competency-list,
   .managed-competency-list {
     @include m.ilios-list-tree;
-    border: 1px solid var(--cultured-grey);
+    border: 1px solid var(--lightest-grey);
     border-radius: 3px;
     margin: 2rem;
 

--- a/packages/frontend/app/styles/components/program-year/manage-objective-competency.scss
+++ b/packages/frontend/app/styles/components/program-year/manage-objective-competency.scss
@@ -41,7 +41,7 @@
   }
 
   .no-cohorts {
-    color: var(--gold);
+    color: var(--dark-yellow);
     font-weight: bold;
   }
 }

--- a/packages/frontend/app/styles/components/program-year/manage-objective-competency.scss
+++ b/packages/frontend/app/styles/components/program-year/manage-objective-competency.scss
@@ -20,7 +20,7 @@
         border-left: 10px solid var(--orange);
 
         .domain-title {
-          color: var(--fern-green);
+          color: var(--green);
           font-weight: bold;
         }
       }

--- a/packages/frontend/app/styles/components/program-year/manage-objective-competency.scss
+++ b/packages/frontend/app/styles/components/program-year/manage-objective-competency.scss
@@ -10,7 +10,7 @@
     height: auto;
 
     .domain {
-      border-left: 10px solid var(--slight-white);
+      border-left: 10px solid var(--white);
 
       .domain-title {
         margin: 0.5rem 0 0 0.5rem;

--- a/packages/frontend/app/styles/components/program-year/new.scss
+++ b/packages/frontend/app/styles/components/program-year/new.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-program-year {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/program-year/new.scss
+++ b/packages/frontend/app/styles/components/program-year/new.scss
@@ -3,7 +3,7 @@
 
 .new-program-year {
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/program-year/objective-list-item-expanded.scss
+++ b/packages/frontend/app/styles/components/program-year/objective-list-item-expanded.scss
@@ -22,7 +22,7 @@
       }
 
       li {
-        border-top: 1px solid var(--davys-grey);
+        border-top: 1px solid var(--grey);
         padding-top: 1rem;
       }
 

--- a/packages/frontend/app/styles/components/program-year/objective-list-item-expanded.scss
+++ b/packages/frontend/app/styles/components/program-year/objective-list-item-expanded.scss
@@ -7,12 +7,12 @@
   grid-column: 1 / -1;
 
   thead {
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
   }
 
   tbody tr {
     &:nth-of-type(even) {
-      background-color: var(--cultured-grey);
+      background-color: var(--lightest-grey);
     }
     ul {
       @include m.ilios-list-reset;

--- a/packages/frontend/app/styles/components/program-year/objective-list.scss
+++ b/packages/frontend/app/styles/components/program-year/objective-list.scss
@@ -10,7 +10,7 @@
       @include m.ilios-button-reset;
       display: flex;
       justify-content: flex-start;
-      border-bottom: 1px solid var(--davys-grey);
+      border-bottom: 1px solid var(--grey);
       padding: 0.5em 0.25em;
     }
   }

--- a/packages/frontend/app/styles/components/program-year/objective-list.scss
+++ b/packages/frontend/app/styles/components/program-year/objective-list.scss
@@ -18,7 +18,7 @@
   .objective-row {
     &.is-inactive {
       .grid-item {
-        background-color: var(--lavender-blush);
+        background-color: var(--lightest-red);
       }
     }
     .actions {

--- a/packages/frontend/app/styles/components/program-year/objective-list.scss
+++ b/packages/frontend/app/styles/components/program-year/objective-list.scss
@@ -30,7 +30,7 @@
         width: 1rem;
 
         &.active {
-          color: var(--blue-munsell);
+          color: var(--light-blue);
         }
       }
 

--- a/packages/frontend/app/styles/components/program-year/objectives.scss
+++ b/packages/frontend/app/styles/components/program-year/objectives.scss
@@ -6,10 +6,6 @@
   @include m.objectives;
 
   .fade-text-control {
-    background-image: linear-gradient(
-      to bottom,
-      transparent,
-      var(--slight-white)
-    );
+    background-image: linear-gradient(to bottom, transparent, var(--white));
   }
 }

--- a/packages/frontend/app/styles/components/program/header.scss
+++ b/packages/frontend/app/styles/components/program/header.scss
@@ -3,7 +3,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .program-header {
-  border-bottom: 1px solid var(--cultured-grey);
+  border-bottom: 1px solid var(--lightest-grey);
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/packages/frontend/app/styles/components/program/new.scss
+++ b/packages/frontend/app/styles/components/program/new.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-program {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/frontend/app/styles/components/program/new.scss
+++ b/packages/frontend/app/styles/components/program/new.scss
@@ -3,7 +3,7 @@
 
 .new-program {
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/programs/list-item.scss
+++ b/packages/frontend/app/styles/components/programs/list-item.scss
@@ -5,7 +5,7 @@
   .actions {
     button {
       @include m.ilios-button-reset;
-      color: var(--crimson);
+      color: var(--red);
     }
   }
 }

--- a/packages/frontend/app/styles/components/programs/list-item.scss
+++ b/packages/frontend/app/styles/components/programs/list-item.scss
@@ -5,7 +5,7 @@
   .actions {
     button {
       @include m.ilios-button-reset;
-      color: var(--red);
+      color: var(--darker-red);
     }
   }
 }

--- a/packages/frontend/app/styles/components/programs/list-item.scss
+++ b/packages/frontend/app/styles/components/programs/list-item.scss
@@ -5,7 +5,7 @@
   .actions {
     button {
       @include m.ilios-button-reset;
-      color: var(--darker-red);
+      color: var(--red);
     }
   }
 }

--- a/packages/frontend/app/styles/components/programyear-details.scss
+++ b/packages/frontend/app/styles/components/programyear-details.scss
@@ -1,7 +1,7 @@
 @use "../ilios-common/colors" as c;
 
 .programyear-details {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   margin: 0 1.5rem;
   padding: 0.8rem;
 }

--- a/packages/frontend/app/styles/components/programyear-overview.scss
+++ b/packages/frontend/app/styles/components/programyear-overview.scss
@@ -21,7 +21,7 @@
       @include m.ilios-overview-actions;
 
       a {
-        color: var(--blue-munsell);
+        color: var(--light-blue);
         @include m.font-size("medium");
       }
     }

--- a/packages/frontend/app/styles/components/programyear-overview.scss
+++ b/packages/frontend/app/styles/components/programyear-overview.scss
@@ -4,7 +4,7 @@
 
 .programyear-overview {
   @include m.ilios-overview(var(--orange));
-  background: var(--slight-white);
+  background: var(--white);
   border-top: 1px dotted var(--orange);
   border-bottom: 0;
   margin: 0 1.5rem;

--- a/packages/frontend/app/styles/components/reports/choose-course.scss
+++ b/packages/frontend/app/styles/components/reports/choose-course.scss
@@ -25,7 +25,7 @@
   .deselect-all {
     @include cm.ilios-button-reset;
     @include cm.font-size("small");
-    color: var(--teal-blue);
+    color: var(--blue);
   }
 
   .select-all {

--- a/packages/frontend/app/styles/components/reports/curriculum-header.scss
+++ b/packages/frontend/app/styles/components/reports/curriculum-header.scss
@@ -18,7 +18,7 @@
 
       &:disabled {
         cursor: default;
-        background-color: var(--davys-grey);
+        background-color: var(--grey);
       }
     }
     .loading-results {

--- a/packages/frontend/app/styles/components/reports/curriculum-loading.scss
+++ b/packages/frontend/app/styles/components/reports/curriculum-loading.scss
@@ -12,6 +12,6 @@
   .reports-curriculum-header .input-buttons button.done {
     @include cm.loading-text;
     cursor: default;
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
   }
 }

--- a/packages/frontend/app/styles/components/reports/new-subject.scss
+++ b/packages/frontend/app/styles/components/reports/new-subject.scss
@@ -3,7 +3,7 @@
 @use "sass:color";
 
 .reports-new-subject {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   margin: 0.5rem 0;
   padding: 1rem 1rem 3rem;
@@ -73,7 +73,7 @@
         background: var(--white);
         border-width: 0 1px 1px 1px;
         border-style: solid;
-        border-color: var(--slight-white);
+        border-color: var(--white);
         box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.2);
         color: var(--raisin-black);
         max-height: 15rem;

--- a/packages/frontend/app/styles/components/reports/new-subject.scss
+++ b/packages/frontend/app/styles/components/reports/new-subject.scss
@@ -99,7 +99,7 @@
           }
 
           &.results-count {
-            color: var(--fern-green);
+            color: var(--green);
           }
         }
       }

--- a/packages/frontend/app/styles/components/reports/new-subject.scss
+++ b/packages/frontend/app/styles/components/reports/new-subject.scss
@@ -49,13 +49,13 @@
 
     button {
       &.disabled {
-        background-color: var(--davys-grey);
+        background-color: var(--grey);
         cursor: default;
       }
 
       &:disabled {
         background-color: var(--cultured-grey);
-        border-color: var(--davys-grey);
+        border-color: var(--grey);
         color: var(--white);
         cursor: default;
       }

--- a/packages/frontend/app/styles/components/reports/new-subject.scss
+++ b/packages/frontend/app/styles/components/reports/new-subject.scss
@@ -75,7 +75,7 @@
         border-style: solid;
         border-color: var(--white);
         box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.2);
-        color: var(--raisin-black);
+        color: var(--black);
         max-height: 15rem;
         overflow-y: scroll;
         transition: all 0.2s ease-in-out;

--- a/packages/frontend/app/styles/components/reports/new-subject.scss
+++ b/packages/frontend/app/styles/components/reports/new-subject.scss
@@ -74,7 +74,7 @@
         border-width: 0 1px 1px 1px;
         border-style: solid;
         border-color: var(--white);
-        box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.2);
+        box-shadow: 0 2px 2px var(--very-transparent-black);
         color: var(--black);
         max-height: 15rem;
         overflow-y: scroll;

--- a/packages/frontend/app/styles/components/reports/new-subject.scss
+++ b/packages/frontend/app/styles/components/reports/new-subject.scss
@@ -36,8 +36,8 @@
       }
 
       select.error {
-        border: 1px solid var(--crimson);
-        outline-color: var(--crimson);
+        border: 1px solid var(--red);
+        outline-color: var(--red);
       }
 
       .mesh-search {

--- a/packages/frontend/app/styles/components/reports/new-subject.scss
+++ b/packages/frontend/app/styles/components/reports/new-subject.scss
@@ -36,8 +36,8 @@
       }
 
       select.error {
-        border: 1px solid var(--red);
-        outline-color: var(--red);
+        border: 1px solid var(--light-red);
+        outline-color: var(--light-red);
       }
 
       .mesh-search {

--- a/packages/frontend/app/styles/components/reports/new-subject.scss
+++ b/packages/frontend/app/styles/components/reports/new-subject.scss
@@ -4,7 +4,7 @@
 
 .reports-new-subject {
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   margin: 0.5rem 0;
   padding: 1rem 1rem 3rem;
 
@@ -54,7 +54,7 @@
       }
 
       &:disabled {
-        background-color: var(--cultured-grey);
+        background-color: var(--lightest-grey);
         border-color: var(--grey);
         color: var(--white);
         cursor: default;
@@ -81,7 +81,7 @@
         transition: all 0.2s ease-in-out;
 
         li {
-          border-bottom: 1px solid var(--cultured-grey);
+          border-bottom: 1px solid var(--lightest-grey);
           width: 100%;
 
           button {
@@ -90,7 +90,7 @@
             padding: 0.6rem 0 0 1rem;
 
             &:hover {
-              background-color: var(--cultured-grey);
+              background-color: var(--lightest-grey);
             }
           }
 

--- a/packages/frontend/app/styles/components/reports/subject-header.scss
+++ b/packages/frontend/app/styles/components/reports/subject-header.scss
@@ -55,7 +55,7 @@
     grid-area: download;
     &:disabled {
       cursor: default;
-      background-color: var(--davys-grey);
+      background-color: var(--grey);
     }
   }
 

--- a/packages/frontend/app/styles/components/reports/subject-header.scss
+++ b/packages/frontend/app/styles/components/reports/subject-header.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/colors" as c;
 
 .reports-subject-header {
-  border-bottom: 1px solid var(--cultured-grey);
+  border-bottom: 1px solid var(--lightest-grey);
   display: grid;
   grid-template-areas:
     "title"

--- a/packages/frontend/app/styles/components/reports/switcher.scss
+++ b/packages/frontend/app/styles/components/reports/switcher.scss
@@ -8,7 +8,7 @@
   a {
     @include cm.ilios-link-button;
     background-color: var(--white);
-    color: var(--teal-blue);
+    color: var(--blue);
     border: 1px solid hsl(from var(--black) h s l / 0.2);
     @include cm.font-size("medium");
     font-weight: 600;
@@ -21,7 +21,7 @@
     }
 
     &.active {
-      background-color: var(--teal-blue);
+      background-color: var(--blue);
       color: var(--white);
     }
   }

--- a/packages/frontend/app/styles/components/reports/switcher.scss
+++ b/packages/frontend/app/styles/components/reports/switcher.scss
@@ -9,7 +9,7 @@
     @include cm.ilios-link-button;
     background-color: var(--white);
     color: var(--blue);
-    border: 1px solid hsl(from var(--black) h s l / 0.2);
+    border: 1px solid var(--very-transparent-black);
     @include cm.font-size("medium");
     font-weight: 600;
     padding: 0.25em 0.5em;

--- a/packages/frontend/app/styles/components/school-competencies-list.scss
+++ b/packages/frontend/app/styles/components/school-competencies-list.scss
@@ -38,7 +38,7 @@
       }
 
       .bigadd {
-        background-color: var(--fern-green);
+        background-color: var(--green);
         color: var(--white);
       }
 
@@ -61,7 +61,7 @@
 
     &.highlight-ok {
       transition: none;
-      background-color: hsl(from var(--fern-green) h s calc(l + 60));
+      background-color: hsl(from var(--green) h s calc(l + 60));
     }
 
     &.is-managing {

--- a/packages/frontend/app/styles/components/school-competencies-list.scss
+++ b/packages/frontend/app/styles/components/school-competencies-list.scss
@@ -65,7 +65,7 @@
     }
 
     &.is-managing {
-      border: 2px solid var(--blue-munsell);
+      border: 2px solid var(--light-blue);
       .grid-item {
         background-color: var(--cultured-grey);
         border: 0;

--- a/packages/frontend/app/styles/components/school-competencies-list.scss
+++ b/packages/frontend/app/styles/components/school-competencies-list.scss
@@ -43,7 +43,7 @@
       }
 
       .bigcancel {
-        background-color: var(--darker-red);
+        background-color: var(--red);
         color: var(--white);
         margin-left: 0.5rem;
       }
@@ -80,7 +80,7 @@
       }
 
       .confirm-message {
-        color: var(--red);
+        color: var(--light-red);
         grid-column: 1 / -1;
         font-weight: bold;
         text-align: center;
@@ -89,10 +89,10 @@
 
       .remove {
         background-color: var(--white);
-        color: var(--red);
+        color: var(--light-red);
 
         &:hover {
-          background-color: var(--red);
+          background-color: var(--light-red);
           color: white;
         }
       }

--- a/packages/frontend/app/styles/components/school-competencies-list.scss
+++ b/packages/frontend/app/styles/components/school-competencies-list.scss
@@ -67,7 +67,7 @@
     &.is-managing {
       border: 2px solid var(--light-blue);
       .grid-item {
-        background-color: var(--cultured-grey);
+        background-color: var(--lightest-grey);
         border: 0;
       }
     }

--- a/packages/frontend/app/styles/components/school-competencies-list.scss
+++ b/packages/frontend/app/styles/components/school-competencies-list.scss
@@ -43,7 +43,7 @@
       }
 
       .bigcancel {
-        background-color: var(--crimson);
+        background-color: var(--red);
         color: var(--white);
         margin-left: 0.5rem;
       }
@@ -80,7 +80,7 @@
       }
 
       .confirm-message {
-        color: var(--crimson);
+        color: var(--red);
         grid-column: 1 / -1;
         font-weight: bold;
         text-align: center;
@@ -89,10 +89,10 @@
 
       .remove {
         background-color: var(--white);
-        color: var(--crimson);
+        color: var(--red);
 
         &:hover {
-          background-color: var(--crimson);
+          background-color: var(--red);
           color: white;
         }
       }

--- a/packages/frontend/app/styles/components/school-competencies-list.scss
+++ b/packages/frontend/app/styles/components/school-competencies-list.scss
@@ -61,7 +61,7 @@
 
     &.highlight-ok {
       transition: none;
-      background-color: hsl(from var(--green) h s calc(l + 60));
+      background-color: var(--transparent-green);
     }
 
     &.is-managing {

--- a/packages/frontend/app/styles/components/school-competencies-list.scss
+++ b/packages/frontend/app/styles/components/school-competencies-list.scss
@@ -73,7 +73,7 @@
     }
 
     &.confirm-removal {
-      background-color: var(--lavender-blush);
+      background-color: var(--lightest-red);
 
       .grid-item {
         border: 0;

--- a/packages/frontend/app/styles/components/school-competencies-list.scss
+++ b/packages/frontend/app/styles/components/school-competencies-list.scss
@@ -14,7 +14,7 @@
     margin-right: 0.5rem;
 
     .grid-item {
-      border-bottom: 1px solid var(--davys-grey);
+      border-bottom: 1px solid var(--grey);
       padding: 0.5rem 0.25rem;
 
       &.competency {

--- a/packages/frontend/app/styles/components/school-competencies-list.scss
+++ b/packages/frontend/app/styles/components/school-competencies-list.scss
@@ -43,7 +43,7 @@
       }
 
       .bigcancel {
-        background-color: var(--red);
+        background-color: var(--darker-red);
         color: var(--white);
         margin-left: 0.5rem;
       }

--- a/packages/frontend/app/styles/components/school-competencies-manager.scss
+++ b/packages/frontend/app/styles/components/school-competencies-manager.scss
@@ -3,7 +3,7 @@
 
 .school-competencies-manager {
   .domain {
-    background-color: var(--light-blue);
+    background-color: var(--lightest-blue);
     border: 1px solid var(--black);
     margin: 1rem;
     padding: 1rem;

--- a/packages/frontend/app/styles/components/school-institutional-information-manager.scss
+++ b/packages/frontend/app/styles/components/school-institutional-information-manager.scss
@@ -30,7 +30,7 @@
     }
 
     .validation-error-message {
-      color: var(--darker-red);
+      color: var(--red);
       display: block;
       @include m.font-size("small");
       font-style: italic;

--- a/packages/frontend/app/styles/components/school-institutional-information-manager.scss
+++ b/packages/frontend/app/styles/components/school-institutional-information-manager.scss
@@ -30,7 +30,7 @@
     }
 
     .validation-error-message {
-      color: var(--rosewood);
+      color: var(--darker-red);
       display: block;
       @include m.font-size("small");
       font-style: italic;

--- a/packages/frontend/app/styles/components/school-list.scss
+++ b/packages/frontend/app/styles/components/school-list.scss
@@ -25,7 +25,7 @@
   }
 
   .new {
-    background-color: var(--slight-white);
+    background-color: var(--white);
     border: 1px solid var(--cultured-grey);
     margin: 0.5rem 0;
     padding: 1rem;

--- a/packages/frontend/app/styles/components/school-list.scss
+++ b/packages/frontend/app/styles/components/school-list.scss
@@ -26,7 +26,7 @@
 
   .new {
     background-color: var(--white);
-    border: 1px solid var(--cultured-grey);
+    border: 1px solid var(--lightest-grey);
     margin: 0.5rem 0;
     padding: 1rem;
 

--- a/packages/frontend/app/styles/components/school-manager.scss
+++ b/packages/frontend/app/styles/components/school-manager.scss
@@ -10,7 +10,7 @@
   }
 
   .school-overview {
-    border-bottom: 1px solid var(--cultured-grey);
+    border-bottom: 1px solid var(--lightest-grey);
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/packages/frontend/app/styles/components/school-session-type-form.scss
+++ b/packages/frontend/app/styles/components/school-session-type-form.scss
@@ -5,7 +5,7 @@
   .form {
     @include m.ilios-form;
     background-color: var(--white);
-    border: 1px solid var(--cultured-grey);
+    border: 1px solid var(--lightest-grey);
     margin: 0.5rem 0;
     padding: 1rem;
 

--- a/packages/frontend/app/styles/components/school-session-type-form.scss
+++ b/packages/frontend/app/styles/components/school-session-type-form.scss
@@ -4,7 +4,7 @@
 .school-session-type-form {
   .form {
     @include m.ilios-form;
-    background-color: var(--slight-white);
+    background-color: var(--white);
     border: 1px solid var(--cultured-grey);
     margin: 0.5rem 0;
     padding: 1rem;

--- a/packages/frontend/app/styles/components/school-vocabularies-expanded.scss
+++ b/packages/frontend/app/styles/components/school-vocabularies-expanded.scss
@@ -20,7 +20,7 @@
     @include m.detail-container-content;
 
     .hierarchical-list {
-      background-color: var(--cultured-grey);
+      background-color: var(--lightest-grey);
       border: 1px solid var(--black);
       margin: 1rem;
       padding: 1rem;

--- a/packages/frontend/app/styles/components/school-vocabularies-list.scss
+++ b/packages/frontend/app/styles/components/school-vocabularies-list.scss
@@ -3,7 +3,7 @@
 
 .school-vocabularies-list {
   .school-vocabularies-list-header {
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
     display: flex;
     justify-content: flex-end;
     padding: 0.5rem 1rem;

--- a/packages/frontend/app/styles/components/school-vocabulary-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-manager.scss
@@ -51,7 +51,7 @@
       @include m.ilios-selectable-list;
 
       em {
-        color: var(--crimson);
+        color: var(--red);
       }
     }
   }

--- a/packages/frontend/app/styles/components/school-vocabulary-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-manager.scss
@@ -51,7 +51,7 @@
       @include m.ilios-selectable-list;
 
       em {
-        color: var(--darker-red);
+        color: var(--red);
       }
     }
   }

--- a/packages/frontend/app/styles/components/school-vocabulary-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-manager.scss
@@ -40,7 +40,7 @@
     width: 80%;
 
     .saved-result {
-      border: 1px solid var(--fern-green);
+      border: 1px solid var(--green);
       display: flex;
       gap: 0.25rem;
       margin: 1rem;

--- a/packages/frontend/app/styles/components/school-vocabulary-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-manager.scss
@@ -51,7 +51,7 @@
       @include m.ilios-selectable-list;
 
       em {
-        color: var(--red);
+        color: var(--darker-red);
       }
     }
   }

--- a/packages/frontend/app/styles/components/school-vocabulary-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-manager.scss
@@ -32,7 +32,7 @@
 
   .terms {
     background-color: var(--white);
-    border: 1px solid var(--blue-munsell);
+    border: 1px solid var(--light-blue);
     height: 10rem;
     margin-bottom: 1rem;
     overflow-y: scroll;

--- a/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
@@ -71,7 +71,7 @@
       @include m.ilios-selectable-list;
 
       em {
-        color: var(--darker-red);
+        color: var(--red);
       }
     }
   }

--- a/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
@@ -71,7 +71,7 @@
       @include m.ilios-selectable-list;
 
       em {
-        color: var(--red);
+        color: var(--darker-red);
       }
     }
   }

--- a/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
@@ -71,7 +71,7 @@
       @include m.ilios-selectable-list;
 
       em {
-        color: var(--crimson);
+        color: var(--red);
       }
     }
   }

--- a/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
+++ b/packages/frontend/app/styles/components/school-vocabulary-term-manager.scss
@@ -39,7 +39,7 @@
 
   .terms {
     background-color: var(--white);
-    border: 1px solid var(--blue-munsell);
+    border: 1px solid var(--light-blue);
     height: 10rem;
     margin-bottom: 1rem;
     overflow-y: scroll;

--- a/packages/frontend/app/styles/components/school/emails-editor.scss
+++ b/packages/frontend/app/styles/components/school/emails-editor.scss
@@ -30,7 +30,7 @@
     }
 
     .validation-error-message {
-      color: var(--darker-red);
+      color: var(--red);
       display: block;
       @include m.font-size("small");
       font-style: italic;

--- a/packages/frontend/app/styles/components/school/emails-editor.scss
+++ b/packages/frontend/app/styles/components/school/emails-editor.scss
@@ -30,7 +30,7 @@
     }
 
     .validation-error-message {
-      color: var(--rosewood);
+      color: var(--darker-red);
       display: block;
       @include m.font-size("small");
       font-style: italic;

--- a/packages/frontend/app/styles/components/update-notification.scss
+++ b/packages/frontend/app/styles/components/update-notification.scss
@@ -3,7 +3,7 @@
 
 .update-notification {
   button {
-    @include m.critical-notice(var(--teal-blue), var(--white), 3rem);
+    @include m.critical-notice(var(--blue), var(--white), 3rem);
     @include m.font-size("large");
   }
 }

--- a/packages/frontend/app/styles/components/user-guide-link.scss
+++ b/packages/frontend/app/styles/components/user-guide-link.scss
@@ -3,7 +3,7 @@
 
 @use "sass:color";
 
-$header-menu-background-color: hsl(from var(--slight-white) h s calc(l - 3));
+$header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
 
 .user-guide-link {
   margin-right: 0.85rem;

--- a/packages/frontend/app/styles/components/user-guide-link.scss
+++ b/packages/frontend/app/styles/components/user-guide-link.scss
@@ -17,7 +17,7 @@ $header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
     background-color: $header-menu-background-color;
     border: 1px solid $header-menu-background-color;
     border-radius: 0.2rem;
-    color: var(--raisin-black);
+    color: var(--black);
     @include cm.font-size("small");
     font-weight: normal;
     margin-left: 0.8rem;

--- a/packages/frontend/app/styles/components/user-guide-link.scss
+++ b/packages/frontend/app/styles/components/user-guide-link.scss
@@ -3,8 +3,6 @@
 
 @use "sass:color";
 
-$header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
-
 .user-guide-link {
   margin-right: 0.85rem;
 
@@ -14,8 +12,8 @@ $header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
 
   a {
     @include cm.ilios-link-button;
-    background-color: $header-menu-background-color;
-    border: 1px solid $header-menu-background-color;
+    background-color: var(--super-light-grey);
+    border: 1px solid var(--super-light-grey);
     border-radius: 0.2rem;
     color: var(--black);
     @include cm.font-size("small");

--- a/packages/frontend/app/styles/components/user-profile-bio.scss
+++ b/packages/frontend/app/styles/components/user-profile-bio.scss
@@ -59,7 +59,7 @@
   meter {
     background: none;
     background-color: var(--white);
-    border: 0.5px solid var(--raisin-black);
+    border: 0.5px solid var(--black);
     height: 0.75rem;
     margin: 0.25rem 0;
     width: 60%;

--- a/packages/frontend/app/styles/components/user-profile-bio.scss
+++ b/packages/frontend/app/styles/components/user-profile-bio.scss
@@ -33,7 +33,7 @@
       }
 
       &.synced-from-directory input {
-        background-color: hsl(from var(--green) h s calc(l + 40));
+        background-color: var(--transparent-green);
         transition: background-color 500ms ease;
       }
     }

--- a/packages/frontend/app/styles/components/user-profile-bio.scss
+++ b/packages/frontend/app/styles/components/user-profile-bio.scss
@@ -75,10 +75,10 @@
   }
 
   meter[value="0"]::-webkit-meter-optimum-value {
-    background: var(--red);
+    background: var(--light-red);
   }
   meter[value="1"]::-webkit-meter-optimum-value {
-    background: var(--red);
+    background: var(--light-red);
   }
   meter[value="2"]::-webkit-meter-optimum-value {
     background: var(--orange);
@@ -91,10 +91,10 @@
   }
 
   meter[value="0"]:-moz-meter-bar {
-    background: var(--red);
+    background: var(--light-red);
   }
   meter[value="1"]:-moz-meter-bar {
-    background: var(--red);
+    background: var(--light-red);
   }
   meter[value="2"]:-moz-meter-bar {
     background: var(--orange);
@@ -114,12 +114,12 @@
     width: 10%;
 
     &.strength-0 {
-      color: var(--red);
+      color: var(--light-red);
       width: 20%;
     }
 
     &.strength-1 {
-      color: var(--red);
+      color: var(--light-red);
     }
 
     &.strength-2 {

--- a/packages/frontend/app/styles/components/user-profile-bio.scss
+++ b/packages/frontend/app/styles/components/user-profile-bio.scss
@@ -84,7 +84,7 @@
     background: var(--orange);
   }
   meter[value="3"]::-webkit-meter-optimum-value {
-    background: var(--gold);
+    background: var(--dark-yellow);
   }
   meter[value="4"]::-webkit-meter-optimum-value {
     background: var(--green);
@@ -100,7 +100,7 @@
     background: var(--orange);
   }
   meter[value="3"]:-moz-meter-bar {
-    background: var(--gold);
+    background: var(--dark-yellow);
   }
   meter[value="4"]:-moz-meter-bar {
     background: var(--green);
@@ -127,7 +127,7 @@
     }
 
     &.strength-3 {
-      color: var(--gold);
+      color: var(--dark-yellow);
     }
 
     &.strength-4 {

--- a/packages/frontend/app/styles/components/user-profile-bio.scss
+++ b/packages/frontend/app/styles/components/user-profile-bio.scss
@@ -75,10 +75,10 @@
   }
 
   meter[value="0"]::-webkit-meter-optimum-value {
-    background: var(--crimson);
+    background: var(--red);
   }
   meter[value="1"]::-webkit-meter-optimum-value {
-    background: var(--crimson);
+    background: var(--red);
   }
   meter[value="2"]::-webkit-meter-optimum-value {
     background: var(--orange);
@@ -91,10 +91,10 @@
   }
 
   meter[value="0"]:-moz-meter-bar {
-    background: var(--crimson);
+    background: var(--red);
   }
   meter[value="1"]:-moz-meter-bar {
-    background: var(--crimson);
+    background: var(--red);
   }
   meter[value="2"]:-moz-meter-bar {
     background: var(--orange);
@@ -114,12 +114,12 @@
     width: 10%;
 
     &.strength-0 {
-      color: var(--crimson);
+      color: var(--red);
       width: 20%;
     }
 
     &.strength-1 {
-      color: var(--crimson);
+      color: var(--red);
     }
 
     &.strength-2 {

--- a/packages/frontend/app/styles/components/user-profile-bio.scss
+++ b/packages/frontend/app/styles/components/user-profile-bio.scss
@@ -33,7 +33,7 @@
       }
 
       &.synced-from-directory input {
-        background-color: hsl(from var(--fern-green) h s calc(l + 40));
+        background-color: hsl(from var(--green) h s calc(l + 40));
         transition: background-color 500ms ease;
       }
     }
@@ -87,7 +87,7 @@
     background: var(--gold);
   }
   meter[value="4"]::-webkit-meter-optimum-value {
-    background: var(--fern-green);
+    background: var(--green);
   }
 
   meter[value="0"]:-moz-meter-bar {
@@ -103,7 +103,7 @@
     background: var(--gold);
   }
   meter[value="4"]:-moz-meter-bar {
-    background: var(--fern-green);
+    background: var(--green);
   }
 
   .password-strength {
@@ -131,7 +131,7 @@
     }
 
     &.strength-4 {
-      color: var(--fern-green);
+      color: var(--green);
     }
   }
 }

--- a/packages/frontend/app/styles/components/user-profile-bio.scss
+++ b/packages/frontend/app/styles/components/user-profile-bio.scss
@@ -43,7 +43,7 @@
     display: flex;
 
     button {
-      background-color: var(--blue-munsell);
+      background-color: var(--light-blue);
       height: 2rem;
       margin-bottom: 0.25rem;
       margin-left: 0.5rem;

--- a/packages/frontend/app/styles/components/user-profile-loading.scss
+++ b/packages/frontend/app/styles/components/user-profile-loading.scss
@@ -8,7 +8,7 @@
     color: transparent;
     margin-bottom: 1rem;
     text-align: center;
-    text-shadow: hsl(from var(--black) h s l / 0.3) 0px 0px 10px;
+    text-shadow: var(--very-transparent-black) 0px 0px 10px;
   }
 
   .blocks {

--- a/packages/frontend/app/styles/components/user-profile-roles.scss
+++ b/packages/frontend/app/styles/components/user-profile-roles.scss
@@ -7,7 +7,7 @@
   }
 
   hr {
-    border-top: 0.5px solid var(--raisin-black);
+    border-top: 0.5px solid var(--black);
   }
 
   .actions {

--- a/packages/frontend/app/styles/components/user-profile-schools.scss
+++ b/packages/frontend/app/styles/components/user-profile-schools.scss
@@ -24,7 +24,7 @@
   }
 
   .more-permissions-notice {
-    color: var(--raisin-black);
+    color: var(--black);
     font-style: italic;
     font-weight: bold;
     text-align: center;

--- a/packages/frontend/app/styles/components/user-profile.scss
+++ b/packages/frontend/app/styles/components/user-profile.scss
@@ -24,7 +24,7 @@
     text-align: center;
 
     .user-is-student {
-      color: var(--fern-green);
+      color: var(--green);
     }
   }
 }
@@ -45,6 +45,6 @@
   }
 
   .refresh-key {
-    background-color: var(--fern-green);
+    background-color: var(--green);
   }
 }

--- a/packages/frontend/app/styles/layout/_noscript.scss
+++ b/packages/frontend/app/styles/layout/_noscript.scss
@@ -5,7 +5,7 @@ noscript {
   p {
     background-color: var(--white);
     border: 2px dashed var(--orange);
-    color: var(--raisin-black);
+    color: var(--black);
     @include m.font-size("xxl");
     font-weight: bold;
     margin: 2rem;

--- a/packages/frontend/app/styles/layout/_noscript.scss
+++ b/packages/frontend/app/styles/layout/_noscript.scss
@@ -3,7 +3,7 @@
 
 noscript {
   p {
-    background-color: var(--slight-white);
+    background-color: var(--white);
     border: 2px dashed var(--orange);
     color: var(--raisin-black);
     @include m.font-size("xxl");

--- a/packages/frontend/app/styles/mixins/admin-blocks.scss
+++ b/packages/frontend/app/styles/mixins/admin-blocks.scss
@@ -13,7 +13,7 @@
 
   .small-component,
   .large-component {
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
     border: 1px solid var(--light-blue);
     border-radius: 5px;
     margin-bottom: 1rem;

--- a/packages/frontend/app/styles/mixins/admin-blocks.scss
+++ b/packages/frontend/app/styles/mixins/admin-blocks.scss
@@ -14,7 +14,7 @@
   .small-component,
   .large-component {
     background-color: var(--cultured-grey);
-    border: 1px solid var(--blue-munsell);
+    border: 1px solid var(--light-blue);
     border-radius: 5px;
     margin-bottom: 1rem;
     min-height: 5rem;

--- a/packages/frontend/app/styles/mixins/admin-blocks.scss
+++ b/packages/frontend/app/styles/mixins/admin-blocks.scss
@@ -52,7 +52,7 @@
   }
 
   .has-saved {
-    background-color: hsl(from var(--green) h s calc(l + 30));
+    background-color: var(--transparent-green);
     transition: background-color 0.5s ease-out;
   }
 

--- a/packages/frontend/app/styles/mixins/admin-blocks.scss
+++ b/packages/frontend/app/styles/mixins/admin-blocks.scss
@@ -22,7 +22,7 @@
 
     &.alert {
       background-color: var(--white);
-      border: 3px solid var(--gold);
+      border: 3px solid var(--dark-yellow);
     }
 
     p {

--- a/packages/frontend/app/styles/mixins/admin-blocks.scss
+++ b/packages/frontend/app/styles/mixins/admin-blocks.scss
@@ -52,7 +52,7 @@
   }
 
   .has-saved {
-    background-color: hsl(from var(--fern-green) h s calc(l + 30));
+    background-color: hsl(from var(--green) h s calc(l + 30));
     transition: background-color 0.5s ease-out;
   }
 

--- a/packages/frontend/app/styles/mixins/header-menu.scss
+++ b/packages/frontend/app/styles/mixins/header-menu.scss
@@ -3,8 +3,6 @@
 
 @use "sass:color";
 
-$header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
-
 @mixin header-menu() {
   margin: 0 0 0 0.5rem;
   position: relative;
@@ -12,7 +10,7 @@ $header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
 
   button {
     background-color: transparent;
-    border: 1px solid $header-menu-background-color;
+    border: 1px solid var(--super-light-grey);
     border-radius: 0.2rem;
     color: var(--black);
     font-weight: normal;
@@ -20,7 +18,7 @@ $header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
   }
 
   .menu {
-    background-color: $header-menu-background-color;
+    background-color: var(--super-light-grey);
     box-shadow: 0 2px 2px var(--very-transparent-black);
     display: flex;
     flex-direction: column;
@@ -34,7 +32,7 @@ $header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
   }
 
   .toggle {
-    background-color: $header-menu-background-color;
+    background-color: var(--super-light-grey);
     span {
       display: none;
 
@@ -57,7 +55,7 @@ $header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
 
 @mixin header-menu-item() {
   border: 0;
-  background-color: $header-menu-background-color;
+  background-color: var(--super-light-grey);
   color: var(--black);
   display: block;
   outline: none;

--- a/packages/frontend/app/styles/mixins/header-menu.scss
+++ b/packages/frontend/app/styles/mixins/header-menu.scss
@@ -21,7 +21,7 @@ $header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
 
   .menu {
     background-color: $header-menu-background-color;
-    box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.2);
+    box-shadow: 0 2px 2px var(--very-transparent-black);
     display: flex;
     flex-direction: column;
     list-style-type: none;

--- a/packages/frontend/app/styles/mixins/header-menu.scss
+++ b/packages/frontend/app/styles/mixins/header-menu.scss
@@ -11,7 +11,7 @@
   button {
     background-color: transparent;
     border: 1px solid var(--super-light-grey);
-    border-radius: 0.2rem;
+    border-radius: 0;
     color: var(--black);
     font-weight: normal;
     padding: 0.25rem;
@@ -66,15 +66,18 @@
 
   &[aria-checked="true"],
   &.active {
-    background-color: hsl(from var(--green) h s calc(l + 25));
+    background-color: var(--green);
+    color: var(--white);
   }
 
   &:hover,
   &:focus {
-    background-color: var(--white);
+    background-color: var(--blue);
+    color: var(--white);
     &[aria-checked="true"],
     &.active {
-      background-color: hsl(from var(--green) h s calc(l + 15));
+      background-color: var(--green);
+      cursor: default;
     }
   }
 }

--- a/packages/frontend/app/styles/mixins/header-menu.scss
+++ b/packages/frontend/app/styles/mixins/header-menu.scss
@@ -68,7 +68,7 @@ $header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
 
   &[aria-checked="true"],
   &.active {
-    background-color: hsl(from var(--fern-green) h s calc(l + 25));
+    background-color: hsl(from var(--green) h s calc(l + 25));
   }
 
   &:hover,
@@ -76,7 +76,7 @@ $header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
     background-color: var(--white);
     &[aria-checked="true"],
     &.active {
-      background-color: hsl(from var(--fern-green) h s calc(l + 15));
+      background-color: hsl(from var(--green) h s calc(l + 15));
     }
   }
 }

--- a/packages/frontend/app/styles/mixins/header-menu.scss
+++ b/packages/frontend/app/styles/mixins/header-menu.scss
@@ -14,7 +14,7 @@ $header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
     background-color: transparent;
     border: 1px solid $header-menu-background-color;
     border-radius: 0.2rem;
-    color: var(--raisin-black);
+    color: var(--black);
     font-weight: normal;
     padding: 0.25rem;
   }

--- a/packages/frontend/app/styles/mixins/header-menu.scss
+++ b/packages/frontend/app/styles/mixins/header-menu.scss
@@ -3,7 +3,7 @@
 
 @use "sass:color";
 
-$header-menu-background-color: hsl(from var(--slight-white) h s calc(l - 3));
+$header-menu-background-color: hsl(from var(--white) h s calc(l - 3));
 
 @mixin header-menu() {
   margin: 0 0 0 0.5rem;

--- a/packages/frontend/app/styles/mixins/verification-preview-table.scss
+++ b/packages/frontend/app/styles/mixins/verification-preview-table.scss
@@ -5,7 +5,7 @@
 @mixin verification-preview-table() {
   td,
   th {
-    border: 1px solid hsl(from var(--cultured-grey) h s calc(l - 15));
+    border: 1px solid hsl(from var(--lightest-grey) h s calc(l - 15));
   }
 
   th {

--- a/packages/frontend/app/styles/mixins/verification-preview-table.scss
+++ b/packages/frontend/app/styles/mixins/verification-preview-table.scss
@@ -5,7 +5,7 @@
 @mixin verification-preview-table() {
   td,
   th {
-    border: 1px solid var(--ligher-grey);
+    border: 1px solid var(--lighter-grey);
   }
 
   th {

--- a/packages/frontend/app/styles/mixins/verification-preview-table.scss
+++ b/packages/frontend/app/styles/mixins/verification-preview-table.scss
@@ -5,7 +5,7 @@
 @mixin verification-preview-table() {
   td,
   th {
-    border: 1px solid hsl(from var(--lightest-grey) h s calc(l - 15));
+    border: 1px solid var(--ligher-grey);
   }
 
   th {

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -4,7 +4,7 @@
   --slightly-transparent-black: hsl(from var(--black) h s l / 0.8);
   --very-transparent-black: hsl(from var(--black) h s l / 0.2);
   --orange: hsl(30, 100%, 40%);
-  --sepia: hsl(30, 100%, 20%);
+  --dark-orange: hsl(30, 100%, 20%);
   --green: hsl(115, 100%, 20%);
   --yellow: hsl(45, 100%, 60%);
   --dark-yellow: hsl(45, 100%, 45%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -6,7 +6,7 @@
   --fern-green: hsl(103, 23%, 36%);
   --gold: hsl(48, 93%, 44%);
   --blue-munsell: hsl(195, 53%, 43%);
-  --teal-blue: hsl(195, 52%, 36%);
+  --blue: hsl(195, 52%, 36%);
   --light-blue: hsl(195, 51%, 92%);
   --davys-grey: hsl(0, 0%, 32%);
   --cultured-grey: hsl(200, 15%, 92%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -7,8 +7,8 @@
   --lightest-grey: hsl(0, 0%, 90%);
   --super-light-grey: hsl(0, 0%, 95%);
 
-  --red: hsl(0, 100%, 40%);
-  --darker-red: hsl(0, 100%, 30%);
+  --red: hsl(0, 100%, 30%);
+  --light-red: hsl(0, 100%, 40%);
   --lightest-red: hsl(0, 100%, 97%);
 
   --orange: hsl(30, 100%, 40%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -5,8 +5,8 @@
   --sepia: hsl(30, 100%, 20%);
   --fern-green: hsl(103, 23%, 36%);
   --gold: hsl(48, 93%, 44%);
-  --blue-munsell: hsl(195, 53%, 43%);
   --blue: hsl(195, 52%, 36%);
+  --light-blue: hsl(195, 50%, 45%);
   --lightest-blue: hsl(195, 50%, 90%);
   --davys-grey: hsl(0, 0%, 32%);
   --cultured-grey: hsl(200, 15%, 92%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -18,6 +18,7 @@
   --darker-yellow: hsl(45, 100%, 20%);
 
   --green: hsl(115, 100%, 20%);
+  --transparent-green: hsl(115, 50%, 50%, 20%);
 
   --blue: hsl(195, 50%, 35%);
   --light-blue: hsl(195, 50%, 45%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -22,6 +22,7 @@
 
   --blue: hsl(195, 50%, 35%);
   --light-blue: hsl(195, 50%, 45%);
+  --lighter-blue: hsl(195, 50%, 80%);
   --lightest-blue: hsl(195, 50%, 92%);
 
   --black: hsl(345, 6%, 13%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -9,7 +9,7 @@
   --light-blue: hsl(195, 50%, 45%);
   --lightest-blue: hsl(195, 50%, 92%);
   --grey: hsl(0, 0%, 30%);
-  --cultured-grey: hsl(200, 15%, 92%);
+  --lightest-grey: hsl(0, 0%, 90%);
   --red: hsl(0, 100%, 40%);
   --lightest-red: hsl(0, 100%, 97%);
   --darker-red: hsl(0, 100%, 30%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -1,7 +1,6 @@
 :root {
-  --slight-white: hsl(0, 0%, 98%);
+  --white: hsl(0, 0%, 98%);
   --raisin-black: hsl(345, 6%, 13%);
-  --white: hsl(0, 100%, 100%);
   --black: hsl(0, 0%, 0%);
   --orange: hsl(30, 100%, 40%);
   --sepia: hsl(30, 100%, 20%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -7,7 +7,7 @@
   --gold: hsl(48, 93%, 44%);
   --blue-munsell: hsl(195, 53%, 43%);
   --blue: hsl(195, 52%, 36%);
-  --light-blue: hsl(195, 51%, 92%);
+  --lightest-blue: hsl(195, 50%, 90%);
   --davys-grey: hsl(0, 0%, 32%);
   --cultured-grey: hsl(200, 15%, 92%);
   --crimson: hsl(346, 82%, 48%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -6,7 +6,9 @@
   --orange: hsl(30, 100%, 40%);
   --sepia: hsl(30, 100%, 20%);
   --green: hsl(115, 100%, 20%);
-  --gold: hsl(48, 93%, 44%);
+  --yellow: hsl(45, 100%, 60%);
+  --dark-yellow: hsl(45, 100%, 45%);
+  --darker-yellow: hsl(45, 100%, 20%);
   --blue: hsl(195, 50%, 35%);
   --light-blue: hsl(195, 50%, 45%);
   --lightest-blue: hsl(195, 50%, 92%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -5,9 +5,9 @@
   --sepia: hsl(30, 100%, 20%);
   --green: hsl(115, 100%, 20%);
   --gold: hsl(48, 93%, 44%);
-  --blue: hsl(195, 52%, 36%);
+  --blue: hsl(195, 50%, 35%);
   --light-blue: hsl(195, 50%, 45%);
-  --lightest-blue: hsl(195, 50%, 90%);
+  --lightest-blue: hsl(195, 50%, 92%);
   --davys-grey: hsl(0, 0%, 32%);
   --cultured-grey: hsl(200, 15%, 92%);
   --red: hsl(0, 100%, 40%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -4,6 +4,7 @@
   --grey: hsl(0, 0%, 30%);
   --lighter-grey: hsl(0, 0%, 80%);
   --lightest-grey: hsl(0, 0%, 90%);
+  --super-light-grey: hsl(0, 0%, 95%);
 
   --red: hsl(0, 100%, 40%);
   --darker-red: hsl(0, 100%, 30%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -10,7 +10,7 @@
   --lightest-blue: hsl(195, 50%, 90%);
   --davys-grey: hsl(0, 0%, 32%);
   --cultured-grey: hsl(200, 15%, 92%);
-  --crimson: hsl(346, 82%, 48%);
+  --red: hsl(0, 100%, 40%);
   --lavender-blush: hsl(346, 80%, 96%);
   --rosewood: hsl(346, 80%, 20%);
 }

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -1,6 +1,8 @@
 :root {
   --white: hsl(0, 0%, 98%);
   --black: hsl(345, 6%, 13%);
+  --slightly-transparent-black: hsl(from var(--black) h s l / 0.8);
+  --very-transparent-black: hsl(from var(--black) h s l / 0.2);
   --orange: hsl(30, 100%, 40%);
   --sepia: hsl(30, 100%, 20%);
   --green: hsl(115, 100%, 20%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -2,6 +2,7 @@
   --white: hsl(0, 0%, 98%);
 
   --grey: hsl(0, 0%, 30%);
+  --light-grey: hsl(0, 0%, 50%);
   --lighter-grey: hsl(0, 0%, 80%);
   --lightest-grey: hsl(0, 0%, 90%);
   --super-light-grey: hsl(0, 0%, 95%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -9,6 +9,7 @@
   --light-blue: hsl(195, 50%, 45%);
   --lightest-blue: hsl(195, 50%, 92%);
   --grey: hsl(0, 0%, 30%);
+  --lighter-grey: hsl(0, 0%, 80%);
   --lightest-grey: hsl(0, 0%, 90%);
   --red: hsl(0, 100%, 40%);
   --lightest-red: hsl(0, 100%, 97%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -1,7 +1,6 @@
 :root {
   --white: hsl(0, 0%, 98%);
-  --raisin-black: hsl(345, 6%, 13%);
-  --black: hsl(0, 0%, 0%);
+  --black: hsl(345, 6%, 13%);
   --orange: hsl(30, 100%, 40%);
   --sepia: hsl(30, 100%, 20%);
   --fern-green: hsl(103, 23%, 36%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -1,21 +1,28 @@
 :root {
   --white: hsl(0, 0%, 98%);
-  --black: hsl(345, 6%, 13%);
-  --slightly-transparent-black: hsl(from var(--black) h s l / 0.8);
-  --very-transparent-black: hsl(from var(--black) h s l / 0.2);
-  --orange: hsl(30, 100%, 40%);
-  --dark-orange: hsl(30, 100%, 20%);
-  --green: hsl(115, 100%, 20%);
-  --yellow: hsl(45, 100%, 60%);
-  --dark-yellow: hsl(45, 100%, 45%);
-  --darker-yellow: hsl(45, 100%, 20%);
-  --blue: hsl(195, 50%, 35%);
-  --light-blue: hsl(195, 50%, 45%);
-  --lightest-blue: hsl(195, 50%, 92%);
+
   --grey: hsl(0, 0%, 30%);
   --lighter-grey: hsl(0, 0%, 80%);
   --lightest-grey: hsl(0, 0%, 90%);
+
   --red: hsl(0, 100%, 40%);
-  --lightest-red: hsl(0, 100%, 97%);
   --darker-red: hsl(0, 100%, 30%);
+  --lightest-red: hsl(0, 100%, 97%);
+
+  --orange: hsl(30, 100%, 40%);
+  --dark-orange: hsl(30, 100%, 20%);
+
+  --yellow: hsl(45, 100%, 60%);
+  --dark-yellow: hsl(45, 100%, 45%);
+  --darker-yellow: hsl(45, 100%, 20%);
+
+  --green: hsl(115, 100%, 20%);
+
+  --blue: hsl(195, 50%, 35%);
+  --light-blue: hsl(195, 50%, 45%);
+  --lightest-blue: hsl(195, 50%, 92%);
+
+  --black: hsl(345, 6%, 13%);
+  --slightly-transparent-black: hsl(from var(--black) h s l / 0.8);
+  --very-transparent-black: hsl(from var(--black) h s l / 0.2);
 }

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -3,7 +3,7 @@
   --black: hsl(345, 6%, 13%);
   --orange: hsl(30, 100%, 40%);
   --sepia: hsl(30, 100%, 20%);
-  --fern-green: hsl(103, 23%, 36%);
+  --green: hsl(115, 100%, 20%);
   --gold: hsl(48, 93%, 44%);
   --blue: hsl(195, 52%, 36%);
   --light-blue: hsl(195, 50%, 45%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -12,5 +12,5 @@
   --cultured-grey: hsl(200, 15%, 92%);
   --red: hsl(0, 100%, 40%);
   --lavender-blush: hsl(346, 80%, 96%);
-  --rosewood: hsl(346, 80%, 20%);
+  --darker-red: hsl(0, 100%, 30%);
 }

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -11,6 +11,6 @@
   --davys-grey: hsl(0, 0%, 32%);
   --cultured-grey: hsl(200, 15%, 92%);
   --red: hsl(0, 100%, 40%);
-  --lavender-blush: hsl(346, 80%, 96%);
+  --lightest-red: hsl(0, 100%, 97%);
   --darker-red: hsl(0, 100%, 30%);
 }

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -8,7 +8,7 @@
   --blue: hsl(195, 50%, 35%);
   --light-blue: hsl(195, 50%, 45%);
   --lightest-blue: hsl(195, 50%, 92%);
-  --davys-grey: hsl(0, 0%, 32%);
+  --grey: hsl(0, 0%, 30%);
   --cultured-grey: hsl(200, 15%, 92%);
   --red: hsl(0, 100%, 40%);
   --lightest-red: hsl(0, 100%, 97%);

--- a/packages/ilios-common/app/styles/ilios-common/components/api-version-notice.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/api-version-notice.scss
@@ -2,7 +2,7 @@
 @use "../mixins" as m;
 
 .api-version-notice {
-  @include m.critical-notice(var(--gold), var(--black), 1rem);
+  @include m.critical-notice(var(--dark-yellow), var(--black), 1rem);
 
   display: none;
   padding: 0.25rem 1rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/api-version-notice.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/api-version-notice.scss
@@ -2,7 +2,7 @@
 @use "../mixins" as m;
 
 .api-version-notice {
-  @include m.critical-notice(var(--gold), var(--raisin-black), 1rem);
+  @include m.critical-notice(var(--gold), var(--black), 1rem);
 
   display: none;
   padding: 0.25rem 1rem;
@@ -13,7 +13,7 @@
 
   .details {
     button {
-      background-color: var(--raisin-black);
+      background-color: var(--black);
       border: 0;
       color: var(--white);
       display: inline-block;

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -79,12 +79,12 @@ p {
 
 .remove,
 .no {
-  color: var(--rosewood);
+  color: var(--darker-red);
 }
 
 .error,
 .is-error {
-  color: var(--rosewood);
+  color: var(--darker-red);
 }
 
 .warning,

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -111,7 +111,7 @@ p {
 }
 
 .scheduled {
-  color: var(--sepia);
+  color: var(--dark-orange);
 }
 
 .backtolink {

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -79,12 +79,12 @@ p {
 
 .remove,
 .no {
-  color: var(--darker-red);
+  color: var(--red);
 }
 
 .error,
 .is-error {
-  color: var(--darker-red);
+  color: var(--red);
 }
 
 .warning,

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -13,7 +13,7 @@ html {
 
 body {
   background-color: var(--white);
-  color: var(--raisin-black);
+  color: var(--black);
   font-family: Nunito, serif;
   margin: 0;
   padding: 0;
@@ -53,7 +53,7 @@ h6 {
 }
 
 select {
-  color: var(--raisin-black);
+  color: var(--black);
   font-family: "Nunito Sans", sans-serif;
 }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -74,7 +74,7 @@ p {
 
 .add,
 .yes {
-  color: var(--fern-green);
+  color: var(--green);
 }
 
 .remove,
@@ -103,7 +103,7 @@ p {
 }
 
 .published {
-  color: var(--fern-green);
+  color: var(--green);
 }
 
 .notpublished {

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -89,7 +89,7 @@ p {
 
 .warning,
 .is-warning {
-  color: var(--gold);
+  color: var(--yellow);
 }
 
 .clickable,

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -12,7 +12,7 @@ html {
 }
 
 body {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   color: var(--raisin-black);
   font-family: Nunito, serif;
   margin: 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -99,7 +99,7 @@ p {
 
 .editable,
 .is-editable {
-  color: var(--teal-blue);
+  color: var(--blue);
 }
 
 .published {

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -107,7 +107,7 @@ p {
 }
 
 .notpublished {
-  color: var(--davys-grey);
+  color: var(--grey);
 }
 
 .scheduled {

--- a/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
@@ -2,12 +2,12 @@
 @use "sass:math";
 
 .breadcrumbs {
-  $breadcrumb-border-color: var(--teal-blue);
+  $breadcrumb-border-color: var(--blue);
   $breadcrumb-border: 1px solid $breadcrumb-border-color;
   $breadcrumb-height: 2rem;
   $breadcrumb-arrow-color: $breadcrumb-border-color;
   $breadcrumb-background: var(--white);
-  $breadcrumb-color: var(--teal-blue);
+  $breadcrumb-color: var(--blue);
   $breadcrumb-link-color-hover: var(--orange);
 
   display: inline-block;

--- a/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
@@ -6,7 +6,7 @@
   $breadcrumb-border: 1px solid $breadcrumb-border-color;
   $breadcrumb-height: 2rem;
   $breadcrumb-arrow-color: $breadcrumb-border-color;
-  $breadcrumb-background: var(--slight-white);
+  $breadcrumb-background: var(--white);
   $breadcrumb-color: var(--teal-blue);
   $breadcrumb-link-color-hover: var(--orange);
 

--- a/packages/ilios-common/app/styles/ilios-common/components/choose-material-type.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/choose-material-type.scss
@@ -9,7 +9,7 @@
 
   button {
     background-color: transparent;
-    border: 1px solid var(--slight-white);
+    border: 1px solid var(--white);
     border-radius: 0.2rem;
     color: var(--raisin-black);
     font-weight: normal;
@@ -17,7 +17,7 @@
   }
 
   .menu {
-    background-color: var(--slight-white);
+    background-color: var(--white);
     box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.8);
     display: flex;
     flex-direction: column;
@@ -31,7 +31,7 @@
 
     button {
       border: 0;
-      background-color: var(--slight-white);
+      background-color: var(--white);
       color: var(--raisin-black);
       display: block;
       outline: none;

--- a/packages/ilios-common/app/styles/ilios-common/components/choose-material-type.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/choose-material-type.scss
@@ -18,7 +18,7 @@
 
   .menu {
     background-color: var(--white);
-    box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.8);
+    box-shadow: 0 2px 2px var(--slightly-transparent-black);
     display: flex;
     flex-direction: column;
     list-style-type: none;

--- a/packages/ilios-common/app/styles/ilios-common/components/choose-material-type.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/choose-material-type.scss
@@ -11,7 +11,7 @@
     background-color: transparent;
     border: 1px solid var(--white);
     border-radius: 0.2rem;
-    color: var(--raisin-black);
+    color: var(--black);
     font-weight: normal;
     padding: 0.25rem 0.5rem;
   }
@@ -32,7 +32,7 @@
     button {
       border: 0;
       background-color: var(--white);
-      color: var(--raisin-black);
+      color: var(--black);
       display: block;
       outline: none;
       padding: 0.5rem 1rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/choose-material-type.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/choose-material-type.scss
@@ -42,14 +42,14 @@
 
       &:hover,
       &:focus {
-        background-color: var(--teal-blue);
+        background-color: var(--blue);
         color: var(--white);
       }
     }
   }
 
   .toggle {
-    background-color: var(--teal-blue);
+    background-color: var(--blue);
     color: var(--white);
 
     &[aria-expanded="true"] {

--- a/packages/ilios-common/app/styles/ilios-common/components/click-choice-buttons.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/click-choice-buttons.scss
@@ -2,7 +2,7 @@
 
 .click-choice-buttons {
   button {
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
     border: 1px outset var(--grey);
     color: var(--black);
 

--- a/packages/ilios-common/app/styles/ilios-common/components/click-choice-buttons.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/click-choice-buttons.scss
@@ -7,8 +7,8 @@
     color: var(--black);
 
     &.active {
-      background-color: var(--teal-blue);
-      border: 1px inset var(--teal-blue);
+      background-color: var(--blue);
+      border: 1px inset var(--blue);
       color: var(--white);
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/click-choice-buttons.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/click-choice-buttons.scss
@@ -3,7 +3,7 @@
 .click-choice-buttons {
   button {
     background-color: var(--cultured-grey);
-    border: 1px outset var(--davys-grey);
+    border: 1px outset var(--grey);
     color: var(--black);
 
     &.active {

--- a/packages/ilios-common/app/styles/ilios-common/components/click-choice-buttons.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/click-choice-buttons.scss
@@ -4,7 +4,7 @@
   button {
     background-color: var(--cultured-grey);
     border: 1px outset var(--davys-grey);
-    color: var(--raisin-black);
+    color: var(--black);
 
     &.active {
       background-color: var(--teal-blue);

--- a/packages/ilios-common/app/styles/ilios-common/components/common-dashboard.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/common-dashboard.scss
@@ -1,5 +1,5 @@
 @use "../colors" as c;
 
 .common-dashboard {
-  border: 1px solid var(--blue-munsell);
+  border: 1px solid var(--light-blue);
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/details.scss
@@ -14,7 +14,7 @@
 
     button {
       @include m.ilios-button-reset;
-      background-color: var(--teal-blue);
+      background-color: var(--blue);
       border-bottom-left-radius: 5px;
       border-bottom-right-radius: 5px;
       box-shadow:

--- a/packages/ilios-common/app/styles/ilios-common/components/course/details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/details.scss
@@ -5,7 +5,7 @@
   @include m.main-section;
 
   $collapse-control-shadow-grey: #e2e2e2;
-  $collapse-control-shadow-black: hsl(from var(--black) h s l / 0.34);
+  $collapse-control-shadow-black: var(--very-transparent-black);
 
   .detail-collapsed-control {
     display: flex;

--- a/packages/ilios-common/app/styles/ilios-common/components/course/loading.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/loading.scss
@@ -36,7 +36,7 @@
 
   .sessions-grid-header {
     @include m.loading-text;
-    background-color: hsl(from var(--grey) h s calc(l + 50));
+    background-color: var(--lighter-grey);
     height: 2rem;
   }
 }
@@ -51,11 +51,11 @@
     width: 100%;
 
     span {
-      background-color: hsl(from var(--grey) h s calc(l + 50));
+      background-color: var(--lighter-grey);
       border-bottom-left-radius: 5px;
       border-bottom-right-radius: 5px;
       padding: 0.25rem 4rem;
-      color: hsl(from var(--grey) h s calc(l + 50));
+      color: var(--lighter-grey);
 
       .expand-collapse-icon {
         margin-left: 0.5rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/course/loading.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/loading.scss
@@ -36,7 +36,7 @@
 
   .sessions-grid-header {
     @include m.loading-text;
-    background-color: hsl(from var(--davys-grey) h s calc(l + 50));
+    background-color: hsl(from var(--grey) h s calc(l + 50));
     height: 2rem;
   }
 }
@@ -51,11 +51,11 @@
     width: 100%;
 
     span {
-      background-color: hsl(from var(--davys-grey) h s calc(l + 50));
+      background-color: hsl(from var(--grey) h s calc(l + 50));
       border-bottom-left-radius: 5px;
       border-bottom-right-radius: 5px;
       padding: 0.25rem 4rem;
-      color: hsl(from var(--davys-grey) h s calc(l + 50));
+      color: hsl(from var(--grey) h s calc(l + 50));
 
       .expand-collapse-icon {
         margin-left: 0.5rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/course/manage-objective-parents.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/manage-objective-parents.scss
@@ -47,7 +47,7 @@
   }
 
   .no-cohorts {
-    color: var(--sepia);
+    color: var(--dark-orange);
     font-weight: bold;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/manage-objective-parents.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/manage-objective-parents.scss
@@ -26,7 +26,7 @@
         border-left: 10px solid var(--orange);
 
         .competency-title {
-          color: var(--fern-green);
+          color: var(--green);
           font-weight: bold;
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/objective-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/objective-list.scss
@@ -14,7 +14,7 @@
         background-image: linear-gradient(
           to bottom,
           transparent,
-          var(--cultured-grey)
+          var(--lightest-grey)
         );
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/overview.scss
@@ -16,6 +16,6 @@
   }
 
   .universallocator {
-    color: var(--davys-grey);
+    color: var(--grey);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/rollover.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/rollover.scss
@@ -9,7 +9,7 @@
 
   .rollover-form {
     @include m.ilios-form;
-    border: 1px solid var(--blue-munsell);
+    border: 1px solid var(--light-blue);
     display: block;
     margin-top: 1rem;
     padding: 1rem 0.5rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/daily-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/daily-calendar.scss
@@ -62,7 +62,7 @@
       grid-row: 1 / -1;
       grid-template-columns: repeat(50, 1fr);
       grid-template-rows: repeat($minute-rows, $hour-height);
-      border: 1px solid var(--cultured-grey);
+      border: 1px solid var(--lightest-grey);
       @for $day from 1 through 7 {
         &.day-#{$day} {
           grid-column: ($day + 1);
@@ -85,7 +85,7 @@
 
     .hour-border,
     .half-hour-border {
-      border-top: 1px solid var(--cultured-grey);
+      border-top: 1px solid var(--lightest-grey);
       grid-column: 2 / -1;
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
@@ -67,7 +67,7 @@
           @include m.ilios-list-reset;
 
           li {
-            color: var(--teal-blue);
+            color: var(--blue);
             cursor: pointer;
           }
         }
@@ -146,7 +146,7 @@
         .filters-clear-filters {
           @include m.ilios-button-reset;
           @include m.font-size("small");
-          color: var(--teal-blue);
+          color: var(--blue);
         }
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
@@ -48,7 +48,7 @@
           @include m.font-size("base");
           display: block;
           background-color: var(--cultured-grey);
-          border-bottom: 0.5px solid var(--davys-grey);
+          border-bottom: 0.5px solid var(--grey);
           height: 7vh;
           padding: 0.25em;
           width: 100%;
@@ -106,7 +106,7 @@
 
       .filters-header {
         background: var(--cultured-grey);
-        border-bottom: 1px solid var(--davys-grey);
+        border-bottom: 1px solid var(--grey);
         @include m.font-size("small");
       }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
@@ -37,7 +37,7 @@
       }
 
       .calendar-filter-list {
-        border: 1px solid var(--blue-munsell);
+        border: 1px solid var(--light-blue);
         float: left;
         @include m.font-size("small");
         margin-bottom: 1em;
@@ -124,23 +124,23 @@
         }
 
         .tag-session-type {
-          background-color: hsl(from var(--blue-munsell) h s calc(l + 30));
+          background-color: hsl(from var(--light-blue) h s calc(l + 30));
         }
 
         .tag-course-level {
-          background-color: hsl(from var(--blue-munsell) h s calc(l + 40));
+          background-color: hsl(from var(--light-blue) h s calc(l + 40));
         }
 
         .tag-cohort {
-          background-color: hsl(from var(--blue-munsell) h s calc(l + 50));
+          background-color: hsl(from var(--light-blue) h s calc(l + 50));
         }
 
         .tag-course {
-          background-color: hsl(from var(--blue-munsell) h s calc(l + 60));
+          background-color: hsl(from var(--light-blue) h s calc(l + 60));
         }
 
         .tag-term {
-          background-color: hsl(from var(--blue-munsell) h s calc(l + 40));
+          background-color: hsl(from var(--light-blue) h s calc(l + 40));
         }
 
         .filters-clear-filters {

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
@@ -143,6 +143,29 @@
           background-color: hsl(from var(--blue) h s calc(l + 40));
         }
 
+        //Support for Safari < 18.x
+        @supports (color: hsl(from orange h s calc(l + 15%))) {
+          .tag-session-type {
+            background-color: hsl(from var(--blue) h s calc(l + 30%));
+          }
+
+          .tag-course-level {
+            background-color: hsl(from var(--blue) h s calc(l + 40%));
+          }
+
+          .tag-cohort {
+            background-color: hsl(from var(--blue) h s calc(l + 50%));
+          }
+
+          .tag-course {
+            background-color: hsl(from var(--blue) h s calc(l + 60%));
+          }
+
+          .tag-term {
+            background-color: hsl(from var(--blue) h s calc(l + 40%));
+          }
+        }
+
         .filters-clear-filters {
           @include m.ilios-button-reset;
           @include m.font-size("small");

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
@@ -124,23 +124,23 @@
         }
 
         .tag-session-type {
-          background-color: hsl(from var(--light-blue) h s calc(l + 30));
+          background-color: hsl(from var(--blue) h s calc(l + 30));
         }
 
         .tag-course-level {
-          background-color: hsl(from var(--light-blue) h s calc(l + 40));
+          background-color: hsl(from var(--blue) h s calc(l + 40));
         }
 
         .tag-cohort {
-          background-color: hsl(from var(--light-blue) h s calc(l + 50));
+          background-color: hsl(from var(--blue) h s calc(l + 50));
         }
 
         .tag-course {
-          background-color: hsl(from var(--light-blue) h s calc(l + 60));
+          background-color: hsl(from var(--blue) h s calc(l + 60));
         }
 
         .tag-term {
-          background-color: hsl(from var(--light-blue) h s calc(l + 40));
+          background-color: hsl(from var(--blue) h s calc(l + 40));
         }
 
         .filters-clear-filters {

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
@@ -47,7 +47,7 @@
           @include m.ilios-heading;
           @include m.font-size("base");
           display: block;
-          background-color: var(--cultured-grey);
+          background-color: var(--lightest-grey);
           border-bottom: 0.5px solid var(--grey);
           height: 7vh;
           padding: 0.25em;
@@ -105,7 +105,7 @@
       padding: 5px;
 
       .filters-header {
-        background: var(--cultured-grey);
+        background: var(--lightest-grey);
         border-bottom: 1px solid var(--grey);
         @include m.font-size("small");
       }
@@ -120,7 +120,7 @@
         }
 
         .fa-close {
-          color: var(--cultured-grey);
+          color: var(--lightest-grey);
         }
 
         .tag-session-type {

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/materials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/materials.scss
@@ -46,7 +46,7 @@
     }
 
     .lm-type-icon {
-      color: var(--davys-grey);
+      color: var(--grey);
     }
 
     .timed-release-info {

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
@@ -66,7 +66,7 @@
     }
 
     &.active {
-      background-color: var(--fern-green);
+      background-color: var(--green);
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
@@ -3,7 +3,7 @@
 @use "../../mixins" as m;
 
 .dashboard-navigation {
-  border-bottom: 1px solid var(--cultured-grey);
+  border-bottom: 1px solid var(--lightest-grey);
   margin: 0.5rem 0 0 0.5rem;
 
   ul {

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/user-context-filter.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/user-context-filter.scss
@@ -5,7 +5,7 @@
   @include m.multi-button;
 
   label.active {
-    background-color: var(--teal-blue);
+    background-color: var(--blue);
     color: var(--white);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-cohort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-cohort-manager.scss
@@ -13,7 +13,7 @@
   .selectable-cohorts {
     @include m.ilios-selectable-list;
     background-color: var(--white);
-    border: 1px solid var(--blue-munsell);
+    border: 1px solid var(--light-blue);
     height: 10rem;
     margin-bottom: 1rem;
     overflow-y: scroll;

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-instructors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-instructors.scss
@@ -2,7 +2,7 @@
 @use "../mixins" as m;
 
 .detail-instructors {
-  @include m.detail-container(var(--teal-blue));
+  @include m.detail-container(var(--blue));
   padding: 1rem 0.5rem;
 
   .detail-instructors-header {

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learnergroups-list-item.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learnergroups-list-item.scss
@@ -4,6 +4,6 @@
 
 .detail-learnergroups-list-item {
   .muted {
-    color: hsl(from var(--black) h s calc(l + 30));
+    color: var(--grey);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learnergroups-list-item.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learnergroups-list-item.scss
@@ -4,6 +4,6 @@
 
 .detail-learnergroups-list-item {
   .muted {
-    color: hsl(from var(--raisin-black) h s calc(l + 30));
+    color: hsl(from var(--black) h s calc(l + 30));
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learnergroups-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learnergroups-list.scss
@@ -13,7 +13,7 @@
       @include m.ilios-removable-list;
 
       .top-level-group {
-        background-color: var(--gold);
+        background-color: var(--dark-yellow);
         color: var(--black);
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learners-and-learner-groups.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learners-and-learner-groups.scss
@@ -2,7 +2,7 @@
 @use "../mixins" as m;
 
 .detail-learners-and-learner-groups {
-  @include m.detail-container(var(--teal-blue));
+  @include m.detail-container(var(--blue));
   padding: 1rem 0.5rem;
 
   .detail-learners-and-learner-groups-header {

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -71,7 +71,7 @@
       }
 
       .learning-material-description {
-        color: var(--davys-grey);
+        color: var(--grey);
         display: block;
         @include m.font-size("small");
         margin-left: 1.9em;
@@ -90,7 +90,7 @@
 
         li {
           border: 0;
-          color: var(--davys-grey);
+          color: var(--grey);
           cursor: inherit;
           display: list-item;
           @include m.font-size("small");

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -39,7 +39,7 @@
       z-index: 10;
 
       li {
-        border-bottom: 1px solid var(--cultured-grey);
+        border-bottom: 1px solid var(--lightest-grey);
         min-height: 3.25rem;
         position: relative;
 
@@ -49,7 +49,7 @@
         }
 
         &:hover {
-          background: var(--cultured-grey);
+          background: var(--lightest-grey);
         }
 
         &:last-of-type {

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -31,7 +31,7 @@
     .lm-search-results {
       @include m.ilios-selectable-list;
       background-color: var(--white);
-      border: 1px solid var(--blue-munsell);
+      border: 1px solid var(--light-blue);
       margin: 0;
       max-height: 15rem;
       overflow-y: scroll;
@@ -120,7 +120,7 @@
 
     .icon-button {
       @include m.ilios-button-reset;
-      color: var(--blue-munsell);
+      color: var(--light-blue);
       &.remove {
         color: var(--crimson);
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -78,7 +78,7 @@
       }
 
       .learning-material-status {
-        color: var(--crimson);
+        color: var(--red);
         @include m.font-size("small");
         position: absolute;
         right: 5px;
@@ -122,7 +122,7 @@
       @include m.ilios-button-reset;
       color: var(--light-blue);
       &.remove {
-        color: var(--crimson);
+        color: var(--red);
       }
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -78,7 +78,7 @@
       }
 
       .learning-material-status {
-        color: var(--red);
+        color: var(--darker-red);
         @include m.font-size("small");
         position: absolute;
         right: 5px;
@@ -121,9 +121,6 @@
     .icon-button {
       @include m.ilios-button-reset;
       color: var(--light-blue);
-      &.remove {
-        color: var(--red);
-      }
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -78,7 +78,7 @@
       }
 
       .learning-material-status {
-        color: var(--darker-red);
+        color: var(--red);
         @include m.font-size("small");
         position: absolute;
         right: 5px;

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-objectives.scss
@@ -22,7 +22,7 @@
   }
 
   .new-objective {
-    border: 1px solid var(--cultured-grey);
+    border: 1px solid var(--lightest-grey);
     margin: 0.5rem;
     padding: 1rem;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
@@ -16,7 +16,7 @@
 
     button {
       background-color: var(--cultured-grey);
-      color: var(--raisin-black);
+      color: var(--black);
       padding: calc(constants.$golden-ratio-small * 0.5rem)
         calc(constants.$golden-ratio-large * 0.5rem);
     }
@@ -30,7 +30,7 @@
     }
 
     .muted {
-      color: hsl(from var(--raisin-black) h s calc(l + 30));
+      color: hsl(from var(--black) h s calc(l + 30));
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
@@ -15,7 +15,7 @@
     @include m.ilios-tag-list;
 
     button {
-      background-color: var(--cultured-grey);
+      background-color: var(--lightest-grey);
       color: var(--black);
       padding: calc(constants.$golden-ratio-small * 0.5rem)
         calc(constants.$golden-ratio-large * 0.5rem);

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
@@ -8,7 +8,7 @@
   margin-bottom: 1rem;
 
   .inactive {
-    color: var(--rosewood);
+    color: var(--darker-red);
   }
 
   .selected-taxonomy-terms {

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
@@ -30,7 +30,7 @@
     }
 
     .muted {
-      color: hsl(from var(--black) h s calc(l + 30));
+      color: var(--grey);
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
@@ -8,7 +8,7 @@
   margin-bottom: 1rem;
 
   .inactive {
-    color: var(--darker-red);
+    color: var(--red);
   }
 
   .selected-taxonomy-terms {

--- a/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
@@ -11,7 +11,7 @@
       background: var(--white);
       border: 1px solid var(--cultured-grey);
       border-radius: 3px;
-      color: var(--raisin-black);
+      color: var(--black);
       cursor: pointer;
       display: inline;
       outline: none;

--- a/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
@@ -47,10 +47,10 @@
         }
 
         &.cancel {
-          color: var(--crimson);
+          color: var(--red);
 
           &:enabled:hover {
-            background-color: var(--crimson);
+            background-color: var(--red);
           }
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
@@ -47,10 +47,10 @@
         }
 
         &.cancel {
-          color: var(--darker-red);
+          color: var(--red);
 
           &:enabled:hover {
-            background-color: var(--darker-red);
+            background-color: var(--red);
           }
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
@@ -39,10 +39,10 @@
         }
 
         &.done {
-          color: var(--fern-green);
+          color: var(--green);
 
           &:enabled:hover {
-            background-color: var(--fern-green);
+            background-color: var(--green);
           }
         }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
@@ -47,10 +47,10 @@
         }
 
         &.cancel {
-          color: var(--red);
+          color: var(--darker-red);
 
           &:enabled:hover {
-            background-color: var(--red);
+            background-color: var(--darker-red);
           }
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
@@ -9,7 +9,7 @@
 
     #{m.$form-input-text-types} {
       background: var(--white);
-      border: 1px solid var(--cultured-grey);
+      border: 1px solid var(--lightest-grey);
       border-radius: 3px;
       color: var(--black);
       cursor: pointer;

--- a/packages/ilios-common/app/styles/ilios-common/components/flatpickr.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/flatpickr.scss
@@ -27,7 +27,7 @@
       text-align-last: right;
 
       option {
-        color: var(--raisin-black);
+        color: var(--black);
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/ilios-calendar-multiday-events.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/ilios-calendar-multiday-events.scss
@@ -2,7 +2,7 @@
 @use "../mixins" as m;
 
 .ilios-calendar-multiday-events {
-  border: 1px dotted var(--blue-munsell);
+  border: 1px dotted var(--light-blue);
   margin-top: 1em;
   padding: 1em 0;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/ilios-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/ilios-calendar.scss
@@ -36,7 +36,7 @@
     }
 
     .on {
-      color: var(--fern-green);
+      color: var(--green);
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/ilios-tooltip.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/ilios-tooltip.scss
@@ -7,7 +7,7 @@
   .content {
     background: var(--white);
     padding: 0.25rem 0.5rem;
-    border: 1px solid var(--davys-grey);
+    border: 1px solid var(--grey);
     border-radius: 4px;
     max-width: 80%;
 
@@ -22,8 +22,8 @@
     .arrow::before {
       content: "";
       transform: rotate(45deg);
-      background: var(--davys-grey);
-      border: 1px solid var(--davys-grey);
+      background: var(--grey);
+      border: 1px solid var(--grey);
     }
   }
   &[data-popper-placement^="top"] .arrow {

--- a/packages/ilios-common/app/styles/ilios-common/components/ilios-tooltip.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/ilios-tooltip.scss
@@ -5,7 +5,7 @@
   z-index: 100;
 
   .content {
-    background: var(--slight-white);
+    background: var(--white);
     padding: 0.25rem 0.5rem;
     border: 1px solid var(--davys-grey);
     border-radius: 4px;

--- a/packages/ilios-common/app/styles/ilios-common/components/leadership-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/leadership-manager.scss
@@ -18,7 +18,7 @@
 
     input[type="search"] {
       background-color: var(--white);
-      border: 1px solid var(--teal-blue);
+      border: 1px solid var(--blue);
       border-radius: 3px;
       height: 2rem;
       width: 100%;

--- a/packages/ilios-common/app/styles/ilios-common/components/leadership-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/leadership-search.scss
@@ -8,7 +8,7 @@
 
   input[type="search"] {
     background-color: var(--white);
-    border: 1px solid var(--teal-blue);
+    border: 1px solid var(--blue);
     border-radius: 3px;
     height: 2rem;
     width: 100%;

--- a/packages/ilios-common/app/styles/ilios-common/components/learnergroup-selection-cohort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learnergroup-selection-cohort-manager.scss
@@ -2,7 +2,7 @@
 @use "../mixins" as m;
 
 .learnergroup-selection-cohort-manager {
-  border: 1px solid var(--blue-munsell);
+  border: 1px solid var(--light-blue);
 
   h5 {
     margin-bottom: 0.5rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/learning-material-uploader.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learning-material-uploader.scss
@@ -12,7 +12,7 @@
     @include m.font-size("base");
     padding: 0.3em 1em;
     &:hover {
-      background-color: var(--davys-grey);
+      background-color: var(--grey);
       color: var(--white);
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/learning-material-uploader.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learning-material-uploader.scss
@@ -3,7 +3,7 @@
 
 .learning-material-uploader {
   .upload-button {
-    background: var(--slight-white);
+    background: var(--white);
     border: 1px solid var(--black);
     border-radius: 3px;
     color: var(--raisin-black);

--- a/packages/ilios-common/app/styles/ilios-common/components/learning-material-uploader.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learning-material-uploader.scss
@@ -6,7 +6,7 @@
     background: var(--white);
     border: 1px solid var(--black);
     border-radius: 3px;
-    color: var(--raisin-black);
+    color: var(--black);
     cursor: pointer;
     display: inline-block;
     @include m.font-size("base");

--- a/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
@@ -67,8 +67,8 @@
     }
 
     .remove-date {
-      border: 1px solid var(--darker-red);
-      color: var(--darker-red);
+      border: 1px solid var(--red);
+      color: var(--red);
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
@@ -67,8 +67,8 @@
     }
 
     .remove-date {
-      border: 1px solid var(--rosewood);
-      color: var(--rosewood);
+      border: 1px solid var(--darker-red);
+      color: var(--darker-red);
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
@@ -34,7 +34,7 @@
 
   h2 {
     @include m.ilios-heading;
-    color: var(--raisin-black);
+    color: var(--black);
     @include m.font-size("base");
     font-weight: bold;
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
@@ -16,7 +16,7 @@
   }
 
   .copy-btn {
-    background-color: var(--fern-green);
+    background-color: var(--green);
   }
 
   .notes,
@@ -62,8 +62,8 @@
     }
 
     .add-date {
-      border: 1px solid var(--fern-green);
-      color: var(--fern-green);
+      border: 1px solid var(--green);
+      color: var(--green);
     }
 
     .remove-date {

--- a/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
@@ -78,8 +78,8 @@
       @include m.ilios-input;
 
       &.error {
-        border: 1px solid var(--crimson);
-        outline-color: var(--crimson);
+        border: 1px solid var(--red);
+        outline-color: var(--red);
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
@@ -3,7 +3,7 @@
 
 .mesh-manager {
   .deprecated {
-    color: var(--darker-red);
+    color: var(--red);
     font-weight: bolder;
   }
 
@@ -78,8 +78,8 @@
       @include m.ilios-input;
 
       &.error {
-        border: 1px solid var(--red);
-        outline-color: var(--red);
+        border: 1px solid var(--light-red);
+        outline-color: var(--light-red);
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
@@ -16,7 +16,7 @@
     @include m.ilios-selectable-list;
 
     background-color: var(--white);
-    border: 1px solid var(--blue-munsell);
+    border: 1px solid var(--light-blue);
     height: 10rem;
     margin-bottom: 1rem;
     overflow-y: scroll;

--- a/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
@@ -3,7 +3,7 @@
 
 .mesh-manager {
   .deprecated {
-    color: var(--rosewood);
+    color: var(--darker-red);
     font-weight: bolder;
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/monthly-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/monthly-calendar.scss
@@ -44,7 +44,7 @@
     }
 
     .day {
-      border: 1px solid var(--cultured-grey);
+      border: 1px solid var(--lightest-grey);
       padding: 5px;
       @for $week from 1 through 6 {
         @for $day from 1 through 7 {
@@ -74,7 +74,7 @@
         @include m.ilios-button-reset;
         cursor: default;
         display: block;
-        border: 1px solid var(--cultured-grey);
+        border: 1px solid var(--lightest-grey);
         border-radius: 3px;
         height: 1.5em;
         overflow: hidden;

--- a/packages/ilios-common/app/styles/ilios-common/components/new-session.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/new-session.scss
@@ -3,7 +3,7 @@
 
 .new-session {
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/new-session.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/new-session.scss
@@ -2,7 +2,7 @@
 @use "../mixins" as m;
 
 .new-session {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   margin: 0.5rem 0;
   padding: 1rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/objective-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/objective-manager.scss
@@ -7,7 +7,7 @@
   }
 
   h2 {
-    background-color: var(--slight-white);
+    background-color: var(--white);
     margin-bottom: 1rem;
     padding: 0.5rem;
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
@@ -85,13 +85,13 @@
 
           button.cancel {
             background: transparent;
-            color: var(--darker-red);
+            color: var(--red);
             margin: 0;
             padding: 0 0.2rem;
 
             &:enabled:hover {
               color: var(--white);
-              background-color: var(--darker-red);
+              background-color: var(--red);
             }
           }
         }
@@ -121,7 +121,7 @@
         width: 5rem;
 
         &:invalid {
-          border: 1px var(--red) solid;
+          border: 1px var(--light-red) solid;
         }
       }
     }
@@ -151,7 +151,7 @@
     }
 
     .validation-error-message {
-      color: var(--darker-red);
+      color: var(--red);
       display: block;
       @include m.font-size("small");
       font-style: italic;

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
@@ -151,7 +151,7 @@
     }
 
     .validation-error-message {
-      color: var(--rosewood);
+      color: var(--darker-red);
       display: block;
       @include m.font-size("small");
       font-style: italic;

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
@@ -85,13 +85,13 @@
 
           button.cancel {
             background: transparent;
-            color: var(--red);
+            color: var(--darker-red);
             margin: 0;
             padding: 0 0.2rem;
 
             &:enabled:hover {
               color: var(--white);
-              background-color: var(--red);
+              background-color: var(--darker-red);
             }
           }
         }

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
@@ -85,13 +85,13 @@
 
           button.cancel {
             background: transparent;
-            color: var(--crimson);
+            color: var(--red);
             margin: 0;
             padding: 0 0.2rem;
 
             &:enabled:hover {
               color: var(--white);
-              background-color: var(--crimson);
+              background-color: var(--red);
             }
           }
         }
@@ -121,7 +121,7 @@
         width: 5rem;
 
         &:invalid {
-          border: 1px var(--crimson) solid;
+          border: 1px var(--red) solid;
         }
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
@@ -34,7 +34,7 @@
 
   &.show-remove-confirmation {
     background-color: var(--lavender-blush);
-    border: 1px solid var(--crimson);
+    border: 1px solid var(--red);
   }
 
   .confirm-removal {
@@ -60,7 +60,7 @@
       color: var(--rosewood);
 
       &:hover {
-        background-color: var(--crimson);
+        background-color: var(--red);
         color: white;
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
@@ -34,7 +34,7 @@
 
   &.show-remove-confirmation {
     background-color: var(--lightest-red);
-    border: 1px solid var(--red);
+    border: 1px solid var(--light-red);
   }
 
   .confirm-removal {
@@ -43,7 +43,7 @@
 
     .confirm-message {
       background-color: var(--lightest-red);
-      color: var(--darker-red);
+      color: var(--red);
       font-weight: bold;
       margin: 0;
       padding: 1rem 8rem;
@@ -57,10 +57,10 @@
 
     .remove {
       background-color: var(--white);
-      color: var(--darker-red);
+      color: var(--red);
 
       &:hover {
-        background-color: var(--red);
+        background-color: var(--light-red);
         color: white;
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
@@ -33,16 +33,16 @@
   }
 
   &.show-remove-confirmation {
-    background-color: var(--lavender-blush);
+    background-color: var(--lightest-red);
     border: 1px solid var(--red);
   }
 
   .confirm-removal {
-    background-color: var(--lavender-blush);
+    background-color: var(--lightest-red);
     grid-column: 1 / -1;
 
     .confirm-message {
-      background-color: var(--lavender-blush);
+      background-color: var(--lightest-red);
       color: var(--darker-red);
       font-weight: bold;
       margin: 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
@@ -43,7 +43,7 @@
 
     .confirm-message {
       background-color: var(--lavender-blush);
-      color: var(--rosewood);
+      color: var(--darker-red);
       font-weight: bold;
       margin: 0;
       padding: 1rem 8rem;
@@ -57,7 +57,7 @@
 
     .remove {
       background-color: var(--white);
-      color: var(--rosewood);
+      color: var(--darker-red);
 
       &:hover {
         background-color: var(--red);

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-url-display.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-url-display.scss
@@ -7,7 +7,7 @@
     margin-left: 0.25em;
 
     &.copying {
-      color: var(--fern-green);
+      color: var(--green);
     }
   }
 }
@@ -19,7 +19,7 @@
     display: none;
   }
   .content {
-    background-color: var(--fern-green);
+    background-color: var(--green);
     color: var(--white);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
@@ -4,7 +4,7 @@
 .print-course {
   .header {
     @include m.course-header;
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
     padding: 0.5rem;
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/progress-bar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/progress-bar.scss
@@ -4,10 +4,10 @@
 @use "sass:math";
 
 .progress-bar {
-  background-color: hsl(from var(--white) h s calc(l - 5));
+  background-color: var(--super-light-grey);
   border: 1px solid var(--lightest-grey);
   border-radius: 3px;
-  box-shadow: inset 0 0 3px 0 hsl(from var(--white) h s calc(l - 55) / 0.15);
+  box-shadow: inset 0 0 3px 0 var(--very-transparent-black);
   margin: 0 auto;
   width: 100%;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/progress-bar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/progress-bar.scss
@@ -5,7 +5,7 @@
 
 .progress-bar {
   background-color: hsl(from var(--white) h s calc(l - 5));
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   border-radius: 3px;
   box-shadow: inset 0 0 3px 0 hsl(from var(--white) h s calc(l - 55) / 0.15);
   margin: 0 auto;

--- a/packages/ilios-common/app/styles/ilios-common/components/progress-bar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/progress-bar.scss
@@ -15,7 +15,7 @@
     background-color: var(--orange);
     background-repeat: repeat-x;
     background-size: 40px 40px;
-    border: 1px solid hsl(from var(--orange) h s calc(l - 15));
+    border: 1px solid var(--dark-orange);
     border-radius: math.div(3px, 1.5);
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/progress-bar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/progress-bar.scss
@@ -4,11 +4,10 @@
 @use "sass:math";
 
 .progress-bar {
-  background-color: hsl(from var(--slight-white) h s calc(l - 5));
+  background-color: hsl(from var(--white) h s calc(l - 5));
   border: 1px solid var(--cultured-grey);
   border-radius: 3px;
-  box-shadow: inset 0 0 3px 0
-    hsl(from var(--slight-white) h s calc(l - 55) / 0.15);
+  box-shadow: inset 0 0 3px 0 hsl(from var(--white) h s calc(l - 55) / 0.15);
   margin: 0 auto;
   width: 100%;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
@@ -40,7 +40,7 @@
       &.danger {
         &:hover,
         &:focus {
-          background-color: var(--crimson);
+          background-color: var(--red);
           color: var(--white);
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
@@ -82,8 +82,8 @@
   &.notpublished {
     .toggle,
     .menu {
-      border-color: var(--davys-grey);
-      color: var(--davys-grey);
+      border-color: var(--grey);
+      color: var(--grey);
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
@@ -90,8 +90,8 @@
   &.scheduled {
     .toggle,
     .menu {
-      border-color: var(--sepia);
-      color: var(--sepia);
+      border-color: var(--dark-orange);
+      color: var(--dark-orange);
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
@@ -40,7 +40,7 @@
       &.danger {
         &:hover,
         &:focus {
-          background-color: var(--red);
+          background-color: var(--light-red);
           color: var(--white);
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
@@ -48,7 +48,7 @@
       &.good {
         &:hover,
         &:focus {
-          background-color: var(--fern-green);
+          background-color: var(--green);
           color: var(--white);
         }
       }
@@ -74,8 +74,8 @@
   &.published {
     .toggle,
     .menu {
-      border-color: var(--fern-green);
-      color: var(--fern-green);
+      border-color: var(--green);
+      color: var(--green);
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
@@ -29,7 +29,7 @@
     button {
       border: 0;
       background-color: var(--white);
-      color: var(--raisin-black);
+      color: var(--black);
       display: block;
       outline: none;
       padding: 0.5rem 1rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
@@ -2,7 +2,7 @@
 @use "../mixins" as m;
 
 .publish-all-sessions {
-  background-color: var(--slight-white);
+  background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   padding-left: 1rem;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
@@ -43,7 +43,7 @@
   }
 
   .publish-all-sessions-review {
-    border: 1px solid var(--fern-green);
+    border: 1px solid var(--green);
     clear: both;
     @include m.font-size("large");
     margin: 1rem;
@@ -61,14 +61,14 @@
     }
 
     p {
-      color: var(--fern-green);
+      color: var(--green);
       font-weight: bold;
       margin: 0;
       margin-bottom: 1rem;
     }
 
     button {
-      background: var(--fern-green);
+      background: var(--green);
       color: var(--white);
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
@@ -3,7 +3,7 @@
 
 .publish-all-sessions {
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   padding-left: 1rem;
 
   section {

--- a/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
@@ -56,7 +56,7 @@
     }
 
     .fa-chart-column {
-      color: var(--blue-munsell);
+      color: var(--light-blue);
       @include m.font-size("small");
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
@@ -51,7 +51,7 @@
     text-align: center;
 
     .unlinked-warning {
-      color: var(--sepia);
+      color: var(--dark-orange);
       @include m.font-size("base");
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/search-box.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/search-box.scss
@@ -12,8 +12,8 @@
       padding-left: 1.5rem;
 
       &.error {
-        border: 1px solid var(--red);
-        outline-color: var(--red);
+        border: 1px solid var(--light-red);
+        outline-color: var(--light-red);
       }
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/search-box.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/search-box.scss
@@ -12,8 +12,8 @@
       padding-left: 1.5rem;
 
       &.error {
-        border: 1px solid var(--crimson);
-        outline-color: var(--crimson);
+        border: 1px solid var(--red);
+        outline-color: var(--red);
       }
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/search-box.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/search-box.scss
@@ -19,7 +19,7 @@
   }
 
   .search-icon {
-    color: var(--blue-munsell);
+    color: var(--light-blue);
     display: inline-block;
     left: 0;
     margin-right: 2px;

--- a/packages/ilios-common/app/styles/ilios-common/components/selectable-terms-list-item.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/selectable-terms-list-item.scss
@@ -3,7 +3,7 @@
 
 .selectable-terms-list-item {
   @include m.ilios-button-reset;
-  border: 1px var(--cultured-grey) solid;
+  border: 1px var(--lightest-grey) solid;
   border-radius: 4px;
   display: block;
   margin-top: 5px;
@@ -14,12 +14,12 @@
 
   &:focus,
   &:hover {
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
     border: 1px var(--black) solid;
   }
 
   &.selected {
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
   }
 
   .actions {

--- a/packages/ilios-common/app/styles/ilios-common/components/session-copy.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-copy.scss
@@ -9,7 +9,7 @@
 
   .copy-form {
     @include m.ilios-form;
-    border: 1px solid var(--blue-munsell);
+    border: 1px solid var(--light-blue);
     display: block;
     margin-top: 1rem;
     padding: 1rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-copy.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-copy.scss
@@ -22,8 +22,8 @@
       @include m.ilios-form-buttons;
 
       button:disabled {
-        background-color: var(--davys-grey);
-        border-color: var(--davys-grey);
+        background-color: var(--grey);
+        border-color: var(--grey);
         color: var(--white);
         cursor: default;
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
@@ -6,7 +6,7 @@
 
 .session-details {
   background-color: var(--lightest-blue);
-  border-color: var(--cultured-grey);
+  border-color: var(--lightest-grey);
   border-style: solid;
   border-top: 0;
   border-width: 0 2px 2px;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
@@ -14,7 +14,7 @@
   table {
     thead,
     th {
-      background-color: var(--teal-blue);
+      background-color: var(--blue);
       color: var(--white);
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
@@ -5,7 +5,7 @@
 }
 
 .session-details {
-  background-color: var(--light-blue);
+  background-color: var(--lightest-blue);
   border-color: var(--cultured-grey);
   border-style: solid;
   border-top: 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-offerings-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-offerings-list.scss
@@ -25,12 +25,12 @@
       }
 
       .offering-block-date-dayofmonth {
-        color: var(--davys-grey);
+        color: var(--grey);
       }
     }
 
     .offering-block-time {
-      border-bottom: 1px dotted var(--davys-grey);
+      border-bottom: 1px dotted var(--grey);
       display: grid;
       grid-column: 1 / -1;
       grid-template-columns: repeat(5, 1fr);
@@ -44,7 +44,7 @@
       .offering-block-time-time-starttime,
       .offering-block-time-time-ends,
       .offering-block-time-time-endtime {
-        color: var(--davys-grey);
+        color: var(--grey);
         display: block;
         font-weight: bold;
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-offerings-time-block-offerings.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-offerings-time-block-offerings.scss
@@ -4,7 +4,7 @@
   grid-column: 2 / -1;
 
   .offering-manager {
-    border-bottom: 1px dotted var(--davys-grey);
+    border-bottom: 1px dotted var(--grey);
     &:last-of-type {
       border-bottom: 0;
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-offerings.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-offerings.scss
@@ -2,7 +2,7 @@
 @use "../mixins" as m;
 
 .session-offerings {
-  @include m.detail-container(var(--teal-blue));
+  @include m.detail-container(var(--blue));
 
   .offering-section-top {
     @include m.detail-container-header;
@@ -27,7 +27,7 @@
     grid-template-columns: repeat(5, 1fr);
 
     div {
-      background-color: var(--teal-blue);
+      background-color: var(--blue);
       border-right: 1px solid var(--white);
       color: var(--white);
       overflow: hidden;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-offerings.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-offerings.scss
@@ -21,7 +21,7 @@
   }
 
   .session-offerings-header {
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
     display: grid;
     font-weight: bold;
     grid-template-columns: repeat(5, 1fr);

--- a/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
@@ -4,7 +4,7 @@
 
 .session-header {
   border-top: 1px solid var(--cultured-grey);
-  border-bottom: 1px solid var(--teal-blue);
+  border-bottom: 1px solid var(--blue);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -32,7 +32,7 @@
 }
 
 .session-overview {
-  @include m.ilios-overview(var(--teal-blue));
+  @include m.ilios-overview(var(--blue));
   border-bottom: 1px dotted var(--orange);
 
   .last-update {

--- a/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
@@ -113,7 +113,7 @@
   }
 
   .fa-copy {
-    color: var(--fern-green);
+    color: var(--green);
   }
 
   .post-requisite-edit {

--- a/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
@@ -36,7 +36,7 @@
   border-bottom: 1px dotted var(--orange);
 
   .last-update {
-    color: var(--davys-grey);
+    color: var(--grey);
     margin-right: 1rem;
     text-align: right;
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
@@ -3,7 +3,7 @@
 @use "../mixins" as m;
 
 .session-header {
-  border-top: 1px solid var(--cultured-grey);
+  border-top: 1px solid var(--lightest-grey);
   border-bottom: 1px solid var(--blue);
   display: flex;
   flex-direction: column;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
@@ -103,7 +103,7 @@
       background-image: linear-gradient(
         to bottom,
         transparent,
-        var(--light-blue)
+        var(--lightest-blue)
       );
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
@@ -12,7 +12,7 @@
       margin: 0;
       position: relative;
       th {
-        background-color: var(--teal-blue);
+        background-color: var(--blue);
         color: var(--white);
         position: sticky;
         top: 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
@@ -41,7 +41,7 @@
   }
   button.remove {
     @include m.ilios-link-button;
-    color: var(--darker-red);
+    color: var(--red);
   }
   .info {
     display: flex;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
@@ -41,7 +41,7 @@
   }
   button.remove {
     @include m.ilios-link-button;
-    color: var(--crimson);
+    color: var(--red);
   }
   .info {
     display: flex;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
@@ -41,7 +41,7 @@
   }
   button.remove {
     @include m.ilios-link-button;
-    color: var(--red);
+    color: var(--darker-red);
   }
   .info {
     display: flex;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
@@ -24,11 +24,11 @@
 
       tbody tr {
         &.active {
-          background-color: var(--fern-green);
+          background-color: var(--green);
           color: var(--white);
         }
         &:hover {
-          outline: 1px solid var(--fern-green);
+          outline: 1px solid var(--green);
         }
 
         button {

--- a/packages/ilios-common/app/styles/ilios-common/components/session-publicationcheck.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-publicationcheck.scss
@@ -2,7 +2,7 @@
 @use "../mixins" as m;
 
 .session-publicationcheck {
-  background-color: var(--light-blue);
+  background-color: var(--lightest-blue);
   border-color: var(--cultured-grey);
   border-style: solid;
   border-top: 0;
@@ -15,7 +15,7 @@
   }
 
   .results {
-    background-color: var(--light-blue);
+    background-color: var(--lightest-blue);
     @include m.detail-container(var(--orange));
 
     .title {

--- a/packages/ilios-common/app/styles/ilios-common/components/session-publicationcheck.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-publicationcheck.scss
@@ -3,7 +3,7 @@
 
 .session-publicationcheck {
   background-color: var(--lightest-blue);
-  border-color: var(--cultured-grey);
+  border-color: var(--lightest-grey);
   border-style: solid;
   border-top: 0;
   border-width: 0 2px 2px;
@@ -26,7 +26,7 @@
       @include m.detail-container-content;
 
       thead {
-        background-color: var(--cultured-grey);
+        background-color: var(--lightest-grey);
       }
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/session/manage-objective-parents.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session/manage-objective-parents.scss
@@ -15,8 +15,7 @@
     }
   }
 
-  .no-groups {
-    color: var(--gold);
-    font-weight: bold;
+  .no-group {
+    color: var(--darker-yellow);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/session/objective-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session/objective-list.scss
@@ -8,7 +8,7 @@
     background-image: linear-gradient(
       to bottom,
       transparent,
-      var(--light-blue)
+      var(--lightest-blue)
     );
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/session/objective-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session/objective-list.scss
@@ -18,7 +18,7 @@
         background-image: linear-gradient(
           to bottom,
           transparent,
-          var(--cultured-grey)
+          var(--lightest-grey)
         );
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-header.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-header.scss
@@ -4,7 +4,7 @@
 .sessions-grid-header {
   @include m.sessions-grid;
   background-color: var(--blue);
-  border-bottom: 1px solid var(--davys-grey);
+  border-bottom: 1px solid var(--grey);
   color: var(--white);
   @include m.font-size("small");
   font-weight: normal;

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-header.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-header.scss
@@ -3,7 +3,7 @@
 
 .sessions-grid-header {
   @include m.sessions-grid;
-  background-color: var(--teal-blue);
+  background-color: var(--blue);
   border-bottom: 1px solid var(--davys-grey);
   color: var(--white);
   @include m.font-size("small");

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-last-updated.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-last-updated.scss
@@ -1,7 +1,7 @@
 @use "../colors" as c;
 
 .sessions-grid-last-updated {
-  color: var(--davys-grey);
+  color: var(--grey);
   margin: auto;
   padding-bottom: 0.5rem;
   text-align: right;

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-loading.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-loading.scss
@@ -11,6 +11,6 @@
   }
   span {
     color: transparent;
-    text-shadow: hsl(from var(--black) h s l / 0.3) 0px 0px 10px;
+    text-shadow: var(--very-transparent-black) 0px 0px 10px;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-loading.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-loading.scss
@@ -6,7 +6,7 @@
     @include m.sessions-grid;
 
     &:nth-child(even) {
-      background-color: var(--cultured-grey);
+      background-color: var(--lightest-grey);
     }
   }
   span {

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
@@ -58,7 +58,7 @@
       background-color: hsl(from var(--lightest-blue) h s calc(l - 10));
     }
     &.was-updated {
-      background-color: hsl(from var(--fern-green) h s calc(l + 30));
+      background-color: hsl(from var(--green) h s calc(l + 30));
     }
     .room {
       overflow-wrap: anywhere;

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
@@ -28,7 +28,7 @@
     padding: 0.2rem 0.5rem;
 
     &.expanded-offering-manager {
-      background-color: var(--light-blue);
+      background-color: var(--lightest-blue);
       padding: 0;
     }
 
@@ -55,7 +55,7 @@
   .sessions-grid-offering {
     transition: background-color 0.5s ease-out;
     &.even {
-      background-color: hsl(from var(--light-blue) h s calc(l - 10));
+      background-color: hsl(from var(--lightest-blue) h s calc(l - 10));
     }
     &.was-updated {
       background-color: hsl(from var(--fern-green) h s calc(l + 30));

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
@@ -48,7 +48,7 @@
   }
 
   .offering-block-date {
-    border-top: 1px solid var(--cultured-grey);
+    border-top: 1px solid var(--lightest-grey);
     font-weight: bold;
   }
 
@@ -75,7 +75,7 @@
 
   .offering-form {
     background-color: var(--white);
-    border: 1px solid var(--cultured-grey);
+    border: 1px solid var(--lightest-grey);
     padding: 0.5rem;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
@@ -58,7 +58,7 @@
       background-color: hsl(from var(--lightest-blue) h s calc(l - 10));
     }
     &.was-updated {
-      background-color: hsl(from var(--green) h s calc(l + 30));
+      background-color: var(--transparent-green);
     }
     .room {
       overflow-wrap: anywhere;

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
@@ -55,7 +55,7 @@
   .sessions-grid-offering {
     transition: background-color 0.5s ease-out;
     &.even {
-      background-color: var(--ligher-blue);
+      background-color: var(--lighter-blue);
     }
     &.was-updated {
       background-color: var(--transparent-green);

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
@@ -55,7 +55,7 @@
   .sessions-grid-offering {
     transition: background-color 0.5s ease-out;
     &.even {
-      background-color: hsl(from var(--lightest-blue) h s calc(l - 10));
+      background-color: var(--ligher-blue);
     }
     &.was-updated {
       background-color: var(--transparent-green);

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-row.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-row.scss
@@ -11,7 +11,7 @@
 
     .instructional-notes,
     .prerequisites {
-      color: var(--fern-green);
+      color: var(--green);
       margin-right: 0.25rem;
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
@@ -20,7 +20,7 @@
     }
 
     .confirm-removal {
-      background-color: var(--lavender-blush);
+      background-color: var(--lightest-red);
       color: var(--darker-red);
       font-weight: bold;
       margin: 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
@@ -10,12 +10,12 @@
 
   .session {
     &:nth-of-type(even) {
-      background-color: var(--light-blue);
+      background-color: var(--lightest-blue);
     }
 
     &.is-expanded {
       border: 1px solid var(--blue-munsell);
-      background-color: var(--light-blue);
+      background-color: var(--lightest-blue);
       margin: 0.5rem 0;
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
@@ -21,7 +21,7 @@
 
     .confirm-removal {
       background-color: var(--lavender-blush);
-      color: var(--rosewood);
+      color: var(--darker-red);
       font-weight: bold;
       margin: 0;
       padding: 1rem 8rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
@@ -14,7 +14,7 @@
     }
 
     &.is-expanded {
-      border: 1px solid var(--blue-munsell);
+      border: 1px solid var(--light-blue);
       background-color: var(--lightest-blue);
       margin: 0.5rem 0;
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
@@ -21,7 +21,7 @@
 
     .confirm-removal {
       background-color: var(--lightest-red);
-      color: var(--darker-red);
+      color: var(--red);
       font-weight: bold;
       margin: 0;
       padding: 1rem 8rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
@@ -20,7 +20,7 @@
 
       li:last-of-type {
         li:last-of-type {
-          border-bottom: 1px dashed var(--davys-grey);
+          border-bottom: 1px dashed var(--grey);
           padding-bottom: 0.25rem;
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event-objective-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event-objective-list.scss
@@ -8,7 +8,7 @@
 
   .display-mode-toggle-btn {
     &.active {
-      background-color: var(--fern-green);
+      background-color: var(--green);
     }
     &.disabled {
       cursor: default;

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event-objective-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event-objective-list.scss
@@ -12,7 +12,7 @@
     }
     &.disabled {
       cursor: default;
-      background-color: var(--davys-grey);
+      background-color: var(--grey);
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
@@ -34,14 +34,14 @@
       }
 
       .recently-updated-icon {
-        color: var(--rosewood);
+        color: var(--darker-red);
         position: absolute;
         right: 2px;
         top: 2px;
       }
 
       .recently-updated-icon-event {
-        color: var(--rosewood);
+        color: var(--darker-red);
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
@@ -34,14 +34,14 @@
       }
 
       .recently-updated-icon {
-        color: var(--darker-red);
+        color: var(--red);
         position: absolute;
         right: 2px;
         top: 2px;
       }
 
       .recently-updated-icon-event {
-        color: var(--darker-red);
+        color: var(--red);
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/taxonomy-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/taxonomy-manager.scss
@@ -3,7 +3,7 @@
 
 .taxonomy-manager {
   .selected-terms {
-    border: 1px solid var(--davys-grey);
+    border: 1px solid var(--grey);
     padding: 10px;
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/toggle-yesno.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/toggle-yesno.scss
@@ -15,7 +15,7 @@
   padding: 0;
 
   &.yes {
-    background-color: var(--fern-green);
+    background-color: var(--green);
   }
 
   .switch-handle {

--- a/packages/ilios-common/app/styles/ilios-common/components/toggle-yesno.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/toggle-yesno.scss
@@ -11,7 +11,7 @@
   height: var(--height);
   position: relative;
   width: var(--width);
-  background-color: var(--rosewood);
+  background-color: var(--darker-red);
   padding: 0;
 
   &.yes {

--- a/packages/ilios-common/app/styles/ilios-common/components/toggle-yesno.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/toggle-yesno.scss
@@ -11,7 +11,7 @@
   height: var(--height);
   position: relative;
   width: var(--width);
-  background-color: var(--darker-red);
+  background-color: var(--red);
   padding: 0;
 
   &.yes {

--- a/packages/ilios-common/app/styles/ilios-common/components/user-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-list.scss
@@ -10,7 +10,7 @@
 
   .user-list-row {
     &:nth-of-type(even) {
-      background-color: var(--cultured-grey);
+      background-color: var(--lightest-grey);
     }
 
     .user-list-campus-id,

--- a/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
@@ -42,7 +42,7 @@
       }
 
       &.results-count {
-        color: var(--fern-green);
+        color: var(--green);
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
@@ -21,7 +21,7 @@
     z-index: 100;
 
     li {
-      border-bottom: 1px solid var(--cultured-grey);
+      border-bottom: 1px solid var(--lightest-grey);
       padding: 0.6rem;
       padding-left: 1rem;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
@@ -32,7 +32,7 @@
       }
 
       &.inactive {
-        color: var(--davys-grey);
+        color: var(--grey);
         cursor: default;
         font-style: italic;
 
@@ -47,7 +47,7 @@
     }
 
     .email {
-      color: var(--davys-grey);
+      color: var(--grey);
       font-style: italic;
       padding-right: 0.2rem;
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
@@ -12,7 +12,7 @@
     border: 1px solid var(--white);
     border-radius: 3px;
     box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.2);
-    color: var(--raisin-black);
+    color: var(--black);
     left: 0;
     max-height: 15rem;
     overflow: scroll;

--- a/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
@@ -11,7 +11,7 @@
     background: var(--white);
     border: 1px solid var(--white);
     border-radius: 3px;
-    box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.2);
+    box-shadow: 0 2px 2px var(--very-transparent-black);
     color: var(--black);
     left: 0;
     max-height: 15rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
@@ -27,7 +27,7 @@
 
       &.active,
       &:hover {
-        background-color: hsl(from var(--light-blue) h s calc(l + 50));
+        background-color: var(--lightest-blue);
         cursor: pointer;
       }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
@@ -9,7 +9,7 @@
   .results {
     @include m.ilios-list-reset;
     background: var(--white);
-    border: 1px solid var(--slight-white);
+    border: 1px solid var(--white);
     border-radius: 3px;
     box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.2);
     color: var(--raisin-black);

--- a/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
@@ -27,7 +27,7 @@
 
       &.active,
       &:hover {
-        background-color: hsl(from var(--blue-munsell) h s calc(l + 50));
+        background-color: hsl(from var(--light-blue) h s calc(l + 50));
         cursor: pointer;
       }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/user-status.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-status.scss
@@ -1,5 +1,5 @@
 @use "../colors" as c;
 
 .user-status {
-  color: var(--davys-grey);
+  color: var(--grey);
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/wait-saving.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/wait-saving.scss
@@ -13,7 +13,7 @@
   align-content: center;
 
   .content {
-    background-color: var(--slight-white);
+    background-color: var(--white);
     padding: 2em;
     border-radius: 1em;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/wait-saving.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/wait-saving.scss
@@ -7,7 +7,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: hsl(from var(--black) h s l / 0.95);
+  background-color: var(--slightly-transparent-black);
   display: grid;
   justify-content: center;
   align-content: center;

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -20,7 +20,7 @@
   .event {
     padding: 0 0.25rem;
     margin: 1rem 0;
-    border-left: 3px solid var(--light-blue);
+    border-left: 3px solid var(--lightest-blue);
 
     &:nth-of-type(even) {
       border-left: 3px solid var(--lavender-blush);

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -23,7 +23,7 @@
     border-left: 3px solid var(--lightest-blue);
 
     &:nth-of-type(even) {
-      border-left: 3px solid var(--lavender-blush);
+      border-left: 3px solid var(--lightest-red);
     }
 
     p {

--- a/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar.scss
@@ -66,7 +66,7 @@
       grid-row: 1 / -1;
       grid-template-columns: repeat(50, 1fr);
       grid-template-rows: repeat($minute-rows, $hour-height);
-      border: 1px solid var(--cultured-grey);
+      border: 1px solid var(--lightest-grey);
       @for $day from 1 through 7 {
         &.day-#{$day} {
           grid-column: ($day + 1);
@@ -89,7 +89,7 @@
 
     .hour-border,
     .half-hour-border {
-      border-top: 1px solid var(--cultured-grey);
+      border-top: 1px solid var(--lightest-grey);
       grid-column: 2 / -1;
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
@@ -55,6 +55,6 @@
   }
 
   .maybe {
-    color: var(--gold);
+    color: var(--dark-yellow);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
@@ -50,7 +50,7 @@
   }
 
   td:first-of-type {
-    color: var(--sepia);
+    color: var(--dark-orange);
     font-weight: bold;
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
@@ -46,7 +46,7 @@
   thead,
   th {
     background-color: var(--cultured-grey);
-    color: var(--raisin-black);
+    color: var(--black);
   }
 
   td:first-of-type {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
@@ -45,7 +45,7 @@
 
   thead,
   th {
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
     color: var(--black);
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/course/header.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/course/header.scss
@@ -6,7 +6,7 @@
 @use "../media";
 
 @mixin course-header {
-  border-bottom: 1px solid var(--cultured-grey);
+  border-bottom: 1px solid var(--lightest-grey);
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/course/overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/course/overview.scss
@@ -24,7 +24,7 @@
     @include ilios-overview.ilios-overview-actions;
 
     span {
-      color: var(--blue-munsell);
+      color: var(--light-blue);
     }
 
     a,

--- a/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
@@ -51,7 +51,7 @@
   }
 
   .bigadd {
-    background-color: var(--fern-green);
+    background-color: var(--green);
     color: var(--white);
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
@@ -56,7 +56,7 @@
   }
 
   .bigcancel {
-    background-color: var(--red);
+    background-color: var(--darker-red);
     color: var(--white);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
@@ -56,7 +56,7 @@
   }
 
   .bigcancel {
-    background-color: var(--darker-red);
+    background-color: var(--red);
     color: var(--white);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
@@ -56,7 +56,7 @@
   }
 
   .bigcancel {
-    background-color: var(--crimson);
+    background-color: var(--red);
     color: var(--white);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/graph-with-data-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/graph-with-data-table.scss
@@ -21,7 +21,7 @@
       @include t.ilios-zebra-table;
 
       thead {
-        background-color: var(--cultured-grey);
+        background-color: var(--lightest-grey);
       }
 
       td {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/icon.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/icon.scss
@@ -2,7 +2,7 @@
 
 @mixin icon {
   &.enabled {
-    color: var(--blue-munsell);
+    color: var(--light-blue);
     cursor: pointer;
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/icon.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/icon.scss
@@ -7,6 +7,6 @@
   }
 
   &.disabled {
-    color: var(--davys-grey);
+    color: var(--grey);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-button.scss
@@ -4,7 +4,7 @@
 
 @mixin ilios-button() {
   appearance: none;
-  background-color: var(--teal-blue);
+  background-color: var(--blue);
   border: 0;
   border-radius: 3px;
   box-sizing: border-box;
@@ -36,6 +36,6 @@
 
 @mixin ilios-link-button() {
   @include ilios-button-reset;
-  color: var(--teal-blue);
+  color: var(--blue);
   text-align: left;
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-fieldset.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-fieldset.scss
@@ -2,7 +2,7 @@
 @use "ilios-heading";
 
 @mixin ilios-fieldset {
-  border: 1px solid var(--blue-munsell);
+  border: 1px solid var(--light-blue);
   border-radius: 10px;
   margin-top: 1em;
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
@@ -114,7 +114,7 @@
 
 @mixin ilios-form-error {
   .validation-error-message {
-    color: var(--rosewood);
+    color: var(--darker-red);
     @include font-size.font-size("small");
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
@@ -93,11 +93,11 @@
 
     &.cancel {
       background-color: var(--white);
-      border-color: var(--red);
-      color: var(--red);
+      border-color: var(--light-red);
+      color: var(--light-red);
 
       &:enabled:hover {
-        background-color: var(--red);
+        background-color: var(--light-red);
       }
     }
   }
@@ -114,13 +114,13 @@
 
 @mixin ilios-form-error {
   .validation-error-message {
-    color: var(--darker-red);
+    color: var(--red);
     @include font-size.font-size("small");
   }
 
   input {
     &.has-error {
-      border-color: var(--red);
+      border-color: var(--light-red);
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
@@ -78,14 +78,14 @@
 
     &.done {
       background-color: var(--white);
-      border-color: var(--fern-green);
+      border-color: var(--green);
       color: var(--black);
 
       &:enabled {
         &:hover,
         &:active,
         &.active {
-          background-color: var(--fern-green);
+          background-color: var(--green);
           color: var(--white);
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
@@ -79,7 +79,7 @@
     &.done {
       background-color: var(--white);
       border-color: var(--fern-green);
-      color: var(--raisin-black);
+      color: var(--black);
 
       &:enabled {
         &:hover,

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
@@ -93,11 +93,11 @@
 
     &.cancel {
       background-color: var(--white);
-      border-color: var(--crimson);
-      color: var(--crimson);
+      border-color: var(--red);
+      color: var(--red);
 
       &:enabled:hover {
-        background-color: var(--crimson);
+        background-color: var(--red);
       }
     }
   }
@@ -120,7 +120,7 @@
 
   input {
     &.has-error {
-      border-color: var(--crimson);
+      border-color: var(--red);
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-heading.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-heading.scss
@@ -2,7 +2,7 @@
 @use "font-size";
 
 @mixin ilios-heading() {
-  color: var(--raisin-black);
+  color: var(--black);
   font-family: "Nunito Sans", sans-serif;
   font-weight: 600;
   margin: 0;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-input.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-input.scss
@@ -6,7 +6,7 @@ $form-input-text-types: 'input[type="text"], input[type="password"], input[type=
 @mixin ilios-input {
   @include ilios-select.ilios-select;
   background: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   border-radius: 3px;
   color: var(--black);
   cursor: pointer;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-input.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-input.scss
@@ -8,7 +8,7 @@ $form-input-text-types: 'input[type="text"], input[type="password"], input[type=
   background: var(--white);
   border: 1px solid var(--cultured-grey);
   border-radius: 3px;
-  color: var(--raisin-black);
+  color: var(--black);
   cursor: pointer;
   font-style: italic;
   min-width: 220px;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-link.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-link.scss
@@ -2,13 +2,13 @@
 @use "../colors" as c;
 
 @mixin ilios-link() {
-  color: var(--teal-blue);
+  color: var(--blue);
   cursor: pointer;
   font-weight: 600;
   text-decoration: none;
 
   &:visited {
-    color: var(--teal-blue);
+    color: var(--blue);
   }
 
   &:hover,

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-link.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-link.scss
@@ -14,7 +14,7 @@
   &:hover,
   &:active,
   &:focus {
-    color: var(--blue-munsell);
+    color: var(--light-blue);
     outline: thin dotted;
     text-decoration: underline;
   }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -97,7 +97,7 @@
   }
 
   li {
-    color: var(--teal-blue);
+    color: var(--blue);
     cursor: pointer;
 
     &.static {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -38,7 +38,7 @@
 @mixin ilios-zebra-list() {
   li {
     &:nth-child(even) {
-      background-color: hsl(from var(--lightest-grey) h s calc(l + 4));
+      background-color: var(--super-light-grey);
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -101,7 +101,7 @@
     cursor: pointer;
 
     &.static {
-      color: var(--raisin-black);
+      color: var(--black);
       cursor: default;
     }
 
@@ -152,7 +152,7 @@
   @include ilios-list-reset;
 
   li {
-    color: var(--raisin-black);
+    color: var(--black);
     margin-left: 20px;
 
     &.branch {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -17,7 +17,7 @@
 @mixin ilios-static-list() {
   @include ilios-list-reset;
   background-color: var(--white);
-  border: 1px solid var(--cultured-grey);
+  border: 1px solid var(--lightest-grey);
   border-radius: 3px;
   padding: 1em 2em;
   width: 80%;
@@ -38,7 +38,7 @@
 @mixin ilios-zebra-list() {
   li {
     &:nth-child(even) {
-      background-color: hsl(from var(--cultured-grey) h s calc(l + 4));
+      background-color: hsl(from var(--lightest-grey) h s calc(l + 4));
     }
   }
 }
@@ -50,7 +50,7 @@
   flex-wrap: wrap;
 
   li {
-    background-color: var(--cultured-grey);
+    background-color: var(--lightest-grey);
     border-radius: 4px;
     margin-right: 0.3em;
     margin-top: 10px;
@@ -127,14 +127,14 @@
   li {
     div {
       background-color: var(--white);
-      border: 1px var(--cultured-grey) solid;
+      border: 1px var(--lightest-grey) solid;
       border-radius: 4px;
       margin-top: 5px;
       padding: 0.2em 0.4em 0.2em 0.6em;
       vertical-align: middle;
 
       &.selected {
-        background-color: var(--cultured-grey);
+        background-color: var(--lightest-grey);
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -106,7 +106,7 @@
     }
 
     &.disabled {
-      color: var(--davys-grey);
+      color: var(--grey);
       cursor: default;
     }
   }
@@ -172,7 +172,7 @@
     }
 
     &.disabled {
-      color: var(--davys-grey);
+      color: var(--grey);
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
@@ -31,7 +31,7 @@
 }
 
 @mixin ilios-overview-title() {
-  color: var(--teal-blue);
+  color: var(--blue);
   @include font-size.font-size("base");
   font-weight: bold;
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
@@ -83,7 +83,7 @@
   }
 
   th {
-    border-bottom: 1px solid hsl(from var(--lightest-grey) h s calc(l - 15));
+    border-bottom: 1px solid var(--lighter-grey);
     background-color: $backgroundColor;
   }
 }
@@ -126,6 +126,6 @@
 
 @mixin ilios-zebra-table() {
   tbody tr:nth-child(even) {
-    background-color: hsl(from var(--lightest-grey) h s calc(l + 4));
+    background-color: var(--super-light-grey);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
@@ -94,7 +94,7 @@
       background-color: var(--lavender-blush);
 
       .confirm-message {
-        color: var(--rosewood);
+        color: var(--darker-red);
         font-weight: bold;
         padding-left: 8em;
         padding-right: 8em;
@@ -113,7 +113,7 @@
 
       .remove {
         background-color: var(--white);
-        color: var(--rosewood);
+        color: var(--darker-red);
 
         &:hover {
           background-color: var(--red);

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
@@ -116,7 +116,7 @@
         color: var(--rosewood);
 
         &:hover {
-          background-color: var(--crimson);
+          background-color: var(--red);
           color: var(--white);
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
@@ -91,7 +91,7 @@
 @mixin ilios-removable-table() {
   tbody {
     .confirm-removal {
-      background-color: var(--lavender-blush);
+      background-color: var(--lightest-red);
 
       .confirm-message {
         color: var(--darker-red);
@@ -108,7 +108,7 @@
       }
 
       &:hover {
-        background-color: var(--lavender-blush);
+        background-color: var(--lightest-red);
       }
 
       .remove {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
@@ -77,7 +77,7 @@
   }
 }
 
-@mixin ilios-table-colors($backgroundColor: var(--slight-white)) {
+@mixin ilios-table-colors($backgroundColor: var(--white)) {
   thead {
     background-color: $backgroundColor;
   }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
@@ -94,7 +94,7 @@
       background-color: var(--lightest-red);
 
       .confirm-message {
-        color: var(--darker-red);
+        color: var(--red);
         font-weight: bold;
         padding-left: 8em;
         padding-right: 8em;
@@ -113,10 +113,10 @@
 
       .remove {
         background-color: var(--white);
-        color: var(--darker-red);
+        color: var(--red);
 
         &:hover {
-          background-color: var(--red);
+          background-color: var(--light-red);
           color: var(--white);
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
@@ -83,7 +83,7 @@
   }
 
   th {
-    border-bottom: 1px solid hsl(from var(--cultured-grey) h s calc(l - 15));
+    border-bottom: 1px solid hsl(from var(--lightest-grey) h s calc(l - 15));
     background-color: $backgroundColor;
   }
 }
@@ -126,6 +126,6 @@
 
 @mixin ilios-zebra-table() {
   tbody tr:nth-child(even) {
-    background-color: hsl(from var(--cultured-grey) h s calc(l + 4));
+    background-color: hsl(from var(--lightest-grey) h s calc(l + 4));
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/loading-box.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/loading-box.scss
@@ -2,7 +2,7 @@
 
 @mixin loading-box() {
   animation: fadein;
-  background-color: var(--cultured-grey);
+  background-color: var(--lightest-grey);
   border: 1px dotted var(--grey);
   transition: opacity 2s ease-out;
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/loading-box.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/loading-box.scss
@@ -3,7 +3,7 @@
 @mixin loading-box() {
   animation: fadein;
   background-color: var(--cultured-grey);
-  border: 1px dotted var(--davys-grey);
+  border: 1px dotted var(--grey);
   transition: opacity 2s ease-out;
 
   @keyframes fadein {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/loading-text.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/loading-text.scss
@@ -1,4 +1,4 @@
 @mixin loading-text {
   color: transparent;
-  text-shadow: hsl(from var(--black) h s l / 0.3) 0 0 10px;
+  text-shadow: var(--very-transparent-black) 0 0 10px;
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
@@ -92,7 +92,7 @@
 }
 
 @mixin main-list-saved-new() {
-  border: 1px solid var(--fern-green);
+  border: 1px solid var(--green);
   margin: 1rem;
   padding: 1rem;
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
@@ -58,7 +58,7 @@
 }
 
 @mixin main-list-box-header() {
-  border-bottom: 1px solid var(--cultured-grey);
+  border-bottom: 1px solid var(--lightest-grey);
   display: flex;
   flex-direction: column;
   padding: 0 0 0.5rem;
@@ -113,7 +113,7 @@
     @include ilios-table.ilios-zebra-table;
 
     thead {
-      background-color: var(--cultured-grey);
+      background-color: var(--lightest-grey);
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
@@ -134,6 +134,6 @@
 
   td {
     color: transparent;
-    text-shadow: hsl(from var(--black) h s l / 0.3) 0px 0px 10px;
+    text-shadow: var(--very-transparent-black) 0px 0px 10px;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/multi-button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/multi-button.scss
@@ -11,7 +11,7 @@
 
   label {
     background-color: var(--white);
-    color: var(--teal-blue);
+    color: var(--blue);
     border: 1px solid hsl(from var(--black) h s l / 0.2);
     display: inline-block;
     @include font-size.font-size("small");
@@ -35,7 +35,7 @@
   }
 
   input:checked + label {
-    background-color: var(--teal-blue);
+    background-color: var(--blue);
     color: var(--white);
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/multi-button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/multi-button.scss
@@ -12,7 +12,7 @@
   label {
     background-color: var(--white);
     color: var(--blue);
-    border: 1px solid hsl(from var(--black) h s l / 0.2);
+    border: 1px solid var(--very-transparent-black);
     display: inline-block;
     @include font-size.font-size("small");
     font-weight: 600;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -114,7 +114,7 @@
 
     &.highlight-ok {
       transition: none;
-      background-color: hsl(from var(--green) h s calc(l + 60));
+      background-color: var(--transparent-green);
     }
 
     &.is-managing {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -38,7 +38,7 @@
   }
 
   .new-objective {
-    background-color: var(--slight-white);
+    background-color: var(--white);
     border: 1px solid var(--cultured-grey);
     margin: 0.5rem 0;
     padding: 1rem;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -120,7 +120,7 @@
     &.is-managing {
       border: 2px solid var(--blue-munsell);
       .grid-item {
-        background-color: var(--light-blue);
+        background-color: var(--lightest-blue);
         border: 0;
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -118,7 +118,7 @@
     }
 
     &.is-managing {
-      border: 2px solid var(--blue-munsell);
+      border: 2px solid var(--light-blue);
       .grid-item {
         background-color: var(--lightest-blue);
         border: 0;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -208,7 +208,7 @@
   }
 
   .bigcancel {
-    background-color: var(--red);
+    background-color: var(--darker-red);
     color: var(--white);
     margin-left: 0.5em;
   }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -149,7 +149,7 @@
     }
 
     &.confirm-removal {
-      background-color: var(--lavender-blush);
+      background-color: var(--lightest-red);
 
       .grid-item {
         border: 0;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -156,7 +156,7 @@
       }
 
       .confirm-message {
-        color: var(--rosewood);
+        color: var(--darker-red);
         grid-column: 1 / -1;
         font-weight: bold;
         text-align: center;
@@ -165,7 +165,7 @@
 
       .remove {
         background-color: var(--white);
-        color: var(--rosewood);
+        color: var(--darker-red);
 
         &:hover {
           background-color: var(--red);

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -39,7 +39,7 @@
 
   .new-objective {
     background-color: var(--white);
-    border: 1px solid var(--cultured-grey);
+    border: 1px solid var(--lightest-grey);
     margin: 0.5rem 0;
     padding: 1rem;
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -105,7 +105,7 @@
 
       .grid-item {
         color: transparent;
-        text-shadow: hsl(from var(--black) h s l / 0.3) 0px 0px 10px;
+        text-shadow: var(--very-transparent-black) 0px 0px 10px;
       }
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -114,7 +114,7 @@
 
     &.highlight-ok {
       transition: none;
-      background-color: hsl(from var(--fern-green) h s calc(l + 60));
+      background-color: hsl(from var(--green) h s calc(l + 60));
     }
 
     &.is-managing {
@@ -203,7 +203,7 @@
   }
 
   .bigadd {
-    background-color: var(--fern-green);
+    background-color: var(--green);
     color: var(--white);
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -168,7 +168,7 @@
         color: var(--rosewood);
 
         &:hover {
-          background-color: var(--crimson);
+          background-color: var(--red);
           color: white;
         }
       }
@@ -208,7 +208,7 @@
   }
 
   .bigcancel {
-    background-color: var(--crimson);
+    background-color: var(--red);
     color: var(--white);
     margin-left: 0.5em;
   }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -156,7 +156,7 @@
       }
 
       .confirm-message {
-        color: var(--darker-red);
+        color: var(--red);
         grid-column: 1 / -1;
         font-weight: bold;
         text-align: center;
@@ -165,10 +165,10 @@
 
       .remove {
         background-color: var(--white);
-        color: var(--darker-red);
+        color: var(--red);
 
         &:hover {
-          background-color: var(--red);
+          background-color: var(--light-red);
           color: white;
         }
       }
@@ -208,7 +208,7 @@
   }
 
   .bigcancel {
-    background-color: var(--darker-red);
+    background-color: var(--red);
     color: var(--white);
     margin-left: 0.5em;
   }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -70,7 +70,7 @@
     grid-template-rows: auto;
 
     .grid-item {
-      border-bottom: 1px solid var(--davys-grey);
+      border-bottom: 1px solid var(--grey);
       padding: 0.5em 0.25em;
 
       &:has(.faded) {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sessions-grid.scss
@@ -60,7 +60,7 @@
     }
 
     & > .disabled {
-      color: var(--davys-grey);
+      color: var(--grey);
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sessions-grid.scss
@@ -55,7 +55,7 @@
     justify-content: space-around;
 
     & > .active {
-      color: var(--blue-munsell);
+      color: var(--light-blue);
       cursor: pointer;
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
@@ -73,7 +73,7 @@
         }
         button {
           &.expand-text-button {
-            background: var(--teal-blue);
+            background: var(--blue);
             border-radius: 3px;
             color: var(--white);
             padding: 0.3em 1em;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
@@ -28,7 +28,7 @@
           background-image: linear-gradient(
             to bottom,
             transparent,
-            var(--cultured-grey)
+            var(--lightest-grey)
           );
         }
       }
@@ -39,7 +39,7 @@
     list-style-type: none;
     .item {
       align-items: center;
-      background-color: var(--cultured-grey);
+      background-color: var(--lightest-grey);
       border-radius: 4px;
       box-sizing: border-box;
       cursor: pointer;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
@@ -7,7 +7,7 @@
     justify-content: flex-end;
 
     .bigadd {
-      background-color: var(--fern-green);
+      background-color: var(--green);
       color: var(--white);
       margin-left: 0.5rem;
     }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
@@ -13,7 +13,7 @@
     }
 
     .bigcancel {
-      background-color: var(--crimson);
+      background-color: var(--red);
       color: var(--white);
       margin: 0 0.5em;
     }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
@@ -13,7 +13,7 @@
     }
 
     .bigcancel {
-      background-color: var(--darker-red);
+      background-color: var(--red);
       color: var(--white);
       margin: 0 0.5em;
     }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
@@ -13,7 +13,7 @@
     }
 
     .bigcancel {
-      background-color: var(--red);
+      background-color: var(--darker-red);
       color: var(--white);
       margin: 0 0.5em;
     }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
@@ -23,7 +23,7 @@
 
   li {
     border-bottom: 1px solid var(--cultured-grey);
-    color: var(--blue-munsell);
+    color: var(--light-blue);
     display: block;
     padding: 0.1rem;
     width: 100%;
@@ -40,7 +40,7 @@
     a,
     &.clickable {
       &:hover {
-        background-color: hsl(from var(--blue-munsell) h s calc(l + 50));
+        background-color: hsl(from var(--light-blue) h s calc(l + 50));
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
@@ -34,7 +34,7 @@
     }
 
     &.summary {
-      color: var(--fern-green);
+      color: var(--green);
     }
 
     a,

--- a/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
@@ -9,7 +9,7 @@
   border: 1px solid var(--white);
   border-radius: 3px;
   box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.2);
-  color: var(--raisin-black);
+  color: var(--black);
   max-height: 23rem;
   overflow-y: scroll;
   position: absolute;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
@@ -29,7 +29,7 @@
     width: 100%;
 
     &.inactive {
-      color: hsl(from var(--lightest-grey) h s calc(l - 20));
+      color: var(--light-grey);
       font-style: italic;
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
@@ -8,7 +8,7 @@
   background: var(--white);
   border: 1px solid var(--white);
   border-radius: 3px;
-  box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.2);
+  box-shadow: 0 2px 2px var(--very-transparent-black);
   color: var(--black);
   max-height: 23rem;
   overflow-y: scroll;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
@@ -6,7 +6,7 @@
 
 @mixin user-search-results() {
   background: var(--white);
-  border: 1px solid var(--slight-white);
+  border: 1px solid var(--white);
   border-radius: 3px;
   box-shadow: 0 2px 2px hsl(from var(--black) h s l / 0.2);
   color: var(--raisin-black);

--- a/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
@@ -22,14 +22,14 @@
   }
 
   li {
-    border-bottom: 1px solid var(--cultured-grey);
+    border-bottom: 1px solid var(--lightest-grey);
     color: var(--light-blue);
     display: block;
     padding: 0.1rem;
     width: 100%;
 
     &.inactive {
-      color: hsl(from var(--cultured-grey) h s calc(l - 20));
+      color: hsl(from var(--lightest-grey) h s calc(l - 20));
       font-style: italic;
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
@@ -59,7 +59,7 @@
     }
 
     .email {
-      color: var(--davys-grey);
+      color: var(--grey);
       font-style: italic;
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/user-search.scss
@@ -40,7 +40,7 @@
     a,
     &.clickable {
       &:hover {
-        background-color: hsl(from var(--light-blue) h s calc(l + 50));
+        background-color: var(--lightest-blue);
       }
     }
 

--- a/packages/test-app/app/styles/app.scss
+++ b/packages/test-app/app/styles/app.scss
@@ -30,7 +30,7 @@
 
   & > nav {
     grid-area: nav;
-    background-color: var(--davys-grey);
+    background-color: var(--grey);
   }
 
   & > .logo {


### PR DESCRIPTION
I've re-aligned all of our colors for accessibility, user experience, and ease of use. Based off of ilios orange colors are somewhere on 15 degree increments on the color wheel. Adjustments to brightness, or transparency give us options within the same color. Most changes are subtle adjustments to existing shades, in many cases completely indistinguishable (and sometimes accidentally identical) so their originals.

As a side effect I was able to remove most of our color adjustments calculations, they proved to be unnecessary as they were either the same as another color, or so common they deserved their own color in our properties.

Best reviewed in individual commits, which get more specific towards the end.