### PR TITLE
Hide School Names While Loading

### DIFF
--- a/packages/frontend/app/styles/components/courses/loading.scss
+++ b/packages/frontend/app/styles/components/courses/loading.scss
@@ -7,4 +7,9 @@
     cursor: default;
     background-color: var(--cultured-grey);
   }
+
+  select {
+    @include cm.loading-text;
+    cursor: default;
+  }
 }


### PR DESCRIPTION
Avoid the first alphabetical school showing up in the list while we wait for loading to finish.

From:
<img width="1153" height="261" alt="Screenshot 2025-07-28 at 11 59 40 AM" src="https://github.com/user-attachments/assets/eb964ff9-a147-4a91-93bc-15c5efd94b57" />

To:
<img width="1135" height="163" alt="Screenshot 2025-07-28 at 11 59 14 AM" src="https://github.com/user-attachments/assets/49ff3f1c-a0ec-4cce-a213-fec16dd3130e" />
