### PR TITLE
add a 10ms delay to scrolling behaviour.

### DIFF
--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -43,7 +43,7 @@ export default class SessionDetailsComponent extends Component {
   <template>
     {{pageTitle " | Session: " @session.title}}
 
-    <div class="back-to-session" {{scrollIntoView delay=500}}>
+    <div class="back-to-session" {{scrollIntoView delay=10}}>
       <LinkTo @route="course" @model={{@session.course}} data-test-back-to-sessions>
         {{t "general.backToSessionList"}}
       </LinkTo>

--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -43,7 +43,7 @@ export default class SessionDetailsComponent extends Component {
   <template>
     {{pageTitle " | Session: " @session.title}}
 
-    <div class="back-to-session" {{scrollIntoView}}>
+    <div class="back-to-session" {{scrollIntoView delay=500}}>
       <LinkTo @route="course" @model={{@session.course}} data-test-back-to-sessions>
         {{t "general.backToSessionList"}}
       </LinkTo>


### PR DESCRIPTION
hold back on scrolling to to the "back to sessions" link due to glitchy behaviour when course details are expanded.
ymmw.

https://github.com/ilios/ilios/issues/6887