### PR TITLE
Use factory to create events on offering and learner-group calendars

### DIFF
--- a/packages/frontend/app/components/learner-group/calendar.gjs
+++ b/packages/frontend/app/components/learner-group/calendar.gjs
@@ -18,6 +18,7 @@ import LoadingSpinner from 'ilios-common/components/loading-spinner';
 
 export default class LearnerGroupCalendarComponent extends Component {
   @service localeDays;
+  @service schoolEvents;
   @tracked selectedDate = DateTime.now();
   @tracked showSubgroupEvents = false;
 
@@ -61,22 +62,27 @@ export default class LearnerGroupCalendarComponent extends Component {
     return await map(flat, async (offering) => {
       const session = await offering.session;
       const course = await session.course;
-      return {
-        startDate: offering.startDate.toISOString(),
-        endDate: offering.endDate.toISOString(),
-        calendarStartDate: offering.startDate.toISOString(),
-        calendarEndDate: offering.endDate.toISOString(),
-        courseTitle: course.title,
-        name: session.title,
-        offering: offering.id,
-        location: offering.location,
-        color: '#84c444',
-        prerequisites: [],
-        postrequisites: [],
-        isScheduled: session.isScheduled || course.isScheduled,
-        isPublished: session.isPublished && course.isPublished,
-        isBlanked: false,
-      };
+      const school = await course.school;
+      return this.schoolEvents.createEventFromData(
+        {
+          startDate: offering.startDate.toISOString(),
+          endDate: offering.endDate.toISOString(),
+          calendarStartDate: offering.startDate.toISOString(),
+          calendarEndDate: offering.endDate.toISOString(),
+          courseTitle: course.title,
+          name: session.title,
+          offering: offering.id,
+          location: offering.location,
+          school: school.id,
+          color: '#84c444',
+          prerequisites: [],
+          postrequisites: [],
+          isScheduled: session.isScheduled || course.isScheduled,
+          isPublished: session.isPublished && course.isPublished,
+          isBlanked: false,
+        },
+        false,
+      );
     });
   }
 

--- a/packages/frontend/tests/acceptance/learnergroup-test.js
+++ b/packages/frontend/tests/acceptance/learnergroup-test.js
@@ -295,7 +295,7 @@ module('Acceptance | Learner Group', function (hooks) {
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     const learnerGroup = this.server.create('learner-group', { cohort });
-    const course = this.server.create('course', { cohorts: [cohort] });
+    const course = this.server.create('course', { school: this.school, cohorts: [cohort] });
     const session = this.server.create('session', { course });
     this.server.create('offering', {
       session,
@@ -323,7 +323,7 @@ module('Acceptance | Learner Group', function (hooks) {
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     const learnerGroup = this.server.create('learner-group', { cohort });
-    const course = this.server.create('course', { cohorts: [cohort] });
+    const course = this.server.create('course', { school: this.school, cohorts: [cohort] });
     const session = this.server.create('session', { course });
     const subgroup = this.server.create('learner-group', {
       cohort,

--- a/packages/frontend/tests/integration/components/learner-group/calendar-test.gjs
+++ b/packages/frontend/tests/integration/components/learner-group/calendar-test.gjs
@@ -12,8 +12,10 @@ module('Integration | Component | learner-group/calendar', function (hooks) {
 
   hooks.beforeEach(async function () {
     const today = DateTime.fromObject({ hour: 8 });
-    const course1 = this.server.create('course');
+    const school = this.server.create('school');
+    const course1 = this.server.create('course', { school });
     const course2 = this.server.create('course', {
+      school,
       publishedAsTbd: true,
       published: true,
     });

--- a/packages/ilios-common/addon/components/offering-calendar.gjs
+++ b/packages/ilios-common/addon/components/offering-calendar.gjs
@@ -7,6 +7,7 @@ import t from 'ember-intl/helpers/t';
 import ToggleYesno from 'ilios-common/components/toggle-yesno';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
+import { service } from '@ember/service';
 import set from 'ember-set-helper/helpers/set';
 import not from 'ember-truth-helpers/helpers/not';
 import toggle from 'ilios-common/helpers/toggle';
@@ -19,6 +20,7 @@ export default class OfferingCalendar extends Component {
   @tracked learnerGroupEvents = [];
   @tracked sessionEvents = [];
   @tracked currentEvent = null;
+  @service schoolEvents;
 
   @cached
   get calendarEventsData() {
@@ -41,19 +43,24 @@ export default class OfferingCalendar extends Component {
         return await map(offerings, async (offering) => {
           const session = await offering.session;
           const course = await session.course;
-          return {
-            startDate: DateTime.fromJSDate(offering.startDate).toISO(),
-            endDate: DateTime.fromJSDate(offering.endDate).toISO(),
-            calendarStartDate: DateTime.fromJSDate(offering.startDate).toISO(),
-            calendarEndDate: DateTime.fromJSDate(offering.endDate).toISO(),
-            courseTitle: course.title,
-            name: session.title,
-            offering: offering.id,
-            location: offering.location,
-            color: '#84c444',
-            postrequisites: [],
-            prerequisites: [],
-          };
+          const school = await course.school;
+          return this.schoolEvents.createEventFromData(
+            {
+              startDate: DateTime.fromJSDate(offering.startDate).toISO(),
+              endDate: DateTime.fromJSDate(offering.endDate).toISO(),
+              calendarStartDate: DateTime.fromJSDate(offering.startDate).toISO(),
+              calendarEndDate: DateTime.fromJSDate(offering.endDate).toISO(),
+              courseTitle: course.title,
+              school: school.id,
+              name: session.title,
+              offering: offering.id,
+              location: offering.location,
+              color: '#84c444',
+              postrequisites: [],
+              prerequisites: [],
+            },
+            false,
+          );
         });
       });
 
@@ -69,36 +76,45 @@ export default class OfferingCalendar extends Component {
       const offerings = await session.offerings;
       const sessionType = await session.sessionType;
       const course = await session.course;
+      const school = await course.school;
       this.sessionEvents = await map(offerings, async (offering) => {
-        return {
-          startDate: DateTime.fromJSDate(offering.startDate).toISO(),
-          endDate: DateTime.fromJSDate(offering.endDate).toISO(),
-          calendarStartDate: DateTime.fromJSDate(offering.startDate).toISO(),
-          calendarEndDate: DateTime.fromJSDate(offering.endDate).toISO(),
-          courseTitle: course.title,
-          name: session.title,
-          offering: offering.id,
-          location: offering.location,
-          color: '#f6f6f6',
-          postrequisites: [],
-          prerequisites: [],
-        };
+        return this.schoolEvents.createEventFromData(
+          {
+            startDate: DateTime.fromJSDate(offering.startDate).toISO(),
+            endDate: DateTime.fromJSDate(offering.endDate).toISO(),
+            calendarStartDate: DateTime.fromJSDate(offering.startDate).toISO(),
+            calendarEndDate: DateTime.fromJSDate(offering.endDate).toISO(),
+            courseTitle: course.title,
+            school: school.id,
+            name: session.title,
+            offering: offering.id,
+            location: offering.location,
+            color: '#f6f6f6',
+            postrequisites: [],
+            prerequisites: [],
+          },
+          false,
+        );
       });
 
-      this.currentEvent = {
-        startDate: DateTime.fromJSDate(startDate).toISO(),
-        endDate: DateTime.fromJSDate(endDate).toISO(),
-        calendarStartDate: DateTime.fromJSDate(startDate).toISO(),
-        calendarEndDate: DateTime.fromJSDate(endDate).toISO(),
-        courseTitle: course.title,
-        name: session.title,
-        isPublished: session.isPublished,
-        offering: 1,
-        location: '',
-        color: sessionType.calendarColor,
-        postrequisites: [],
-        prerequisites: [],
-      };
+      this.currentEvent = this.schoolEvents.createEventFromData(
+        {
+          startDate: DateTime.fromJSDate(startDate).toISO(),
+          endDate: DateTime.fromJSDate(endDate).toISO(),
+          calendarStartDate: DateTime.fromJSDate(startDate).toISO(),
+          calendarEndDate: DateTime.fromJSDate(endDate).toISO(),
+          courseTitle: course.title,
+          school: school.id,
+          name: session.title,
+          isPublished: session.isPublished,
+          offering: 1,
+          location: '',
+          color: sessionType.calendarColor,
+          postrequisites: [],
+          prerequisites: [],
+        },
+        false,
+      );
     }
   }
 

--- a/packages/test-app/tests/integration/components/offering-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/offering-calendar-test.gjs
@@ -12,7 +12,8 @@ module('Integration | Component | offering-calendar', function (hooks) {
   test('shows events', async function (assert) {
     const today = DateTime.fromObject({ hour: 8 });
     const tomorrow = today.plus({ day: 1 });
-    const course = this.server.create('course');
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
     const sessionType = this.server.create('session-type');
     const session = this.server.create('session', {
       course,


### PR DESCRIPTION
extracted from #8956 

this standardizes how events are created for calendars across the entire application. 

offerings for the learner-group calendar and offering-calendar are now created as school events. this close a minor context gap - prior to this change these were neither user- nor school-events, the calendar components expect either one of these event types as input.