### PR TITLE
Fix up print preview

### DIFF
--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -385,10 +385,6 @@ export default class PrintCourseSessionComponent extends Component {
               </tbody>
             </table>
           </div>
-        {{else}}
-          <p>
-            {{t "general.noOfferings"}}
-          </p>
         {{/if}}
       </section>
     </div>

--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -8,6 +8,8 @@ import removeHtmlTags from 'ilios-common/helpers/remove-html-tags';
 import DetailTermsList from 'ilios-common/components/detail-terms-list';
 import sortBy from 'ilios-common/helpers/sort-by';
 import formatDate from 'ember-intl/helpers/format-date';
+import notEq from 'ember-truth-helpers/helpers/not-eq';
+import sub_ from 'ember-math-helpers/helpers/sub';
 import { guidFor } from '@ember/object/internals';
 
 export default class PrintCourseSessionComponent extends Component {
@@ -36,6 +38,11 @@ export default class PrintCourseSessionComponent extends Component {
     return new TrackedAsyncData(this.args.session.terms);
   }
 
+  @cached
+  get prerequisitesData() {
+    return new TrackedAsyncData(this.args.session.prerequisites);
+  }
+
   get sessionObjectives() {
     return this.sessionObjectivesData.isResolved ? this.sessionObjectivesData.value : [];
   }
@@ -55,6 +62,11 @@ export default class PrintCourseSessionComponent extends Component {
   get terms() {
     return this.termsData.isResolved ? this.termsData.value : [];
   }
+
+  get prerequisites() {
+    return this.prerequisitesData.isResolved ? this.prerequisitesData.value : null;
+  }
+
   get uniqueId() {
     return guidFor(this);
   }
@@ -128,6 +140,19 @@ export default class PrintCourseSessionComponent extends Component {
                 id="attendance-{{this.uniqueId}}"
                 type="checkbox"
                 checked={{@session.attendanceRequired}}
+                disabled="disabled"
+              />
+            </div>
+          </div>
+          <div class="inline-label-data-block">
+            <label for="attendance-{{this.uniqueId}}">
+              {{t "general.independentLearning"}}:
+            </label>
+            <div>
+              <input
+                id="independent-learning-{{this.uniqueId}}"
+                type="checkbox"
+                checked={{@session.isIndependentLearning}}
                 disabled="disabled"
               />
             </div>
@@ -279,6 +304,17 @@ export default class PrintCourseSessionComponent extends Component {
                 </tr>
               </tbody>
             </table>
+            {{#if @session.hasPrerequisites}}
+              <div class="inline-label-data-block">
+                <label>{{t "general.prerequisites"}}:</label>
+                <span>
+                  {{#each this.prerequisites as |prerequisite index|~}}
+                    {{prerequisite.title}}{{#if (notEq index (sub_ this.prerequisites.length 1))}},
+                    {{/if}}
+                  {{~/each}}
+                </span>
+              </div>
+            {{/if}}
           </div>
         </section>
       {{/if}}

--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -157,7 +157,57 @@ export default class PrintCourseSessionComponent extends Component {
               />
             </div>
           </div>
-          <br />
+        </div>
+      </section>
+      {{#if @session.isIndependentLearning}}
+        <section class="block" data-test-session-ilm-section>
+          <div class="title">
+            {{t "general.independentLearning"}}
+          </div>
+          <div class="content">
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    {{t "general.hours"}}
+                  </th>
+                  <th>
+                    {{t "general.dueBy"}}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    {{@session.ilmSession.hours}}
+                  </td>
+                  <td>
+                    {{formatDate
+                      @session.ilmSession.dueDate
+                      month="2-digit"
+                      day="2-digit"
+                      year="numeric"
+                    }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            {{#if @session.hasPrerequisites}}
+              <div class="inline-label-data-block">
+                <label>{{t "general.prerequisites"}}:</label>
+                <span>
+                  {{#each this.prerequisites as |prerequisite index|~}}
+                    {{prerequisite.title}}{{#if (notEq index (sub_ this.prerequisites.length 1))}},
+                    {{/if}}
+                  {{~/each}}
+                </span>
+              </div>
+            {{/if}}
+          </div>
+        </section>
+      {{/if}}
+      <section class="block" data-test-session-description>
+        <div class="content">
           <div class="inline-label-data-block">
             <label>
               {{t "general.description"}}:
@@ -271,53 +321,6 @@ export default class PrintCourseSessionComponent extends Component {
           </div>
         {{/if}}
       </section>
-      {{#if @session.isIndependentLearning}}
-        <section class="block" data-test-session-ilm-section>
-          <div class="title">
-            {{t "general.independentLearning"}}
-          </div>
-          <div class="content">
-            <table>
-              <thead>
-                <tr>
-                  <th>
-                    {{t "general.hours"}}
-                  </th>
-                  <th>
-                    {{t "general.dueBy"}}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>
-                    {{@session.ilmSession.hours}}
-                  </td>
-                  <td>
-                    {{formatDate
-                      @session.ilmSession.dueDate
-                      month="2-digit"
-                      day="2-digit"
-                      year="numeric"
-                    }}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            {{#if @session.hasPrerequisites}}
-              <div class="inline-label-data-block">
-                <label>{{t "general.prerequisites"}}:</label>
-                <span>
-                  {{#each this.prerequisites as |prerequisite index|~}}
-                    {{prerequisite.title}}{{#if (notEq index (sub_ this.prerequisites.length 1))}},
-                    {{/if}}
-                  {{~/each}}
-                </span>
-              </div>
-            {{/if}}
-          </div>
-        </section>
-      {{/if}}
       <section class="block" data-test-session-offerings>
         <div class="title">
           {{t "general.offerings"}}

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -168,6 +168,26 @@ export default class PrintCourseComponent extends Component {
               {{formatDate @course.endDate day="2-digit" month="2-digit" year="numeric"}}
             </div>
           </div>
+          <div class="inline-label-data-block">
+            <label>
+              {{t "general.clerkshipType"}}:
+            </label>
+            <div>
+              {{#if @course.clerkshipType}}
+                {{@course.clerkshipType.title}}
+              {{else}}
+                {{t "general.notAClerkship"}}
+              {{/if}}
+            </div>
+          </div>
+          <div class="inline-label-data-block">
+            <label>
+              {{t "general.level"}}:
+            </label>
+            <div>
+              {{@course.level}}
+            </div>
+          </div>
           <br />
           <br />
           <div class="inline-label-data-block">


### PR DESCRIPTION
Fixes ilios/ilios#5023 ilios/ilios#5024 ilios/ilios#5025

This does a number of things to improve the course print preview route:
* Adds missing course overview fields
* Added a missing Independent Learning field to the session overview
* Moved the ILM section up closer to the session overview checkboxes so that the Due By and Hours fields were more obviously present
* Added PreReqs to ILM section
* Removed missing offerings message as it was redundant with the count, inconsistent compared to other sections, and took up space