### PR TITLE
Add Search Suggestions to Global Search Results

### DIFF
--- a/packages/frontend/app/components/global-search.gjs
+++ b/packages/frontend/app/components/global-search.gjs
@@ -14,6 +14,8 @@ import add from 'ember-math-helpers/helpers/add';
 import { fn } from '@ember/helper';
 import includes from 'ilios-common/helpers/includes';
 import PaginationLinks from 'frontend/components/pagination-links';
+import { htmlSafe } from '@ember/template';
+import { modifier } from 'ember-modifier';
 
 const COURSES_PER_PAGE = 10;
 
@@ -80,6 +82,14 @@ export default class GlobalSearchComponent extends Component {
     return [];
   }
 
+  get didYouMeanResults() {
+    if (this.resultsData.isResolved && this.resultsData.value) {
+      return this.resultsData.value.didYouMean;
+    }
+
+    return [];
+  }
+
   get totalResults() {
     if (this.resultsData.isResolved && this.resultsData.value) {
       //the PaginationLinks component expects an array of results, we get a number so fake that up into an array
@@ -120,6 +130,11 @@ export default class GlobalSearchComponent extends Component {
   <template>
     <div class="global-search" data-test-global-search ...attributes>
       <GlobalSearchBox @query={{@query}} @search={{@setQuery}} />
+      <DidYouMean
+        @results={{this.didYouMeanResults}}
+        @selectedSchools={{@selectedSchools}}
+        @selectedYears={{@selectedYears}}
+      />
       <ul
         class="results {{if (and this.resultsData.isPending (not this.hasResults)) 'hidden'}}"
         data-test-results
@@ -186,5 +201,58 @@ export default class GlobalSearchComponent extends Component {
       @size={{COURSES_PER_PAGE}}
       @onSelectPage={{@setPage}}
     />
+  </template>
+}
+
+class DidYouMean extends Component {
+  @service router;
+
+  get shouldDisplay() {
+    return this.args.results?.score > 0.03;
+  }
+
+  get highlightedSafe() {
+    return htmlSafe(this.args.results.highlighted);
+  }
+
+  get href() {
+    return this.router.urlFor('search', {
+      queryParams: {
+        q: this.args.results.didYouMean,
+        schools: this.args.selectedSchools?.length ? this.args.selectedSchools.join('-') : null,
+        years: this.args.selectedYears?.length ? this.args.selectedYears.join('-') : null,
+      },
+    });
+  }
+
+  /**
+   * We can't reliable pass a link into a translation
+   * without it causing a full page load when it is clicked.
+   * As a fallback we find the link in the DOM and use the router to make the transition
+   **/
+  overrideLink = modifier((element) => {
+    const link = element.querySelector('a');
+    link.addEventListener(
+      'click',
+      (e) => {
+        e.preventDefault();
+        this.router.transitionTo('search', {
+          queryParams: {
+            q: this.args.results.didYouMean,
+            schools: this.args.selectedSchools.length ? this.args.selectedSchools.join('-') : null,
+            years: this.args.selectedYears.length ? this.args.selectedYears.join('-') : null,
+          },
+        });
+      },
+      { passive: false, once: true },
+    );
+  });
+
+  <template>
+    {{#if this.shouldDisplay}}
+      <div class="did-you-mean" {{this.overrideLink}} data-test-did-you-mean>
+        {{t "general.didYouMean" suggestion=this.highlightedSafe href=this.href htmlSafe=true}}
+      </div>
+    {{/if}}
   </template>
 }

--- a/packages/frontend/app/styles/components/global-search.scss
+++ b/packages/frontend/app/styles/components/global-search.scss
@@ -5,21 +5,22 @@
   display: grid;
   grid-template-areas:
     "search"
+    "did-you-mean"
     "filters"
     "results";
-  grid-column-gap: 0;
-  grid-row-gap: 1rem;
 
   @include m.for-tablet-and-up {
     grid-template-areas:
       "search search"
+      "did-you-mean filters"
       "results filters";
     grid-template-columns: 1fr auto;
+    grid-template-rows: min-content 1rem 1fr;
   }
 
   .global-search-box {
     grid-area: search;
-    margin: 0.75rem 0 1rem 10%;
+    margin: 0.75rem 0 0.5rem 10%;
     width: 80%;
     border: 1px solid var(--davys-grey);
   }
@@ -69,6 +70,18 @@
       .fa-spinner.orange {
         color: var(--orange);
       }
+    }
+  }
+
+  .did-you-mean {
+    grid-area: did-you-mean;
+    text-align: center;
+    .original {
+      font-weight: 600;
+    }
+
+    .highlight {
+      font-style: italic;
     }
   }
 }

--- a/packages/frontend/tests/pages/components/global-search.js
+++ b/packages/frontend/tests/pages/components/global-search.js
@@ -22,6 +22,10 @@ const definition = {
   }),
   searchResults: collection('[data-test-course-search-result]', courseSearchResult),
   searchIsRunning: isVisible('[data-test-searching]'),
+  didYouMean: {
+    scope: '[data-test-did-you-mean]',
+    url: property('href', 'a'),
+  },
 };
 
 export default definition;

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -116,6 +116,7 @@ general:
   deselectUser: Deselect User
   details: Course Details
   developer: Developer
+  didYouMean: Did you mean <a href="{href}">{suggestion}</a>?
   director: Director
   disableUser: Disable User
   doesNotMatchUserRecord: 'Uploaded {description} does not match the information in Ilios, which is "{record}"'

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -116,6 +116,7 @@ general:
   deselectUser: Deseleccione usuario
   details: Detalles de Curso
   developer: Desarrollador
+  didYouMean: ¿Quería decir <a href="{href}">{suggestion}</a>?
   director: Director
   disableUser: Desactivar el usuario
   doesNotMatchUserRecord: 'Cargado {description} no coincide con la información en Ilios, cuál es "{record}"'

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -116,6 +116,7 @@ general:
   deselectUser: "Désélectionner l'utilisateur "
   details: Détails de Cours
   developer: Administrateur
+  didYouMean: Confirmez-vous <a href="{href}">{suggestion}</a>?
   director: Directeur
   disableUser: Désactiver compte d’utilisateur
   doesNotMatchUserRecord: 'Téléchargé {description} ne correspond pas aux informations dans Ilios, qui est "{record}"'


### PR DESCRIPTION
When we get back data from the API that suggests a different search term display that to users so they can click it and immediately run that search.