### PR TITLE
removes exception for obsolete deprecation warning.

### DIFF
--- a/packages/frontend/app/deprecation-workflow.js
+++ b/packages/frontend/app/deprecation-workflow.js
@@ -26,7 +26,6 @@ setupDeprecationWorkflow({
     { handler: 'silence', matchId: 'deprecate-import-onerror-from-ember' },
     { handler: 'silence', matchId: 'deprecate-import-default-value-from-ember' },
     { handler: 'silence', matchId: 'ember-data:deprecate-non-strict-types' },
-    { handler: 'silence', matchId: 'ember-concurrency.deprecate-task-group' },
     { handler: 'silence', matchId: 'warp-drive:deprecate-legacy-request-methods' },
   ],
 });

--- a/packages/lti-course-manager/app/deprecation-workflow.js
+++ b/packages/lti-course-manager/app/deprecation-workflow.js
@@ -26,7 +26,6 @@ setupDeprecationWorkflow({
     { handler: 'silence', matchId: 'deprecate-import-onerror-from-ember' },
     { handler: 'silence', matchId: 'deprecate-import-default-value-from-ember' },
     { handler: 'silence', matchId: 'ember-data:deprecate-non-strict-types' },
-    { handler: 'silence', matchId: 'ember-concurrency.deprecate-task-group' },
     { handler: 'silence', matchId: 'warp-drive:deprecate-legacy-request-methods' },
   ],
 });

--- a/packages/lti-dashboard/app/deprecation-workflow.js
+++ b/packages/lti-dashboard/app/deprecation-workflow.js
@@ -26,7 +26,6 @@ setupDeprecationWorkflow({
     { handler: 'silence', matchId: 'deprecate-import-onerror-from-ember' },
     { handler: 'silence', matchId: 'deprecate-import-default-value-from-ember' },
     { handler: 'silence', matchId: 'ember-data:deprecate-non-strict-types' },
-    { handler: 'silence', matchId: 'ember-concurrency.deprecate-task-group' },
     { handler: 'silence', matchId: 'warp-drive:deprecate-legacy-request-methods' },
   ],
 });

--- a/packages/test-app/app/deprecation-workflow.js
+++ b/packages/test-app/app/deprecation-workflow.js
@@ -26,7 +26,6 @@ setupDeprecationWorkflow({
     { handler: 'silence', matchId: 'deprecate-import-onerror-from-ember' },
     { handler: 'silence', matchId: 'deprecate-import-default-value-from-ember' },
     { handler: 'silence', matchId: 'ember-data:deprecate-non-strict-types' },
-    { handler: 'silence', matchId: 'ember-concurrency.deprecate-task-group' },
     { handler: 'silence', matchId: 'warp-drive:deprecate-legacy-request-methods' },
   ],
 });


### PR DESCRIPTION
we're not using the deprecated task-group feature of ember-concurrency anymore, so we don't need to suppress warnings for it.