### PR TITLE
Adds counts to Single Event sections

### DIFF
--- a/packages/ilios-common/addon/components/single-event-objective-list.gjs
+++ b/packages/ilios-common/addon/components/single-event-objective-list.gjs
@@ -62,6 +62,7 @@ export default class SingleEventObjectiveList extends Component {
           data-test-expand-collapse
         >
           {{@title}}
+          ({{this.domains.length}})
           <FaIcon @icon={{if this.isExpanded "caret-down" "caret-right"}} />
         </button>
         {{#if this.showDisplayModeToggle}}

--- a/packages/ilios-common/addon/components/single-event.gjs
+++ b/packages/ilios-common/addon/components/single-event.gjs
@@ -20,6 +20,7 @@ import eq from 'ember-truth-helpers/helpers/eq';
 import OfferingUrlDisplay from 'ilios-common/components/offering-url-display';
 import { on } from '@ember/modifier';
 import set from 'ember-set-helper/helpers/set';
+import add from 'ember-math-helpers/helpers/add';
 import SingleEventLearningmaterialList from 'ilios-common/components/single-event-learningmaterial-list';
 import SingleEventObjectiveList from 'ilios-common/components/single-event-objective-list';
 import NotFound from 'ilios-common/components/not-found';
@@ -467,6 +468,7 @@ export default class SingleEvent extends Component {
               data-test-expand-collapse
             >
               {{t "general.materials"}}
+              ({{add this.sessionLearningMaterials.length this.preworkMaterials.length}})
               <FaIcon @icon={{if this.isSessionMaterialsListExpanded "caret-down" "caret-right"}} />
             </button>
             {{#if (and @event.isUserEvent this.userIsStudent)}}
@@ -519,6 +521,7 @@ export default class SingleEvent extends Component {
               data-test-expand-collapse
             >
               {{t "general.courseMaterials"}}
+              ({{this.courseLearningMaterials.length}})
               <FaIcon @icon={{if this.isCourseMaterialsListExpanded "caret-down" "caret-right"}} />
             </button>
           </h3>

--- a/packages/test-app/tests/integration/components/single-event-objective-list-test.gjs
+++ b/packages/test-app/tests/integration/components/single-event-objective-list-test.gjs
@@ -37,7 +37,7 @@ module('Integration | Component | ilios calendar single event objective list', f
       </template>,
     );
 
-    assert.strictEqual(component.title.expandCollapseSwitcher.text, title);
+    assert.strictEqual(component.title.expandCollapseSwitcher.text, 'Course Objectives (2)');
     assert.strictEqual(component.title.expandCollapseSwitcher.ariaExpanded, 'true');
     assert.strictEqual(component.title.expandCollapseSwitcher.ariaLabel, 'Hide objectives');
     assert.strictEqual(component.title.displayModeSwitcher.text, listByPriorityPhrase);

--- a/packages/test-app/tests/integration/components/single-event-test.gjs
+++ b/packages/test-app/tests/integration/components/single-event-test.gjs
@@ -141,7 +141,10 @@ module('Integration | Component | ilios calendar single event', function (hooks)
       component.sessionLearningMaterials.expandCollapseSwitcher.ariaLabel,
       'Hide session materials',
     );
-    assert.strictEqual(component.sessionLearningMaterials.expandCollapseSwitcher.text, 'Materials');
+    assert.strictEqual(
+      component.sessionLearningMaterials.expandCollapseSwitcher.text,
+      'Materials (2)',
+    );
     assert.strictEqual(
       component.courseObjectives.objectiveList.title.expandCollapseSwitcher.ariaExpanded,
       'false',
@@ -160,7 +163,7 @@ module('Integration | Component | ilios calendar single event', function (hooks)
     );
     assert.strictEqual(
       component.courseLearningMaterials.expandCollapseSwitcher.text,
-      'Course Materials',
+      'Course Materials (0)',
     );
 
     await component.courseObjectives.objectiveList.title.expandCollapseSwitcher.toggle();


### PR DESCRIPTION
Fixes ilios/ilios#6036

This adds counts to the Course Objectives/Materials sections, as requested by the issue. However, it seemed prudent and consistent to add the same thing to the Session Objectives/Materials, so I did.