### PR TITLE
Fix Course Print Preview objectives from scrolling

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
@@ -59,6 +59,7 @@
     }
 
     button {
+      &.collapse-text-button,
       &.expand-text-button {
         display: none;
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
@@ -54,7 +54,7 @@
     .display-text-wrapper {
       &.faded {
         max-height: none;
-        overflow: auto;
+        overflow: visible;
       }
     }
 


### PR DESCRIPTION
Fixes ilios/ilios#6351

Also, since it's related to the `FadeText` component, I hid the collapse icon since we're not fading anything when previewing (expand was already hidden, but collapse was missed).