### PR TITLE
Choose Calendar Color Based on Session Type

### DIFF
--- a/packages/ilios-common/addon-mirage-support/factories/schoolevent.js
+++ b/packages/ilios-common/addon-mirage-support/factories/schoolevent.js
@@ -9,4 +9,5 @@ export default Factory.extend({
   courseObjectives: [],
   prerequisites: [],
   postrequisites: [],
+  color: '#ffffff',
 });

--- a/packages/ilios-common/addon/components/daily-calendar-event.gjs
+++ b/packages/ilios-common/addon/components/daily-calendar-event.gjs
@@ -14,6 +14,7 @@ import FaIcon from 'ilios-common/components/fa-icon';
 import t from 'ember-intl/helpers/t';
 import not from 'ember-truth-helpers/helpers/not';
 import formatDate from 'ember-intl/helpers/format-date';
+import Color from 'color';
 
 export default class DailyCalendarEventComponent extends Component {
   @service intl;
@@ -106,9 +107,13 @@ export default class DailyCalendarEventComponent extends Component {
     const { color } = this.args.event;
     const darkcolor = colorChange(color, -0.15);
 
+    const isLight = Color(color).isLight();
+    const textColor = isLight ? '--black' : '--white';
+
     return new htmlSafe(
       `background-color: ${color};
        border-left: .25rem solid ${darkcolor};
+       color: var(${textColor});
        grid-column-start: span ${this.span};
        grid-row-start: ${this.startMinuteRounded + 1};
        grid-row-end: span ${this.totalMinutesRounded};`,

--- a/packages/ilios-common/addon/components/ilios-calendar-event-month.gjs
+++ b/packages/ilios-common/addon/components/ilios-calendar-event-month.gjs
@@ -14,6 +14,7 @@ import IliosTooltip from 'ilios-common/components/ilios-tooltip';
 import FaIcon from 'ilios-common/components/fa-icon';
 import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
+import Color from 'color';
 
 export default class IliosCalendarEventMonthComponent extends Component {
   @service intl;
@@ -46,8 +47,12 @@ export default class IliosCalendarEventMonthComponent extends Component {
     const { color } = this.args.event;
     const darkcolor = colorChange(color, -0.15);
 
+    const isLight = Color(color).isLight();
+    const textColor = isLight ? '--black' : '--white';
+
     return new htmlSafe(
       `background-color: ${color};
+       color: var(${textColor});
        border-left: 4px solid ${darkcolor};`,
     );
   }

--- a/packages/ilios-common/addon/components/weekly-calendar-event.gjs
+++ b/packages/ilios-common/addon/components/weekly-calendar-event.gjs
@@ -14,6 +14,7 @@ import FaIcon from 'ilios-common/components/fa-icon';
 import t from 'ember-intl/helpers/t';
 import not from 'ember-truth-helpers/helpers/not';
 import formatDate from 'ember-intl/helpers/format-date';
+import Color from 'color';
 
 export default class WeeklyCalendarEventComponent extends Component {
   @service intl;
@@ -115,9 +116,13 @@ export default class WeeklyCalendarEventComponent extends Component {
     const { color } = this.args.event;
     const darkcolor = colorChange(color, -0.15);
 
+    const isLight = Color(color).isLight();
+    const textColor = isLight ? '--black' : '--white';
+
     return new htmlSafe(
       `background-color: ${color};
        border-left: .25rem solid ${darkcolor};
+       color: var(${textColor});
        grid-column-start: span ${this.span};
        grid-row-start: ${this.startMinuteRounded + 1};
        grid-row-end: span ${this.totalMinutesRounded};`,

--- a/packages/ilios-common/app/styles/ilios-common/components/daily-calendar-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/daily-calendar-event.scss
@@ -8,7 +8,6 @@
   display: flex;
   flex-direction: column;
   justify-content: start;
-  color: var(--raisin-black);
   @include m.font-size("small");
   border: 1px solid var(--white);
   margin: 1px;
@@ -22,7 +21,6 @@
   }
 
   .ilios-calendar-event-time {
-    color: var(--rosewood);
     display: block;
     @include m.font-size("small");
     font-weight: bold;

--- a/packages/ilios-common/app/styles/ilios-common/components/monthly-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/monthly-calendar.scss
@@ -94,7 +94,6 @@
         }
 
         .ilios-calendar-event-time {
-          color: var(--black);
           display: inline;
         }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar-event.scss
@@ -8,7 +8,6 @@
   display: flex;
   flex-direction: column;
   justify-content: start;
-  color: var(--raisin-black);
   @include m.font-size("small");
   border: 1px solid var(--white);
   margin: 1px;
@@ -22,7 +21,6 @@
   }
 
   .ilios-calendar-event-time {
-    color: var(--rosewood);
     display: block;
     @include m.font-size("small");
     font-weight: bold;

--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -33,6 +33,7 @@
     "broccoli-file-creator": "^2.1.1",
     "broccoli-funnel": "^3.0.0",
     "broccoli-merge-trees": "^4.0.0",
+    "color": "^5.0.0",
     "ember-async-data": "^2.0.0",
     "ember-auto-import": "^2.10.0",
     "ember-cli-babel": "^8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,9 @@ importers:
       broccoli-merge-trees:
         specifier: ^4.0.0
         version: 4.2.0
+      color:
+        specifier: ^5.0.0
+        version: 5.0.0
       ember-async-data:
         specifier: ^2.0.0
         version: 2.0.1(@babel/core@7.28.0)
@@ -4304,14 +4307,26 @@ packages:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
+  color-convert@3.1.0:
+    resolution: {integrity: sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==}
+    engines: {node: '>=14.6'}
+
   color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-name@2.0.0:
+    resolution: {integrity: sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==}
+    engines: {node: '>=12.20'}
+
   color-string@1.9.1:
     resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color-string@2.0.1:
+    resolution: {integrity: sha512-5z9FbYTZPAo8iKsNEqRNv+OlpBbDcoE+SY9GjLfDUHEfcNNV7tS9eSAlFHEaub/r5tBL9LtskAeq1l9SaoZ5tQ==}
+    engines: {node: '>=18'}
 
   color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
@@ -4320,6 +4335,10 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  color@5.0.0:
+    resolution: {integrity: sha512-16BlyiuyLq3MLxpRWyOTiWsO3ii/eLQLJUQXBSNcxMBBSnyt1ee9YUdaozQp03ifwm5woztEZGDbk9RGVuCsdw==}
+    engines: {node: '>=18'}
 
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
@@ -14514,14 +14533,24 @@ snapshots:
     dependencies:
       color-name: 1.1.4
 
+  color-convert@3.1.0:
+    dependencies:
+      color-name: 2.0.0
+
   color-name@1.1.3: {}
 
   color-name@1.1.4: {}
+
+  color-name@2.0.0: {}
 
   color-string@1.9.1:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
+
+  color-string@2.0.1:
+    dependencies:
+      color-name: 2.0.0
 
   color-support@1.1.3: {}
 
@@ -14529,6 +14558,11 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
+
+  color@5.0.0:
+    dependencies:
+      color-convert: 3.1.0
+      color-string: 2.0.1
 
   colord@2.9.3: {}
 


### PR DESCRIPTION
Session type colors are user selected across any range, we can't rely on them to be high contrasting with our text colors. Instead we need to determine the relative luminosity of the background color and then choose a light or dark alternative.

There is going to be a css way to handle this in the future, but for now, this is the best I could find.

Sample:
<img width="1880" height="1314" alt="Screenshot 2025-07-25 at 8 55 26 AM" src="https://github.com/user-attachments/assets/af5f9a51-fa2a-4498-a342-27d93b7f95e2" />

