### PR TITLE
removes misapplied aria labels from button.

### DIFF
--- a/packages/frontend/app/components/instructor-group/course-associations.gjs
+++ b/packages/frontend/app/components/instructor-group/course-associations.gjs
@@ -124,7 +124,6 @@ export default class InstructorGroupCourseAssociationsComponent extends Componen
                     type="button"
                     aria-expanded="true"
                     aria-controls="content-{{templateId}}"
-                    aria-label={{t "general.hideAssociatedCourses"}}
                     data-test-toggle
                     {{on "click" (fn @setIsExpanded false)}}
                   >
@@ -138,7 +137,6 @@ export default class InstructorGroupCourseAssociationsComponent extends Componen
                     type="button"
                     aria-expanded="false"
                     aria-controls="content-{{templateId}}"
-                    aria-label={{t "general.showAssociatedCourses"}}
                     data-test-toggle
                     {{on "click" (fn @setIsExpanded true)}}
                   >

--- a/packages/frontend/app/components/learner-group/course-associations.gjs
+++ b/packages/frontend/app/components/learner-group/course-associations.gjs
@@ -123,7 +123,6 @@ export default class LearnerGroupCourseAssociationsComponent extends Component {
                     type="button"
                     aria-expanded="true"
                     aria-controls="content-{{templateId}}"
-                    aria-label={{t "general.hideAssociatedCourses"}}
                     data-test-toggle
                     {{on "click" (fn @setIsExpanded false)}}
                   >
@@ -137,7 +136,6 @@ export default class LearnerGroupCourseAssociationsComponent extends Component {
                     type="button"
                     aria-expanded="false"
                     aria-controls="content-{{templateId}}"
-                    aria-label={{t "general.showAssociatedCourses"}}
                     data-test-toggle
                     {{on "click" (fn @setIsExpanded true)}}
                   >

--- a/packages/frontend/app/components/program-year/course-associations.gjs
+++ b/packages/frontend/app/components/program-year/course-associations.gjs
@@ -92,7 +92,6 @@ export default class ProgramYearCourseAssociationsComponent extends Component {
                     type="button"
                     aria-expanded="true"
                     aria-controls="content-{{templateId}}"
-                    aria-label={{t "general.hideAssociatedCourses"}}
                     data-test-toggle
                     {{on "click" (fn @setIsExpanded false)}}
                   >
@@ -106,7 +105,6 @@ export default class ProgramYearCourseAssociationsComponent extends Component {
                     type="button"
                     aria-expanded="false"
                     aria-controls="content-{{templateId}}"
-                    aria-label={{t "general.showAssociatedCourses"}}
                     data-test-toggle
                     {{on "click" (fn @setIsExpanded true)}}
                   >

--- a/packages/frontend/tests/integration/components/instructor-group/course-associations-test.gjs
+++ b/packages/frontend/tests/integration/components/instructor-group/course-associations-test.gjs
@@ -63,7 +63,6 @@ module('Integration | Component | instructor-group/course-associations', functio
     assert.notOk(component.header.toggle.isCollapsed);
     assert.ok(component.header.toggle.isExpanded);
     assert.strictEqual(component.header.toggle.ariaExpanded, 'true');
-    assert.strictEqual(component.header.toggle.ariaLabel, 'Hide associated courses');
     assert.notOk(component.content.isHidden);
     assert.strictEqual(component.header.title, 'Associated Courses (3)');
 
@@ -141,7 +140,6 @@ module('Integration | Component | instructor-group/course-associations', functio
     assert.ok(component.header.toggle.isCollapsed);
     assert.notOk(component.header.toggle.isExpanded);
     assert.strictEqual(component.header.toggle.ariaExpanded, 'false');
-    assert.strictEqual(component.header.toggle.ariaLabel, 'Show associated courses');
     assert.ok(component.content.isHidden);
     assert.strictEqual(component.header.title, 'Associated Courses (3)');
     await a11yAudit(this.element);

--- a/packages/frontend/tests/integration/components/learner-group/course-associations-test.gjs
+++ b/packages/frontend/tests/integration/components/learner-group/course-associations-test.gjs
@@ -68,7 +68,6 @@ module('Integration | Component | learner-group/course-associations', function (
     assert.notOk(component.header.toggle.isCollapsed);
     assert.ok(component.header.toggle.isExpanded);
     assert.strictEqual(component.header.toggle.ariaExpanded, 'true');
-    assert.strictEqual(component.header.toggle.ariaLabel, 'Hide associated courses');
     assert.notOk(component.content.isHidden);
     assert.strictEqual(component.header.title, 'Associated Courses (3)');
 
@@ -146,7 +145,6 @@ module('Integration | Component | learner-group/course-associations', function (
     assert.ok(component.header.toggle.isCollapsed);
     assert.notOk(component.header.toggle.isExpanded);
     assert.strictEqual(component.header.toggle.ariaExpanded, 'false');
-    assert.strictEqual(component.header.toggle.ariaLabel, 'Show associated courses');
     assert.ok(component.content.isHidden);
     assert.strictEqual(component.header.title, 'Associated Courses (3)');
     await a11yAudit(this.element);

--- a/packages/frontend/tests/integration/components/program-year/course-associations-test.gjs
+++ b/packages/frontend/tests/integration/components/program-year/course-associations-test.gjs
@@ -47,7 +47,6 @@ module('Integration | Component | program-year/course-associations', function (h
     assert.notOk(component.header.toggle.isCollapsed);
     assert.ok(component.header.toggle.isExpanded);
     assert.strictEqual(component.header.toggle.ariaExpanded, 'true');
-    assert.strictEqual(component.header.toggle.ariaLabel, 'Hide associated courses');
     assert.notOk(component.content.isHidden);
     assert.strictEqual(component.header.title, 'Associated Courses (3)');
 
@@ -91,7 +90,6 @@ module('Integration | Component | program-year/course-associations', function (h
     assert.ok(component.header.toggle.isCollapsed);
     assert.notOk(component.header.toggle.isExpanded);
     assert.strictEqual(component.header.toggle.ariaExpanded, 'false');
-    assert.strictEqual(component.header.toggle.ariaLabel, 'Show associated courses');
     assert.ok(component.content.isHidden);
     assert.strictEqual(component.header.title, 'Associated Courses (3)');
     await a11yAudit(this.element);

--- a/packages/frontend/tests/pages/components/instructor-group/course-associations.js
+++ b/packages/frontend/tests/pages/components/instructor-group/course-associations.js
@@ -19,7 +19,6 @@ const definition = {
       isExpanded: isPresent('[data-icon="caret-down"]'),
       ariaExpanded: attribute('aria-expanded'),
       ariaControls: attribute('aria-controls'),
-      ariaLabel: attribute('aria-label'),
     },
   },
   content: {

--- a/packages/frontend/tests/pages/components/learner-group/course-associations.js
+++ b/packages/frontend/tests/pages/components/learner-group/course-associations.js
@@ -19,7 +19,6 @@ const definition = {
       isExpanded: isPresent('[data-icon="caret-down"]'),
       ariaExpanded: attribute('aria-expanded'),
       ariaControls: attribute('aria-controls'),
-      ariaLabel: attribute('aria-label'),
     },
   },
   content: {

--- a/packages/frontend/tests/pages/components/program-year/course-associations.js
+++ b/packages/frontend/tests/pages/components/program-year/course-associations.js
@@ -19,7 +19,6 @@ const definition = {
       isExpanded: isPresent('[data-icon="caret-down"]'),
       ariaExpanded: attribute('aria-expanded'),
       ariaControls: attribute('aria-controls'),
-      ariaLabel: attribute('aria-label'),
     },
   },
   content: {

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -161,7 +161,6 @@ general:
   good: Good
   goToUser: Show user record in ilios
   groupMembers: Members of current group
-  hideAssociatedCourses: Hide associated courses
   hideRolesInCourses: Hide roles in courses
   hideRolesInPrograms: Hide roles in programs
   hideRolesInProgramYears: Hide roles in program years
@@ -403,7 +402,6 @@ general:
   sessionTitlePlaceholder: Enter a title for this session
   sessionTypeConfirmRemoval: Are you sure you want to delete this session type? This action cannot be undone.
   sessionTypeTitlePlaceholder: Enter a title for this session type
-  showAssociatedCourses: Show associated courses
   showRolesInCourses: Show roles in courses
   showRolesInPrograms: Show roles in programs
   showRolesInProgramYears: Show roles in program years

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -161,7 +161,6 @@ general:
   good: Bueno
   goToUser: Mostrar registro de usuario en Ilios
   groupMembers: Miembros de grupo corriente
-  hideAssociatedCourses: Ocultar cursos asociados
   hideRolesInCourses: Ocultar roles en cursos
   hideRolesInPrograms: Ocultar roles en programas
   hideRolesInProgramYears: Ocultar roles en los años del programa
@@ -403,7 +402,6 @@ general:
   sessionTitlePlaceholder: Entre en un titulo para esta sesión
   sessionTypeConfirmRemoval: ¿Está seguro de que desea eliminar este tipo de sesión? Esta acción no se puede deshacer.
   sessionTypeTitlePlaceholder: Entre en un titulo para este tipo de sesión
-  showAssociatedCourses: Mostrar cursos asociados
   showRolesInCourses: Mostrar roles en cursos
   showRolesInPrograms: Mostrar roles en programas
   showRolesInProgramYears: Mostrar roles en años de programa

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -161,7 +161,6 @@ general:
   good: Bon
   goToUser: "Présentant enregistrement d'utilisateur en Ilios"
   groupMembers: Membres du groupe courant
-  hideAssociatedCourses: Masquer les cours associés
   hideRolesInCourses: Masquer les rôles dans les cours
   hideRolesInPrograms: Masquer les rôles dans les programmes
   hideRolesInProgramYears: Masquer les rôles dans les années du programme
@@ -404,7 +403,6 @@ general:
   sessionTitlePlaceholder: Ajoutez un titre pour ce session
   sessionTypeConfirmRemoval: "Voulez-vous vraiment supprimer ce type de session ? Cette action ne peut pas être annulée."
   sessionTypeTitlePlaceholder: Ajoutez un titre pour ce type de session
-  showAssociatedCourses: Afficher les cours associés
   showRolesInCourses: Afficher les rôles dans les cours
   showRolesInPrograms: Afficher les rôles dans les programmes
   showRolesInProgramYears: Afficher les rôles dans les années du programme


### PR DESCRIPTION
according to SiteImprove, the accessible name of any interactive element should contain its visible text label. which makes adding an aria-label attribute to these buttons pointless.

i checked into aria-description as an alternative, but according to MDN the usage of that attribute is discouraged since it's still in Draft mode in the spec.

fixes https://github.com/ilios/ilios/issues/6369