### PR TITLE
Hide Empty Instructors List

### DIFF
--- a/packages/frontend/app/components/instructor-group/users.gjs
+++ b/packages/frontend/app/components/instructor-group/users.gjs
@@ -97,14 +97,16 @@ export default class InstructorGroupUsersComponent extends Component {
             />
           {{/unless}}
         {{else}}
-          <ul class="instructor-group-users-list" data-test-users-list>
-            {{#each (sortBy "fullName" this.users) as |user|}}
-              <li data-test-user>
-                <UserStatus @user={{user}} />
-                <UserNameInfo @user={{user}} />
-              </li>
-            {{/each}}
-          </ul>
+          {{#if this.users.length}}
+            <ul class="instructor-group-users-list" data-test-users-list>
+              {{#each (sortBy "fullName" this.users) as |user|}}
+                <li data-test-user>
+                  <UserStatus @user={{user}} />
+                  <UserNameInfo @user={{user}} />
+                </li>
+              {{/each}}
+            </ul>
+          {{/if}}
         {{/if}}
       </div>
     </section>


### PR DESCRIPTION
For better a11y this empty list should be hidden.

This is flagged by siteimprove, but not by other checkers. There is some debate over weather [5.2.5 Required Owned Elements](https://www.w3.org/TR/wai-aria-1.1/#mustContain) applies to a straight html `<ul>` tag or if it would only apply when `role=list` is explicitly added. Thus we can't really test this, though we have some tests that would cover this if the axe-core checker changed to catch it.