### PR TITLE
Show empty row with message when no data in Curricular Inventory Report tables

### DIFF
--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table1.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table1.gjs
@@ -25,32 +25,30 @@ import t from 'ember-intl/helpers/t';
         </tr>
       </thead>
       <tbody>
-        {{#if @data.length}}
-          {{#each @data as |row|}}
-            <tr>
-              <td>
-                {{t "general.notApplicableAbbr"}}
-              </td>
-              <td colspan="3">
-                {{! template-lint-disable no-triple-curlies}}
-                {{{row.title}}}
-              </td>
-              <td colspan="2">
-                <ul>
-                  {{#each row.pcrs as |pcrs|}}
-                    <li>
-                      {{pcrs}}
-                    </li>
-                  {{/each}}
-                </ul>
-              </td>
-            </tr>
-          {{/each}}
+        {{#each @data as |row|}}
+          <tr>
+            <td>
+              {{t "general.notApplicableAbbr"}}
+            </td>
+            <td colspan="3">
+              {{! template-lint-disable no-triple-curlies}}
+              {{{row.title}}}
+            </td>
+            <td colspan="2">
+              <ul>
+                {{#each row.pcrs as |pcrs|}}
+                  <li>
+                    {{pcrs}}
+                  </li>
+                {{/each}}
+              </ul>
+            </td>
+          </tr>
         {{else}}
           <tr>
             <td colspan="6">{{t "general.none"}}</td>
           </tr>
-        {{/if}}
+        {{/each}}
       </tbody>
     </table>
   </div>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table1.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table1.gjs
@@ -6,9 +6,9 @@ import t from 'ember-intl/helpers/t';
     data-test-curriculum-inventory-verification-preview-table1
     ...attributes
   >
-    <h4 data-test-title>
+    <h3 data-test-title>
       {{t "general.table1ProgramExpectationsMappedToPcrs"}}
-    </h4>
+    </h3>
     <table>
       <thead>
         <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table1.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table1.gjs
@@ -25,26 +25,32 @@ import t from 'ember-intl/helpers/t';
         </tr>
       </thead>
       <tbody>
-        {{#each @data as |row|}}
+        {{#if @data.length}}
+          {{#each @data as |row|}}
+            <tr>
+              <td>
+                {{t "general.notApplicableAbbr"}}
+              </td>
+              <td colspan="3">
+                {{! template-lint-disable no-triple-curlies}}
+                {{{row.title}}}
+              </td>
+              <td colspan="2">
+                <ul>
+                  {{#each row.pcrs as |pcrs|}}
+                    <li>
+                      {{pcrs}}
+                    </li>
+                  {{/each}}
+                </ul>
+              </td>
+            </tr>
+          {{/each}}
+        {{else}}
           <tr>
-            <td>
-              {{t "general.notApplicableAbbr"}}
-            </td>
-            <td colspan="3">
-              {{! template-lint-disable no-triple-curlies}}
-              {{{row.title}}}
-            </td>
-            <td colspan="2">
-              <ul>
-                {{#each row.pcrs as |pcrs|}}
-                  <li>
-                    {{pcrs}}
-                  </li>
-                {{/each}}
-              </ul>
-            </td>
+            <td colspan="6">{{t "general.none"}}</td>
           </tr>
-        {{/each}}
+        {{/if}}
       </tbody>
     </table>
   </div>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table2.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table2.gjs
@@ -41,9 +41,9 @@ export default class CurriculumInventoryVerificationPreviewTable2Component exten
       data-test-curriculum-inventory-verification-preview-table2
       ...attributes
     >
-      <h4 data-test-title>
+      <h3 data-test-title>
         {{t "general.table2PrimaryInstructionalMethodByNonClerkshipSequenceBlock"}}
-      </h4>
+      </h3>
       <table>
         <thead>
           <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table2.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table2.gjs
@@ -69,26 +69,32 @@ export default class CurriculumInventoryVerificationPreviewTable2Component exten
           </tr>
         </thead>
         <tbody>
-          {{#each this.nonClerkships as |clerkship|}}
-            <tr>
-              <td colspan="2">
-                {{clerkship.title}}
-              </td>
-              <td>
-                {{clerkship.startingLevel}}
-                -
-                {{clerkship.endingLevel}}
-              </td>
-              {{#each clerkship.methods as |method|}}
-                <td>
-                  {{method}}
+          {{#if this.nonClerkships.length}}
+            {{#each this.nonClerkships as |clerkship|}}
+              <tr>
+                <td colspan="2">
+                  {{clerkship.title}}
                 </td>
-              {{/each}}
-              <td>
-                {{clerkship.total}}
-              </td>
+                <td>
+                  {{clerkship.startingLevel}}
+                  -
+                  {{clerkship.endingLevel}}
+                </td>
+                {{#each clerkship.methods as |method|}}
+                  <td>
+                    {{method}}
+                  </td>
+                {{/each}}
+                <td>
+                  {{clerkship.total}}
+                </td>
+              </tr>
+            {{/each}}
+          {{else}}
+            <tr>
+              <td colspan="4">{{t "general.none"}}</td>
             </tr>
-          {{/each}}
+          {{/if}}
         </tbody>
         <tfoot>
           <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table2.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table2.gjs
@@ -69,32 +69,30 @@ export default class CurriculumInventoryVerificationPreviewTable2Component exten
           </tr>
         </thead>
         <tbody>
-          {{#if this.nonClerkships.length}}
-            {{#each this.nonClerkships as |clerkship|}}
-              <tr>
-                <td colspan="2">
-                  {{clerkship.title}}
-                </td>
+          {{#each this.nonClerkships as |clerkship|}}
+            <tr>
+              <td colspan="2">
+                {{clerkship.title}}
+              </td>
+              <td>
+                {{clerkship.startingLevel}}
+                -
+                {{clerkship.endingLevel}}
+              </td>
+              {{#each clerkship.methods as |method|}}
                 <td>
-                  {{clerkship.startingLevel}}
-                  -
-                  {{clerkship.endingLevel}}
+                  {{method}}
                 </td>
-                {{#each clerkship.methods as |method|}}
-                  <td>
-                    {{method}}
-                  </td>
-                {{/each}}
-                <td>
-                  {{clerkship.total}}
-                </td>
-              </tr>
-            {{/each}}
+              {{/each}}
+              <td>
+                {{clerkship.total}}
+              </td>
+            </tr>
           {{else}}
             <tr>
               <td colspan="4">{{t "general.none"}}</td>
             </tr>
-          {{/if}}
+          {{/each}}
         </tbody>
         <tfoot>
           <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table3a.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table3a.gjs
@@ -6,9 +6,9 @@ import t from 'ember-intl/helpers/t';
     data-test-curriculum-inventory-verification-preview-table3a
     ...attributes
   >
-    <h4 data-test-title>
+    <h3 data-test-title>
       {{t "general.table3aNonClerkshipSequenceBlockInstructionalTime"}}
-    </h4>
+    </h3>
     <table>
       <thead>
         <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table3a.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table3a.gjs
@@ -27,24 +27,30 @@ import t from 'ember-intl/helpers/t';
         </tr>
       </thead>
       <tbody>
-        {{#each @data as |row|}}
+        {{#if @data.length}}
+          {{#each @data as |row|}}
+            <tr>
+              <td colspan="2">
+                {{row.title}}
+              </td>
+              <td>
+                {{row.starting_level}}
+                -
+                {{row.ending_level}}
+              </td>
+              <td>
+                {{row.weeks}}
+              </td>
+              <td>
+                {{row.avg}}
+              </td>
+            </tr>
+          {{/each}}
+        {{else}}
           <tr>
-            <td colspan="2">
-              {{row.title}}
-            </td>
-            <td>
-              {{row.starting_level}}
-              -
-              {{row.ending_level}}
-            </td>
-            <td>
-              {{row.weeks}}
-            </td>
-            <td>
-              {{row.avg}}
-            </td>
+            <td colspan="5">{{t "general.none"}}</td>
           </tr>
-        {{/each}}
+        {{/if}}
       </tbody>
     </table>
   </div>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table3a.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table3a.gjs
@@ -27,30 +27,28 @@ import t from 'ember-intl/helpers/t';
         </tr>
       </thead>
       <tbody>
-        {{#if @data.length}}
-          {{#each @data as |row|}}
-            <tr>
-              <td colspan="2">
-                {{row.title}}
-              </td>
-              <td>
-                {{row.starting_level}}
-                -
-                {{row.ending_level}}
-              </td>
-              <td>
-                {{row.weeks}}
-              </td>
-              <td>
-                {{row.avg}}
-              </td>
-            </tr>
-          {{/each}}
+        {{#each @data as |row|}}
+          <tr>
+            <td colspan="2">
+              {{row.title}}
+            </td>
+            <td>
+              {{row.starting_level}}
+              -
+              {{row.ending_level}}
+            </td>
+            <td>
+              {{row.weeks}}
+            </td>
+            <td>
+              {{row.avg}}
+            </td>
+          </tr>
         {{else}}
           <tr>
             <td colspan="5">{{t "general.none"}}</td>
           </tr>
-        {{/if}}
+        {{/each}}
       </tbody>
     </table>
   </div>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table3b.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table3b.gjs
@@ -27,24 +27,30 @@ import t from 'ember-intl/helpers/t';
         </tr>
       </thead>
       <tbody>
-        {{#each @data as |row|}}
+        {{#if @data.length}}
+          {{#each @data as |row|}}
+            <tr>
+              <td colspan="2">
+                {{row.title}}
+              </td>
+              <td>
+                {{row.starting_level}}
+                -
+                {{row.ending_level}}
+              </td>
+              <td>
+                {{row.weeks}}
+              </td>
+              <td>
+                {{row.avg}}
+              </td>
+            </tr>
+          {{/each}}
+        {{else}}
           <tr>
-            <td colspan="2">
-              {{row.title}}
-            </td>
-            <td>
-              {{row.starting_level}}
-              -
-              {{row.ending_level}}
-            </td>
-            <td>
-              {{row.weeks}}
-            </td>
-            <td>
-              {{row.avg}}
-            </td>
+            <td colspan="5">{{t "general.none"}}</td>
           </tr>
-        {{/each}}
+        {{/if}}
       </tbody>
     </table>
   </div>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table3b.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table3b.gjs
@@ -6,9 +6,9 @@ import t from 'ember-intl/helpers/t';
     data-test-curriculum-inventory-verification-preview-table3b
     ...attributes
   >
-    <h4 data-test-title>
+    <h3 data-test-title>
       {{t "general.table3bClerkshipSequenceBlockInstructionalTime"}}
-    </h4>
+    </h3>
     <table>
       <thead>
         <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table3b.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table3b.gjs
@@ -27,30 +27,28 @@ import t from 'ember-intl/helpers/t';
         </tr>
       </thead>
       <tbody>
-        {{#if @data.length}}
-          {{#each @data as |row|}}
-            <tr>
-              <td colspan="2">
-                {{row.title}}
-              </td>
-              <td>
-                {{row.starting_level}}
-                -
-                {{row.ending_level}}
-              </td>
-              <td>
-                {{row.weeks}}
-              </td>
-              <td>
-                {{row.avg}}
-              </td>
-            </tr>
-          {{/each}}
+        {{#each @data as |row|}}
+          <tr>
+            <td colspan="2">
+              {{row.title}}
+            </td>
+            <td>
+              {{row.starting_level}}
+              -
+              {{row.ending_level}}
+            </td>
+            <td>
+              {{row.weeks}}
+            </td>
+            <td>
+              {{row.avg}}
+            </td>
+          </tr>
         {{else}}
           <tr>
             <td colspan="5">{{t "general.none"}}</td>
           </tr>
-        {{/if}}
+        {{/each}}
       </tbody>
     </table>
   </div>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table4.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table4.gjs
@@ -41,28 +41,26 @@ export default class CurriculumInventoryVerificationPreviewTable4Component exten
           </tr>
         </thead>
         <tbody>
-          {{#if @data.length}}
-            {{#each @data as |row|}}
-              <tr>
-                <td>
-                  {{row.id}}
-                </td>
-                <td colspan="2">
-                  {{row.title}}
-                </td>
-                <td>
-                  {{row.num_events_primary_method}}
-                </td>
-                <td>
-                  {{row.num_events_non_primary_method}}
-                </td>
-              </tr>
-            {{/each}}
+          {{#each @data as |row|}}
+            <tr>
+              <td>
+                {{row.id}}
+              </td>
+              <td colspan="2">
+                {{row.title}}
+              </td>
+              <td>
+                {{row.num_events_primary_method}}
+              </td>
+              <td>
+                {{row.num_events_non_primary_method}}
+              </td>
+            </tr>
           {{else}}
             <tr>
               <td colspan="5">{{t "general.none"}}</td>
             </tr>
-          {{/if}}
+          {{/each}}
         </tbody>
         <tfoot>
           <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table4.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table4.gjs
@@ -41,22 +41,28 @@ export default class CurriculumInventoryVerificationPreviewTable4Component exten
           </tr>
         </thead>
         <tbody>
-          {{#each @data as |row|}}
+          {{#if @data.length}}
+            {{#each @data as |row|}}
+              <tr>
+                <td>
+                  {{row.id}}
+                </td>
+                <td colspan="2">
+                  {{row.title}}
+                </td>
+                <td>
+                  {{row.num_events_primary_method}}
+                </td>
+                <td>
+                  {{row.num_events_non_primary_method}}
+                </td>
+              </tr>
+            {{/each}}
+          {{else}}
             <tr>
-              <td>
-                {{row.id}}
-              </td>
-              <td colspan="2">
-                {{row.title}}
-              </td>
-              <td>
-                {{row.num_events_primary_method}}
-              </td>
-              <td>
-                {{row.num_events_non_primary_method}}
-              </td>
+              <td colspan="5">{{t "general.none"}}</td>
             </tr>
-          {{/each}}
+          {{/if}}
         </tbody>
         <tfoot>
           <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table4.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table4.gjs
@@ -20,9 +20,9 @@ export default class CurriculumInventoryVerificationPreviewTable4Component exten
       data-test-curriculum-inventory-verification-preview-table4
       ...attributes
     >
-      <h4 data-test-title>
+      <h3 data-test-title>
         {{t "general.table4InstructionalMethodCounts"}}
-      </h4>
+      </h3>
       <table>
         <thead>
           <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table5.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table5.gjs
@@ -63,32 +63,38 @@ export default class CurriculumInventoryVerificationPreviewTable5Component exten
           </tr>
         </thead>
         <tbody>
-          {{#each this.nonClerkships as |nonClerkship|}}
-            <tr>
-              <td colspan="2">
-                {{nonClerkship.title}}
-              </td>
-              <td>
-                {{nonClerkship.startingLevel}}
-                -
-                {{nonClerkship.endingLevel}}
-              </td>
-              <td>
-                {{nonClerkship.numExams}}
-              </td>
-              {{#each nonClerkship.methods as |method|}}
-                <td>
-                  {{method}}
+          {{#if this.nonClerkships.length}}
+            {{#each this.nonClerkships as |nonClerkship|}}
+              <tr>
+                <td colspan="2">
+                  {{nonClerkship.title}}
                 </td>
-              {{/each}}
-              <td>
-                {{nonClerkship.hasFormativeAssessments}}
-              </td>
-              <td>
-                {{nonClerkship.hasNarrativeAssessments}}
-              </td>
+                <td>
+                  {{nonClerkship.startingLevel}}
+                  -
+                  {{nonClerkship.endingLevel}}
+                </td>
+                <td>
+                  {{nonClerkship.numExams}}
+                </td>
+                {{#each nonClerkship.methods as |method|}}
+                  <td>
+                    {{method}}
+                  </td>
+                {{/each}}
+                <td>
+                  {{nonClerkship.hasFormativeAssessments}}
+                </td>
+                <td>
+                  {{nonClerkship.hasNarrativeAssessments}}
+                </td>
+              </tr>
+            {{/each}}
+          {{else}}
+            <tr>
+              <td colspan="13">{{t "general.none"}}</td>
             </tr>
-          {{/each}}
+          {{/if}}
         </tbody>
       </table>
     </div>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table5.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table5.gjs
@@ -63,38 +63,36 @@ export default class CurriculumInventoryVerificationPreviewTable5Component exten
           </tr>
         </thead>
         <tbody>
-          {{#if this.nonClerkships.length}}
-            {{#each this.nonClerkships as |nonClerkship|}}
-              <tr>
-                <td colspan="2">
-                  {{nonClerkship.title}}
-                </td>
+          {{#each this.nonClerkships as |nonClerkship|}}
+            <tr>
+              <td colspan="2">
+                {{nonClerkship.title}}
+              </td>
+              <td>
+                {{nonClerkship.startingLevel}}
+                -
+                {{nonClerkship.endingLevel}}
+              </td>
+              <td>
+                {{nonClerkship.numExams}}
+              </td>
+              {{#each nonClerkship.methods as |method|}}
                 <td>
-                  {{nonClerkship.startingLevel}}
-                  -
-                  {{nonClerkship.endingLevel}}
+                  {{method}}
                 </td>
-                <td>
-                  {{nonClerkship.numExams}}
-                </td>
-                {{#each nonClerkship.methods as |method|}}
-                  <td>
-                    {{method}}
-                  </td>
-                {{/each}}
-                <td>
-                  {{nonClerkship.hasFormativeAssessments}}
-                </td>
-                <td>
-                  {{nonClerkship.hasNarrativeAssessments}}
-                </td>
-              </tr>
-            {{/each}}
+              {{/each}}
+              <td>
+                {{nonClerkship.hasFormativeAssessments}}
+              </td>
+              <td>
+                {{nonClerkship.hasNarrativeAssessments}}
+              </td>
+            </tr>
           {{else}}
             <tr>
               <td colspan="13">{{t "general.none"}}</td>
             </tr>
-          {{/if}}
+          {{/each}}
         </tbody>
       </table>
     </div>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table5.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table5.gjs
@@ -26,9 +26,9 @@ export default class CurriculumInventoryVerificationPreviewTable5Component exten
       data-test-curriculum-inventory-verification-preview-table5
       ...attributes
     >
-      <h4 data-test-title id="verification-preview-table5">
+      <h3 data-test-title id="verification-preview-table5">
         {{t "general.table5NonClerkshipSequenceBlockAssessmentMethods"}}
-      </h4>
+      </h3>
       <table>
         <thead>
           <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table6.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table6.gjs
@@ -24,9 +24,9 @@ export default class CurriculumInventoryVerificationPreviewTable6Component exten
       data-test-curriculum-inventory-verification-preview-table6
       ...attributes
     >
-      <h4 data-test-title id="verification-preview-table6">
+      <h3 data-test-title id="verification-preview-table6">
         {{t "general.table6ClerkshipSequenceBlockAssessmentMethods"}}
-      </h4>
+      </h3>
       <table>
         <thead>
           <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table6.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table6.gjs
@@ -58,29 +58,35 @@ export default class CurriculumInventoryVerificationPreviewTable6Component exten
           </tr>
         </thead>
         <tbody>
-          {{#each this.clerkships as |clerkship|}}
-            <tr>
-              <td colspan="2">
-                {{clerkship.title}}
-              </td>
-              <td>
-                {{clerkship.startingLevel}}
-                -
-                {{clerkship.endingLevel}}
-              </td>
-              {{#each clerkship.methods as |method|}}
-                <td>
-                  {{method}}
+          {{#if this.clerkships.length}}
+            {{#each this.clerkships as |clerkship|}}
+              <tr>
+                <td colspan="2">
+                  {{clerkship.title}}
                 </td>
-              {{/each}}
-              <td>
-                {{clerkship.hasFormativeAssessments}}
-              </td>
-              <td>
-                {{clerkship.hasNarrativeAssessments}}
-              </td>
+                <td>
+                  {{clerkship.startingLevel}}
+                  -
+                  {{clerkship.endingLevel}}
+                </td>
+                {{#each clerkship.methods as |method|}}
+                  <td>
+                    {{method}}
+                  </td>
+                {{/each}}
+                <td>
+                  {{clerkship.hasFormativeAssessments}}
+                </td>
+                <td>
+                  {{clerkship.hasNarrativeAssessments}}
+                </td>
+              </tr>
+            {{/each}}
+          {{else}}
+            <tr>
+              <td colspan="11">{{t "general.none"}}</td>
             </tr>
-          {{/each}}
+          {{/if}}
         </tbody>
       </table>
     </div>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table6.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table6.gjs
@@ -58,35 +58,33 @@ export default class CurriculumInventoryVerificationPreviewTable6Component exten
           </tr>
         </thead>
         <tbody>
-          {{#if this.clerkships.length}}
-            {{#each this.clerkships as |clerkship|}}
-              <tr>
-                <td colspan="2">
-                  {{clerkship.title}}
-                </td>
+          {{#each this.clerkships as |clerkship|}}
+            <tr>
+              <td colspan="2">
+                {{clerkship.title}}
+              </td>
+              <td>
+                {{clerkship.startingLevel}}
+                -
+                {{clerkship.endingLevel}}
+              </td>
+              {{#each clerkship.methods as |method|}}
                 <td>
-                  {{clerkship.startingLevel}}
-                  -
-                  {{clerkship.endingLevel}}
+                  {{method}}
                 </td>
-                {{#each clerkship.methods as |method|}}
-                  <td>
-                    {{method}}
-                  </td>
-                {{/each}}
-                <td>
-                  {{clerkship.hasFormativeAssessments}}
-                </td>
-                <td>
-                  {{clerkship.hasNarrativeAssessments}}
-                </td>
-              </tr>
-            {{/each}}
+              {{/each}}
+              <td>
+                {{clerkship.hasFormativeAssessments}}
+              </td>
+              <td>
+                {{clerkship.hasNarrativeAssessments}}
+              </td>
+            </tr>
           {{else}}
             <tr>
               <td colspan="11">{{t "general.none"}}</td>
             </tr>
-          {{/if}}
+          {{/each}}
         </tbody>
       </table>
     </div>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table7.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table7.gjs
@@ -41,28 +41,26 @@ export default class CurriculumInventoryVerificationPreviewTable7Component exten
           </tr>
         </thead>
         <tbody>
-          {{#if @data.length}}
-            {{#each @data as |row|}}
-              <tr>
-                <td>
-                  {{row.id}}
-                </td>
-                <td colspan="2">
-                  {{row.title}}
-                </td>
-                <td>
-                  {{row.num_summative_assessments}}
-                </td>
-                <td>
-                  {{row.num_formative_assessments}}
-                </td>
-              </tr>
-            {{/each}}
+          {{#each @data as |row|}}
+            <tr>
+              <td>
+                {{row.id}}
+              </td>
+              <td colspan="2">
+                {{row.title}}
+              </td>
+              <td>
+                {{row.num_summative_assessments}}
+              </td>
+              <td>
+                {{row.num_formative_assessments}}
+              </td>
+            </tr>
           {{else}}
             <tr>
               <td colspan="5">{{t "general.none"}}</td>
             </tr>
-          {{/if}}
+          {{/each}}
         </tbody>
         <tfoot>
           <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table7.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table7.gjs
@@ -20,9 +20,9 @@ export default class CurriculumInventoryVerificationPreviewTable7Component exten
       data-test-curriculum-inventory-verification-preview-table7
       ...attributes
     >
-      <h4 data-test-title id="verification-preview-table7">
+      <h3 data-test-title id="verification-preview-table7">
         {{t "general.table7AllEventsWithAssessmentsTaggedAsFormativeOrSummative"}}
-      </h4>
+      </h3>
       <table>
         <thead>
           <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table7.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table7.gjs
@@ -41,22 +41,28 @@ export default class CurriculumInventoryVerificationPreviewTable7Component exten
           </tr>
         </thead>
         <tbody>
-          {{#each @data as |row|}}
+          {{#if @data.length}}
+            {{#each @data as |row|}}
+              <tr>
+                <td>
+                  {{row.id}}
+                </td>
+                <td colspan="2">
+                  {{row.title}}
+                </td>
+                <td>
+                  {{row.num_summative_assessments}}
+                </td>
+                <td>
+                  {{row.num_formative_assessments}}
+                </td>
+              </tr>
+            {{/each}}
+          {{else}}
             <tr>
-              <td>
-                {{row.id}}
-              </td>
-              <td colspan="2">
-                {{row.title}}
-              </td>
-              <td>
-                {{row.num_summative_assessments}}
-              </td>
-              <td>
-                {{row.num_formative_assessments}}
-              </td>
+              <td colspan="5">{{t "general.none"}}</td>
             </tr>
-          {{/each}}
+          {{/if}}
         </tbody>
         <tfoot>
           <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table8.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table8.gjs
@@ -6,9 +6,9 @@ import t from 'ember-intl/helpers/t';
     data-test-curriculum-inventory-verification-preview-table8
     ...attributes
   >
-    <h4 data-test-title id="verification-preview-table8">
+    <h3 data-test-title id="verification-preview-table8">
       {{t "general.table8AllResourceTypes"}}
-    </h4>
+    </h3>
     <table>
       <thead>
         <tr>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table8.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table8.gjs
@@ -24,25 +24,23 @@ import t from 'ember-intl/helpers/t';
         </tr>
       </thead>
       <tbody>
-        {{#if @data.length}}
-          {{#each @data as |row|}}
-            <tr>
-              <td>
-                {{row.id}}
-              </td>
-              <td colspan="2">
-                {{row.title}}
-              </td>
-              <td>
-                {{row.count}}
-              </td>
-            </tr>
-          {{/each}}
+        {{#each @data as |row|}}
+          <tr>
+            <td>
+              {{row.id}}
+            </td>
+            <td colspan="2">
+              {{row.title}}
+            </td>
+            <td>
+              {{row.count}}
+            </td>
+          </tr>
         {{else}}
           <tr>
             <td colspan="4">{{t "general.none"}}</td>
           </tr>
-        {{/if}}
+        {{/each}}
       </tbody>
     </table>
   </div>

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview-table8.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview-table8.gjs
@@ -24,19 +24,25 @@ import t from 'ember-intl/helpers/t';
         </tr>
       </thead>
       <tbody>
-        {{#each @data as |row|}}
+        {{#if @data.length}}
+          {{#each @data as |row|}}
+            <tr>
+              <td>
+                {{row.id}}
+              </td>
+              <td colspan="2">
+                {{row.title}}
+              </td>
+              <td>
+                {{row.count}}
+              </td>
+            </tr>
+          {{/each}}
+        {{else}}
           <tr>
-            <td>
-              {{row.id}}
-            </td>
-            <td colspan="2">
-              {{row.title}}
-            </td>
-            <td>
-              {{row.count}}
-            </td>
+            <td colspan="4">{{t "general.none"}}</td>
           </tr>
-        {{/each}}
+        {{/if}}
       </tbody>
     </table>
   </div>

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table2.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview-table2.scss
@@ -12,8 +12,10 @@
       vertical-align: top;
     }
 
-    td:nth-last-child(1) {
-      font-weight: bold;
+    tfoot {
+      td:nth-last-child(1) {
+        font-weight: bold;
+      }
     }
   }
 }

--- a/packages/frontend/app/styles/components/curriculum-inventory/verification-preview.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/verification-preview.scss
@@ -1,3 +1,5 @@
+@use "../../ilios-common/mixins" as m;
+
 .curriculum-inventory-verification-preview {
   .back-to-toc {
     display: block;
@@ -8,5 +10,9 @@
     list-style-type: none;
     margin-left: 0;
     padding-left: 1rem;
+  }
+
+  h3 {
+    @include m.ilios-heading-h4;
   }
 }


### PR DESCRIPTION
Fixes ilios/ilios#6356

Show a single table row with "None" if there is no data to be displayed. Also fixed the `<h#>` descendant a11y issue.