### PR TITLE
Add Fallback for User Menu

### DIFF
--- a/packages/frontend/app/components/user-menu.gjs
+++ b/packages/frontend/app/components/user-menu.gjs
@@ -4,7 +4,7 @@ import { cached, tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
 import { TrackedAsyncData } from 'ember-async-data';
-import { uniqueId, get, hash } from '@ember/helper';
+import { uniqueId, hash } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import FaIcon from 'ilios-common/components/fa-icon';
@@ -23,6 +23,10 @@ export default class UserMenuComponent extends Component {
   @cached
   get model() {
     return this.userModel.isResolved ? this.userModel.value : null;
+  }
+
+  get menuTitle() {
+    return this.model?.fullName || this.intl.t('general.userMenu');
   }
 
   focusFirstLink = task(async () => {
@@ -105,7 +109,7 @@ export default class UserMenuComponent extends Component {
         >
           <FaIcon @icon="user" />
           <span id="{{templateId}}-user-menu-title">
-            {{get this.model "fullName"}}
+            {{this.menuTitle}}
           </span>
           <FaIcon @icon={{if this.isOpen "caret-down" "caret-right"}} />
         </button>

--- a/packages/frontend/tests/integration/components/user-menu-test.gjs
+++ b/packages/frontend/tests/integration/components/user-menu-test.gjs
@@ -14,11 +14,8 @@ module('Integration | Component | user-menu', function (hooks) {
   // My Profile and Logout
   const linkCount = 2;
 
-  hooks.beforeEach(async function () {
-    await setupAuthentication();
-  });
-
   test('it renders and is accessible', async function (assert) {
+    await setupAuthentication();
     await render(<template><UserMenu /></template>);
 
     await a11yAudit(this.element);
@@ -31,6 +28,7 @@ module('Integration | Component | user-menu', function (hooks) {
   });
 
   test('click opens menu', async function (assert) {
+    await setupAuthentication();
     await render(<template><UserMenu /></template>);
 
     assert.strictEqual(component.links.length, 0);
@@ -39,6 +37,7 @@ module('Integration | Component | user-menu', function (hooks) {
   });
 
   test('down opens menu', async function (assert) {
+    await setupAuthentication();
     await render(<template><UserMenu /></template>);
 
     assert.strictEqual(component.links.length, 0);
@@ -47,6 +46,7 @@ module('Integration | Component | user-menu', function (hooks) {
   });
 
   test('escape closes menu', async function (assert) {
+    await setupAuthentication();
     await render(<template><UserMenu /></template>);
 
     await component.toggle.down();
@@ -56,6 +56,7 @@ module('Integration | Component | user-menu', function (hooks) {
   });
 
   test('click closes menu', async function (assert) {
+    await setupAuthentication();
     await render(<template><UserMenu /></template>);
 
     await component.toggle.down();
@@ -65,6 +66,7 @@ module('Integration | Component | user-menu', function (hooks) {
   });
 
   test('keyboard navigation', async function (assert) {
+    await setupAuthentication();
     await render(<template><UserMenu /></template>);
     await component.toggle.click();
     assert.strictEqual(component.links.length, linkCount, `has ${linkCount} links`);
@@ -116,5 +118,14 @@ module('Integration | Component | user-menu', function (hooks) {
     assert.ok(component.links[0].link.hasFocus);
     await component.links[0].tab();
     assert.strictEqual(component.links.length, 0);
+  });
+
+  test('it renders fallback text when no logged in user', async function (assert) {
+    await render(<template><UserMenu /></template>);
+
+    await a11yAudit(this.element);
+    assert.strictEqual(component.text, 'User menu');
+
+    assert.ok(true, 'no a11y errors found!');
   });
 });


### PR DESCRIPTION
Sometimes, in some situations, the username doesn't fully load and we end up with a blank here. This may only happen with Siteimprove tests, but in case it's ever visible to users we now fall back to a generic User menu instead of a blank.