### PR TITLE
Improve a11y of Monthly Calendar

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/monthly-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/monthly-calendar.scss
@@ -15,9 +15,9 @@
 
   .calendar {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(7, minmax(3rem, 1fr));
     grid-gap: 5px;
-    grid-template-rows: 1rem repeat(5, 7rem);
+    grid-template-rows: 1rem repeat(5, minmax(7rem, min-content));
     width: 100%;
 
     .day-heading {
@@ -70,19 +70,21 @@
         }
       }
 
-      .month-event {
+      .month-event,
+      .month-more-events {
         @include m.ilios-button-reset;
-        cursor: default;
-        display: block;
-        border: 1px solid var(--lightest-grey);
-        border-radius: 3px;
         height: 1.5em;
         overflow: hidden;
         padding: 0 8px 0 0;
         position: relative;
         text-align: left;
         width: 100%;
+      }
 
+      .month-event {
+        border: 1px solid var(--lightest-grey);
+        border-radius: 3px;
+        cursor: default;
         &.clickable {
           cursor: pointer;
         }
@@ -104,17 +106,23 @@
       }
 
       .month-more-events {
-        @include m.ilios-link-button;
-        display: block;
-        width: 100%;
-        @include m.font-size("small");
         text-align: right;
-        margin-top: 0.5rem;
+        margin-top: 1rem;
+        color: var(--blue);
+
+        .fa-ellipsis {
+          vertical-align: text-bottom;
+          display: none;
+
+          @include m.for-laptop-and-up {
+            display: inline;
+          }
+        }
 
         .text {
           display: none;
 
-          @include m.for-tablet-and-up {
+          @include m.for-laptop-and-up {
             display: inline;
           }
         }


### PR DESCRIPTION
Give a little bit more room to the Show More button when it's present to ensure it is clickable.

Add a minimum width to calendar boxes, which makes the screen break a bit on extremely small windows, but ensures the days are still clickable to users can navigate to them and they're not hidden.

Before:
<img width="200" height="853" alt="old-tiny" src="https://github.com/user-attachments/assets/719d815e-5b00-48c4-a0d6-e230f50c57ca" />

<img width="400" height="836" alt="old-phone" src="https://github.com/user-attachments/assets/086c9de4-d720-4643-8060-c3381aeae277" />

<img width="400" height="305" alt="old-laptop" src="https://github.com/user-attachments/assets/841636c5-19e2-43f2-9864-794d522bf9de" />


After:

<img width="188" height="800" alt="new-tiny" src="https://github.com/user-attachments/assets/20e70f4c-dd66-423a-adb9-017b25dde251" />
<img width="400" height="849" alt="new-phone" src="https://github.com/user-attachments/assets/c438cef7-0979-4405-8cd6-4e2afd0d641b" />
<img width="400" height="305" alt="new-laptop" src="https://github.com/user-attachments/assets/22e845d9-4503-4b0f-9043-4a320837f462" />
