### PR TITLE
Improve Course deletion styling

### DIFF
--- a/packages/frontend/app/components/courses/list-item.gjs
+++ b/packages/frontend/app/components/courses/list-item.gjs
@@ -48,8 +48,10 @@ export default class CoursesListItemComponent extends Component {
   }
   <template>
     <tr
-      class="courses-list-item
-        {{if (includes @course.id @coursesForRemovalConfirmation) 'confirm-removal'}}"
+      class="courses-list-item{{if
+          (includes @course.id @coursesForRemovalConfirmation)
+          ' confirm-removal'
+        }}"
       data-test-courses-list-item
     >
       <td class="text-left" colspan="8" data-test-course-title>

--- a/packages/frontend/app/components/courses/list.gjs
+++ b/packages/frontend/app/components/courses/list.gjs
@@ -193,7 +193,7 @@ export default class CoursesListComponent extends Component {
               />
               {{#if (includes course.id this.coursesForRemovalConfirmation)}}
                 <tr class="confirm-removal">
-                  <ResponsiveTd @smallScreenSpan="10" @largeScreenSpan="15">
+                  <ResponsiveTd @smallScreenSpan="11" @largeScreenSpan="16">
                     <div class="confirm-message">
                       {{t
                         "general.confirmRemoveCourse"

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-table.scss
@@ -94,8 +94,11 @@
       background-color: var(--lightest-red);
 
       .confirm-message {
+        background-color: var(--lightest-red);
         color: var(--red);
         font-weight: bold;
+        padding-bottom: 0;
+        padding-top: 0.75em;
         padding-left: 8em;
         padding-right: 8em;
         text-align: center;
@@ -103,12 +106,8 @@
       }
 
       .confirm-buttons {
-        padding-bottom: 1.5em;
+        padding-bottom: 1.1em;
         padding-top: 1.1em;
-      }
-
-      &:hover {
-        background-color: var(--lightest-red);
       }
 
       .remove {


### PR DESCRIPTION
Fixes ilios/ilios#5889

This makes the red background on a Course confirm message consistent across the container, and without requiring hover. I also made the spacing above and below the content consistent. Finally, I fixed some `class=""` spacing in the rendered template to avoid huge swaths of space and line breaks.