### PR TITLE
display end-of-day, ILM-based events in the calendar

### DIFF
--- a/packages/frontend/app/components/learner-group/calendar.gjs
+++ b/packages/frontend/app/components/learner-group/calendar.gjs
@@ -64,6 +64,8 @@ export default class LearnerGroupCalendarComponent extends Component {
       return {
         startDate: offering.startDate.toISOString(),
         endDate: offering.endDate.toISOString(),
+        calendarStartDate: offering.startDate.toISOString(),
+        calendarEndDate: offering.endDate.toISOString(),
         courseTitle: course.title,
         name: session.title,
         offering: offering.id,

--- a/packages/ilios-common/addon/components/daily-calendar-event.gjs
+++ b/packages/ilios-common/addon/components/daily-calendar-event.gjs
@@ -22,9 +22,9 @@ export default class DailyCalendarEventComponent extends Component {
   constructor() {
     super(...arguments);
     const allMinutesInDay = Array(60 * 24).fill(0);
-    this.args.allDayEvents.forEach(({ startDate, endDate }) => {
-      const start = this.getMinuteInTheDay(startDate);
-      const end = this.getMinuteInTheDay(endDate);
+    this.args.allDayEvents.forEach(({ calendarStartDate, calendarEndDate }) => {
+      const start = this.getMinuteInTheDay(calendarStartDate);
+      const end = this.getMinuteInTheDay(calendarEndDate);
       for (let i = start; i <= end; i++) {
         allMinutesInDay[i - 1]++;
       }
@@ -66,11 +66,11 @@ export default class DailyCalendarEventComponent extends Component {
   }
 
   get startLuxon() {
-    return DateTime.fromISO(this.args.event.startDate);
+    return DateTime.fromISO(this.args.event.calendarStartDate);
   }
 
   get endLuxon() {
-    return DateTime.fromISO(this.args.event.endDate);
+    return DateTime.fromISO(this.args.event.calendarEndDate);
   }
 
   get startOfDayLuxon() {
@@ -94,8 +94,8 @@ export default class DailyCalendarEventComponent extends Component {
   }
 
   get span() {
-    const start = this.getMinuteInTheDay(this.args.event.startDate);
-    const end = this.getMinuteInTheDay(this.args.event.endDate);
+    const start = this.getMinuteInTheDay(this.args.event.calendarStartDate);
+    const end = this.getMinuteInTheDay(this.args.event.calendarEndDate);
 
     const minutes = this.minutes.slice(start, end - 1);
     const max = Math.max(...minutes);

--- a/packages/ilios-common/addon/components/daily-calendar.gjs
+++ b/packages/ilios-common/addon/components/daily-calendar.gjs
@@ -32,7 +32,7 @@ export default class DailyCalendarComponent extends Component {
     }
 
     return this.sortedEvents.reduce((earliestHour, event) => {
-      const { hour } = DateTime.fromISO(event.startDate);
+      const { hour } = DateTime.fromISO(event.calendarStartDate);
       return hour < earliestHour ? hour : earliestHour;
     }, 24);
   }
@@ -42,7 +42,7 @@ export default class DailyCalendarComponent extends Component {
       return [];
     }
 
-    return sortBy(this.args.events, ['startDate', 'endDate', 'name']);
+    return sortBy(this.args.events, ['calendarStartDate', 'calendarEndDate', 'name']);
   }
 
   get hours() {

--- a/packages/ilios-common/addon/components/ilios-calendar-day.gjs
+++ b/packages/ilios-common/addon/components/ilios-calendar-day.gjs
@@ -30,8 +30,8 @@ export default class IliosCalendarDayComponent extends Component {
   get events() {
     return this.args.calendarEvents.filter(
       (event) =>
-        DateTime.fromISO(event.startDate).hasSame(this.today, 'day') ||
-        DateTime.fromISO(event.endDate).hasSame(this.today, 'day'),
+        DateTime.fromISO(event.calendarStartDate).hasSame(this.today, 'day') ||
+        DateTime.fromISO(event.calendarEndDate).hasSame(this.today, 'day'),
     );
   }
   get ilmPreWorkEvents() {
@@ -57,12 +57,19 @@ export default class IliosCalendarDayComponent extends Component {
 
   get singleDayEvents() {
     return this.nonIlmPreWorkEvents.filter((event) =>
-      DateTime.fromISO(event.startDate).hasSame(DateTime.fromISO(event.endDate), 'day'),
+      DateTime.fromISO(event.calendarStartDate).hasSame(
+        DateTime.fromISO(event.calendarEndDate),
+        'day',
+      ),
     );
   }
   get multiDayEvents() {
     return this.nonIlmPreWorkEvents.filter(
-      (event) => !DateTime.fromISO(event.startDate).hasSame(DateTime.fromISO(event.endDate), 'day'),
+      (event) =>
+        !DateTime.fromISO(event.calendarStartDate).hasSame(
+          DateTime.fromISO(event.calendarEndDate),
+          'day',
+        ),
     );
   }
   <template>

--- a/packages/ilios-common/addon/components/ilios-calendar-month.gjs
+++ b/packages/ilios-common/addon/components/ilios-calendar-month.gjs
@@ -29,13 +29,20 @@ export default class IliosCalendarMonthComponent extends Component {
 
   get singleDayEvents() {
     return this.nonIlmPreWorkEvents.filter((event) =>
-      DateTime.fromISO(event.startDate).hasSame(DateTime.fromISO(event.endDate), 'day'),
+      DateTime.fromISO(event.calendarStartDate).hasSame(
+        DateTime.fromISO(event.calendarEndDate),
+        'day',
+      ),
     );
   }
 
   get multiDayEventsList() {
     return this.nonIlmPreWorkEvents.filter(
-      (event) => !DateTime.fromISO(event.startDate).hasSame(DateTime.fromISO(event.endDate), 'day'),
+      (event) =>
+        !DateTime.fromISO(event.calendarStartDate).hasSame(
+          DateTime.fromISO(event.calendarEndDate),
+          'day',
+        ),
     );
   }
 

--- a/packages/ilios-common/addon/components/ilios-calendar-week.gjs
+++ b/packages/ilios-common/addon/components/ilios-calendar-week.gjs
@@ -44,12 +44,19 @@ export default class IliosCalendarWeekComponent extends Component {
   }
   get singleDayEvents() {
     return this.nonIlmPreWorkEvents.filter((event) =>
-      DateTime.fromISO(event.startDate).hasSame(DateTime.fromISO(event.endDate), 'day'),
+      DateTime.fromISO(event.calendarStartDate).hasSame(
+        DateTime.fromISO(event.calendarEndDate),
+        'day',
+      ),
     );
   }
   get multiDayEventsList() {
     return this.nonIlmPreWorkEvents.filter(
-      (event) => !DateTime.fromISO(event.startDate).hasSame(DateTime.fromISO(event.endDate), 'day'),
+      (event) =>
+        !DateTime.fromISO(event.calendarStartDate).hasSame(
+          DateTime.fromISO(event.calendarEndDate),
+          'day',
+        ),
     );
   }
 

--- a/packages/ilios-common/addon/components/monthly-calendar.gjs
+++ b/packages/ilios-common/addon/components/monthly-calendar.gjs
@@ -21,7 +21,7 @@ export default class MonthlyCalendarComponent extends Component {
       return [];
     }
 
-    return sortBy(this.args.events, ['startDate', 'endDate', 'name']);
+    return sortBy(this.args.events, ['calendarStartDate', 'calendarEndDate', 'name']);
   }
 
   get firstDayOfMonth() {
@@ -51,7 +51,9 @@ export default class MonthlyCalendarComponent extends Component {
           month: 'numeric',
           day: 'numeric',
         }),
-        events: this.sortedEvents.filter((e) => date.hasSame(DateTime.fromISO(e.startDate), 'day')),
+        events: this.sortedEvents.filter((e) =>
+          date.hasSame(DateTime.fromISO(e.calendarStartDate), 'day'),
+        ),
       };
     });
   }
@@ -104,7 +106,7 @@ export default class MonthlyCalendarComponent extends Component {
               {{#if event.isMulti}}
                 <IliosCalendarEventMonth
                   @event={{event}}
-                  @selectEvent={{fn @changeToDayView event.startDate}}
+                  @selectEvent={{fn @changeToDayView event.calendarStartDate}}
                 />
               {{else}}
                 <IliosCalendarEventMonth @event={{event}} @selectEvent={{fn @selectEvent event}} />

--- a/packages/ilios-common/addon/components/offering-calendar.gjs
+++ b/packages/ilios-common/addon/components/offering-calendar.gjs
@@ -44,6 +44,8 @@ export default class OfferingCalendar extends Component {
           return {
             startDate: DateTime.fromJSDate(offering.startDate).toISO(),
             endDate: DateTime.fromJSDate(offering.endDate).toISO(),
+            calendarStartDate: DateTime.fromJSDate(offering.startDate).toISO(),
+            calendarEndDate: DateTime.fromJSDate(offering.endDate).toISO(),
             courseTitle: course.title,
             name: session.title,
             offering: offering.id,
@@ -71,6 +73,8 @@ export default class OfferingCalendar extends Component {
         return {
           startDate: DateTime.fromJSDate(offering.startDate).toISO(),
           endDate: DateTime.fromJSDate(offering.endDate).toISO(),
+          calendarStartDate: DateTime.fromJSDate(offering.startDate).toISO(),
+          calendarEndDate: DateTime.fromJSDate(offering.endDate).toISO(),
           courseTitle: course.title,
           name: session.title,
           offering: offering.id,
@@ -84,6 +88,8 @@ export default class OfferingCalendar extends Component {
       this.currentEvent = {
         startDate: DateTime.fromJSDate(startDate).toISO(),
         endDate: DateTime.fromJSDate(endDate).toISO(),
+        calendarStartDate: DateTime.fromJSDate(startDate).toISO(),
+        calendarEndDate: DateTime.fromJSDate(endDate).toISO(),
         courseTitle: course.title,
         name: session.title,
         isPublished: session.isPublished,

--- a/packages/ilios-common/addon/components/weekly-calendar-event.gjs
+++ b/packages/ilios-common/addon/components/weekly-calendar-event.gjs
@@ -29,9 +29,9 @@ export default class WeeklyCalendarEventComponent extends Component {
 
   get minutes() {
     const allMinutesInDay = Array(60 * 24).fill(0);
-    this.args.allDayEvents.forEach(({ startDate, endDate }) => {
-      const start = this.getMinuteInTheDay(DateTime.fromISO(startDate));
-      const end = this.getMinuteInTheDay(DateTime.fromISO(endDate));
+    this.args.allDayEvents.forEach(({ calendarStartDate, calendarEndDate }) => {
+      const start = this.getMinuteInTheDay(DateTime.fromISO(calendarStartDate));
+      const end = this.getMinuteInTheDay(DateTime.fromISO(calendarEndDate));
       for (let i = start; i <= end; i++) {
         allMinutesInDay[i - 1]++;
       }
@@ -41,11 +41,11 @@ export default class WeeklyCalendarEventComponent extends Component {
   }
 
   get startDateTime() {
-    return DateTime.fromISO(this.args.event.startDate);
+    return DateTime.fromISO(this.args.event.calendarStartDate);
   }
 
   get endDateTime() {
-    return DateTime.fromISO(this.args.event.endDate);
+    return DateTime.fromISO(this.args.event.calendarEndDate);
   }
 
   get startDate() {

--- a/packages/ilios-common/addon/components/weekly-calendar.gjs
+++ b/packages/ilios-common/addon/components/weekly-calendar.gjs
@@ -54,7 +54,7 @@ export default class WeeklyCalendarComponent extends Component {
     }
 
     return this.sortedEvents.reduce((earliestHour, event) => {
-      const hour = Number(DateTime.fromISO(event.startDate).toFormat('HH'));
+      const hour = Number(DateTime.fromISO(event.calendarStartDate).toFormat('HH'));
       return hour < earliestHour ? hour : earliestHour;
     }, 24);
   }
@@ -64,7 +64,7 @@ export default class WeeklyCalendarComponent extends Component {
       return [];
     }
 
-    return sortBy(this.args.events, ['startDate', 'endDate', 'name']);
+    return sortBy(this.args.events, ['calendarStartDate', 'calendarEndDate', 'name']);
   }
 
   get days() {

--- a/packages/test-app/tests/classes/events-base-test.js
+++ b/packages/test-app/tests/classes/events-base-test.js
@@ -1,0 +1,53 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { DateTime } from 'luxon';
+import EventsBase from 'ilios-common/classes/events-base';
+module('Unit | Services | events-base', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    // EventsBase is declared in a non-standard location (i.e. not in a `/services` subdirectory).
+    // So it doesn't get automatically registered as service here.
+    this.owner.register('service:events-base', EventsBase);
+    this.eventsBase = this.owner.lookup('service:events-base');
+  });
+
+  // See issue ilios/ilios#6631 for reference.
+  test.each(
+    'createEventFromData() - end-of-day events based on ILMs',
+    [
+      ['2025-11-10T09:45:00', '2025-11-10T10:00:00', '2025-11-10T09:45:00', '2025-11-10T10:00:00'],
+      // these are edge-cases for ILM-based events.
+      // If the event starts at 11:45p or later in the given day,
+      // then pin the calendar start- and end-date to 11:45p and 11:59p of that day.
+      ['2025-11-10T23:45:00', '2025-11-11T00:00:00', '2025-11-10T23:45:00', '2025-11-10T23:59:00'],
+      ['2025-11-10T23:50:00', '2026-11-11T00:05:00', '2025-11-10T23:45:00', '2025-11-10T23:59:00'],
+      ['2025-11-10T23:59:00', '2026-11-11T00:14:00', '2025-11-10T23:45:00', '2025-11-10T23:59:00'],
+    ],
+    async function (
+      assert,
+      [startDate, endDate, expectedCalendarStartDate, expectedCalendarEndDate],
+    ) {
+      let event = this.eventsBase.createEventFromData(
+        {
+          ilmSession: 111,
+          startDate: startDate,
+          endDate: endDate,
+          prerequisites: [],
+          postrequisites: [],
+        },
+        true,
+      );
+      assert.strictEqual(event.startDate, startDate);
+      assert.strictEqual(event.endDate, endDate);
+      assert.strictEqual(
+        DateTime.fromISO(event.calendarStartDate).toISO(),
+        DateTime.fromISO(expectedCalendarStartDate).toISO(),
+      );
+      assert.strictEqual(
+        DateTime.fromISO(event.calendarEndDate).toISO(),
+        DateTime.fromISO(expectedCalendarEndDate).toISO(),
+      );
+    },
+  );
+});

--- a/packages/test-app/tests/integration/components/daily-calendar-event-test.gjs
+++ b/packages/test-app/tests/integration/components/daily-calendar-event-test.gjs
@@ -20,6 +20,8 @@ module('Integration | Component | daily-calendar-event', function (hooks) {
       lastModified,
       isPublished,
       isScheduled,
+      calendarStartDate: startDate,
+      calendarEndDate: endDate,
     });
   };
 

--- a/packages/test-app/tests/integration/components/daily-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/daily-calendar-test.gjs
@@ -23,6 +23,8 @@ module('Integration | Component | daily-calendar', function (hooks) {
     this.server.create('userevent', {
       startDate: DateTime.fromFormat(startDate, 'y-MM-dd h:m:s').toISO(),
       endDate: DateTime.fromFormat(endDate, 'y-MM-dd h:m:s').toISO(),
+      calendarStartDate: DateTime.fromFormat(startDate, 'y-MM-dd h:m:s').toISO(),
+      calendarEndDate: DateTime.fromFormat(endDate, 'y-MM-dd h:m:s').toISO(),
       color: color || '#' + Math.floor(Math.random() * 16777215).toString(16),
       lastModified: endDate,
     });
@@ -131,6 +133,8 @@ module('Integration | Component | daily-calendar', function (hooks) {
     this.server.create('userevent', {
       startDate: january9th2019.toISO(),
       endDate: january9th2019.plus({ hour: 1 }).toISO(),
+      calendarStartDate: january9th2019.toISO(),
+      calendarEndDate: january9th2019.plus({ hour: 1 }).toISO(),
       offering: 1,
     });
     this.set('events', this.server.db.userevents);
@@ -164,6 +168,8 @@ module('Integration | Component | daily-calendar', function (hooks) {
     this.server.create('userevent', {
       startDate: december111980.toISO(),
       endDate: december111980.plus({ hour: 1 }).toISO(),
+      calendarStartDate: december111980.toISO(),
+      calendarEndDate: december111980.plus({ hour: 1 }).toISO(),
     });
     this.set('events', this.server.db.userevents);
     this.set('date', december111980.toJSDate());

--- a/packages/test-app/tests/integration/components/ilios-calendar-event-month-test.gjs
+++ b/packages/test-app/tests/integration/components/ilios-calendar-event-month-test.gjs
@@ -15,6 +15,8 @@ module('Integration | Component | ilios calendar event month', function (hooks) 
       color: '#00cc65',
       startDate: november111984.toJSDate(),
       endDate: november111984.plus({ hour: 1 }).toJSDate(),
+      calendarStartDate: november111984.toJSDate(),
+      calendarEndDate: november111984.plus({ hour: 1 }).toJSDate(),
       lastModified: november111984.toJSDate(),
       name: 'test',
     });

--- a/packages/test-app/tests/integration/components/ilios-calendar-month-test.gjs
+++ b/packages/test-app/tests/integration/components/ilios-calendar-month-test.gjs
@@ -17,14 +17,20 @@ module('Integration | Component | ilios calendar month', function (hooks) {
     firstEvent.name = 'Some new thing';
     firstEvent.startDate = date.toISO();
     firstEvent.endDate = date.plus({ hour: 1 }).toISO();
+    firstEvent.calendarStartDate = firstEvent.startDate;
+    firstEvent.calendarEndDate = firstEvent.endDate;
     const secondEvent = createUserEventObject();
     secondEvent.name = 'Second new thing';
     secondEvent.startDate = date.plus({ hour: 1 }).toISO();
     secondEvent.endDate = date.plus({ hour: 3 }).toISO();
+    secondEvent.calendarStartDate = secondEvent.startDate;
+    secondEvent.calendarEndDate = secondEvent.endDate;
     const thirdEvent = createUserEventObject();
     thirdEvent.name = 'Third new thing';
     thirdEvent.startDate = date.plus({ hour: 3 }).toISO();
     thirdEvent.endDate = date.plus({ hour: 4 }).toISO();
+    thirdEvent.calendarStartDate = thirdEvent.startDate;
+    thirdEvent.calendarEndDate = thirdEvent.endDate;
     this.set('events', [firstEvent, secondEvent, thirdEvent]);
     await render(
       <template>
@@ -47,10 +53,14 @@ module('Integration | Component | ilios calendar month', function (hooks) {
     firstEvent.name = 'Some new thing';
     firstEvent.startDate = date.toISO();
     firstEvent.endDate = date.plus({ hour: 1 }).toISO();
+    firstEvent.calendarStartDate = firstEvent.startDate;
+    firstEvent.calendarEndDate = firstEvent.endDate;
     const secondEvent = createUserEventObject();
     secondEvent.name = 'Second new thing';
     secondEvent.startDate = date.plus({ hour: 1 }).toISO();
     secondEvent.endDate = date.plus({ hour: 3 }).toISO();
+    secondEvent.calendarStartDate = secondEvent.startDate;
+    secondEvent.calendarEndDate = secondEvent.endDate;
     this.set('events', [firstEvent, secondEvent]);
     await render(
       <template>
@@ -114,9 +124,13 @@ module('Integration | Component | ilios calendar month', function (hooks) {
     const event = createUserEventObject();
     event.startDate = date.toISO();
     event.endDate = date.plus({ hour: 24 }).toISO();
+    event.calendarStartDate = event.startDate;
+    event.calendarEndDate = event.endDate;
     const event2 = createUserEventObject();
     event2.startDate = date.plus({ hour: 48 }).toISO();
     event2.endDate = date.plus({ hour: 72 }).toISO();
+    event2.calendarStartDate = event2.startDate;
+    event2.calendarEndDate = event2.endDate;
     this.set('date', date.toJSDate());
     this.set('events', [event, event2]);
     await render(

--- a/packages/test-app/tests/integration/components/monthly-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/monthly-calendar-test.gjs
@@ -66,6 +66,8 @@ module('Integration | Component | monthly-calendar', function (hooks) {
     this.server.createList('userevent', 2, {
       startDate: january9th2019.toISO(),
       endDate: january9th2019.plus({ hour: 1 }).toISO(),
+      calendarStartDate: january9th2019.toISO(),
+      calendarEndDate: january9th2019.plus({ hour: 1 }).toISO(),
     });
     this.set('events', this.server.db.userevents);
     this.set('date', january9th2019.toJSDate());
@@ -103,6 +105,8 @@ module('Integration | Component | monthly-calendar', function (hooks) {
     this.server.createList('userevent', 3, {
       startDate: january9th2019.toISO(),
       endDate: january9th2019.plus({ hour: 1 }).toISO(),
+      calendarStartDate: january9th2019.toISO(),
+      calendarEndDate: january9th2019.plus({ hour: 1 }).toISO(),
     });
     this.set('events', this.server.db.userevents);
     this.set('date', january9th2019.toJSDate());
@@ -167,6 +171,8 @@ module('Integration | Component | monthly-calendar', function (hooks) {
     this.server.create('userevent', {
       startDate: january9th2019.toISO(),
       endDate: january9th2019.plus({ hour: 1 }).toISO(),
+      calendarStartDate: january9th2019.toISO(),
+      calendarEndDate: january9th2019.plus({ hour: 1 }).toISO(),
       offering: 1,
     });
     this.set('events', this.server.db.userevents);
@@ -201,6 +207,8 @@ module('Integration | Component | monthly-calendar', function (hooks) {
     this.server.createList('userevent', 3, {
       startDate: january9th2019.toISO(),
       endDate: january9th2019.plus({ hour: 1 }).toISO(),
+      calendarStartDate: january9th2019.toISO(),
+      calendarEndDate: january9th2019.plus({ hour: 1 }).toISO(),
     });
     this.set('events', this.server.db.userevents);
     this.set('date', january9th2019.toJSDate());
@@ -235,6 +243,8 @@ module('Integration | Component | monthly-calendar', function (hooks) {
       isMulti: true,
       startDate: january9th2019.toISO(),
       endDate: january9th2019.plus({ hour: 1 }).toISO(),
+      calendarStartDate: january9th2019.toISO(),
+      calendarEndDate: january9th2019.plus({ hour: 1 }).toISO(),
       offering: 1,
     });
     this.set('events', this.server.db.userevents);
@@ -269,6 +279,8 @@ module('Integration | Component | monthly-calendar', function (hooks) {
     this.server.create('userevent', {
       startDate: december112017.toISO(),
       endDate: december112017.plus({ hour: 1 }).toISO(),
+      calendarStartDate: december112017.toISO(),
+      calendarEndDate: december112017.plus({ hour: 1 }).toISO(),
     });
     this.set('events', this.server.db.userevents);
     this.set('date', december112017.toJSDate());
@@ -311,6 +323,8 @@ module('Integration | Component | monthly-calendar', function (hooks) {
     this.server.create('userevent', {
       startDate: february1st2020.toISO(),
       endDate: february1st2020.plus({ hour: 1 }).toISO(),
+      calendarStartDate: february1st2020.toISO(),
+      calendarEndDate: february1st2020.plus({ hour: 1 }).toISO(),
     });
     this.set('events', this.server.db.userevents);
     this.set('date', february1st2020.toJSDate());

--- a/packages/test-app/tests/integration/components/weekly-calendar-event-test.gjs
+++ b/packages/test-app/tests/integration/components/weekly-calendar-event-test.gjs
@@ -16,6 +16,8 @@ module('Integration | Component | weekly-calendar-event', function (hooks) {
     this.server.create('userevent', {
       startDate: DateTime.fromFormat(startDate, 'yyyy-LL-dd hh:mm:ss').toISO(),
       endDate: DateTime.fromFormat(endDate, 'yyyy-LL-dd hh:mm:ss').toISO(),
+      calendarStartDate: DateTime.fromFormat(startDate, 'yyyy-LL-dd hh:mm:ss').toISO(),
+      calendarEndDate: DateTime.fromFormat(endDate, 'yyyy-LL-dd hh:mm:ss').toISO(),
       color,
       lastModified: DateTime.fromFormat(lastModified, 'yyyy-LL-dd hh:mm:ss').toISO(),
       isPublished,

--- a/packages/test-app/tests/integration/components/weekly-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/weekly-calendar-test.gjs
@@ -23,6 +23,8 @@ module('Integration | Component | weekly-calendar', function (hooks) {
     this.server.create('userevent', {
       startDate: DateTime.fromFormat(startDate, 'yyyy-LL-dd hh:mm:ss').toISO(),
       endDate: DateTime.fromFormat(endDate, 'yyyy-LL-dd hh:mm:ss').toISO(),
+      calendarStartDate: DateTime.fromFormat(startDate, 'yyyy-LL-dd hh:mm:ss').toISO(),
+      calendarEndDate: DateTime.fromFormat(endDate, 'yyyy-LL-dd hh:mm:ss').toISO(),
       color: color || '#' + Math.floor(Math.random() * 16777215).toString(16),
       lastModified: endDate,
     });
@@ -213,6 +215,8 @@ module('Integration | Component | weekly-calendar', function (hooks) {
     this.server.create('userevent', {
       startDate: january9th2019.toISO(),
       endDate: january9th2019.plus({ hour: 1 }).toISO(),
+      calendarStartDate: january9th2019.toISO(),
+      calendarEndDate: january9th2019.plus({ hour: 1 }).toISO(),
       offering: 1,
     });
     this.set('events', this.server.db.userevents);
@@ -248,6 +252,8 @@ module('Integration | Component | weekly-calendar', function (hooks) {
       isMulti: true,
       startDate: january9th2019.toISO(),
       endDate: january9th2019.plus({ hour: 1 }).toISO(),
+      calendarStartDate: january9th2019.toISO(),
+      calendarEndDate: january9th2019.plus({ hour: 1 }).toISO(),
       offering: 1,
     });
     this.set('events', this.server.db.userevents);
@@ -282,6 +288,8 @@ module('Integration | Component | weekly-calendar', function (hooks) {
     this.server.create('userevent', {
       startDate: december111980.toISO(),
       endDate: december111980.plus({ hour: 1 }).toISO(),
+      calendarStartDate: december111980.toISO(),
+      calendarEndDate: december111980.plus({ hour: 1 }).toISO(),
     });
     this.set('events', this.server.db.userevents);
     this.set('date', december111980.toJSDate());
@@ -331,6 +339,8 @@ module('Integration | Component | weekly-calendar', function (hooks) {
     this.server.create('userevent', {
       startDate: february252020.toISO(),
       endDate: february252020.plus({ hour: 1 }).toISO(),
+      calendarStartDate: february252020.toISO(),
+      calendarEndDate: february252020.plus({ hour: 1 }).toISO(),
     });
     this.set('events', this.server.db.userevents);
     this.set('date', february252020.toJSDate());


### PR DESCRIPTION
fixes ilios/ilios#6631

couple of notes:

- `calendarStartDate` and `calendarEndDate` are derived values and should really be getters. as a follow-up, make event objects based on an actual class, rather than using a plain JS object. then, we can make these attrs actual getters.
- in our test coverage, it is currently  not possible to retrieve the start/end date and -time of events on the calendar via cli page objects. i think this can be rectified by adding `data-test-` attrs to the event notes in the calendar grid that would carry this information, which would allow us to the read them back out during testing. another follow-up item.