### PR TITLE
Pin and Separate Days in Week at a Glance

### DIFF
--- a/packages/frontend/tests/acceptance/dashboard/week-test.js
+++ b/packages/frontend/tests/acceptance/dashboard/week-test.js
@@ -164,7 +164,6 @@ module('Acceptance | Dashboard Week at a Glance', function (hooks) {
 
     await page.visit();
     const options = {
-      weekday: 'long',
       hour: 'numeric',
       minute: 'numeric',
     };

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/week-glance.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/week-glance.js
@@ -6,6 +6,7 @@ const definition = {
   title: text('[data-test-week-title]'),
   eventsByDate: collection('[data-test-events-by-date]', {
     events: collection('[data-test-week-glance-event]', weekGlanceEvent),
+    days: collection('[data-test-day]'),
   }),
 };
 

--- a/packages/ilios-common/addon/components/week-glance-event.gjs
+++ b/packages/ilios-common/addon/components/week-glance-event.gjs
@@ -69,8 +69,8 @@ export default class WeekGlanceEvent extends Component {
     return 0;
   }
   <template>
-    <div class="event" data-test-week-glance-event>
-      <h3 id={{concat "event" @event.slug}} class="event-title">
+    <li class="event" data-test-week-glance-event>
+      <h4 id={{concat "event" @event.slug}} class="event-title">
         <span id={{concat "event" @event.slug "title"}} data-test-event-title>
           <LinkTo
             id={{concat "event" @event.slug "link"}}
@@ -91,9 +91,9 @@ export default class WeekGlanceEvent extends Component {
               {{t "general.dueBy"}}
             </span>
           {{/if}}
-          {{formatDate @event.startDate weekday="long" hour="2-digit" minute="2-digit"}}
+          {{formatDate @event.startDate hour="2-digit" minute="2-digit"}}
         </span>
-      </h3>
+      </h4>
       <div>
         <span class="sessiontype" data-test-session-type>
           {{@event.sessionTypeTitle}}
@@ -158,6 +158,6 @@ export default class WeekGlanceEvent extends Component {
           @learningMaterials={{this.sessionLearningMaterials}}
         />
       {{/if}}
-    </div>
+    </li>
   </template>
 }

--- a/packages/ilios-common/addon/components/week-glance.gjs
+++ b/packages/ilios-common/addon/components/week-glance.gjs
@@ -12,6 +12,7 @@ import optional from 'ilios-common/helpers/optional';
 import t from 'ember-intl/helpers/t';
 import FaIcon from 'ilios-common/components/fa-icon';
 import WeekGlanceEvent from 'ilios-common/components/week-glance-event';
+import formatDate from 'ember-intl/helpers/format-date';
 
 export default class WeeklyGlance extends Component {
   @service userEvents;
@@ -121,12 +122,16 @@ export default class WeeklyGlance extends Component {
       const startDate = DateTime.fromISO(event.startDate);
       const date = startDate.toISODate();
       if (!eventsByDate.has(date)) {
-        eventsByDate.set(date, []);
+        eventsByDate.set(date, {
+          events: [],
+          startDate,
+        });
       }
-      eventsByDate.get(date).push(event);
+      eventsByDate.get(date).events.push(event);
     });
-    return eventsByDate;
+    return eventsByDate.values();
   }
+
   <template>
     <div
       class="week-glance"
@@ -158,13 +163,24 @@ export default class WeeklyGlance extends Component {
       {{#unless @collapsed}}
         {{#if this.eventsLoaded}}
           {{#if (gt this.nonIlmPreWorkEvents.length 0)}}
-            {{#each-in this.nonPreWorkEventsByDay as |date eventsByDay|}}
+            {{#each this.nonPreWorkEventsByDay as |date|}}
               <div class="events-by-date" data-test-events-by-date>
-                {{#each eventsByDay as |event|}}
-                  <WeekGlanceEvent @event={{event}} />
-                {{/each}}
+                <h3 class="day long" data-test-day>{{formatDate date.startDate weekday="long"}}</h3>
+                <h3 class="day short" data-test-day>{{formatDate
+                    date.startDate
+                    weekday="short"
+                  }}</h3>
+                <h3 class="day narrow" data-test-day>{{formatDate
+                    date.startDate
+                    weekday="narrow"
+                  }}</h3>
+                <ul>
+                  {{#each date.events as |event|}}
+                    <WeekGlanceEvent @event={{event}} />
+                  {{/each}}
+                </ul>
               </div>
-            {{/each-in}}
+            {{/each}}
           {{else}}
             <p>
               {{t "general.none"}}

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -56,7 +56,7 @@
     }
 
     ul {
-      margin: 0;
+      margin: 0.25rem 0 0 0;
     }
   }
 
@@ -67,6 +67,10 @@
 
     &:nth-of-type(even) {
       border-left: 3px solid var(--lightest-red);
+    }
+
+    &:first-of-type {
+      margin-top: 0;
     }
 
     p {

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -15,6 +15,49 @@
 
   .events-by-date {
     border-top: 1px dotted var(--orange);
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+    .day {
+      @include m.ilios-heading-h4;
+      align-self: flex-start;
+      position: sticky;
+      top: 0.25rem;
+
+      @include m.for-phone-only {
+        &.narrow {
+          display: block;
+        }
+        &.long,
+        &.short {
+          display: none;
+        }
+      }
+
+      @include m.for-phone-and-up {
+        &.short {
+          display: block;
+        }
+        &.long,
+        &.narrow {
+          display: none;
+        }
+      }
+
+      @include m.for-tablet-and-up {
+        &.long {
+          display: block;
+        }
+        &.short,
+        &.narrow {
+          display: none;
+        }
+      }
+    }
+
+    ul {
+      margin: 0;
+    }
   }
 
   .event {

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -56,7 +56,8 @@
     }
 
     ul {
-      margin: 0.25rem 0 0 0;
+      @include m.ilios-list-reset;
+      margin-top: 0.25rem;
     }
   }
 

--- a/packages/test-app/tests/integration/components/week-glance-test.gjs
+++ b/packages/test-app/tests/integration/components/week-glance-test.gjs
@@ -135,8 +135,14 @@ module('Integration | Component | week-glance', function (hooks) {
 
     assert.strictEqual(component.title, this.getTitle(true));
     assert.strictEqual(component.eventsByDate.length, 2);
+    assert.strictEqual(component.eventsByDate[0].days[0].text, 'Thursday');
+    assert.strictEqual(component.eventsByDate[0].days[1].text, 'Thu');
+    assert.strictEqual(component.eventsByDate[0].days[2].text, 'T');
     assert.strictEqual(component.eventsByDate[0].events.length, 1);
     assert.strictEqual(component.eventsByDate[0].events[0].title, 'Learn to Learn');
+    assert.strictEqual(component.eventsByDate[1].days[0].text, 'Friday');
+    assert.strictEqual(component.eventsByDate[1].days[1].text, 'Fri');
+    assert.strictEqual(component.eventsByDate[1].days[2].text, 'F');
     assert.strictEqual(component.eventsByDate[1].events.length, 2);
     assert.strictEqual(component.eventsByDate[1].events[0].title, 'Finding the Point in Life');
     assert.strictEqual(component.eventsByDate[1].events[1].title, 'Schedule some materials');


### PR DESCRIPTION
It can be difficult in a busy week to see the split between days, and in a busy day as you scroll to remember where you are on the page. Adding a border to split the days makes it easier and as you scroll down the page the day of the week pins itself to the top. This allows us to remove the day from each even making them easier to read as well.