### PR TITLE
adds background color to list items on active/hover state

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -48,10 +48,6 @@
           text-align: left;
         }
 
-        &:hover {
-          background: var(--lightest-grey);
-        }
-
         &:last-of-type {
           border-bottom: none;
           min-height: auto;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -106,6 +106,11 @@
     color: var(--blue);
     cursor: pointer;
 
+    &.active,
+    &:hover {
+      background-color: var(--lightest-grey);
+    }
+
     &.static {
       color: var(--black);
       cursor: default;


### PR DESCRIPTION
fixes ilios/ilios#6481

this expands the requested scope beyond mesh search results by applying this to all lists that use this style mixin.

mesh search (anywhere)

<img width="1484" height="369" alt="image" src="https://github.com/user-attachments/assets/bbe2118c-7024-4ac4-9771-f8b7f400a42e" />

school management - vocabulary/term manager

<img width="1374" height="418" alt="image" src="https://github.com/user-attachments/assets/34d1decb-f423-47d7-af68-f4a92ad00324" />


course management - cohort manager
<img width="1522" height="314" alt="image" src="https://github.com/user-attachments/assets/3a454514-ff4b-46fe-9313-3bf70864ee8b" />


