### PR TITLE
Add Cohort Members toggle component to Program Years

### DIFF
--- a/packages/frontend/app/components/program-year/cohort-members.gjs
+++ b/packages/frontend/app/components/program-year/cohort-members.gjs
@@ -1,0 +1,133 @@
+import Component from '@glimmer/component';
+import { cached, tracked } from '@glimmer/tracking';
+import { fn, uniqueId } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { LinkTo } from '@ember/routing';
+import { service } from '@ember/service';
+import { TrackedAsyncData } from 'ember-async-data';
+import t from 'ember-intl/helpers/t';
+import eq from 'ember-truth-helpers/helpers/eq';
+import or from 'ember-truth-helpers/helpers/or';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import SortableTh from 'ilios-common/components/sortable-th';
+import UserNameInfo from 'ilios-common/components/user-name-info';
+import sortBy from 'ilios-common/helpers/sort-by';
+import { faCaretDown, faCaretRight } from '@fortawesome/free-solid-svg-icons';
+
+export default class ProgramYearCohortMembersComponent extends Component {
+  @service iliosConfig;
+  @service intl;
+  @tracked sortBy = 'fullName';
+
+  @cached
+  get membersData() {
+    return new TrackedAsyncData(this.getMembers(this.args.programYear));
+  }
+
+  get members() {
+    return this.membersData.isResolved ? this.membersData.value : [];
+  }
+
+  get hasMembers() {
+    return !!this.members.length;
+  }
+
+  get sortedAscending() {
+    return !this.sortBy.includes(':desc');
+  }
+
+  @action
+  setSortBy(what) {
+    if (this.sortBy === what) {
+      what += ':desc';
+    }
+    this.sortBy = what;
+  }
+
+  async getMembers(programYear) {
+    const cohort = await programYear.cohort;
+    return await cohort.users;
+  }
+
+  <template>
+    {{#let (uniqueId) as |templateId|}}
+      <section class="program-year-cohort-members" data-test-program-year-cohort-members>
+        {{#if this.membersData.isResolved}}
+          <div class="header" data-test-header>
+            <h2 class="title" data-test-title>
+              {{#if this.hasMembers}}
+                {{#if @isExpanded}}
+                  <button
+                    class="title link-button"
+                    type="button"
+                    aria-expanded="true"
+                    aria-controls="content-{{templateId}}"
+                    data-test-toggle
+                    {{on "click" (fn @setIsExpanded false)}}
+                  >
+                    {{t "general.members"}}
+                    ({{this.members.length}})
+                    <FaIcon @icon={{faCaretDown}} />
+                  </button>
+                {{else}}
+                  <button
+                    class="title link-button"
+                    type="button"
+                    aria-expanded="false"
+                    aria-controls="content-{{templateId}}"
+                    data-test-toggle
+                    {{on "click" (fn @setIsExpanded true)}}
+                  >
+                    {{t "general.members"}}
+                    ({{this.members.length}})
+                    <FaIcon @icon={{faCaretRight}} />
+                  </button>
+                {{/if}}
+              {{else}}
+                {{t "general.members"}}
+                ({{this.members.length}})
+              {{/if}}
+            </h2>
+          </div>
+          {{#if this.hasMembers}}
+            <div
+              id="content-{{templateId}}"
+              class="content{{if @isExpanded '' ' hidden'}}"
+              data-test-content
+              hidden={{@isExpanded}}
+            >
+              <table
+                class="ilios-table ilios-table-colors ilios-zebra-table"
+                data-test-associations
+              >
+                <thead>
+                  <tr>
+                    <SortableTh
+                      @sortedAscending={{this.sortedAscending}}
+                      @onClick={{fn this.setSortBy "fullName"}}
+                      @sortedBy={{or (eq this.sortBy "fullName") (eq this.sortBy "fullName:desc")}}
+                    >
+                      {{t "general.name"}}
+                    </SortableTh>
+                  </tr>
+                </thead>
+                <tbody>
+                  {{#each (sortBy this.sortBy this.members) as |user|}}
+                    <tr>
+                      <td>
+                        <LinkTo @route="user" @model={{user}} data-test-user-link>
+                          <UserNameInfo @user={{user}} />
+                        </LinkTo>
+                      </td>
+                    </tr>
+                  {{/each}}
+                </tbody>
+              </table>
+            </div>
+          {{/if}}
+        {{/if}}
+      </section>
+    {{/let}}
+  </template>
+}

--- a/packages/frontend/app/components/program-year/cohort-members.gjs
+++ b/packages/frontend/app/components/program-year/cohort-members.gjs
@@ -97,10 +97,7 @@ export default class ProgramYearCohortMembersComponent extends Component {
               data-test-content
               hidden={{@isExpanded}}
             >
-              <table
-                class="ilios-table ilios-table-colors ilios-zebra-table"
-                data-test-associations
-              >
+              <table class="ilios-table ilios-table-colors ilios-zebra-table" data-test-members>
                 <thead>
                   <tr>
                     <SortableTh

--- a/packages/frontend/app/components/program-year/details.gjs
+++ b/packages/frontend/app/components/program-year/details.gjs
@@ -11,6 +11,7 @@ import CollapsedObjectives from 'frontend/components/program-year/collapsed-obje
 import DetailTaxonomies from 'ilios-common/components/detail-taxonomies';
 import CollapsedTaxonomies from 'ilios-common/components/collapsed-taxonomies';
 import CourseAssociations from 'frontend/components/program-year/course-associations';
+import CohortMembers from 'frontend/components/program-year/cohort-members';
 
 <template>
   <div class="programyear-details" data-test-program-year-details ...attributes>
@@ -75,6 +76,11 @@ import CourseAssociations from 'frontend/components/program-year/course-associat
       @programYear={{@programYear}}
       @isExpanded={{@showCourseAssociations}}
       @setIsExpanded={{@setShowCourseAssociations}}
+    />
+    <CohortMembers
+      @programYear={{@programYear}}
+      @isExpanded={{@showCohortMembers}}
+      @setIsExpanded={{@setShowCohortMembers}}
     />
   </div>
 </template>

--- a/packages/frontend/app/controllers/program-year.js
+++ b/packages/frontend/app/controllers/program-year.js
@@ -11,6 +11,7 @@ export default class ProgramYearIndexController extends Controller {
     'managePyCompetencies',
     'managePyLeadership',
     'showCourseAssociations',
+    'showCohortMembers',
     'expandedObjectives',
   ];
 
@@ -22,6 +23,7 @@ export default class ProgramYearIndexController extends Controller {
   @tracked managePyCompetencies = false;
   @tracked managePyLeadership = false;
   @tracked showCourseAssociations = false;
+  @tracked showCohortMembers = false;
   @tracked expandedObjectives = null;
 
   @cached

--- a/packages/frontend/app/routes/program-year.js
+++ b/packages/frontend/app/routes/program-year.js
@@ -17,6 +17,7 @@ export default class ProgramYearRoute extends Route {
     pyLeadershipDetails: { replace: true },
     managePyCompetencies: { replace: true },
     managePyLeadership: { replace: true },
+    showCohortMembers: { replace: true },
     expandedObjectives: { replace: true },
   };
 

--- a/packages/frontend/app/styles/components.scss
+++ b/packages/frontend/app/styles/components.scss
@@ -95,6 +95,7 @@
 @forward "components/program/header";
 @forward "components/program/new";
 
+@forward "components/program-year/cohort-members";
 @forward "components/program-year/collapsed-objectives";
 @forward "components/program-year/competencies";
 @forward "components/program-year/course-associations";

--- a/packages/frontend/app/styles/components/program-year/cohort-members.scss
+++ b/packages/frontend/app/styles/components/program-year/cohort-members.scss
@@ -1,0 +1,27 @@
+@use "../../ilios-common/mixins" as m;
+
+.program-year-cohort-members {
+  @include m.detail-container-content;
+
+  .header {
+    @include m.detail-container-header;
+
+    .title {
+      @include m.collapsed-container-title;
+    }
+  }
+
+  .content {
+    @include m.main-list-box-table;
+
+    &.hidden {
+      display: none;
+    }
+
+    tbody {
+      td {
+        vertical-align: top;
+      }
+    }
+  }
+}

--- a/packages/frontend/app/styles/components/program-year/course-associations.scss
+++ b/packages/frontend/app/styles/components/program-year/course-associations.scss
@@ -1,7 +1,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .program-year-course-associations {
-  @include m.detail-container-content;
+  @include m.detail-container(var(--orange));
 
   .header {
     @include m.detail-container-header;

--- a/packages/frontend/app/templates/program-year.gjs
+++ b/packages/frontend/app/templates/program-year.gjs
@@ -23,6 +23,8 @@ import set from 'ember-set-helper/helpers/set';
     @setManageProgramYearLeadership={{set @controller "managePyLeadership"}}
     @showCourseAssociations={{@controller.showCourseAssociations}}
     @setShowCourseAssociations={{set @controller "showCourseAssociations"}}
+    @showCohortMembers={{@controller.showCohortMembers}}
+    @setShowCohortMembers={{set @controller "showCohortMembers"}}
     @expandedObjectiveIds={{@controller.expandedObjectiveIds}}
     @setExpandedObjectiveIds={{@controller.setExpandedObjectiveIds}}
   />

--- a/packages/frontend/tests/acceptance/program-year/cohort-members-test.js
+++ b/packages/frontend/tests/acceptance/program-year/cohort-members-test.js
@@ -1,0 +1,63 @@
+import { currentURL } from '@ember/test-helpers';
+import percySnapshot from '@percy/ember';
+import { test, module } from 'qunit';
+import { setupAuthentication } from 'ilios-common';
+import { setupApplicationTest, takeScreenshot } from 'frontend/tests/helpers';
+import page from 'frontend/tests/pages/program-year';
+
+module('Acceptance | Program Year - Cohort members', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(async function () {
+    const school = this.server.create('school');
+    await setupAuthentication({ school, administeredSchools: [school] });
+    const program = this.server.create('program', { school });
+    const programYear = this.server.create('program-year', { program });
+    const cohort = this.server.create('cohort', { programYear });
+    this.server.create('user', { cohorts: [cohort] });
+    this.program = program;
+    this.programYear = programYear;
+  });
+
+  test('expand and collapse cohort members', async function (assert) {
+    await page.visit({ programId: this.program.id, programYearId: this.programYear.id });
+    await takeScreenshot(assert);
+    await percySnapshot(assert);
+    assert.strictEqual(
+      currentURL(),
+      `/programs/${this.program.id}/programyears/${this.programYear.id}`,
+    );
+    assert.ok(page.details.cohortMembers.header.title, 'Members (1)');
+    assert.ok(page.details.cohortMembers.header.toggle.isCollapsed);
+
+    await page.details.cohortMembers.header.toggle.click();
+    assert.ok(page.details.cohortMembers.header.toggle.isExpanded);
+    assert.strictEqual(
+      currentURL(),
+      `/programs/${this.program.id}/programyears/${this.programYear.id}?showCohortMembers=true`,
+    );
+
+    await page.details.cohortMembers.header.toggle.click();
+    assert.ok(page.details.cohortMembers.header.toggle.isCollapsed);
+    assert.strictEqual(
+      currentURL(),
+      `/programs/${this.program.id}/programyears/${this.programYear.id}`,
+    );
+  });
+
+  test('cohort members are expanded if URL contains corresponding parameter', async function (assert) {
+    await page.visit({
+      programId: this.program.id,
+      programYearId: this.programYear.id,
+      showCohortMembers: 'true',
+    });
+    await takeScreenshot(assert);
+    await percySnapshot(assert);
+    assert.strictEqual(
+      currentURL(),
+      `/programs/${this.program.id}/programyears/${this.programYear.id}?showCohortMembers=true`,
+    );
+    assert.ok(page.details.cohortMembers.header.title, 'Members (1)');
+    assert.ok(page.details.cohortMembers.header.toggle.isExpanded);
+  });
+});

--- a/packages/frontend/tests/integration/components/program-year/cohort-members-test.gjs
+++ b/packages/frontend/tests/integration/components/program-year/cohort-members-test.gjs
@@ -1,0 +1,201 @@
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import noop from 'ilios-common/helpers/noop';
+import { setupRenderingTest } from 'frontend/tests/helpers';
+import { setupMirage } from 'frontend/tests/test-support/mirage';
+import { component } from 'frontend/tests/pages/components/program-year/cohort-members';
+import CohortMembers from 'frontend/components/program-year/cohort-members';
+
+module('Integration | Component | program-year/cohort-members', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    const school = this.server.create('school');
+    const program = this.server.create('program', { school });
+    const programYear = this.server.create('program-year', { program });
+    this.cohort = this.server.create('cohort', { programYear });
+    this.programYear = programYear;
+    this.school = school;
+  });
+
+  test('it renders expanded with data', async function (assert) {
+    const otherSchool = this.server.create('school');
+    this.server.createList('user', 3, {
+      cohorts: [this.cohort],
+    });
+    this.server.create('course', { school: otherSchool, year: 2025, cohorts: [this.cohort] });
+
+    const programYear = await this.owner
+      .lookup('service:store')
+      .findRecord('program-year', this.programYear.id);
+    this.set('programYear', programYear);
+    await render(
+      <template>
+        <CohortMembers
+          @programYear={{this.programYear}}
+          @isExpanded={{true}}
+          @setIsExpanded={{(noop)}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(component.header.toggle.ariaControls, component.content.id);
+    assert.notOk(component.header.toggle.isCollapsed);
+    assert.ok(component.header.toggle.isExpanded);
+    assert.strictEqual(component.header.toggle.ariaExpanded, 'true');
+    assert.notOk(component.content.isHidden);
+    assert.strictEqual(component.header.title, 'Members (3)');
+
+    assert.strictEqual(component.content.headers.member.text, 'Name');
+
+    assert.strictEqual(component.content.members.length, 3);
+    assert.strictEqual(component.content.members[0].member.text, '0 guy M. Mc0son');
+    assert.strictEqual(component.content.members[0].member.link, '/users/1');
+    assert.strictEqual(component.content.members[1].member.text, '1 guy M. Mc1son');
+    assert.strictEqual(component.content.members[1].member.link, '/users/2');
+    assert.strictEqual(component.content.members[2].member.text, '2 guy M. Mc2son');
+    assert.strictEqual(component.content.members[2].member.link, '/users/3');
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders collapsed with data', async function (assert) {
+    const otherSchool = this.server.create('school');
+    this.server.createList('user', 3, {
+      cohorts: [this.cohort],
+    });
+    this.server.create('course', { school: otherSchool, year: 2025, cohorts: [this.cohort] });
+
+    const programYear = await this.owner
+      .lookup('service:store')
+      .findRecord('program-year', this.programYear.id);
+    this.set('programYear', programYear);
+    await render(
+      <template>
+        <CohortMembers
+          @programYear={{this.programYear}}
+          @isExpanded={{false}}
+          @setIsExpanded={{(noop)}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(component.header.toggle.ariaControls, component.content.id);
+    assert.ok(component.header.toggle.isCollapsed);
+    assert.notOk(component.header.toggle.isExpanded);
+    assert.strictEqual(component.header.toggle.ariaExpanded, 'false');
+    assert.ok(component.content.isHidden);
+    assert.strictEqual(component.header.title, 'Members (3)');
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders without data', async function (assert) {
+    const programYear = await this.owner
+      .lookup('service:store')
+      .findRecord('program-year', this.programYear.id);
+    this.set('programYear', programYear);
+    await render(
+      <template>
+        <CohortMembers
+          @programYear={{this.programYear}}
+          @isExpanded={{false}}
+          @setIsExpanded={{(noop)}}
+        />
+      </template>,
+    );
+
+    assert.notOk(component.header.toggle.isPresent);
+    assert.strictEqual(component.header.title, 'Members (0)');
+    assert.notOk(component.content.isPresent);
+  });
+
+  test('sorting works', async function (assert) {
+    this.server.createList('user', 2, {
+      cohorts: [this.cohort],
+    });
+
+    const programYear = await this.owner
+      .lookup('service:store')
+      .findRecord('program-year', this.programYear.id);
+    this.set('programYear', programYear);
+    await render(
+      <template>
+        <CohortMembers
+          @programYear={{this.programYear}}
+          @isExpanded={{true}}
+          @setIsExpanded={{(noop)}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(component.content.members.length, 2);
+    assert.ok(component.content.headers.member.isSortedAscending);
+    assert.strictEqual(component.content.members[0].member.text, '0 guy M. Mc0son');
+    assert.strictEqual(component.content.members[1].member.text, '1 guy M. Mc1son');
+
+    await component.content.headers.member.sort();
+    assert.ok(component.content.headers.member.isSortedDescending);
+    assert.strictEqual(component.content.members[0].member.text, '1 guy M. Mc1son');
+    assert.strictEqual(component.content.members[1].member.text, '0 guy M. Mc0son');
+
+    await component.content.headers.member.sort();
+    assert.ok(component.content.headers.member.isSortedAscending);
+    assert.strictEqual(component.content.members[0].member.text, '0 guy M. Mc0son');
+    assert.strictEqual(component.content.members[1].member.text, '1 guy M. Mc1son');
+  });
+
+  test('collapse action fires', async function (assert) {
+    this.server.create('user', {
+      cohorts: [this.cohort],
+    });
+    const programYear = await this.owner
+      .lookup('service:store')
+      .findRecord('program-year', this.programYear.id);
+    this.set('programYear', programYear);
+    this.set('setIsExpanded', (value) => {
+      assert.step('setIsExpanded called');
+      assert.notOk(value);
+    });
+    await render(
+      <template>
+        <CohortMembers
+          @programYear={{this.programYear}}
+          @isExpanded={{true}}
+          @setIsExpanded={{this.setIsExpanded}}
+        />
+      </template>,
+    );
+
+    await component.header.toggle.click();
+    assert.verifySteps(['setIsExpanded called']);
+  });
+
+  test('expand action fires', async function (assert) {
+    this.server.create('user', {
+      cohorts: [this.cohort],
+    });
+    const programYear = await this.owner
+      .lookup('service:store')
+      .findRecord('program-year', this.programYear.id);
+    this.set('programYear', programYear);
+    this.set('setIsExpanded', (value) => {
+      assert.step('setIsExpanded called');
+      assert.ok(value);
+    });
+    await render(
+      <template>
+        <CohortMembers
+          @programYear={{this.programYear}}
+          @isExpanded={{false}}
+          @setIsExpanded={{this.setIsExpanded}}
+        />
+      </template>,
+    );
+
+    await component.header.toggle.click();
+    assert.verifySteps(['setIsExpanded called']);
+  });
+});

--- a/packages/frontend/tests/pages/components/program-year/cohort-members.js
+++ b/packages/frontend/tests/pages/components/program-year/cohort-members.js
@@ -1,0 +1,48 @@
+import {
+  attribute,
+  clickable,
+  collection,
+  create,
+  hasClass,
+  isPresent,
+  text,
+} from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-program-year-cohort-members]',
+  header: {
+    scope: '[data-test-header]',
+    title: text('[data-test-title]'),
+    toggle: {
+      scope: '[data-test-toggle]',
+      isCollapsed: isPresent('[data-icon="caret-right"]'),
+      isExpanded: isPresent('[data-icon="caret-down"]'),
+      ariaExpanded: attribute('aria-expanded'),
+      ariaControls: attribute('aria-controls'),
+    },
+  },
+  content: {
+    scope: '[data-test-content]',
+    id: attribute('id'),
+    isHidden: hasClass('hidden'),
+    headers: {
+      scope: '[data-test-members] thead tr:nth-of-type(1)',
+      member: {
+        scope: 'th:nth-of-type(1)',
+        isSortedAscending: hasClass('fa-arrow-down-a-z', 'svg'),
+        isSortedDescending: hasClass('fa-arrow-down-z-a', 'svg'),
+        isNotSorted: hasClass('fa-sort', 'svg'),
+        sort: clickable('button'),
+      },
+    },
+    members: collection('[data-test-members] tbody tr', {
+      member: {
+        scope: 'td:nth-of-type(1)',
+        link: attribute('href', 'a'),
+      },
+    }),
+  },
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/frontend/tests/pages/components/program-year/details.js
+++ b/packages/frontend/tests/pages/components/program-year/details.js
@@ -2,6 +2,7 @@ import { create } from 'ember-cli-page-object';
 import objectives from './objectives';
 import competencies from './competencies';
 import courseAssociations from './course-associations';
+import cohortMembers from './cohort-members';
 import expandedLeadership from 'ilios-common/page-objects/components/leadership-expanded';
 import detailTaxonomies from 'ilios-common/page-objects/components/detail-taxonomies';
 import collapsedTaxonomies from 'ilios-common/page-objects/components/collapsed-taxonomies';
@@ -16,6 +17,7 @@ const definition = {
   expandedLeadership,
   collapsedLeadership,
   courseAssociations,
+  cohortMembers,
 };
 
 export default definition;


### PR DESCRIPTION
Fixes ilios/ilios#6872

This adds a `ProgramYearCohortMembers` component and places it under the `AssociatedCourses` component on a `ProgramYear` detail route. It works much like that component, except it shows members, and they link to their user detail route.