### PR TITLE
Add Space in WaaG

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance/learning-materials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance/learning-materials.scss
@@ -33,9 +33,10 @@
     .week-glance-learning-material-list-item {
       align-items: center;
       display: flex;
+      margin: 0.5rem 0;
 
-      &.fa-download {
-        margin-left: 0.1rem;
+      .fa-download {
+        margin-left: 0.5rem;
       }
     }
   }


### PR DESCRIPTION
The list of materials is difficult to click when it is super compact, I've added a little bit of room to make it easier and meet a11y requirements.