### PR TITLE
ensure that new competencies are saved.

### DIFF
--- a/packages/frontend/app/components/school-competencies-expanded.gjs
+++ b/packages/frontend/app/components/school-competencies-expanded.gjs
@@ -106,12 +106,15 @@ export default class SchoolCompetenciesExpandedComponent extends Component {
     await all(competenciesToRemove.map((competency) => competency.destroyRecord()));
     await all(domainsToRemove.map((domain) => domain.destroyRecord()));
 
-    // set the school on new competencies
-    filterBy(this.competencies, 'isNew').forEach((competency) => {
-      competency.set('school', this.args.school);
-    });
+    // set the school on new competencies and save them.
+    await all(
+      filterBy(this.competencies, 'isNew').map((competency) => {
+        competency.set('school', this.args.school);
+        competency.save();
+      }),
+    );
 
-    // update all modified competencies (this will include new ones).
+    // then update all modified competencies.
     await all(
       filterBy(this.competencies, 'hasDirtyAttributes').map((competency) => competency.save()),
     );


### PR DESCRIPTION
fixes ilios/ilios#6881

band-aid fix to this problem by saving new competencies separately from modified ones.

as an aside - this is the _only_ component in the entire frontend where we're calling the [`hasDirtyAttributes`](https://canary.warp-drive.io/api/@ember-data/model/index/classes/default#hasdirtyattributes) getter on models. something must have changed within ember-data on this and it went past us. 

```
$ grep -r 'hasDirtyAttributes' packages --exclude-dir=dist --exclude-dir=node_modules                                                                                                         
packages/frontend/app/components/school-competencies-expanded.gjs:      filterBy(this.competencies, 'hasDirtyAttributes').map((competency) => competency.save()),
```

i'm recommending a rewrite of this editing workflow as a follow-up - instead of bulk-saving, these additions and edits should be persisted as soon as they happen, and not when you "save" the form. i believe that most of the UI can be salvaged, but we'll need to replace the "save" and "cancel" buttons with a "close" button.

<img width="569" height="226" alt="image" src="https://github.com/user-attachments/assets/659a2cbc-602a-4805-a41c-ac0aaf2744b1" />

to be continued.