### PR TITLE
code cleanup.

### DIFF
--- a/packages/ilios-common/addon/components/course/visualize-instructor-term-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-instructor-term-graph.gjs
@@ -147,10 +147,8 @@ export default class CourseVisualizeInstructorTermGraph extends Component {
         return set;
       }, [])
       .map((obj) => {
-        ((obj.description = `${obj.meta.vocabulary.title} - ${obj.meta.term.title} - ${
-          obj.data
-        } ${this.intl.t('general.minutes')}`),
-          delete obj.id);
+        obj.description = `${obj.meta.vocabulary.title} - ${obj.meta.term.title} - ${obj.data} ${this.intl.t('general.minutes')}`;
+        delete obj.id;
         return obj;
       })
       .sort((first, second) => {


### PR DESCRIPTION
there was a comma in there that's supposed to be a semicolon.
cleaning that up allowed us to remove these crazy parenthesis.