### PR TITLE
group ember-intl package dependency updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
         patterns:
           - "@ember-data/*"
           - "@warp-drive/*"
+      ember-intl:
+        patterns:
+          - "ember-intl"
+          - "@ember-intl/*"
       fontawesome:
         patterns:
           - "@fortawesome/*"


### PR DESCRIPTION
with ember-intl v7, we're now consuming three related packages instead of one. let's group their dependency updates as they seem to  release together.