### PR TITLE
New Curriculum Report: Session Offerings

### DIFF
--- a/packages/frontend/app/components/reports/curriculum.gjs
+++ b/packages/frontend/app/components/reports/curriculum.gjs
@@ -3,6 +3,7 @@ import { service } from '@ember/service';
 import { cached, tracked } from '@glimmer/tracking';
 import { ensureSafeComponent } from '@embroider/util';
 import SessionObjectives from './curriculum/session-objectives';
+import SessionOfferings from './curriculum/session-offerings';
 import LearnerGroups from './curriculum/learner-groups';
 import Header from 'frontend/components/reports/curriculum/header';
 import ChooseCourse from 'frontend/components/reports/curriculum/choose-course';
@@ -66,6 +67,8 @@ export default class ReportsCurriculumComponent extends Component {
     switch (this.selectedReportValue) {
       case 'sessionObjectives':
         return ensureSafeComponent(SessionObjectives, this);
+      case 'sessionOfferings':
+        return ensureSafeComponent(SessionOfferings, this);
       case 'learnerGroups':
         return ensureSafeComponent(LearnerGroups, this);
     }

--- a/packages/frontend/app/components/reports/curriculum/header.gjs
+++ b/packages/frontend/app/components/reports/curriculum/header.gjs
@@ -70,6 +70,14 @@ export default class ReportsCurriculumHeader extends Component {
           }),
         },
         {
+          value: 'sessionOfferings',
+          label: this.intl.t('general.sessionOfferings'),
+          summary: this.intl.t('general.sessionOfferingsReportSummaryMultiSchool', {
+            courseCount: this.args.countSelectedCourses,
+            schoolCount: this.countSelectedSchools,
+          }),
+        },
+        {
           value: 'learnerGroups',
           label: this.intl.t('general.learnerGroups'),
           summary: this.intl.t('general.learnerGroupsReportSummaryMultiSchool', {
@@ -84,6 +92,13 @@ export default class ReportsCurriculumHeader extends Component {
           value: 'sessionObjectives',
           label: this.intl.t('general.sessionObjectives'),
           summary: this.intl.t('general.sessionObjectivesReportSummary', {
+            courseCount: this.args.countSelectedCourses,
+          }),
+        },
+        {
+          value: 'sessionOfferings',
+          label: this.intl.t('general.sessionOfferings'),
+          summary: this.intl.t('general.sessionOfferingsReportSummary', {
             courseCount: this.args.countSelectedCourses,
           }),
         },

--- a/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
+++ b/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
@@ -190,7 +190,7 @@ export default class ReportsCurriculumSessionOfferingsComponent extends Componen
       rhett[this.intl.t('general.course')] = o.courseTitle;
       rhett[this.intl.t('general.year')] = o.courseYear;
       rhett[this.intl.t('general.session')] = o.sessionTitle;
-      rhett[this.intl.t('general.date')] = o.offeringDate;
+      rhett[this.intl.t('general.offeringDate')] = o.offeringDate;
       if (o.learnerGroups) {
         rhett[this.intl.t('general.learnerGroups')] = o.learnerGroups.join(', ');
       }

--- a/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
+++ b/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
@@ -195,7 +195,7 @@ export default class ReportsCurriculumSessionOfferingsComponent extends Componen
       if (o.learnerGroups) {
         rhett[this.intl.t('general.learnerGroups')] = o.learnerGroups.join(', ');
       }
-      rhett[this.intl.t('general.sessionLink')] = o.sessionLink;
+      rhett[this.intl.t('general.link')] = o.sessionLink;
 
       return rhett;
     });

--- a/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
+++ b/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
@@ -127,7 +127,11 @@ export default class ReportsCurriculumSessionOfferingsComponent extends Componen
       return a.courseTitle.localeCompare(b.courseTitle);
     }
 
-    return a.sessionTitle.localeCompare(b.sessionTitle);
+    if (a.sessionTitle !== b.sessionTitle) {
+      return a.sessionTitle.localeCompare(b.sessionTitle);
+    }
+
+    return a.offeringDate.localeCompare(b.offeringDate);
   };
 
   get selectedSchoolIds() {

--- a/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
+++ b/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
@@ -86,10 +86,6 @@ export default class ReportsCurriculumSessionOfferingsComponent extends Componen
     });
   }
 
