### PR TITLE
Remove Code Coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ concurrency:
 
 env:
   SW_DISABLED: true
-  COVERAGE: false
 
 jobs:
   lint:
@@ -61,20 +60,6 @@ jobs:
         run: pnpm install
       - name: Run Tests
         run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance --write-execution-file
-        env:
-          COVERAGE: true
-      - name: Store Code Coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-${{matrix.workspace}}
-          path: ./packages/${{matrix.workspace}}/coverage
-          retention-days: 1
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: replay-${{matrix.workspace}}-test.json
-          path: ./packages/${{matrix.workspace}}/test-execution-*.json
-          retention-days: 7
 
   build:
     name: Build

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -4,9 +4,6 @@ on:
   pull_request_target:
     types: [labeled]
 
-env:
-  COVERAGE: false
-
 jobs:
   deploy:
     name: Deploy PR Preview

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,7 +6,6 @@ on:
       - "*"
 
 env:
-  COVERAGE: false
   SENTRY_ORG: ilios
   SENTRY_PROJECT: frontend
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - master
 
-env:
-  COVERAGE: false
-
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   SW_DISABLED: true
-  COVERAGE: false
 
 jobs:
   percy:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -10,7 +10,6 @@ concurrency:
 
 env:
   SW_DISABLED: true
-  COVERAGE: false
 
 jobs:
   browserstack-test:

