### PR TITLE
make table headers in learner-group user management sticky.

### DIFF
--- a/packages/frontend/app/components/learner-group/cohort-user-manager.gjs
+++ b/packages/frontend/app/components/learner-group/cohort-user-manager.gjs
@@ -123,7 +123,7 @@ export default class LearnerGroupCohortUserManagerComponent extends Component {
         {{#if @users.length}}
           <div class="learner-group-cohort-user-manager-content">
             <div class="list">
-              <table class="ilios-table ilios-table-colors ilios-zebra-table">
+              <table class="ilios-table ilios-table-colors ilios-zebra-table sticky-header">
                 <thead data-test-headers>
                   <tr>
                     {{#if @canUpdate}}

--- a/packages/frontend/app/components/learner-group/members.gjs
+++ b/packages/frontend/app/components/learner-group/members.gjs
@@ -63,7 +63,7 @@ export default class LearnerGroupUserMembersComponent extends Component {
         {{#if this.usersInGroup.length}}
           <div class="learner-group-members-content">
             <div class="list">
-              <table class="ilios-table ilios-table-colors ilios-zebra-table">
+              <table class="ilios-table ilios-table-colors ilios-zebra-table sticky-header">
                 <thead>
                   <tr>
                     <SortableTh

--- a/packages/frontend/app/components/learner-group/user-manager.gjs
+++ b/packages/frontend/app/components/learner-group/user-manager.gjs
@@ -225,7 +225,7 @@ export default class LearnerGroupUserManagerComponent extends Component {
                 ({{this.groupUsers.length}})
               </div>
               <table
-                class="ilios-table ilios-table-colors ilios-zebra-table"
+                class="ilios-table ilios-table-colors ilios-zebra-table sticky-header"
                 data-test-assigned-users
               >
                 <thead>
@@ -353,7 +353,7 @@ export default class LearnerGroupUserManagerComponent extends Component {
                 ({{this.nonGroupUsers.length}})
               </div>
               <table
-                class="ilios-table ilios-table-colors ilios-zebra-table"
+                class="ilios-table ilios-table-colors ilios-zebra-table sticky-header"
                 data-test-assignable-users
               >
                 <thead>


### PR DESCRIPTION
fixes ilios/ilios#6924