### PR TITLE
make header of session types list sticky.

### DIFF
--- a/packages/frontend/app/components/school-session-types-list.gjs
+++ b/packages/frontend/app/components/school-session-types-list.gjs
@@ -3,7 +3,7 @@ import sortBy from 'ilios-common/helpers/sort-by';
 import SchoolSessionTypesListItem from 'frontend/components/school-session-types-list-item';
 <template>
   <div class="school-session-types-list" data-test-school-session-types-list ...attributes>
-    <table class="ilios-table ilios-table-colors ilios-removable-table">
+    <table class="ilios-table ilios-table-colors ilios-removable-table sticky-header">
       <thead>
         <tr>
           <th colspan="3">


### PR DESCRIPTION
<img width="1739" height="320" alt="image" src="https://github.com/user-attachments/assets/a52a91f8-0029-4e97-9c98-5fd39c87e4ac" />


fixes ilios/ilios#4296