### PR TITLE
added a parenthetical course and status to 'back to session list' link

### DIFF
--- a/packages/frontend/tests/acceptance/course/session/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/session/overview-test.js
@@ -19,6 +19,40 @@ module('Acceptance | Session - Overview', function (hooks) {
     });
   });
 
+  test('check back to sessions list', async function (assert) {
+    await setupAuthentication(
+      {
+        school: this.school,
+        administeredSchools: [this.school],
+      },
+      true,
+    );
+    this.server.create('session', {
+      course: this.course,
+      sessionType: this.sessionTypes[0],
+    });
+    await page.visit({ courseId: 1, sessionId: 1 });
+    assert.strictEqual(page.backToSessions.text, 'Back to Session List');
+    assert.strictEqual(page.courseAndStatus.course, 'course 0');
+    assert.strictEqual(page.courseAndStatus.status, 'Not Published');
+
+    const coursePublished = this.server.create('course', {
+      id: 2,
+      school: this.school,
+      published: true,
+    });
+    this.server.create('session', {
+      id: 1,
+      course: coursePublished,
+      sessionType: this.sessionTypes[0],
+    });
+
+    await page.visit({ courseId: 2, sessionId: 1 });
+    assert.strictEqual(page.backToSessions.text, 'Back to Session List');
+    assert.strictEqual(page.courseAndStatus.course, 'course 1');
+    assert.strictEqual(page.courseAndStatus.status, 'Published');
+  });
+
   test('check fields', async function (assert) {
     await setupAuthentication(
       {

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/session.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/session.js
@@ -3,13 +3,13 @@ import details from './components/session-details';
 
 export default create({
   visit: visitable('/courses/:courseId/sessions/:sessionId'),
-  backToSessions: {
-    scope: '[data-test-back-to-sessions]',
-  },
   courseAndStatus: {
     scope: '[data-test-course-and-status]',
     course: text('[data-test-course]'),
     status: text('[data-test-status]'),
+  },
+  backToSessions: {
+    scope: '[data-test-back-to-sessions]',
   },
   details,
 });

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/session.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/session.js
@@ -1,10 +1,15 @@
-import { create, visitable } from 'ember-cli-page-object';
+import { create, text, visitable } from 'ember-cli-page-object';
 import details from './components/session-details';
 
 export default create({
   visit: visitable('/courses/:courseId/sessions/:sessionId'),
   backToSessions: {
     scope: '[data-test-back-to-sessions]',
+  },
+  courseAndStatus: {
+    scope: '[data-test-course-and-status]',
+    course: text('[data-test-course]'),
+    status: text('[data-test-status]'),
   },
   details,
 });

--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -20,6 +20,7 @@ import DetailTaxonomies from 'ilios-common/components/detail-taxonomies';
 import CollapsedTaxonomies from 'ilios-common/components/collapsed-taxonomies';
 import DetailMesh from 'ilios-common/components/detail-mesh';
 import SessionOfferings from 'ilios-common/components/session-offerings';
+import PublicationStatus from 'ilios-common/components/publication-status';
 import { pageTitle } from 'ember-page-title';
 
 export default class SessionDetailsComponent extends Component {
@@ -28,17 +29,21 @@ export default class SessionDetailsComponent extends Component {
     return new TrackedAsyncData(this.args.session.course);
   }
 
+  get course() {
+    return this.courseData.isResolved ? this.courseData.value : null;
+  }
+
   @cached
   get cohortsData() {
     return new TrackedAsyncData(this.course?.cohorts);
   }
 
-  get course() {
-    return this.courseData.isResolved ? this.courseData.value : null;
-  }
-
   get cohorts() {
     return this.cohortsData.isResolved ? this.cohortsData.value : null;
+  }
+
+  get courseTitle() {
+    return this.course.externalId?.trim() || this.course.title;
   }
   <template>
     {{pageTitle " | Session: " @session.title}}
@@ -47,6 +52,14 @@ export default class SessionDetailsComponent extends Component {
       <LinkTo @route="course" @model={{@session.course}} data-test-back-to-sessions>
         {{t "general.backToSessionList"}}
       </LinkTo>
+      {{#if this.course}}
+        <span class="course-and-status" data-test-course-and-status>
+          <span data-test-title>({{this.courseTitle}}</span>
+          <span class="status" data-test-status>
+            <PublicationStatus @item={{this.course}} @showText={{false}} />)
+          </span>
+        </span>
+      {{/if}}
     </div>
 
     <section class="session-details" data-test-session-details>

--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -49,19 +49,17 @@ export default class SessionDetailsComponent extends Component {
     {{pageTitle " | Session: " @session.title}}
 
     <div class="back-to-session" {{scrollIntoView delay=10}}>
-      <LinkTo @route="course" @model={{@session.course}} data-test-back-to-sessions>
-        {{t "general.backToSessionList"}}
-      </LinkTo>
       {{#if this.course}}
         <span class="course-and-status" data-test-course-and-status>
-          (
-          <span class="course" data-test-course>{{this.courseTitle}}</span>
           <span class="status" data-test-status>
             <PublicationStatus @item={{this.course}} @showText={{false}} />
           </span>
-          )
+          <span class="course" data-test-course>{{this.courseTitle}}</span>
         </span>
       {{/if}}
+      <LinkTo @route="course" @model={{@session.course}} data-test-back-to-sessions>
+        {{t "general.backToSessionList"}}
+      </LinkTo>
     </div>
 
     <section class="session-details" data-test-session-details>

--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -54,10 +54,12 @@ export default class SessionDetailsComponent extends Component {
       </LinkTo>
       {{#if this.course}}
         <span class="course-and-status" data-test-course-and-status>
-          <span data-test-title>({{this.courseTitle}}</span>
+          (
+          <span class="course" data-test-course>{{this.courseTitle}}</span>
           <span class="status" data-test-status>
-            <PublicationStatus @item={{this.course}} @showText={{false}} />)
+            <PublicationStatus @item={{this.course}} @showText={{false}} />
           </span>
+          )
         </span>
       {{/if}}
     </div>

--- a/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
@@ -6,8 +6,12 @@
   .course-and-status {
     display: flex;
 
+    .status {
+      padding-right: 3px;
+    }
+
     .course {
-      padding-right: 5px;
+      padding-right: 10px;
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
@@ -5,10 +5,9 @@
 
   .course-and-status {
     display: flex;
-    gap: 5px;
 
-    .status {
-      display: flex;
+    .course {
+      padding-right: 5px;
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
@@ -1,5 +1,16 @@
 .back-to-session {
+  display: flex;
+  gap: 5px;
   margin-bottom: 1rem;
+
+  .course-and-status {
+    display: flex;
+    gap: 5px;
+
+    .status {
+      display: flex;
+    }
+  }
 }
 
 .session-details {


### PR DESCRIPTION
Fixes ilios/ilios#6846

<img width="642" height="292" alt="Screenshot 2026-02-06 at 10 06 40 AM" src="https://github.com/user-attachments/assets/c5e9ac49-1817-486b-acdb-39d79f6df5db" />

Adds a parenthetical label to the `Back to Session List` link at the top of a session detail route. It contains the `Course` `externalId` if existing, otherwise the `title`. It also has the icon for the `Course`'s publication status.