### PR TITLE
Reclaim helpful Global Search features

### DIFF
--- a/packages/frontend/app/components/global-search-box.gjs
+++ b/packages/frontend/app/components/global-search-box.gjs
@@ -6,7 +6,8 @@ import { cleanQuery } from 'ilios-common/utils/query-utils';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import pick from 'ilios-common/helpers/pick';
-import set from 'ember-set-helper/helpers/set';
+import perform from 'ember-concurrency/helpers/perform';
+import { restartableTask } from 'ember-concurrency';
 import onKey from 'ember-keyboard/modifiers/on-key';
 import FaIcon from 'ilios-common/components/fa-icon';
 
@@ -56,6 +57,15 @@ export default class GlobalSearchBox extends Component {
     }
   }
 
+  setInternalQuery = restartableTask(async (q) => {
+    this.internalQuery = q;
+    if (this.router.currentRouteName === 'search') {
+      if (q === '') {
+        this.args.search('');
+      }
+    }
+  });
+
   /**
    * Clear all the caches and query local copies
    * This component is complicated by the many types of user interaction
@@ -74,7 +84,7 @@ export default class GlobalSearchBox extends Component {
         data-test-input
         type="search"
         value={{this.computedQuery}}
-        {{on "input" (pick "target.value" (set this "internalQuery"))}}
+        {{on "input" (pick "target.value" (perform this.setInternalQuery))}}
         {{onKey "Escape" this.onEscapeKey}}
         {{onKey "Enter" this.onEnterKey}}
         {{onKey "ArrowUp" this.onArrowKey}}

--- a/packages/frontend/app/components/ilios-header.gjs
+++ b/packages/frontend/app/components/ilios-header.gjs
@@ -47,7 +47,6 @@ export default class IliosHeaderComponent extends Component {
     return (
       this.searchEnabled &&
       this.session.isAuthenticated &&
-      this.router.currentRouteName !== 'search' &&
       this.currentUser.performsNonLearnerFunction &&
       this.userModelData.isResolved &&
       this.primarySchoolData.isResolved

--- a/packages/frontend/app/styles/components/global-search-box.scss
+++ b/packages/frontend/app/styles/components/global-search-box.scss
@@ -7,6 +7,7 @@
   display: flex;
   align-items: center;
   max-width: 40rem;
+  border: 1px solid transparent;
   border-radius: 3px;
   flex-direction: row-reverse;
 

--- a/packages/frontend/app/styles/components/global-search.scss
+++ b/packages/frontend/app/styles/components/global-search.scss
@@ -21,7 +21,11 @@
     grid-area: search;
     margin: 0.75rem 0 1rem 10%;
     width: 80%;
-    border: 1px solid var(--davys-grey);
+    border: 1px solid var(--light-grey);
+
+    &:focus-within {
+      outline: 2px solid var(--light-blue);
+    }
   }
 
   .filters {


### PR DESCRIPTION
Fixes ilios/ilios#6384

* Brings the global header GSB back to the search page for consistency
* Adds a border around local route GSB above search results so it's distinct again
* Removes search value from querystring if you clear the input's value so a refresh won't bring back the old search

The GSB in the global header still doesn't do dropdown results as I suspect is intended, and bringing them back, if possible, is out of scope for this PR.