### PR TITLE
Remove restriction on searching the same query again

### DIFF
--- a/packages/frontend/app/controllers/search.js
+++ b/packages/frontend/app/controllers/search.js
@@ -25,11 +25,8 @@ export default class SearchController extends Controller {
   }
 
   setQuery = (query) => {
-    // don't reset the page when returning back to the same query
-    if (query !== this.query) {
-      this.page = 1;
-      this.query = query;
-    }
+    this.page = 1;
+    this.query = query;
   };
 
   setSchools = (schools) => {


### PR DESCRIPTION
I removed the 'query cant equal last query' condition on searching, and now hitting enter re-runs the search (if it's good enough Google, it's good enough for us, yah?).