### PR TITLE
better differentiate active, focus, and hover states in header menus

### DIFF
--- a/packages/frontend/app/components/locale-chooser.gjs
+++ b/packages/frontend/app/components/locale-chooser.gjs
@@ -95,13 +95,7 @@ export default class LocaleChooserComponent extends Component {
         break;
     }
   }
-  @action
-  clearFocus(event) {
-    const buttons = event.target.parentElement.children;
-    for (let i = 0; i < buttons.length; i++) {
-      buttons[i].blur();
-    }
-  }
+
   @action
   toggleMenu(event) {
     const { key } = event;
@@ -151,7 +145,7 @@ export default class LocaleChooserComponent extends Component {
               data-test-item
               {{on "click" (fn this.changeLocale loc.id)}}
               {{on "keydown" this.moveFocus}}
-              {{on "mouseenter" this.clearFocus}}
+              {{on "keyup" this.moveFocus}}
               {{focus (eq index 0)}}
             >
               {{loc.text}}

--- a/packages/frontend/app/components/locale-chooser.gjs
+++ b/packages/frontend/app/components/locale-chooser.gjs
@@ -145,7 +145,6 @@ export default class LocaleChooserComponent extends Component {
               data-test-item
               {{on "click" (fn this.changeLocale loc.id)}}
               {{on "keydown" this.moveFocus}}
-              {{on "keyup" this.moveFocus}}
               {{focus (eq index 0)}}
             >
               {{loc.text}}

--- a/packages/frontend/app/styles/shared/header-menu.scss
+++ b/packages/frontend/app/styles/shared/header-menu.scss
@@ -49,22 +49,8 @@
       text-decoration: none;
       white-space: nowrap;
 
-      &[aria-checked="true"],
-      &.active {
-        background-color: var(--green);
-        border-color: var(--green);
-        color: var(--white);
-        cursor: default;
-        &:focus {
-          border-color: var(--white);
-        }
-        &:hover {
-          background-color: var(--green);
-        }
-      }
       &:focus {
-        border-color: var(--black);
-        border-style: dashed;
+        border-color: var(--grey);
         border-collapse: separate;
       }
 
@@ -73,7 +59,21 @@
         border-color: var(--blue);
         color: var(--white);
         &:focus {
-          border-color: var(--white);
+          border-color: var(--lightest-blue);
+        }
+      }
+
+      &[aria-checked="true"],
+      &.active {
+        background-color: var(--green);
+        border-color: var(--green);
+        color: var(--white);
+        cursor: default;
+        &:focus {
+          border-color: var(--lightest-green);
+        }
+        &:hover {
+          background-color: var(--green);
         }
       }
     }

--- a/packages/frontend/app/styles/shared/header-menu.scss
+++ b/packages/frontend/app/styles/shared/header-menu.scss
@@ -53,16 +53,25 @@
       &.active {
         background-color: var(--green);
         color: var(--white);
+        cursor: default;
+        &:hover {
+          border-color: var(--white);
+        }
+        &:focus {
+          background-color: var(--green);
+        }
       }
 
-      &:hover,
+      &:hover {
+        border: 2px dashed var(--black);
+        border-collapse: separate;
+      }
+
       &:focus {
         background-color: var(--blue);
         color: var(--white);
-        &[aria-checked="true"],
-        &.active {
-          background-color: var(--green);
-          cursor: default;
+        &:hover {
+          border-color: var(--white);
         }
       }
     }

--- a/packages/frontend/app/styles/shared/header-menu.scss
+++ b/packages/frontend/app/styles/shared/header-menu.scss
@@ -35,7 +35,7 @@
     }
 
     .header-menu-item {
-      border: 0;
+      border: 2px solid var(--super-light-grey);
       background-color: var(--super-light-grey);
       color: var(--black);
       display: block;
@@ -52,6 +52,7 @@
       &[aria-checked="true"],
       &.active {
         background-color: var(--green);
+        border-color: var(--green);
         color: var(--white);
         cursor: default;
         &:hover {
@@ -59,16 +60,19 @@
         }
         &:focus {
           background-color: var(--green);
+          border-color: var(--green);
         }
       }
 
       &:hover {
-        border: 2px dashed var(--black);
+        border-color: var(--black);
+        border-style: dashed;
         border-collapse: separate;
       }
 
       &:focus {
         background-color: var(--blue);
+        border-color: var(--blue);
         color: var(--white);
         &:hover {
           border-color: var(--white);

--- a/packages/frontend/app/styles/shared/header-menu.scss
+++ b/packages/frontend/app/styles/shared/header-menu.scss
@@ -55,26 +55,24 @@
         border-color: var(--green);
         color: var(--white);
         cursor: default;
-        &:hover {
+        &:focus {
           border-color: var(--white);
         }
-        &:focus {
+        &:hover {
           background-color: var(--green);
-          border-color: var(--green);
         }
       }
-
-      &:hover {
+      &:focus {
         border-color: var(--black);
         border-style: dashed;
         border-collapse: separate;
       }
 
-      &:focus {
+      &:hover {
         background-color: var(--blue);
         border-color: var(--blue);
         color: var(--white);
-        &:hover {
+        &:focus {
           border-color: var(--white);
         }
       }

--- a/packages/frontend/tests/integration/components/locale-chooser-test.gjs
+++ b/packages/frontend/tests/integration/components/locale-chooser-test.gjs
@@ -141,19 +141,6 @@ module('Integration | Component | locale-chooser', function (hooks) {
     assert.strictEqual(component.locales.length, 0, 'tab key closes menu');
   });
 
-  test('mouse entering locale-button clears focus', async function (assert) {
-    await render(<template><LocaleChooser /></template>);
-    await component.toggle.click();
-    assert.strictEqual(component.locales.length, 3);
-    assert.ok(component.locales[0].hasFocus);
-    assert.notOk(component.locales[1].hasFocus);
-    assert.notOk(component.locales[2].hasFocus);
-    await component.locales[0].mouseEnter();
-    assert.notOk(component.locales[0].hasFocus);
-    assert.notOk(component.locales[1].hasFocus);
-    assert.notOk(component.locales[2].hasFocus);
-  });
-
   test('changing locale', async function (assert) {
     await render(<template><LocaleChooser /></template>);
     assert.strictEqual(component.toggle.text, 'English (en)');

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -20,6 +20,7 @@
   --darker-yellow: hsl(45, 100%, 20%);
 
   --green: hsl(115, 100%, 20%);
+  --lightest-green: hsl(115, 100%, 92%);
   --transparent-green: hsl(115, 50%, 50%, 20%);
 
   --blue: hsl(195, 50%, 35%);


### PR DESCRIPTION
fourth attempt at fixing this. this time around, i'm de-emphasizing the hover state.

a grey, solid border now indicates that the given menu item is in focus. green background still indicates the active menu item. a blue background now highlights the menu item that the user is hovering over, with the exception of the currently active item (which remains green). focused elements in a hover and active state have light-green and light-blue solid borders around.

<img width="511" height="238" alt="image" src="https://github.com/user-attachments/assets/cb8f0d99-db30-4717-bf1d-db99bfaf5072" />

<img width="508" height="202" alt="image" src="https://github.com/user-attachments/assets/749acd7e-f8f8-4b0a-8746-054e1325aad7" />

<img width="508" height="217" alt="image" src="https://github.com/user-attachments/assets/343878c6-0c40-405f-a4df-48ab497880ba" />

<img width="291" height="243" alt="image" src="https://github.com/user-attachments/assets/78c2e949-1745-43a6-8181-e38797078962" />

<img width="448" height="229" alt="image" src="https://github.com/user-attachments/assets/4ba736f5-aecc-4b57-89b3-a71c053bdd67" />


let me know what you think, thanks.

fixes ilios/ilios#6912

