### PR TITLE
Rm unused event attrs

### DIFF
--- a/packages/ilios-common/addon/classes/event.js
+++ b/packages/ilios-common/addon/classes/event.js
@@ -28,16 +28,7 @@ export default class Event {
     // converts pre- and post-requisites into Events as well.
     this.prerequisites = sortBy(
       this.prerequisites.map((prereq) => {
-        const rhett = new Event(
-          {
-            ...prereq,
-            ...{
-              postrequisiteName: this.name,
-              postrequisiteSlug: this.slug,
-            },
-          },
-          this.isUserEvent,
-        );
+        const rhett = new Event(prereq, this.isUserEvent);
         // overwrite the pre-req's start date with its target event's start date.
         rhett.startDate = this.startDate;
         return rhett;

--- a/packages/test-app/tests/classes/event-test.js
+++ b/packages/test-app/tests/classes/event-test.js
@@ -146,14 +146,10 @@ module('Unit | Classes | Event', function (hooks) {
     assert.ok(event.prerequisites[0] instanceof Event);
     assert.strictEqual(event.prerequisites[0].name, 'event 1');
     assert.strictEqual(event.prerequisites[0].slug, 'U20250910I445');
-    assert.strictEqual(event.prerequisites[0].postrequisiteName, 'event 0');
-    assert.strictEqual(event.prerequisites[0].postrequisiteSlug, event.slug);
     assert.strictEqual(event.prerequisites[0].startDate, event.startDate);
     assert.ok(event.prerequisites[1] instanceof Event);
     assert.strictEqual(event.prerequisites[1].name, 'event 2');
     assert.strictEqual(event.prerequisites[1].slug, 'U20251109I123');
-    assert.strictEqual(event.prerequisites[1].postrequisiteName, 'event 0');
-    assert.strictEqual(event.prerequisites[1].postrequisiteSlug, event.slug);
     assert.strictEqual(event.prerequisites[1].startDate, event.startDate);
   });
 


### PR DESCRIPTION
```
stefan@nichtsnutz: ~/dev/projects/frontend on master[$]
$ egrep -r 'postrequisite(Name|Slug)' packages --exclude-dir=dist --exclude-dir=node_modules                                                                                                         
packages/test-app/tests/classes/event-test.js:    assert.strictEqual(event.prerequisites[0].postrequisiteName, 'event 0');
packages/test-app/tests/classes/event-test.js:    assert.strictEqual(event.prerequisites[0].postrequisiteSlug, event.slug);
packages/test-app/tests/classes/event-test.js:    assert.strictEqual(event.prerequisites[1].postrequisiteName, 'event 0');
packages/test-app/tests/classes/event-test.js:    assert.strictEqual(event.prerequisites[1].postrequisiteSlug, event.slug);
packages/ilios-common/addon/classes/event.js:              postrequisiteName: this.name,
packages/ilios-common/addon/classes/event.js:              postrequisiteSlug: this.slug
```

begone!