### PR TITLE
adds side-loading for learnergroup offerings to session data loader.

### DIFF
--- a/packages/ilios-common/addon/services/data-loader.js
+++ b/packages/ilios-common/addon/services/data-loader.js
@@ -105,6 +105,7 @@ export default class DataLoaderService extends Service {
         'offerings.learners',
         'offerings.instructors',
         'offerings.instructorGroups.users',
+        'offerings.learnerGroups.offerings',
         'offerings.learnerGroups.users',
         'ilmSession.learners',
         'ilmSession.instructors',


### PR DESCRIPTION
this is a workaround to prevent ember-data from re-fetching offerings that should already be in the store when loading the offering calendar. without it, the offering in view will reload, forcing a re-render that is effectively closing the opened calendar prematurely.

refs https://github.com/ilios/ilios/issues/6931