### PR TITLE
Hide Unmatched Sessions in Search

### DIFF
--- a/packages/frontend/app/components/course-search-result.gjs
+++ b/packages/frontend/app/components/course-search-result.gjs
@@ -12,9 +12,13 @@ import FaIcon from 'ilios-common/components/fa-icon';
 export default class CourseSearchResultComponent extends Component {
   @tracked showMore = false;
 
-  get sessions() {
+  get filteredSessions() {
     const { sessions } = this.args.course;
-    return this.showMore ? sessions : sessions.slice(0, 3);
+    return sessions.filter((s) => s.matchedIn.length);
+  }
+
+  get sessions() {
+    return this.showMore ? this.filteredSessions : this.filteredSessions.slice(0, 3);
   }
   <template>
     <li class="course-search-result" data-test-course-search-result ...attributes>
@@ -29,48 +33,50 @@ export default class CourseSearchResultComponent extends Component {
         {{t "general.course"}}
       </span>
       <GlobalSearchTags @tags={{@course.matchedIn}} />
-      <ul>
-        <li class="sessions">
-          {{t "general.sessions"}}:
-        </li>
-        {{#each this.sessions as |session|}}
-          <li class="session-row">
-            <LinkTo
-              @route="session"
-              @models={{array @course.id session.id}}
-              class="session-title-link"
-            >
-              {{session.title}}
-            </LinkTo>
-            <GlobalSearchTags @tags={{session.matchedIn}} />
+      {{#if this.sessions}}
+        <ul>
+          <li class="sessions">
+            {{t "general.sessions"}}:
           </li>
-        {{/each}}
-        {{#if (gt @course.sessions.length 3)}}
-          {{#if this.showMore}}
-            <li>
-              <button
-                class="show-less link-button"
-                type="button"
-                {{on "click" (set this "showMore" false)}}
+          {{#each this.sessions as |session|}}
+            <li class="session-row">
+              <LinkTo
+                @route="session"
+                @models={{array @course.id session.id}}
+                class="session-title-link"
               >
-                <FaIcon @icon="angle-up" />
-                {{t "general.showLess"}}
-              </button>
+                {{session.title}}
+              </LinkTo>
+              <GlobalSearchTags @tags={{session.matchedIn}} />
             </li>
-          {{else}}
-            <li>
-              <button
-                class="show-more link-button"
-                type="button"
-                {{on "click" (set this "showMore" true)}}
-              >
-                <FaIcon @icon="angle-down" />
-                {{t "general.showMore"}}
-              </button>
-            </li>
+          {{/each}}
+          {{#if (gt @course.sessions.length 3)}}
+            {{#if this.showMore}}
+              <li>
+                <button
+                  class="show-less link-button"
+                  type="button"
+                  {{on "click" (set this "showMore" false)}}
+                >
+                  <FaIcon @icon="angle-up" />
+                  {{t "general.showLess"}}
+                </button>
+              </li>
+            {{else}}
+              <li>
+                <button
+                  class="show-more link-button"
+                  type="button"
+                  {{on "click" (set this "showMore" true)}}
+                >
+                  <FaIcon @icon="angle-down" />
+                  {{t "general.showMore"}}
+                </button>
+              </li>
+            {{/if}}
           {{/if}}
-        {{/if}}
-      </ul>
+        </ul>
+      {{/if}}
     </li>
   </template>
 }

--- a/packages/frontend/app/components/course-search-result.gjs
+++ b/packages/frontend/app/components/course-search-result.gjs
@@ -50,7 +50,7 @@ export default class CourseSearchResultComponent extends Component {
               <GlobalSearchTags @tags={{session.matchedIn}} />
             </li>
           {{/each}}
-          {{#if (gt @course.sessions.length 3)}}
+          {{#if (gt this.filteredSessions.length 3)}}
             {{#if this.showMore}}
               <li>
                 <button

--- a/packages/frontend/tests/integration/components/course-search-result-test.gjs
+++ b/packages/frontend/tests/integration/components/course-search-result-test.gjs
@@ -66,4 +66,48 @@ module('Integration | Component | course-search-result', function (hooks) {
     assert.ok(component.showMoreIsVisible);
     assert.strictEqual(component.sessions.length, 3);
   });
+
+  test('no show more link when sessions are filtered out', async function (assert) {
+    assert.expect(8);
+
+    const course = {
+      id: 1,
+      title: 'Course 1',
+      school: 'Medicine',
+      year: '1980',
+      sessions: [
+        {
+          id: 1,
+          title: 'Session 1',
+          matchedIn: ['title'],
+        },
+        {
+          id: 2,
+          title: 'Session 2',
+          matchedIn: ['title'],
+        },
+        {
+          id: 3,
+          title: 'Session 3',
+          matchedIn: [],
+        },
+        {
+          id: 4,
+          title: 'Session 4',
+          matchedIn: ['title'],
+        },
+      ],
+    };
+    this.set('course', course);
+    await render(<template><CourseSearchResult @course={{this.course}} /></template>);
+    assert.strictEqual(component.courseTitle, '1980 Course 1');
+    assert.strictEqual(component.schoolTitle, 'Medicine');
+    assert.strictEqual(component.sessions[0].text, 'Session 1');
+    assert.strictEqual(component.sessions[1].text, 'Session 2');
+    assert.strictEqual(component.sessions[2].text, 'Session 4');
+    assert.strictEqual(component.sessions.length, 3);
+
+    assert.notOk(component.showLessIsVisible);
+    assert.notOk(component.showMoreIsVisible);
+  });
 });

--- a/packages/frontend/tests/integration/components/course-search-result-test.gjs
+++ b/packages/frontend/tests/integration/components/course-search-result-test.gjs
@@ -19,18 +19,27 @@ module('Integration | Component | course-search-result', function (hooks) {
         {
           id: 1,
           title: 'Session 1',
+          matchedIn: ['title'],
         },
         {
           id: 2,
           title: 'Session 2',
+          matchedIn: ['title'],
         },
         {
           id: 3,
           title: 'Session 3',
+          matchedIn: [],
         },
         {
           id: 4,
           title: 'Session 4',
+          matchedIn: ['title'],
+        },
+        {
+          id: 4,
+          title: 'Session 5',
+          matchedIn: ['title'],
         },
       ],
     };
@@ -40,7 +49,7 @@ module('Integration | Component | course-search-result', function (hooks) {
     assert.strictEqual(component.schoolTitle, 'Medicine');
     assert.strictEqual(component.sessions[0].text, 'Session 1');
     assert.strictEqual(component.sessions[1].text, 'Session 2');
-    assert.strictEqual(component.sessions[2].text, 'Session 3');
+    assert.strictEqual(component.sessions[2].text, 'Session 4');
     assert.strictEqual(component.sessions.length, 3);
 
     assert.notOk(component.showLessIsVisible);
@@ -49,7 +58,7 @@ module('Integration | Component | course-search-result', function (hooks) {
 
     assert.ok(component.showLessIsVisible);
     assert.notOk(component.showMoreIsVisible);
-    assert.strictEqual(component.sessions[3].text, 'Session 4');
+    assert.strictEqual(component.sessions[3].text, 'Session 5');
     assert.strictEqual(component.sessions.length, 4);
 
     await component.showLess();


### PR DESCRIPTION
When we only have a course match, but the session is small enough that just the course data match scores it -  displaying it is confusing for users as the badge is missing and the data isn't part of the session. Instead we can check for matchedIn and know if there was any data in the session that matched the search terms and filter out any sessions with only course data matching.

Fixes ilios/ilios#6458