### PR TITLE
Improve Session Copy Data Loading

### DIFF
--- a/packages/frontend/app/components/global-search.gjs
+++ b/packages/frontend/app/components/global-search.gjs
@@ -24,6 +24,7 @@ export default class GlobalSearchComponent extends Component {
   @service intl;
   @service('search') iliosSearch;
   @service store;
+  @service dataLoader;
 
   @cached
   get resultsData() {
@@ -47,7 +48,7 @@ export default class GlobalSearchComponent extends Component {
 
   @cached
   get academicYearData() {
-    return new TrackedAsyncData(this.store.findAll('academic-year'));
+    return new TrackedAsyncData(this.dataLoader.loadAcademicYears());
   }
 
   crossesBoundaryConfig = new TrackedAsyncData(

--- a/packages/frontend/app/routes/courses.js
+++ b/packages/frontend/app/routes/courses.js
@@ -24,7 +24,7 @@ export default class CoursesRoute extends Route {
     return hash({
       schools: this.store.findAll('school'),
       primarySchool: this.dataLoader.loadSchoolForCourses(user.belongsTo('school').id()),
-      years: this.store.findAll('academic-year'),
+      years: this.dataLoader.loadAcademicYears(),
     });
   }
 }

--- a/packages/frontend/app/routes/dashboard.js
+++ b/packages/frontend/app/routes/dashboard.js
@@ -6,6 +6,7 @@ export default class DashboardRoute extends Route {
   @service store;
   @service currentUser;
   @service session;
+  @service dataLoader;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, 'login');
@@ -14,7 +15,7 @@ export default class DashboardRoute extends Route {
   async model() {
     return hash({
       schools: this.store.findAll('school'),
-      academicYears: this.store.findAll('academic-year'),
+      academicYears: this.dataLoader.loadAcademicYears(),
     });
   }
 }

--- a/packages/ilios-common/addon/routes/session/copy.js
+++ b/packages/ilios-common/addon/routes/session/copy.js
@@ -6,11 +6,22 @@ export default class SessionCopyRoute extends Route {
   @service session;
   @service currentUser;
   @service router;
+  @service dataLoader;
+  @service store;
 
   canUpdate = false;
 
   async afterModel(session) {
-    this.canUpdate = await this.permissionChecker.canUpdateSession(session);
+    const course = await session.course;
+    const school = await course.school;
+    //preload to improve component performance
+    const [canUpdate] = await Promise.all([
+      this.permissionChecker.canUpdateSession(session),
+      this.dataLoader.loadAcademicYears(),
+      this.dataLoader.loadSchoolForCourses(school.id),
+    ]);
+
+    this.canUpdate = canUpdate;
   }
 
   beforeModel(transition) {

--- a/packages/ilios-common/addon/services/data-loader.js
+++ b/packages/ilios-common/addon/services/data-loader.js
@@ -8,6 +8,7 @@ export default class DataLoaderService extends Service {
   #learnerGroupCohorts = {};
   #courses = {};
   #courseSessions = {};
+  #academicYears = null;
 
   async loadSchoolForCalendar(id) {
     if (!(id in this.#calendarSchools)) {
@@ -124,5 +125,11 @@ export default class DataLoaderService extends Service {
       });
     }
     return this.#courseSessions[id];
+  }
+  async loadAcademicYears() {
+    if (!this.#academicYears) {
+      this.#academicYears = this.store.findAll('academic-year');
+    }
+    return this.#academicYears;
   }
 }

--- a/packages/test-app/tests/integration/components/session-copy-test.gjs
+++ b/packages/test-app/tests/integration/components/session-copy-test.gjs
@@ -11,6 +11,10 @@ module('Integration | Component | session copy', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
+  hooks.beforeEach(async function () {
+    this.store = this.owner.lookup('service:store');
+  });
+
   test('it renders', async function (assert) {
     const now = DateTime.fromObject({ hour: 8 });
     const thisYear = now.year;
@@ -47,7 +51,7 @@ module('Integration | Component | session copy', function (hooks) {
     }
     this.owner.register('service:permissionChecker', PermissionCheckerMock);
 
-    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+    const sessionModel = await this.store.findRecord('session', session.id);
     this.set('session', sessionModel);
 
     await render(<template><SessionCopy @session={{this.session}} /></template>);
@@ -125,7 +129,7 @@ module('Integration | Component | session copy', function (hooks) {
       }
     }
     this.owner.register('service:permissionChecker', PermissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+    const sessionModel = await this.store.findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 2);
@@ -136,7 +140,7 @@ module('Integration | Component | session copy', function (hooks) {
 
     await click('.done');
 
-    const sessions = await this.owner.lookup('service:store').findAll('session');
+    const sessions = await this.store.findAll('session');
     assert.strictEqual(sessions.length, 2);
     const newSession = findById(sessions, '2');
     assert.strictEqual(session.attireRequired, newSession.attireRequired);
@@ -159,7 +163,7 @@ module('Integration | Component | session copy', function (hooks) {
     assert.strictEqual(newSessionLm.belongsTo('session').id(), newSession.id);
     assert.strictEqual(newSessionLm.belongsTo('learningMaterial').id(), learningMaterial.id);
 
-    const sessionObjectives = await this.owner.lookup('service:store').findAll('session-objective');
+    const sessionObjectives = await this.store.findAll('session-objective');
     assert.strictEqual(sessionObjectives.length, 2);
     const newSessionObjective = findById(sessionObjectives, '2');
     assert.strictEqual(newSessionObjective.title, sessionObjective.title);
@@ -195,7 +199,7 @@ module('Integration | Component | session copy', function (hooks) {
       }
     }
     this.owner.register('service:permissionChecker', PermissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+    const sessionModel = await this.store.findRecord('session', session.id);
     this.set('session', sessionModel);
 
     await render(<template><SessionCopy @session={{this.session}} /></template>);
@@ -239,7 +243,7 @@ module('Integration | Component | session copy', function (hooks) {
       }
     }
     this.owner.register('service:permissionChecker', PermissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+    const sessionModel = await this.store.findRecord('session', session.id);
     this.set('session', sessionModel);
     await render(<template><SessionCopy @session={{this.session}} /></template>);
     const yearSelect = '.year-select select';
@@ -297,7 +301,7 @@ module('Integration | Component | session copy', function (hooks) {
       }
     }
     this.owner.register('service:permissionChecker', PermissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+    const sessionModel = await this.store.findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 2);
@@ -313,7 +317,7 @@ module('Integration | Component | session copy', function (hooks) {
     assert.dom(courseSelect).hasValue(course3.id, 'first course is selected');
     await click('.done');
 
-    const sessions = await this.owner.lookup('service:store').findAll('session');
+    const sessions = await this.store.findAll('session');
     assert.strictEqual(sessions.length, 2);
     const newSession = findById(sessions, '2');
     assert.strictEqual(newSession.belongsTo('course').id(), course3.id);
@@ -352,7 +356,7 @@ module('Integration | Component | session copy', function (hooks) {
       }
     }
     this.owner.register('service:permissionChecker', PermissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+    const sessionModel = await this.store.findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 3);
@@ -364,7 +368,7 @@ module('Integration | Component | session copy', function (hooks) {
 
     await click('.done');
 
-    const sessions = await this.owner.lookup('service:store').findAll('session');
+    const sessions = await this.store.findAll('session');
     assert.strictEqual(sessions.length, 3);
     const newSession = findById(sessions, '3');
     assert.strictEqual(session.title, newSession.title);
@@ -410,7 +414,7 @@ module('Integration | Component | session copy', function (hooks) {
       }
     }
     this.owner.register('service:permissionChecker', PermissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+    const sessionModel = await this.store.findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 3);
@@ -423,7 +427,7 @@ module('Integration | Component | session copy', function (hooks) {
     await fillIn(courseSelect, secondCourse.id);
     await click('.done');
 
-    const sessions = await this.owner.lookup('service:store').findAll('session');
+    const sessions = await this.store.findAll('session');
     assert.strictEqual(sessions.length, 3);
     const newSession = findById(sessions, '3');
     assert.strictEqual(session.title, newSession.title);
@@ -469,7 +473,7 @@ module('Integration | Component | session copy', function (hooks) {
       }
     }
     this.owner.register('service:permissionChecker', PermissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+    const sessionModel = await this.store.findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 4);
@@ -481,7 +485,7 @@ module('Integration | Component | session copy', function (hooks) {
 
     await click('.done');
 
-    const sessions = await this.owner.lookup('service:store').findAll('session');
+    const sessions = await this.store.findAll('session');
     assert.strictEqual(sessions.length, 4);
     const newSession = findById(sessions, '4');
     assert.strictEqual(session.title, newSession.title);
@@ -531,7 +535,7 @@ module('Integration | Component | session copy', function (hooks) {
       }
     }
     this.owner.register('service:permissionChecker', PermissionCheckerMock);
-    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+    const sessionModel = await this.store.findRecord('session', session.id);
     this.set('session', sessionModel);
     this.set('visit', (newSession) => {
       assert.strictEqual(parseInt(newSession.id, 10), 4);
@@ -545,7 +549,7 @@ module('Integration | Component | session copy', function (hooks) {
     await fillIn(courseSelect, secondCourse.id);
     await click('.done');
 
-    const sessions = await this.owner.lookup('service:store').findAll('session');
+    const sessions = await this.store.findAll('session');
     assert.strictEqual(sessions.length, 4);
     const newSession = findById(sessions, '4');
     assert.strictEqual(session.title, newSession.title);


### PR DESCRIPTION
Not only were we getting some a11y issues from an empty year list in some places, but we were re-loading a lot of data that is already in the store when navigating here from the courses page.

I've optimized the loading of academic years and applied our existing data loaders to getting all the courses in a school loaded. This speeds up loading a lot on this page and improves the a11y as well.

Fixes ilios/ilios#6505