### PR TITLE
Removes italic styling for Admin->User List filter to improve legibility

### DIFF
--- a/packages/frontend/app/styles/components/ilios-users.scss
+++ b/packages/frontend/app/styles/components/ilios-users.scss
@@ -6,6 +6,10 @@
 
     .filter {
       @include m.main-list-filter;
+
+      input {
+        font-style: normal;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes ilios/ilios#3848

I feel like removing _italic_ styling from all `<input>` elements is an even better change, but needs discussion. This PR at least fixes it in context of the issue at hand.