### PR TITLE
Reduce top/bottom padding from LG members

### DIFF
--- a/packages/frontend/app/styles/components/learner-group/members.scss
+++ b/packages/frontend/app/styles/components/learner-group/members.scss
@@ -6,7 +6,7 @@
   border-bottom: 0;
   display: grid;
   grid-template-columns: 3fr 1fr;
-  padding-left: 0;
+  padding: 0;
 
   .title {
     @include m.detail-container-title-style;


### PR DESCRIPTION
Fixes ilios/ilios#4156

Top Before/After:
<img width="1135" height="189" alt="members-top-before" src="https://github.com/user-attachments/assets/8293fe62-a42a-41ec-bd87-878958d65d2d" />
<img width="1138" height="177" alt="members-top-after" src="https://github.com/user-attachments/assets/7bc51cb4-f8dc-4a09-8323-c998b672ba17" />

Bottom Before/After:
<img width="1142" height="161" alt="members-bot-before" src="https://github.com/user-attachments/assets/fc30dede-ccfd-4ed3-9c9e-dcd580aeb684" />
<img width="1142" height="144" alt="members-bot-after" src="https://github.com/user-attachments/assets/7062c0dd-25ee-4b1b-8453-36f4cddac28b" />
