### PR TITLE
explicitly provide year as context when routing to weeklyevents page.

### DIFF
--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/dashboard/week.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/dashboard/week.js
@@ -1,9 +1,12 @@
-import { create, text } from 'ember-cli-page-object';
+import { attribute, create } from 'ember-cli-page-object';
 import weekGlance from '../week-glance';
 
 const definition = {
   scope: '[data-test-dashboard-week]',
-  weeklyLink: text('[data-test-weekly-link] a'),
+  weeklyLink: {
+    scope: '[data-test-weekly-link] a',
+    url: attribute('href'),
+  },
   weekGlance,
 };
 

--- a/packages/ilios-common/addon/components/dashboard/week.gjs
+++ b/packages/ilios-common/addon/components/dashboard/week.gjs
@@ -69,7 +69,10 @@ export default class DashboardWeekComponent extends Component {
           data-test-weekly-link
         >
           {{t "general.view"}}:
-          <LinkTo @route="weeklyevents" @query={{hash expanded=this.expanded week=this.week}}>
+          <LinkTo
+            @route="weeklyevents"
+            @query={{hash expanded=this.expanded week=this.week year=this.year}}
+          >
             {{t "general.allWeeks"}}
           </LinkTo>
         </div>

--- a/packages/ilios-common/addon/routes/weeklyevents.js
+++ b/packages/ilios-common/addon/routes/weeklyevents.js
@@ -11,6 +11,9 @@ export default class WeeklyeventsRoute extends Route {
     week: {
       replace: true,
     },
+    year: {
+      replace: true,
+    },
   };
 
   beforeModel(transition) {

--- a/packages/test-app/tests/integration/components/dashboard/week-test.gjs
+++ b/packages/test-app/tests/integration/components/dashboard/week-test.gjs
@@ -99,7 +99,7 @@ module('Integration | Component | dashboard/week', function (hooks) {
 
     await render(<template><Week /></template>);
     const expectedTitle = this.getTitle();
-    assert.strictEqual(component.weeklyLink, 'All Weeks');
+    assert.strictEqual(component.weeklyLink.text, 'All Weeks');
     assert.strictEqual(component.weekGlance.title, expectedTitle);
     assert.strictEqual(component.weekGlance.eventsByDate.length, 1);
     assert.strictEqual(
@@ -118,7 +118,7 @@ module('Integration | Component | dashboard/week', function (hooks) {
     this.setupEvents([]);
     await render(<template><Week /></template>);
     const expectedTitle = this.getTitle();
-    assert.strictEqual(component.weeklyLink, 'All Weeks');
+    assert.strictEqual(component.weeklyLink.text, 'All Weeks');
     assert.strictEqual(component.weekGlance.title, expectedTitle);
     assert.strictEqual(component.weekGlance.eventsByDate.length, 0);
   });
@@ -233,5 +233,21 @@ module('Integration | Component | dashboard/week', function (hooks) {
       { year: 2005, month: 6, day: 24 },
       'June 19-25 Week at a Glance',
     );
+  });
+
+  test('link to weeklyevent without year', async function (assert) {
+    this.setupEvents([]);
+    const dt = DateTime.fromObject({ year: 2024, month: 12, day: 23 });
+    freezeDateAt(dt.toJSDate());
+    await render(<template><Week /></template>);
+    assert.strictEqual(component.weeklyLink.url, '/weeklyevents?expanded=51-52-1&week=52');
+  });
+
+  test('link to weeklyevent with year', async function (assert) {
+    this.setupEvents([]);
+    const dt = DateTime.fromObject({ year: 2024, month: 12, day: 30 });
+    freezeDateAt(dt.toJSDate());
+    await render(<template><Week /></template>);
+    assert.strictEqual(component.weeklyLink.url, '/weeklyevents?expanded=52-1-2&week=1&year=2025');
   });
 });


### PR DESCRIPTION
this deals with an edge case around the end of the year when the current week is technically the first week of the new year. in that case, adding the year to the query string provides the necessary context to land the user in the correct year for weekly-events.

fixes https://github.com/ilios/ilios/issues/5910