### PR TITLE
Vocabular(ies/y) by Session Type now has proper unique `<title>`

### DIFF
--- a/packages/frontend/app/components/school/session-type-visualize-vocabularies.gjs
+++ b/packages/frontend/app/components/school/session-type-visualize-vocabularies.gjs
@@ -1,8 +1,21 @@
 import { LinkTo } from '@ember/routing';
 import { hash } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
+import { pageTitle } from 'ember-page-title';
 import VisualizeSessionTypeVocabulariesGraph from 'frontend/components/school/visualize-session-type-vocabularies-graph';
 <template>
+  {{pageTitle
+    "Schools | "
+    @model.school.title
+    " | "
+    (t "general.visualizations")
+    " | "
+    (t "general.sessionTypes")
+    " | "
+    @model.title
+    " | "
+    (t "general.vocabularies")
+  }}
   <section
     class="school-session-type-visualize-vocabularies data-visualization"
     data-test-school-session-type-visualize-vocabularies

--- a/packages/frontend/app/components/school/session-type-visualize-vocabularies.gjs
+++ b/packages/frontend/app/components/school/session-type-visualize-vocabularies.gjs
@@ -5,7 +5,8 @@ import { pageTitle } from 'ember-page-title';
 import VisualizeSessionTypeVocabulariesGraph from 'frontend/components/school/visualize-session-type-vocabularies-graph';
 <template>
   {{pageTitle
-    "Schools | "
+    (t "general.schools")
+    " | "
     @model.school.title
     " | "
     (t "general.visualizations")

--- a/packages/frontend/app/components/school/session-type-visualize-vocabulary.gjs
+++ b/packages/frontend/app/components/school/session-type-visualize-vocabulary.gjs
@@ -1,8 +1,23 @@
 import { LinkTo } from '@ember/routing';
 import { hash } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
+import { pageTitle } from 'ember-page-title';
 import VisualizeSessionTypeVocabularyGraph from 'frontend/components/school/visualize-session-type-vocabulary-graph';
 <template>
+  {{pageTitle
+    "Schools | "
+    @model.vocabulary.school.title
+    " | "
+    (t "general.visualizations")
+    " | "
+    (t "general.sessionTypes")
+    " | "
+    @model.sessionType.title
+    " | "
+    (t "general.vocabularies")
+    " | "
+    @model.vocabulary.title
+  }}
   <section
     class="school-session-type-visualize-vocabulary data-visualization"
     data-test-school-session-type-visualize-vocabulary

--- a/packages/frontend/app/components/school/session-type-visualize-vocabulary.gjs
+++ b/packages/frontend/app/components/school/session-type-visualize-vocabulary.gjs
@@ -5,7 +5,8 @@ import { pageTitle } from 'ember-page-title';
 import VisualizeSessionTypeVocabularyGraph from 'frontend/components/school/visualize-session-type-vocabulary-graph';
 <template>
   {{pageTitle
-    "Schools | "
+    (t "general.schools")
+    " | "
     @model.vocabulary.school.title
     " | "
     (t "general.visualizations")


### PR DESCRIPTION
Fixes ilios/ilios#6896