### PR TITLE
Normalize Deletion Confirmation dropdown sections

### DIFF
--- a/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
@@ -119,7 +119,7 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
       <tr class="confirm-removal" data-test-confirm-removal>
         <ResponsiveTd @smallScreenSpan="8" @largeScreenSpan="16">
           <div class="confirm-message">
-            {{t "general.reportConfirmRemove"}}
+            {{t "general.confirmRemoveReport"}}
             <br />
             <div class="confirm-buttons">
               <button

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
@@ -93,7 +93,7 @@ export default class CurriculumInventorySequenceBlockListItemComponent extends C
       <tr class="confirm-removal" data-test-confirm-removal>
         <ResponsiveTd @smallScreenSpan="9" @largeScreenSpan="15">
           <div class="confirm-message">
-            {{t "general.sequenceBlockConfirmRemove"}}
+            {{t "general.confirmRemoveSequenceBlock"}}
             <br />
             <div class="confirm-buttons">
               <button

--- a/packages/frontend/app/components/instructor-groups/list-item.gjs
+++ b/packages/frontend/app/components/instructor-groups/list-item.gjs
@@ -7,6 +7,7 @@ import { LinkTo } from '@ember/routing';
 import { on } from '@ember/modifier';
 import set from 'ember-set-helper/helpers/set';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import ResponsiveTd from 'frontend/components/responsive-td';
 import t from 'ember-intl/helpers/t';
 import perform from 'ember-concurrency/helpers/perform';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
