### PR TITLE
Improve Readability of Single Events

### DIFF
--- a/packages/ilios-common/addon/components/single-event.gjs
+++ b/packages/ilios-common/addon/components/single-event.gjs
@@ -23,6 +23,7 @@ import set from 'ember-set-helper/helpers/set';
 import SingleEventLearningmaterialList from 'ilios-common/components/single-event-learningmaterial-list';
 import SingleEventObjectiveList from 'ilios-common/components/single-event-objective-list';
 import NotFound from 'ilios-common/components/not-found';
+import { htmlSafe } from '@ember/template';
 
 export default class SingleEvent extends Component {
   @service currentUser;
@@ -215,6 +216,10 @@ export default class SingleEvent extends Component {
     return this.currentUser.performsNonLearnerFunction;
   }
 
+  get sessionDescription() {
+    return htmlSafe(this.args.event.sessionDescription);
+  }
+
   @action
   transitionToMyMaterials() {
     this.router.transitionTo('dashboard.materials', {
@@ -322,7 +327,7 @@ export default class SingleEvent extends Component {
           </h2>
           <div class="single-event-offered-at" data-test-offered-at>
             {{#if (gt @event.postrequisites.length 0)}}
-              <p>
+              <span>
                 {{t "general.dueBefore"}}
                 <a href={{this.postrequisiteLink}}>{{get
                     (objectAt 0 @event.postrequisites)
@@ -338,10 +343,10 @@ export default class SingleEvent extends Component {
                   hour="2-digit"
                   minute="2-digit"
                 }})
-              </p>
+              </span>
             {{/if}}
             {{#unless @event.ilmSession}}
-              <p>
+              <span>
                 {{#if (eq @event.startDate @event.endDate)}}
                   {{formatDate
                     @event.startDate
@@ -389,12 +394,12 @@ export default class SingleEvent extends Component {
                     minute="2-digit"
                   }}
                 {{/if}}
-              </p>
+              </span>
             {{/unless}}
-          </div>
-          <div class="single-event-location">
-            <OfferingUrlDisplay @url={{@event.url}} />
-            {{@event.location}}
+            <span class="single-event-location">
+              <OfferingUrlDisplay @url={{@event.url}} />
+              {{@event.location}}
+            </span>
           </div>
           {{#if this.taughtBy}}
             <div class="single-event-instructors">
@@ -402,45 +407,39 @@ export default class SingleEvent extends Component {
             </div>
           {{/if}}
           <div class="single-event-session-is">
-            <strong>{{t "general.sessionType"}}:</strong>
+            {{t "general.sessionType"}}:
             {{@event.sessionTypeTitle}}
           </div>
           {{#if @event.equipmentRequired}}
             <div class="single-event-equipment-required">
-              {{! template-lint-disable no-triple-curlies }}
-              {{{t "general.specialEquipmentIs_Required_"}}}
               <FaIcon @icon="flask" @title={{t "general.specialEquipment"}} />
+              {{t "general.specialEquipmentIsRequired"}}
             </div>
           {{/if}}
           {{#if @event.attireRequired}}
             <div class="single-event-attire-required">
-              {{! template-lint-disable no-triple-curlies }}
-              {{{t "general.specialAttireIs_Required_"}}}
               <FaIcon
                 @icon="black-tie"
                 @prefix="brands"
                 @title={{t "general.whitecoatsSlashSpecialAttire"}}
               />
+              {{t "general.specialAttireIsRequired"}}
             </div>
           {{/if}}
           {{#if @event.attendanceRequired}}
             <div class="single-event-attendance-required">
-              {{! template-lint-disable no-triple-curlies }}
-              {{{t "general.attendanceIs_Required_"}}}
               <FaIcon @icon="calendar-check" @title={{t "general.attendanceIsRequired"}} />
+              {{t "general.attendanceIsRequired"}}
             </div>
           {{/if}}
           {{#if @event.supplemental}}
             <div class="single-event-supplemental">
-              <strong>
-                {{t "general.supplementalCurriculum"}}
-              </strong>
               <FaIcon @icon="calendar-minus" @title={{t "general.supplementalCurriculum"}} />
+              {{t "general.supplementalCurriculum"}}
             </div>
           {{/if}}
           {{#if @event.sessionDescription}}
-            {{! template-lint-disable no-triple-curlies }}
-            {{{@event.sessionDescription}}}
+            {{this.sessionDescription}}
             <br />
           {{/if}}
         </div>

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
@@ -56,6 +56,7 @@
 
   .single-event-offered-at {
     font-weight: bold;
+    margin: 0.5rem 0;
   }
 
   .single-event-instructors {

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -17,7 +17,6 @@ general:
   apiVersionMismatchDetails: "This is usually a temporary error in your browser; Ilios is in read-only mode until it is resolved. If updating does not help, please notify an administrator or technical owner of the system regarding this error. You may also wish to try a different browser."
   assignedTerms: Assigned Terms
   associatedGroups: Associated Groups
-  attendanceIs_Required_: "Attendance is '<strong><em>'required'</em></strong>'"
   attendanceIsRequired: Attendance is required
   attendanceRequired: Attendance Required
   attireRequired: Attire Required
@@ -347,10 +346,10 @@ general:
   smallGroups: Small Groups
   sortMaterials: Sort Materials
   sortObjectives: Sort Objectives
-  specialAttireIs_Required_: "Special Attire is '<strong><em>'required'</em></strong>'"
+  specialAttireIsRequired: "Special Attire is required"
   specialAttireRequired: Special Attire Required
   specialEquipment: Special Equipment
-  specialEquipmentIs_Required_: "Special Equipment is '<strong><em>'required'</em></strong>'"
+  specialEquipmentIsRequired: "Special Equipment is required"
   specialEquipmentRequired: Special Equipment Required
   start: Start
   startDate: Start Date

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -17,7 +17,6 @@ general:
   apiVersionMismatchDetails: "Por lo general, se trata de un error temporal de su navegador; Ilios está en modo de solo lectura hasta que se resuelva. Si la actualización no soluciona el problema, notifique a un administrador o al propietario técnico del sistema sobre este error. También puede probar con otro navegador."
   assignedTerms: Términos asignados
   associatedGroups: Grupos Associados
-  attendanceIs_Required_: "Se '<strong><em>'require'</em></strong>' asistencia"
   attendanceIsRequired: Se require asistencia
   attendanceRequired: Asistencia Requerida
   attireRequired: Atuendo Requerida
@@ -347,10 +346,10 @@ general:
   showOnlyMyInstructorActivities: Mostrar solo las actividades de mi instructor
   showOnlyMyLearnerActivities: Mostrar solo mis actividades de aprendizaje
   sortObjectives: Clasificar los objetivos
-  specialAttireIs_Required_: "Se '<strong><em>'require'</em></strong>' vestimenta especial"
+  specialAttireIsRequired: "Se require vestimenta especial"
   specialAttireRequired: Vestimenta Especial Requerido
   specialEquipment: Equipo especial
-  specialEquipmentIs_Required_: "Se '<strong><em>'require'</em></strong>' equipo especial"
+  specialEquipmentIsRequired: "Se require equipo especial"
   specialEquipmentRequired: Equipo Especial Requerido
   start: Inicio
   startDate: Fecha de Iniciar

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -17,7 +17,6 @@ general:
   apiVersionMismatchDetails: "Il s'agit généralement d'une erreur temporaire dans votre navigateur; Ilios est en mode lecture seule jusqu'à ce qu'il soit résolu. Si la mise à jour ne vous aide pas, veuillez aviser un administrateur ou le propriétaire de la technologie du système de cette erreur. Vous pouvez également essayer un autre navigateur."
   assignedTerms: Termes assignées
   associatedGroups: Groupes Associés
-  attendanceIs_Required_: "Présence '<strong><em>'requise'</em></strong>'"
   attendanceIsRequired: Présence requise
   attendanceRequired: Participation Requise
   attireRequired: Tenue Requise
@@ -347,10 +346,10 @@ general:
   smallGroups: Groupes Particulaires
   sortMaterials: Trier les matériaux
   sortObjectives: Trier les objectifs
-  specialAttireIs_Required_: "Vêtements particuliers est '<strong><em>'requis'</em></strong>'"
+  specialAttireIsRequired: "Vêtements particuliers est requis"
   specialAttireRequired: Vêtements particuliers requis
   specialEquipment: Équipage particulier
-  specialEquipmentIs_Required_: "Équipage particulier est '<strong><em>'requis'</em></strong>'"
+  specialEquipmentIsRequired: "Équipage particulier est requis"
   specialEquipmentRequired: Équipage particulier requis
   start: Commencer
   startDate: Jour Commencer


### PR DESCRIPTION
The spacing and mix of bold and italic type made the critical information here difficult to read. I've removed most of that and used the icons to call out the attributes. I moved the location into the same visual space as the time as I think that makes it easier to understand what it is.

I also got rid of the triple curlies and used a getter to process the session description, this does the same thing, but doesn't require us to ignore a linting error.

Old:
<img width="500" height="596" alt="Screen Shot 2025-08-18 at 10 28 59" src="https://github.com/user-attachments/assets/d22c4191-f2b2-4add-ab59-934e7b5baba5" />


New:
<img width="500" height="596" alt="Screen Shot 2025-08-18 at 10 28 45" src="https://github.com/user-attachments/assets/e6fc2c90-3849-496c-b56d-f67c5e981fb3" />

