### PR TITLE
Learner Group Management cleanup

### DIFF
--- a/packages/frontend/app/components/learner-group/root.gjs
+++ b/packages/frontend/app/components/learner-group/root.gjs
@@ -397,6 +397,10 @@ export default class LearnerGroupRootComponent extends Component {
     const topLevelGroup = await this.args.learnerGroup.topLevelGroup;
     const groups = await topLevelGroup.removeUserFromGroupAndAllDescendants(user);
     await all(groups.map((group) => group.save()));
+
+    if (!this.usersForMembersList.length) {
+      this.args.setIsEditing(false);
+    }
   });
 
   addUsersToGroup = task({ enqueue: true }, async (users) => {
@@ -426,6 +430,10 @@ export default class LearnerGroupRootComponent extends Component {
       groupsToSave = [...groupsToSave, ...removeGroups];
     }
     await all(uniqueValues(groupsToSave).map((group) => group.save()));
+
+    if (!this.usersForMembersList.length) {
+      this.args.setIsEditing(false);
+    }
   });
 
   createUsersToPassToCohortManager = task(async () => {
@@ -620,7 +628,7 @@ export default class LearnerGroupRootComponent extends Component {
                   data-test-filter
                 />
               {{/if}}
-              {{#if (or @isEditing @isBulkAssigning)}}
+              {{#if (and this.usersForMembersList.length (or @isEditing @isBulkAssigning))}}
                 <button
                   class="close"
                   type="button"

--- a/packages/frontend/app/components/learner-group/root.gjs
+++ b/packages/frontend/app/components/learner-group/root.gjs
@@ -653,16 +653,16 @@ export default class LearnerGroupRootComponent extends Component {
                   >
                     {{t "general.uploadGroupAssignments"}}
                   </button>
-                  {{#if this.usersForUserManager.length}}
-                    <button
-                      class="manage"
-                      type="button"
-                      data-test-manage
-                      {{on "click" (fn @setIsEditing true)}}
-                    >
-                      {{t "general.manage"}}
-                    </button>
-                  {{/if}}
+                  <button
+                    class="manage{{unless this.usersForUserManager.length ' disabled'}}"
+                    type="button"
+                    disabled={{not this.usersForUserManager.length}}
+                    title={{unless this.usersForUserManager.length (t "general.noMembers")}}
+                    data-test-manage
+                    {{on "click" (fn @setIsEditing true)}}
+                  >
+                    {{t "general.manageMembers"}}
+                  </button>
                 {{/if}}
               {{/if}}
             </div>

--- a/packages/frontend/app/components/learner-group/root.gjs
+++ b/packages/frontend/app/components/learner-group/root.gjs
@@ -638,14 +638,12 @@ export default class LearnerGroupRootComponent extends Component {
                   {{t "general.close"}}
                 </button>
               {{else}}
-                {{#if this.usersForMembersList.length}}
-                  <ToggleButtons
-                    @firstOptionSelected={{not @showCalendar}}
-                    @firstLabel={{t "general.hideCalendar"}}
-                    @secondLabel={{t "general.showCalendar"}}
-                    @toggle={{@setShowCalendar}}
-                  />
-                {{/if}}
+                <ToggleButtons
+                  @firstOptionSelected={{not @showCalendar}}
+                  @firstLabel={{t "general.hideCalendar"}}
+                  @secondLabel={{t "general.showCalendar"}}
+                  @toggle={{@setShowCalendar}}
+                />
                 {{#if @canUpdate}}
                   <button
                     class="bulk-assign"

--- a/packages/frontend/app/components/learner-group/root.gjs
+++ b/packages/frontend/app/components/learner-group/root.gjs
@@ -628,7 +628,7 @@ export default class LearnerGroupRootComponent extends Component {
                   data-test-filter
                 />
               {{/if}}
-              {{#if (and this.usersForMembersList.length (or @isEditing @isBulkAssigning))}}
+              {{#if (and this.usersForUserManager.length (or @isEditing @isBulkAssigning))}}
                 <button
                   class="close"
                   type="button"
@@ -655,7 +655,7 @@ export default class LearnerGroupRootComponent extends Component {
                   >
                     {{t "general.uploadGroupAssignments"}}
                   </button>
-                  {{#if this.usersForMembersList.length}}
+                  {{#if this.usersForUserManager.length}}
                     <button
                       class="manage"
                       type="button"

--- a/packages/frontend/app/components/learner-group/root.gjs
+++ b/packages/frontend/app/components/learner-group/root.gjs
@@ -610,14 +610,16 @@ export default class LearnerGroupRootComponent extends Component {
               {{/if}}
             </div>
             <div class="actions" data-test-buttons>
-              <input
-                type="text"
-                value={{this.filter}}
-                placeholder={{t "general.filterByNameOrEmail"}}
-                aria-label={{t "general.filterByNameOrEmail"}}
-                {{on "input" (pick "target.value" (set this "filter"))}}
-                data-test-filter
-              />
+              {{#if this.usersForMembersList.length}}
+                <input
+                  type="text"
+                  value={{this.filter}}
+                  placeholder={{t "general.filterByNameOrEmail"}}
+                  aria-label={{t "general.filterByNameOrEmail"}}
+                  {{on "input" (pick "target.value" (set this "filter"))}}
+                  data-test-filter
+                />
+              {{/if}}
               {{#if (or @isEditing @isBulkAssigning)}}
                 <button
                   class="close"
@@ -628,12 +630,14 @@ export default class LearnerGroupRootComponent extends Component {
                   {{t "general.close"}}
                 </button>
               {{else}}
-                <ToggleButtons
-                  @firstOptionSelected={{not @showCalendar}}
-                  @firstLabel={{t "general.hideCalendar"}}
-                  @secondLabel={{t "general.showCalendar"}}
-                  @toggle={{@setShowCalendar}}
-                />
+                {{#if this.usersForMembersList.length}}
+                  <ToggleButtons
+                    @firstOptionSelected={{not @showCalendar}}
+                    @firstLabel={{t "general.hideCalendar"}}
+                    @secondLabel={{t "general.showCalendar"}}
+                    @toggle={{@setShowCalendar}}
+                  />
+                {{/if}}
                 {{#if @canUpdate}}
                   <button
                     class="bulk-assign"
@@ -643,14 +647,16 @@ export default class LearnerGroupRootComponent extends Component {
                   >
                     {{t "general.uploadGroupAssignments"}}
                   </button>
-                  <button
-                    class="manage"
-                    type="button"
-                    data-test-manage
-                    {{on "click" (fn @setIsEditing true)}}
-                  >
-                    {{t "general.manage"}}
-                  </button>
+                  {{#if this.usersForMembersList.length}}
+                    <button
+                      class="manage"
+                      type="button"
+                      data-test-manage
+                      {{on "click" (fn @setIsEditing true)}}
+                    >
+                      {{t "general.manage"}}
+                    </button>
+                  {{/if}}
                 {{/if}}
               {{/if}}
             </div>

--- a/packages/frontend/app/styles/components/learner-group/root.scss
+++ b/packages/frontend/app/styles/components/learner-group/root.scss
@@ -5,6 +5,7 @@
 .learner-group-root {
   .learner-group-overview {
     margin-top: 0.5rem;
+
     .block {
       display: flex;
       align-items: flex-start;
@@ -75,6 +76,7 @@
 
   .subgroups {
     @include m.detail-container-content;
+    border-top: 1px dotted var(--orange);
 
     .header {
       @include m.detail-container-header;

--- a/packages/frontend/app/styles/components/learner-group/root.scss
+++ b/packages/frontend/app/styles/components/learner-group/root.scss
@@ -61,6 +61,13 @@
         input {
           margin-right: 1rem;
         }
+
+        button {
+          &:disabled {
+            cursor: default;
+            background-color: var(--grey);
+          }
+        }
       }
     }
   }

--- a/packages/frontend/tests/acceptance/learnergroup-test.js
+++ b/packages/frontend/tests/acceptance/learnergroup-test.js
@@ -23,27 +23,50 @@ module('Acceptance | Learner Group', function (hooks) {
     this.server.createList('user', 2, { cohorts: [cohort] });
 
     await page.visit({ learnerGroupId: 1 });
-    await page.root.actions.buttons.manageUsers.click();
-    assert.strictEqual(page.root.userManager.usersInCurrentGroup.length, 0);
-    assert.strictEqual(page.root.cohortUserManager.users.length, 2);
+
+    assert.strictEqual(
+      page.root.userManager.usersInCurrentGroup.length,
+      0,
+      'current group user count correct',
+    );
+    assert.strictEqual(
+      page.root.cohortUserManager.users.length,
+      2,
+      'potential cohort user count correct',
+    );
     assert.strictEqual(
       page.root.cohortUserManager.users[0].name.userNameInfo.fullName,
       '1 guy M. Mc1son',
+      'first cohort user name correct',
     );
     assert.strictEqual(
       page.root.cohortUserManager.users[1].name.userNameInfo.fullName,
       '2 guy M. Mc2son',
+      'second cohort user name correct',
     );
+
     await page.root.cohortUserManager.users[0].add();
-    assert.strictEqual(page.root.userManager.usersInCurrentGroup.length, 1);
+    await page.root.actions.buttons.manageUsers.click();
+
+    assert.strictEqual(
+      page.root.userManager.usersInCurrentGroup.length,
+      1,
+      'user count in current group correct',
+    );
     assert.strictEqual(
       page.root.userManager.usersInCurrentGroup[0].name.userNameInfo.fullName,
       '1 guy M. Mc1son',
+      'current group user name correct',
     );
-    assert.strictEqual(page.root.cohortUserManager.users.length, 1);
+    assert.strictEqual(
+      page.root.cohortUserManager.users.length,
+      1,
+      'potential cohort user count correct',
+    );
     assert.strictEqual(
       page.root.cohortUserManager.users[0].name.userNameInfo.fullName,
       '2 guy M. Mc2son',
+      'remaining cohort user name correct',
     );
   });
 
@@ -307,6 +330,7 @@ module('Acceptance | Learner Group', function (hooks) {
       updatedAt: Date.now(),
     });
     this.server.create('offering');
+    this.server.createList('user', 2, { cohorts: [cohort], learnerGroups: [learnerGroup] });
 
     await page.visit({ learnerGroupId: 1 });
     assert.ok(
@@ -372,6 +396,7 @@ module('Acceptance | Learner Group', function (hooks) {
       updatedAt: Date.now(),
     });
     this.server.create('offering');
+    this.server.createList('user', 2, { cohorts: [cohort], learnerGroups: [learnerGroup] });
 
     await page.visit({ learnerGroupId: 1 });
     assert.strictEqual(
@@ -508,50 +533,58 @@ module('Acceptance | Learner Group', function (hooks) {
     );
 
     await page.root.subgroups.list.items[0].clickTitle();
-    await page.root.actions.buttons.manageUsers.click();
+
     assert.strictEqual(
       page.root.userManager.usersInCurrentGroup.length,
       0,
-      'users in current group count correct',
+      'users in current (first) subgroup count correct',
     );
     assert.strictEqual(
       page.root.userManager.usersNotInCurrentGroup.length,
       0,
-      'users not in current group count correct',
+      'users not in current (first) subgroup count correct',
     );
+
     assert.strictEqual(page.root.cohortUserManager.users.length, 3, 'cohort users count correct');
+
     await page.root.cohortUserManager.users[0].add();
+    await page.root.actions.buttons.manageUsers.click();
+
     assert.strictEqual(
       page.root.userManager.usersInCurrentGroup.length,
       1,
-      'users in current group count correct',
+      'users in current (first) subgroup count correct',
     );
     assert.strictEqual(
       page.root.userManager.usersNotInCurrentGroup.length,
       0,
-      'users not in current group count correct',
+      'users not in current (first) subgroup count correct',
     );
     assert.strictEqual(page.root.cohortUserManager.users.length, 2, 'cohort users count correct');
     assert.strictEqual(
       page.root.userManager.usersInCurrentGroup[0].name.userNameInfo.fullName,
       '1 guy M. Mc1son',
-      'name of first user in current group correct',
+      'name of first user in current (first) subgroup correct',
     );
+
     await page.root.header.breadcrumb.crumbs[2].visit();
     await page.root.subgroups.list.items[1].clickTitle();
     await page.root.actions.buttons.manageUsers.click();
+
     assert.strictEqual(
       page.root.userManager.usersInCurrentGroup.length,
       0,
-      'users in current group count correct',
+      'users in current (second) subgroup count correct',
     );
     assert.strictEqual(
       page.root.userManager.usersNotInCurrentGroup.length,
       1,
-      'users not in current group count correct',
+      'users not in current (second) subgroup count correct',
     );
     assert.strictEqual(page.root.cohortUserManager.users.length, 2, 'cohort users count correct');
+
     await page.root.userManager.usersNotInCurrentGroup[0].add();
+
     assert.strictEqual(
       page.root.userManager.usersInCurrentGroup.length,
       1,

--- a/packages/frontend/tests/integration/components/learner-group/root-test.gjs
+++ b/packages/frontend/tests/integration/components/learner-group/root-test.gjs
@@ -115,6 +115,124 @@ module('Integration | Component | learner-group/root', function (hooks) {
     assert.notOk(component.actions.buttons.close.isVisible);
   });
 
+  test('renders with data, but no members', async function (assert) {
+    const user1 = this.server.create('user');
+    const user2 = this.server.create('user');
+    const user3 = this.server.create('user');
+    const cohort = this.server.create('cohort', {
+      title: 'this cohort',
+      users: [user1, user2, user3],
+      programYear: this.programYear,
+    });
+
+    const course = this.server.create('course', { school: this.school });
+    const session = this.server.create('session', { course });
+    const offering = this.server.create('offering', { session });
+
+    const learnerGroup = this.server.create('learner-group', {
+      title: 'test group',
+      location: 'test location',
+      offerings: [offering],
+      cohort,
+    });
+    const learnerGroupModel = await this.owner
+      .lookup('service:store')
+      .findRecord('learner-group', learnerGroup.id);
+
+    this.set('learnerGroup', learnerGroupModel);
+
+    await render(
+      <template>
+        <Root
+          @canUpdate={{true}}
+          @setIsEditing={{(noop)}}
+          @setSortUsersBy={{(noop)}}
+          @setIsBulkAssigning={{(noop)}}
+          @sortUsersBy="fullName"
+          @learnerGroup={{this.learnerGroup}}
+          @isEditing={{false}}
+          @isBulkAssigning={{false}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(
+      component.defaultLocation.text,
+      'Default Location: test location',
+      'default location text correct',
+    );
+
+    assert.notOk(component.actions.buttons.toggle.isVisible, 'calendar toggle not visible');
+    assert.ok(component.actions.buttons.bulkAssignment.isVisible, 'bulk assignment button visible');
+    assert.notOk(
+      component.actions.buttons.manageUsers.isVisible,
+      'manager users button not visible',
+    );
+    assert.notOk(component.actions.buttons.close.isVisible, 'close button not visible');
+    assert.strictEqual(component.actions.title, 'Members (0)', 'member count correct');
+  });
+
+  test('renders with no members, but one member in subgroup', async function (assert) {
+    const user1 = this.server.create('user');
+    const user2 = this.server.create('user');
+    const user3 = this.server.create('user');
+    const cohort = this.server.create('cohort', {
+      title: 'this cohort',
+      users: [user1, user2],
+      programYear: this.programYear,
+    });
+
+    const course = this.server.create('course', { school: this.school });
+    const session = this.server.create('session', { course });
+    const offering = this.server.create('offering', { session });
+
+    const subGroup = this.server.create('learner-group', {
+      title: 'test sub-group',
+      cohort,
+      users: [user3],
+    });
+
+    const learnerGroup = this.server.create('learner-group', {
+      title: 'test group',
+      location: 'test location',
+      offerings: [offering],
+      children: [subGroup],
+      cohort,
+    });
+    const learnerGroupModel = await this.owner
+      .lookup('service:store')
+      .findRecord('learner-group', learnerGroup.id);
+
+    this.set('learnerGroup', learnerGroupModel);
+
+    await render(
+      <template>
+        <Root
+          @canUpdate={{true}}
+          @setIsEditing={{(noop)}}
+          @setSortUsersBy={{(noop)}}
+          @setIsBulkAssigning={{(noop)}}
+          @sortUsersBy="fullName"
+          @learnerGroup={{this.learnerGroup}}
+          @isEditing={{false}}
+          @isBulkAssigning={{false}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(
+      component.defaultLocation.text,
+      'Default Location: test location',
+      'default location text correct',
+    );
+
+    assert.notOk(component.actions.buttons.toggle.isVisible, 'calendar toggle not visible');
+    assert.ok(component.actions.buttons.bulkAssignment.isVisible, 'bulk assignment button visible');
+    assert.ok(component.actions.buttons.manageUsers.isVisible, 'manager users button visible');
+    assert.notOk(component.actions.buttons.close.isVisible, 'close button not visible');
+    assert.strictEqual(component.actions.title, 'Members (0)', 'member count correct');
+  });
+
   test('renders with data in read-only mode', async function (assert) {
     const cohort = this.server.create('cohort', {
       title: 'this cohort',

--- a/packages/frontend/tests/integration/components/learner-group/root-test.gjs
+++ b/packages/frontend/tests/integration/components/learner-group/root-test.gjs
@@ -145,10 +145,16 @@ module('Integration | Component | learner-group/root', function (hooks) {
       </template>,
     );
 
-    assert.ok(component.actions.buttons.toggle.isVisible);
-    assert.notOk(component.actions.buttons.bulkAssignment.isVisible);
-    assert.notOk(component.actions.buttons.manageUsers.isVisible);
-    assert.notOk(component.actions.buttons.close.isVisible);
+    assert.notOk(component.actions.buttons.toggle.isVisible, 'calendar toggle buttons not visible');
+    assert.notOk(
+      component.actions.buttons.bulkAssignment.isVisible,
+      'bulk assignment button not visible',
+    );
+    assert.notOk(
+      component.actions.buttons.manageUsers.isVisible,
+      'manage users button not visible',
+    );
+    assert.notOk(component.actions.buttons.close.isVisible, 'close button not visible');
     assert.strictEqual(component.actions.title, 'Members (0)');
   });
 
@@ -742,8 +748,16 @@ module('Integration | Component | learner-group/root', function (hooks) {
   });
 
   test('learnergroup calendar', async function (assert) {
+    const user1 = this.server.create('user');
+    const user2 = this.server.create('user');
+    const course = this.server.create('course', { school: this.school });
+    const session = this.server.create('session', { course });
+    const offering = this.server.create('offering', { session });
     const learnerGroup = this.server.create('learner-group', {
-      url: 'https://iliosproject.org/',
+      title: 'test group',
+      location: 'test location',
+      users: [user1, user2],
+      offerings: [offering],
       cohort: this.cohort,
     });
     const learnerGroupModel = await this.owner
@@ -781,8 +795,16 @@ module('Integration | Component | learner-group/root', function (hooks) {
   });
 
   test('manage users', async function (assert) {
+    const user1 = this.server.create('user');
+    const user2 = this.server.create('user');
+    const course = this.server.create('course', { school: this.school });
+    const session = this.server.create('session', { course });
+    const offering = this.server.create('offering', { session });
     const learnerGroup = this.server.create('learner-group', {
-      url: 'https://iliosproject.org/',
+      title: 'test group',
+      location: 'test location',
+      users: [user1, user2],
+      offerings: [offering],
       cohort: this.cohort,
     });
     const learnerGroupModel = await this.owner
@@ -813,8 +835,16 @@ module('Integration | Component | learner-group/root', function (hooks) {
   });
 
   test('bulk assignment', async function (assert) {
+    const user1 = this.server.create('user');
+    const user2 = this.server.create('user');
+    const course = this.server.create('course', { school: this.school });
+    const session = this.server.create('session', { course });
+    const offering = this.server.create('offering', { session });
     const learnerGroup = this.server.create('learner-group', {
-      url: 'https://iliosproject.org/',
+      title: 'test group',
+      location: 'test location',
+      users: [user1, user2],
+      offerings: [offering],
       cohort: this.cohort,
     });
     const learnerGroupModel = await this.owner

--- a/packages/frontend/tests/integration/components/learner-group/root-test.gjs
+++ b/packages/frontend/tests/integration/components/learner-group/root-test.gjs
@@ -162,7 +162,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       'default location text correct',
     );
 
-    assert.notOk(component.actions.buttons.toggle.isVisible, 'calendar toggle not visible');
+    assert.ok(component.actions.buttons.toggle.isVisible, 'calendar toggle visible');
     assert.ok(component.actions.buttons.bulkAssignment.isVisible, 'bulk assignment button visible');
     assert.notOk(
       component.actions.buttons.manageUsers.isVisible,
@@ -226,7 +226,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       'default location text correct',
     );
 
-    assert.notOk(component.actions.buttons.toggle.isVisible, 'calendar toggle not visible');
+    assert.ok(component.actions.buttons.toggle.isVisible, 'calendar toggle visible');
     assert.ok(component.actions.buttons.bulkAssignment.isVisible, 'bulk assignment button visible');
     assert.ok(component.actions.buttons.manageUsers.isVisible, 'manager users button visible');
     assert.notOk(component.actions.buttons.close.isVisible, 'close button not visible');
@@ -263,7 +263,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
       </template>,
     );
 
-    assert.notOk(component.actions.buttons.toggle.isVisible, 'calendar toggle buttons not visible');
+    assert.ok(component.actions.buttons.toggle.isVisible, 'calendar toggle visible');
     assert.notOk(
       component.actions.buttons.bulkAssignment.isVisible,
       'bulk assignment button not visible',

--- a/packages/frontend/tests/integration/components/learner-group/root-test.gjs
+++ b/packages/frontend/tests/integration/components/learner-group/root-test.gjs
@@ -164,10 +164,8 @@ module('Integration | Component | learner-group/root', function (hooks) {
 
     assert.ok(component.actions.buttons.toggle.isVisible, 'calendar toggle visible');
     assert.ok(component.actions.buttons.bulkAssignment.isVisible, 'bulk assignment button visible');
-    assert.notOk(
-      component.actions.buttons.manageUsers.isVisible,
-      'manager users button not visible',
-    );
+    assert.ok(component.actions.buttons.manageUsers.isVisible, 'manager users button visible');
+    assert.ok(component.actions.buttons.manageUsers.isDisabled, 'manage members button disabled');
     assert.notOk(component.actions.buttons.close.isVisible, 'close button not visible');
     assert.strictEqual(component.actions.title, 'Members (0)', 'member count correct');
   });
@@ -228,7 +226,11 @@ module('Integration | Component | learner-group/root', function (hooks) {
 
     assert.ok(component.actions.buttons.toggle.isVisible, 'calendar toggle visible');
     assert.ok(component.actions.buttons.bulkAssignment.isVisible, 'bulk assignment button visible');
-    assert.ok(component.actions.buttons.manageUsers.isVisible, 'manager users button visible');
+    assert.ok(component.actions.buttons.manageUsers.isVisible, 'manage members button visible');
+    assert.notOk(
+      component.actions.buttons.manageUsers.isDisabled,
+      'manage members button not disabled',
+    );
     assert.notOk(component.actions.buttons.close.isVisible, 'close button not visible');
     assert.strictEqual(component.actions.title, 'Members (0)', 'member count correct');
   });
@@ -270,7 +272,7 @@ module('Integration | Component | learner-group/root', function (hooks) {
     );
     assert.notOk(
       component.actions.buttons.manageUsers.isVisible,
-      'manage users button not visible',
+      'manage members button not visible',
     );
     assert.notOk(component.actions.buttons.close.isVisible, 'close button not visible');
     assert.strictEqual(component.actions.title, 'Members (0)');

--- a/packages/frontend/tests/pages/components/learner-group/root.js
+++ b/packages/frontend/tests/pages/components/learner-group/root.js
@@ -4,6 +4,7 @@ import {
   fillable,
   isPresent,
   isVisible,
+  property,
   text,
   value,
 } from 'ember-cli-page-object';
@@ -69,6 +70,7 @@ const definition = {
       },
       manageUsers: {
         scope: '[data-test-manage]',
+        isDisabled: property('disabled'),
       },
     },
   },

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -203,6 +203,7 @@ general:
   manageGroupMembership: Manage Group Membership
   manageInstitutionalInformation: Manage Institutional Information
   manageLearningMaterialAttributes: Manage Learning Material Attributes
+  manageMembers: Manage Members
   manageSessionAttributes: Manage Session Attributes
   manageUsersSummaryTitle: Ilios Users
   matchGroups: Match Groups
@@ -244,6 +245,7 @@ general:
   noAccountExists: "Your account {accountName} does not match any user records in Ilios. If you need further assistance, please contact your school’s Ilios administrator."
   noCohortsAvailableForStudentAssignment: There are no cohorts available for student assignment in this school.
   noInstitutionalInformation: No institutional information has been configured for this school.
+  noMembers: There are no learner group members to manage
   nonClerkshipSequenceBlocks: Non-Clerkship Sequence Blocks
   nonStudent: Non-Student
   noPopulateGroup: "No!  Leave it empty, I'll add students myself."

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -183,7 +183,7 @@ general:
   learner: Aprendedor
   learnerGroupsReportSummary: "informe para {courseCount, plural, one {un curso} other {# cursos}}. Cada grupo de alumnos adjunto se enumera junto con los instructores y los datos del curso."
   learnerGroupsReportSummaryMultiSchool: "informe para {courseCount, plural, one {un curso} other {# cursos}}{schoolCount, plural, zero {} one {} other {, en # escuelas}}. Cada grupo de alumnos adjunto se enumera junto con los instructores y los datos del curso."
-  learnerGroupTitle: Título de Grupo de Instructores
+  learnerGroupTitle: Título de Grupo de Aprendedores
   learnerGroupTitleFilterPlaceholder: Aplicar un Filtro por Título de Grupo de Aprendedor
   learnerGroupTitlePlaceholder: Entre en un Título para este grupo de aprendedores
   learningMaterial: Material de Aprendizaje

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -203,6 +203,7 @@ general:
   manageGroupMembership: Administrar membresía de grupo
   manageInstitutionalInformation: Administrar información institucional
   manageLearningMaterialAttributes: Maneje Atributos del Material de Aprendizaje
+  manageMembers: Manaje Miembros
   manageSessionAttributes: Maneje Atributos de la Sesión
   manageUsersSummaryTitle: Usuarios de Ilios
   matchGroups: Igualar Grupos
@@ -244,6 +245,7 @@ general:
   noAccountExists: "Su cuenta {accountName} no coincide con los registros de Ilios. Si usted necesita más asistencia, póngase en contacto con su administrador de Ilios"
   noCohortsAvailableForStudentAssignment: "No hay cohortes disponibles para la asignación de estudiantes en esta escuela."
   noInstitutionalInformation: No se ha configurado información institucional para esta escuela.
+  noMembers: No hay miembros de grupo de aprendedores que manejar
   nonClerkshipSequenceBlocks: Bloques de secuencia que no son de la rotación
   nonStudent: No estudiante
   noPopulateGroup: ¡No! Déjelo vacío. Voy a agregar alumnos yo mismo.

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -203,6 +203,7 @@ general:
   manageGroupMembership: "Gérer l'appartenance au groupe"
   manageInstitutionalInformation: Manager les informations institutionnelles
   manageLearningMaterialAttributes: "Gérer Attributs du Matériel d'Étude"
+  manageMembers: Gérer les Membres
   manageSessionAttributes: Gérer Attributs de Séance
   manageUsersSummaryTitle: "utilisateurs d'Ilios"
   matchGroups: "Départagez les Groupes "
@@ -244,6 +245,7 @@ general:
   noAccountExists: "Votre compte d'utilisateur {accountName} ne correspond pas à ceux des utilisateur enregistre en Ilios. Si vous avez besoin d'aide, n'hesitez pas à communiquer avec votre administrateur  d'Ilios."
   noCohortsAvailableForStudentAssignment: "Il n'y a pas de cohortes disponibles pour l'affectation des étudiants dans cette école."
   noInstitutionalInformation: "Aucune information institutionnelle n'a été configurée pour cette école."
+  noMembers: Il n'y a pas de membres du groupe d'apprenants à gérer
   nonClerkshipSequenceBlocks: Blocs de séquence non stage
   nonStudent: Non étudiant
   noPopulateGroup: "Non!  Laissez-la vide, j'ajouterai des étudiants moi-même"


### PR DESCRIPTION
Fixes ilios/ilios#6865
Fixes ilios/ilios#7042

This change hides the name filter, calendar toggle, and manage buttons if there are no members, since they are not meaningful in that state.

- [x] Hide elements as appropriate
- [x] Update tests