### PR TITLE
Mostly replace `font-size($step)` SASS mixin with equivalent CSS classes

### DIFF
--- a/packages/frontend/app/components/bulk-new-users.gjs
+++ b/packages/frontend/app/components/bulk-new-users.gjs
@@ -436,7 +436,7 @@ export default class BulkNewUsersComponent extends Component {
               />
             </div>
             {{#if this.updateSelectedFile.isRunning}}
-              <div class="file-is-loading">
+              <div class="file-is-loading font-size-xxxl">
                 <LoadingSpinner />
               </div>
             {{else if (gte this.proposedUsers.length 1)}}

--- a/packages/frontend/app/components/course-search-result.gjs
+++ b/packages/frontend/app/components/course-search-result.gjs
@@ -27,16 +27,16 @@ export default class CourseSearchResultComponent extends Component {
         <small>{{@course.year}}</small>
         {{@course.title}}
       </LinkTo>
-      <span class="school-flag" data-test-school-title>
+      <span class="school-flag font-size-smallest" data-test-school-title>
         {{@course.school}}
       </span>
-      <span class="course-flag">
+      <span class="course-flag font-size-smallest">
         {{t "general.course"}}
       </span>
       <GlobalSearchTags @tags={{@course.matchedIn}} />
       {{#if this.sessions}}
         <ul>
-          <li class="sessions">
+          <li class="sessions font-size-small">
             {{t "general.sessions"}}:
           </li>
           {{#each this.sessions as |session|}}
@@ -44,7 +44,7 @@ export default class CourseSearchResultComponent extends Component {
               <LinkTo
                 @route="session"
                 @models={{array @course.id session.id}}
-                class="session-title-link"
+                class="session-title-link font-size-small"
               >
                 {{session.title}}
               </LinkTo>
@@ -55,7 +55,7 @@ export default class CourseSearchResultComponent extends Component {
             {{#if this.showMore}}
               <li>
                 <button
-                  class="show-less link-button"
+                  class="show-less link-button font-size-small"
                   type="button"
                   {{on "click" (set this "showMore" false)}}
                 >
@@ -66,7 +66,7 @@ export default class CourseSearchResultComponent extends Component {
             {{else}}
               <li>
                 <button
-                  class="show-more link-button"
+                  class="show-more link-button font-size-small"
                   type="button"
                   {{on "click" (set this "showMore" true)}}
                 >

--- a/packages/frontend/app/components/curriculum-inventory/new-sequence-block.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/new-sequence-block.gjs
@@ -462,7 +462,7 @@ export default class CurriculumInventoryNewSequenceBlock extends Component {
               {{/each}}
             </select>
             {{#if this.course}}
-              <span class="details" data-test-course-details>
+              <span class="details font-size-small" data-test-course-details>
                 {{t "general.level"}}:
                 {{this.course.level}},
                 {{t "general.startDate"}}:

--- a/packages/frontend/app/components/curriculum-inventory/report-overview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-overview.gjs
@@ -240,7 +240,7 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
             <LinkTo
               @route="verification-preview"
               @model={{@report}}
-              class="verification-preview"
+              class="verification-preview font-size-medium"
               title={{t "general.verificationPreviewFor" name=@report.name}}
               data-test-transition-to-verification-preview
             >
@@ -248,7 +248,7 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
             </LinkTo>
             {{#if this.showRollover}}
               <button
-                class="link-button rollover"
+                class="link-button rollover font-size-medium"
                 type="button"
                 aria-label={{t "general.curriculumInventoryReportRollover"}}
                 {{on "click" this.transitionToRollover}}

--- a/packages/frontend/app/components/curriculum-inventory/report-overview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-overview.gjs
@@ -233,7 +233,7 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
     >
       {{#let (uniqueId) as |templateId|}}
         <div class="report-overview-header">
-          <div class="title" data-test-title>
+          <div class="title font-size-base" data-test-title>
             {{t "general.overview"}}
           </div>
           <div class="report-overview-actions">

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.gjs
@@ -695,7 +695,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
               </span>
               {{#if this.selectedCourse}}
                 {{#if this.selectedCourse.id}}
-                  <span class="details" data-test-course-details>
+                  <span class="details font-size-small" data-test-course-details>
                     {{t "general.level"}}:
                     {{this.selectedCourse.level}},
                     {{t "general.startDate"}}:
@@ -720,7 +720,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
                   </span>
                 {{/if}}
               {{else if this.course}}
-                <span class="details" data-test-course-details>
+                <span class="details font-size-small" data-test-course-details>
                   {{t "general.level"}}:
                   {{this.course.level}},
                   {{t "general.startDate"}}:

--- a/packages/frontend/app/components/global-search-tags.gjs
+++ b/packages/frontend/app/components/global-search-tags.gjs
@@ -5,7 +5,7 @@ import { concat } from '@ember/helper';
   {{#if @tags}}
     <div class="global-search-tags" data-test-global-search-tags>
       {{#each @tags as |tag|}}
-        <span class="global-search-tag" data-test-global-search-tag>
+        <span class="global-search-tag font-size-smallest" data-test-global-search-tag>
           {{#if (eq tag "meshdescriptors")}}
             {{t "general.mesh"}}
           {{else if (eq tag "learningmaterials")}}

--- a/packages/frontend/app/components/learner-group/upload-data.gjs
+++ b/packages/frontend/app/components/learner-group/upload-data.gjs
@@ -266,7 +266,7 @@ export default class LearnerGroupUploadDataComponent extends Component {
         />
       {{/if}}
       {{#if this.uploadData.isPending}}
-        <LoadingSpinner class="loading-file" />
+        <LoadingSpinner class="loading-file font-size-xxl" />
       {{/if}}
       {{#if this.invalidUsers}}
         <p class="error">

--- a/packages/frontend/app/components/manage-users-summary.gjs
+++ b/packages/frontend/app/components/manage-users-summary.gjs
@@ -264,13 +264,13 @@ export default class ManageUsersSummaryComponent extends Component {
               @query={{hash showNewUserForm=true showBulkNewUserForm=false filter=null}}
               data-test-create-user-link
             >
-              <button type="button">
+              <button type="button" class="font-size-base">
                 {{t "general.create"}}
               </button>
             </LinkTo>
             {{#if (notEq this.userSearchType "ldap")}}
               <LinkTo @route="users" @query={{hash showBulkNewUserForm=true showNewUserForm=false}}>
-                <button type="button">
+                <button type="button" class="font-size-base">
                   {{t "general.createBulk"}}
                 </button>
               </LinkTo>
@@ -324,7 +324,7 @@ export default class ManageUsersSummaryComponent extends Component {
               {{#if (eq result.type "user")}}
                 <li class="user clickable">
                   <button
-                    class="link-button"
+                    class="link-button font-size-base"
                     type="button"
                     disabled={{this.clickUser.isRunning}}
                     data-userid={{result.user.id}}

--- a/packages/frontend/app/components/my-profile.gjs
+++ b/packages/frontend/app/components/my-profile.gjs
@@ -171,7 +171,7 @@ export default class MyProfileComponent extends Component {
           />
           <LearnerGroups @user={{@user}} />
         </div>
-        <section class="token-maintenance" data-test-token-maintenance>
+        <section class="token-maintenance font-size-small" data-test-token-maintenance>
           <h3>
             {{t "general.manageAPITokens"}}
           </h3>

--- a/packages/frontend/app/components/pending-updates-summary.gjs
+++ b/packages/frontend/app/components/pending-updates-summary.gjs
@@ -132,7 +132,7 @@ export default class PendingUpdatesSummaryComponent extends Component {
               @query={{hash school=this.bestSelectedSchool.id}}
               data-test-manage
             >
-              <button type="button">
+              <button type="button" class="font-size-base">
                 {{t "general.manage"}}
               </button>
             </LinkTo>

--- a/packages/frontend/app/components/program-year/collapsed-objectives.gjs
+++ b/packages/frontend/app/components/program-year/collapsed-objectives.gjs
@@ -58,7 +58,7 @@ export default class ProgramYearCollapsedObjectivesComponent extends Component {
         </button>
       </div>
       <div class="content">
-        <table class="ilios-table ilios-table-colors">
+        <table class="ilios-table ilios-table-colors font-size-small">
           <thead>
             <tr>
               <th class="text-left">

--- a/packages/frontend/app/components/program-year/header.gjs
+++ b/packages/frontend/app/components/program-year/header.gjs
@@ -35,7 +35,7 @@ export default class ProgramYearHeaderComponent extends Component {
             <FaIcon @icon={{faLock}} data-test-lock />
           {{/if}}
           {{#if @programYear}}
-            <h3 data-test-matriculation-year>
+            <h3 class="font-size-large" data-test-matriculation-year>
               {{t "general.matriculationYear"}}
               {{#if this.academicYearCrossesCalendarYearBoundaries}}
                 {{@programYear.startYear}}
@@ -45,7 +45,7 @@ export default class ProgramYearHeaderComponent extends Component {
                 {{@programYear.startYear}}
               {{/if}}
             </h3>
-            <h3 data-test-cohort>
+            <h3 class="font-size-large" data-test-cohort>
               {{#if @programYear.cohort.title}}
                 ({{@programYear.cohort.title}})
               {{else}}

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -301,7 +301,7 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
           </button>
         {{/if}}
       </div>
-      <div class="description grid-item" data-test-description>
+      <div class="description grid-item font-size-base" data-test-description>
         <FadeText
           @forceExpanded={{this.fadeTextExpanded}}
           @setExpanded={{set this "fadeTextExpanded"}}

--- a/packages/frontend/app/components/program-year/overview.gjs
+++ b/packages/frontend/app/components/program-year/overview.gjs
@@ -13,6 +13,7 @@ import { faChartColumn } from '@fortawesome/free-solid-svg-icons';
           @route="program-year-visualize-objectives"
           @model={{@programYear}}
           title={{t "general.programYearVisualizations"}}
+          class="font-size-medium"
           data-test-go-to-visualizations
         >
           <FaIcon @icon={{faChartColumn}} />

--- a/packages/frontend/app/components/program-year/overview.gjs
+++ b/packages/frontend/app/components/program-year/overview.gjs
@@ -5,7 +5,7 @@ import { faChartColumn } from '@fortawesome/free-solid-svg-icons';
 <template>
   <div class="programyear-overview" data-test-program-year-overview ...attributes>
     <div class="programyear-overview-header">
-      <h4 data-test-title>
+      <h4 class="font-size-base" data-test-title>
         {{t "general.overview"}}
       </h4>
       <div class="programyear-overview-actions" data-test-actions>

--- a/packages/frontend/app/components/program/overview.gjs
+++ b/packages/frontend/app/components/program/overview.gjs
@@ -59,7 +59,7 @@ export default class ProgramOverviewComponent extends Component {
   }
   <template>
     <div class="program-overview" data-test-program-overview ...attributes>
-      <h2>
+      <h2 class="font-size-base">
         {{t "general.overview"}}
       </h2>
       <div class="program-overview-content">

--- a/packages/frontend/app/components/reports/curriculum/choose-course.gjs
+++ b/packages/frontend/app/components/reports/curriculum/choose-course.gjs
@@ -130,7 +130,7 @@ export default class ReportsCurriculumChooseCourse extends Component {
           <button
             type="button"
             aria-label={{t "general.deselectAllCourses"}}
-            class="deselect-all"
+            class="deselect-all font-size-small"
             {{on "click" @removeAll}}
             data-test-deselect-all
           >

--- a/packages/frontend/app/components/reports/curriculum/header.gjs
+++ b/packages/frontend/app/components/reports/curriculum/header.gjs
@@ -156,7 +156,7 @@ export default class ReportsCurriculumHeader extends Component {
   };
   <template>
     <div class="reports-curriculum-header" data-test-reports-curriculum-header>
-      <div class="run">
+      <div class="run font-size-medium">
         <p data-test-run-summary>
           {{#if @countSelectedCourses}}
             {{#if @showReportResults}}

--- a/packages/frontend/app/components/reports/switcher.gjs
+++ b/packages/frontend/app/components/reports/switcher.gjs
@@ -5,11 +5,12 @@ import t from 'ember-intl/helpers/t';
     <LinkTo
       @route="reports.subjects"
       @current-when="reports.subjects reports.subject"
+      class="font-size-medium"
       data-test-subject
     >
       {{t "general.subjectReports"}}
     </LinkTo>
-    <LinkTo @route="reports.curriculum" data-test-curriculum>
+    <LinkTo @route="reports.curriculum" class="font-size-medium" data-test-curriculum>
       {{t "general.curriculumReports"}}
     </LinkTo>
   </div>

--- a/packages/frontend/app/components/school-competencies-collapsed.gjs
+++ b/packages/frontend/app/components/school-competencies-collapsed.gjs
@@ -55,7 +55,7 @@ export default class SchoolCompetenciesCollapsedComponent extends Component {
         </button>
       </div>
       <div class="content">
-        <table class="ilios-table ilios-table-colors condensed">
+        <table class="ilios-table ilios-table-colors condensed font-size-small">
           <thead>
             <tr>
               <th class="text-left">

--- a/packages/frontend/app/components/school-session-attributes-collapsed.gjs
+++ b/packages/frontend/app/components/school-session-attributes-collapsed.gjs
@@ -21,7 +21,7 @@ import { faCaretRight, faBan, faCheck } from '@fortawesome/free-solid-svg-icons'
       </button>
     </div>
     <div class="content">
-      <table class="ilios-table ilios-table-colors condensed">
+      <table class="ilios-table ilios-table-colors condensed font-size-small">
         <thead>
           <tr>
             <th class="text-left">

--- a/packages/frontend/app/components/school-session-attributes-manager.gjs
+++ b/packages/frontend/app/components/school-session-attributes-manager.gjs
@@ -4,7 +4,7 @@ import { on } from '@ember/modifier';
 <template>
   {{#let (uniqueId) as |templateId|}}
     <div data-test-school-session-attributes-manager ...attributes>
-      <table class="ilios-table ilios-table-colors condensed">
+      <table class="ilios-table ilios-table-colors condensed font-size-small">
         <thead>
           <tr>
             <th class="text-left">

--- a/packages/frontend/app/components/school-session-types-collapsed.gjs
+++ b/packages/frontend/app/components/school-session-types-collapsed.gjs
@@ -49,7 +49,7 @@ export default class SchoolSessionTypesCollapseComponent extends Component {
       </div>
 
       <div class="content">
-        <table class="ilios-table ilios-table-colors condensed">
+        <table class="ilios-table ilios-table-colors condensed font-size-small">
           <thead>
             <tr>
               <th class="text-left">

--- a/packages/frontend/app/components/school-vocabularies-collapsed.gjs
+++ b/packages/frontend/app/components/school-vocabularies-collapsed.gjs
@@ -44,7 +44,7 @@ export default class SchoolVocabulariesCollapsedComponent extends Component {
         <LoadingSpinner />
       {{else}}
         <div class="content">
-          <table class="ilios-table ilios-table-colors condensed">
+          <table class="ilios-table ilios-table-colors condensed font-size-small">
             <thead>
               <tr>
                 <th class="text-left">

--- a/packages/frontend/app/components/update-notification.gjs
+++ b/packages/frontend/app/components/update-notification.gjs
@@ -26,7 +26,7 @@ export default class UpdateNotificationComponent extends Component {
   <template>
     {{#if this.newVersion.isNewVersionAvailable}}
       <div class="update-notification critical-notice" data-test-update-notification>
-        <button type="button" {{on "click" (perform this.click)}}>
+        <button type="button" class="font-size-large" {{on "click" (perform this.click)}}>
           {{t "general.iliosUpdatePending"}}
         </button>
       </div>

--- a/packages/frontend/app/components/user-guide-link.gjs
+++ b/packages/frontend/app/components/user-guide-link.gjs
@@ -5,6 +5,7 @@ import { faQuestion } from '@fortawesome/free-solid-svg-icons';
   <div class="user-guide-link" data-test-user-guide-link>
     <a
       href="https://iliosproject.gitbook.io/ilios-user-guide"
+      class="font-size-small"
       target="_blank"
       title={{t "general.iliosUserGuide"}}
       rel="noopener noreferrer"

--- a/packages/frontend/app/components/user-profile-bio-details.gjs
+++ b/packages/frontend/app/components/user-profile-bio-details.gjs
@@ -10,7 +10,7 @@ import { faPenToSquare } from '@fortawesome/free-solid-svg-icons';
         <button
           aria-label={{t "general.manage"}}
           type="button"
-          class="manage"
+          class="manage font-size-base"
           {{on "click" (fn @setIsManaging true)}}
           data-test-manage
         >
@@ -25,7 +25,7 @@ import { faPenToSquare } from '@fortawesome/free-solid-svg-icons';
       </div>
     {{/unless}}
 
-    <p class="primary-school" data-test-school>
+    <p class="primary-school font-size-medium" data-test-school>
       <strong>
         {{t "general.primarySchool"}}:
       </strong>

--- a/packages/frontend/app/components/user-profile-bio-manager.gjs
+++ b/packages/frontend/app/components/user-profile-bio-manager.gjs
@@ -310,7 +310,7 @@ export default class UserProfileBioManagerComponent extends Component {
         <button
           aria-label={{t "general.save"}}
           type="button"
-          class="bigadd"
+          class="bigadd font-size-base"
           {{on "click" (perform this.save)}}
           data-test-save
         >
@@ -323,7 +323,7 @@ export default class UserProfileBioManagerComponent extends Component {
           aria-label={{t "general.cancel"}}
           type="button"
           disabled={{this.save.isRunning}}
-          class="bigcancel"
+          class="bigcancel font-size-base"
           {{on "click" this.cancel}}
           data-test-cancel
         >
@@ -337,7 +337,7 @@ export default class UserProfileBioManagerComponent extends Component {
         </div>
       {{/unless}}
 
-      <p class="primary-school" data-test-school>
+      <p class="primary-school font-size-medium" data-test-school>
         <strong>
           {{t "general.primarySchool"}}:
         </strong>
@@ -438,7 +438,7 @@ export default class UserProfileBioManagerComponent extends Component {
               {{#unless @canEditUsernameAndPassword}}
                 <button
                   type="button"
-                  class="directory-sync"
+                  class="directory-sync font-size-base"
                   title={{t "general.updateUserFromDirectory"}}
                   disabled={{this.directorySync.isRunning}}
                   {{on "click" (perform this.directorySync)}}
@@ -654,7 +654,8 @@ export default class UserProfileBioManagerComponent extends Component {
                 />
                 {{#if this.checkPasswordStrength}}
                   <span
-                    class="password-strength {{concat 'strength-' this.passwordStrengthScore}}"
+                    class="password-strength font-size-base
+                      {{concat 'strength-' this.passwordStrengthScore}}"
                     data-test-password-strength-text
                   >
                     {{#if (eq this.passwordStrengthScore 0)}}
@@ -676,7 +677,7 @@ export default class UserProfileBioManagerComponent extends Component {
                   ></meter>
                 {{/if}}
                 <button
-                  class="link-button cancel-password-field"
+                  class="link-button cancel-password-field font-size-base"
                   type="button"
                   {{on "click" this.cancelChangeUserPassword}}
                   data-test-password-cancel
@@ -685,7 +686,7 @@ export default class UserProfileBioManagerComponent extends Component {
                 </button>
               {{else}}
                 <button
-                  class="link-button activate-password-field"
+                  class="link-button activate-password-field font-size-base"
                   type="button"
                   {{on "click" (set this "changeUserPassword" true)}}
                   data-test-change-password

--- a/packages/frontend/app/components/user-profile-cohorts.gjs
+++ b/packages/frontend/app/components/user-profile-cohorts.gjs
@@ -185,7 +185,7 @@ export default class UserProfileCohortsComponent extends Component {
               <button
                 type="button"
                 disabled={{or this.save.isRunning this.cancel.isRunning}}
-                class="bigadd"
+                class="bigadd font-size-base"
                 aria-label={{t "general.save"}}
                 {{on "click" (perform this.save)}}
                 data-test-save
@@ -198,7 +198,7 @@ export default class UserProfileCohortsComponent extends Component {
               <button
                 type="button"
                 disabled={{or this.save.isRunning this.cancel.isRunning}}
-                class="bigcancel"
+                class="bigcancel font-size-base"
                 aria-label={{t "general.cancel"}}
                 {{on "click" (perform this.cancel)}}
                 data-test-cancel
@@ -209,7 +209,7 @@ export default class UserProfileCohortsComponent extends Component {
               <button
                 aria-label={{t "general.manage"}}
                 type="button"
-                class="manage"
+                class="manage font-size-base"
                 {{on "click" (fn @setIsManaging true)}}
                 data-test-manage
               >

--- a/packages/frontend/app/components/user-profile-ics.gjs
+++ b/packages/frontend/app/components/user-profile-ics.gjs
@@ -116,7 +116,7 @@ export default class UserProfileIcsComponent extends Component {
             type="button"
             disabled={{this.refreshKey.isRunning}}
             title={{t "general.refreshIcsFeedKey"}}
-            class="refresh-key"
+            class="refresh-key font-size-base"
             data-test-refresh-key
             {{on "click" (perform this.refreshKey)}}
           >
@@ -128,7 +128,7 @@ export default class UserProfileIcsComponent extends Component {
           <button
             type="button"
             disabled={{this.refreshKey.isRunning}}
-            class="bigcancel"
+            class="bigcancel font-size-base"
             data-test-cancel
             title={{t "general.close"}}
             {{on "click" (fn @setIsManaging false)}}
@@ -138,7 +138,7 @@ export default class UserProfileIcsComponent extends Component {
         {{else if @isManageable}}
           <button
             type="button"
-            class="manage"
+            class="manage font-size-base"
             data-test-manage
             title={{t "general.refreshIcsFeedKey"}}
             {{on "click" (fn @setIsManaging true)}}

--- a/packages/frontend/app/components/user-profile-permissions.gjs
+++ b/packages/frontend/app/components/user-profile-permissions.gjs
@@ -532,7 +532,11 @@ export default class UserProfilePermissionsComponent extends Component {
             <h3 class="title" data-test-title>
               <button
                 aria-expanded={{if this.programCollapsed "false" "true"}}
-                class="toggle-button {{if this.programCollapsed 'collapsed' 'expanded'}}"
+                class="toggle-button font-size-base{{if
+                    this.programCollapsed
+                    ' collapsed'
+                    ' expanded'
+                  }}"
                 type="button"
                 {{on "click" (set this "programCollapsed" (not this.programCollapsed))}}
               >
@@ -569,7 +573,11 @@ export default class UserProfilePermissionsComponent extends Component {
             <h3 class="title" data-test-title>
               <button
                 aria-expanded={{if this.programYearCollapsed "false" "true"}}
-                class="toggle-button {{if this.programYearCollapsed 'collapsed' 'expanded'}}"
+                class="toggle-button font-size-base{{if
+                    this.programYearCollapsed
+                    ' collapsed'
+                    ' expanded'
+                  }}"
                 type="button"
                 {{on "click" (set this "programYearCollapsed" (not this.programYearCollapsed))}}
               >
@@ -612,7 +620,11 @@ export default class UserProfilePermissionsComponent extends Component {
             <h3 class="title" data-test-title>
               <button
                 aria-expanded={{if this.courseCollapsed "false" "true"}}
-                class="toggle-button {{if this.courseCollapsed 'collapsed' 'expanded'}}"
+                class="toggle-button font-size-base{{if
+                    this.courseCollapsed
+                    ' collapsed'
+                    ' expanded'
+                  }}"
                 type="button"
                 {{on "click" (set this "courseCollapsed" (not this.courseCollapsed))}}
               >
@@ -731,7 +743,11 @@ export default class UserProfilePermissionsComponent extends Component {
             <h3 class="title" data-test-title>
               <button
                 aria-expanded={{if this.sessionCollapsed "false" "true"}}
-                class="toggle-button {{if this.sessionCollapsed 'collapsed' 'expanded'}}"
+                class="toggle-button font-size-base{{if
+                    this.sessionCollapsed
+                    ' collapsed'
+                    ' expanded'
+                  }}"
                 type="button"
                 {{on "click" (set this "sessionCollapsed" (not this.sessionCollapsed))}}
               >

--- a/packages/frontend/app/components/user-profile-roles.gjs
+++ b/packages/frontend/app/components/user-profile-roles.gjs
@@ -118,7 +118,7 @@ export default class UserProfileRolesComponent extends Component {
         {{#if @isManaging}}
           <button
             type="button"
-            class="bigadd"
+            class="bigadd font-size-base"
             data-test-save
             aria-label={{t "general.save"}}
             {{on "click" (perform this.save)}}
@@ -131,7 +131,7 @@ export default class UserProfileRolesComponent extends Component {
           <button
             type="button"
             disabled={{this.save.isRunning}}
-            class="bigcancel"
+            class="bigcancel font-size-base"
             aria-label={{t "general.cancel"}}
             {{on "click" this.cancel}}
           >
@@ -141,7 +141,7 @@ export default class UserProfileRolesComponent extends Component {
           <button
             aria-label={{t "general.manage"}}
             type="button"
-            class="manage"
+            class="manage font-size-base"
             data-test-manage
             {{on "click" (fn @setIsManaging true)}}
           >

--- a/packages/frontend/app/styles/components/bulk-new-users.scss
+++ b/packages/frontend/app/styles/components/bulk-new-users.scss
@@ -62,7 +62,6 @@
 
   .file-is-loading {
     display: flex;
-    @include m.font-size("xxxl");
     font-weight: 600;
     justify-content: center;
   }

--- a/packages/frontend/app/styles/components/course-search-result.scss
+++ b/packages/frontend/app/styles/components/course-search-result.scss
@@ -10,7 +10,6 @@
     bottom: 2px;
     color: var(--white);
     display: inline-block;
-    @include m.font-size("smallest");
     padding: 2px 3px 1px;
     position: relative;
   }
@@ -21,7 +20,6 @@
     bottom: 2px;
     color: var(--white);
     display: inline-block;
-    @include m.font-size("smallest");
     padding: 2px 3px 1px;
     position: relative;
   }
@@ -32,21 +30,14 @@
 
     .sessions {
       color: var(--grey);
-      @include m.font-size("small");
     }
-  }
-
-  .session-title-link {
-    @include m.font-size("small");
   }
 
   .show-more,
   .show-less {
-    @include m.font-size("small");
     text-transform: capitalize;
 
     .fa-angle-down {
-      @include m.font-size("base");
       margin-right: 0.125rem;
       position: relative;
       top: 2px;
@@ -63,7 +54,6 @@
       border-radius: 0.125rem;
       color: var(--black);
       display: inline-block;
-      @include m.font-size("smallest");
       margin-right: 0.375rem;
       padding: 0.125rem;
     }

--- a/packages/frontend/app/styles/components/curriculum-inventory/new-sequence-block.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/new-sequence-block.scss
@@ -23,12 +23,6 @@
     }
   }
 
-  .course {
-    .details {
-      @include m.font-size("small");
-    }
-  }
-
   .description {
     grid-column: 1 / -1;
     min-height: 10rem;

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-overview.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-overview.scss
@@ -18,7 +18,6 @@
       a,
       span {
         color: var(--light-blue);
-        @include m.font-size("medium");
         margin-right: 0.5rem;
       }
     }

--- a/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-overview.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-overview.scss
@@ -21,10 +21,6 @@
         span {
           display: flex;
         }
-
-        .details {
-          @include m.font-size("small");
-        }
       }
 
       &.description {

--- a/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-overview.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-overview.scss
@@ -46,10 +46,6 @@
       &.sessions {
         grid-column: 1 / -1;
       }
-
-      &.title {
-        @include m.ilios-overview-title;
-      }
     }
 
     .curriculum-inventory-sequence-block-overview-content {

--- a/packages/frontend/app/styles/components/ilios-footer.scss
+++ b/packages/frontend/app/styles/components/ilios-footer.scss
@@ -16,7 +16,6 @@
     border-radius: 0.2rem;
     color: var(--black);
     display: flex;
-    @include cm.font-size("smallest");
     font-weight: 200;
     justify-content: center;
     margin: 0.25rem;

--- a/packages/frontend/app/styles/components/ilios-navigation.scss
+++ b/packages/frontend/app/styles/components/ilios-navigation.scss
@@ -26,7 +26,9 @@
       line-height: 1.1;
 
       @include m.for-laptop-and-up {
-        @include m.font-size("small");
+        // @include m.font-size("small");
+        font-size: var(--fs-small);
+        line-height: calc(4px + 2ex);
         height: auto;
         text-align: left;
 

--- a/packages/frontend/app/styles/components/ilios-navigation.scss
+++ b/packages/frontend/app/styles/components/ilios-navigation.scss
@@ -26,9 +26,7 @@
       line-height: 1.1;
 
       @include m.for-laptop-and-up {
-        // @include m.font-size("small");
-        font-size: var(--fs-small);
-        line-height: calc(4px + 2ex);
+        @include m.font-size("small");
         height: auto;
         text-align: left;
 

--- a/packages/frontend/app/styles/components/instructor-group/root.scss
+++ b/packages/frontend/app/styles/components/instructor-group/root.scss
@@ -6,11 +6,4 @@
   .backtolink {
     margin: 0.5rem;
   }
-
-  .instructor-group-loading {
-    display: block;
-    @include m.font-size("xl");
-    margin: auto;
-    text-align: center;
-  }
 }

--- a/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
+++ b/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
@@ -15,7 +15,6 @@
 
       i {
         color: var(--light-blue);
-        @include m.font-size("xxl");
         font-weight: 600;
         margin: 0;
         padding: 0;

--- a/packages/frontend/app/styles/components/learner-group/calendar.scss
+++ b/packages/frontend/app/styles/components/learner-group/calendar.scss
@@ -12,7 +12,6 @@
 
   h2 {
     @include m.ilios-heading;
-    @include m.font-size("medium");
     margin-bottom: 1rem;
     text-align: center;
     width: 100%;

--- a/packages/frontend/app/styles/components/learner-group/root.scss
+++ b/packages/frontend/app/styles/components/learner-group/root.scss
@@ -45,15 +45,6 @@
     }
   }
 
-  .cohortmembers {
-    .cohortmembers-loading {
-      display: block;
-      @include m.font-size("xxl");
-      margin: auto;
-      text-align: center;
-    }
-  }
-
   .subgroups {
     @include m.detail-container-content;
 

--- a/packages/frontend/app/styles/components/my-profile.scss
+++ b/packages/frontend/app/styles/components/my-profile.scss
@@ -35,7 +35,6 @@
 
   .token-maintenance {
     border-top: 1px dotted var(--orange);
-    @include cm.font-size("small");
     margin-top: 1rem;
     padding: 1rem 0 0;
 

--- a/packages/frontend/app/styles/components/pagination-links.scss
+++ b/packages/frontend/app/styles/components/pagination-links.scss
@@ -21,7 +21,6 @@
     }
 
     svg {
-      @include m.font-size("medium");
       margin-left: 0.25rem;
       position: relative;
       top: 2px;

--- a/packages/frontend/app/styles/components/programyear-header.scss
+++ b/packages/frontend/app/styles/components/programyear-header.scss
@@ -28,7 +28,6 @@
       .editable,
       h3 {
         display: block;
-        @include m.font-size("large");
 
         @include m.for-laptop-and-up {
           display: inline;

--- a/packages/frontend/app/styles/components/programyear-overview.scss
+++ b/packages/frontend/app/styles/components/programyear-overview.scss
@@ -21,7 +21,6 @@
 
       a {
         color: var(--light-blue);
-        @include m.font-size("medium");
       }
     }
   }

--- a/packages/frontend/app/styles/components/reports/choose-course.scss
+++ b/packages/frontend/app/styles/components/reports/choose-course.scss
@@ -23,7 +23,6 @@
 
   .deselect-all {
     @include cm.ilios-button-reset;
-    @include cm.font-size("small");
     color: var(--blue);
   }
 

--- a/packages/frontend/app/styles/components/reports/curriculum-header.scss
+++ b/packages/frontend/app/styles/components/reports/curriculum-header.scss
@@ -13,7 +13,6 @@
   }
 
   .run {
-    @include cm.font-size("medium");
     min-height: 2rem;
   }
 

--- a/packages/frontend/app/styles/components/reports/switcher.scss
+++ b/packages/frontend/app/styles/components/reports/switcher.scss
@@ -4,12 +4,12 @@
   display: flex;
   justify-content: center;
   margin: 1em;
+
   a {
     @include cm.ilios-link-button;
     background-color: var(--white);
     color: var(--blue);
     border: 1px solid var(--very-transparent-black);
-    @include cm.font-size("medium");
     font-weight: 600;
     padding: 0.25em 0.5em;
     text-align: center;

--- a/packages/frontend/app/styles/components/school-institutional-information-manager.scss
+++ b/packages/frontend/app/styles/components/school-institutional-information-manager.scss
@@ -30,7 +30,6 @@
     .validation-error-message {
       color: var(--red);
       display: block;
-      @include m.font-size("small");
       font-style: italic;
       margin-top: 0.25rem;
     }

--- a/packages/frontend/app/styles/components/school/emails-editor.scss
+++ b/packages/frontend/app/styles/components/school/emails-editor.scss
@@ -30,7 +30,6 @@
     .validation-error-message {
       color: var(--red);
       display: block;
-      @include m.font-size("small");
       font-style: italic;
       margin-top: 0.25rem;
     }

--- a/packages/frontend/app/styles/components/update-notification.scss
+++ b/packages/frontend/app/styles/components/update-notification.scss
@@ -1,10 +1,4 @@
-@use "../ilios-common/mixins" as m;
-
 .update-notification {
-  button {
-    @include m.font-size("large");
-  }
-
   &.critical-notice {
     background-color: var(--blue);
 

--- a/packages/frontend/app/styles/components/user-guide-link.scss
+++ b/packages/frontend/app/styles/components/user-guide-link.scss
@@ -15,7 +15,6 @@
     border: 1px solid var(--super-light-grey);
     border-radius: 0.2rem;
     color: var(--black);
-    @include cm.font-size("small");
     font-weight: 400;
     margin-left: 0.8rem;
     padding: 0.25em;

--- a/packages/frontend/app/styles/components/user-profile-bio.scss
+++ b/packages/frontend/app/styles/components/user-profile-bio.scss
@@ -16,8 +16,7 @@
   }
 
   .primary-school {
-    @include m.font-size("medium");
-    padding: 0;
+    padding: 0 0.5rem;
   }
 
   .form {
@@ -106,7 +105,6 @@
 
   .password-strength {
     display: inline-block;
-    @include m.font-size("base");
     font-variant: small-caps;
     text-align: right;
     width: 10%;

--- a/packages/frontend/app/styles/layout/_noscript.scss
+++ b/packages/frontend/app/styles/layout/_noscript.scss
@@ -5,7 +5,6 @@ noscript {
     background-color: var(--white);
     border: 2px dashed var(--orange);
     color: var(--black);
-    @include m.font-size("xxl");
     font-weight: 600;
     margin: 2rem;
     padding: 2rem;

--- a/packages/frontend/app/styles/shared/admin-block.scss
+++ b/packages/frontend/app/styles/shared/admin-block.scss
@@ -29,10 +29,6 @@
       margin-top: 1rem;
     }
 
-    button {
-      @include cm.font-size("base");
-    }
-
     select {
       max-width: 88vw;
 

--- a/packages/frontend/app/templates/application.gjs
+++ b/packages/frontend/app/templates/application.gjs
@@ -44,7 +44,7 @@ import FlashMessages from 'frontend/components/flash-messages';
       {{/if}}
     </main>
     <footer class="ilios-footer">
-      <div class="version">
+      <div class="version font-size-smallest">
         {{@controller.iliosVersionTag}}
         {{@controller.apiVersionTag}}
         {{@controller.frontendVersionTag}}

--- a/packages/frontend/config/environment.js
+++ b/packages/frontend/config/environment.js
@@ -40,6 +40,8 @@ module.exports = function (environment) {
       dsn: 'https://ded7a44cf4084601a2fb468484bbe3ed@sentry.io/1311608',
     },
     noScript: {
+      content:
+        "<p class='font-size-xxl'>For full functionality of this site it is necessary to enable JavaScript. Here are the <a href='https://www.enable-javascript.com/' target='_blank'>instructions on how to enable JavaScript in your web browser</a>.</p>",
       placeIn: 'body-footer',
     },
     disableServiceWorker: [true, 'true'].includes(process.env.SW_DISABLED),

--- a/packages/ilios-common/addon/components/collapsed-competencies.gjs
+++ b/packages/ilios-common/addon/components/collapsed-competencies.gjs
@@ -65,7 +65,7 @@ export default class CollapsedCompetenciesComponent extends Component {
         <LoadingSpinner />
       {{else}}
         <div class="content">
-          <table class="ilios-table ilios-table-colors">
+          <table class="ilios-table ilios-table-colors font-size-small">
             <thead>
               <tr>
                 <th class="text-left">

--- a/packages/ilios-common/addon/components/collapsed-taxonomies.gjs
+++ b/packages/ilios-common/addon/components/collapsed-taxonomies.gjs
@@ -23,7 +23,7 @@ import { faCaretRight } from '@fortawesome/free-solid-svg-icons';
     </div>
     {{#if @subject.associatedVocabularies}}
       <div class="content">
-        <table class="ilios-table ilios-table-colors condensed">
+        <table class="ilios-table ilios-table-colors condensed font-size-small">
           <thead>
             <tr>
               <th class="text-left">

--- a/packages/ilios-common/addon/components/copy-button.gjs
+++ b/packages/ilios-common/addon/components/copy-button.gjs
@@ -13,7 +13,7 @@ export default class CopyButtonComponent extends Component {
   <template>
     <button
       type="button"
-      class="copy-btn"
+      class="copy-btn font-size-base"
       data-test-copy-button
       ...attributes
       {{on "click" (perform this.copy)}}

--- a/packages/ilios-common/addon/components/course/collapsed-objectives.gjs
+++ b/packages/ilios-common/addon/components/course/collapsed-objectives.gjs
@@ -54,7 +54,7 @@ export default class CourseCollapsedObjectivesComponent extends Component {
       </div>
       {{#if this.objectives.length}}
         <div class="content">
-          <table class="ilios-table ilios-table-colors condensed">
+          <table class="ilios-table ilios-table-colors condensed font-size-small">
             <thead>
               <tr>
                 <th class="text-left">

--- a/packages/ilios-common/addon/components/course/loading.gjs
+++ b/packages/ilios-common/addon/components/course/loading.gjs
@@ -64,7 +64,7 @@ import { faSquarePlus } from '@fortawesome/free-solid-svg-icons';
         <input disabled />
       </div>
       <section>
-        <div class="sessions-grid-header loading-text"></div>
+        <div class="sessions-grid-header font-size-small loading-text"></div>
       </section>
     </section>
   </div>

--- a/packages/ilios-common/addon/components/course/objective-list-item-parents.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item-parents.gjs
@@ -19,7 +19,10 @@ export default class CourseObjectiveListItemParentsComponent extends Component {
     return `<ul>${items}</ul>`;
   }
   <template>
-    <div class="course-objective-list-item-parents grid-item" data-test-objective-list-item-parents>
+    <div
+      class="course-objective-list-item-parents grid-item font-size-base"
+      data-test-objective-list-item-parents
+    >
       {{#if @isManaging}}
         <button
           type="button"

--- a/packages/ilios-common/addon/components/course/overview.gjs
+++ b/packages/ilios-common/addon/components/course/overview.gjs
@@ -244,7 +244,7 @@ export default class CourseOverview extends Component {
             <LinkTo
               @route="course-materials"
               @model={{@course}}
-              class="materials"
+              class="materials font-size-medium"
               title={{t "general.learningMaterialsSummary"}}
             >
               <FaIcon @icon={{faBoxArchive}} @fixedWidth={{true}} />
@@ -254,7 +254,7 @@ export default class CourseOverview extends Component {
               @model={{@course}}
               @query={{hash unpublished=true}}
               title={{t "general.printSummary"}}
-              class="print"
+              class="print font-size-medium"
             >
               <FaIcon @icon={{faPrint}} @fixedWidth={{true}} />
             </LinkTo>
@@ -262,7 +262,7 @@ export default class CourseOverview extends Component {
               <LinkTo
                 @route="course.rollover"
                 @model={{@course}}
-                class="rollover"
+                class="rollover font-size-medium"
                 title={{t "general.courseRollover"}}
               >
                 <FaIcon @icon={{faShuffle}} @fixedWidth={{true}} />
@@ -271,6 +271,7 @@ export default class CourseOverview extends Component {
             <LinkTo
               @route="course-visualizations"
               @model={{@course}}
+              class="font-size-medium"
               title={{t "general.courseVisualizations"}}
             >
               <FaIcon @icon={{faChartColumn}} />

--- a/packages/ilios-common/addon/components/course/overview.gjs
+++ b/packages/ilios-common/addon/components/course/overview.gjs
@@ -237,7 +237,7 @@ export default class CourseOverview extends Component {
     <section class="course-overview" data-test-course-overview>
       {{#let (uniqueId) as |templateId|}}
         <div class="course-overview-header">
-          <div class="title">
+          <div class="title font-size-base">
             {{t "general.overview"}}
           </div>
           <div class="course-overview-actions">

--- a/packages/ilios-common/addon/components/course/summary-header.gjs
+++ b/packages/ilios-common/addon/components/course/summary-header.gjs
@@ -32,7 +32,7 @@ export default class CourseSummaryHeaderComponent extends Component {
   <template>
     <div class="course-summary-header" ...attributes>
       <div class="course-summary-header-top">
-        <h2>
+        <h2 class="font-size-base">
           {{@course.title}}
         </h2>
         <div class="course-summary-actions">

--- a/packages/ilios-common/addon/components/course/summary-header.gjs
+++ b/packages/ilios-common/addon/components/course/summary-header.gjs
@@ -40,12 +40,12 @@ export default class CourseSummaryHeaderComponent extends Component {
             @route="print-course"
             @model={{@course}}
             @query={{hash unpublished=true}}
-            class="print"
+            class="print font-size-medium"
           >
             <FaIcon @icon={{faPrint}} @title={{t "general.printSummary"}} @fixedWidth={{true}} />
           </LinkTo>
           {{#if this.canRollover}}
-            <LinkTo @route="course.rollover" @model={{@course}} class="rollover">
+            <LinkTo @route="course.rollover" @model={{@course}} class="rollover font-size-medium">
               <FaIcon
                 @icon={{faShuffle}}
                 @title={{t "general.courseRollover"}}

--- a/packages/ilios-common/addon/components/daily-calendar-event.gjs
+++ b/packages/ilios-common/addon/components/daily-calendar-event.gjs
@@ -121,7 +121,10 @@ export default class DailyCalendarEventComponent extends Component {
   }
   <template>
     <button
-      class="daily-calendar-event{{if this.isIlm ' ilm'}}{{if this.clickable ' clickable'}}"
+      class="daily-calendar-event font-size-small{{if this.isIlm ' ilm'}}{{if
+          this.clickable
+          ' clickable'
+        }}"
       {{! template-lint-disable no-inline-styles }}
       style={{this.style}}
       type="button"

--- a/packages/ilios-common/addon/components/daily-calendar-event.gjs
+++ b/packages/ilios-common/addon/components/daily-calendar-event.gjs
@@ -159,7 +159,7 @@ export default class DailyCalendarEventComponent extends Component {
           <FaIcon @icon={{faClock}} data-test-scheduled-icon />
         {{/if}}
       </span>
-      <span class="ilios-calendar-event-time" data-test-time>
+      <span class="ilios-calendar-event-time font-size-small" data-test-time>
         {{#if this.isIlm}}
           <span class="ilios-calendar-event-start">
             {{t "general.ilmDue"}}:

--- a/packages/ilios-common/addon/components/dashboard/calendar-filters.gjs
+++ b/packages/ilios-common/addon/components/dashboard/calendar-filters.gjs
@@ -67,10 +67,10 @@ export default class DashboardCalendarFiltersComponent extends Component {
         />
         <div
           id="calendar-sessiontypefilter"
-          class="calendar-filter-list sessiontypefilter"
+          class="calendar-filter-list sessiontypefilter font-size-small"
           data-test-session-type-filter
         >
-          <h2>
+          <h2 class="font-size-base">
             {{t "general.sessionTypes"}}
           </h2>
           <div class="filters">
@@ -103,10 +103,10 @@ export default class DashboardCalendarFiltersComponent extends Component {
       {{else}}
         <div
           id="calendar-sessiontypefilter"
-          class="calendar-filter-list sessiontypefilter"
+          class="calendar-filter-list sessiontypefilter font-size-small"
           data-test-session-type-filter
         >
-          <h2>
+          <h2 class="font-size-base">
             {{t "general.sessionTypes"}}
           </h2>
           <div class="filters">
@@ -132,10 +132,10 @@ export default class DashboardCalendarFiltersComponent extends Component {
         </div>
         <div
           id="calendar-courselevelfilter"
-          class="calendar-filter-list courselevelfilter"
+          class="calendar-filter-list courselevelfilter font-size-small"
           data-test-course-level-filter
         >
-          <h2>
+          <h2 class="font-size-base">
             {{t "general.courseLevels"}}
           </h2>
           <div class="filters">

--- a/packages/ilios-common/addon/components/dashboard/cohort-calendar-filter.gjs
+++ b/packages/ilios-common/addon/components/dashboard/cohort-calendar-filter.gjs
@@ -6,10 +6,10 @@ import { fn } from '@ember/helper';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 <template>
   <div
-    class="calendar-filter-list large-filter-list dashboard-cohort-calendar-filter"
+    class="calendar-filter-list large-filter-list dashboard-cohort-calendar-filter font-size-small"
     data-test-cohort-calendar-filter
   >
-    <h2>{{t "general.programAndCohort"}}</h2>
+    <h2 class="font-size-base">{{t "general.programAndCohort"}}</h2>
     <ul class="cohorts filters">
       {{#each (sortBy "classOfYear:desc" @cohortProxies) as |obj|}}
         <li data-test-cohort>

--- a/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.gjs
+++ b/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.gjs
@@ -150,10 +150,10 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
   }
   <template>
     <div
-      class="calendar-filter-list large-filter-list dashboard-courses-calendar-filter"
+      class="calendar-filter-list large-filter-list dashboard-courses-calendar-filter font-size-small"
       data-test-courses-calendar-filter
     >
-      <h2>
+      <h2 class="font-size-base">
         {{t "general.courses"}}
         {{#if this.expandedYearWithoutTitleView}}
           {{#if this.academicYearCrossesCalendarYearBoundaries}}

--- a/packages/ilios-common/addon/components/dashboard/filter-tags.gjs
+++ b/packages/ilios-common/addon/components/dashboard/filter-tags.gjs
@@ -131,10 +131,10 @@ export default class DashboardFilterTagsComponent extends Component {
     {{#if this.activeFilters.length}}
       <section class="filters-list" data-test-dashboard-filter-tags>
         {{#if this.filterTags}}
-          <header class="filters-header">
+          <header class="filters-header font-size-small">
             {{t "general.activeFilters"}}:
           </header>
-          <div class="filter-tags">
+          <div class="filter-tags font-size-small">
             {{#each (sortBy "name" this.filterTags) as |tag|}}
               <button
                 class="filter-tag {{tag.class}}"
@@ -148,7 +148,7 @@ export default class DashboardFilterTagsComponent extends Component {
             {{/each}}
             <button
               id="calendar-clear-filters"
-              class="filters-clear-filters"
+              class="filters-clear-filters font-size-small"
               type="button"
               {{on "click" @clearFilters}}
               data-test-clear-filters

--- a/packages/ilios-common/addon/components/dashboard/material-list-item.gjs
+++ b/packages/ilios-common/addon/components/dashboard/material-list-item.gjs
@@ -35,7 +35,7 @@ export default class DashboardMaterialListItemComponent extends Component {
             <FaIcon @icon={{faClock}} @title={{t "general.timedRelease"}} data-test-is-blanked />
           </span>
           {{@lm.title}}
-          <span class="timed-release-info">
+          <span class="timed-release-info font-size-small">
             <TimedReleaseSchedule @endDate={{@lm.endDate}} @startDate={{@lm.startDate}} />
           </span>
         {{else}}

--- a/packages/ilios-common/addon/components/dashboard/terms-calendar-filter.gjs
+++ b/packages/ilios-common/addon/components/dashboard/terms-calendar-filter.gjs
@@ -51,8 +51,8 @@ export default class DashboardTermsCalendarFilterComponent extends Component {
     return null;
   }
   <template>
-    <div class="calendar-filter-list vocabularyfilter" data-test-vocabulary-filter>
-      <h2>
+    <div class="calendar-filter-list vocabularyfilter font-size-small" data-test-vocabulary-filter>
+      <h2 class="font-size-base">
         {{t "general.terms"}}
         {{#if this.vocabularyWithoutTitleView}}
           ({{this.vocabularyWithoutTitleView}})

--- a/packages/ilios-common/addon/components/dashboard/user-context-filter.gjs
+++ b/packages/ilios-common/addon/components/dashboard/user-context-filter.gjs
@@ -29,7 +29,10 @@ export default class DashboardUserContextFilterComponent extends Component {
       />
       <label
         for={{concat "instructing-toggle-" this.uniqueId}}
-        class={{if (or (not @userContext) (eq @userContext "instructor")) "active"}}
+        class="font-size-small{{if
+            (or (not @userContext) (eq @userContext 'instructor'))
+            ' active'
+          }}"
         title={{if
           (eq @userContext "instructor")
           (t "general.showAllMyActivities")
@@ -53,7 +56,7 @@ export default class DashboardUserContextFilterComponent extends Component {
       />
       <label
         for={{concat "learning-toggle-" this.uniqueId}}
-        class={{if (or (not @userContext) (eq @userContext "learner")) "active"}}
+        class="font-size-small{{if (or (not @userContext) (eq @userContext 'learner')) ' active'}}"
         title={{if
           (eq @userContext "learner")
           (t "general.showAllMyActivities")
@@ -77,7 +80,10 @@ export default class DashboardUserContextFilterComponent extends Component {
       />
       <label
         for={{concat "admin-toggle-" this.uniqueId}}
-        class={{if (or (not @userContext) (eq @userContext "administrator")) "active"}}
+        class="font-size-small{{if
+            (or (not @userContext) (eq @userContext 'administrator'))
+            ' active'
+          }}"
         title={{if
           (eq @userContext "administrator")
           (t "general.showAllMyActivities")

--- a/packages/ilios-common/addon/components/fade-text.gjs
+++ b/packages/ilios-common/addon/components/fade-text.gjs
@@ -173,7 +173,7 @@ class FadedTextComponent extends Component {
       data-test-done={{this.sanitizerData.isResolved}}
       id={{@id}}
     >
-      <div class="display-text" {{onResize @resize}} data-test-text>
+      <div class="display-text font-size-base" {{onResize @resize}} data-test-text>
         {{this.displayText}}
       </div>
     </div>

--- a/packages/ilios-common/addon/components/ilios-calendar-event-month.gjs
+++ b/packages/ilios-common/addon/components/ilios-calendar-event-month.gjs
@@ -94,21 +94,21 @@ export default class IliosCalendarEventMonthComponent extends Component {
             @title={{t "general.newUpdates"}}
           />
         {{/if}}
-        <span class="ilios-calendar-event-time">
-          <span class="ilios-calendar-event-start">
+        <span class="ilios-calendar-event-time font-size-smallest">
+          <span class="ilios-calendar-event-start font-size-smallest">
             {{formatDate @event.startDate hour12=true hour="2-digit" minute="2-digit"}}
           </span>
-          <span class="ilios-calendar-event-end">
+          <span class="ilios-calendar-event-end font-size-smallest">
             -
             {{formatDate @event.endDate hour12=true hour="2-digit" minute="2-digit"}}
           </span>
         </span>
         {{#unless @event.isMulti}}
-          <span class="ilios-calendar-event-location">
+          <span class="ilios-calendar-event-location font-size-smallest">
             {{@event.location}}:
           </span>
         {{/unless}}
-        <span class="ilios-calendar-event-name">
+        <span class="ilios-calendar-event-name font-size-smallest">
           {{#if @event.isMulti}}
             {{@event.name}},
             <em>

--- a/packages/ilios-common/addon/components/ilios-calendar-multiday-events.gjs
+++ b/packages/ilios-common/addon/components/ilios-calendar-multiday-events.gjs
@@ -3,7 +3,7 @@ import IliosCalendarMultidayEvent from 'ilios-common/components/ilios-calendar-m
 <template>
   {{#if @events.length}}
     <div class="ilios-calendar-multiday-events" data-test-ilios-calendar-multiday-events>
-      <h3 class="title" data-test-title>
+      <h3 class="title font-size-medium" data-test-title>
         {{t "general.multidayEvents"}}
       </h3>
       <ul>

--- a/packages/ilios-common/addon/components/leadership-collapsed.gjs
+++ b/packages/ilios-common/addon/components/leadership-collapsed.gjs
@@ -31,7 +31,7 @@ export default class LeadershipCollapsed extends Component {
         </button>
       </div>
       <div class="content">
-        <table class="ilios-table ilios-table-colors condensed">
+        <table class="ilios-table ilios-table-colors condensed font-size-small">
           <thead>
             <tr>
               <th colspan="2" class="text-left">

--- a/packages/ilios-common/addon/components/learning-material-uploader.gjs
+++ b/packages/ilios-common/addon/components/learning-material-uploader.gjs
@@ -50,11 +50,11 @@ export default class LearningMaterialUploaderComponent extends Component {
     <span class="learning-material-uploader" data-test-learning-material-uploader ...attributes>
       {{#let (fileQueue name=this.uploadQueueName onFileAdded=(perform this.upload)) as |queue|}}
         {{#if (and (not this.fileUploadErrorMessage) queue.files.length)}}
-          <span class="upload-button">
+          <span class="upload-button font-size-base">
             <LoadingSpinner />{{queue.progress}}%
           </span>
         {{else}}
-          <label class="upload-button" for={{@for}}>
+          <label class="upload-button font-size-base" for={{@for}}>
             {{t "general.chooseFile"}}
             <input type="file" id={{@for}} hidden {{queue.selectFile}} />
           </label>

--- a/packages/ilios-common/addon/components/learning-materials-sort-manager.gjs
+++ b/packages/ilios-common/addon/components/learning-materials-sort-manager.gjs
@@ -138,7 +138,7 @@ export default class LearningMaterialsSortManagerComponent extends Component {
                       {{item.learningMaterial.title}}
                     </span>
                   </span>
-                  <span class="details">
+                  <span class="details font-size-small">
                     {{capitalize item.learningMaterial.type}},
                     {{t "general.ownedBy" owner=item.learningMaterial.owningUser.fullName}},
                     {{t "general.status"}}:

--- a/packages/ilios-common/addon/components/learningmaterial-search.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-search.gjs
@@ -119,16 +119,16 @@ export default class LearningMaterialSearchComponent extends Component {
                     {{learningMaterial.title}}
                   </span>
                 </div>
-                <span class="learning-material-description">
+                <span class="learning-material-description font-size-small">
                   {{! template-lint-disable no-triple-curlies }}
                   {{{learningMaterial.description}}}
                 </span>
                 {{#if learningMaterial.status.title}}
-                  <span class="learning-material-status">
+                  <span class="learning-material-status font-size-small">
                     {{learningMaterial.status.title}}
                   </span>
                 {{/if}}
-                <ul class="learning-material-properties">
+                <ul class="learning-material-properties font-size-small">
                   <li>
                     {{t "general.owner"}}:
                     {{learningMaterial.owningUser.fullName}}

--- a/packages/ilios-common/addon/components/mesh-manager.gjs
+++ b/packages/ilios-common/addon/components/mesh-manager.gjs
@@ -204,7 +204,7 @@ export default class MeshManagerComponent extends Component {
                     <span class="descriptor-name" data-test-name>
                       {{term.name}}
                     </span>
-                    <span class="descriptor-id">
+                    <span class="descriptor-id font-size-small">
                       {{term.id}}
                       {{#if term.trees.length}}
                         -

--- a/packages/ilios-common/addon/components/offering-calendar.gjs
+++ b/packages/ilios-common/addon/components/offering-calendar.gjs
@@ -141,7 +141,7 @@ export default class OfferingCalendar extends Component {
   <template>
     <div class="offering-calendar">
       {{#if this.calendarEventsData.isResolved}}
-        <h2 class="offering-calendar-title">
+        <h2 class="offering-calendar-title font-size-medium">
           {{t "general.calendar"}}
         </h2>
         <p class="offering-calendar-filter-options">

--- a/packages/ilios-common/addon/components/offering-form.gjs
+++ b/packages/ilios-common/addon/components/offering-form.gjs
@@ -838,7 +838,9 @@ export default class OfferingForm extends Component {
                   <label for="location-{{templateId}}">
                     {{t "general.location"}}:
                     {{#unless @offering}}
-                      <span class="label-description">({{t "general.defaultNotLoaded"}})</span>
+                      <span class="label-description font-size-small">({{t
+                          "general.defaultNotLoaded"
+                        }})</span>
                     {{/unless}}
                   </label>
                   <input
@@ -860,7 +862,9 @@ export default class OfferingForm extends Component {
                   <label for="url-{{templateId}}">
                     {{t "general.virtualLearningLink"}}:
                     {{#unless @offering}}
-                      <span class="label-description">({{t "general.defaultNotLoaded"}})</span>
+                      <span class="label-description font-size-small">({{t
+                          "general.defaultNotLoaded"
+                        }})</span>
                     {{/unless}}
                   </label>
                   {{! template-lint-disable no-bare-strings}}

--- a/packages/ilios-common/addon/components/offering-manager.gjs
+++ b/packages/ilios-common/addon/components/offering-manager.gjs
@@ -154,7 +154,10 @@ export default class OfferingManagerComponent extends Component {
   });
   <template>
     <div
-      class="offering-manager{{if this.showRemoveConfirmation ' show-remove-confirmation'}}"
+      class="offering-manager font-size-small{{if
+          this.showRemoveConfirmation
+          ' show-remove-confirmation'
+        }}"
       data-test-offering-manager
       ...attributes
     >

--- a/packages/ilios-common/addon/components/publish-all-sessions.gjs
+++ b/packages/ilios-common/addon/components/publish-all-sessions.gjs
@@ -552,9 +552,9 @@ export default class PublishAllSessionsComponent extends Component {
           {{/if}}
         </div>
       </section>
-      <div class="publish-all-sessions-review" data-test-review>
+      <div class="publish-all-sessions-review font-size-large" data-test-review>
         {{#if this.showWarning}}
-          <span class="unlinked-warning" data-test-unlinked-warning>
+          <span class="unlinked-warning font-size-base" data-test-unlinked-warning>
             {{t "general.unlinkedObjectives"}}
           </span>
           <LinkTo

--- a/packages/ilios-common/addon/components/selected-instructor-groups.gjs
+++ b/packages/ilios-common/addon/components/selected-instructor-groups.gjs
@@ -10,7 +10,7 @@ import { faUsers, faXmark } from '@fortawesome/free-solid-svg-icons';
     <label class="heading" data-test-heading>
       {{t "general.selectedInstructorGroups"}}:
       {{#if @showDefaultNotLoaded}}
-        <span class="label-description">({{t "general.defaultNotLoaded"}})</span>
+        <span class="label-description font-size-small">({{t "general.defaultNotLoaded"}})</span>
       {{/if}}
     </label>
     <div data-test-selected-instructor-groups>

--- a/packages/ilios-common/addon/components/selected-instructors.gjs
+++ b/packages/ilios-common/addon/components/selected-instructors.gjs
@@ -11,7 +11,7 @@ import { faXmark } from '@fortawesome/free-solid-svg-icons';
     <label class="heading" data-test-heading>
       {{t "general.selectedInstructors"}}:
       {{#if @showDefaultNotLoaded}}
-        <span class="label-description">({{t "general.defaultNotLoaded"}})</span>
+        <span class="label-description font-size-small">({{t "general.defaultNotLoaded"}})</span>
       {{/if}}
     </label>
     {{#if @instructors.length}}

--- a/packages/ilios-common/addon/components/session-offerings-list.gjs
+++ b/packages/ilios-common/addon/components/session-offerings-list.gjs
@@ -51,7 +51,7 @@ export default class SessionOfferingsListComponent extends Component {
         {{#each this.offeringBlocks as |block|}}
           <div class="offering-block">
             <div class="offering-block-date">
-              <span class="offering-block-date-dayofweek">
+              <span class="offering-block-date-dayofweek font-size-medium">
                 {{formatDate block.date weekday="long"}}
               </span>
               <span class="offering-block-date-dayofmonth">

--- a/packages/ilios-common/addon/components/session/collapsed-objectives.gjs
+++ b/packages/ilios-common/addon/components/session/collapsed-objectives.gjs
@@ -54,7 +54,7 @@ export default class SessionCollapsedObjectivesComponent extends Component {
       </div>
       {{#if this.objectivesData.isResolved}}
         <div class="content">
-          <table class="ilios-table ilios-table-colors condensed">
+          <table class="ilios-table ilios-table-colors condensed font-size-small">
             <thead>
               <tr>
                 <th class="text-left">

--- a/packages/ilios-common/addon/components/session/objective-list-item-parents.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item-parents.gjs
@@ -21,7 +21,7 @@ export default class SessionObjectiveListItemParentsComponent extends Component 
 
   <template>
     <div
-      class="session-objective-list-item-parents grid-item"
+      class="session-objective-list-item-parents grid-item font-size-base"
       data-test-objective-list-item-parents
     >
       {{#if @isManaging}}

--- a/packages/ilios-common/addon/components/session/overview.gjs
+++ b/packages/ilios-common/addon/components/session/overview.gjs
@@ -397,7 +397,7 @@ export default class SessionOverview extends Component {
 
             <div class="session-overview-header">
 
-              <div class="title">
+              <div class="title font-size-base">
                 {{t "general.overview"}}
               </div>
 

--- a/packages/ilios-common/addon/components/session/overview.gjs
+++ b/packages/ilios-common/addon/components/session/overview.gjs
@@ -406,7 +406,7 @@ export default class SessionOverview extends Component {
                   <LinkTo
                     @route="session.copy"
                     @models={{array @session.course @session}}
-                    class="copy"
+                    class="copy font-size-medium"
                     title={{t "general.copySession"}}
                     data-test-copy
                   >

--- a/packages/ilios-common/addon/components/sessions-grid-header.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-header.gjs
@@ -31,10 +31,10 @@ export default class SessionsGridHeader extends Component {
   });
   <template>
     <div
-      class="sessions-grid-header{{if @headerIsLocked ' locked'}}"
+      class="sessions-grid-header font-size-small{{if @headerIsLocked ' locked'}}"
       data-test-sessions-grid-header
     >
-      <span class="expand-collapse-control" data-test-expand-collapse-all>
+      <span class="expand-collapse-control font-size-medium" data-test-expand-collapse-all>
         {{#if @showExpandAll}}
           <button
             type="button"

--- a/packages/ilios-common/addon/components/sessions-grid-loading.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-loading.gjs
@@ -18,7 +18,7 @@ export default class SessionsGridLoading extends Component {
     >
       {{#each (repeat @count)}}
         <div data-test-row>
-          <span class="expand-collapse-control"></span>
+          <span class="expand-collapse-control font-size-medium"></span>
           <span class="session-grid-title">
             {{truncate (repeat (random 3 10) "ilios rocks") 100}}
           </span>

--- a/packages/ilios-common/addon/components/sessions-grid-offering-table.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-offering-table.gjs
@@ -52,23 +52,23 @@ export default class SessionsGridOfferingTable extends Component {
     >
       <thead class={{if @headerIsLocked "locked"}}>
         <tr>
-          <th colspan="2">
+          <th colspan="2" class="font-size-small">
             {{t "general.when"}}
           </th>
-          <th>
+          <th class="font-size-small">
             {{t "general.location"}}
           </th>
-          <th colspan="2">
+          <th colspan="2" class="font-size-small">
             {{t "general.learners"}}
           </th>
-          <th colspan="2">
+          <th colspan="2" class="font-size-small">
             {{t "general.learnerGroups"}}
           </th>
-          <th colspan="2">
+          <th colspan="2" class="font-size-small">
             {{t "general.instructors"}}
           </th>
           {{#if this.canUpdate}}
-            <th class="text-center">
+            <th class="text-center font-size-small">
               {{t "general.actions"}}
             </th>
           {{/if}}

--- a/packages/ilios-common/addon/components/sessions-grid-row.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-row.gjs
@@ -69,7 +69,7 @@ export default class SessionsGridRowComponent extends Component {
         }}"
       data-test-sessions-grid-row
     >
-      <span class="expand-collapse-control" data-test-expand-collapse-control>
+      <span class="expand-collapse-control font-size-medium" data-test-expand-collapse-control>
         {{#if (includes @session.id @expandedSessionIds)}}
           <button
             class="link-button"

--- a/packages/ilios-common/addon/components/single-event-learningmaterial-list-item.gjs
+++ b/packages/ilios-common/addon/components/single-event-learningmaterial-list-item.gjs
@@ -19,7 +19,10 @@ import { faDownload, faSquarePen } from '@fortawesome/free-solid-svg-icons';
         <div class="single-event-learningmaterial-item-title" data-test-title>
           {{@learningMaterial.title}}
         </div>
-        <div class="single-event-learningmaterial-item-timing-info" data-test-timing-info>
+        <div
+          class="single-event-learningmaterial-item-timing-info font-size-small"
+          data-test-timing-info
+        >
           <TimedReleaseSchedule
             @startDate={{@learningMaterial.startDate}}
             @endDate={{@learningMaterial.endDate}}
@@ -67,7 +70,10 @@ import { faDownload, faSquarePen } from '@fortawesome/free-solid-svg-icons';
                     {{@learningMaterial.title}}
                   </a>
                 {{/if}}
-                <span class="single-event-learningmaterial-filesize" data-test-filesize>
+                <span
+                  class="single-event-learningmaterial-filesize font-size-small"
+                  data-test-filesize
+                >
                   {{#if @learningMaterial.filesize}}
                     ({{filesize @learningMaterial.filesize}})
                   {{/if}}
@@ -88,7 +94,10 @@ import { faDownload, faSquarePen } from '@fortawesome/free-solid-svg-icons';
             {{else}}
               {{@learningMaterial.title}}
               {{#if @learningMaterial.absoluteFileUri}}
-                <span class="single-event-learningmaterial-filesize" data-test-filesize>
+                <span
+                  class="single-event-learningmaterial-filesize font-size-small"
+                  data-test-filesize
+                >
                   {{#if @learningMaterial.filesize}}
                     ({{filesize @learningMaterial.filesize}})
                   {{/if}}
@@ -102,7 +111,10 @@ import { faDownload, faSquarePen } from '@fortawesome/free-solid-svg-icons';
             {{@learningMaterial.citation}}
           </div>
         {{/if}}
-        <div class="single-event-learningmaterial-item-timing-info" data-test-timing-info>
+        <div
+          class="single-event-learningmaterial-item-timing-info font-size-small"
+          data-test-timing-info
+        >
           <TimedReleaseSchedule
             @startDate={{@learningMaterial.startDate}}
             @endDate={{@learningMaterial.endDate}}
@@ -116,7 +128,10 @@ import { faDownload, faSquarePen } from '@fortawesome/free-solid-svg-icons';
           </div>
         {{/if}}
         {{#if @learningMaterial.publicNotes}}
-          <div class="single-event-learningmaterial-item-notes" data-test-public-notes>
+          <div
+            class="single-event-learningmaterial-item-notes font-size-small"
+            data-test-public-notes
+          >
             {{! template-lint-disable no-triple-curlies }}
             <FaIcon @icon={{faSquarePen}} />
             <p>

--- a/packages/ilios-common/addon/components/single-event-objective-list.gjs
+++ b/packages/ilios-common/addon/components/single-event-objective-list.gjs
@@ -113,7 +113,7 @@ export default class SingleEventObjectiveList extends Component {
               <li class="objective" data-test-objective>
                 {{! template-lint-disable no-triple-curlies }}
                 <span data-test-objective-title>{{{objective.title}}}</span>
-                <div class="details" data-test-domain>
+                <div class="details font-size-small" data-test-domain>
                   {{objective.domain}}
                 </div>
               </li>

--- a/packages/ilios-common/addon/components/toggle-buttons.gjs
+++ b/packages/ilios-common/addon/components/toggle-buttons.gjs
@@ -33,7 +33,11 @@ export default class ToggleButtons extends Component {
         data-test-first-input
         {{on "click" this.firstChoice}}
       />
-      <label for={{concat "first-toggle-" this.uniqueId}} data-test-first-label>
+      <label
+        for={{concat "first-toggle-" this.uniqueId}}
+        class="font-size-small"
+        data-test-first-label
+      >
         {{@firstLabel}}
       </label>
       <input
@@ -44,7 +48,11 @@ export default class ToggleButtons extends Component {
         data-test-second-input
         {{on "click" this.secondChoice}}
       />
-      <label for={{concat "second-toggle-" this.uniqueId}} data-test-second-label>
+      <label
+        class="font-size-small"
+        for={{concat "second-toggle-" this.uniqueId}}
+        data-test-second-label
+      >
         {{@secondLabel}}
       </label>
     </span>

--- a/packages/ilios-common/addon/components/user-status.gjs
+++ b/packages/ilios-common/addon/components/user-status.gjs
@@ -7,7 +7,7 @@ import { faUserXmark } from '@fortawesome/free-solid-svg-icons';
     <FaIcon
       @icon={{faUserXmark}}
       @title={{t "general.disabledUserAccount"}}
-      class="user-status"
+      class="user-status font-size-small"
       data-test-user-status
     />
   {{/unless}}

--- a/packages/ilios-common/addon/components/week-glance/learning-material-list-item.gjs
+++ b/packages/ilios-common/addon/components/week-glance/learning-material-list-item.gjs
@@ -100,7 +100,7 @@ import { faClock, faDownload } from '@fortawesome/free-solid-svg-icons';
         </p>
       {{/if}}
     {{/if}}
-    <span class="timed-release-info" data-test-time-release-info>
+    <span class="timed-release-info font-size-small" data-test-time-release-info>
       <TimedReleaseSchedule
         @startDate={{@lm.startDate}}
         @endDate={{@lm.endDate}}

--- a/packages/ilios-common/addon/components/weekly-calendar-event.gjs
+++ b/packages/ilios-common/addon/components/weekly-calendar-event.gjs
@@ -130,7 +130,7 @@ export default class WeeklyCalendarEventComponent extends Component {
   }
   <template>
     <button
-      class="weekly-calendar-event day-{{@day}}{{if this.isIlm ' ilm'}}{{if
+      class="weekly-calendar-event font-size-small day-{{@day}}{{if this.isIlm ' ilm'}}{{if
           this.clickable
           ' clickable'
         }}"

--- a/packages/ilios-common/addon/components/weekly-calendar.gjs
+++ b/packages/ilios-common/addon/components/weekly-calendar.gjs
@@ -109,7 +109,7 @@ export default class WeeklyCalendarComponent extends Component {
       aria-live="polite"
       data-test-weekly-calendar
     >
-      <h2 class="week-of-year" data-test-week-of-year>
+      <h2 class="week-of-year font-size-medium" data-test-week-of-year>
         {{#if @isLoadingEvents}}
           <FaIcon @icon={{faSpinner}} @spin={{true}} />
           {{t "general.loadingEvents"}}

--- a/packages/ilios-common/addon/components/yup-validation-message.gjs
+++ b/packages/ilios-common/addon/components/yup-validation-message.gjs
@@ -31,7 +31,7 @@ export default class YupValidationMessage extends Component {
     {{#if this.messages.length}}
       <span aria-live="polite" ...attributes>
         {{#each this.messages as |m|}}
-          <span class="validation-error-message" data-test-validation-error-message>
+          <span class="validation-error-message font-size-small" data-test-validation-error-message>
             {{m}}
           </span>
         {{/each}}

--- a/packages/ilios-common/app/styles/ilios-common/components/course/publicationcheck.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/publicationcheck.scss
@@ -14,7 +14,6 @@
 
     .fa-link-slash {
       color: var(--black);
-      @include m.font-size("small");
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/summary-header.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/summary-header.scss
@@ -18,7 +18,6 @@
       text-align: right;
 
       a {
-        @include m.font-size("medium");
         margin-right: 0.5rem;
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/visualize-objectives-graph.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/visualize-objectives-graph.scss
@@ -5,10 +5,6 @@
     p {
       margin-top: 0.5rem;
     }
-
-    .fa-face-meh {
-      @include m.font-size("huge");
-    }
   }
 
   .objective-row {

--- a/packages/ilios-common/app/styles/ilios-common/components/daily-calendar-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/daily-calendar-event.scss
@@ -7,7 +7,6 @@
   display: flex;
   flex-direction: column;
   justify-content: start;
-  @include m.font-size("small");
   border: 1px solid var(--white);
   margin: 1px;
   padding: 0.25rem;
@@ -21,7 +20,6 @@
 
   .ilios-calendar-event-time {
     display: block;
-    @include m.font-size("small");
     font-weight: 600;
     padding-bottom: 0.5em;
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
@@ -36,13 +36,11 @@
       .calendar-filter-list {
         border: 1px solid var(--light-blue);
         float: left;
-        @include m.font-size("small");
         margin-bottom: 1em;
         width: 33%;
 
         h2 {
           @include m.ilios-heading;
-          @include m.font-size("base");
           display: block;
           background-color: var(--lightest-grey);
           border-bottom: 0.5px solid var(--grey);
@@ -108,13 +106,11 @@
       .filters-header {
         background: var(--lightest-grey);
         border-bottom: 1px solid var(--grey);
-        @include m.font-size("small");
       }
 
       .filter-tags {
         .filter-tag {
           @include m.ilios-button-reset;
-          @include m.font-size("small");
           border-radius: 3px;
           display: inline-block;
           padding: 2px 5px;
@@ -169,7 +165,6 @@
 
         .filters-clear-filters {
           @include m.ilios-button-reset;
-          @include m.font-size("small");
           color: var(--blue);
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/materials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/materials.scss
@@ -46,10 +46,6 @@
       color: var(--grey);
     }
 
-    .timed-release-info {
-      @include m.font-size("small");
-    }
-
     table {
       grid-column: 1 / -1;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
@@ -27,19 +27,14 @@
         text-align: center;
         width: 90%;
 
-        /* stylelint-disable property-disallowed-list */
         .highlight {
           align-items: center;
           display: flex;
           color: var(--orange);
-          // @include m.font-size("large");
-          font-size: var(--fs-large);
-          line-height: calc(4px + 2ex);
+          @include m.font-size("large");
 
           @include m.for-phone-only {
-            // @include m.font-size("medium");
-            font-size: var(--fs-medium);
-            line-height: calc(4px + 2ex);
+            @include m.font-size("medium");
           }
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
@@ -27,14 +27,19 @@
         text-align: center;
         width: 90%;
 
+        /* stylelint-disable property-disallowed-list */
         .highlight {
           align-items: center;
           display: flex;
           color: var(--orange);
-          @include m.font-size("large");
+          // @include m.font-size("large");
+          font-size: var(--fs-large);
+          line-height: calc(4px + 2ex);
 
           @include m.for-phone-only {
-            @include m.font-size("medium");
+            // @include m.font-size("medium");
+            font-size: var(--fs-medium);
+            line-height: calc(4px + 2ex);
           }
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -68,13 +68,11 @@
       .learning-material-description {
         color: var(--grey);
         display: block;
-        @include m.font-size("small");
         margin-left: 1.9em;
       }
 
       .learning-material-status {
         color: var(--red);
-        @include m.font-size("small");
         position: absolute;
         right: 5px;
         top: 0;
@@ -88,7 +86,6 @@
           color: var(--grey);
           cursor: inherit;
           display: list-item;
-          @include m.font-size("small");
           margin: 0;
           min-height: 0;
           padding: 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/flatpickr.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/flatpickr.scss
@@ -15,8 +15,8 @@
   .flatpickr-current-month {
     align-items: center;
     display: flex;
-    @include m.font-size("medium");
     justify-content: center;
+
     .flatpickr-monthDropdown-months {
       appearance: none;
       -moz-appearance: none;

--- a/packages/ilios-common/app/styles/ilios-common/components/ilios-calendar-multiday-events.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/ilios-calendar-multiday-events.scss
@@ -6,7 +6,6 @@
   padding: 1em 0;
 
   .title {
-    @include m.font-size("medium");
     font-weight: 600;
     margin-top: 0;
     padding-left: 1rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/ilios-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/ilios-calendar.scss
@@ -29,11 +29,6 @@
   .calendar-view-picker {
     float: right;
 
-    .highlight {
-      color: var(--orange);
-      @include m.font-size("medium");
-    }
-
     .on {
       color: var(--green);
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/learning-material-uploader.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learning-material-uploader.scss
@@ -8,8 +8,8 @@
     color: var(--black);
     cursor: pointer;
     display: inline-block;
-    @include m.font-size("base");
     padding: 0.3em 1em;
+
     &:hover {
       background-color: var(--grey);
       color: var(--white);

--- a/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
@@ -53,13 +53,6 @@
     width: 100%;
   }
 
-  h2 {
-    @include m.ilios-heading;
-    color: var(--black);
-    @include m.font-size("base");
-    font-weight: 600;
-  }
-
   .mesh-manager {
     grid-column: 1 / -1;
     margin: 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
@@ -33,7 +33,6 @@
 
     .descriptor-id {
       display: block;
-      @include m.font-size("small");
     }
 
     .mesh-concepts {

--- a/packages/ilios-common/app/styles/ilios-common/components/monthly-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/monthly-calendar.scss
@@ -86,7 +86,6 @@
 
         span {
           background-color: transparent;
-          @include m.font-size("smallest");
           font-weight: 400;
         }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-calendar.scss
@@ -11,7 +11,6 @@
   position: relative;
 
   h2 {
-    @include m.font-size("medium");
     margin-bottom: 1rem;
     text-align: center;
     width: 100%;

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
@@ -151,7 +151,6 @@
     .validation-error-message {
       color: var(--red);
       display: block;
-      @include m.font-size("small");
       font-style: italic;
       margin-top: 0.5rem;
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
@@ -1,7 +1,6 @@
 @use "../mixins" as m;
 
 .offering-manager {
-  @include m.font-size("small");
   display: grid;
   grid-template-columns: repeat(3, 2fr) 1fr;
   margin-bottom: 0.5rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
@@ -45,18 +45,15 @@
   .publish-all-sessions-review {
     border: 1px solid var(--green);
     clear: both;
-    @include m.font-size("large");
     padding: 1rem;
     text-align: center;
 
     .unlinked-warning {
       color: var(--dark-orange);
-      @include m.font-size("base");
     }
 
     .fa-chart-column {
       color: var(--light-blue);
-      @include m.font-size("small");
     }
 
     p {
@@ -74,6 +71,5 @@
 
   .fa-link-slash {
     color: var(--black);
-    @include m.font-size("small");
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-offerings-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-offerings-list.scss
@@ -18,7 +18,6 @@
       .offering-block-date-dayofweek {
         color: var(--dark-orange);
         display: block;
-        @include m.font-size("medium");
         font-weight: 600;
         width: 100%;
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
@@ -51,7 +51,6 @@
       @include m.ilios-overview-actions;
 
       a {
-        @include m.font-size("medium");
         margin-right: 0.5rem;
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-publicationcheck.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-publicationcheck.scss
@@ -32,6 +32,5 @@
 
   .fa-link-slash {
     color: var(--black);
-    @include m.font-size("small");
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-header.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-header.scss
@@ -7,7 +7,6 @@
   font-weight: 400;
   top: 0;
   z-index: 1;
-  @include m.font-size("small");
   @include m.sessions-grid;
 
   &.locked {

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
@@ -14,7 +14,6 @@
     }
 
     th {
-      @include m.font-size("small");
       font-weight: 400;
       padding: 0.2rem 0.5rem;
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event-learningmaterial-list.scss
@@ -27,11 +27,9 @@
   }
 
   .single-event-learningmaterial-item-timing-info {
-    @include m.font-size("small");
     font-weight: 400;
   }
   .single-event-learningmaterial-item-notes {
-    @include m.font-size("small");
     .fa-square-pen {
       margin-right: 5px;
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event-objective-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event-objective-list.scss
@@ -31,7 +31,6 @@
     }
 
     .details {
-      @include m.font-size("small");
       font-weight: 600;
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
@@ -6,10 +6,6 @@
   h3 {
     @include m.ilios-heading-h4;
     margin: 0.5rem 0;
-
-    .fa-box-archive {
-      @include m.font-size("base");
-    }
   }
 
   p.no-content {
@@ -70,7 +66,6 @@
   }
 
   .single-event-learningmaterial-filesize {
-    @include m.font-size("small");
     font-style: italic;
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/toggle-yesno.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/toggle-yesno.scss
@@ -29,10 +29,6 @@
     display: grid;
     justify-content: center;
     align-content: center;
-
-    svg {
-      @include m.font-size("small");
-    }
   }
 
   &[aria-checked="true"] .switch-handle {

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance/learning-materials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance/learning-materials.scss
@@ -16,11 +16,6 @@
       }
     }
 
-    .fa-external-link-square {
-      color: var(--orange);
-      @include m.font-size("small");
-    }
-
     .public-notes {
       padding-left: 0.3em;
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance/learning-materials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance/learning-materials.scss
@@ -20,10 +20,6 @@
       padding-left: 0.3em;
     }
 
-    .timed-release-info {
-      @include m.font-size("small");
-    }
-
     .week-glance-learning-material-list-item {
       align-items: center;
       display: flex;

--- a/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar-event.scss
@@ -7,7 +7,6 @@
   display: flex;
   flex-direction: column;
   justify-content: start;
-  @include m.font-size("small");
   border: 1px solid var(--white);
   margin: 1px;
   padding: 0.25rem;
@@ -21,7 +20,6 @@
 
   .ilios-calendar-event-time {
     display: block;
-    @include m.font-size("small");
     font-weight: 600;
     padding-bottom: 0.5em;
   }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
@@ -25,8 +25,6 @@
 }
 
 @mixin collapsed-container-table() {
-  @include font-size.font-size("small");
-
   table,
   tr {
     margin: 0;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
@@ -1,5 +1,4 @@
 @use "detail-container";
-@use "font-size";
 @use "ilios-heading";
 @use "media";
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/course/overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/course/overview.scss
@@ -28,7 +28,6 @@
 
     a,
     span {
-      @include font-size.font-size("medium");
       margin-right: 0.5rem;
 
       &:last-child {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/font-size.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/font-size.scss
@@ -1,5 +1,10 @@
 /* stylelint-disable property-disallowed-list */
 
+@mixin font-size($step) {
+  font-size: var(--fs-#{$step});
+  line-height: calc(4px + 2ex);
+}
+
 @mixin text-align-bottom() {
   display: flex;
   align-items: flex-end;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/font-size.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/font-size.scss
@@ -1,10 +1,5 @@
 /* stylelint-disable property-disallowed-list */
 
-@mixin font-size($step) {
-  font-size: var(--fs-#{$step});
-  line-height: calc(4px + 2ex);
-}
-
 @mixin text-align-bottom() {
   display: flex;
   align-items: flex-end;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-button.scss
@@ -16,12 +16,10 @@
 
   @content;
 
-  // @include font-size.font-size("base");
-  /* stylelint-disable property-disallowed-list */
-  font-size: var(--fs-base);
-  line-height: calc(4px + 2ex);
+  @include font-size.font-size("base");
   //at small sizes scale to keep button text in the button
   @include media.for-phone-only {
+    /* stylelint-disable property-disallowed-list */
     font-size: 3vw;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-button.scss
@@ -16,10 +16,12 @@
 
   @content;
 
-  @include font-size.font-size("base");
+  // @include font-size.font-size("base");
+  /* stylelint-disable property-disallowed-list */
+  font-size: var(--fs-base);
+  line-height: calc(4px + 2ex);
   //at small sizes scale to keep button text in the button
   @include media.for-phone-only {
-    /* stylelint-disable property-disallowed-list */
     font-size: 3vw;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
@@ -1,4 +1,3 @@
-@use "font-size";
 @use "ilios-button";
 @use "ilios-input";
 @use "ilios-select";

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
@@ -119,7 +119,6 @@
 @mixin ilios-form-error {
   .validation-error-message {
     color: var(--red);
-    @include font-size.font-size("small");
   }
 
   input {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
@@ -112,7 +112,6 @@
   font-weight: 600;
 
   .label-description {
-    @include font-size.font-size("small");
     font-weight: 400;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-heading.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-heading.scss
@@ -12,42 +12,30 @@
 
 @mixin ilios-heading-h1() {
   @include ilios-heading;
-  // @include font-size.font-size("xxxl");
-  font-size: var(--fs-xxxl);
-  line-height: calc(4px + 2ex);
+  @include font-size.font-size("xxxl");
 }
 
 @mixin ilios-heading-h2() {
   @include ilios-heading;
-  // @include font-size.font-size("xxl");
-  font-size: var(--fs-xxl);
-  line-height: calc(4px + 2ex);
+  @include font-size.font-size("xxl");
 }
 
 @mixin ilios-heading-h3() {
   @include ilios-heading;
-  // @include font-size.font-size("xl");
-  font-size: var(--fs-xl);
-  line-height: calc(4px + 2ex);
+  @include font-size.font-size("xl");
 }
 
 @mixin ilios-heading-h4() {
   @include ilios-heading;
-  // @include font-size.font-size("large");
-  font-size: var(--fs-large);
-  line-height: calc(4px + 2ex);
+  @include font-size.font-size("large");
 }
 
 @mixin ilios-heading-h5() {
   @include ilios-heading;
-  // @include font-size.font-size("medium");
-  font-size: var(--fs-medium);
-  line-height: calc(4px + 2ex);
+  @include font-size.font-size("medium");
 }
 
 @mixin ilios-heading-h6() {
   @include ilios-heading;
-  // @include font-size.font-size("base");
-  font-size: var(--fs-base);
-  line-height: calc(4px + 2ex);
+  @include font-size.font-size("base");
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-heading.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-heading.scss
@@ -8,32 +8,46 @@
   padding: 0;
 }
 
+/* stylelint-disable property-disallowed-list */
+
 @mixin ilios-heading-h1() {
   @include ilios-heading;
-  @include font-size.font-size("xxxl");
+  // @include font-size.font-size("xxxl");
+  font-size: var(--fs-xxxl);
+  line-height: calc(4px + 2ex);
 }
 
 @mixin ilios-heading-h2() {
   @include ilios-heading;
-  @include font-size.font-size("xxl");
+  // @include font-size.font-size("xxl");
+  font-size: var(--fs-xxl);
+  line-height: calc(4px + 2ex);
 }
 
 @mixin ilios-heading-h3() {
   @include ilios-heading;
-  @include font-size.font-size("xl");
+  // @include font-size.font-size("xl");
+  font-size: var(--fs-xl);
+  line-height: calc(4px + 2ex);
 }
 
 @mixin ilios-heading-h4() {
   @include ilios-heading;
-  @include font-size.font-size("large");
+  // @include font-size.font-size("large");
+  font-size: var(--fs-large);
+  line-height: calc(4px + 2ex);
 }
 
 @mixin ilios-heading-h5() {
   @include ilios-heading;
-  @include font-size.font-size("medium");
+  // @include font-size.font-size("medium");
+  font-size: var(--fs-medium);
+  line-height: calc(4px + 2ex);
 }
 
 @mixin ilios-heading-h6() {
   @include ilios-heading;
-  @include font-size.font-size("base");
+  // @include font-size.font-size("base");
+  font-size: var(--fs-base);
+  line-height: calc(4px + 2ex);
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
@@ -31,7 +31,6 @@
 
 @mixin ilios-overview-title() {
   color: var(--black);
-  @include font-size.font-size("base");
   font-weight: 600;
 }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
@@ -1,4 +1,3 @@
-@use "font-size";
 @use "ilios-form";
 @use "media";
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-select.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-select.scss
@@ -2,10 +2,7 @@
 
 @mixin ilios-select() {
   box-sizing: border-box;
-  // @include font-size.font-size("base");
-  /* stylelint-disable property-disallowed-list */
-  font-size: var(--fs-base);
-  line-height: calc(4px + 2ex);
+  @include font-size.font-size("base");
   height: 2em;
   padding: 4px 4px 4px 8px;
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-select.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-select.scss
@@ -2,7 +2,10 @@
 
 @mixin ilios-select() {
   box-sizing: border-box;
-  @include font-size.font-size("base");
+  // @include font-size.font-size("base");
+  /* stylelint-disable property-disallowed-list */
+  font-size: var(--fs-base);
+  line-height: calc(4px + 2ex);
   height: 2em;
   padding: 4px 4px 4px 8px;
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
@@ -1,4 +1,3 @@
-@use "font-size";
 @use "ilios-heading";
 @use "ilios-input";
 @use "ilios-select";

--- a/packages/ilios-common/app/styles/ilios-common/mixins/multi-button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/multi-button.scss
@@ -17,7 +17,6 @@
     color: var(--blue);
     border: 1px solid var(--very-transparent-black);
     display: inline-block;
-    @include font-size.font-size("small");
     font-weight: 600;
     min-width: 3em;
     padding: 0.25em 0.5em;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/multi-button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/multi-button.scss
@@ -1,5 +1,3 @@
-@use "font-size";
-
 @mixin multi-button {
   display: flex;
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -149,23 +149,16 @@
 
     .description {
       p {
-        @include font-size.font-size("base");
         margin: 0;
       }
       button {
         @include ilios-button.ilios-link-button;
-        @include font-size.font-size("base");
-
-        p {
-          @include font-size.font-size("base");
-        }
       }
     }
 
     .course-objective-list-item-parents,
     .session-objective-list-item-parents {
       p {
-        @include font-size.font-size("base");
         margin: 0;
       }
     }
@@ -224,10 +217,6 @@
 
       &:last-of-type {
         margin-bottom: 0;
-      }
-
-      .display-text {
-        @include font-size.font-size("base");
       }
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -1,4 +1,3 @@
-@use "font-size";
 @use "ilios-button";
 @use "ilios-form";
 @use "ilios-heading";

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sessions-grid.scss
@@ -48,7 +48,6 @@
   }
 
   .expand-collapse-control {
-    @include font-size.font-size("medium");
     display: flex;
     flex-direction: column;
     justify-content: space-around;
@@ -61,9 +60,5 @@
     & > .disabled {
       color: var(--grey);
     }
-  }
-
-  .fa-user-clock {
-    @include font-size.font-size("small");
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sessions-grid.scss
@@ -1,4 +1,3 @@
-@use "font-size";
 @use "media";
 
 @mixin sessions-grid() {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
@@ -1,5 +1,3 @@
-@use "font-size";
-
 @mixin sort-manager() {
   .actions {
     display: flex;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/sort-manager.scss
@@ -44,9 +44,6 @@
       .fa {
         vertical-align: top;
       }
-      .details {
-        @include font-size.font-size("small");
-      }
 
       .title {
         display: inline-block;

--- a/packages/ilios-common/app/styles/ilios-common/shared.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared.scss
@@ -1,5 +1,6 @@
 @forward "shared/critical-notice";
 @forward "shared/data-visualization";
+@forward "shared/font-size";
 @forward "shared/graph-with-data-table";
 @forward "shared/icons";
 @forward "shared/ilios-removable-table";

--- a/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
@@ -17,6 +17,7 @@
 .description.font-size-base p,
 .description.font-size-base button,
 .description.font-size-base p button,
+.link-button.font-size-base,
 .course-objective-list-item-parents.font-size-base p,
 .session-objective-list-item-parents.font-size-base p {
   font-size: var(--fs-base);

--- a/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
@@ -5,7 +5,8 @@
   line-height: calc(4px + 2ex);
 }
 .font-size-small,
-.link-button.font-size-small {
+.link-button.font-size-small,
+.user-guide-link a.font-size-small {
   font-size: var(--fs-small);
   line-height: calc(4px + 2ex);
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
@@ -5,8 +5,11 @@
   line-height: calc(4px + 2ex);
 }
 .font-size-small,
+.daily-calendar-event.font-size-small,
+.weekly-calendar-event.font-size-small,
 .link-button.font-size-small,
-.user-guide-link a.font-size-small {
+.user-guide-link a.font-size-small,
+.reports-choose-course .deselect-all.font-size-small {
   font-size: var(--fs-small);
   line-height: calc(4px + 2ex);
 }
@@ -14,7 +17,8 @@
   font-size: var(--fs-base);
   line-height: calc(4px + 2ex);
 }
-.font-size-medium {
+.font-size-medium,
+.reports-switcher a.font-size-medium {
   font-size: var(--fs-medium);
   line-height: calc(4px + 2ex);
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
@@ -8,10 +8,12 @@
 .daily-calendar-event.font-size-small,
 .weekly-calendar-event.font-size-small,
 .link-button.font-size-small,
-.user-guide-link a.font-size-small,
 .reports-choose-course .deselect-all.font-size-small {
   font-size: var(--fs-small);
   line-height: calc(4px + 2ex);
+}
+.user-guide-link a.font-size-small {
+  font-size: var(--fs-small);
 }
 .font-size-base,
 .description.font-size-base p,

--- a/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
@@ -1,0 +1,38 @@
+/* stylelint-disable property-disallowed-list */
+
+.font-size-smallest {
+  font-size: var(--fs-smallest);
+  line-height: calc(4px + 2ex);
+}
+.font-size-small {
+  font-size: var(--fs-small);
+  line-height: calc(4px + 2ex);
+}
+.font-size-base {
+  font-size: var(--fs-base);
+  line-height: calc(4px + 2ex);
+}
+.font-size-medium {
+  font-size: var(--fs-medium);
+  line-height: calc(4px + 2ex);
+}
+.font-size-large {
+  font-size: var(--fs-large);
+  line-height: calc(4px + 2ex);
+}
+.font-size-xl {
+  font-size: var(--fs-xl);
+  line-height: calc(4px + 2ex);
+}
+.font-size-xxl {
+  font-size: var(--fs-xxl);
+  line-height: calc(4px + 2ex);
+}
+.font-size-xxxl {
+  font-size: var(--fs-xxxl);
+  line-height: calc(4px + 2ex);
+}
+.font-size-huge {
+  font-size: var(--fs-huge);
+  line-height: calc(4px + 2ex);
+}

--- a/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
@@ -4,7 +4,8 @@
   font-size: var(--fs-smallest);
   line-height: calc(4px + 2ex);
 }
-.font-size-small {
+.font-size-small,
+.link-button.font-size-small {
   font-size: var(--fs-small);
   line-height: calc(4px + 2ex);
 }
@@ -24,7 +25,8 @@
   font-size: var(--fs-xl);
   line-height: calc(4px + 2ex);
 }
-.font-size-xxl {
+.font-size-xxl,
+.loading-file.font-size-xxl i {
   font-size: var(--fs-xxl);
   line-height: calc(4px + 2ex);
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/font-size.scss
@@ -13,7 +13,12 @@
   font-size: var(--fs-small);
   line-height: calc(4px + 2ex);
 }
-.font-size-base {
+.font-size-base,
+.description.font-size-base p,
+.description.font-size-base button,
+.description.font-size-base p button,
+.course-objective-list-item-parents.font-size-base p,
+.session-objective-list-item-parents.font-size-base p {
   font-size: var(--fs-base);
   line-height: calc(4px + 2ex);
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/ilios-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/ilios-table.scss
@@ -56,8 +56,6 @@
   }
 
   &.condensed {
-    @include font-size.font-size("small");
-
     tr,
     td,
     th {

--- a/packages/ilios-common/app/styles/ilios-common/shared/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/user-search.scss
@@ -54,10 +54,6 @@
       }
     }
 
-    .name i {
-      @include font-size.font-size("small");
-    }
-
     .email {
       color: var(--grey);
       font-style: italic;


### PR DESCRIPTION
Refs ilios/ilios#6608
Fixes ilios/ilios#6710

This is a biggie, and will be done in several passes:
1) "easy" fixes where the mixin **does not** mince words with another mixin, either under or alongside
2) "medium" fixes where the mixin targets an element that never shows up in a template (cruft?)
3) "hard" fixes where the mixin **does** mingle with another mixin, either under or alongside

I'm trying to keep commits generally within those boundaries so my journey can be properly followed along with.