### PR TITLE
Dashboard Courses Filter now shows proper loading spinner

### DIFF
--- a/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.gjs
+++ b/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.gjs
@@ -49,15 +49,6 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
   }
 
   @cached
-  get schoolCalendarData() {
-    return new TrackedAsyncData(this.dataLoader.loadSchoolForCalendar(this.args.school.id));
-  }
-
-  get schoolCalendar() {
-    return this.schoolCalendarData.isResolved ? this.schoolCalendarData.value : null;
-  }
-
-  @cached
   get coursesRelationshipData() {
     return new TrackedAsyncData(this.args.school.courses);
   }


### PR DESCRIPTION
Fixes ilios/ilios#6428

I also removed an unused `schoolCalendar()` method that might've been leftover from when we were removing ember render modifiers.