### PR TITLE
show the membership total on top-level learner-groups, but only if it exceeds 0.

### DIFF
--- a/packages/frontend/tests/acceptance/course/session/learner-groups-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learner-groups-test.js
@@ -75,15 +75,15 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       );
       assert.strictEqual(
         selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         selectedLearnerGroups.detailLearnergroupsList.trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
     });
 
@@ -128,17 +128,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         learnergroupSelectionManager.selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0]
           .text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         learnergroupSelectionManager.selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1]
           .text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         learnergroupSelectionManager.selectedLearnerGroups.detailLearnergroupsList.trees[0].items[2]
           .text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       assert.strictEqual(learnergroupSelectionManager.availableGroups.cohorts.length, 1);
       assert.strictEqual(learnergroupSelectionManager.availableGroups.cohorts[0].trees.length, 5);
@@ -435,17 +435,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       await page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager.availableGroups.cohorts[0].trees[2].toggle();
       await page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager.availableGroups.cohorts[0].trees[3].subgroups[0].toggle();
@@ -463,22 +463,22 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[2].text,
-        'learner group 2 (0)',
+        'learner group 2',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[3].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
@@ -505,22 +505,22 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[2].text,
-        'learner group 2 (0)',
+        'learner group 2',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[3].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
@@ -547,17 +547,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       await page.details.detailLearnersAndLearnerGroups.manage();
 
@@ -569,17 +569,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
 
       await page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager.availableGroups.cohorts[0].trees[3].subgroups[0].toggle();
@@ -592,17 +592,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
@@ -625,17 +625,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
@@ -662,12 +662,12 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       await page.details.detailLearnersAndLearnerGroups.manage();
 
@@ -679,12 +679,12 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.notOk(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager.availableGroups
@@ -719,17 +719,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
@@ -752,17 +752,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
@@ -795,12 +795,12 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.notOk(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager.availableGroups
@@ -835,17 +835,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
@@ -878,17 +878,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
@@ -906,17 +906,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
@@ -944,17 +944,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
 
       await page.details.detailLearnersAndLearnerGroups.manage();
@@ -971,12 +971,12 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.learnergroupSelectionManager
           .selectedLearnerGroups.detailLearnergroupsList.trees[0].items[1].text,
-        'learner group 2 (0)',
+        'learner group 2',
       );
 
       await page.details.detailLearnersAndLearnerGroups.cancel();
@@ -990,17 +990,17 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[0].text,
-        'learner group 0 (0)',
+        'learner group 0',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[1].text,
-        'learner group 1 (0)',
+        'learner group 1',
       );
       assert.strictEqual(
         page.details.detailLearnersAndLearnerGroups.selectedLearnerGroups.detailLearnergroupsList
           .trees[0].items[2].text,
-        'learner group 3 (0)',
+        'learner group 3',
       );
     });
 
@@ -1163,7 +1163,7 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     assert.strictEqual(selectedLearnerGroups.detailLearnergroupsList.trees[0].items.length, 1);
     assert.strictEqual(
       selectedLearnerGroups.detailLearnergroupsList.trees[0].items[0].text,
-      'learner group 0 (0)',
+      'learner group 0',
     );
   });
 });

--- a/packages/ilios-common/addon/components/detail-learnergroups-list-item.gjs
+++ b/packages/ilios-common/addon/components/detail-learnergroups-list-item.gjs
@@ -36,6 +36,9 @@ export default class DetailLearnergroupsListItemComponent extends Component {
         >
           {{#if @group.isTopLevelGroup}}
             {{@group.title}}
+            {{#if @group.usersOnlyAtThisLevelCount}}
+              ({{@group.usersOnlyAtThisLevelCount}})
+            {{/if}}
           {{else}}
             {{#each this.allParentTitles as |title|}}
               {{! template-lint-disable no-bare-strings}}
@@ -59,6 +62,9 @@ export default class DetailLearnergroupsListItemComponent extends Component {
       {{else}}
         {{#if @group.isTopLevelGroup}}
           {{@group.title}}
+          {{#if @group.usersOnlyAtThisLevelCount}}
+            ({{@group.usersOnlyAtThisLevelCount}})
+          {{/if}}
         {{else}}
           {{#each this.allParentTitles as |title|}}
             {{! template-lint-disable no-bare-strings}}

--- a/packages/test-app/tests/integration/components/detail-learnergroups-list-test.gjs
+++ b/packages/test-app/tests/integration/components/detail-learnergroups-list-test.gjs
@@ -77,7 +77,7 @@ module('Integration | Component | detail-learnergroups-list', function (hooks) {
     );
     assert.strictEqual(component.trees[1].title, 'program 0 cohort 1');
     assert.strictEqual(component.trees[1].items.length, 2);
-    assert.strictEqual(component.trees[1].items[0].text, 'tlg2');
+    assert.strictEqual(component.trees[1].items[0].text, 'tlg2 (2)');
     assert.strictEqual(component.trees[1].items[1].text, 'tlg2 » sub group 2 (0)');
   });
 

--- a/packages/test-app/tests/integration/components/detail-learners-and-learnergroups-test.gjs
+++ b/packages/test-app/tests/integration/components/detail-learners-and-learnergroups-test.gjs
@@ -139,7 +139,7 @@ module('Integration | Component | detail-learners-and-learner-groups', function 
     );
     assert.strictEqual(
       component.selectedLearnerGroups.detailLearnergroupsList.trees[1].items[0].text,
-      'Top Group 3 (0)',
+      'Top Group 3',
     );
   });
 
@@ -208,7 +208,7 @@ module('Integration | Component | detail-learners-and-learner-groups', function 
     );
     assert.strictEqual(
       component.selectedLearnerGroups.detailLearnergroupsList.trees[1].items[0].text,
-      'Top Group 3 (0)',
+      'Top Group 3',
     );
     assert.strictEqual(component.learnergroupSelectionManager.availableGroups.cohorts.length, 2);
     assert.strictEqual(


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/6401