### PR TITLE
rm obsolete getter.

### DIFF
--- a/packages/ilios-common/addon/models/course-objective.js
+++ b/packages/ilios-common/addon/models/course-objective.js
@@ -111,11 +111,4 @@ export default class CourseObjective extends Model {
     }
     await this.save();
   }
-
-  /**
-   * @todo check if this method is obsolete, if so remove it [ST 2020/07/08]
-   */
-  get shortTitle() {
-    return this.title?.substr(0, 200) ?? '';
-  }
 }


### PR DESCRIPTION
this one isn't  used anywhere. the only `shortTitle` attr on a model that comes up is the one on the program class.

```
stefan@nichtsnutz: ~/dev/projects/frontend on ungunk[$]
$ grep -r '\.shortTitle' packages --exclude-dir=dist --exclude-dir=node_modules --exclude-dir=tests
packages/frontend/app/components/program/overview.gjs:    this.shortTitle = this.args.program.shortTitle;
packages/frontend/app/components/program/overview.gjs:    if (this.shortTitle !== this.args.program.shortTitle) {
packages/frontend/app/components/program/overview.gjs:      this.args.program.set('shortTitle', this.shortTitle);
packages/frontend/app/components/program/overview.gjs:      this.shortTitle = this.args.program.shortTitle;
packages/frontend/app/components/program/overview.gjs:                @value={{this.shortTitle}}
packages/frontend/app/components/program/overview.gjs:                  value={{this.shortTitle}}
packages/frontend/app/components/program/overview.gjs:                @validationErrors={{this.validations.errors.shortTitle}}
packages/frontend/app/components/program/overview.gjs:              {{this.shortTitle}}
packages/frontend/app/components/curriculum-inventory/report-overview.gjs:              {{#if @report.program.shortTitle}}
packages/frontend/app/components/curriculum-inventory/report-overview.gjs:                ({{@report.program.shortTitle}})
```