### PR TITLE
rm rogue "this" from task invocation.

### DIFF
--- a/packages/ilios-common/addon/components/sessions-grid-offering.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-offering.gjs
@@ -108,7 +108,6 @@ export default class SessionsGridOffering extends Component {
   });
 
   save = dropTask(
-    this,
     async (
       startDate,
       endDate,


### PR DESCRIPTION
seems to be benign at the moment, but becomes a problem when upgrading to the v5 syntax of ember-concurrency.