### PR TITLE
remove pointless data transformation.

### DIFF
--- a/packages/ilios-common/addon/components/ilios-calendar.gjs
+++ b/packages/ilios-common/addon/components/ilios-calendar.gjs
@@ -36,8 +36,7 @@ export default class IliosCalendarComponent extends Component {
         if (!(hash in hashedEvents)) {
           hashedEvents[hash] = [];
         }
-        //clone our event, so we don't trample on the original when we change location
-        hashedEvents[hash].push(Object.assign({}, event));
+        hashedEvents[hash].push(event);
       });
       const compiledEvents = [];
       let hash;


### PR DESCRIPTION
this doesn't do anything meaningful and gets in the way of using a more robust data structure, like a class with getters or a Proxy object. begone!

extracted from #8956 

**side-note**

further down, we're modifying the events by setting a `isMulti` flag if applicable. i believe that the removed code is related to that, although i can't back that claim up based on commit messages.

ideally, we'd not be modifying these events at all, once they're generated. conceptually, they are "read only".

will explore a solution that gets rid of a `event.isMulti` as a separate issue.