### PR TITLE
My Profile->Permissions header size/content and a11y fixes

### DIFF
--- a/packages/frontend/app/components/user-profile-permissions.gjs
+++ b/packages/frontend/app/components/user-profile-permissions.gjs
@@ -525,11 +525,6 @@ export default class UserProfilePermissionsComponent extends Component {
           {{#if this.directedPrograms.length}}
             <h3 class="title" data-test-title>
               <button
-                aria-label={{if
-                  this.programCollapsed
-                  (t "general.showRolesInPrograms")
-                  (t "general.hideRolesInPrograms")
-                }}
                 aria-expanded={{if this.programCollapsed "false" "true"}}
                 class="toggle-button {{if this.programCollapsed 'collapsed' 'expanded'}}"
                 type="button"
@@ -567,11 +562,6 @@ export default class UserProfilePermissionsComponent extends Component {
           {{#if this.directedProgramYears.length}}
             <h3 class="title" data-test-title>
               <button
-                aria-label={{if
-                  this.programYearCollapsed
-                  (t "general.showRolesInProgramYears")
-                  (t "general.hideRolesInProgramYears")
-                }}
                 aria-expanded={{if this.programYearCollapsed "false" "true"}}
                 class="toggle-button {{if this.programYearCollapsed 'collapsed' 'expanded'}}"
                 type="button"
@@ -615,11 +605,6 @@ export default class UserProfilePermissionsComponent extends Component {
           {{#if this.courseCount}}
             <h3 class="title" data-test-title>
               <button
-                aria-label={{if
-                  this.courseCollapsed
-                  (t "general.showRolesInCourses")
-                  (t "general.hideRolesInCourses")
-                }}
                 aria-expanded={{if this.courseCollapsed "false" "true"}}
                 class="toggle-button {{if this.courseCollapsed 'collapsed' 'expanded'}}"
                 type="button"
@@ -739,11 +724,6 @@ export default class UserProfilePermissionsComponent extends Component {
           {{#if this.sessionCount}}
             <h3 class="title" data-test-title>
               <button
-                aria-label={{if
-                  this.sessionCollapsed
-                  (t "general.showRolesInSessions")
-                  (t "general.hideRolesInSessions")
-                }}
                 aria-expanded={{if this.sessionCollapsed "false" "true"}}
                 class="toggle-button {{if this.sessionCollapsed 'collapsed' 'expanded'}}"
                 type="button"

--- a/packages/frontend/app/components/user-profile-permissions.gjs
+++ b/packages/frontend/app/components/user-profile-permissions.gjs
@@ -17,7 +17,6 @@ import reverse from 'ilios-common/helpers/reverse';
 import YesNo from 'frontend/components/yes-no';
 import set from 'ember-set-helper/helpers/set';
 import not from 'ember-truth-helpers/helpers/not';
-import and from 'ember-truth-helpers/helpers/and';
 import add from 'ember-math-helpers/helpers/add';
 import { LinkTo } from '@ember/routing';
 import { array } from '@ember/helper';
@@ -523,8 +522,8 @@ export default class UserProfilePermissionsComponent extends Component {
         </p>
 
         <p class="section" data-test-program-permissions>
-          <h3 class="title" data-test-title>
-            {{#if this.directedPrograms.length}}
+          {{#if this.directedPrograms.length}}
+            <h3 class="title" data-test-title>
               <button
                 aria-label={{if
                   this.programCollapsed
@@ -543,27 +542,30 @@ export default class UserProfilePermissionsComponent extends Component {
                   class="disabled"
                 />
               </button>
-            {{else}}
+            </h3>
+            {{#if this.programExpanded}}
+              <h4>
+                {{t "general.director"}}
+              </h4>
+              <ul data-test-directors>
+                {{#each (sortBy0 "title" this.directedPrograms) as |program|}}
+                  <li data-test-program>
+                    {{program.title}}
+                  </li>
+                {{/each}}
+              </ul>
+            {{/if}}
+          {{else}}
+            <span class="title" data-test-title>
               {{t "general.programs"}}
               ({{this.directedPrograms.length}})
-            {{/if}}
-          </h3>
-          {{#if (and this.directedPrograms.length this.programExpanded)}}
-            <h4>
-              {{t "general.director"}}
-            </h4>
-            <ul data-test-directors>
-              {{#each (sortBy0 "title" this.directedPrograms) as |program|}}
-                <li data-test-program>
-                  {{program.title}}
-                </li>
-              {{/each}}
-            </ul>
+            </span>
           {{/if}}
         </p>
+
         <p class="section" data-test-program-year-permissions>
-          <h3 class="title" data-test-title>
-            {{#if this.directedProgramYears.length}}
+          {{#if this.directedProgramYears.length}}
+            <h3 class="title" data-test-title>
               <button
                 aria-label={{if
                   this.programYearCollapsed
@@ -582,30 +584,36 @@ export default class UserProfilePermissionsComponent extends Component {
                   class="disabled"
                 />
               </button>
-            {{else}}
+            </h3>
+            {{#if this.programYearExpanded}}
+              <h4>
+                {{t "general.director"}}
+              </h4>
+              <ul data-test-directors>
+                {{#each
+                  (sortBy0 "program.title" "title" this.directedProgramYears)
+                  as |programYear|
+                }}
+                  <li data-test-program>
+                    {{programYear.program.title}}
+                    <strong>
+                      {{programYear.cohort.title}}
+                    </strong>
+                  </li>
+                {{/each}}
+              </ul>
+            {{/if}}
+          {{else}}
+            <span class="title" data-test-title>
               {{t "general.programYears"}}
               ({{this.directedProgramYears.length}})
-            {{/if}}
-          </h3>
-          {{#if (and this.directedProgramYears.length this.programYearExpanded)}}
-            <h4>
-              {{t "general.director"}}
-            </h4>
-            <ul data-test-directors>
-              {{#each (sortBy0 "program.title" "title" this.directedProgramYears) as |programYear|}}
-                <li data-test-program>
-                  {{programYear.program.title}}
-                  <strong>
-                    {{programYear.cohort.title}}
-                  </strong>
-                </li>
-              {{/each}}
-            </ul>
+            </span>
           {{/if}}
         </p>
+
         <p class="section" data-test-course-permissions>
-          <h3 class="title" data-test-title>
-            {{#if this.courseCount}}
+          {{#if this.courseCount}}
+            <h3 class="title" data-test-title>
               <button
                 aria-label={{if
                   this.courseCollapsed
@@ -624,109 +632,112 @@ export default class UserProfilePermissionsComponent extends Component {
                   class="disabled"
                 />
               </button>
-            {{else}}
+            </h3>
+            {{#if this.courseExpanded}}
+              <h4>
+                {{t "general.director"}}
+              </h4>
+              <ul data-test-directors>
+                {{#each (sortBy0 "title" this.directedCourses) as |course|}}
+                  <li data-test-course>
+                    {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                      {{course.year}}
+                      -
+                      {{add course.year 1}}
+                    {{else}}
+                      {{course.year}}
+                    {{/if}}
+                    <LinkTo @route="course" @model={{course}}>
+                      {{course.title}}
+                    </LinkTo>
+                  </li>
+                {{else}}
+                  <li data-test-none>
+                    {{t "general.none"}}
+                  </li>
+                {{/each}}
+              </ul>
+              <h4>
+                {{t "general.administrator"}}
+              </h4>
+              <ul data-test-administrators>
+                {{#each (sortBy0 "title" this.administeredCourses) as |course|}}
+                  <li data-test-course>
+                    {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                      {{course.year}}
+                      -
+                      {{add course.year 1}}
+                    {{else}}
+                      {{course.year}}
+                    {{/if}}
+                    <LinkTo @route="course" @model={{course}}>
+                      {{course.title}}
+                    </LinkTo>
+                  </li>
+                {{else}}
+                  <li data-test-none>
+                    {{t "general.none"}}
+                  </li>
+                {{/each}}
+              </ul>
+              <h4>
+                {{t "general.instructor"}}
+              </h4>
+              <ul data-test-instructors>
+                {{#each (sortBy0 "title" this.instructedCourses) as |course|}}
+                  <li data-test-course>
+                    {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                      {{course.year}}
+                      -
+                      {{add course.year 1}}
+                    {{else}}
+                      {{course.year}}
+                    {{/if}}
+                    <LinkTo @route="course" @model={{course}}>
+                      {{course.title}}
+                    </LinkTo>
+                  </li>
+                {{else}}
+                  <li data-test-none>
+                    {{t "general.none"}}
+                  </li>
+                {{/each}}
+              </ul>
+              <h4>
+                {{t "general.studentAdvisors"}}
+              </h4>
+              <ul data-test-student-advisors>
+                {{#each this.studentAdvisedCourses as |course|}}
+                  <li data-test-course>
+                    {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                      {{course.year}}
+                      -
+                      {{add course.year 1}}
+                    {{else}}
+                      {{course.year}}
+                    {{/if}}
+                    <LinkTo @route="course" @model={{course}}>
+                      {{course.title}}
+                    </LinkTo>
+                  </li>
+                {{else}}
+                  <li data-test-none>
+                    {{t "general.none"}}
+                  </li>
+                {{/each}}
+              </ul>
+            {{/if}}
+          {{else}}
+            <span class="title" data-test-title>
               {{t "general.courses"}}
               ({{this.courseCount}})
-            {{/if}}
-          </h3>
-          {{#if (and this.courseCount this.courseExpanded)}}
-            <h4>
-              {{t "general.director"}}
-            </h4>
-            <ul data-test-directors>
-              {{#each (sortBy0 "title" this.directedCourses) as |course|}}
-                <li data-test-course>
-                  {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                    {{course.year}}
-                    -
-                    {{add course.year 1}}
-                  {{else}}
-                    {{course.year}}
-                  {{/if}}
-                  <LinkTo @route="course" @model={{course}}>
-                    {{course.title}}
-                  </LinkTo>
-                </li>
-              {{else}}
-                <li data-test-none>
-                  {{t "general.none"}}
-                </li>
-              {{/each}}
-            </ul>
-            <h4>
-              {{t "general.administrator"}}
-            </h4>
-            <ul data-test-administrators>
-              {{#each (sortBy0 "title" this.administeredCourses) as |course|}}
-                <li data-test-course>
-                  {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                    {{course.year}}
-                    -
-                    {{add course.year 1}}
-                  {{else}}
-                    {{course.year}}
-                  {{/if}}
-                  <LinkTo @route="course" @model={{course}}>
-                    {{course.title}}
-                  </LinkTo>
-                </li>
-              {{else}}
-                <li data-test-none>
-                  {{t "general.none"}}
-                </li>
-              {{/each}}
-            </ul>
-            <h4>
-              {{t "general.instructor"}}
-            </h4>
-            <ul data-test-instructors>
-              {{#each (sortBy0 "title" this.instructedCourses) as |course|}}
-                <li data-test-course>
-                  {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                    {{course.year}}
-                    -
-                    {{add course.year 1}}
-                  {{else}}
-                    {{course.year}}
-                  {{/if}}
-                  <LinkTo @route="course" @model={{course}}>
-                    {{course.title}}
-                  </LinkTo>
-                </li>
-              {{else}}
-                <li data-test-none>
-                  {{t "general.none"}}
-                </li>
-              {{/each}}
-            </ul>
-            <h4>
-              {{t "general.studentAdvisors"}}
-            </h4>
-            <ul data-test-student-advisors>
-              {{#each this.studentAdvisedCourses as |course|}}
-                <li data-test-course>
-                  {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                    {{course.year}}
-                    -
-                    {{add course.year 1}}
-                  {{else}}
-                    {{course.year}}
-                  {{/if}}
-                  <LinkTo @route="course" @model={{course}}>
-                    {{course.title}}
-                  </LinkTo>
-                </li>
-              {{else}}
-                <li data-test-none>
-                  {{t "general.none"}}
-                </li>
-              {{/each}}
-            </ul>
+            </span>
           {{/if}}
         </p>
+
         <p class="section" data-test-session-permissions>
-          <h3 class="title" data-test-title>
-            {{#if this.sessionCount}}
+          {{#if this.sessionCount}}
+            <h3 class="title" data-test-title>
               <button
                 aria-label={{if
                   this.sessionCollapsed
@@ -745,91 +756,93 @@ export default class UserProfilePermissionsComponent extends Component {
                   class="disabled"
                 />
               </button>
-            {{else}}
+            </h3>
+            {{#if this.sessionExpanded}}
+              <h4>
+                {{t "general.administrator"}}
+              </h4>
+              <ul data-test-administrators>
+                {{#each this.administeredSessions as |session|}}
+                  {{! template-lint-disable no-bare-strings }}
+                  <li data-test-course>
+                    {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                      {{session.course.year}}
+                      -
+                      {{add session.course.year 1}}
+                    {{else}}
+                      {{session.course.year}}
+                    {{/if}}
+                    {{session.course.title}}
+                    &raquo;
+                    <LinkTo @route="session" @models={{array session.course session}}>
+                      {{session.title}}
+                    </LinkTo>
+                  </li>
+                {{else}}
+                  <li data-test-none>
+                    {{t "general.none"}}
+                  </li>
+                {{/each}}
+              </ul>
+              <h4>
+                {{t "general.instructor"}}
+              </h4>
+              <ul data-test-instructors>
+                {{#each
+                  (sortBy0 "course.year:desc" "course.title" "title" this.instructedSessions)
+                  as |session|
+                }}
+                  <li data-test-course>
+                    {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                      {{session.course.year}}
+                      -
+                      {{add session.course.year 1}}
+                    {{else}}
+                      {{session.course.year}}
+                    {{/if}}
+                    {{session.course.title}}
+                    &raquo;
+                    <LinkTo @route="session" @models={{array session.course session}}>
+                      {{session.title}}
+                    </LinkTo>
+                  </li>
+                {{else}}
+                  <li data-test-none>
+                    {{t "general.none"}}
+                  </li>
+                {{/each}}
+              </ul>
+              <h4>
+                {{t "general.studentAdvisors"}}
+              </h4>
+              <ul data-test-student-advisors>
+                {{#each this.studentAdvisedSessions as |session|}}
+                  <li data-test-course>
+                    {{#if this.academicYearCrossesCalendarYearBoundaries}}
+                      {{session.course.year}}
+                      -
+                      {{add session.course.year 1}}
+                    {{else}}
+                      {{session.course.year}}
+                    {{/if}}
+                    {{session.course.title}}
+                    &raquo;
+                    <LinkTo @route="session" @models={{array session.course session}}>
+                      {{session.title}}
+                    </LinkTo>
+                  </li>
+                {{else}}
+                  <li data-test-none>
+                    {{t "general.none"}}
+                  </li>
+                {{/each}}
+              </ul>
+            {{/if}}
+          {{else}}
+            <span class="title" data-test-title>
               {{t "general.sessions"}}
               ({{this.sessionCount}})
-            {{/if}}
-          </h3>
-          {{#if (and this.sessionCount this.sessionExpanded)}}
-            <h4>
-              {{t "general.administrator"}}
-            </h4>
-            <ul data-test-administrators>
-              {{#each this.administeredSessions as |session|}}
-                {{! template-lint-disable no-bare-strings }}
-                <li data-test-course>
-                  {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                    {{session.course.year}}
-                    -
-                    {{add session.course.year 1}}
-                  {{else}}
-                    {{session.course.year}}
-                  {{/if}}
-                  {{session.course.title}}
-                  &raquo;
-                  <LinkTo @route="session" @models={{array session.course session}}>
-                    {{session.title}}
-                  </LinkTo>
-                </li>
-              {{else}}
-                <li data-test-none>
-                  {{t "general.none"}}
-                </li>
-              {{/each}}
-            </ul>
-            <h4>
-              {{t "general.instructor"}}
-            </h4>
-            <ul data-test-instructors>
-              {{#each
-                (sortBy0 "course.year:desc" "course.title" "title" this.instructedSessions)
-                as |session|
-              }}
-                <li data-test-course>
-                  {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                    {{session.course.year}}
-                    -
-                    {{add session.course.year 1}}
-                  {{else}}
-                    {{session.course.year}}
-                  {{/if}}
-                  {{session.course.title}}
-                  &raquo;
-                  <LinkTo @route="session" @models={{array session.course session}}>
-                    {{session.title}}
-                  </LinkTo>
-                </li>
-              {{else}}
-                <li data-test-none>
-                  {{t "general.none"}}
-                </li>
-              {{/each}}
-            </ul>
-            <h4>
-              {{t "general.studentAdvisors"}}
-            </h4>
-            <ul data-test-student-advisors>
-              {{#each this.studentAdvisedSessions as |session|}}
-                <li data-test-course>
-                  {{#if this.academicYearCrossesCalendarYearBoundaries}}
-                    {{session.course.year}}
-                    -
-                    {{add session.course.year 1}}
-                  {{else}}
-                    {{session.course.year}}
-                  {{/if}}
-                  {{session.course.title}}
-                  &raquo;
-                  <LinkTo @route="session" @models={{array session.course session}}>
-                    {{session.title}}
-                  </LinkTo>
-                </li>
-              {{else}}
-                <li data-test-none>
-                  {{t "general.none"}}
-                </li>
-              {{/each}}
-            </ul>
+            </span>
           {{/if}}
         </p>
       {{/if}}

--- a/packages/frontend/app/styles/components/user-profile-permissions.scss
+++ b/packages/frontend/app/styles/components/user-profile-permissions.scss
@@ -18,6 +18,10 @@
       @include m.ilios-button-reset;
     }
 
+    span.title {
+      @include m.ilios-heading-h5;
+    }
+
     h3.title {
       @include m.ilios-heading-h5;
 

--- a/packages/frontend/app/styles/components/user-profile-permissions.scss
+++ b/packages/frontend/app/styles/components/user-profile-permissions.scss
@@ -3,7 +3,7 @@
 
 .user-profile-permissions {
   .title {
-    @include m.ilios-heading-h5;
+    @include m.ilios-heading-h3;
     margin-bottom: 0.5rem;
   }
 

--- a/packages/frontend/app/styles/components/user-profile-permissions.scss
+++ b/packages/frontend/app/styles/components/user-profile-permissions.scss
@@ -3,7 +3,7 @@
 
 .user-profile-permissions {
   .title {
-    @include m.ilios-heading-h3;
+    @include m.ilios-heading-h5;
     margin-bottom: 0.5rem;
   }
 
@@ -20,6 +20,10 @@
 
     h3.title {
       @include m.ilios-heading-h5;
+
+      button {
+        @include m.ilios-heading-h5;
+      }
     }
 
     h4 {

--- a/packages/frontend/app/styles/components/user-profile.scss
+++ b/packages/frontend/app/styles/components/user-profile.scss
@@ -30,6 +30,10 @@
 }
 
 .user-profile-learnergroups {
+  h2.title {
+    @include cm.ilios-heading-h3;
+  }
+
   p {
     margin-bottom: 2rem;
   }

--- a/packages/frontend/tests/integration/components/user-profile-permissions-test.gjs
+++ b/packages/frontend/tests/integration/components/user-profile-permissions-test.gjs
@@ -175,16 +175,13 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
 
     assert.strictEqual(component.programs.title, 'Programs (1)');
     assert.strictEqual(component.programs.ariaExpanded, 'true');
-    assert.strictEqual(component.programs.ariaLabel, 'Hide roles in programs');
     assert.strictEqual(component.programs.directors.length, 1);
     assert.strictEqual(component.programs.directors[0].text, 'program 0');
     await component.programs.toggle();
     assert.strictEqual(component.programs.ariaExpanded, 'false');
-    assert.strictEqual(component.programs.ariaLabel, 'Show roles in programs');
     assert.strictEqual(component.programs.directors.length, 0);
     await component.programs.toggle();
     assert.strictEqual(component.programs.ariaExpanded, 'true');
-    assert.strictEqual(component.programs.ariaLabel, 'Hide roles in programs');
     assert.strictEqual(component.programs.directors.length, 1);
 
     await a11yAudit(this.element);
@@ -214,16 +211,13 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
 
     assert.strictEqual(component.programYears.title, 'Program Years (1)');
     assert.strictEqual(component.programYears.ariaExpanded, 'true');
-    assert.strictEqual(component.programYears.ariaLabel, 'Hide roles in program years');
     assert.strictEqual(component.programYears.directors.length, 1);
     assert.strictEqual(component.programYears.directors[0].text, 'program 0 cohort 0');
     await component.programYears.toggle();
     assert.strictEqual(component.programYears.ariaExpanded, 'false');
-    assert.strictEqual(component.programYears.ariaLabel, 'Show roles in program years');
     assert.strictEqual(component.programYears.directors.length, 0);
     await component.programYears.toggle();
     assert.strictEqual(component.programYears.ariaExpanded, 'true');
-    assert.strictEqual(component.programYears.ariaLabel, 'Hide roles in program years');
     assert.strictEqual(component.programYears.directors.length, 1);
 
     await a11yAudit(this.element);
@@ -266,7 +260,6 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
 
     assert.strictEqual(component.courses.title, 'Courses (4)');
     assert.strictEqual(component.courses.ariaExpanded, 'true');
-    assert.strictEqual(component.courses.ariaLabel, 'Hide roles in courses');
     assert.strictEqual(component.courses.directors.length, 1);
     assert.strictEqual(component.courses.directors[0].text, `${this.currentAcademicYear} course 0`);
     assert.strictEqual(component.courses.administrators.length, 1);
@@ -298,14 +291,12 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
     assert.ok(component.sessions.notStudentAdvising);
     await component.courses.toggle();
     assert.strictEqual(component.courses.ariaExpanded, 'false');
-    assert.strictEqual(component.courses.ariaLabel, 'Show roles in courses');
     assert.strictEqual(component.courses.administrators.length, 0);
     assert.strictEqual(component.courses.directors.length, 0);
     assert.strictEqual(component.courses.instructors.length, 0);
     assert.strictEqual(component.courses.studentAdvisors.length, 0);
     await component.courses.toggle();
     assert.strictEqual(component.courses.ariaExpanded, 'true');
-    assert.strictEqual(component.courses.ariaLabel, 'Hide roles in courses');
     assert.strictEqual(component.courses.administrators.length, 1);
     assert.strictEqual(component.courses.directors.length, 1);
     assert.strictEqual(component.courses.instructors.length, 1);
@@ -355,7 +346,6 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
     assert.strictEqual(component.sessions.title, 'Sessions (3)');
     assert.strictEqual(component.sessions.administrators.length, 1);
     assert.strictEqual(component.sessions.ariaExpanded, 'true');
-    assert.strictEqual(component.sessions.ariaLabel, 'Hide roles in sessions');
     assert.strictEqual(
       component.sessions.administrators[0].text,
       `${this.currentAcademicYear} course 0 » session 0`,
@@ -372,13 +362,11 @@ module('Integration | Component | user-profile-permissions', function (hooks) {
     );
     await component.sessions.toggle();
     assert.strictEqual(component.sessions.ariaExpanded, 'false');
-    assert.strictEqual(component.sessions.ariaLabel, 'Show roles in sessions');
     assert.strictEqual(component.sessions.administrators.length, 0);
     assert.strictEqual(component.sessions.instructors.length, 0);
     assert.strictEqual(component.sessions.studentAdvisors.length, 0);
     await component.sessions.toggle();
     assert.strictEqual(component.sessions.ariaExpanded, 'true');
-    assert.strictEqual(component.sessions.ariaLabel, 'Hide roles in sessions');
     assert.strictEqual(component.sessions.administrators.length, 1);
     assert.strictEqual(component.sessions.instructors.length, 1);
     assert.strictEqual(component.sessions.studentAdvisors.length, 1);


### PR DESCRIPTION
Fixes ilios/ilios#6375, ilios/ilios#6376, ilios/ilios#6377

This fixes the following issues with My Profile->Permissions:
1. Headers were not consistent size both when there was content or not
2. Headers can not be followed by empty content so they were switched out for `<span>`
3. Header buttons had unneeded `aria-label` attributes and were causing visible/accessible mismatches when there was content