### PR TITLE
adds some spacing between lock icon and course title.

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/mixins/course/header.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/course/header.scss
@@ -23,6 +23,10 @@
   h2 {
     @include ilios-heading.ilios-heading-h4;
     @include font-size.text-align-bottom;
+
+    .fa-lock {
+      margin-right: 0.5rem;
+    }
   }
 
   .academic-year {


### PR DESCRIPTION
<img width="915" height="173" alt="image" src="https://github.com/user-attachments/assets/2c909b9c-8901-4b57-835c-d7fac4ad556d" />


fixes ilios/ilios#6524