### PR TITLE
Style Input Accents

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -28,6 +28,10 @@ button {
   @include m.ilios-button;
 }
 
+input {
+  accent-color: var(--blue);
+}
+
 h1 {
   @include m.ilios-heading-h1;
 }


### PR DESCRIPTION
This aligns our checkbox and radio button styles with our buttons so the blue isn't so harshly contrasting and dependent on the browsers style.

Before:
<img width="500" height="285" alt="before" src="https://github.com/user-attachments/assets/704e656e-3b64-4195-807e-6e7edb4fa16b" />


After:
<img width="500" height="290" alt="after" src="https://github.com/user-attachments/assets/c14e1c63-4c44-4a26-ba00-016c6788bc05" />
