### PR TITLE
remove on-focus styling from header menu item.

### DIFF
--- a/packages/frontend/app/styles/shared/header-menu.scss
+++ b/packages/frontend/app/styles/shared/header-menu.scss
@@ -55,8 +55,7 @@
         color: var(--white);
       }
 
-      &:hover,
-      &:focus {
+      &:hover {
         background-color: var(--blue);
         color: var(--white);
         &[aria-checked="true"],


### PR DESCRIPTION
applying styles on focus turns out to be too much - the first header list item is always in focus when the menu is expanded, permanently coloring it blue.
that's not what we want.
removing the :focus pseudo-class seems to be the only viable option here.

fixes ilios/ilios#6912