### PR TITLE
Subject Reports for all schools now show school name in session type object dropdown

### DIFF
--- a/packages/frontend/app/components/reports/subject/new/session-type.gjs
+++ b/packages/frontend/app/components/reports/subject/new/session-type.gjs
@@ -31,6 +31,16 @@ export default class ReportsSubjectNewSessionTypeComponent extends Component {
   }
 
   get sortedSessionTypes() {
+    if (!this.args.school) {
+      return sortBy(
+        this.filteredSessionTypes.map((s) => ({
+          ...s,
+          title: `${s.school.get('title')}: ${s.title}`,
+        })),
+        'title',
+      );
+    }
+
     return sortBy(this.filteredSessionTypes, 'title');
   }
 


### PR DESCRIPTION
Fixes ilios/ilios#6527

<img width="815" height="939" alt="Screenshot 2025-09-24 at 4 51 39 PM" src="https://github.com/user-attachments/assets/be97f398-3874-48d6-bedc-1ff2c5888695" />
