### PR TITLE
Add duration to Week at a Glance events

### DIFF
--- a/packages/frontend/tests/acceptance/dashboard/week-test.js
+++ b/packages/frontend/tests/acceptance/dashboard/week-test.js
@@ -171,12 +171,12 @@ module('Acceptance | Dashboard Week at a Glance', function (hooks) {
     assert.strictEqual(page.week.weekGlance.eventsByDate[0].events.length, 1);
     assert.strictEqual(
       page.week.weekGlance.eventsByDate[0].events[0].text,
-      'event 0 ' + this.intl.formatTime(startOfTheWeek.toJSDate(), options),
+      'event 0 ' + this.intl.formatTime(startOfTheWeek.toJSDate(), options) + ' (Duration: 1 hour)',
     );
     assert.strictEqual(page.week.weekGlance.eventsByDate[1].events.length, 1);
     assert.strictEqual(
       page.week.weekGlance.eventsByDate[1].events[0].text,
-      'event 1 ' + this.intl.formatTime(endOfTheWeek.toJSDate(), options),
+      'event 1 ' + this.intl.formatTime(endOfTheWeek.toJSDate(), options) + ' (Duration: 1 hour)',
     );
   });
 

--- a/packages/ilios-common/addon/components/week-glance-event.gjs
+++ b/packages/ilios-common/addon/components/week-glance-event.gjs
@@ -109,7 +109,7 @@ export default class WeekGlanceEvent extends Component {
             </span>
           {{/if}}
           {{formatDate @event.startDate hour="2-digit" minute="2-digit"}}
-          ({{this.eventDuration}})
+          <span class="duration">({{this.eventDuration}})</span>
         </span>
       </h4>
       <div>

--- a/packages/ilios-common/addon/components/week-glance-event.gjs
+++ b/packages/ilios-common/addon/components/week-glance-event.gjs
@@ -1,7 +1,9 @@
 import Component from '@glimmer/component';
 import createTypedLearningMaterialProxy from 'ilios-common/utils/create-typed-learning-material-proxy';
+import { service } from '@ember/service';
 import { concat } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
+import { DateTime } from 'luxon';
 import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
 import OfferingUrlDisplay from 'ilios-common/components/offering-url-display';
@@ -13,6 +15,11 @@ import or from 'ember-truth-helpers/helpers/or';
 import LearningMaterialList from 'ilios-common/components/week-glance/learning-material-list';
 
 export default class WeekGlanceEvent extends Component {
+  @service intl;
+
+  constructor() {
+    super(...arguments);
+  }
   sortString(a, b) {
     return a.localeCompare(b);
   }
@@ -38,6 +45,19 @@ export default class WeekGlanceEvent extends Component {
         .sort(this.sessionLearningMaterialSortingCalling);
       return rhett;
     });
+  }
+
+  get eventDuration() {
+    const end = DateTime.fromISO(this.args.event.endDate, {
+      locale: this.intl.get('primaryLocale'),
+    });
+    const start = DateTime.fromISO(this.args.event.startDate, {
+      locale: this.intl.get('primaryLocale'),
+    });
+    // create a Duration object
+    const duration = end.diff(start, ['days', 'hours', 'minutes']);
+    // display Duration object like so: "Duration: 2 hours, 30 minutes"
+    return `${this.intl.t('general.duration')}: ` + duration.toHuman({ showZeros: false });
   }
 
   getTypedLearningMaterialProxies(learningMaterials) {
@@ -92,6 +112,7 @@ export default class WeekGlanceEvent extends Component {
             </span>
           {{/if}}
           {{formatDate @event.startDate hour="2-digit" minute="2-digit"}}
+          ({{this.eventDuration}})
         </span>
       </h4>
       <div>

--- a/packages/ilios-common/addon/components/week-glance-event.gjs
+++ b/packages/ilios-common/addon/components/week-glance-event.gjs
@@ -17,9 +17,6 @@ import LearningMaterialList from 'ilios-common/components/week-glance/learning-m
 export default class WeekGlanceEvent extends Component {
   @service intl;
 
-  constructor() {
-    super(...arguments);
-  }
   sortString(a, b) {
     return a.localeCompare(b);
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -86,6 +86,13 @@
 
       .date {
         font-weight: 400;
+
+        .duration {
+          /* stylelint-disable-next-line property-disallowed-list */
+          font-size: var(--fs-base);
+          padding-left: 0.25em;
+          vertical-align: bottom;
+        }
       }
     }
 

--- a/packages/test-app/tests/integration/components/week-glance-event-test.gjs
+++ b/packages/test-app/tests/integration/components/week-glance-event-test.gjs
@@ -153,6 +153,86 @@ module('Integration | Component | week-glance-event', function (hooks) {
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
+
+  test('it renders durations properly', async function (assert) {
+    const event = {
+      name: 'Learn to Learn',
+      startDate: today.toISO(),
+      location: 'Room 123',
+      url: 'https://zoom.example.com/123?p=456',
+      sessionTypeTitle: 'Lecture',
+      courseExternalId: 'C1',
+      sessionDescription:
+        'Best <strong>Session</strong> For Sure' +
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
+      isBlanked: false,
+      isPublished: true,
+      isScheduled: false,
+      learningMaterials: [
+        {
+          title: 'Citation LM',
+          required: true,
+          publicNotes: 'This is cool.',
+          citation: 'citationtext',
+          sessionLearningMaterial: 1,
+        },
+        {
+          title: 'Link LM',
+          required: false,
+          link: 'http://myhost.com/url2',
+          sessionLearningMaterial: 2,
+        },
+        {
+          title: 'File LM',
+          filename: 'This is a PDF',
+          mimetype: 'application/pdf',
+          required: true,
+          absoluteFileUri: 'http://myhost.com/url1',
+          sessionLearningMaterial: 3,
+        },
+      ],
+      attireRequired: true,
+      equipmentRequired: true,
+      attendanceRequired: true,
+      supplemental: true,
+    };
+
+    event.endDate = today.plus({ minutes: 1 });
+    await render(<template><WeekGlanceEvent @event={{event}} /></template>);
+    assert.strictEqual(component.date, '08:00 AM (Duration: 1 minute)');
+
+    event.endDate = today.plus({ minutes: 15 });
+    await render(<template><WeekGlanceEvent @event={{event}} /></template>);
+    assert.strictEqual(component.date, '08:00 AM (Duration: 15 minutes)');
+
+    event.endDate = today.plus({ minutes: 90 });
+    await render(<template><WeekGlanceEvent @event={{event}} /></template>);
+    assert.strictEqual(component.date, '08:00 AM (Duration: 1 hour, 30 minutes)');
+
+    event.endDate = today.plus({ hours: 1 });
+    await render(<template><WeekGlanceEvent @event={{event}} /></template>);
+    assert.strictEqual(component.date, '08:00 AM (Duration: 1 hour)');
+
+    event.endDate = today.plus({ hours: 2, minutes: 25 });
+    await render(<template><WeekGlanceEvent @event={{event}} /></template>);
+    assert.strictEqual(component.date, '08:00 AM (Duration: 2 hours, 25 minutes)');
+
+    event.endDate = today.plus({ hours: 36 });
+    await render(<template><WeekGlanceEvent @event={{event}} /></template>);
+    assert.strictEqual(component.date, '08:00 AM (Duration: 1 day, 12 hours)');
+
+    event.endDate = today.plus({ days: 1, hours: 0, minutes: 0 });
+    await render(<template><WeekGlanceEvent @event={{event}} /></template>);
+    assert.strictEqual(component.date, '08:00 AM (Duration: 1 day)');
+
+    event.endDate = today.plus({ days: 1, hours: 0, minutes: 55 });
+    await render(<template><WeekGlanceEvent @event={{event}} /></template>);
+    assert.strictEqual(component.date, '08:00 AM (Duration: 1 day, 55 minutes)');
+
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
   test('it renders schedule materials', async function (assert) {
     this.set('event', {
       name: 'Schedule some materials',


### PR DESCRIPTION
Fixes ilios/ilios#4084

Week at a Glance now displays the duration of an event (via `luxon`'s `Duration` object), translations fully supported

<img width="630" height="593" alt="Screenshot 2025-09-04 at 2 37 55 PM" src="https://github.com/user-attachments/assets/50d8de49-41c4-4ddb-b283-24281df81c6b" />
