### PR TITLE
Visualization "no data" translation message update

### DIFF
--- a/packages/frontend/tests/acceptance/course/visualizations-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { currentURL } from '@ember/test-helpers';
-import { setupApplicationTest } from 'frontend/tests/helpers';
+import { setupApplicationTest, takeScreenshot } from 'frontend/tests/helpers';
 import page from 'ilios-common/page-objects/course-visualizations';
 import { setupAuthentication } from 'ilios-common';
+import percySnapshot from '@percy/ember';
 
 module('Acceptance | course visualizations', function (hooks) {
   setupApplicationTest(hooks);
@@ -18,6 +19,8 @@ module('Acceptance | course visualizations', function (hooks) {
 
   test('visiting /data/courses/1', async function (assert) {
     await page.visit({ courseId: 1 });
+    await takeScreenshot(assert);
+    await percySnapshot(assert);
     assert.strictEqual(currentURL(), '/data/courses/1');
     assert.ok(page.visualizations.objectives.isVisible);
     assert.ok(page.visualizations.sessionTypes.isVisible);

--- a/packages/ilios-common/addon/components/course/visualize-objectives-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-objectives-graph.gjs
@@ -258,7 +258,7 @@ export default class CourseVisualizeObjectivesGraph extends Component {
             {{#if @showNoChartDataError}}
               <div class="with-hours" data-test-with-hours>
                 <p>
-                  {{t "general.objectivesWithNoLink"}}
+                  {{t "general.courseVisualizationsObjectivesGraphNoLink"}}
                   <FaIcon @icon={{faFaceMeh}} />
                 </p>
               </div>
@@ -283,7 +283,7 @@ export default class CourseVisualizeObjectivesGraph extends Component {
           {{else}}
             <div class="with-hours" data-test-with-hours>
               <p>
-                {{t "general.objectivesWithNoLink"}}
+                {{t "general.courseVisualizationsObjectivesGraphNoLink"}}
                 <FaIcon @icon={{faFaceMeh}} />
               </p>
             </div>
@@ -296,7 +296,7 @@ export default class CourseVisualizeObjectivesGraph extends Component {
               {{t "general.unusedObjectives"}}:
             </h4>
             <p>
-              {{t "general.objectivesWithNoHours"}}
+              {{t "general.courseVisualizationsObjectivesGraphNoHours"}}
             </p>
             <ul>
               {{#each (sortBy0 "meta.courseObjective.title" this.objectiveWithoutMinutes) as |obj|}}

--- a/packages/ilios-common/addon/components/course/visualize-objectives-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-objectives-graph.gjs
@@ -257,10 +257,8 @@ export default class CourseVisualizeObjectivesGraph extends Component {
           {{else}}
             {{#if @showNoChartDataError}}
               <div class="with-hours" data-test-with-hours>
-                <p>
-                  {{t "general.courseVisualizationsObjectivesGraphNoLink"}}
-                  <FaIcon @icon={{faFaceMeh}} />
-                </p>
+                {{t "general.courseVisualizationsObjectivesGraphNoLink"}}
+                <FaIcon @icon={{faFaceMeh}} />
               </div>
             {{/if}}
           {{/if}}

--- a/packages/ilios-common/addon/components/course/visualize-session-types-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-session-types-graph.gjs
@@ -217,14 +217,14 @@ export default class CourseVisualizeSessionTypesGraph extends Component {
           {{else}}
             {{#if @showNoChartDataError}}
               <div class="no-data" data-test-no-data>
-                {{t "general.courseVisualizationsNoSessions"}}
+                {{t "general.courseVisualizationsSessionTypesGraphNoData"}}
               </div>
             {{/if}}
           {{/if}}
         {{/if}}
         {{#if (and (not @isIcon) (not this.hasData))}}
           <div class="no-data" data-test-no-data>
-            {{t "general.courseVisualizationsNoSessions"}}
+            {{t "general.courseVisualizationsSessionTypesGraphNoData"}}
           </div>
         {{/if}}
         {{#if (and (not @isIcon) this.hasData @showDataTable)}}

--- a/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.gjs
@@ -210,14 +210,14 @@ export default class CourseVisualizeVocabulariesGraph extends Component {
           {{else}}
             {{#if @showNoChartDataError}}
               <div class="no-data" data-test-no-data>
-                {{t "general.courseVisualizationsNoSessionVocabularyTerms"}}
+                {{t "general.courseVisualizationsSessionVocabularyTermsGraphNoData"}}
               </div>
             {{/if}}
           {{/if}}
         {{/if}}
         {{#if (and (not @isIcon) (not this.hasData))}}
           <div class="no-data" data-test-no-data>
-            {{t "general.courseVisualizationsNoSessionVocabularyTerms"}}
+            {{t "general.courseVisualizationsSessionVocabularyTermsGraphNoData"}}
           </div>
         {{/if}}
         {{#if (and (not @isIcon) this.hasData @showDataTable)}}

--- a/packages/ilios-common/app/styles/ilios-common/components/course/visualize-objectives-graph.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/visualize-objectives-graph.scss
@@ -2,12 +2,9 @@
 
 .course-visualize-objectives-graph {
   .with-hours {
-    p {
-      margin-top: 0.5rem;
-    }
-
     .fa-face-meh {
       @include m.font-size("huge");
+      margin-top: 10px;
     }
   }
 

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -86,9 +86,9 @@ general:
   courseVisualizationsInstructorNoData: "{instructor} is not instructing any sessions in this course."
   courseVisualizationsInstructorsGraphNoData: No instructors have been linked to any sessions in this course.
   courseVisualizationsObjectivesGraphNoHours: "The following course objectives are either not linked to any session, or only linked to sessions without offering or duration data."
-  courseVisualizationsObjectivesGraphNoLink: No course objectives currently linked to instructional time.
+  courseVisualizationsObjectivesGraphNoLink: No course objectives are currently linked to instructional time.
   courseVisualizationsSessionTypeGraphNoData: "No vocabulary terms have been linked to any {sessionType} sessions in this course."
-  courseVisualizationsSessionTypesGraphNoData: No sessions currently linked to instructional time.
+  courseVisualizationsSessionTypesGraphNoData: No sessions are currently linked to instructional time.
   courseVisualizationsSessionVocabularyTermsGraphNoData: No vocabularies have been linked to any sessions in this course.
   courseVisualizationsTermGraphNoData: "The vocabulary term {term} has not been linked to any sessions in this course."
   courseVisualizationsVocabularyGraphNoData: "No {vocabulary} vocabulary terms have been linked to any sessions in this course."

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -83,11 +83,13 @@ general:
   courseTitle: Course Title
   courseTitlePlaceholder: Enter a title for this course
   courseVisualizations: Course Visualizations
-  courseVisualizationsNoSessions: "This course has no sessions."
-  courseVisualizationsNoSessionVocabularyTerms: No vocabularies have been linked to any sessions in this course.
   courseVisualizationsInstructorNoData: "{instructor} is not instructing any sessions in this course."
   courseVisualizationsInstructorsGraphNoData: No instructors have been linked to any sessions in this course.
+  courseVisualizationsObjectivesGraphNoHours: "The following course objectives are either not linked to any session, or only linked to sessions without offering or duration data."
+  courseVisualizationsObjectivesGraphNoLink: No course objectives currently linked to instructional time.
   courseVisualizationsSessionTypeGraphNoData: "No vocabulary terms have been linked to any {sessionType} sessions in this course."
+  courseVisualizationsSessionTypesGraphNoData: No sessions currently linked to instructional time.
+  courseVisualizationsSessionVocabularyTermsGraphNoData: No vocabularies have been linked to any sessions in this course.
   courseVisualizationsTermGraphNoData: "The vocabulary term {term} has not been linked to any sessions in this course."
   courseVisualizationsVocabularyGraphNoData: "No {vocabulary} vocabulary terms have been linked to any sessions in this course."
   currentlySearchingPrompt: searching...
@@ -253,8 +255,6 @@ general:
   notStarted: Not Started
   objectiveCount: "There {count, plural, =1 {is 1 objective} other {are # objectives}}"
   objectives: Objectives
-  objectivesWithNoHours: "The following course objectives are either not linked to any session, or only linked to sessions without offering or duration data."
-  objectivesWithNoLink: No course objectives currently linked to instructional time.
   offering: Offering
   offerings: Offerings
   overview: Overview

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -83,11 +83,13 @@ general:
   courseTitle: Titulo de Curso
   courseTitlePlaceholder: Entre en un título para este curso
   courseVisualizations: Visualizaciones de Cursos
-  courseVisualizationsNoSessions: Este curso no tiene sesiones.
-  courseVisualizationsNoSessionVocabularyTerms: No se han vinculado vocabularios a ninguna sesión de este curso.
   courseVisualizationsInstructorNoData: "{instructor} no está impartiendo ninguna sesión en este curso."
   courseVisualizationsInstructorsGraphNoData: No se han vinculado instructores a ninguna sesión de este curso.
+  courseVisualizationsObjectivesGraphNoHours: "Los siguientes objetivos del curso no están vinculados a ninguna sesión, o están vinculados sólo a las sesiones sin datos de duración."
+  courseVisualizationsObjectivesGraphNoLink: No hay objetivos del curso actualmente vinculados a tiempo de instrucción.
   courseVisualizationsSessionTypeGraphNoData: "No se han vinculado términos de vocabulario a ninguna sesión {sessionType} en este curso."
+  courseVisualizationsSessionTypesGraphNoData: No hay sesión actualmente vinculados a tiempo de instrucción.
+  courseVisualizationsSessionVocabularyTermsGraphNoData: No se han vinculado vocabularios a ninguna sesión de este curso.
   courseVisualizationsTermGraphNoData: "El término de vocabulario {term} no se ha vinculado a ninguna sesión de este curso."
   courseVisualizationsVocabularyGraphNoData: "No se han vinculado términos del vocabulario {vocabulary} a ninguna sesión de este curso."
   currentlySearchingPrompt: buscando...
@@ -253,8 +255,6 @@ general:
   notStarted: No Comenzado
   objectiveCount: "Hay {count, plural, =1 {1 objectivo} other {# objectivos}}"
   objectives: Objetivos
-  objectivesWithNoHours: "Los siguientes objetivos del curso no están vinculados a ninguna sesión, o están vinculados sólo a las sesiones sin datos de duración."
-  objectivesWithNoLink: No hay objetivos del curso actualmente vinculados a tiempo de instrucción.
   offering: Ofrecimiento
   offerings: Ofrecimientos
   overview: Visión Amplia

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -83,11 +83,13 @@ general:
   courseTitle: Titre de Cours
   courseTitlePlaceholder: Ajoutez titre par ce cours
   courseVisualizations: Cours Visualisations
-  courseVisualizationsNoSessions: Ce cours n'a pas de séances.
-  courseVisualizationsNoSessionVocabularyTerms: "Aucun vocabulaires n'a été lié à aucune session de ce cours."
   courseVisualizationsInstructorNoData: "{instructor} n'enseigne aucune séance dans ce cours."
   courseVisualizationsInstructorsGraphNoData: Aucun instructeur n'a été lié à aucune session de ce cours.
+  courseVisualizationsObjectivesGraphNoHours: "Les objectifs de cours suivant ne sont ou liés avec aucune séance, ou liés seulement aux séance sans offrir ou ou des données de durée."
+  courseVisualizationsObjectivesGraphNoLink: Nul objectifs de course actuellement lié au temps dénseignment.
   courseVisualizationsSessionTypeGraphNoData: "Aucun terme de vocabulaire n'a été lié à une session {sessionType} dans ce cours."
+  courseVisualizationsSessionTypesGraphNoData: Nul séance actuellement lié au temps dénseignment.
+  courseVisualizationsSessionVocabularyTermsGraphNoData: "Aucun vocabulaires n'a été lié à aucune session de ce cours."
   courseVisualizationsTermGraphNoData: "Le terme de vocabulaire {term} n'a été lié à aucune session de ce cours."
   courseVisualizationsVocabularyGraphNoData: "Aucun terme de vocabulaire {vocabulary} n'a été lié à aucune session de ce cours."
   currentlySearchingPrompt: Recherchent...
@@ -253,8 +255,6 @@ general:
   notStarted: Non Commencé
   objectiveCount: "Il y a {count, plural, =1 {1 objectif} other {# objectifs}}"
   objectives: Objectifs
-  objectivesWithNoHours: "Les objectifs de cours suivant ne sont ou liés avec aucune séance, ou liés seulement aux séance sans offrir ou ou des données de durée."
-  objectivesWithNoLink: Nul objectifs de course actuellement lié au temps dénseignment.
   offering: Offre
   offerings: Offres
   overview: Conception Général

--- a/packages/test-app/tests/integration/components/course/visualize-objectives-graph-test.gjs
+++ b/packages/test-app/tests/integration/components/course/visualize-objectives-graph-test.gjs
@@ -339,7 +339,7 @@ module('Integration | Component | course/visualize-objectives-graph', function (
     assert.ok(component.unlinkedObjectives.isPresent);
     assert.strictEqual(
       component.unlinkedObjectives.text,
-      'No course objectives currently linked to instructional time.',
+      'No course objectives are currently linked to instructional time.',
     );
   });
 

--- a/packages/test-app/tests/integration/components/course/visualize-session-types-graph-test.gjs
+++ b/packages/test-app/tests/integration/components/course/visualize-session-types-graph-test.gjs
@@ -275,7 +275,7 @@ module('Integration | Component | course/visualize-session-types-graph', functio
     assert.notOk(component.dataTable.isVisible);
     assert.strictEqual(
       component.noData.text,
-      'No sessions currently linked to instructional time.',
+      'No sessions are currently linked to instructional time.',
     );
   });
 

--- a/packages/test-app/tests/integration/components/course/visualize-session-types-graph-test.gjs
+++ b/packages/test-app/tests/integration/components/course/visualize-session-types-graph-test.gjs
@@ -273,7 +273,10 @@ module('Integration | Component | course/visualize-session-types-graph', functio
     );
     assert.notOk(component.chart.isVisible);
     assert.notOk(component.dataTable.isVisible);
-    assert.strictEqual(component.noData.text, 'This course has no sessions.');
+    assert.strictEqual(
+      component.noData.text,
+      'No sessions currently linked to instructional time.',
+    );
   });
 
   test('only zero time data', async function (assert) {


### PR DESCRIPTION
Fixes ilios/ilios#6893

This fixes one visualization route translation message (`SessionTypes`) to be more consistent with the `Objectives` message, and more accurate. It also reorganizes some translation labels to be better grouped, contextually.