@@ -74,8 +75,7 @@ export default class InstructorGroupsListItemComponent extends Component {
     </tr>
     {{#if this.showRemoveConfirmation}}
       <tr class="confirm-removal" data-test-confirm-removal>
-        <td class="hide-from-small-screen"></td>
-        <td colspan="3">
+        <ResponsiveTd @smallScreenSpan="3" @largeScreenSpan="5">
           <div class="confirm-message">
             {{t
               "general.confirmRemoveInstructorGroup"
@@ -101,8 +101,7 @@ export default class InstructorGroupsListItemComponent extends Component {
               </button>
             </div>
           </div>
-        </td>
-        <td class="hide-from-small-screen"></td>
+        </ResponsiveTd>
       </tr>
     {{/if}}
   </template>

--- a/packages/frontend/app/components/learner-group/list-item.gjs
+++ b/packages/frontend/app/components/learner-group/list-item.gjs
@@ -7,6 +7,7 @@ import { TrackedAsyncData } from 'ember-async-data';
 import { service } from '@ember/service';
 import { LinkTo } from '@ember/routing';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import ResponsiveTd from 'frontend/components/responsive-td';
 import t from 'ember-intl/helpers/t';
 import and from 'ember-truth-helpers/helpers/and';
 import not from 'ember-truth-helpers/helpers/not';
@@ -201,30 +202,30 @@ export default class LearnerGroupListItemComponent extends Component {
     </tr>
     {{#if this.showRemoveConfirmation}}
       <tr class="confirm-removal" data-test-confirm-removal>
-        <td class="hide-from-small-screen"></td>
-        <td colspan="3" class="confirm-message">
-          {{t "general.confirmRemoveLearnerGroup" subgroupCount=@learnerGroup.children.length}}
-          <br />
-          <div class="confirm-buttons">
-            <button
-              type="button"
-              class="remove text"
-              {{on "click" (perform this.remove)}}
-              data-test-confirm
-            >
-              {{t "general.yes"}}
-            </button>
-            <button
-              type="button"
-              class="done text"
-              {{on "click" (set this "showRemoveConfirmation" false)}}
-              data-test-cancel
-            >
-              {{t "general.cancel"}}
-            </button>
+        <ResponsiveTd @smallScreenSpan="3" @largeScreenSpan="5">
+          <div class="confirm-message">
+            {{t "general.confirmRemoveLearnerGroup" subgroupCount=@learnerGroup.children.length}}
+            <br />
+            <div class="confirm-buttons">
+              <button
+                type="button"
+                class="remove text"
+                {{on "click" (perform this.remove)}}
+                data-test-confirm
+              >
+                {{t "general.yes"}}
+              </button>
+              <button
+                type="button"
+                class="done text"
+                {{on "click" (set this "showRemoveConfirmation" false)}}
+                data-test-cancel
+              >
+                {{t "general.cancel"}}
+              </button>
+            </div>
           </div>
-        </td>
-        <td class="hide-from-small-screen"></td>
+        </ResponsiveTd>
       </tr>
     {{/if}}
     {{#if this.showCopyConfirmation}}

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -422,7 +422,7 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
 
       {{#if this.showRemoveConfirmation}}
         <div class="confirm-message" data-test-confirm-removal>
-          {{t "general.confirmObjectiveRemoval"}}
+          {{t "general.confirmRemoveObjective"}}
           <button
             class="remove"
             type="button"

--- a/packages/frontend/app/components/reports/table.gjs
+++ b/packages/frontend/app/components/reports/table.gjs
@@ -68,7 +68,7 @@ export default class ReportsListComponent extends Component {
             <tr class="confirm-removal">
               <td colspan="12">
                 <div class="confirm-message">
-                  {{t "general.reportConfirmRemove"}}
+                  {{t "general.confirmRemoveReport"}}
                   <br />
                   <div class="confirm-buttons">
                     <button

--- a/packages/frontend/app/components/school-session-types-list-item.gjs
+++ b/packages/frontend/app/components/school-session-types-list-item.gjs
@@ -28,7 +28,7 @@ export default class SchoolSessionTypesListItemComponent extends Component {
   });
   <template>
     <tr
-      class="school-session-types-list-item"
+      class="school-session-types-list-item{{if this.showRemoveConfirmation ' confirm-removal'}}"
       data-test-school-session-types-list-item
       ...attributes
     >

--- a/packages/frontend/app/components/school-session-types-list-item.gjs
+++ b/packages/frontend/app/components/school-session-types-list-item.gjs
@@ -122,7 +122,7 @@ export default class SchoolSessionTypesListItemComponent extends Component {
       <tr class="confirm-removal">
         <td colspan="11" class="hide-from-small-screen">
           <div class="confirm-message" data-test-message>
-            {{t "general.sessionTypeConfirmRemoval"}}
+            {{t "general.confirmRemoveSessionType"}}
             <br />
             <div class="confirm-buttons">
               <button
@@ -146,7 +146,7 @@ export default class SchoolSessionTypesListItemComponent extends Component {
         </td>
         <td colspan="5" class="hide-from-large-screen" data-test-confirm-removal>
           <div class="confirm-message" data-test-message>
-            {{t "general.sessionTypeConfirmRemoval"}}
+            {{t "general.confirmRemoveSessionType"}}
             <br />
             <div class="confirm-buttons">
               <button

--- a/packages/frontend/app/components/school-vocabularies-list.gjs
+++ b/packages/frontend/app/components/school-vocabularies-list.gjs
@@ -123,7 +123,7 @@ export default class SchoolVocabulariesListComponent extends Component {
                   <tr class="confirm-removal" data-test-confirm-removal={{index}}>
                     <td colspan="5">
                       <div class="confirm-message">
-                        {{t "general.confirmVocabularyRemoval"}}
+                        {{t "general.confirmRemoveVocabulary"}}
                         <br />
                         <div class="confirm-buttons">
                           <button

--- a/packages/frontend/tests/acceptance/instructorgroups-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroups-test.js
@@ -195,7 +195,7 @@ module('Acceptance | Instructor Groups', function (hooks) {
       assert.strictEqual(page.list.items[0].title, 'instructor group 0');
       await page.list.items[0].remove();
       assert.strictEqual(
-        page.list.removalConfirmationMessage,
+        page.list.confirmRemoval.message,
         'Are you sure you want to delete this instructor group, with 5 instructors? This action cannot be undone. Yes Cancel',
       );
     });

--- a/packages/frontend/tests/acceptance/learnergroups-test.js
+++ b/packages/frontend/tests/acceptance/learnergroups-test.js
@@ -295,7 +295,7 @@ module('Acceptance | Learner Groups', function (hooks) {
     await page.list.items[0].remove();
     assert.ok(page.list.items[0].hasRemoveStyle);
     assert.strictEqual(
-      page.list.confirmRemoval.text,
+      page.list.confirmRemoval.message,
       'Are you sure you want to delete this learner group, with 2 subgroups? This action cannot be undone. Yes Cancel',
     );
   });

--- a/packages/frontend/tests/pages/components/instructor-groups/list.js
+++ b/packages/frontend/tests/pages/components/instructor-groups/list.js
@@ -30,10 +30,10 @@ const definition = {
   },
   confirmRemoval: {
     scope: '[data-test-confirm-removal]',
-    confirm: clickable('[data-test-confirm]'),
-    cancel: clickable('[data-test-cancel]'),
+    message: text('td:first-of-type .confirm-message'),
+    confirm: clickable('td:first-of-type [data-test-confirm]'),
+    cancel: clickable('td:first-of-type [data-test-cancel]'),
   },
-  removalConfirmationMessage: text('.confirm-removal .confirm-message'),
 };
 
 export default definition;

--- a/packages/frontend/tests/pages/components/learner-group/list.js
+++ b/packages/frontend/tests/pages/components/learner-group/list.js
@@ -30,9 +30,10 @@ const definition = {
   items: collection('[data-test-learner-group-list-item]', listItem),
   confirmRemoval: {
     scope: '[data-test-confirm-removal]',
-    confirm: clickable('[data-test-confirm]'),
-    cancel: clickable('[data-test-cancel]'),
-    canCancel: isPresent('[data-test-cancel]'),
+    message: text('td:first-of-type .confirm-message'),
+    confirm: clickable('td:first-of-type [data-test-confirm]'),
+    cancel: clickable('td:first-of-type [data-test-cancel]'),
+    canCancel: isPresent('td:first-of-type [data-test-cancel]'),
   },
   confirmCopy: {
     scope: '[data-test-confirm-copy]',
@@ -42,7 +43,6 @@ const definition = {
     copyWithoutLearners: clickable('[data-test-confirm-without-learners]'),
     cancel: clickable('[data-test-cancel]'),
   },
-  removalConfirmationMessage: text('.confirm-removal .confirm-message'),
 };
 
 export default definition;

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -62,7 +62,7 @@ general:
   confirmRemoveLearnerGroup: "Are you sure you want to delete this learner group, with {subgroupCount} subgroups? This action cannot be undone."
   confirmRemoveProgram: Are you sure you want to delete this program? This action cannot be undone.
   confirmRemoveProgramYear: "Are you sure you want to delete this program year? Doing so will also remove its associated student cohort and groups, and associations with {courseCount} course(s), and cannot be undone."
-  confirmVocabularyRemoval: Are you sure you want to delete this vocabulary?
+  confirmVocabularyRemoval: Are you sure you want to delete this vocabulary? This action cannot be undone.
   connectionLost: Connection Lost.
   continue: Continue
   copiedCurriculumReportUrl: Copied Curriculum Report Link successfully
@@ -166,7 +166,7 @@ general:
   instructorGroupTitleFilterPlaceholder: Filter by Instructor Group Title
   instructorGroupTitlePlaceholder: Enter a title for this instructor group
   invalidateTokens: Invalidate All Tokens
-  invalidateTokensConfirmation: This will invalidate all existing API tokens and you will need to generate new ones for any applications you have.  Are you sure you want to do this?
+  invalidateTokensConfirmation: This will invalidate all existing API tokens and you will need to generate new ones for any applications you have. Are you sure you want to do this?
   invalidUsers: Invalid Users
   isSelective: Is Selective
   isTrack: Is Track

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -62,7 +62,10 @@ general:
   confirmRemoveLearnerGroup: "Are you sure you want to delete this learner group, with {subgroupCount} subgroups? This action cannot be undone."
   confirmRemoveProgram: Are you sure you want to delete this program? This action cannot be undone.
   confirmRemoveProgramYear: "Are you sure you want to delete this program year? Doing so will also remove its associated student cohort and groups, and associations with {courseCount} course(s), and cannot be undone."
-  confirmVocabularyRemoval: Are you sure you want to delete this vocabulary? This action cannot be undone.
+  confirmRemoveReport: Are you sure you want to delete this report? This action cannot be undone.
+  confirmRemoveSequenceBlock: Are you sure you want to delete this sequence block? This action cannot be undone.
+  confirmRemoveSessionType: Are you sure you want to delete this session type? This action cannot be undone.
+  confirmRemoveVocabulary: Are you sure you want to delete this vocabulary? This action cannot be undone.
   connectionLost: Connection Lost.
   continue: Continue
   copiedCurriculumReportUrl: Copied Curriculum Report Link successfully
@@ -300,7 +303,6 @@ general:
   removeCohort: Remove Cohort
   removeLearnerToCohort: "{count, plural, =1 {Remove learner to {cohort}} other {Remove # learners to {cohort}}}"
   removePrimaryCohort: Remove Primary Cohort
-  reportConfirmRemove: Are you sure you want to delete this report? This action cannot be undone.
   reportDescriptionPlaceholder: Please enter a brief description about this report.
   reportDisplayDescriptionWithObject: 'This report shows all {subject} associated with {objectType} "{object}" {year} in {school}.'
   reportDisplayDescriptionWithoutObject: "This report shows all {subject} in {school}."
@@ -334,7 +336,6 @@ general:
   selectPolite: (please select one)
   selectUser: Select User
   sequenceBlock: Sequence Block
-  sequenceBlockConfirmRemove: Are you sure you want to delete this sequence block? This action cannot be undone.
   sequenceBlockDescriptionPlaceholder: Enter a description for this sequence block.
   sequenceBlockIsSelective: This sequence block has been marked as a selective.
   sequenceBlocks: Sequence Blocks
@@ -350,7 +351,6 @@ general:
   sessionOfferingsReportSummaryMultiSchool: "report for {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, across # schools}}. Each session offering is listed along with instructors, learner groups, and course data."
   sessionTerm: Session Term
   sessionTerms: Session Terms
-  sessionTypeConfirmRemoval: Are you sure you want to delete this session type? This action cannot be undone.
   sessionTypeTitlePlaceholder: Enter a title for this session type
   showLess: Show less
   showSubgroupEvents: Show events for all subgroups

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -62,7 +62,7 @@ general:
   confirmRemoveLearnerGroup: "¿Estás seguro que quieres borrar este grupo de aprendedores, con {subgroupCount} grupos subordinados? Esta acción no se puede deshacer."
   confirmRemoveProgram: ¿Estás seguro que quieres borrar este programa? Esta accion no se puede deshacer.
   confirmRemoveProgramYear: "¿Está seguro de que desea eliminar este año del programa?   Hacer tan también quitará su cohorte estudiantil asociada y grupos y asociaciones con {courseCount} curso(s), y no se puede deshacer."
-  confirmVocabularyRemoval: ¿Está seguro que desea eliminar este vocabulario?
+  confirmVocabularyRemoval: ¿Está seguro que desea eliminar este vocabulario? Esta accion no se puede deshacer.
   connectionLost: Conexión Perdida.
   continue: Continuar
   copiedCurriculumReportUrl: Copiado Enlace de Inventario de plan de Estudios Correctamente

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -62,7 +62,10 @@ general:
   confirmRemoveLearnerGroup: "¿Estás seguro que quieres borrar este grupo de aprendedores, con {subgroupCount} grupos subordinados? Esta acción no se puede deshacer."
   confirmRemoveProgram: ¿Estás seguro que quieres borrar este programa? Esta accion no se puede deshacer.
   confirmRemoveProgramYear: "¿Está seguro de que desea eliminar este año del programa?   Hacer tan también quitará su cohorte estudiantil asociada y grupos y asociaciones con {courseCount} curso(s), y no se puede deshacer."
-  confirmVocabularyRemoval: ¿Está seguro que desea eliminar este vocabulario? Esta accion no se puede deshacer.
+  confirmRemoveReport: ¿Está seguro que desea eliminar este informe? Esta acción no se puede deshacer.
+  confirmRemoveSequenceBlock: ¿Está seguro que desea eliminar este bloque de secuencia? Esta acción no se puede deshacer.
+  confirmRemoveSessionType: ¿Está seguro de que desea eliminar este tipo de sesión? Esta acción no se puede deshacer.
+  confirmRemoveVocabulary: ¿Está seguro que desea eliminar este vocabulario? Esta accion no se puede deshacer.
   connectionLost: Conexión Perdida.
   continue: Continuar
   copiedCurriculumReportUrl: Copiado Enlace de Inventario de plan de Estudios Correctamente
@@ -300,7 +303,6 @@ general:
   removeCohort: Remover Cohorte
   removeLearnerToCohort: "{count, plural, =1 {Quite estudiante a {cohort}} other {Quite # estudiantes a {cohort}}}"
   removePrimaryCohort: Remover Principal Cohorte
-  reportConfirmRemove: ¿Está seguro que desea eliminar este informe? Esta acción no se puede deshacer.
   reportDescriptionPlaceholder: Por favor entre en una breve descripción sobre este informe.
   reportDisplayDescriptionWithObject: 'Este informe muestra todos los {subject} asociados con {objectType} "{object}" {year} en {school}.'
   reportDisplayDescriptionWithoutObject: "Este informe muestra todos los {subject} en {school}."
@@ -334,7 +336,6 @@ general:
   selectPolite: (seleccione uno, por favor)
   selectUser: Seleccione usuario
   sequenceBlock: Bloque de Secuencia
-  sequenceBlockConfirmRemove: ¿Está seguro que desea eliminar este bloque de secuencia? Esta acción no se puede deshacer.
   sequenceBlockDescriptionPlaceholder: "Introduzca una descripción para este bloque de la secuencia."
   sequenceBlockIsSelective: Esta bloque de la secuencia ha sido marcada como selectiva.
   sequenceBlocks: Bloques de la Secuencia
@@ -350,7 +351,6 @@ general:
   sessionOfferingsReportSummaryMultiSchool: "informe para {courseCount, plural, one {un curso} other {# cursos}}{schoolCount, plural, zero {} one {} other {, en # escuelas}}. Se enumera el ofrecimiento de cada sesión junto con los instructores, los grupos de aprendedores, y los datos del curso."
   sessionTerm: Término de Sesión
   sessionTerms: Términos de Sesión
-  sessionTypeConfirmRemoval: ¿Está seguro de que desea eliminar este tipo de sesión? Esta acción no se puede deshacer.
   sessionTypeTitlePlaceholder: Entre en un titulo para este tipo de sesión
   showLess: Mostrar menos
   showSubgroupEvents: Mostrar eventos para todos los grupos subordinados

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -62,7 +62,7 @@ general:
   confirmRemoveLearnerGroup: "Êtes-vous sûr vous voulez supprimer cette groupe d'apprenants, avec {subgroupCount} sous-groupes? Ça action ne peut pas être défait."
   confirmRemoveProgram: Êtes-vous certain que vous voulez supprimer ce diplôme? Cette action ne peut être annulée.
   confirmRemoveProgramYear: "Êtes-vous certain que vous voulez supprimer cette année de diplôme? Cette action va supprimer tous les cohortes et groupes des étudiants associées, et liaisons avec {courseCount} des cours, et ne peut être annulée."
-  confirmVocabularyRemoval: Êtes vous sûr de vouloir supprimer cette vocabulaire?
+  confirmVocabularyRemoval: Êtes vous sûr de vouloir supprimer cette vocabulaire? Cette action ne peut être annulée.
   connectionLost: Connexion perdu
   continue: Continuez
   copiedCurriculumReportUrl: Copié lien vers le rapport d'inventaire des programmes d'étude avec succès

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -62,7 +62,10 @@ general:
   confirmRemoveLearnerGroup: "Êtes-vous sûr vous voulez supprimer cette groupe d'apprenants, avec {subgroupCount} sous-groupes? Ça action ne peut pas être défait."
   confirmRemoveProgram: Êtes-vous certain que vous voulez supprimer ce diplôme? Cette action ne peut être annulée.
   confirmRemoveProgramYear: "Êtes-vous certain que vous voulez supprimer cette année de diplôme? Cette action va supprimer tous les cohortes et groupes des étudiants associées, et liaisons avec {courseCount} des cours, et ne peut être annulée."
-  confirmVocabularyRemoval: Êtes vous sûr de vouloir supprimer cette vocabulaire? Cette action ne peut être annulée.
+  confirmRemoveReport: Êtes-vous sûrs que vous voulez supprimer ce rapport? Cette action ne peut pas être défaite.
+  confirmRemoveSequenceBlock: Êtes-vous sûrs que vous voulez supprimer ce bloc séquence? Cette action ne peut pas être défaite.
+  confirmRemoveSessionType: "Voulez-vous vraiment supprimer ce type de session ? Cette action ne peut pas être annulée."
+  confirmRemoveVocabulary: Êtes vous sûr de vouloir supprimer cette vocabulaire? Cette action ne peut être annulée.
   connectionLost: Connexion perdu
   continue: Continuez
   copiedCurriculumReportUrl: Copié lien vers le rapport d'inventaire des programmes d'étude avec succès
@@ -300,7 +303,6 @@ general:
   removeCohort: Supprîmer Cohorte
   removeLearnerToCohort: "{count, plural, =1 {Renvoyer l’étudiant à {cohort}} other {Renvoyer # étudiants à {cohort}}}"
   removePrimaryCohort: Supprîmer Cohorte Primaire
-  reportConfirmRemove: Êtes-vous sûrs que vous voulez supprimer ce rapport? Cette action ne peut pas être défaite.
   reportDescriptionPlaceholder: "Entrez S'il vous plaît dans une description brève de ce rapport."
   reportDisplayDescriptionWithObject: 'This report shows all {subject} associated with {objectType} "{object}" {year} in {school}.'
   reportDisplayDescriptionWithoutObject: "Ce rapport montre tous les {subject} de {school}."
@@ -334,7 +336,6 @@ general:
   selectPolite: (veuillez en sélectionner un)
   selectUser: "Choisi l'utilisateur"
   sequenceBlock: Bloc séquence
-  sequenceBlockConfirmRemove: Êtes-vous sûrs que vous voulez supprimer ce bloc séquence? Cette action ne peut pas être défaite.
   sequenceBlockDescriptionPlaceholder: "Entrez une description pour ceci bloc séquence."
   sequenceBlockIsSelective: Cette bloc séquence a été marquée comme sélective.
   sequenceBlocks: Blocs séquence
@@ -350,7 +351,6 @@ general:
   sessionOfferingsReportSummaryMultiSchool: "Rapport de {courseCount, plural, one {one course} other {# courses}}{schoolCount, plural, zero {} one {} other {, dans # écoles}}. Chaque offre de séance est listée avec des instructeurs, groupes d'étudiants, et cours données."
   sessionTerm: Terme de Séance
   sessionTerms: Termes de Séance
-  sessionTypeConfirmRemoval: "Voulez-vous vraiment supprimer ce type de session ? Cette action ne peut pas être annulée."
   sessionTypeTitlePlaceholder: Ajoutez un titre pour ce type de session
   showLess: Afficher moins
   showSubgroupEvents: Afficher les événements pour tous les sous-groupes

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -305,26 +305,29 @@ export default class CourseObjectiveListItemComponent extends Component {
       {{#if this.showRemoveConfirmation}}
         <div class="confirm-message" data-test-confirm-removal>
           {{t "general.confirmObjectiveRemoval"}}
-          <button
-            class="remove"
-            type="button"
-            data-test-confirm
-            {{on "click" (perform this.deleteObjective)}}
-          >
-            {{#if this.deleteObjective.isRunning}}
-              <FaIcon @icon={{faSpinner}} @spin={{true}} />
-            {{else}}
-              {{t "general.yes"}}
-            {{/if}}
-          </button>
-          <button
-            class="done"
-            type="button"
-            data-test-cancel
-            {{on "click" (set this "showRemoveConfirmation" false)}}
-          >
-            {{t "general.cancel"}}
-          </button>
+          <br />
+          <div class="confirm-buttons">
+            <button
+              class="remove"
+              type="button"
+              data-test-confirm
+              {{on "click" (perform this.deleteObjective)}}
+            >
+              {{#if this.deleteObjective.isRunning}}
+                <FaIcon @icon={{faSpinner}} @spin={{true}} />
+              {{else}}
+                {{t "general.yes"}}
+              {{/if}}
+            </button>
+            <button
+              class="done"
+              type="button"
+              data-test-cancel
+              {{on "click" (set this "showRemoveConfirmation" false)}}
+            >
+              {{t "general.cancel"}}
+            </button>
+          </div>
         </div>
       {{/if}}
 

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -304,7 +304,7 @@ export default class CourseObjectiveListItemComponent extends Component {
 
       {{#if this.showRemoveConfirmation}}
         <div class="confirm-message" data-test-confirm-removal>
-          {{t "general.confirmObjectiveRemoval"}}
+          {{t "general.confirmRemoveObjective"}}
           <br />
           <div class="confirm-buttons">
             <button

--- a/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
@@ -152,7 +152,7 @@ export default class DetailLearningMaterialsItemComponent extends Component {
       <tr class="confirm-removal" data-test-confirm-removal>
         <td colspan="14">
           <div class="confirm-message">
-            {{t "general.confirmRemoval"}}
+            {{t "general.confirmRemoveLearningMaterial"}}
             <br />
             <div class="confirm-buttons">
               <button

--- a/packages/ilios-common/addon/components/offering-manager.gjs
+++ b/packages/ilios-common/addon/components/offering-manager.gjs
@@ -262,7 +262,10 @@ export default class OfferingManagerComponent extends Component {
           {{#if this.showRemoveConfirmation}}
             <div class="confirm-removal">
               <div class="confirm-message">
-                {{t "general.confirmRemove" learnerGroupCount=@offering.learnerGroups.length}}
+                {{t
+                  "general.confirmRemoveSessionOffering"
+                  learnerGroupCount=@offering.learnerGroups.length
+                }}
                 <br />
                 <div class="confirm-buttons">
                   <button type="button" class="remove text" {{on "click" (fn @remove @offering)}}>

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -287,7 +287,7 @@ export default class SessionObjectiveListItemComponent extends Component {
 
       {{#if this.showRemoveConfirmation}}
         <div class="confirm-message" data-test-confirm-removal>
-          {{t "general.confirmObjectiveRemoval"}}
+          {{t "general.confirmRemoveObjective"}}
           <br />
           <div class="confirm-buttons">
             <button

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -288,26 +288,29 @@ export default class SessionObjectiveListItemComponent extends Component {
       {{#if this.showRemoveConfirmation}}
         <div class="confirm-message" data-test-confirm-removal>
           {{t "general.confirmObjectiveRemoval"}}
-          <button
-            class="remove"
-            type="button"
-            data-test-confirm
-            {{on "click" (perform this.deleteObjective)}}
-          >
-            {{#if this.deleteObjective.isRunning}}
-              <FaIcon @icon={{faSpinner}} @spin={{true}} />
-            {{else}}
-              {{t "general.yes"}}
-            {{/if}}
-          </button>
-          <button
-            class="done"
-            type="button"
-            data-test-cancel
-            {{on "click" (set this "showRemoveConfirmation" false)}}
-          >
-            {{t "general.cancel"}}
-          </button>
+          <br />
+          <div class="confirm-buttons">
+            <button
+              class="remove"
+              type="button"
+              data-test-confirm
+              {{on "click" (perform this.deleteObjective)}}
+            >
+              {{#if this.deleteObjective.isRunning}}
+                <FaIcon @icon={{faSpinner}} @spin={{true}} />
+              {{else}}
+                {{t "general.yes"}}
+              {{/if}}
+            </button>
+            <button
+              class="done"
+              type="button"
+              data-test-cancel
+              {{on "click" (set this "showRemoveConfirmation" false)}}
+            >
+              {{t "general.cancel"}}
+            </button>
+          </div>
         </div>
       {{/if}}
 

--- a/packages/ilios-common/addon/components/sessions-grid-row.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-row.gjs
@@ -62,7 +62,13 @@ export default class SessionsGridRowComponent extends Component {
     return `${this.intl.t('general.prerequisites')}: ${titles}`;
   }
   <template>
-    <div class="sessions-grid-row" data-test-sessions-grid-row>
+    <div
+      class="sessions-grid-row{{if
+          (includes @session.id @sessionsForRemovalConfirmation)
+          ' confirm'
+        }}"
+      data-test-sessions-grid-row
+    >
       <span class="expand-collapse-control" data-test-expand-collapse-control>
         {{#if (includes @session.id @expandedSessionIds)}}
           <button

--- a/packages/ilios-common/addon/components/sessions-grid.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid.gjs
@@ -230,7 +230,7 @@ export default class SessionsGrid extends Component {
           />
           {{#if (includes session.id this.confirmDeleteSessionIds)}}
             <div class="confirm-removal" data-test-confirm-removal>
-              {{t "general.confirmSessionRemoval"}}
+              {{t "general.confirmRemoveSession"}}
               <div class="confirm-buttons">
                 <button
                   type="button"

--- a/packages/ilios-common/addon/components/sessions-grid.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid.gjs
@@ -222,6 +222,7 @@ export default class SessionsGrid extends Component {
         >
           <SessionsGridRow
             @session={{session}}
+            @sessionsForRemovalConfirmation={{this.confirmDeleteSessionIds}}
             @confirmDelete={{this.confirmDelete}}
             @closeSession={{@closeSession}}
             @expandSession={{this.expandSession}}

--- a/packages/ilios-common/addon/components/sessions-grid.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid.gjs
@@ -232,11 +232,11 @@ export default class SessionsGrid extends Component {
               {{t "general.confirmSessionRemoval"}}
               <div class="confirm-buttons">
                 <button
-                  class="cancel"
                   type="button"
-                  data-test-yes
+                  class="remove"
                   disabled={{this.removeSession.isRunning}}
                   {{on "click" (perform this.removeSession session)}}
+                  data-test-yes
                 >
                   {{#if this.removeSession.isRunning}}
                     <LoadingSpinner />
@@ -244,7 +244,12 @@ export default class SessionsGrid extends Component {
                     {{t "general.yes"}}
                   {{/if}}
                 </button>
-                <button class="done" type="button" {{on "click" (fn this.cancelDelete session.id)}}>
+                <button
+                  type="button"
+                  class="done text"
+                  {{on "click" (fn this.cancelDelete session.id)}}
+                  data-test-cancel
+                >
                   {{t "general.cancel"}}
                 </button>
               </div>

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-row.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-row.scss
@@ -4,6 +4,10 @@
   padding: 0.25rem 0;
   @include m.sessions-grid;
 
+  &.confirm {
+    background-color: var(--lightest-red);
+  }
+
   .session-grid-status {
     display: flex;
     justify-content: flex-end;

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
@@ -32,8 +32,16 @@
       }
 
       .confirm-buttons {
-        @include m.ilios-form-buttons {
-          padding-top: 1rem;
+        padding-top: 1rem;
+
+        .remove {
+          background-color: var(--white);
+          color: var(--red);
+
+          &:hover {
+            background-color: var(--light-red);
+            color: var(--white);
+          }
         }
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -186,7 +186,11 @@
         padding: 1rem 4rem;
 
         @include media.for-tablet-and-up {
-          padding: 1rem 8rem;
+          padding: 1rem 8rem 0;
+        }
+
+        .confirm-buttons {
+          padding-top: 1.1em;
         }
       }
 

--- a/packages/ilios-common/app/styles/ilios-common/shared/ilios-removable-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/ilios-removable-table.scss
@@ -3,6 +3,12 @@
 
 .ilios-removable-table {
   tbody {
+    tr:nth-child(even) {
+      &.confirm-removal {
+        background-color: var(--lightest-red);
+      }
+    }
+
     .confirm-removal {
       background-color: var(--lightest-red);
 

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -51,10 +51,10 @@ general:
   competencies: Competencies
   complete: Complete
   completeSessions: "Sessions Complete: ready to publish"
-  confirmObjectiveRemoval: Are you sure you want to delete this objective? This action cannot be undone.
-  confirmRemoval: Are you sure you want to remove this learning material? This action cannot be undone.
-  confirmRemove: "Are you sure you want to delete this offering with {learnerGroupCount} learner groups? This action cannot be undone."
-  confirmSessionRemoval: Are you sure you want to delete this session? This action cannot be undone.
+  confirmRemoveLearningMaterial: Are you sure you want to remove this learning material? This action cannot be undone.
+  confirmRemoveObjective: Are you sure you want to delete this objective? This action cannot be undone.
+  confirmRemoveSession: Are you sure you want to delete this session? This action cannot be undone.
+  confirmRemoveSessionOffering: "Are you sure you want to delete this offering with {learnerGroupCount} learner groups? This action cannot be undone."
   contentAuthor: Content Author
   copiedIcsFeedUrl: Copied My ICS Link successfully
   copiedSuccessfully: Copied successfully

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -51,10 +51,10 @@ general:
   competencies: Competencies
   complete: Complete
   completeSessions: "Sessions Complete: ready to publish"
-  confirmObjectiveRemoval: Are you sure you want to delete this objective?
-  confirmRemoval: Are you sure you want to remove this learning material?
+  confirmObjectiveRemoval: Are you sure you want to delete this objective? This action cannot be undone.
+  confirmRemoval: Are you sure you want to remove this learning material? This action cannot be undone.
   confirmRemove: "Are you sure you want to delete this offering with {learnerGroupCount} learner groups? This action cannot be undone."
-  confirmSessionRemoval: Are you sure you want to delete this session?
+  confirmSessionRemoval: Are you sure you want to delete this session? This action cannot be undone.
   contentAuthor: Content Author
   copiedIcsFeedUrl: Copied My ICS Link successfully
   copiedSuccessfully: Copied successfully

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -51,10 +51,10 @@ general:
   competencies: Competencias
   complete: Completo
   completeSessions: "Sesiónes Completas: Listo a Publicar"
-  confirmObjectiveRemoval: ¿Está seguro que desea eliminar este objetivo? Esta acción no se puede deshacer.
-  confirmRemoval: ¿Está seguro que desea eliminar este material de aprendizaje? Esta acción no se puede deshacer.
-  confirmRemove: "¿Estás seguro que quieres borrar este ofrecimiento con {learnerGroupCount} grupos de aprendedores? Esta acción no se puede deshacer."
-  confirmSessionRemoval: ¿Está seguro que desea eliminar este sessión? Esta acción no se puede deshacer.
+  confirmRemoveLearningMaterial: ¿Está seguro que desea eliminar este material de aprendizaje? Esta acción no se puede deshacer.
+  confirmRemoveObjective: ¿Está seguro que desea eliminar este objetivo? Esta acción no se puede deshacer.
+  confirmRemoveSession: ¿Está seguro que desea eliminar este sessión? Esta acción no se puede deshacer.
+  confirmRemoveSessionOffering: "¿Estás seguro que quieres borrar este ofrecimiento con {learnerGroupCount} grupos de aprendedores? Esta acción no se puede deshacer."
   contentAuthor: Autor del Contenido
   copiedIcsFeedUrl: Copiado Mi Enlace ICS con éxito
   copiedSuccessfully: Copiado con éxito

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -51,10 +51,10 @@ general:
   competencies: Competencias
   complete: Completo
   completeSessions: "Sesiónes Completas: Listo a Publicar"
-  confirmObjectiveRemoval: ¿Está seguro que desea eliminar este objetivo?
-  confirmRemoval: ¿Está seguro que desea eliminar este material de aprendizaje?
+  confirmObjectiveRemoval: ¿Está seguro que desea eliminar este objetivo? Esta acción no se puede deshacer.
+  confirmRemoval: ¿Está seguro que desea eliminar este material de aprendizaje? Esta acción no se puede deshacer.
   confirmRemove: "¿Estás seguro que quieres borrar este ofrecimiento con {learnerGroupCount} grupos de aprendedores? Esta acción no se puede deshacer."
-  confirmSessionRemoval: ¿Está seguro que desea eliminar este sessión?
+  confirmSessionRemoval: ¿Está seguro que desea eliminar este sessión? Esta acción no se puede deshacer.
   contentAuthor: Autor del Contenido
   copiedIcsFeedUrl: Copiado Mi Enlace ICS con éxito
   copiedSuccessfully: Copiado con éxito

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -51,10 +51,10 @@ general:
   competencies: Compétences
   complete: Accompli
   completeSessions: "Séances complète: prêt à publier"
-  confirmObjectiveRemoval: Êtes vous sûr de vouloir supprimer cet objectif? Ça action ne peut pas être défait.
-  confirmRemoval: "Êtes-vous sûr vous voulez supprimer cette matériel d'étude? Ça action ne peut pas être défait."
-  confirmRemove: "Êtes-vous sûr vous voulez supprimer cette offre avec {learnerGroupCount} groupes d'apprenants? Ça action ne peut pas être défait."
-  confirmSessionRemoval: Êtes vous sûr de vouloir supprimer cette séance? Ça action ne peut pas être défait.
+  confirmRemoveLearningMaterial: "Êtes-vous sûr vous voulez supprimer cette matériel d'étude? Ça action ne peut pas être défait."
+  confirmRemoveObjective: Êtes vous sûr de vouloir supprimer cet objectif? Ça action ne peut pas être défait.
+  confirmRemoveSession: Êtes vous sûr de vouloir supprimer cette séance? Ça action ne peut pas être défait.
+  confirmRemoveSessionOffering: "Êtes-vous sûr vous voulez supprimer cette offre avec {learnerGroupCount} groupes d'apprenants? Ça action ne peut pas être défait."
   contentAuthor: Auteur
   copiedIcsFeedUrl: Copié mon lien ICS avec succès
   copiedSuccessfully: Copié avec succès

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -51,10 +51,10 @@ general:
   competencies: Compétences
   complete: Accompli
   completeSessions: "Séances complète: prêt à publier"
-  confirmObjectiveRemoval: Êtes vous sûr de vouloir supprimer cet objectif?
-  confirmRemoval: "Êtes-vous sûr vous voulez supprimer cette matériel d'étude?"
-  confirmRemove: "Êtes-vous sûr vous voulez supprimer cette offre avec {learnerGroupCount} groupes d'apprenants?  Ça action ne peut pas être défait."
-  confirmSessionRemoval: Êtes vous sûr de vouloir supprimer cette séance?
+  confirmObjectiveRemoval: Êtes vous sûr de vouloir supprimer cet objectif? Ça action ne peut pas être défait.
+  confirmRemoval: "Êtes-vous sûr vous voulez supprimer cette matériel d'étude? Ça action ne peut pas être défait."
+  confirmRemove: "Êtes-vous sûr vous voulez supprimer cette offre avec {learnerGroupCount} groupes d'apprenants? Ça action ne peut pas être défait."
+  confirmSessionRemoval: Êtes vous sûr de vouloir supprimer cette séance? Ça action ne peut pas être défait.
   contentAuthor: Auteur
   copiedIcsFeedUrl: Copié mon lien ICS avec succès
   copiedSuccessfully: Copié avec succès


### PR DESCRIPTION
Fixes ilios/ilios#6866

This makes the following deletion confirmation sections consistent (light red spans container, row targeted shares background color, buttons consistent and wrapped all the same, message consistent):

- [x] Course
- [x] Course Objective
- [x] Course LM
- [x] Session (Yes (red - hover) / Cancel (no - hover)) <-- NTS: real outlier
- [x] Session Objective
- [x] Session LM
- [x] Session Offering
- [x] Learner Group
- [x] Instructor Group
- [x] School Session Type
- [x] School Vocab
- [x] Program
- [x] ProgramYear
- [x] Subject Report
- [x] Curriculum Inventory Report
- [x] CIR Sequence Block 