### PR TITLE
Fix All Weeks Year Calculation

### DIFF
--- a/packages/frontend/tests/acceptance/weeklyevents-test.js
+++ b/packages/frontend/tests/acceptance/weeklyevents-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
-import { setupAuthentication } from 'ilios-common';
+import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
 import { setupApplicationTest } from 'frontend/tests/helpers';
 import page from 'ilios-common/page-objects/weeklyevents';
+import { DateTime } from 'luxon';
 
 module('Acceptance | Weekly events', function (hooks) {
   setupApplicationTest(hooks);
@@ -10,8 +11,45 @@ module('Acceptance | Weekly events', function (hooks) {
     this.user = await setupAuthentication();
   });
 
+  hooks.afterEach(() => {
+    unfreezeDate();
+  });
+
   test('back link is not visible', async function (assert) {
     await page.visit();
     assert.notOk(page.backLink.isPresent);
+  });
+
+  test('shows the right weeks in 2025 #6366', async function (assert) {
+    assert.expect(3);
+
+    const dt = DateTime.fromObject({ year: 2025, month: 1, day: 1 });
+    freezeDateAt(dt.toJSDate());
+    await page.visit();
+    assert.deepEqual(page.weeklyEvents.weeks.length, 52);
+    assert.deepEqual(page.weeklyEvents.weeks[0].title, 'December 29 - January 4');
+    assert.deepEqual(page.weeklyEvents.weeks[51].title, 'December 21-27');
+  });
+
+  test('shows the right weeks in 2026 #6366', async function (assert) {
+    assert.expect(3);
+
+    const dt = DateTime.fromObject({ year: 2026, month: 7, day: 15 });
+    freezeDateAt(dt.toJSDate());
+    await page.visit();
+    assert.deepEqual(page.weeklyEvents.weeks.length, 53);
+    assert.deepEqual(page.weeklyEvents.weeks[0].title, 'December 28 - January 3');
+    assert.deepEqual(page.weeklyEvents.weeks[52].title, 'December 27 - January 2');
+  });
+
+  test('shows the right weeks in 2027 #6366', async function (assert) {
+    assert.expect(3);
+
+    const dt = DateTime.fromObject({ year: 2027, month: 7, day: 15 });
+    freezeDateAt(dt.toJSDate());
+    await page.visit();
+    assert.deepEqual(page.weeklyEvents.weeks.length, 52);
+    assert.deepEqual(page.weeklyEvents.weeks[0].title, 'January 3-9');
+    assert.deepEqual(page.weeklyEvents.weeks[51].title, 'December 26 - January 1');
   });
 });

--- a/packages/ilios-common/addon/components/weekly-events.gjs
+++ b/packages/ilios-common/addon/components/weekly-events.gjs
@@ -11,7 +11,7 @@ import { fn } from '@ember/helper';
 
 export default class WeeklyEvents extends Component {
   get weeksInYear() {
-    const { weeksInWeekYear } = DateTime.fromObject({ year: this.args.year });
+    const { weeksInWeekYear } = DateTime.fromObject({ weekYear: this.args.year });
     const weeks = [];
     for (let i = 1; i <= weeksInWeekYear; i++) {
       weeks.push(`${i}`);


### PR DESCRIPTION
DateTime.fromObject uses a default of january 1st of no day or month are specified. In a year with 53 weeks january 1st falls into the last week of the previous year. By using year in this calculation we were causing the year after a year with 53 weeks to also, but incorrectly, have too many weeks. Luxon provides a tool to do this correctly, we just needed to use it.

Fixes ilios/ilios#6366