--- a/packages/frontend/ember-cli-build.js
+++ b/packages/frontend/ember-cli-build.js
@@ -19,10 +19,7 @@ module.exports = async function (defaults) {
 
     hinting: isTestBuild,
     babel: {
-      plugins: [
-        require.resolve('ember-concurrency/async-arrow-task-transform'),
-        ...require('ember-cli-code-coverage').buildBabelPlugin({ embroider: true }),
-      ],
+      plugins: [require.resolve('ember-concurrency/async-arrow-task-transform')],
     },
     'ember-cli-image-transformer': {
       images: [

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -67,7 +67,6 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-browserstack": "^3.0.0",
     "ember-cli-bundle-analyzer": "^1.0.0",
-    "ember-cli-code-coverage": "^3.0.1",
     "ember-cli-dependency-checker": "^3.3.3",
     "ember-cli-dependency-lint": "2.0.1",
     "ember-cli-deploy": "2.0.0",

--- a/packages/frontend/tests/test-helper.js
+++ b/packages/frontend/tests/test-helper.js
@@ -7,7 +7,6 @@ import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
 import { setupEmberOnerrorValidation } from 'ember-qunit';
 
-import { forceModulesToBeLoaded, sendCoverage } from 'ember-cli-code-coverage/test-support';
 import DefaultAdapter from 'ember-cli-page-object/adapters/rfc268';
 import { setAdapter } from 'ember-cli-page-object/adapters';
 import {
@@ -26,21 +25,6 @@ setRunOptions({
 });
 setupGlobalA11yHooks(() => true);
 setupQUnitA11yAuditToggle(QUnit);
-
-//Needed for: https://github.com/testem/testem/issues/1577
-//See: https://github.com/ember-cli-code-coverage/ember-cli-code-coverage/issues/420
-if (typeof Testem !== 'undefined') {
-  //eslint-disable-next-line no-undef
-  Testem?.afterTests(function (config, data, callback) {
-    forceModulesToBeLoaded();
-    sendCoverage(callback);
-  });
-} else if (typeof QUnit !== 'undefined') {
-  QUnit.done(async function () {
-    forceModulesToBeLoaded();
-    await sendCoverage();
-  });
-}
 
 setAdapter(new DefaultAdapter());
 setApplication(Application.create(config.APP));

--- a/packages/frontend/tests/test-support/mirage-server.js
+++ b/packages/frontend/tests/test-support/mirage-server.js
@@ -25,7 +25,6 @@ export default function (config) {
     routes() {
       this.timing = 100;
       this.namespace = '/';
-      this.passthrough('/write-coverage');
       commonRoutes(this);
       this.post('auth/login', function (schema, request) {
         const errors = [];

--- a/packages/lti-course-manager/ember-cli-build.js
+++ b/packages/lti-course-manager/ember-cli-build.js
@@ -26,9 +26,6 @@ module.exports = async function (defaults) {
       enabled: true,
     },
     hinting: isTestBuild,
-    babel: {
-      plugins: [...require('ember-cli-code-coverage').buildBabelPlugin({ embroider: true })],
-    },
   };
   const app = new EmberApp(defaults, config);
 

--- a/packages/lti-course-manager/package.json
+++ b/packages/lti-course-manager/package.json
@@ -58,7 +58,6 @@
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-browserstack": "^3.0.0",
-    "ember-cli-code-coverage": "^3.0.1",
     "ember-cli-dependency-checker": "^3.3.3",
     "ember-cli-dependency-lint": "2.0.1",
     "ember-cli-deploy": "^2.0.0",

--- a/packages/lti-course-manager/tests/test-helper.js
+++ b/packages/lti-course-manager/tests/test-helper.js
@@ -8,22 +8,7 @@ import { setup } from 'qunit-dom';
 import { setupEmberOnerrorValidation } from 'ember-qunit';
 
 import start from 'ember-exam/test-support/start';
-import { forceModulesToBeLoaded, sendCoverage } from 'ember-cli-code-coverage/test-support';
 
-//Needed for: https://github.com/testem/testem/issues/1577
-//See: https://github.com/ember-cli-code-coverage/ember-cli-code-coverage/issues/420
-if (typeof Testem !== 'undefined') {
-  //eslint-disable-next-line no-undef
-  Testem?.afterTests(function (config, data, callback) {
-    forceModulesToBeLoaded();
-    sendCoverage(callback);
-  });
-} else if (typeof QUnit !== 'undefined') {
-  QUnit.done(async function () {
-    forceModulesToBeLoaded();
-    await sendCoverage();
-  });
-}
 setApplication(Application.create(config.APP));
 
 setup(QUnit.assert);

--- a/packages/lti-dashboard/ember-cli-build.js
+++ b/packages/lti-dashboard/ember-cli-build.js
@@ -27,9 +27,6 @@ module.exports = async function (defaults) {
       enabled: true,
     },
     hinting: isTestBuild,
-    babel: {
-      plugins: [...require('ember-cli-code-coverage').buildBabelPlugin({ embroider: true })],
-    },
   };
   const app = new EmberApp(defaults, config);
 

--- a/packages/lti-dashboard/package.json
+++ b/packages/lti-dashboard/package.json
@@ -58,7 +58,6 @@
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-browserstack": "^3.0.0",
-    "ember-cli-code-coverage": "^3.0.1",
     "ember-cli-dependency-checker": "^3.3.3",
     "ember-cli-dependency-lint": "2.0.1",
     "ember-cli-deploy": "^2.0.0",

--- a/packages/lti-dashboard/tests/test-helper.js
+++ b/packages/lti-dashboard/tests/test-helper.js
@@ -10,22 +10,6 @@ import { setupEmberOnerrorValidation } from 'ember-qunit';
 import start from 'ember-exam/test-support/start';
 import DefaultAdapter from 'ember-cli-page-object/adapters/rfc268';
 import { setAdapter } from 'ember-cli-page-object/adapters';
-import { forceModulesToBeLoaded, sendCoverage } from 'ember-cli-code-coverage/test-support';
-
-//Needed for: https://github.com/testem/testem/issues/1577
-//See: https://github.com/ember-cli-code-coverage/ember-cli-code-coverage/issues/420
-if (typeof Testem !== 'undefined') {
-  //eslint-disable-next-line no-undef
-  Testem?.afterTests(function (config, data, callback) {
-    forceModulesToBeLoaded();
-    sendCoverage(callback);
-  });
-} else if (typeof QUnit !== 'undefined') {
-  QUnit.done(async function () {
-    forceModulesToBeLoaded();
-    await sendCoverage();
-  });
-}
 
 setAdapter(new DefaultAdapter());
 setApplication(Application.create(config.APP));

--- a/packages/test-app/ember-cli-build.js
+++ b/packages/test-app/ember-cli-build.js
@@ -25,7 +25,6 @@ module.exports = async function (defaults) {
       plugins: [
         require.resolve('ember-auto-import/babel-plugin'),
         require.resolve('ember-concurrency/async-arrow-task-transform'),
-        ...require('ember-cli-code-coverage').buildBabelPlugin({ embroider: true }),
       ],
     },
   });

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -53,7 +53,6 @@
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-browserstack": "^3.0.0",
-    "ember-cli-code-coverage": "^3.0.1",
     "ember-cli-dependency-checker": "^3.3.3",
     "ember-cli-deprecation-workflow": "^3.4.0",
     "ember-cli-htmlbars": "^6.3.0",

--- a/packages/test-app/tests/test-helper.js
+++ b/packages/test-app/tests/test-helper.js
@@ -7,7 +7,6 @@ import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
 import { setupEmberOnerrorValidation } from 'ember-qunit';
 
-import { forceModulesToBeLoaded, sendCoverage } from 'ember-cli-code-coverage/test-support';
 import {
   setRunOptions,
   setupGlobalA11yHooks,
@@ -23,21 +22,6 @@ setRunOptions({
 });
 setupGlobalA11yHooks(() => true);
 setupQUnitA11yAuditToggle(QUnit);
-
-//Needed for: https://github.com/testem/testem/issues/1577
-//See: https://github.com/ember-cli-code-coverage/ember-cli-code-coverage/issues/420
-if (typeof Testem !== 'undefined') {
-  //eslint-disable-next-line no-undef
-  Testem?.afterTests(function (config, data, callback) {
-    forceModulesToBeLoaded();
-    sendCoverage(callback);
-  });
-} else if (typeof QUnit !== 'undefined') {
-  QUnit.done(async function () {
-    forceModulesToBeLoaded();
-    await sendCoverage();
-  });
-}
 
 setApplication(Application.create(config.APP));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ importers:
       ember-cli-bundle-analyzer:
         specifier: ^1.0.0
         version: 1.0.0
-      ember-cli-code-coverage:
-        specifier: ^3.0.1
-        version: 3.1.0(@embroider/compat@3.8.5(@embroider/core@3.5.7))(@embroider/core@3.5.7)
       ember-cli-dependency-checker:
         specifier: ^3.3.3
         version: 3.3.3(ember-cli@6.7.0(@types/node@24.5.2)(babel-core@6.26.3)(ejs@3.1.10)(handlebars@4.7.8)(underscore@1.13.7))
@@ -751,9 +748,6 @@ importers:
       ember-cli-browserstack:
         specifier: ^3.0.0
         version: 3.0.0
-      ember-cli-code-coverage:
-        specifier: ^3.0.1
-        version: 3.1.0(@embroider/compat@3.8.5(@embroider/core@3.5.7))(@embroider/core@3.5.7)
       ember-cli-dependency-checker:
         specifier: ^3.3.3
         version: 3.3.3(ember-cli@6.7.0(@types/node@24.5.2)(babel-core@6.26.3)(ejs@3.1.10)(handlebars@4.7.8)(underscore@1.13.7))
@@ -985,9 +979,6 @@ importers:
       ember-cli-browserstack:
         specifier: ^3.0.0
         version: 3.0.0
-      ember-cli-code-coverage:
-        specifier: ^3.0.1
-        version: 3.1.0(@embroider/compat@3.8.5(@embroider/core@3.5.7))(@embroider/core@3.5.7)
       ember-cli-dependency-checker:
         specifier: ^3.3.3
         version: 3.3.3(ember-cli@6.7.0(@types/node@24.5.2)(babel-core@6.26.3)(ejs@3.1.10)(handlebars@4.7.8)(underscore@1.13.7))
@@ -1213,9 +1204,6 @@ importers:
       ember-cli-browserstack:
         specifier: ^3.0.0
         version: 3.0.0
-      ember-cli-code-coverage:
-        specifier: ^3.0.1
-        version: 3.1.0(@embroider/compat@3.8.5(@embroider/core@3.5.7))(@embroider/core@3.5.7)
       ember-cli-dependency-checker:
         specifier: ^3.3.3
         version: 3.3.3(ember-cli@6.7.0(@types/node@24.5.2)(babel-core@6.26.3)(ejs@3.1.10)(handlebars@4.7.8)(underscore@1.13.7))
@@ -2653,14 +2641,6 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@istanbuljs/load-nyc-config@1.1.0':
-    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
-    engines: {node: '>=8'}
-
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
-    engines: {node: '>=8'}
-
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -3810,10 +3790,6 @@ packages:
     resolution: {integrity: sha512-QWjjFgSKtSRIcsBhJmEwS2laIdrA6na8HAlc/pEAhjHgQsah/gMiBFRZvbQTy//hWxR4BMwV7/Mya7q5H8uHeA==}
     engines: {node: 10.* || >= 12.*}
 
-  babel-plugin-istanbul@6.1.1:
-    resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
-    engines: {node: '>=8'}
-
   babel-plugin-module-resolver@3.2.0:
     resolution: {integrity: sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==}
     engines: {node: '>= 6.0.0'}
@@ -4196,10 +4172,6 @@ packages:
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
-
-  camelcase@5.3.1:
-    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
   can-symlink@1.0.0:
@@ -5189,18 +5161,6 @@ packages:
   ember-cli-bundle-analyzer@1.0.0:
     resolution: {integrity: sha512-c35N8XIdg+5zS+Mxj3lSihuqsQQa8kLpoUXJts8TqMR+owHidClzVKOX7dy5rJGlQdM6qcbpSh5kQfKBaCu2DQ==}
     engines: {node: 16.* || >= 18}
-
-  ember-cli-code-coverage@3.1.0:
-    resolution: {integrity: sha512-ODRYNClYaUglbGZX86iOhOTIZI86QDxmEgKVHqaPjQNKKhoBeJcfb9n4sRSFK8w6YrYsjenKI6V6h9oT3lVhtg==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@embroider/compat': ^0.47.0 || ^1.0.0 || ^2.0.0 || >=3.0.0
-      '@embroider/core': ^0.47.0 || ^1.0.0 || ^2.0.0 || >=3.0.0
-    peerDependenciesMeta:
-      '@embroider/compat':
-        optional: true
-      '@embroider/core':
-        optional: true
 
   ember-cli-dependency-checker@3.3.3:
     resolution: {integrity: sha512-mvp+HrE0M5Zhc2oW8cqs8wdhtqq0CfQXAYzaIstOzHJJn/U01NZEGu3hz7J7zl/+jxZkyygylzcS57QqmPXMuQ==}
@@ -6343,10 +6303,6 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
-  get-package-type@0.1.0:
-    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
-    engines: {node: '>=8.0.0'}
-
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
@@ -7089,26 +7045,6 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
-  istanbul-lib-coverage@3.2.2:
-    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
-    engines: {node: '>=8'}
-
-  istanbul-lib-instrument@5.2.1:
-    resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
-    engines: {node: '>=8'}
-
-  istanbul-lib-report@3.0.1:
-    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
-    engines: {node: '>=10'}
-
-  istanbul-lib-source-maps@4.0.1:
-    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
-    engines: {node: '>=10'}
-
-  istanbul-reports@3.2.0:
-    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
-    engines: {node: '>=8'}
-
   istextorbinary@2.1.0:
     resolution: {integrity: sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==}
     engines: {node: '>=0.12'}
@@ -7467,10 +7403,6 @@ packages:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
 
-  make-dir@4.0.0:
-    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
-    engines: {node: '>=10'}
-
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
@@ -7772,10 +7704,6 @@ packages:
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
-
-  node-dir@0.1.17:
-    resolution: {integrity: sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==}
-    engines: {node: '>= 0.10.5'}
 
   node-html-light@1.4.0:
     resolution: {integrity: sha512-sYlCrvhn5us6MW3ZLGpM0MXFlHUo14kN9itVFM3pjbaJG1a+B/3BCFoqAEAReqTDFxXs68ngkZ89edNxD0ja4Q==}
@@ -9332,10 +9260,6 @@ packages:
     resolution: {integrity: sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==}
     engines: {node: '>=10'}
     hasBin: true
-
-  test-exclude@6.0.0:
-    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
-    engines: {node: '>=8'}
 
   testem-failure-only-reporter@1.0.0:
     resolution: {integrity: sha512-G3fC1FSW/mI2ElrzaJfGEtTHBB7U1IFimwC1oIpUc1+wYsgw+2tCUV1t+cB/dsBbryq4Cbe1NQ397fJ2maCs7g==}
@@ -12270,16 +12194,6 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@istanbuljs/load-nyc-config@1.1.0':
-    dependencies:
-      camelcase: 5.3.1
-      find-up: 4.1.0
-      get-package-type: 0.1.0
-      js-yaml: 3.14.1
-      resolve-from: 5.0.0
-
-  '@istanbuljs/schema@0.1.3': {}
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -13771,16 +13685,6 @@ snapshots:
       parse-static-imports: 1.1.0
       string.prototype.matchall: 4.0.12
 
-  babel-plugin-istanbul@6.1.1:
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@istanbuljs/load-nyc-config': 1.1.0
-      '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 5.2.1
-      test-exclude: 6.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-module-resolver@3.2.0:
     dependencies:
       find-babel-config: 1.2.2
@@ -14536,8 +14440,6 @@ snapshots:
   call-me-maybe@1.0.2: {}
 
   callsites@3.1.0: {}
-
-  camelcase@5.3.1: {}
 
   can-symlink@1.0.0:
     dependencies:
@@ -15580,25 +15482,6 @@ snapshots:
       intercept-stdout: 0.1.2
       node-html-light: 1.4.0
       source-map-explorer: 2.5.3
-    transitivePeerDependencies:
-      - supports-color
-
-  ember-cli-code-coverage@3.1.0(@embroider/compat@3.8.5(@embroider/core@3.5.7))(@embroider/core@3.5.7):
-    dependencies:
-      babel-plugin-istanbul: 6.1.1
-      body-parser: 1.20.3
-      ember-cli-babel: 7.26.11
-      express: 4.21.2
-      fs-extra: 9.1.0
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
-      istanbul-reports: 3.2.0
-      node-dir: 0.1.17
-      walk-sync: 2.2.0
-    optionalDependencies:
-      '@embroider/compat': 3.8.5(@embroider/core@3.5.7)
-      '@embroider/core': 3.5.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17660,8 +17543,6 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
-  get-package-type@0.1.0: {}
-
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
@@ -18458,37 +18339,6 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  istanbul-lib-coverage@3.2.2: {}
-
-  istanbul-lib-instrument@5.2.1:
-    dependencies:
-      '@babel/core': 7.28.4(supports-color@8.1.1)
-      '@babel/parser': 7.28.4
-      '@istanbuljs/schema': 0.1.3
-      istanbul-lib-coverage: 3.2.2
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  istanbul-lib-report@3.0.1:
-    dependencies:
-      istanbul-lib-coverage: 3.2.2
-      make-dir: 4.0.0
-      supports-color: 7.2.0
-
-  istanbul-lib-source-maps@4.0.1:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      istanbul-lib-coverage: 3.2.2
-      source-map: 0.6.1
-    transitivePeerDependencies:
-      - supports-color
-
-  istanbul-reports@3.2.0:
-    dependencies:
-      html-escaper: 2.0.2
-      istanbul-lib-report: 3.0.1
-
   istextorbinary@2.1.0:
     dependencies:
       binaryextensions: 2.3.0
@@ -18870,10 +18720,6 @@ snapshots:
     dependencies:
       semver: 6.3.1
 
-  make-dir@4.0.0:
-    dependencies:
-      semver: 7.7.2
-
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
@@ -19181,10 +19027,6 @@ snapshots:
 
   node-addon-api@7.1.1:
     optional: true
-
-  node-dir@0.1.17:
-    dependencies:
-      minimatch: 3.1.2
 
   node-html-light@1.4.0:
     dependencies:
@@ -20985,12 +20827,6 @@ snapshots:
       acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
-
-  test-exclude@6.0.0:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 7.2.3
-      minimatch: 3.1.2
 
   testem-failure-only-reporter@1.0.0(babel-core@6.26.3)(ejs@3.1.10)(handlebars@4.7.8)(underscore@1.13.7):
     dependencies:


### PR DESCRIPTION
We can't use this information in any meaningful way right now because of issues with generating coverage for things in common that are tested in test-app and it's causing build errors that are hard to diagnose. Rid ourselves of this entirely for now.

This will immediately unblock our ember concurrency update in #8823