### PR TITLE
Make Snapshot Name Unique

### DIFF
--- a/packages/frontend/tests/acceptance/course/objectiveparents-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-test.js
@@ -106,10 +106,9 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
       page.details.objectives.objectiveList.objectives[0].parents.list[0].text,
       'program-year objective 0',
     );
-
-    await percySnapshot(getUniqueName(assert, 'default background color'));
+    await percySnapshot(getUniqueName(assert, 'objective list'));
     await page.details.objectives.objectiveList.objectives[0].parents.manage();
-    await percySnapshot(getUniqueName(assert, 'default background color'));
+    await percySnapshot(getUniqueName(assert, 'objective manager'));
 
     const m = page.details.objectives.objectiveList.objectives[0].parentManager;
 


### PR DESCRIPTION
These were identical which could cause a mismatch failure. First identified in #8671