### PR TITLE
Overview title text no longer looks like link

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
@@ -30,7 +30,7 @@
 }
 
 @mixin ilios-overview-title() {
-  color: var(--blue);
+  color: var(--black);
   @include font-size.font-size("base");
   font-weight: 600;
 }


### PR DESCRIPTION
Fixes ilios/ilios#6801

Switched from blue to black (🎵 Blue on bla-a-ack 🎵 /guitar-noodling) so "Overview" doesn't read as a link anymore. This affects Course, Session, Program, Program Year, and Curriculum Inventory Report sections (I think that's all of them?).