### PR TITLE
Program overview label/value elements aligned and shortTitle revert mechanism fixed

### DIFF
--- a/packages/frontend/app/components/program/overview.gjs
+++ b/packages/frontend/app/components/program/overview.gjs
@@ -54,6 +54,11 @@ export default class ProgramOverviewComponent extends Component {
   });
 
   @action
+  revertShortTitleChanges() {
+    this.shortTitle = this.args.program.shortTitle;
+  }
+
+  @action
   setDuration(ev) {
     this.duration = Number(ev.target.value);
   }
@@ -72,7 +77,7 @@ export default class ProgramOverviewComponent extends Component {
               <EditableField
                 @value={{this.shortTitle}}
                 @save={{perform this.changeShortTitle}}
-                @close={{set this "duration" @program.duration}}
+                @close={{this.revertShortTitleChanges}}
                 @clickPrompt={{t "general.clickToEdit"}}
                 as |keyboard isSaving|
               >
@@ -86,11 +91,11 @@ export default class ProgramOverviewComponent extends Component {
                   {{keyboard}}
                   {{focus}}
                 />
+                <YupValidationMessage
+                  @validationErrors={{this.validations.errors.shortTitle}}
+                  data-test-title-validation-error-message
+                />
               </EditableField>
-              <YupValidationMessage
-                @validationErrors={{this.validations.errors.shortTitle}}
-                data-test-title-validation-error-message
-              />
             {{else}}
               {{this.shortTitle}}
             {{/if}}

--- a/packages/frontend/app/styles/components/program-overview.scss
+++ b/packages/frontend/app/styles/components/program-overview.scss
@@ -12,5 +12,9 @@
     @include m.ilios-overview-content {
       padding-top: 0.5rem;
     }
+
+    .block {
+      @include m.ilios-overview-block;
+    }
   }
 }

--- a/packages/frontend/tests/acceptance/program/overview-test.js
+++ b/packages/frontend/tests/acceptance/program/overview-test.js
@@ -48,6 +48,10 @@ module('Acceptance | Program - Overview', function (hooks) {
     assert.strictEqual(page.root.header.title.text, 'program 0');
     await page.root.header.title.edit();
     await page.root.header.title.set('test new title');
+    await page.root.header.title.cancel();
+    assert.strictEqual(page.root.header.title.text, 'program 0');
+    await page.root.header.title.edit();
+    await page.root.header.title.set('test new title');
     await page.root.header.title.save();
     assert.strictEqual(page.root.header.title.text, 'test new title');
   });
@@ -59,6 +63,10 @@ module('Acceptance | Program - Overview', function (hooks) {
     });
     await page.visit({ programId: 1 });
 
+    assert.strictEqual(page.root.overview.shortTitle.text, 'Title (short): short_0');
+    await page.root.overview.shortTitle.edit();
+    await page.root.overview.shortTitle.set('newshort');
+    await page.root.overview.shortTitle.cancel();
     assert.strictEqual(page.root.overview.shortTitle.text, 'Title (short): short_0');
     await page.root.overview.shortTitle.edit();
     await page.root.overview.shortTitle.set('newshort');

--- a/packages/frontend/tests/pages/components/program/overview.js
+++ b/packages/frontend/tests/pages/components/program/overview.js
@@ -7,6 +7,7 @@ const definition = {
     edit: clickable('[data-test-edit]'),
     set: fillable('input'),
     save: clickable('.done'),
+    cancel: clickable('.cancel'),
     editable: isPresent('[data-test-edit]'),
     value: text('[data-test-value]'),
     hasError: isPresent('[data-test-title-validation-error-message]'),


### PR DESCRIPTION
Fixes ilios/ilios#6874
Fixes ilios/ilios#6889

While updating the proper alignment of the Program overview label/value elements, I noticed that changing the shortTitle and then canceling did not do what it was supposed to do. So, that is rolled into this fix, as well.