### PR TITLE
New ProgramYear selection now disables unavailable years instead of removing them

### DIFF
--- a/packages/frontend/app/components/program-year/new.gjs
+++ b/packages/frontend/app/components/program-year/new.gjs
@@ -30,24 +30,26 @@ export default class NewProgramYearComponent extends Component {
     return mapBy(this.args.programYears ?? [], 'startYear');
   }
 
-  get academicYears() {
-    return this.allYears.map((startYear) => {
-      return {
-        label: this.args.academicYearCrossesCalendarYearBoundaries
-          ? `${startYear} - ${startYear + 1}`
-          : startYear.toString(),
-        value: startYear.toString(),
-      };
-    });
-  }
-
   get availableAcademicYears() {
-    return this.allYears.filter((year) => !this.academicYears.includes(year));
+    const years = this.allYears
+      .filter((year) => !this.existingStartYears.includes(year))
+      .map((startYear) => {
+        return {
+          label: this.args.academicYearCrossesCalendarYearBoundaries
+            ? `${startYear} - ${startYear + 1}`
+            : startYear.toString(),
+          value: startYear.toString(),
+        };
+      });
+
+    return years;
   }
 
   get selectedYear() {
     if (!this.year) {
-      return this.availableAcademicYears[0];
+      return this.existingStartYears.length
+        ? this.availableAcademicYears.filter((year) => this.existingStartYears.includes(year))[0]
+        : this.availableAcademicYears[0];
     }
     return findBy(this.availableAcademicYears, 'value', this.year);
   }
@@ -72,7 +74,7 @@ export default class NewProgramYearComponent extends Component {
               {{on "change" (pick "target.value" (set this "year"))}}
               data-test-year
             >
-              {{#each (sortBy "value" this.academicYears) as |obj|}}
+              {{#each (sortBy "value" this.availableAcademicYears) as |obj|}}
                 <option
                   value={{obj.value}}
                   selected={{eq obj.value this.selectedYear.value}}

--- a/packages/frontend/tests/acceptance/program/programyear-list-test.js
+++ b/packages/frontend/tests/acceptance/program/programyear-list-test.js
@@ -54,7 +54,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
     await page.programYears.expandCollapse.toggle();
     await percySnapshot(getUniqueName(assert, 'show programYears'));
     await takeScreenshot(assert, 'show programYears');
-    assert.strictEqual(page.programYears.newProgramYear.years.options.length, 6);
+    assert.strictEqual(page.programYears.newProgramYear.years.options.length, 10);
   });
 
   test('check competencies', async function (assert) {
@@ -196,7 +196,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
     assert.strictEqual(page.programYears.items[0].directors.text, '3');
     assert.strictEqual(page.programYears.items[0].terms.text, '3');
     await page.programYears.expandCollapse.toggle();
-    assert.strictEqual(page.programYears.newProgramYear.years.options.length, 9);
+    assert.strictEqual(page.programYears.newProgramYear.years.options.length, 10);
     await page.programYears.newProgramYear.years.select(thisYear + 1);
     await page.programYears.newProgramYear.done.click();
     assert.strictEqual(page.programYears.items.length, 2);
@@ -207,7 +207,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
     assert.strictEqual(page.programYears.items[1].directors.text, '3');
     assert.strictEqual(page.programYears.items[1].terms.text, '3');
     await page.programYears.expandCollapse.toggle();
-    assert.strictEqual(page.programYears.newProgramYear.years.options.length, 8);
+    assert.strictEqual(page.programYears.newProgramYear.years.options.length, 10);
   });
 
   test('privileged users can lock and unlock program-year', async function (assert) {


### PR DESCRIPTION
Fixes ilios/ilios#6730

All possible years are now listed in dropdown, but only non-existing ones are selectable, and the first selectable year is now the default.