### PR TITLE
Enable WCAG 2.2 A and AA Tests

### DIFF
--- a/packages/frontend/tests/helpers/index.js
+++ b/packages/frontend/tests/helpers/index.js
@@ -7,6 +7,18 @@ import { setupMSW } from 'ilios-common/msw';
 import { setupIntl } from 'ember-intl/test-support';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
 
+/**
+ * In order to get wcag22 rules we have to specify the tags manually.
+ * see: https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md#wcag-22-level-a--aa-rules
+ *
+ * There is no supported way to add tags, only to send the entire list.
+ * see https://github.com/dequelabs/axe-core/issues/4717
+ */
+const runOnly = {
+  type: 'tag',
+  values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice', 'wcag22a', 'wcag22aa'],
+};
+
 // This file exists to provide wrappers around ember-qunit's
 // test setup functions. This way, you can easily extend the setup that is
 // needed per test type.
@@ -28,6 +40,13 @@ function setupApplicationTest(hooks, options) {
   //
   setupIntl(hooks, 'en-us'); // ember-intl
   setupMSW(hooks);
+
+  hooks.before(() => {
+    setRunOptions({
+      preload: false,
+      runOnly,
+    });
+  });
 }
 
 function setupRenderingTest(hooks, options) {
@@ -42,6 +61,8 @@ function setupRenderingTest(hooks, options) {
    */
   hooks.before(() => {
     setRunOptions({
+      preload: false,
+      runOnly,
       rules: {
         'color-contrast': { enabled: false },
         listitem: { enabled: false },

--- a/packages/frontend/tests/test-helper.js
+++ b/packages/frontend/tests/test-helper.js
@@ -11,7 +11,6 @@ import { setupEmberOnerrorValidation } from 'ember-qunit';
 import DefaultAdapter from 'ember-cli-page-object/adapters/rfc268';
 import { setAdapter } from 'ember-cli-page-object/adapters';
 import {
-  setRunOptions,
   setupGlobalA11yHooks,
   setupQUnitA11yAuditToggle,
   setupConsoleLogger,
@@ -24,9 +23,6 @@ QUnit.done(async () => {
 });
 
 setupConsoleLogger();
-setRunOptions({
-  preload: false,
-});
 setupGlobalA11yHooks(() => true);
 setupQUnitA11yAuditToggle(QUnit);
 

--- a/packages/test-app/tests/helpers/index.js
+++ b/packages/test-app/tests/helpers/index.js
@@ -7,6 +7,18 @@ import { setupMSW } from 'ilios-common/msw';
 import { setupIntl } from 'ember-intl/test-support';
 import { setRunOptions } from 'ember-a11y-testing/test-support';
 
+/**
+ * In order to get wcag22 rules we have to specify the tags manually.
+ * see: https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md#wcag-22-level-a--aa-rules
+ *
+ * There is no supported way to add tags, only to send the entire list.
+ * see https://github.com/dequelabs/axe-core/issues/4717
+ */
+const runOnly = {
+  type: 'tag',
+  values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice', 'wcag22a', 'wcag22aa'],
+};
+
 // This file exists to provide wrappers around ember-qunit's
 // test setup functions. This way, you can easily extend the setup that is
 // needed per test type.
@@ -28,6 +40,13 @@ function setupApplicationTest(hooks, options) {
   //
   setupIntl(hooks, 'en-us'); // ember-intl
   setupMSW(hooks);
+
+  hooks.before(() => {
+    setRunOptions({
+      preload: false,
+      runOnly,
+    });
+  });
 }
 
 function setupRenderingTest(hooks, options) {
@@ -35,12 +54,15 @@ function setupRenderingTest(hooks, options) {
   setupIntl(hooks, 'en-us'); // ember-intl
 
   // Additional setup for rendering tests can be done here.
+
   /**
    * These tests are run in issolation without a full application shell, so many items
    * will appear out of source order and with no styles (such as background color)
    */
   hooks.before(() => {
     setRunOptions({
+      preload: false,
+      runOnly,
       rules: {
         'color-contrast': { enabled: false },
         listitem: { enabled: false },

--- a/packages/test-app/tests/test-helper.js
+++ b/packages/test-app/tests/test-helper.js
@@ -8,7 +8,6 @@ import { setup } from 'qunit-dom';
 import { setupEmberOnerrorValidation } from 'ember-qunit';
 
 import {
-  setRunOptions,
   setupGlobalA11yHooks,
   setupQUnitA11yAuditToggle,
   setupConsoleLogger,
@@ -17,9 +16,6 @@ import {
 import start from 'ember-exam/test-support/start';
 
 setupConsoleLogger();
-setRunOptions({
-  preload: false,
-});
 setupGlobalA11yHooks(() => true);
 setupQUnitA11yAuditToggle(QUnit);
 


### PR DESCRIPTION
This is higher than our current target conformance level, but it's a starting place to target any changes we think are worth it before we make this our official supported standard.