### PR TITLE
Remove text underline on button hover

### DIFF
--- a/packages/frontend/app/styles/components/reports/switcher.scss
+++ b/packages/frontend/app/styles/components/reports/switcher.scss
@@ -4,6 +4,7 @@
   display: flex;
   justify-content: center;
   margin: 1em;
+
   a {
     background-color: var(--white);
     color: var(--blue);
@@ -16,6 +17,7 @@
 
     &:hover {
       cursor: pointer;
+      text-decoration: none;
     }
 
     &.active {

--- a/packages/frontend/app/styles/components/unassigned-students-summary.scss
+++ b/packages/frontend/app/styles/components/unassigned-students-summary.scss
@@ -3,5 +3,9 @@
 .unassigned-students-summary {
   .manage-link {
     @include m.ilios-button;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }


### PR DESCRIPTION
Fixes ilios/ilios#6878

I did a few sweeps of the site, and the only two I could find were on the Subject/Curriculum switcher and the Unassigned Students Summary manage buttons.