### PR TITLE
Breadcrumb links hover improvement

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
@@ -1,13 +1,8 @@
 @use "sass:math";
 
 .breadcrumbs {
-  $breadcrumb-border-color: var(--blue);
-  $breadcrumb-border: 1px solid $breadcrumb-border-color;
+  $breadcrumb-border: 1px solid var(--blue);
   $breadcrumb-height: 2rem;
-  $breadcrumb-arrow-color: $breadcrumb-border-color;
-  $breadcrumb-background: var(--white);
-  $breadcrumb-color: var(--blue);
-  $breadcrumb-link-color-hover: var(--white);
 
   display: inline-block;
   margin: 0.8rem;
@@ -16,17 +11,17 @@
   a {
     &:focus,
     &:hover {
-      color: $breadcrumb-link-color-hover;
+      color: var(--white);
       text-decoration: none;
     }
   }
 
   /* stylelint-disable property-disallowed-list */
   span {
-    background-color: $breadcrumb-background;
+    background-color: var(--white);
     border: $breadcrumb-border;
     border-left: 0;
-    color: $breadcrumb-color;
+    color: var(--blue);
     cursor: pointer;
     display: inline-block;
     font-size: 0.8rem;
@@ -54,26 +49,26 @@
     }
 
     &::before {
-      border-left-color: $breadcrumb-arrow-color;
+      border-left-color: var(--blue);
       margin-left: 1px;
       z-index: 1;
     }
 
     &::after {
-      border-left-color: $breadcrumb-background;
+      border-left-color: var(--white);
     }
 
     &:hover {
-      background-color: $breadcrumb-border-color;
-      color: $breadcrumb-link-color-hover;
+      background-color: var(--blue);
+      color: var(--white);
 
       a,
       button {
-        color: $breadcrumb-link-color-hover;
+        color: var(--white);
       }
 
       &::after {
-        border-left-color: $breadcrumb-border-color;
+        border-left-color: var(--blue);
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
@@ -7,7 +7,7 @@
   $breadcrumb-arrow-color: $breadcrumb-border-color;
   $breadcrumb-background: var(--white);
   $breadcrumb-color: var(--blue);
-  $breadcrumb-link-color-hover: var(--orange);
+  $breadcrumb-link-color-hover: var(--white);
 
   display: inline-block;
   margin: 0.8rem;
@@ -17,6 +17,7 @@
     &:focus,
     &:hover {
       color: $breadcrumb-link-color-hover;
+      text-decoration: none;
     }
   }
 
@@ -35,13 +36,6 @@
     padding: 0 math.div($breadcrumb-height, 4) 0 math.div($breadcrumb-height, 2);
     position: relative;
     text-decoration: none;
-
-    &:first-child {
-      border-bottom-left-radius: 3px;
-      border-left: $breadcrumb-border;
-      border-top-left-radius: 3px;
-      padding-left: math.div($breadcrumb-height, 2);
-    }
 
     &::after,
     &::before {
@@ -69,10 +63,31 @@
       border-left-color: $breadcrumb-background;
     }
 
-    &:last-child,
-    &:last-child:hover {
-      border-bottom-right-radius: 3px;
-      border-top-right-radius: 3px;
+    &:hover {
+      background-color: $breadcrumb-border-color;
+      color: $breadcrumb-link-color-hover;
+
+      a,
+      button {
+        color: $breadcrumb-link-color-hover;
+      }
+
+      &::after {
+        border-left-color: $breadcrumb-border-color;
+      }
+    }
+
+    &:first-child {
+      border-bottom-left-radius: 3px;
+      border-left: $breadcrumb-border;
+      border-top-left-radius: 3px;
+      padding-left: math.div($breadcrumb-height, 2);
+    }
+
+    &:last-child {
+      background-color: inherit;
+      border: none;
+      color: var(--black);
       cursor: default;
       padding-right: math.div($breadcrumb-height, 2);
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
@@ -86,9 +86,13 @@
 
     &:last-child {
       background-color: inherit;
-      border: none;
+      border-color: var(--lighter-grey);
+      border-bottom-right-radius: 3px;
+      border-top-right-radius: 3px;
       color: var(--black);
       cursor: default;
+      /* stylelint-disable scales/font-weights */
+      font-weight: 700;
       padding-right: math.div($breadcrumb-height, 2);
     }
 


### PR DESCRIPTION
Fixes ilios/ilios#6857

![breadcrumb-hover](https://github.com/user-attachments/assets/d58e88a3-c6ea-4538-804b-9f0fea8dfc10)

Breadcrumb links now do a color/bgcolor flip when hovered over, and the text does not underline. The last bit, where you currently are, has had its border removed and changed to neutral black color as it is not a link. Some re-organizing of rule order was necessary to pass linting, too.