### PR TITLE
Course Print Preview Overhaul

### DIFF
--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -204,10 +204,10 @@ export default class CourseObjectiveListItemComponent extends Component {
   <template>
     <div
       id="objective-{{@courseObjective.id}}"
-      class="grid-row objective-row{{if this.showRemoveConfirmation ' confirm-removal'}}{{if
-          this.highlightSave.isRunning
-          ' highlight-ok'
-        }}{{if this.isManaging ' is-managing'}}"
+      class="grid-row objective-row{{if this.showRemoveConfirmation ' confirm-removal'}}{{unless
+          @editable
+          ' no-actions'
+        }}{{if this.highlightSave.isRunning ' highlight-ok'}}{{if this.isManaging ' is-managing'}}"
       data-test-course-objective-list-item
     >
       <div class="description grid-item" data-test-description>
@@ -272,28 +272,30 @@ export default class CourseObjectiveListItemComponent extends Component {
         @cancel={{this.cancel}}
       />
 
-      <div class="actions grid-item" data-test-actions>
-        {{#if
-          (and
-            @editable
-            (not this.isManaging)
-            (not this.showRemoveConfirmation)
-            (not this.showRemoveConfirmation)
-          )
-        }}
-          <button
-            class="link-button"
-            type="button"
-            aria-label={{t "general.remove"}}
-            {{on "click" (set this "showRemoveConfirmation" true)}}
-            data-test-remove
-          >
-            <FaIcon @icon="trash" class="enabled remove" />
-          </button>
-        {{else}}
-          <FaIcon @icon="trash" class="disabled" />
-        {{/if}}
-      </div>
+      {{#if @editable}}
+        <div class="actions grid-item" data-test-actions>
+          {{#if
+            (and
+              @editable
+              (not this.isManaging)
+              (not this.showRemoveConfirmation)
+              (not this.showRemoveConfirmation)
+            )
+          }}
+            <button
+              class="link-button"
+              type="button"
+              aria-label={{t "general.remove"}}
+              {{on "click" (set this "showRemoveConfirmation" true)}}
+              data-test-remove
+            >
+              <FaIcon @icon="trash" class="enabled remove" />
+            </button>
+          {{else}}
+            <FaIcon @icon="trash" class="disabled" />
+          {{/if}}
+        </div>
+      {{/if}}
 
       {{#if this.showRemoveConfirmation}}
         <div class="confirm-message" data-test-confirm-removal>

--- a/packages/ilios-common/addon/components/course/objective-list.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list.gjs
@@ -144,12 +144,14 @@ export default class CourseObjectiveListComponent extends Component {
             {{t "general.sortObjectives"}}
           </button>
         {{/if}}
-        <div class="grid-row headers" data-test-headers>
+        <div class="grid-row headers{{unless @editable ' no-actions'}}" data-test-headers>
           <span class="grid-item" data-test-header>{{t "general.description"}}</span>
           <span class="grid-item" data-test-header>{{t "general.parentObjectives"}}</span>
           <span class="grid-item" data-test-header>{{t "general.vocabularyTerms"}}</span>
           <span class="grid-item" data-test-header>{{t "general.meshTerms"}}</span>
-          <span class="actions grid-item" data-test-header>{{t "general.actions"}}</span>
+          {{#if @editable}}
+            <span class="actions grid-item" data-test-header>{{t "general.actions"}}</span>
+          {{/if}}
         </div>
         {{#if (and (isArray this.courseObjectives) this.cohortObjectivesLoaded)}}
           {{#each this.courseObjectives as |courseObjective|}}

--- a/packages/ilios-common/addon/components/detail-terms-list.gjs
+++ b/packages/ilios-common/addon/components/detail-terms-list.gjs
@@ -66,7 +66,7 @@ export default class DetailTermsListComponent extends Component {
             </span>
           {{/if}}
         </div>
-        <ul class="{{if @canEdit 'removable-list'}} selected-taxonomy-terms">
+        <ul class="selected-taxonomy-terms{{if @canEdit ' removable-list'}}">
           {{#each this.terms as |term|}}
             {{#if @canEdit}}
               <DetailTermsListItem @canEdit={{true}} @remove={{@remove}} @term={{term}} />

--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -235,13 +235,15 @@ export default class PrintCourseSessionComponent extends Component {
           ({{this.meshDescriptors.length}})
         </div>
         <div class="content">
-          <ul class="inline-list">
-            {{#each (sortBy "title" this.meshDescriptors) as |descriptor|}}
-              <li>
-                {{descriptor.name}}
-              </li>
-            {{/each}}
-          </ul>
+          {{#if this.meshDescriptors.length}}
+            <ul class="inline-list">
+              {{#each (sortBy "title" this.meshDescriptors) as |descriptor|}}
+                <li>
+                  {{descriptor.name}}
+                </li>
+              {{/each}}
+            </ul>
+          {{/if}}
         </div>
       </section>
       {{#if @session.isIndependentLearning}}

--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -229,7 +229,7 @@ export default class PrintCourseSessionComponent extends Component {
           </div>
         </div>
       </section>
-      <section class="block">
+      <section class="block" data-test-session-mesh-terms>
         <div class="title">
           {{t "general.mesh"}}
           ({{this.meshDescriptors.length}})
@@ -280,7 +280,7 @@ export default class PrintCourseSessionComponent extends Component {
           </div>
         </section>
       {{/if}}
-      <section class="block">
+      <section class="block" data-test-session-offerings>
         <div class="title">
           {{t "general.offerings"}}
           ({{this.offerings.length}})

--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -331,13 +331,15 @@ export default class PrintCourseSessionComponent extends Component {
                       {{offering.room}}
                     </td>
                     <td class="text-left offering-instructors">
-                      <ul>
-                        {{#each offering.allInstructors as |user|}}
-                          <li>
-                            {{user.fullName}}
-                          </li>
-                        {{/each}}
-                      </ul>
+                      {{#if offering.allInstructors.length}}
+                        <ul>
+                          {{#each offering.allInstructors as |user|}}
+                            <li>
+                              {{user.fullName}}
+                            </li>
+                          {{/each}}
+                        </ul>
+                      {{/if}}
                     </td>
                   </tr>
                 {{/each}}

--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -222,11 +222,9 @@ export default class PrintCourseSessionComponent extends Component {
           ({{this.terms.length}})
         </div>
         <div class="content">
-          <div class="content">
-            {{#each @session.associatedVocabularies as |vocab|}}
-              <DetailTermsList @vocabulary={{vocab}} @terms={{this.terms}} @canEdit={{false}} />
-            {{/each}}
-          </div>
+          {{#each @session.associatedVocabularies as |vocab|}}
+            <DetailTermsList @vocabulary={{vocab}} @terms={{this.terms}} @canEdit={{false}} />
+          {{/each}}
         </div>
       </section>
       <section class="block" data-test-session-mesh-terms>

--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -159,8 +159,8 @@ export default class PrintCourseSessionComponent extends Component {
           {{t "general.learningMaterials"}}
           ({{this.learningMaterials.length}})
         </div>
-        <div class="content">
-          {{#if this.learningMaterials.length}}
+        {{#if this.learningMaterials.length}}
+          <div class="content">
             <table>
               <thead>
                 <tr>
@@ -213,27 +213,29 @@ export default class PrintCourseSessionComponent extends Component {
                 {{/each}}
               </tbody>
             </table>
-          {{/if}}
-        </div>
+          </div>
+        {{/if}}
       </section>
       <section class="block" data-test-session-terms>
         <div class="title">
           {{t "general.terms"}}
           ({{this.terms.length}})
         </div>
-        <div class="content">
-          {{#each @session.associatedVocabularies as |vocab|}}
-            <DetailTermsList @vocabulary={{vocab}} @terms={{this.terms}} @canEdit={{false}} />
-          {{/each}}
-        </div>
+        {{#if @session.associatedVocabularies.length}}
+          <div class="content">
+            {{#each @session.associatedVocabularies as |vocab|}}
+              <DetailTermsList @vocabulary={{vocab}} @terms={{this.terms}} @canEdit={{false}} />
+            {{/each}}
+          </div>
+        {{/if}}
       </section>
       <section class="block" data-test-session-mesh-terms>
         <div class="title">
           {{t "general.mesh"}}
           ({{this.meshDescriptors.length}})
         </div>
-        <div class="content">
-          {{#if this.meshDescriptors.length}}
+        {{#if this.meshDescriptors.length}}
+          <div class="content">
             <ul class="inline-list">
               {{#each (sortBy "title" this.meshDescriptors) as |descriptor|}}
                 <li>
@@ -241,8 +243,8 @@ export default class PrintCourseSessionComponent extends Component {
                 </li>
               {{/each}}
             </ul>
-          {{/if}}
-        </div>
+          </div>
+        {{/if}}
       </section>
       {{#if @session.isIndependentLearning}}
         <section class="block" data-test-session-ilm-section>
@@ -285,8 +287,8 @@ export default class PrintCourseSessionComponent extends Component {
           {{t "general.offerings"}}
           ({{this.offerings.length}})
         </div>
-        <div class="content">
-          {{#if this.offerings.length}}
+        {{#if this.offerings.length}}
+          <div class="content">
             <table>
               <thead>
                 <tr>
@@ -343,12 +345,12 @@ export default class PrintCourseSessionComponent extends Component {
                 {{/each}}
               </tbody>
             </table>
-          {{else}}
-            <p>
-              {{t "general.noOfferings"}}
-            </p>
-          {{/if}}
-        </div>
+          </div>
+        {{else}}
+          <p>
+            {{t "general.noOfferings"}}
+          </p>
+        {{/if}}
       </section>
     </div>
   </template>

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -312,7 +312,7 @@ export default class PrintCourseComponent extends Component {
         </div>
       </section>
       {{#each (sortBy "title" this.sessions) as |session|}}
-        <PrintCourseSession @session={{session}} />
+        <PrintCourseSession @session={{session}} @editable={{false}} />
       {{/each}}
     </section>
   </template>

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -8,6 +8,7 @@ import PublicationStatus from 'ilios-common/components/publication-status';
 import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
 import { sortBy as sortArrayBy } from 'ilios-common/utils/array-helpers';
+import and from 'ember-truth-helpers/helpers/and';
 import sortBy from 'ilios-common/helpers/sort-by';
 import DetailTermsList from 'ilios-common/components/detail-terms-list';
 import ObjectiveList from 'ilios-common/components/course/objective-list';
@@ -173,7 +174,7 @@ export default class PrintCourseComponent extends Component {
             <label>
               {{t "general.directors"}}:
             </label>
-            {{#if this.directorsData.isResolved}}
+            {{#if (and this.directorsData.isResolved this.directorsData.value.length)}}
               <div>
                 <span>{{this.directors}}</span>
               </div>

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -7,6 +7,7 @@ import add from 'ember-math-helpers/helpers/add';
 import PublicationStatus from 'ilios-common/components/publication-status';
 import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
+import { sortBy as sortArrayBy } from 'ilios-common/utils/array-helpers';
 import sortBy from 'ilios-common/helpers/sort-by';
 import DetailTermsList from 'ilios-common/components/detail-terms-list';
 import ObjectiveList from 'ilios-common/components/course/objective-list';
@@ -63,7 +64,11 @@ export default class PrintCourseComponent extends Component {
   }
 
   get directors() {
-    return this.directorsData.isResolved ? this.directorsData.value : [];
+    return this.directorsData.isResolved
+      ? sortArrayBy(this.directorsData.value, 'fullName')
+          .map((director) => director.fullName)
+          .join(', ')
+      : '';
   }
 
   get courseLearningMaterialsRelationship() {
@@ -168,13 +173,11 @@ export default class PrintCourseComponent extends Component {
             <label>
               {{t "general.directors"}}:
             </label>
-            <div>
-              <span>
-                {{#each (sortBy "fullName" this.directors) as |user|}}
-                  {{user.fullName}},
-                {{/each}}
-              </span>
-            </div>
+            {{#if this.directorsData.isResolved}}
+              <div>
+                <span>{{this.directors}}</span>
+              </div>
+            {{/if}}
           </div>
         </div>
       </section>

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -187,8 +187,8 @@ export default class PrintCourseComponent extends Component {
           {{t "general.competencies"}}
           ({{this.competencies.length}})
         </div>
-        <div class="content">
-          {{#if this.competencies.length}}
+        {{#if this.competencies.length}}
+          <div class="content">
             <ul class="static-list">
               {{#each @course.domainsWithSubcompetencies as |domain|}}
                 <li>
@@ -205,19 +205,21 @@ export default class PrintCourseComponent extends Component {
                 </li>
               {{/each}}
             </ul>
-          {{/if}}
-        </div>
+          </div>
+        {{/if}}
       </section>
       <section class="block" data-test-course-terms>
         <div class="title">
           {{t "general.terms"}}
           ({{@course.terms.length}})
         </div>
-        <div class="content">
-          {{#each @course.associatedVocabularies as |vocab|}}
-            <DetailTermsList @vocabulary={{vocab}} @terms={{this.terms}} @canEdit={{false}} />
-          {{/each}}
-        </div>
+        {{#if @course.associatedVocabularies.length}}
+          <div class="content">
+            {{#each @course.associatedVocabularies as |vocab|}}
+              <DetailTermsList @vocabulary={{vocab}} @terms={{this.terms}} @canEdit={{false}} />
+            {{/each}}
+          </div>
+        {{/if}}
       </section>
       <section class="block" data-test-course-objectives>
         <div class="title">
@@ -235,8 +237,8 @@ export default class PrintCourseComponent extends Component {
           {{t "general.learningMaterials"}}
           ({{this.courseLearningMaterials.length}})
         </div>
-        <div class="content">
-          {{#if this.courseLearningMaterials}}
+        {{#if this.courseLearningMaterials}}
+          <div class="content">
             <table>
               <thead>
                 <tr>
@@ -297,23 +299,25 @@ export default class PrintCourseComponent extends Component {
                 {{/each}}
               </tbody>
             </table>
-          {{/if}}
-        </div>
+          </div>
+        {{/if}}
       </section>
       <section class="block" data-test-course-mesh>
         <div class="title">
           {{t "general.mesh"}}
           ({{@course.meshDescriptors.length}})
         </div>
-        <div class="content">
-          <ul class="inline-list">
-            {{#each (sortBy "title" this.meshDescriptors) as |descriptor|}}
-              <li>
-                {{descriptor.name}}
-              </li>
-            {{/each}}
-          </ul>
-        </div>
+        {{#if @course.meshDescriptors.length}}
+          <div class="content">
+            <ul class="inline-list">
+              {{#each (sortBy "title" this.meshDescriptors) as |descriptor|}}
+                <li>
+                  {{descriptor.name}}
+                </li>
+              {{/each}}
+            </ul>
+          </div>
+        {{/if}}
       </section>
       {{#each (sortBy "title" this.sessions) as |session|}}
         <PrintCourseSession @session={{session}} @editable={{false}} />

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -187,10 +187,10 @@ export default class SessionObjectiveListItemComponent extends Component {
   <template>
     <div
       id="objective-{{@sessionObjective.id}}"
-      class="grid-row objective-row{{if this.showRemoveConfirmation ' confirm-removal'}}{{if
-          this.highlightSave.isRunning
-          ' highlight-ok'
-        }}{{if this.isManaging ' is-managing'}}"
+      class="grid-row objective-row{{if this.showRemoveConfirmation ' confirm-removal'}}{{unless
+          @editable
+          ' no-actions'
+        }}{{if this.highlightSave.isRunning ' highlight-ok'}}{{if this.isManaging ' is-managing'}}"
       data-test-session-objective-list-item
     >
       <div class="description grid-item" data-test-description>
@@ -255,28 +255,30 @@ export default class SessionObjectiveListItemComponent extends Component {
         @cancel={{this.cancel}}
       />
 
-      <div class="actions grid-item" data-test-actions>
-        {{#if
-          (and
-            @editable
-            (not this.isManaging)
-            (not this.showRemoveConfirmation)
-            (not this.showRemoveConfirmation)
-          )
-        }}
-          <button
-            class="link-button"
-            type="button"
-            aria-label={{t "general.remove"}}
-            {{on "click" (set this "showRemoveConfirmation" true)}}
-            data-test-remove
-          >
-            <FaIcon @icon="trash" class="enabled remove" />
-          </button>
-        {{else}}
-          <FaIcon @icon="trash" class="disabled" />
-        {{/if}}
-      </div>
+      {{#if @editable}}
+        <div class="actions grid-item" data-test-actions>
+          {{#if
+            (and
+              @editable
+              (not this.isManaging)
+              (not this.showRemoveConfirmation)
+              (not this.showRemoveConfirmation)
+            )
+          }}
+            <button
+              class="link-button"
+              type="button"
+              aria-label={{t "general.remove"}}
+              {{on "click" (set this "showRemoveConfirmation" true)}}
+              data-test-remove
+            >
+              <FaIcon @icon="trash" class="enabled remove" />
+            </button>
+          {{else}}
+            <FaIcon @icon="trash" class="disabled" />
+          {{/if}}
+        </div>
+      {{/if}}
 
       {{#if this.showRemoveConfirmation}}
         <div class="confirm-message" data-test-confirm-removal>

--- a/packages/ilios-common/addon/components/session/objective-list.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list.gjs
@@ -62,12 +62,14 @@ export default class SessionObjectiveListComponent extends Component {
             {{t "general.sortObjectives"}}
           </button>
         {{/if}}
-        <div class="grid-row headers" data-test-headers>
+        <div class="grid-row headers{{unless @editable ' no-actions'}}" data-test-headers>
           <span class="grid-item" data-test-header>{{t "general.description"}}</span>
           <span class="grid-item" data-test-header>{{t "general.parentObjectives"}}</span>
           <span class="grid-item" data-test-header>{{t "general.vocabularyTerms"}}</span>
           <span class="grid-item" data-test-header>{{t "general.meshTerms"}}</span>
-          <span class="actions grid-item" data-test-header>{{t "general.actions"}}</span>
+          {{#if @editable}}
+            <span class="actions grid-item" data-test-header>{{t "general.actions"}}</span>
+          {{/if}}
         </div>
         {{#if (and (isArray this.sessionObjectives) (isArray this.courseObjectives))}}
           {{#each this.sessionObjectives as |sessionObjective|}}

--- a/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
@@ -28,7 +28,7 @@
 
         label {
           font-weight: bold;
-          margin-right: 0.5rem;
+          margin-right: 0.25rem;
         }
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
@@ -52,6 +52,10 @@
 
   .offering-instructors {
     @include m.ilios-list-reset;
+
+    ul {
+      margin-left: 0;
+    }
   }
 
   .fade-text {

--- a/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
@@ -23,6 +23,14 @@
 
     .content {
       @include m.detail-container-content;
+      .inline-label-data-block {
+        display: flex;
+
+        label {
+          font-weight: bold;
+          margin-right: 0.5rem;
+        }
+      }
     }
 
     .static-list {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -25,17 +25,17 @@
   li {
     font-weight: bold;
 
+    ul,
+    ol {
+      margin-left: 1em;
+
+      li {
+        font-weight: normal;
+      }
+    }
+
     &:last-of-type {
       margin-bottom: 0;
-    }
-  }
-
-  ul {
-    margin-left: 1em;
-
-    /* stylelint-disable-next-line no-descending-specificity */
-    li {
-      font-weight: normal;
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -19,16 +19,21 @@
   background-color: var(--white);
   border: 1px solid var(--cultured-grey);
   border-radius: 3px;
-  padding: 1em 2em;
+  padding: 1em;
   width: 80%;
 
   li {
     font-weight: bold;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
   }
 
   ul {
     margin-left: 1em;
 
+    /* stylelint-disable-next-line no-descending-specificity */
     li {
       font-weight: normal;
     }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -57,6 +57,7 @@
   li {
     background-color: var(--cultured-grey);
     border-radius: 4px;
+    margin-bottom: 0;
     margin-right: 0.3em;
     margin-top: 10px;
     padding: 0.2em 0.4em 0.2em 0.6em;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -69,6 +69,10 @@
     grid-template-columns: 5fr 3fr 3fr 3fr 1fr;
     grid-template-rows: auto;
 
+    &.no-actions {
+      grid-template-columns: 5fr 3fr 3fr 3fr;
+    }
+
     .grid-item {
       border-bottom: 1px solid var(--davys-grey);
       padding: 0.5em 0.25em;


### PR DESCRIPTION
This PR is to give the `/courses/[course_id]/print` route a visual and a11y overhaul.

Thus far:
* Inline header elements that weren't actually inlined
* Improve consistency in spacing for `static-list` elements
* Remove `Actions` column as it's not valid in this context
* Improve Directors display in header
* Add missing testing element attributes
* Stop creating empty lists
* Stop creating empty `<div class="content">` elements
* Make Session Offering Instructors flush with header
* Generally tidy up spacing here and there