### PR TITLE
pin SASS dependency to version 1.91.0

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -121,7 +121,7 @@
     "query-string": "^9.1.0",
     "qunit": "^2.24.1",
     "qunit-dom": "^3.4.0",
-    "sass": "^1.89.2",
+    "sass": "^1.91.0",
     "striptags": "^3.2.0",
     "stylelint": "^16.20.0",
     "stylelint-config-recommended-scss": "^15.0.0",

--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -132,7 +132,7 @@
     "loader.js": "^4.7.0",
     "prettier": "^3.5.3",
     "prettier-plugin-ember-template-tag": "^2.0.6",
-    "sass": "^1.89.2",
+    "sass": "^1.91.0",
     "stylelint": "^16.20.0",
     "stylelint-config-recommended-scss": "^15.0.0",
     "stylelint-config-standard": "^36.0.1",

--- a/packages/lti-course-manager/package.json
+++ b/packages/lti-course-manager/package.json
@@ -91,7 +91,7 @@
     "prettier-plugin-ember-template-tag": "^2.0.6",
     "qunit": "^2.24.1",
     "qunit-dom": "^3.4.0",
-    "sass": "^1.89.2",
+    "sass": "^1.91.0",
     "stylelint": "^16.20.0",
     "stylelint-config-recommended-scss": "^15.0.0",
     "stylelint-config-standard": "^36.0.1",

--- a/packages/lti-dashboard/package.json
+++ b/packages/lti-dashboard/package.json
@@ -91,7 +91,7 @@
     "prettier-plugin-ember-template-tag": "^2.0.6",
     "qunit": "^2.24.1",
     "qunit-dom": "^3.4.0",
-    "sass": "^1.89.2",
+    "sass": "^1.91.0",
     "stylelint": "^16.20.0",
     "stylelint-config-recommended-scss": "^15.0.0",
     "stylelint-config-standard": "^36.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,7 +301,7 @@ importers:
         specifier: ^3.4.0
         version: 3.5.0
       sass:
-        specifier: ^1.89.2
+        specifier: ^1.91.0
         version: 1.91.0
       striptags:
         specifier: ^3.2.0
@@ -611,7 +611,7 @@ importers:
         specifier: ^2.0.6
         version: 2.1.0(prettier@3.6.2)
       sass:
-        specifier: ^1.89.2
+        specifier: ^1.91.0
         version: 1.91.0
       stylelint:
         specifier: ^16.20.0
@@ -839,7 +839,7 @@ importers:
         specifier: ^3.4.0
         version: 3.5.0
       sass:
-        specifier: ^1.89.2
+        specifier: ^1.91.0
         version: 1.91.0
       stylelint:
         specifier: ^16.20.0
@@ -1067,7 +1067,7 @@ importers:
         specifier: ^3.4.0
         version: 3.5.0
       sass:
-        specifier: ^1.89.2
+        specifier: ^1.91.0
         version: 1.91.0
       stylelint:
         specifier: ^16.20.0


### PR DESCRIPTION
this is the version we're already using. pinning it here, since the next version - 1.92.0 - contains a breaking change that we're not prepared to handle, yet.

see https://github.com/sass/dart-sass/blob/main/CHANGELOG.md#1920 for reference.

refs https://github.com/ilios/frontend/pull/8059
refs https://github.com/ilios/frontend/pull/8793