### PR TITLE
drop obsolete enlint-env config comments.

### DIFF
--- a/packages/frontend/config/coverage.js
+++ b/packages/frontend/config/coverage.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 module.exports = {
   //we need to go up two directories to get to the root of the monorepo
   reporters: [['lcov', { projectRoot: '../..' }], 'html'],

--- a/packages/frontend/config/dependency-lint.js
+++ b/packages/frontend/config/dependency-lint.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = {

--- a/packages/frontend/config/deploy.js
+++ b/packages/frontend/config/deploy.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 const API_VERSION = require('ilios-common/config/api-version.js');
 
 module.exports = function (deployTarget) {

--- a/packages/frontend/lib/ilios-error/index.js
+++ b/packages/frontend/lib/ilios-error/index.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 /* eslint n/no-extraneous-require: 0 */
 
 'use strict';

--- a/packages/frontend/lib/ilios-loading/index.js
+++ b/packages/frontend/lib/ilios-loading/index.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = {

--- a/packages/ilios-common/config/api-version.js
+++ b/packages/ilios-common/config/api-version.js
@@ -1,3 +1,1 @@
-/* eslint-env node */
-
 module.exports = 'v3.13';

--- a/packages/lti-course-manager/config/dependency-lint.js
+++ b/packages/lti-course-manager/config/dependency-lint.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = {

--- a/packages/lti-course-manager/config/deploy.js
+++ b/packages/lti-course-manager/config/deploy.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = function (deployTarget) {

--- a/packages/lti-course-manager/lib/ilios-error/index.js
+++ b/packages/lti-course-manager/lib/ilios-error/index.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 /* eslint n/no-extraneous-require: 0 */
 'use strict';
 

--- a/packages/lti-course-manager/lib/ilios-loading/index.js
+++ b/packages/lti-course-manager/lib/ilios-loading/index.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = {

--- a/packages/lti-dashboard/config/dependency-lint.js
+++ b/packages/lti-dashboard/config/dependency-lint.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = {

--- a/packages/lti-dashboard/config/deploy.js
+++ b/packages/lti-dashboard/config/deploy.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 module.exports = function (deployTarget) {
   var ENV = {
     build: {},

--- a/packages/lti-dashboard/lib/ilios-error/index.js
+++ b/packages/lti-dashboard/lib/ilios-error/index.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 /* eslint n/no-extraneous-require: 0 */
 'use strict';
 

--- a/packages/lti-dashboard/lib/ilios-loading/index.js
+++ b/packages/lti-dashboard/lib/ilios-loading/index.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = {


### PR DESCRIPTION
eslint v10 is ignoring these now and emitting a warning. stripping these out completely does not raise any new linter warnings, so these can be dropped without replacement.

please see https://eslint.org/docs/latest/use/configure/migration-guide#eslint-env-configuration-comments for reference.

fixes ilios/ilios#6923

