### PR TITLE
Keep track of expanded/collapsed sessions

### DIFF
--- a/packages/ilios-common/addon/components/course/sessions.gjs
+++ b/packages/ilios-common/addon/components/course/sessions.gjs
@@ -29,7 +29,6 @@ export default class CourseSessionsComponent extends Component {
   @service permissionChecker;
   @service dataLoader;
 
-  @tracked expandedSessionIds = [];
   @tracked filterByLocalCache = [];
   @tracked showNewSessionForm = false;
 
@@ -111,22 +110,10 @@ export default class CourseSessionsComponent extends Component {
   }
 
   get allSessionsExpanded() {
-    if (this.args.expandAllSessions) {
-      return true;
-    }
-
     return (
       this.sessionsWithOfferings.length &&
-      this.expandedSessionIds.length === this.sessionsWithOfferings.length
+      this.args.expandedSessionIds?.length === this.sessionsWithOfferings.length
     );
-  }
-
-  get allExpandedSessionIds() {
-    if (this.args.expandAllSessions) {
-      return this.sessionsWithOfferingsIds;
-    }
-
-    return this.expandedSessionIds;
   }
 
   get filterByDebounced() {
@@ -145,17 +132,12 @@ export default class CourseSessionsComponent extends Component {
 
   expandSession = task(async (session) => {
     await timeout(1);
-    this.expandedSessionIds = [...this.expandedSessionIds, session.id];
-
-    if (this.expandedSessionIds.length === this.sessionsWithOfferings.length) {
-      this.args.setExpandAllSessions(true);
-    }
+    this.args.setExpandedSessionIds([...this.args.expandedSessionIds, Number(session.id)]);
   });
 
   closeSession = task(async (session) => {
     await timeout(1);
-    this.expandedSessionIds = this.expandedSessionIds.filter((id) => id !== session.id);
-    this.args.setExpandAllSessions(false);
+    this.args.setExpandedSessionIds(this.args.expandedSessionIds.filter((id) => id !== session.id));
   });
 
   changeFilterBy = restartableTask(async (event) => {
@@ -167,12 +149,10 @@ export default class CourseSessionsComponent extends Component {
 
   @action
   toggleExpandAll() {
-    if (this.expandedSessionIds.length === this.sessionsWithOfferings.length) {
-      this.expandedSessionIds = [];
-      this.args.setExpandAllSessions(false);
+    if (this.args.expandedSessionIds?.length === this.sessionsWithOfferings.length) {
+      this.args.setExpandedSessionIds(null);
     } else {
-      this.expandedSessionIds = this.sessionsWithOfferingsIds;
-      this.args.setExpandAllSessions(true);
+      this.args.setExpandedSessionIds(this.sessionsWithOfferingsIds);
     }
   }
   <template>
@@ -253,7 +233,7 @@ export default class CourseSessionsComponent extends Component {
               @sessions={{this.sessions}}
               @sortBy={{@sortBy}}
               @filterBy={{@filterBy}}
-              @expandedSessionIds={{this.allExpandedSessionIds}}
+              @expandedSessionIds={{@expandedSessionIds}}
               @closeSession={{perform this.closeSession}}
               @expandSession={{perform this.expandSession}}
               @headerIsLocked={{this.tableHeadersLocked}}

--- a/packages/ilios-common/addon/controllers/course/index.js
+++ b/packages/ilios-common/addon/controllers/course/index.js
@@ -1,9 +1,10 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 export default class CourseIndexController extends Controller {
-  queryParams = ['sortSessionsBy', 'filterSessionsBy'];
+  queryParams = ['sortSessionsBy', 'filterSessionsBy', 'expandAllSessions'];
   @tracked sortSessionsBy = null;
   filterSessionsBy = '';
+  expandAllSessions = false;
   canCreateSession = false;
   canUpdateCourse = false;
 

--- a/packages/ilios-common/addon/controllers/course/index.js
+++ b/packages/ilios-common/addon/controllers/course/index.js
@@ -1,14 +1,29 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 export default class CourseIndexController extends Controller {
-  queryParams = ['sortSessionsBy', 'filterSessionsBy', 'expandAllSessions'];
-  @tracked sortSessionsBy = null;
+  queryParams = ['sortSessionsBy', 'filterSessionsBy', 'expandedSessions'];
+
   filterSessionsBy = '';
-  expandAllSessions = false;
   canCreateSession = false;
   canUpdateCourse = false;
+
+  @tracked sortSessionsBy = null;
+  @tracked expandedSessions = null;
 
   get sortBy() {
     return this.sortSessionsBy ?? 'title';
   }
+
+  get expandedSessionIds() {
+    return this.expandedSessions?.split('-') ?? [];
+  }
+
+  setExpandedSessionIds = (ids) => {
+    if (!ids || !ids.length) {
+      this.expandedSessions = null;
+    } else {
+      //use a Set to remove duplicates
+      this.expandedSessions = [...new Set(ids)].join('-');
+    }
+  };
 }

--- a/packages/ilios-common/addon/routes/course/index.js
+++ b/packages/ilios-common/addon/routes/course/index.js
@@ -36,7 +36,7 @@ export default class CourseIndexRoute extends Route {
     filterSessionsBy: {
       replace: true,
     },
-    expandAllSessions: {
+    expandedSessions: {
       replace: true,
     },
   };

--- a/packages/ilios-common/addon/routes/course/index.js
+++ b/packages/ilios-common/addon/routes/course/index.js
@@ -36,6 +36,9 @@ export default class CourseIndexRoute extends Route {
     filterSessionsBy: {
       replace: true,
     },
+    expandAllSessions: {
+      replace: true,
+    },
   };
 
   @action

--- a/packages/ilios-common/addon/templates/course/index.gjs
+++ b/packages/ilios-common/addon/templates/course/index.gjs
@@ -9,7 +9,7 @@ import set from 'ember-set-helper/helpers/set';
     @setSortBy={{set @controller "sortSessionsBy"}}
     @filterBy={{@controller.filterSessionsBy}}
     @setFilterBy={{set @controller "filterSessionsBy"}}
-    @expandAllSessions={{@controller.expandAllSessions}}
-    @setExpandAllSessions={{set @controller "expandAllSessions"}}
+    @expandedSessionIds={{@controller.expandedSessionIds}}
+    @setExpandedSessionIds={{@controller.setExpandedSessionIds}}
   />
 </template>

--- a/packages/ilios-common/addon/templates/course/index.gjs
+++ b/packages/ilios-common/addon/templates/course/index.gjs
@@ -9,5 +9,7 @@ import set from 'ember-set-helper/helpers/set';
     @setSortBy={{set @controller "sortSessionsBy"}}
     @filterBy={{@controller.filterSessionsBy}}
     @setFilterBy={{set @controller "filterSessionsBy"}}
+    @expandAllSessions={{@controller.expandAllSessions}}
+    @setExpandAllSessions={{set @controller "expandAllSessions"}}
   />
 </template>

--- a/packages/test-app/tests/integration/components/course/sessions-test.gjs
+++ b/packages/test-app/tests/integration/components/course/sessions-test.gjs
@@ -93,4 +93,33 @@ module('Integration | Component | course/sessions', function (hooks) {
     assert.strictEqual(component.header.title, 'Sessions (2)');
     assert.ok(component.sessionsGridHeader.expandCollapse.toggle.isVisible);
   });
+
+  test('expandAllSessions argument causes all sessions with offerings to be expanded on load', async function (assert) {
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
+    const sessionType = this.server.create('session-type', { school });
+    const sessions = this.server.createList('session', 2, { course, sessionType });
+    this.server.create('offering', {
+      session: sessions[0],
+    });
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+    this.set('course', courseModel);
+    await render(
+      <template>
+        <Sessions
+          @course={{this.course}}
+          @sortBy="title"
+          @setSortBy={{(noop)}}
+          @filterBy={{null}}
+          @setFilterBy={{(noop)}}
+          @expandAllSessions={{true}}
+          @setExpandAllSessions={{(noop)}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(component.header.title, 'Sessions (2)');
+    assert.ok(component.sessionsGridHeader.expandCollapse.toggle.isVisible);
+    assert.ok(component.sessionsGridHeader.expandCollapse.allAreExpanded);
+  });
 });

--- a/packages/test-app/tests/integration/components/course/sessions-test.gjs
+++ b/packages/test-app/tests/integration/components/course/sessions-test.gjs
@@ -86,24 +86,36 @@ module('Integration | Component | course/sessions', function (hooks) {
           @setSortBy={{(noop)}}
           @filterBy={{null}}
           @setFilterBy={{(noop)}}
+          @expandedSessionIds={{null}}
+          @setExpandedSessionIds={{(noop)}}
         />
       </template>,
     );
 
-    assert.strictEqual(component.header.title, 'Sessions (2)');
-    assert.ok(component.sessionsGridHeader.expandCollapse.toggle.isVisible);
+    assert.strictEqual(component.header.title, 'Sessions (2)', 'header title is correct');
+    assert.ok(
+      component.sessionsGridHeader.expandCollapse.toggle.isVisible,
+      'expand all toggle is visible',
+    );
   });
 
-  test('expandAllSessions argument causes all sessions with offerings to be expanded on load', async function (assert) {
+  test('expand and collapse', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
     const sessionType = this.server.create('session-type', { school });
-    const sessions = this.server.createList('session', 2, { course, sessionType });
+    const sessions = this.server.createList('session', 3, { course, sessionType });
     this.server.create('offering', {
       session: sessions[0],
     });
+    this.server.create('offering', {
+      session: sessions[1],
+    });
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
+    this.set('expandedSessionIds', null);
+    this.set('setExpandedSessionIds', function (sessionIds) {
+      assert.deepEqual(sessionIds, [sessions[0].id, sessions[1].id]);
+    });
     await render(
       <template>
         <Sessions
@@ -112,14 +124,57 @@ module('Integration | Component | course/sessions', function (hooks) {
           @setSortBy={{(noop)}}
           @filterBy={{null}}
           @setFilterBy={{(noop)}}
-          @expandAllSessions={{true}}
-          @setExpandAllSessions={{(noop)}}
+          @expandedSessionIds={{this.expandedSessionIds}}
+          {{!-- @setExpandedSessionIds={{this.setExpandedSessionIds}} --}}
+          @setExpandedSessionIds={{(noop)}}
         />
       </template>,
     );
 
-    assert.strictEqual(component.header.title, 'Sessions (2)');
-    assert.ok(component.sessionsGridHeader.expandCollapse.toggle.isVisible);
-    assert.ok(component.sessionsGridHeader.expandCollapse.allAreExpanded);
+    assert.strictEqual(component.header.title, 'Sessions (3)', 'header title is correct');
+    assert.ok(
+      component.sessionsGridHeader.expandCollapse.toggle.isVisible,
+      'expand all toggle is visible',
+    );
+    assert.notOk(
+      component.sessionsGridHeader.expandCollapse.allAreExpanded,
+      'all sessions are not expanded',
+    );
+
+    assert.strictEqual(
+      component.sessionsGrid.sessions[0].row.title,
+      'session 0',
+      'first session title should be correct',
+    );
+    assert.strictEqual(
+      component.sessionsGrid.sessions[1].row.title,
+      'session 1',
+      'second session title should be correct',
+    );
+    assert.strictEqual(
+      component.sessionsGrid.sessions[2].row.title,
+      'session 2',
+      'third session title should be correct',
+    );
+    assert.notOk(
+      component.sessionsGrid.sessions[0].row.isExpanded,
+      'first session row is not expanded',
+    );
+    assert.notOk(
+      component.sessionsGrid.sessions[1].row.isExpanded,
+      'second session row is not expanded',
+    );
+    assert.notOk(
+      component.sessionsGrid.sessions[2].row.isExpanded,
+      'third session row is not expanded',
+    );
+
+    await component.sessionsGridHeader.expandCollapse.toggle.click();
+    assert.ok(component.sessionsGrid.sessions[0].row.isExpanded, 'first session row is expanded');
+    assert.ok(component.sessionsGrid.sessions[1].row.isExpanded, 'second session row is expanded');
+    assert.notOk(
+      component.sessionsGrid.sessions[2].row.isExpanded,
+      'third session row is not expanded',
+    );
   });
 });

--- a/packages/test-app/tests/integration/components/course/sessions-test.gjs
+++ b/packages/test-app/tests/integration/components/course/sessions-test.gjs
@@ -99,7 +99,7 @@ module('Integration | Component | course/sessions', function (hooks) {
     );
   });
 
-  test('expand and collapse', async function (assert) {
+  test('previously expanded sessions are re-expanded', async function (assert) {
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
     const sessionType = this.server.create('session-type', { school });
@@ -112,10 +112,7 @@ module('Integration | Component | course/sessions', function (hooks) {
     });
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
-    this.set('expandedSessionIds', null);
-    this.set('setExpandedSessionIds', function (sessionIds) {
-      assert.deepEqual(sessionIds, [sessions[0].id, sessions[1].id]);
-    });
+    this.set('expandedSessionIds', ['1', '2']);
     await render(
       <template>
         <Sessions
@@ -125,51 +122,12 @@ module('Integration | Component | course/sessions', function (hooks) {
           @filterBy={{null}}
           @setFilterBy={{(noop)}}
           @expandedSessionIds={{this.expandedSessionIds}}
-          {{!-- @setExpandedSessionIds={{this.setExpandedSessionIds}} --}}
-          @setExpandedSessionIds={{(noop)}}
         />
       </template>,
     );
 
     assert.strictEqual(component.header.title, 'Sessions (3)', 'header title is correct');
-    assert.ok(
-      component.sessionsGridHeader.expandCollapse.toggle.isVisible,
-      'expand all toggle is visible',
-    );
-    assert.notOk(
-      component.sessionsGridHeader.expandCollapse.allAreExpanded,
-      'all sessions are not expanded',
-    );
 
-    assert.strictEqual(
-      component.sessionsGrid.sessions[0].row.title,
-      'session 0',
-      'first session title should be correct',
-    );
-    assert.strictEqual(
-      component.sessionsGrid.sessions[1].row.title,
-      'session 1',
-      'second session title should be correct',
-    );
-    assert.strictEqual(
-      component.sessionsGrid.sessions[2].row.title,
-      'session 2',
-      'third session title should be correct',
-    );
-    assert.notOk(
-      component.sessionsGrid.sessions[0].row.isExpanded,
-      'first session row is not expanded',
-    );
-    assert.notOk(
-      component.sessionsGrid.sessions[1].row.isExpanded,
-      'second session row is not expanded',
-    );
-    assert.notOk(
-      component.sessionsGrid.sessions[2].row.isExpanded,
-      'third session row is not expanded',
-    );
-
-    await component.sessionsGridHeader.expandCollapse.toggle.click();
     assert.ok(component.sessionsGrid.sessions[0].row.isExpanded, 'first session row is expanded');
     assert.ok(component.sessionsGrid.sessions[1].row.isExpanded, 'second session row is expanded');
     assert.notOk(


### PR DESCRIPTION
Fixes ilios/ilios#4304

Session expansion status is now tracked at the controller/router level (much like Curriculum Reports), so that a refresh or router forward and then back should maintain the status.