### PR TITLE
Only get/set localStorage for locale if not testing

### DIFF
--- a/packages/frontend/app/components/locale-chooser.gjs
+++ b/packages/frontend/app/components/locale-chooser.gjs
@@ -12,7 +12,6 @@ import { fn } from '@ember/helper';
 import eq from 'ember-truth-helpers/helpers/eq';
 import focus from 'ilios-common/modifiers/focus';
 import { faGlobe, faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons';
-import { isTesting } from '@embroider/macros';
 
 export default class LocaleChooserComponent extends Component {
   @service intl;
@@ -60,9 +59,7 @@ export default class LocaleChooserComponent extends Component {
   changeLocale(id, event) {
     this.isOpen = false;
     this.intl.setLocale(id);
-    if (!isTesting()) {
-      this.localStorage.set('locale', id);
-    }
+    this.localStorage.set('locale', id);
     window.document.querySelector('html').setAttribute('lang', id);
     window.document
       .querySelector('meta[name="description"]')

--- a/packages/frontend/app/components/locale-chooser.gjs
+++ b/packages/frontend/app/components/locale-chooser.gjs
@@ -12,6 +12,7 @@ import { fn } from '@ember/helper';
 import eq from 'ember-truth-helpers/helpers/eq';
 import focus from 'ilios-common/modifiers/focus';
 import { faGlobe, faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons';
+import { isTesting } from '@embroider/macros';
 
 export default class LocaleChooserComponent extends Component {
   @service intl;
@@ -59,7 +60,9 @@ export default class LocaleChooserComponent extends Component {
   changeLocale(id, event) {
     this.isOpen = false;
     this.intl.setLocale(id);
-    this.localStorage.set('locale', id);
+    if (!isTesting()) {
+      this.localStorage.set('locale', id);
+    }
     window.document.querySelector('html').setAttribute('lang', id);
     window.document
       .querySelector('meta[name="description"]')

--- a/packages/frontend/app/routes/application.js
+++ b/packages/frontend/app/routes/application.js
@@ -6,6 +6,7 @@ import { loadPolyfills } from 'ilios-common/utils/load-polyfills';
 import { launchWorker } from '../utils/launch-worker';
 import { formats } from 'ilios-common/app/ember-intl';
 import config from 'frontend/config/environment';
+import { isTesting } from '@embroider/macros';
 
 export default class AuthenticatedRoute extends Route {
   @service currentUser;
@@ -55,11 +56,13 @@ export default class AuthenticatedRoute extends Route {
 
   // check if a saved, valid locale exists
   initialLocale() {
-    const savedLocale = this.localStorage.get('locale');
+    if (!isTesting()) {
+      const savedLocale = this.localStorage.get('locale');
 
-    if (savedLocale !== undefined) {
-      if (config.APP.SUPPORTED_LOCALES.includes(savedLocale)) {
-        return savedLocale;
+      if (savedLocale !== undefined) {
+        if (config.APP.SUPPORTED_LOCALES.includes(savedLocale)) {
+          return savedLocale;
+        }
       }
     }
     return config.APP.DEFAULTS.localStorage['locale'];

--- a/packages/frontend/app/routes/application.js
+++ b/packages/frontend/app/routes/application.js
@@ -6,7 +6,6 @@ import { loadPolyfills } from 'ilios-common/utils/load-polyfills';
 import { launchWorker } from '../utils/launch-worker';
 import { formats } from 'ilios-common/app/ember-intl';
 import config from 'frontend/config/environment';
-import { isTesting } from '@embroider/macros';
 
 export default class AuthenticatedRoute extends Route {
   @service currentUser;
@@ -56,13 +55,11 @@ export default class AuthenticatedRoute extends Route {
 
   // check if a saved, valid locale exists
   initialLocale() {
-    if (!isTesting()) {
-      const savedLocale = this.localStorage.get('locale');
+    const savedLocale = this.localStorage.get('locale');
 
-      if (savedLocale !== undefined) {
-        if (config.APP.SUPPORTED_LOCALES.includes(savedLocale)) {
-          return savedLocale;
-        }
+    if (savedLocale !== undefined) {
+      if (config.APP.SUPPORTED_LOCALES.includes(savedLocale)) {
+        return savedLocale;
       }
     }
     return config.APP.DEFAULTS.localStorage['locale'];

--- a/packages/frontend/app/routes/application.js
+++ b/packages/frontend/app/routes/application.js
@@ -57,7 +57,7 @@ export default class AuthenticatedRoute extends Route {
   initialLocale() {
     const savedLocale = this.localStorage.get('locale');
 
-    if (savedLocale !== undefined) {
+    if (savedLocale) {
       if (config.APP.SUPPORTED_LOCALES.includes(savedLocale)) {
         return savedLocale;
       }

--- a/packages/frontend/app/services/local-storage.js
+++ b/packages/frontend/app/services/local-storage.js
@@ -30,10 +30,7 @@ export default class LocalStorageService extends Service {
 
   set(item, value) {
     if (isTesting()) {
-      localStorage.setItem(
-        config.APP.LOCAL_STORAGE_KEY,
-        config.APP.DEFAULTS.localStorage['locale'],
-      );
+      return;
     } else {
       const key = JSON.parse(localStorage.getItem(config.APP.LOCAL_STORAGE_KEY));
 
@@ -61,15 +58,13 @@ export default class LocalStorageService extends Service {
               }),
             );
           }
-
-          return null;
         }
       }
       // if the key doesn't exist at all, create default key
       else {
         const obj = {};
         obj[item] = value;
-        return localStorage.setItem(config.APP.LOCAL_STORAGE_KEY, JSON.stringify(obj));
+        localStorage.setItem(config.APP.LOCAL_STORAGE_KEY, JSON.stringify(obj));
       }
     }
   }

--- a/packages/frontend/app/services/local-storage.js
+++ b/packages/frontend/app/services/local-storage.js
@@ -1,10 +1,15 @@
 import Service, { service } from '@ember/service';
+import { isTesting } from '@embroider/macros';
 import config from 'frontend/config/environment';
 
 export default class LocalStorageService extends Service {
   @service intl;
 
   get(item = null) {
+    if (isTesting()) {
+      return null;
+    }
+
     const key = JSON.parse(localStorage.getItem(config.APP.LOCAL_STORAGE_KEY));
 
     if (key) {
@@ -24,41 +29,48 @@ export default class LocalStorageService extends Service {
   }
 
   set(item, value) {
-    const key = JSON.parse(localStorage.getItem(config.APP.LOCAL_STORAGE_KEY));
+    if (isTesting()) {
+      localStorage.setItem(
+        config.APP.LOCAL_STORAGE_KEY,
+        config.APP.DEFAULTS.localStorage['locale'],
+      );
+    } else {
+      const key = JSON.parse(localStorage.getItem(config.APP.LOCAL_STORAGE_KEY));
 
-    // if localStorage[key] exists, move on
-    if (key) {
-      // if localStorage[key][item] exists, move on
-      if (key[item] !== undefined) {
-        key[item] = value;
-        localStorage.setItem(config.APP.LOCAL_STORAGE_KEY, JSON.stringify(key));
-      }
-      // otherwise, check if item has default value
-      else {
-        // if so, set item to default value
-        if (Object.hasOwn(config.APP.DEFAULTS.localStorage, item)) {
-          key[item] = config.APP.DEFAULTS.localStorage[item];
+      // if localStorage[key] exists, move on
+      if (key) {
+        // if localStorage[key][item] exists, move on
+        if (key[item] !== undefined) {
+          key[item] = value;
           localStorage.setItem(config.APP.LOCAL_STORAGE_KEY, JSON.stringify(key));
         }
-        // otherwise, throw error
+        // otherwise, check if item has default value
         else {
-          console.error(
-            this.intl.t('errors.localStorageSetItemFail', {
-              keyName: config.APP.LOCAL_STORAGE_KEY,
-              itemName: item,
-              value: value,
-            }),
-          );
-        }
+          // if so, set item to default value
+          if (Object.hasOwn(config.APP.DEFAULTS.localStorage, item)) {
+            key[item] = config.APP.DEFAULTS.localStorage[item];
+            localStorage.setItem(config.APP.LOCAL_STORAGE_KEY, JSON.stringify(key));
+          }
+          // otherwise, throw error
+          else {
+            console.error(
+              this.intl.t('errors.localStorageSetItemFail', {
+                keyName: config.APP.LOCAL_STORAGE_KEY,
+                itemName: item,
+                value: value,
+              }),
+            );
+          }
 
-        return null;
+          return null;
+        }
       }
-    }
-    // if the key doesn't exist at all, create default key
-    else {
-      const obj = {};
-      obj[item] = value;
-      return localStorage.setItem(config.APP.LOCAL_STORAGE_KEY, JSON.stringify(obj));
+      // if the key doesn't exist at all, create default key
+      else {
+        const obj = {};
+        obj[item] = value;
+        return localStorage.setItem(config.APP.LOCAL_STORAGE_KEY, JSON.stringify(obj));
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes ilios/ilios#6841

Due to the change in [ilios/ilios#9045](https://github.com/ilios/frontend/pull/9045), the locale is now being saved in localStorage. However, this means tests in the browser can fail if the locale has been changed from the default. This PR makes it so the app only interacts with localStorage if it's not testing.