-  get summaryReport() {
-    return this.summary;
-  }
-
   get results() {
     const origin = window.location.origin;
     return this.reportWithInstructors.reduce((acc, c) => {
@@ -274,7 +270,7 @@ export default class ReportsCurriculumSessionOfferingsComponent extends Componen
               </tr>
             {{/each}}
           {{else}}
-            {{#each (sortBy "courseTitle" this.summaryReport) as |o|}}
+            {{#each (sortBy "courseTitle" this.summary) as |o|}}
               <tr data-test-result>
                 {{#if this.hasMultipleSchools}}
                   <td>{{o.schoolTitle}}</td>

--- a/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
+++ b/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
@@ -101,7 +101,7 @@ export default class ReportsCurriculumSessionOfferingsComponent extends Componen
             courseTitle: c.title,
             courseYear: c.year,
             sessionTitle: s.title,
-            offeringDate: DateTime.fromISO(o.startDate).toFormat('yyyy-MM-dd, h:mm a'),
+            offeringDate: o.startDate,
             instructors: s.instructors,
             learnerGroups: o.learnerGroups.map((lg) => lg.title),
             sessionLink: `${origin}${path}`,
@@ -131,7 +131,10 @@ export default class ReportsCurriculumSessionOfferingsComponent extends Componen
       return a.sessionTitle.localeCompare(b.sessionTitle);
     }
 
-    return a.offeringDate.localeCompare(b.offeringDate);
+    return (
+      DateTime.fromISO(a.offeringDate).toUnixInteger() -
+      DateTime.fromISO(b.offeringDate).toUnixInteger()
+    );
   };
 
   get selectedSchoolIds() {
@@ -194,7 +197,9 @@ export default class ReportsCurriculumSessionOfferingsComponent extends Componen
       rhett[this.intl.t('general.course')] = o.courseTitle;
       rhett[this.intl.t('general.year')] = o.courseYear;
       rhett[this.intl.t('general.session')] = o.sessionTitle;
-      rhett[this.intl.t('general.offeringDate')] = o.offeringDate;
+      rhett[this.intl.t('general.offeringDate')] = DateTime.fromISO(o.offeringDate).toFormat(
+        'yyyy-MM-dd, h:mm a',
+      );
       rhett[this.intl.t('general.instructors')] = o.instructors.join(', ');
       if (o.learnerGroups) {
         rhett[this.intl.t('general.learnerGroups')] = o.learnerGroups.join(', ');

--- a/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
+++ b/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import PapaParse from 'papaparse';
+import { DateTime } from 'luxon';
 import { task, timeout } from 'ember-concurrency';
 import createDownloadFile from 'frontend/utils/create-download-file';
 import { cached, tracked } from '@glimmer/tracking';
@@ -100,11 +101,10 @@ export default class ReportsCurriculumSessionOfferingsComponent extends Componen
             courseTitle: c.title,
             courseYear: c.year,
             sessionTitle: s.title,
-            offeringDate: o.startDate,
+            offeringDate: DateTime.fromISO(o.startDate).toFormat('yyyy-MM-dd, h:mm a'),
             instructors: s.instructors,
             learnerGroups: o.learnerGroups.map((lg) => lg.title),
             sessionLink: `${origin}${path}`,
-            learnerGroupLink: `${origin}${path}`,
           };
 
           if (this.hasMultipleSchools) {
@@ -191,12 +191,11 @@ export default class ReportsCurriculumSessionOfferingsComponent extends Componen
       rhett[this.intl.t('general.year')] = o.courseYear;
       rhett[this.intl.t('general.session')] = o.sessionTitle;
       rhett[this.intl.t('general.offeringDate')] = o.offeringDate;
+      rhett[this.intl.t('general.instructors')] = o.instructors.join(', ');
       if (o.learnerGroups) {
         rhett[this.intl.t('general.learnerGroups')] = o.learnerGroups.join(', ');
       }
-      rhett[this.intl.t('general.instructors')] = o.instructors.join(', ');
       rhett[this.intl.t('general.sessionLink')] = o.sessionLink;
-      rhett[this.intl.t('general.learnerGroupLink')] = o.learnerGroupLink;
 
       return rhett;
     });

--- a/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
+++ b/packages/frontend/app/components/reports/curriculum/session-offerings.gjs
@@ -1,0 +1,291 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import PapaParse from 'papaparse';
+import { task, timeout } from 'ember-concurrency';
+import createDownloadFile from 'frontend/utils/create-download-file';
+import { cached, tracked } from '@glimmer/tracking';
+import { TrackedAsyncData } from 'ember-async-data';
+import { chunk } from 'ilios-common/utils/array-helpers';
+import Header from 'frontend/components/reports/curriculum/header';
+import noop from 'ilios-common/helpers/noop';
+import perform from 'ember-concurrency/helpers/perform';
+import add from 'ember-math-helpers/helpers/add';
+import t from 'ember-intl/helpers/t';
+import sortBy from 'ilios-common/helpers/sort-by';
+import { LinkTo } from '@ember/routing';
+
+export default class ReportsCurriculumSessionOfferingsComponent extends Component {
+  @service router;
+  @service intl;
+  @service store;
+  @service graphql;
+  @service reporting;
+  @tracked finishedBuildingReport = false;
+
+  @cached
+  get queryPromises() {
+    const chunks = chunk(this.args.courses, 5);
+    const userData = ['id', 'firstName', 'lastName', 'middleName', 'displayName'].join(', ');
+    const sessionData = [
+      'id',
+      'title',
+      `offerings { id, startDate, learnerGroups { id, title }, instructors { ${userData} }, instructorGroups { id, users { ${userData} } } }`,
+      `ilmSession { id, dueDate, hours, instructors { ${userData} }, instructorGroups { id, users { ${userData} } } }`,
+    ].join(', ');
+
+    const data = ['id', 'title', 'year', 'school { id, title }', `sessions { ${sessionData} }`];
+
+    return chunks.map((courses) => {
+      const courseIds = courses.map((c) => c.id);
+      const filters = [`ids: [${courseIds.join(', ')}]`];
+      return new TrackedAsyncData(this.graphql.find('courses', filters, data.join(', ')));
+    });
+  }
+
+  get completedPromises() {
+    return this.queryPromises.filter((tad) => tad.isResolved);
+  }
+
+  get reportRunning() {
+    return this.queryPromises.length > this.completedPromises.length;
+  }
+
+  get reportResults() {
+    if (this.reportRunning) {
+      return [];
+    }
+    return this.completedPromises
+      .map(({ value }) => value)
+      .map(({ data }) => data.courses)
+      .flat();
+  }
+
+  get reportWithInstructors() {
+    return this.reportResults.map((c) => {
+      c.sessions = c.sessions.map(this.reporting.consolidateSessionInstructorsGraph);
+
+      return c;
+    });
+  }
+
+  get summary() {
+    return this.reportWithInstructors.map((c) => {
+      return {
+        schoolTitle: c.school.title,
+        courseId: c.id,
+        courseTitle: c.title,
+        courseYear: c.year,
+        sessionCount: c.sessions.length,
+        sessionOfferingCount: [].concat(...c.sessions.map((s) => s.offerings)).flat().length,
+        instructorsCount: this.reporting.countUniqueValuesInArray(c.sessions, 'instructors'),
+        learnerGroupsCount: []
+          .concat(...c.sessions.map((s) => s.offerings.map((o) => o.learnerGroups)))
+          .flat().length,
+      };
+    });
+  }
+
+  get summaryReport() {
+    return this.summary;
+  }
+
+  get results() {
+    const origin = window.location.origin;
+    return this.reportWithInstructors.reduce((acc, c) => {
+      c.sessions.forEach((s) => {
+        const path = this.router.urlFor('session', c.id, s.id);
+        s.offerings.forEach((o) => {
+          const sessionOffering = {
+            courseId: c.id,
+            courseTitle: c.title,
+            courseYear: c.year,
+            sessionTitle: s.title,
+            offeringDate: o.startDate,
+            instructors: s.instructors,
+            learnerGroups: o.learnerGroups.map((lg) => lg.title),
+            sessionLink: `${origin}${path}`,
+            learnerGroupLink: `${origin}${path}`,
+          };
+
+          if (this.hasMultipleSchools) {
+            sessionOffering.schoolTitle = c.school.title;
+          }
+
+          acc.push(sessionOffering);
+        });
+      });
+      return acc;
+    }, []);
+  }
+
+  get sortedResults() {
+    return this.results.sort(this.sortResults);
+  }
+
+  sortResults = (a, b) => {
+    if (a.courseTitle !== b.courseTitle) {
+      return a.courseTitle.localeCompare(b.courseTitle);
+    }
+
+    return a.sessionTitle.localeCompare(b.sessionTitle);
+  };
+
+  get selectedSchoolIds() {
+    if (!this.args.courses) {
+      return [];
+    }
+    const schools = this.store.peekAll('school');
+    let schoolIds = [];
+    this.args.courses.map((course) => {
+      const schoolForCourse = schools.find((school) =>
+        school.hasMany('courses').ids().includes(course.id),
+      );
+
+      if (schoolForCourse) {
+        schoolIds = [...schoolIds, schoolForCourse.id];
+      }
+    });
+    return [...new Set(schoolIds)];
+  }
+
+  get countSelectedSchools() {
+    return this.selectedSchoolIds.length;
+  }
+
+  get hasMultipleSchools() {
+    return this.countSelectedSchools > 1;
+  }
+
+  get schoolTitlePlaceholder() {
+    return 'School';
+  }
+
+  get yearPlaceholder() {
+    return '2025';
+  }
+
+  get sessionCountPlaceholder() {
+    return '11';
+  }
+
+  get sessionOfferingCountPlaceholder() {
+    return '22';
+  }
+
+  get instructorsCountPlaceholder() {
+    return '11';
+  }
+
+  get learnerGroupsCountPlaceholder() {
+    return '84';
+  }
+
+  downloadReport = task({ drop: true }, async () => {
+    const data = this.sortedResults.map((o) => {
+      const rhett = {};
+
+      if (this.hasMultipleSchools) {
+        rhett[this.intl.t('general.school')] = o.schoolTitle;
+      }
+      rhett[this.intl.t('general.course')] = o.courseTitle;
+      rhett[this.intl.t('general.year')] = o.courseYear;
+      rhett[this.intl.t('general.session')] = o.sessionTitle;
+      rhett[this.intl.t('general.date')] = o.offeringDate;
+      if (o.learnerGroups) {
+        rhett[this.intl.t('general.learnerGroups')] = o.learnerGroups.join(', ');
+      }
+      rhett[this.intl.t('general.instructors')] = o.instructors.join(', ');
+      rhett[this.intl.t('general.sessionLink')] = o.sessionLink;
+      rhett[this.intl.t('general.learnerGroupLink')] = o.learnerGroupLink;
+
+      return rhett;
+    });
+
+    const csv = PapaParse.unparse(data);
+    this.finishedBuildingReport = true;
+    createDownloadFile(`offerings.csv`, csv, 'text/csv');
+    await timeout(2000);
+    this.finishedBuildingReport = false;
+  });
+  <template>
+    <Header
+      @selectedSchoolIds={{this.selectedSchoolIds}}
+      @countSelectedCourses={{@courses.length}}
+      @showReportResults={{true}}
+      @loading={{this.reportRunning}}
+      @selectedReportValue="sessionOfferings"
+      @changeSelectedReport={{(noop)}}
+      @close={{@close}}
+      @download={{perform this.downloadReport}}
+      @finished={{this.finishedBuildingReport}}
+    />
+    <div class="progress-container">
+      {{#if this.reportRunning}}
+        <progress
+          value={{add 1 this.completedPromises.length}}
+          max={{add 1 this.queryPromises.length}}
+        ></progress>
+      {{/if}}
+    </div>
+    <div
+      class="report-results{{if this.reportRunning ' loading-shimmer loading-text running'}}"
+      data-test-report-results
+    >
+      <table>
+        <caption>{{t "general.resultsSummary"}}</caption>
+        <thead>
+          <tr>
+            {{#if this.hasMultipleSchools}}
+              <th>{{t "general.school"}}</th>
+            {{/if}}
+            <th>{{t "general.course"}}</th>
+            <th>{{t "general.year"}}</th>
+            <th>{{t "general.sessions"}}</th>
+            <th>{{t "general.offerings"}}</th>
+            <th>{{t "general.instructors"}}</th>
+            <th>{{t "general.learnerGroups"}}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#if this.reportRunning}}
+            {{#each (sortBy "title" @courses) as |c|}}
+              <tr>
+                {{#if this.hasMultipleSchools}}
+                  <td>{{this.schoolTitlePlaceholder}}</td>
+                {{/if}}
+                <td>
+                  <LinkTo @route="course" @model={{c.id}}>
+                    {{c.title}}
+                  </LinkTo>
+                </td>
+                <td>{{this.yearPlaceholder}}</td>
+                <td>{{this.sessionCountPlaceholder}}</td>
+                <td>{{this.sessionOfferingCountPlaceholder}}</td>
+                <td>{{this.instructorsCountPlaceholder}}</td>
+                <td>{{this.learnerGroupsCountPlaceholder}}</td>
+              </tr>
+            {{/each}}
+          {{else}}
+            {{#each (sortBy "courseTitle" this.summaryReport) as |o|}}
+              <tr data-test-result>
+                {{#if this.hasMultipleSchools}}
+                  <td>{{o.schoolTitle}}</td>
+                {{/if}}
+                <td>
+                  <LinkTo @route="course" @model={{o.courseId}}>
+                    {{o.courseTitle}}
+                  </LinkTo>
+                </td>
+                <td>{{o.courseYear}}</td>
+                <td>{{o.sessionCount}}</td>
+                <td>{{o.sessionOfferingCount}}</td>
+                <td>{{o.instructorsCount}}</td>
+                <td>{{o.learnerGroupsCount}}</td>
+              </tr>
+            {{/each}}
+          {{/if}}
+        </tbody>
+      </table>
+    </div>
+  </template>
+}

--- a/packages/frontend/tests/integration/components/reports/curriculum/header-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/curriculum/header-test.gjs
@@ -25,29 +25,38 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.reportSelector.isPresent, 'ReportSelector component is present');
+    assert.ok(component.reportSelector.isPresent, 'report types selector component is present');
     assert.strictEqual(
       component.reportSelector.options.length,
-      2,
-      'ReportSelector component has two options',
+      3,
+      'report types selector has correct number of options',
     );
     assert.strictEqual(
       component.reportSelector.options[0].text,
       'Session Objectives',
-      'ReportSelector has correct first option text',
+      'report types selector has correct first option text',
     );
     assert.ok(
       component.reportSelector.options[0].isSelected,
-      'ReportSelector first option is chosen',
+      'report types selector first option is chosen',
     );
     assert.strictEqual(
       component.reportSelector.options[1].text,
-      'Learner Groups',
-      'ReportSelector has correct second option text',
+      'Session Offerings',
+      'report types selector has correct second option text',
     );
     assert.notOk(
       component.reportSelector.options[1].isSelected,
-      'ReportSelector second option is not chosen',
+      'report types selector second option is not chosen',
+    );
+    assert.strictEqual(
+      component.reportSelector.options[2].text,
+      'Learner Groups',
+      'report types selector has correct third option text',
+    );
+    assert.notOk(
+      component.reportSelector.options[2].isSelected,
+      'report types selector third option is not chosen',
     );
     assert.ok(
       component.runSummaryText.includes('for 3 courses'),
@@ -59,8 +68,8 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
         'summary text is correct',
       ),
     );
-    assert.ok(component.runReport.isPresent);
-    assert.ok(component.copy.isPresent);
+    assert.ok(component.runReport.isPresent, 'run report button is present');
+    assert.ok(component.copy.isPresent, 'copy report button is present');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -87,7 +96,7 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
     assert.ok(component.reportSelector.isPresent, 'report types selector is present');
     assert.strictEqual(
       component.reportSelector.options.length,
-      2,
+      3,
       'report types selector has correct number of options',
     );
     assert.strictEqual(
@@ -101,12 +110,21 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
     );
     assert.strictEqual(
       component.reportSelector.options[1].text,
-      'Learner Groups',
+      'Session Offerings',
       'second report type option text is correct',
     );
     assert.notOk(
       component.reportSelector.options[1].isSelected,
       'second report type option is not selected',
+    );
+    assert.strictEqual(
+      component.reportSelector.options[2].text,
+      'Learner Groups',
+      'third report type option text is correct',
+    );
+    assert.notOk(
+      component.reportSelector.options[2].isSelected,
+      'third report type option is not selected',
     );
     assert.ok(
       component.runSummaryText.includes('for 2 courses, across 2 schools'),
@@ -115,6 +133,133 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
     assert.ok(
       component.runSummaryText.includes(
         'Each session objective is listed along with instructors and course data.',
+      ),
+    );
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
+  });
+
+  test('it renders for session offerings and is accessible', async function (assert) {
+    await render(
+      <template>
+        <Header
+          @countSelectedCourses={{3}}
+          @showReportResults={{false}}
+          @selectedReportValue="sessionOfferings"
+          @changeSelectedReport={{(noop)}}
+          @runReport={{(noop)}}
+          @close={{(noop)}}
+        />
+      </template>,
+    );
+    assert.ok(component.reportSelector.isPresent, 'report types selector component is present');
+    assert.strictEqual(
+      component.reportSelector.options.length,
+      3,
+      'report types selector has correct number of options',
+    );
+    assert.strictEqual(
+      component.reportSelector.options[0].text,
+      'Session Objectives',
+      'report types selector has correct first option text',
+    );
+    assert.notOk(
+      component.reportSelector.options[0].isSelected,
+      'report types selector first option is not chosen',
+    );
+    assert.strictEqual(
+      component.reportSelector.options[1].text,
+      'Session Offerings',
+      'report types selector has correct second option text',
+    );
+    assert.ok(
+      component.reportSelector.options[1].isSelected,
+      'report types selector second option is chosen',
+    );
+    assert.strictEqual(
+      component.reportSelector.options[2].text,
+      'Learner Groups',
+      'report types selector has correct third option text',
+    );
+    assert.notOk(
+      component.reportSelector.options[2].isSelected,
+      'report types selector third option is not chosen',
+    );
+    assert.ok(
+      component.runSummaryText.includes('for 3 courses'),
+      'summary text has correct number of courses',
+    );
+    assert.ok(
+      component.runSummaryText.includes(
+        'Each session offering is listed along with instructors, learner groups, and course data.',
+        'summary text is correct',
+      ),
+    );
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders for session offerings across multiple schools', async function (assert) {
+    this.schools = this.server.createList('school', 2);
+    const course1 = this.server.create('course', { school: this.schools[0] });
+    const course2 = this.server.create('course', { school: this.schools[1] });
+    this.courses = [course1, course2];
+
+    await render(
+      <template>
+        <Header
+          @selectedSchoolIds={{array "1" "2"}}
+          @countSelectedCourses={{2}}
+          @showReportResults={{false}}
+          @selectedReportValue="sessionOfferings"
+          @changeSelectedReport={{(noop)}}
+          @runReport={{(noop)}}
+          @close={{(noop)}}
+        />
+      </template>,
+    );
+    assert.ok(component.reportSelector.isPresent, 'report types selector is present');
+    assert.strictEqual(
+      component.reportSelector.options.length,
+      3,
+      'report types selector has correct number of options',
+    );
+    assert.strictEqual(
+      component.reportSelector.options[0].text,
+      'Session Objectives',
+      'first report type option text is correct',
+    );
+    assert.notOk(
+      component.reportSelector.options[0].isSelected,
+      'first report type option is not selected',
+    );
+    assert.strictEqual(
+      component.reportSelector.options[1].text,
+      'Session Offerings',
+      'second report type option text is correct',
+    );
+    assert.ok(
+      component.reportSelector.options[1].isSelected,
+      'second report type option is selected',
+    );
+    assert.strictEqual(
+      component.reportSelector.options[2].text,
+      'Learner Groups',
+      'third report type option text is correct',
+    );
+    assert.notOk(
+      component.reportSelector.options[2].isSelected,
+      'third report type option is not selected',
+    );
+    assert.ok(
+      component.runSummaryText.includes('for 2 courses, across 2 schools'),
+      'summary includes correct number of courses and schools',
+    );
+    assert.ok(
+      component.runSummaryText.includes(
+        'Each session offering is listed along with instructors, learner groups, and course data.',
       ),
     );
     assert.ok(component.runReport.isPresent);
@@ -134,12 +279,18 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.reportSelector.isPresent);
-    assert.strictEqual(component.reportSelector.options.length, 2);
+    assert.ok(component.reportSelector.isPresent, 'report types selector is present');
+    assert.strictEqual(
+      component.reportSelector.options.length,
+      3,
+      'report selector has correct number of options',
+    );
     assert.strictEqual(component.reportSelector.options[0].text, 'Session Objectives');
     assert.notOk(component.reportSelector.options[0].isSelected);
-    assert.strictEqual(component.reportSelector.options[1].text, 'Learner Groups');
-    assert.ok(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Session Offerings');
+    assert.notOk(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Learner Groups');
+    assert.ok(component.reportSelector.options[2].isSelected);
     assert.ok(component.runSummaryText.includes('for 5 courses'));
     assert.ok(
       component.runSummaryText.includes(
@@ -169,7 +320,7 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
     assert.ok(component.reportSelector.isPresent, 'report types selector is present');
     assert.strictEqual(
       component.reportSelector.options.length,
-      2,
+      3,
       'report types selector has correct number of options',
     );
     assert.strictEqual(
@@ -183,12 +334,21 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
     );
     assert.strictEqual(
       component.reportSelector.options[1].text,
-      'Learner Groups',
+      'Session Offerings',
       'second report type option text is correct',
     );
-    assert.ok(
+    assert.notOk(
       component.reportSelector.options[1].isSelected,
       'second report type option text is not chosen',
+    );
+    assert.strictEqual(
+      component.reportSelector.options[2].text,
+      'Learner Groups',
+      'third report type option text is correct',
+    );
+    assert.ok(
+      component.reportSelector.options[2].isSelected,
+      'third report type option text is not chosen',
     );
     assert.ok(component.runSummaryText.includes('for 5 courses, across 3 schools'));
     assert.ok(
@@ -218,6 +378,13 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
       </template>,
     );
     assert.strictEqual(component.reportSelector.value, 'sessionObjectives');
+    await component.reportSelector.set('sessionOfferings');
+    assert.strictEqual(component.reportSelector.value, 'sessionOfferings');
+    assert.ok(
+      component.runSummaryText.includes(
+        'Each session offering is listed along with instructors, learner groups, and course data.',
+      ),
+    );
     await component.reportSelector.set('learnerGroups');
     assert.strictEqual(component.reportSelector.value, 'learnerGroups');
     assert.ok(

--- a/packages/frontend/tests/integration/components/reports/curriculum/session-offerings-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/curriculum/session-offerings-test.gjs
@@ -1,0 +1,101 @@
+import { module, test, skip } from 'qunit';
+import { setupRenderingTest } from 'frontend/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { setupMirage } from 'frontend/tests/test-support/mirage';
+import { component } from 'frontend/tests/pages/components/reports/curriculum/session-offerings';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { graphQL } from 'frontend/tests/helpers/curriculum-report';
+import SessionOfferings from 'frontend/components/reports/curriculum/session-offerings';
+import { array } from '@ember/helper';
+import noop from 'ilios-common/helpers/noop';
+
+module('Integration | Component | reports/curriculum/session-offerings', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.school = this.server.create('school');
+    const course = this.server.create('course', { school: this.school });
+    const sessionType = this.server.create('sessionType');
+    const session = this.server.create('session', { course, sessionType });
+    this.server.create('sessionObjective', { session });
+    const offering = this.server.create('offering', { session });
+    const offeringInstructorGroup = this.server.create('instructorGroup', {
+      offerings: [offering],
+    });
+    this.server.create('user', { instructorGroups: [offeringInstructorGroup] });
+    this.server.create('user', { instructedOfferings: [offering] });
+
+    const ilmSession = this.server.create('ilmSession', { session });
+    const ilmSessionInstructorGroup = this.server.create('instructorGroup', {
+      ilmSessions: [ilmSession],
+    });
+    this.server.create('user', { instructorGroups: [ilmSessionInstructorGroup] });
+    this.server.create('user', { instructorIlmSessions: [ilmSession] });
+    this.server.post('api/graphql', (schema) => {
+      //use all the courses, getting the id filter from graphQL is a bit tricky
+      const courseIds = schema.db.courses.map((c) => c.id);
+      const rawCourses = courseIds.map((id) => graphQL.fetchCourse(schema.db, id));
+      const courses = rawCourses.map((course) => {
+        course.sessions.forEach((session) => {
+          session.sessionObjectives = schema.db.sessionObjectives
+            .where({ sessionId: session.id })
+            .map(({ id, title }) => ({ id, title }));
+        });
+
+        return course;
+      });
+      return { data: { courses } };
+    });
+  });
+
+  test('it renders and is accessible', async function (assert) {
+    const courseModels = await this.owner.lookup('service:store').findAll('course');
+    this.set('courses', courseModels);
+
+    await render(
+      <template>
+        <SessionOfferings
+          @courses={{this.courses}}
+          @selectedSchoolIds={{array "1"}}
+          @countSelectedSchools={{1}}
+          @hasMultipleSchools={{false}}
+          @close={{(noop)}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(
+      component.header.runSummaryText,
+      'Run Session Offerings report for one course. Each session offering is listed along with instructors, learner groups, and course data.',
+    );
+
+    assert.strictEqual(component.results.length, 1);
+    assert.strictEqual(component.results.objectAt(0).courseTitle, 'course 0');
+    assert.strictEqual(component.results.objectAt(0).courseYear, '2013');
+    assert.strictEqual(component.results.objectAt(0).sessionCount, '1');
+    assert.strictEqual(component.results.objectAt(0).offeringCount, '1');
+    assert.strictEqual(component.results.objectAt(0).instructorCount, '4');
+    assert.strictEqual(component.results.objectAt(0).learnerGroupCount, '1');
+
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  skip('download report', async function (assert) {
+    const courseModels = await this.owner.lookup('service:store').findAll('course');
+    this.set('courses', courseModels);
+
+    await render(
+      <template><SessionOfferings @courses={{this.courses}} @close={{(noop)}} /></template>,
+    );
+
+    assert.strictEqual(
+      component.header.runSummaryText,
+      'Run Session Offerings report for one course. Each session offering is listed along with instructors, learner groups, and course data.',
+    );
+
+    await component.header.download.click();
+    assert.ok(true, 'downloaded report');
+  });
+});

--- a/packages/frontend/tests/pages/components/reports/curriculum/session-offerings.js
+++ b/packages/frontend/tests/pages/components/reports/curriculum/session-offerings.js
@@ -1,0 +1,27 @@
+import { create, collection, text } from 'ember-cli-page-object';
+
+import header from './header';
+
+const definition = {
+  header,
+  results: collection('[data-test-report-results] [data-test-result]', {
+    courseTitle: text('td', { at: 0 }),
+    courseYear: text('td', { at: 1 }),
+    sessionCount: text('td', { at: 2 }),
+    offeringCount: text('td', { at: 3 }),
+    instructorCount: text('td', { at: 4 }),
+    learnerGroupCount: text('td', { at: 5 }),
+  }),
+  resultsMultiSchool: collection('[data-test-report-results] [data-test-result]', {
+    schoolTitle: text('td', { at: 0 }),
+    courseTitle: text('td', { at: 1 }),
+    courseYear: text('td', { at: 2 }),
+    sessionCount: text('td', { at: 3 }),
+    offeringCount: text('td', { at: 4 }),
+    instructorCount: text('td', { at: 5 }),
+    learnerGroupCount: text('td', { at: 6 }),
+  }),
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -195,7 +195,6 @@ general:
   lastName: Last Name
   learner: Learner
   learnerAssignments: "{groupTitle} Learner Assignments"
-  learnerGroupLink: Learner Group URL
   learnerGroupsReportSummary: "report for {courseCount, plural, one {one course} other {# courses}}. Each attached learner group is listed along with instructors and course data."
   learnerGroupsReportSummaryMultiSchool: "report for {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, across # schools}}. Each attached learner group is listed along with instructors and course data."
   learnerGroupTitle: Learner Group Title

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -404,8 +404,8 @@ general:
   sessionObjectivesReportSummary: "report for {courseCount, plural, one {one course} other {# courses}}. Each session objective is listed along with instructors and course data."
   sessionObjectivesReportSummaryMultiSchool: "report for {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, across # schools}}. Each session objective is listed along with instructors and course data."
   sessionOfferings: Session Offerings
-  sessionOfferingsReportSummary: "report for {courseCount, plural, one {one course} other {# courses}}. Each session offering is listed along with learner groups, instructors, and course data."
-  sessionOfferingsReportSummaryMultiSchool: "report for {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, across # schools}}. Each session offering is listed along with learner groups, instructors, and course data."
+  sessionOfferingsReportSummary: "report for {courseCount, plural, one {one course} other {# courses}}. Each session offering is listed along with instructors, learner groups, and course data."
+  sessionOfferingsReportSummaryMultiSchool: "report for {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, across # schools}}. Each session offering is listed along with instructors, learner groups, and course data."
   sessionTitlePlaceholder: Enter a title for this session
   sessionTypeConfirmRemoval: Are you sure you want to delete this session type? This action cannot be undone.
   sessionTypeTitlePlaceholder: Enter a title for this session type

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -398,7 +398,6 @@ general:
   sequenceBlockTitlePlaceholder: Enter a title for this sequence block
   sequenceNumber: "Sequence #"
   sessionAttributes: Session Attributes
-  sessionLink: Session URL
   sessionObjectives: Session Objectives
   sessionObjectivesReportSummary: "report for {courseCount, plural, one {one course} other {# courses}}. Each session objective is listed along with instructors and course data."
   sessionObjectivesReportSummaryMultiSchool: "report for {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, across # schools}}. Each session objective is listed along with instructors and course data."

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -297,6 +297,7 @@ general:
   objectiveParentsTitle: Select Parent Objectives
   objectiveTitle: Session Objective
   off: Off
+  offeringDate: Offering Date
   ok: OK
   on: On
   openSmallGroupGenerator: Open Offering Small Group Generator

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -195,6 +195,7 @@ general:
   lastName: Last Name
   learner: Learner
   learnerAssignments: "{groupTitle} Learner Assignments"
+  learnerGroupLink: Learner Group URL
   learnerGroupsReportSummary: "report for {courseCount, plural, one {one course} other {# courses}}. Each attached learner group is listed along with instructors and course data."
   learnerGroupsReportSummaryMultiSchool: "report for {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, across # schools}}. Each attached learner group is listed along with instructors and course data."
   learnerGroupTitle: Learner Group Title
@@ -397,9 +398,13 @@ general:
   sequenceBlockTitlePlaceholder: Enter a title for this sequence block
   sequenceNumber: "Sequence #"
   sessionAttributes: Session Attributes
+  sessionLink: Session URL
   sessionObjectives: Session Objectives
   sessionObjectivesReportSummary: "report for {courseCount, plural, one {one course} other {# courses}}. Each session objective is listed along with instructors and course data."
   sessionObjectivesReportSummaryMultiSchool: "report for {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, across # schools}}. Each session objective is listed along with instructors and course data."
+  sessionOfferings: Session Offerings
+  sessionOfferingsReportSummary: "report for {courseCount, plural, one {one course} other {# courses}}. Each session offering is listed along with learner groups, instructors, and course data."
+  sessionOfferingsReportSummaryMultiSchool: "report for {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, across # schools}}. Each session offering is listed along with learner groups, instructors, and course data."
   sessionTitlePlaceholder: Enter a title for this session
   sessionTypeConfirmRemoval: Are you sure you want to delete this session type? This action cannot be undone.
   sessionTypeTitlePlaceholder: Enter a title for this session type

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -398,7 +398,6 @@ general:
   sequenceBlockTitlePlaceholder: "Introduzca un título para esta bloque de la secuencia"
   sequenceNumber: No. de Secuencia
   sessionAttributes: Atributos de la Sesión
-  sessionLink: Enlace de Sesión
   sessionObjectives: Objetivos de la sesión
   sessionObjectivesReportSummary: "informe para {courseCount, plural, one {un curso} other {# cursos}}. Se enumera el objetivo de cada sesión junto con los instructores y los datos del curso."
   sessionObjectivesReportSummaryMultiSchool: "informe para {courseCount, plural, one {un curso} other {# cursos}}{schoolCount, plural, zero {} one {} other {, en # escuelas}}. Se enumera el objetivo de cada sesión junto con los instructores y los datos del curso."

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -400,6 +400,9 @@ general:
   sessionObjectives: Objetivos de la sesión
   sessionObjectivesReportSummary: "informe para {courseCount, plural, one {un curso} other {# cursos}}. Se enumera el objetivo de cada sesión junto con los instructores y los datos del curso."
   sessionObjectivesReportSummaryMultiSchool: "informe para {courseCount, plural, one {un curso} other {# cursos}}{schoolCount, plural, zero {} one {} other {, en # escuelas}}. Se enumera el objetivo de cada sesión junto con los instructores y los datos del curso."
+  sessionOfferings: Ofrecimientos de la Sesión
+  sessionOfferingsReportSummary: "informe para {courseCount, plural, one {un curso} other {# cursos}}. Se enumera el ofrecimiento de cada sesión junto con los grupos de aprendedores, los instructores, y los datos del curso."
+  sessionOfferingsReportSummaryMultiSchool: "informe para {courseCount, plural, one {un curso} other {# cursos}}{schoolCount, plural, zero {} one {} other {, en # escuelas}}. Se enumera el ofrecimiento de cada sesión junto con los grupos de aprendedores, los instructores, y los datos del curso."
   sessionTitlePlaceholder: Entre en un titulo para esta sesión
   sessionTypeConfirmRemoval: ¿Está seguro de que desea eliminar este tipo de sesión? Esta acción no se puede deshacer.
   sessionTypeTitlePlaceholder: Entre en un titulo para este tipo de sesión

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -296,6 +296,7 @@ general:
   objectiveParentsTitle: Seleccione Objetivos Matrices
   objectiveTitle: Objetivos de la Sesión
   off: Apagado
+  offeringDate: Fecha de Ofrecimiento
   on: Encendido
   ok: OK
   openSmallGroupGenerator: Abrir el Generador de Ofrecimientos para Grupos Pequeños

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -402,8 +402,8 @@ general:
   sessionObjectivesReportSummary: "informe para {courseCount, plural, one {un curso} other {# cursos}}. Se enumera el objetivo de cada sesión junto con los instructores y los datos del curso."
   sessionObjectivesReportSummaryMultiSchool: "informe para {courseCount, plural, one {un curso} other {# cursos}}{schoolCount, plural, zero {} one {} other {, en # escuelas}}. Se enumera el objetivo de cada sesión junto con los instructores y los datos del curso."
   sessionOfferings: Ofrecimientos de la Sesión
-  sessionOfferingsReportSummary: "informe para {courseCount, plural, one {un curso} other {# cursos}}. Se enumera el ofrecimiento de cada sesión junto con los grupos de aprendedores, los instructores, y los datos del curso."
-  sessionOfferingsReportSummaryMultiSchool: "informe para {courseCount, plural, one {un curso} other {# cursos}}{schoolCount, plural, zero {} one {} other {, en # escuelas}}. Se enumera el ofrecimiento de cada sesión junto con los grupos de aprendedores, los instructores, y los datos del curso."
+  sessionOfferingsReportSummary: "informe para {courseCount, plural, one {un curso} other {# cursos}}. Se enumera el ofrecimiento de cada sesión junto con los instructores, los grupos de aprendedores, y los datos del curso."
+  sessionOfferingsReportSummaryMultiSchool: "informe para {courseCount, plural, one {un curso} other {# cursos}}{schoolCount, plural, zero {} one {} other {, en # escuelas}}. Se enumera el ofrecimiento de cada sesión junto con los instructores, los grupos de aprendedores, y los datos del curso."
   sessionTitlePlaceholder: Entre en un titulo para esta sesión
   sessionTypeConfirmRemoval: ¿Está seguro de que desea eliminar este tipo de sesión? Esta acción no se puede deshacer.
   sessionTypeTitlePlaceholder: Entre en un titulo para este tipo de sesión

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -398,6 +398,7 @@ general:
   sequenceBlockTitlePlaceholder: "Introduzca un título para esta bloque de la secuencia"
   sequenceNumber: No. de Secuencia
   sessionAttributes: Atributos de la Sesión
+  sessionLink: Enlace de Sesión
   sessionObjectives: Objetivos de la sesión
   sessionObjectivesReportSummary: "informe para {courseCount, plural, one {un curso} other {# cursos}}. Se enumera el objetivo de cada sesión junto con los instructores y los datos del curso."
   sessionObjectivesReportSummaryMultiSchool: "informe para {courseCount, plural, one {un curso} other {# cursos}}{schoolCount, plural, zero {} one {} other {, en # escuelas}}. Se enumera el objetivo de cada sesión junto con los instructores y los datos del curso."

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -399,7 +399,6 @@ general:
   sequenceBlockTitlePlaceholder: "Entrez une titre pour ceci bloc séquence"
   sequenceNumber: No. de séquence
   sessionAttributes: Attributs de Séance
-  sessionLink: Address de Séance
   sessionObjectives: Objectifs de séance
   sessionObjectivesReportSummary: "Rapport de {courseCount, plural, one {one course} other {# courses}}. Chaque objectif de séance est listée avec des instructeurs et cours données."
   sessionObjectivesReportSummaryMultiSchool: "Rapport de {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, dans # écoles}}. Chaque objectif de séance est listée avec des instructeurs et cours données."

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -403,8 +403,8 @@ general:
   sessionObjectivesReportSummary: "Rapport de {courseCount, plural, one {one course} other {# courses}}. Chaque objectif de séance est listée avec des instructeurs et cours données."
   sessionObjectivesReportSummaryMultiSchool: "Rapport de {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, dans # écoles}}. Chaque objectif de séance est listée avec des instructeurs et cours données."
   sessionOfferings: Offres de séance
-  sessionOfferingsReportSummary: "Rapport de {courseCount, plural, one {one course} other {# courses}}. Chaque offre de séance est listée avec des groupes d'étudiants, instructeurs, et cours données."
-  sessionOfferingsReportSummaryMultiSchool: "Rapport de {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, dans # écoles}}. Chaque offre de séance est listée avec des groupes d'étudiants, instructeurs, et cours données."
+  sessionOfferingsReportSummary: "Rapport de {courseCount, plural, one {one course} other {# courses}}. Chaque offre de séance est listée avec des instructeurs, groupes d'étudiants, et cours données."
+  sessionOfferingsReportSummaryMultiSchool: "Rapport de {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, dans # écoles}}. Chaque offre de séance est listée avec des instructeurs, groupes d'étudiants, et cours données."
   sessionTitlePlaceholder: Ajoutez un titre pour ce session
   sessionTypeConfirmRemoval: "Voulez-vous vraiment supprimer ce type de session ? Cette action ne peut pas être annulée."
   sessionTypeTitlePlaceholder: Ajoutez un titre pour ce type de session

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -297,6 +297,7 @@ general:
   objectiveParentsTitle: Affichez objectifs mères
   objectiveTitle: Objectif de Séance
   off: Éteindre
+  offeringDate: Date de l'offre
   ok: OK
   on: Allumer
   openSmallGroupGenerator: Générateur des petites groupes

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -399,6 +399,7 @@ general:
   sequenceBlockTitlePlaceholder: "Entrez une titre pour ceci bloc séquence"
   sequenceNumber: No. de séquence
   sessionAttributes: Attributs de Séance
+  sessionLink: Address de Séance
   sessionObjectives: Objectifs de séance
   sessionObjectivesReportSummary: "Rapport de {courseCount, plural, one {one course} other {# courses}}. Chaque objectif de séance est listée avec des instructeurs et cours données."
   sessionObjectivesReportSummaryMultiSchool: "Rapport de {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, dans # écoles}}. Chaque objectif de séance est listée avec des instructeurs et cours données."

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -401,6 +401,9 @@ general:
   sessionObjectives: Objectifs de séance
   sessionObjectivesReportSummary: "Rapport de {courseCount, plural, one {one course} other {# courses}}. Chaque objectif de séance est listée avec des instructeurs et cours données."
   sessionObjectivesReportSummaryMultiSchool: "Rapport de {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, dans # écoles}}. Chaque objectif de séance est listée avec des instructeurs et cours données."
+  sessionOfferings: Offres de séance
+  sessionOfferingsReportSummary: "Rapport de {courseCount, plural, one {one course} other {# courses}}. Chaque offre de séance est listée avec des groupes d'étudiants, instructeurs, et cours données."
+  sessionOfferingsReportSummaryMultiSchool: "Rapport de {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, dans # écoles}}. Chaque offre de séance est listée avec des groupes d'étudiants, instructeurs, et cours données."
   sessionTitlePlaceholder: Ajoutez un titre pour ce session
   sessionTypeConfirmRemoval: "Voulez-vous vraiment supprimer ce type de session ? Cette action ne peut pas être annulée."
   sessionTypeTitlePlaceholder: Ajoutez un titre pour ce type de session


### PR DESCRIPTION
Fixes ilios/ilios#6225

This adds another option to the Curriculum Reports choices: Session Offerings. It is very similar to the Session Objectives report, but swaps out objectives for offerings, and adds Learner Groups (count to summary, and names to download).