### PR TITLE
Add Accessibility Check to Learning Materials

### DIFF
--- a/packages/frontend/app/components/school-learning-material-attributes-collapsed.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-collapsed.gjs
@@ -44,13 +44,13 @@ import { faCaretRight, faBan, faCheck } from '@fortawesome/free-solid-svg-icons'
               />
             </td>
           </tr>
-          <tr data-test-accessibility-required-message>
+          <tr data-test-accessibility-requirements-link>
             <td>
-              {{t "general.accessibilityRequiredMessage"}}
+              {{t "general.accessibilityRequirementsLink"}}
             </td>
             <td>
               <span>
-                {{@accessibilityRequiredMessage}}
+                {{@accessibilityRequirementsLink}}
               </span>
             </td>
           </tr>

--- a/packages/frontend/app/components/school-learning-material-attributes-collapsed.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-collapsed.gjs
@@ -1,0 +1,51 @@
+import { on } from '@ember/modifier';
+import t from 'ember-intl/helpers/t';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faCaretRight, faBan, faCheck } from '@fortawesome/free-solid-svg-icons';
+<template>
+  <section
+    class="school-learning-material-attributes-collapsed"
+    data-test-school-learning-material-attributes-collapsed
+    ...attributes
+  >
+    <div>
+      <button
+        class="title link-button"
+        type="button"
+        aria-expanded="false"
+        data-test-title
+        {{on "click" @expand}}
+      >
+        {{t "general.learningMaterialAttributes"}}
+        <FaIcon @icon={{faCaretRight}} />
+      </button>
+    </div>
+    <div class="content">
+      <table class="ilios-table ilios-table-colors condensed">
+        <thead>
+          <tr>
+            <th class="text-left">
+              {{t "general.attribute"}}
+            </th>
+            <th class="text-left">
+              {{t "general.enabled"}}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-test-accessibility-required>
+            <td>
+              {{t "general.accessibilityRequired"}}
+            </td>
+            <td>
+              <FaIcon
+                @icon={{if @showLearningMaterialAccessibilityRequired faCheck faBan}}
+                class={{if @showLearningMaterialAccessibilityRequired "yes" "no"}}
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</template>

--- a/packages/frontend/app/components/school-learning-material-attributes-collapsed.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-collapsed.gjs
@@ -39,8 +39,8 @@ import { faCaretRight, faBan, faCheck } from '@fortawesome/free-solid-svg-icons'
             </td>
             <td>
               <FaIcon
-                @icon={{if @learningMaterialAccessibilityRequired faCheck faBan}}
-                class={{if @learningMaterialAccessibilityRequired "yes" "no"}}
+                @icon={{if @accessibilityRequired faCheck faBan}}
+                class={{if @accessibilityRequired "yes" "no"}}
               />
             </td>
           </tr>
@@ -50,7 +50,7 @@ import { faCaretRight, faBan, faCheck } from '@fortawesome/free-solid-svg-icons'
             </td>
             <td>
               <span>
-                {{@learningMaterialAccessibilityRequiredMessage}}
+                {{@accessibilityRequiredMessage}}
               </span>
             </td>
           </tr>

--- a/packages/frontend/app/components/school-learning-material-attributes-collapsed.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-collapsed.gjs
@@ -39,9 +39,19 @@ import { faCaretRight, faBan, faCheck } from '@fortawesome/free-solid-svg-icons'
             </td>
             <td>
               <FaIcon
-                @icon={{if @showLearningMaterialAccessibilityRequired faCheck faBan}}
-                class={{if @showLearningMaterialAccessibilityRequired "yes" "no"}}
+                @icon={{if @learningMaterialAccessibilityRequired faCheck faBan}}
+                class={{if @learningMaterialAccessibilityRequired "yes" "no"}}
               />
+            </td>
+          </tr>
+          <tr data-test-accessibility-required-message>
+            <td>
+              {{t "general.accessibilityRequiredMessage"}}
+            </td>
+            <td>
+              <span>
+                {{@learningMaterialAccessibilityRequiredMessage}}
+              </span>
             </td>
           </tr>
         </tbody>

--- a/packages/frontend/app/components/school-learning-material-attributes-expanded.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-expanded.gjs
@@ -27,7 +27,6 @@ export default class SchoolLearningMaterialAttributesExpandedComponent extends C
 
   @action
   updateAccessibilityRequirementsLink(link) {
-    // console.log('updateAccessibilityRequirementsLink', link);
     this.accessibilityRequirementsLink = link;
   }
 

--- a/packages/frontend/app/components/school-learning-material-attributes-expanded.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-expanded.gjs
@@ -18,23 +18,30 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 export default class SchoolLearningMaterialAttributesExpandedComponent extends Component {
-  @tracked flippedShowLearningMaterialAccessibilityRequired = false;
+  @tracked flippedLearningMaterialAccessibilityRequired = false;
+  @tracked learningMaterialAccessibilityRequiredMessage =
+    this.args.learningMaterialAccessibilityRequiredMessage || '';
 
-  get showLearningMaterialAccessibilityRequired() {
-    if (this.flippedShowLearningMaterialAccessibilityRequired) {
-      return !this.args.showLearningMaterialAccessibilityRequired;
+  get learningMaterialAccessibilityRequired() {
+    if (this.flippedLearningMaterialAccessibilityRequired) {
+      return !this.args.learningMaterialAccessibilityRequired;
     }
-    return this.args.showLearningMaterialAccessibilityRequired;
+    return this.args.learningMaterialAccessibilityRequired;
   }
 
   resetFlipped() {
-    this.flippedShowLearningMaterialAccessibilityRequired = false;
+    this.flippedLearningMaterialAccessibilityRequired = false;
   }
 
   @action
   cancel() {
     this.args.manage(false);
     this.resetFlipped();
+  }
+
+  @action
+  updateLearningMaterialRequiredMessage(msg) {
+    this.learningMaterialAccessibilityRequiredMessage = msg;
   }
 
   @action
@@ -52,7 +59,8 @@ export default class SchoolLearningMaterialAttributesExpandedComponent extends C
   save = task({ drop: true }, async () => {
     //read the flipped values before we reset them
     const all = {
-      showLearningMaterialAccessibilityRequired: this.showLearningMaterialAccessibilityRequired,
+      learningMaterialAccessibilityRequired: this.learningMaterialAccessibilityRequired,
+      learningMaterialAccessibilityRequiredMessage: `"${this.learningMaterialAccessibilityRequiredMessage}"`, //make sure text is in quotes so db value is valid
     };
     this.resetFlipped(); //reset before we save, otherwise there will be a flash of the old values
     await this.args.saveAll(all);
@@ -113,9 +121,11 @@ export default class SchoolLearningMaterialAttributesExpandedComponent extends C
       <div class="school-learning-material-attributes-expanded-content" data-test-expanded>
         {{#if @isManaging}}
           <SchoolLearningMaterialAttributesManager
-            @showLearningMaterialAccessibilityRequired={{this.showLearningMaterialAccessibilityRequired}}
+            @learningMaterialAccessibilityRequired={{this.learningMaterialAccessibilityRequired}}
+            @learningMaterialAccessibilityRequiredMessage={{@learningMaterialAccessibilityRequiredMessage}}
             @enable={{this.enableLearningMaterialAttributeConfig}}
             @disable={{this.disableLearningMaterialAttributeConfig}}
+            @update={{this.updateLearningMaterialRequiredMessage}}
           />
         {{else}}
           <table class="ilios-table ilios-table-colors" data-test-attributes>
@@ -136,9 +146,19 @@ export default class SchoolLearningMaterialAttributesExpandedComponent extends C
                 </td>
                 <td>
                   <FaIcon
-                    @icon={{if this.showLearningMaterialAccessibilityRequired faCheck faBan}}
-                    class={{if this.showLearningMaterialAccessibilityRequired "yes" "no"}}
+                    @icon={{if this.learningMaterialAccessibilityRequired faCheck faBan}}
+                    class={{if this.learningMaterialAccessibilityRequired "yes" "no"}}
                   />
+                </td>
+              </tr>
+              <tr data-test-accessibility-required-message>
+                <td>
+                  {{t "general.accessibilityRequiredMessage"}}
+                </td>
+                <td>
+                  <span>
+                    {{@learningMaterialAccessibilityRequiredMessage}}
+                  </span>
                 </td>
               </tr>
             </tbody>

--- a/packages/frontend/app/components/school-learning-material-attributes-expanded.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-expanded.gjs
@@ -1,0 +1,150 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { task } from 'ember-concurrency';
+import { capitalize } from '@ember/string';
+import t from 'ember-intl/helpers/t';
+import { on } from '@ember/modifier';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import perform from 'ember-concurrency/helpers/perform';
+import { fn } from '@ember/helper';
+import SchoolLearningMaterialAttributesManager from 'frontend/components/school-learning-material-attributes-manager';
+import {
+  faArrowRotateLeft,
+  faCaretDown,
+  faCheck,
+  faSpinner,
+  faBan,
+} from '@fortawesome/free-solid-svg-icons';
+
+export default class SchoolLearningMaterialAttributesExpandedComponent extends Component {
+  @tracked flippedShowLearningMaterialAccessibilityRequired = false;
+
+  get showLearningMaterialAccessibilityRequired() {
+    if (this.flippedShowLearningMaterialAccessibilityRequired) {
+      return !this.args.showLearningMaterialAccessibilityRequired;
+    }
+    return this.args.showLearningMaterialAccessibilityRequired;
+  }
+
+  resetFlipped() {
+    this.flippedShowLearningMaterialAccessibilityRequired = false;
+  }
+
+  @action
+  cancel() {
+    this.args.manage(false);
+    this.resetFlipped();
+  }
+
+  @action
+  enableLearningMaterialAttributeConfig(name) {
+    const bufferName = 'flipped' + capitalize(name);
+    this[bufferName] = !this.args[name];
+  }
+
+  @action
+  disableLearningMaterialAttributeConfig(name) {
+    const bufferName = 'flipped' + capitalize(name);
+    this[bufferName] = this.args[name];
+  }
+
+  save = task({ drop: true }, async () => {
+    //read the flipped values before we reset them
+    const all = {
+      showLearningMaterialAccessibilityRequired: this.showLearningMaterialAccessibilityRequired,
+    };
+    this.resetFlipped(); //reset before we save, otherwise there will be a flash of the old values
+    await this.args.saveAll(all);
+  });
+  <template>
+    <section
+      class="school-learning-material-attributes-expanded"
+      data-test-school-learning-material-attributes-expanded
+      ...attributes
+    >
+      <div class="school-learning-material-attributes-expanded-header">
+        {{#if @isManaging}}
+          <div class="title" data-test-title>
+            {{t "general.learningMaterialAttributes"}}
+          </div>
+        {{else}}
+          <button
+            class="title link-button"
+            type="button"
+            aria-expanded="true"
+            data-test-title
+            {{on "click" @collapse}}
+          >
+            {{t "general.learningMaterialAttributes"}}
+            <FaIcon @icon={{faCaretDown}} />
+          </button>
+        {{/if}}
+        <div class="actions">
+          {{#if @isManaging}}
+            <button
+              type="button"
+              class="bigadd"
+              aria-label={{t "general.save"}}
+              {{on "click" (perform this.save)}}
+              data-test-save
+            >
+              <FaIcon
+                @icon={{if this.save.isRunning faSpinner faCheck}}
+                @spin={{this.save.isRunning}}
+              />
+            </button>
+            <button
+              type="button"
+              class="bigcancel"
+              aria-label={{t "general.cancel"}}
+              {{on "click" this.cancel}}
+              data-test-cancel
+            >
+              <FaIcon @icon={{faArrowRotateLeft}} />
+            </button>
+          {{else if @canUpdate}}
+            <button type="button" {{on "click" (fn @manage true)}} data-test-manage>
+              {{t "general.manageLearningMaterialAttributes"}}
+            </button>
+          {{/if}}
+        </div>
+      </div>
+      <div class="school-learning-material-attributes-expanded-content" data-test-expanded>
+        {{#if @isManaging}}
+          <SchoolLearningMaterialAttributesManager
+            @showLearningMaterialAccessibilityRequired={{this.showLearningMaterialAccessibilityRequired}}
+            @enable={{this.enableLearningMaterialAttributeConfig}}
+            @disable={{this.disableLearningMaterialAttributeConfig}}
+          />
+        {{else}}
+          <table class="ilios-table ilios-table-colors" data-test-attributes>
+            <thead>
+              <tr>
+                <th class="text-left">
+                  {{t "general.attribute"}}
+                </th>
+                <th class="text-left">
+                  {{t "general.enabled"}}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr data-test-accessibility-required>
+                <td>
+                  {{t "general.accessibilityRequired"}}
+                </td>
+                <td>
+                  <FaIcon
+                    @icon={{if this.showLearningMaterialAccessibilityRequired faCheck faBan}}
+                    class={{if this.showLearningMaterialAccessibilityRequired "yes" "no"}}
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        {{/if}}
+      </div>
+    </section>
+  </template>
+}

--- a/packages/frontend/app/components/school-learning-material-attributes-expanded.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-expanded.gjs
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
-import { capitalize } from '@ember/string';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
@@ -18,51 +17,29 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 export default class SchoolLearningMaterialAttributesExpandedComponent extends Component {
-  @tracked flippedLearningMaterialAccessibilityRequired = false;
-  @tracked learningMaterialAccessibilityRequiredMessage =
-    this.args.learningMaterialAccessibilityRequiredMessage || '';
-
-  get learningMaterialAccessibilityRequired() {
-    if (this.flippedLearningMaterialAccessibilityRequired) {
-      return !this.args.learningMaterialAccessibilityRequired;
-    }
-    return this.args.learningMaterialAccessibilityRequired;
-  }
-
-  resetFlipped() {
-    this.flippedLearningMaterialAccessibilityRequired = false;
-  }
+  @tracked accessibilityRequired = this.args.accessibilityRequired || false;
+  @tracked accessibilityRequiredMessage = this.args.accessibilityRequiredMessage || '';
 
   @action
   cancel() {
     this.args.manage(false);
-    this.resetFlipped();
   }
 
   @action
   updateLearningMaterialRequiredMessage(msg) {
-    this.learningMaterialAccessibilityRequiredMessage = msg;
+    this.accessibilityRequiredMessage = msg;
   }
 
   @action
-  enableLearningMaterialAttributeConfig(name) {
-    const bufferName = 'flipped' + capitalize(name);
-    this[bufferName] = !this.args[name];
-  }
-
-  @action
-  disableLearningMaterialAttributeConfig(name) {
-    const bufferName = 'flipped' + capitalize(name);
-    this[bufferName] = this.args[name];
+  toggleAccessibilityRequired() {
+    this.accessibilityRequired = !this.accessibilityRequired;
   }
 
   save = task({ drop: true }, async () => {
-    //read the flipped values before we reset them
     const all = {
-      learningMaterialAccessibilityRequired: this.learningMaterialAccessibilityRequired,
-      learningMaterialAccessibilityRequiredMessage: `"${this.learningMaterialAccessibilityRequiredMessage}"`, //make sure text is in quotes so db value is valid
+      learningMaterialAccessibilityRequired: this.accessibilityRequired,
+      learningMaterialAccessibilityRequiredMessage: this.accessibilityRequiredMessage,
     };
-    this.resetFlipped(); //reset before we save, otherwise there will be a flash of the old values
     await this.args.saveAll(all);
   });
   <template>
@@ -121,10 +98,9 @@ export default class SchoolLearningMaterialAttributesExpandedComponent extends C
       <div class="school-learning-material-attributes-expanded-content" data-test-expanded>
         {{#if @isManaging}}
           <SchoolLearningMaterialAttributesManager
-            @learningMaterialAccessibilityRequired={{this.learningMaterialAccessibilityRequired}}
-            @learningMaterialAccessibilityRequiredMessage={{@learningMaterialAccessibilityRequiredMessage}}
-            @enable={{this.enableLearningMaterialAttributeConfig}}
-            @disable={{this.disableLearningMaterialAttributeConfig}}
+            @accessibilityRequired={{this.accessibilityRequired}}
+            @accessibilityRequiredMessage={{@accessibilityRequiredMessage}}
+            @toggle={{this.toggleAccessibilityRequired}}
             @update={{this.updateLearningMaterialRequiredMessage}}
           />
         {{else}}
@@ -146,8 +122,8 @@ export default class SchoolLearningMaterialAttributesExpandedComponent extends C
                 </td>
                 <td>
                   <FaIcon
-                    @icon={{if this.learningMaterialAccessibilityRequired faCheck faBan}}
-                    class={{if this.learningMaterialAccessibilityRequired "yes" "no"}}
+                    @icon={{if this.accessibilityRequired faCheck faBan}}
+                    class={{if this.accessibilityRequired "yes" "no"}}
                   />
                 </td>
               </tr>
@@ -157,7 +133,7 @@ export default class SchoolLearningMaterialAttributesExpandedComponent extends C
                 </td>
                 <td>
                   <span>
-                    {{@learningMaterialAccessibilityRequiredMessage}}
+                    {{@accessibilityRequiredMessage}}
                   </span>
                 </td>
               </tr>

--- a/packages/frontend/app/components/school-learning-material-attributes-expanded.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-expanded.gjs
@@ -18,7 +18,7 @@ import {
 
 export default class SchoolLearningMaterialAttributesExpandedComponent extends Component {
   @tracked accessibilityRequired = this.args.accessibilityRequired || false;
-  @tracked accessibilityRequiredMessage = this.args.accessibilityRequiredMessage || '';
+  @tracked accessibilityRequirementsLink = this.args.accessibilityRequirementsLink || '';
 
   @action
   cancel() {
@@ -26,8 +26,9 @@ export default class SchoolLearningMaterialAttributesExpandedComponent extends C
   }
 
   @action
-  updateLearningMaterialRequiredMessage(msg) {
-    this.accessibilityRequiredMessage = msg;
+  updateAccessibilityRequirementsLink(link) {
+    // console.log('updateAccessibilityRequirementsLink', link);
+    this.accessibilityRequirementsLink = link;
   }
 
   @action
@@ -38,7 +39,7 @@ export default class SchoolLearningMaterialAttributesExpandedComponent extends C
   save = task({ drop: true }, async () => {
     const all = {
       learningMaterialAccessibilityRequired: this.accessibilityRequired,
-      learningMaterialAccessibilityRequiredMessage: this.accessibilityRequiredMessage,
+      learningMaterialAccessibilityRequirementsLink: this.accessibilityRequirementsLink,
     };
     await this.args.saveAll(all);
   });
@@ -99,9 +100,9 @@ export default class SchoolLearningMaterialAttributesExpandedComponent extends C
         {{#if @isManaging}}
           <SchoolLearningMaterialAttributesManager
             @accessibilityRequired={{this.accessibilityRequired}}
-            @accessibilityRequiredMessage={{@accessibilityRequiredMessage}}
+            @accessibilityRequirementsLink={{@accessibilityRequirementsLink}}
             @toggle={{this.toggleAccessibilityRequired}}
-            @update={{this.updateLearningMaterialRequiredMessage}}
+            @update={{this.updateAccessibilityRequirementsLink}}
           />
         {{else}}
           <table class="ilios-table ilios-table-colors" data-test-attributes>
@@ -127,13 +128,13 @@ export default class SchoolLearningMaterialAttributesExpandedComponent extends C
                   />
                 </td>
               </tr>
-              <tr data-test-accessibility-required-message>
+              <tr data-test-accessibility-requirements-link>
                 <td>
-                  {{t "general.accessibilityRequiredMessage"}}
+                  {{t "general.accessibilityRequirementsLink"}}
                 </td>
                 <td>
                   <span>
-                    {{@accessibilityRequiredMessage}}
+                    {{@accessibilityRequirementsLink}}
                   </span>
                 </td>
               </tr>

--- a/packages/frontend/app/components/school-learning-material-attributes-manager.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-manager.gjs
@@ -1,44 +1,66 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
 import { uniqueId, fn } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-<template>
-  {{#let (uniqueId) as |templateId|}}
-    <div data-test-school-learning-material-attributes-manager ...attributes>
-      <table class="ilios-table ilios-table-colors condensed">
-        <thead>
-          <tr>
-            <th class="text-left">
-              {{t "general.attribute"}}
-            </th>
-            <th class="text-left">
-              {{t "general.enabled"}}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr data-test-accessibility-required>
-            <td id="accessibility-required-{{templateId}}">
-              {{t "general.accessibilityRequired"}}
-            </td>
-            <td>
-              {{#if @showLearningMaterialAccessibilityRequired}}
+import pick from 'ilios-common/helpers/pick';
+import pipe from 'ilios-common/helpers/pipe';
+
+export default class SchoolLearningMaterialAttributesManager extends Component {
+  @service intl;
+
+  <template>
+    {{#let (uniqueId) as |templateId|}}
+      <div class="form" data-test-school-learning-material-attributes-manager ...attributes>
+        <table class="ilios-table ilios-table-colors condensed">
+          <thead>
+            <tr>
+              <th class="text-left">
+                {{t "general.attribute"}}
+              </th>
+              <th class="text-left">
+                {{t "general.enabled"}}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-test-accessibility-required>
+              <td id="accessibility-required-{{templateId}}">
+                {{t "general.accessibilityRequired"}}
+              </td>
+              <td>
+                {{#if @learningMaterialAccessibilityRequired}}
+                  <input
+                    type="checkbox"
+                    checked={{true}}
+                    {{on "click" (fn @disable "learningMaterialAccessibilityRequired")}}
+                    aria-labelledby="accessibility-required-{{templateId}}"
+                  />
+                {{else}}
+                  <input
+                    type="checkbox"
+                    {{on "click" (fn @enable "learningMaterialAccessibilityRequired")}}
+                    aria-labelledby="accessibility-required-{{templateId}}"
+                  />
+                {{/if}}
+              </td>
+            </tr>
+            <tr data-test-accessibility-required-message>
+              <td id="accessibility-required-message-{{templateId}}">
+                {{t "general.accessibilityRequiredMessage"}}
+              </td>
+              <td>
                 <input
-                  type="checkbox"
-                  checked={{true}}
-                  {{on "click" (fn @disable "showLearningMaterialAccessibilityRequired")}}
-                  aria-labelledby="accessibility-required-{{templateId}}"
+                  type="text"
+                  value={{@learningMaterialAccessibilityRequiredMessage}}
+                  {{on "input" (pick "target.value" (pipe @update))}}
+                  aria-labelledby="accessibility-required-message-{{templateId}}"
                 />
-              {{else}}
-                <input
-                  type="checkbox"
-                  {{on "click" (fn @enable "showLearningMaterialAccessibilityRequired")}}
-                  aria-labelledby="accessibility-required-{{templateId}}"
-                />
-              {{/if}}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  {{/let}}
-</template>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    {{/let}}
+  </template>
+}

--- a/packages/frontend/app/components/school-learning-material-attributes-manager.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-manager.gjs
@@ -1,0 +1,44 @@
+import { uniqueId, fn } from '@ember/helper';
+import t from 'ember-intl/helpers/t';
+import { on } from '@ember/modifier';
+<template>
+  {{#let (uniqueId) as |templateId|}}
+    <div data-test-school-learning-material-attributes-manager ...attributes>
+      <table class="ilios-table ilios-table-colors condensed">
+        <thead>
+          <tr>
+            <th class="text-left">
+              {{t "general.attribute"}}
+            </th>
+            <th class="text-left">
+              {{t "general.enabled"}}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-test-accessibility-required>
+            <td id="accessibility-required-{{templateId}}">
+              {{t "general.accessibilityRequired"}}
+            </td>
+            <td>
+              {{#if @showLearningMaterialAccessibilityRequired}}
+                <input
+                  type="checkbox"
+                  checked={{true}}
+                  {{on "click" (fn @disable "showLearningMaterialAccessibilityRequired")}}
+                  aria-labelledby="accessibility-required-{{templateId}}"
+                />
+              {{else}}
+                <input
+                  type="checkbox"
+                  {{on "click" (fn @enable "showLearningMaterialAccessibilityRequired")}}
+                  aria-labelledby="accessibility-required-{{templateId}}"
+                />
+              {{/if}}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  {{/let}}
+</template>

--- a/packages/frontend/app/components/school-learning-material-attributes-manager.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-manager.gjs
@@ -6,7 +6,6 @@ import { uniqueId } from '@ember/helper';
 import { on } from '@ember/modifier';
 import t from 'ember-intl/helpers/t';
 import pick from 'ilios-common/helpers/pick';
-import pipe from 'ilios-common/helpers/pipe';
 import { string } from 'yup';
 import YupValidations from 'ilios-common/classes/yup-validations';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
@@ -40,7 +39,6 @@ export default class SchoolLearningMaterialAttributesManager extends Component {
 
   @action
   changeURL(value) {
-    // console.log('changeUrl', value);
     this.validations.addErrorDisplayFor('accessibilityRequirementsLink');
     value = value.trim();
     const regex = RegExp('https://http[s]?:');
@@ -49,6 +47,7 @@ export default class SchoolLearningMaterialAttributesManager extends Component {
     }
     this.accessibilityRequirementsLink = value;
     this.accessibilityRequirementsLinkChanged = true;
+    this.args.update(value);
   }
 
   <template>
@@ -90,9 +89,8 @@ export default class SchoolLearningMaterialAttributesManager extends Component {
                   placeholder="https://example.com"
                   value={{this.bestUrl}}
                   inputmode="url"
-                  {{on "input" (pick "target.value" this.changeUrl)}}
+                  {{on "input" (pick "target.value" this.changeURL)}}
                   {{on "focus" this.selectAllText}}
-                  {{on "keydown" (pick "target.value" (pipe @update))}}
                   aria-labelledby="accessibility-requirements-link-{{templateId}}"
                   {{this.validations.attach "accessibilityRequirementsLink"}}
                 />

--- a/packages/frontend/app/components/school-learning-material-attributes-manager.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-manager.gjs
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
-import { uniqueId, fn } from '@ember/helper';
+import { uniqueId } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import pick from 'ilios-common/helpers/pick';
@@ -29,20 +29,12 @@ export default class SchoolLearningMaterialAttributesManager extends Component {
                 {{t "general.accessibilityRequired"}}
               </td>
               <td>
-                {{#if @learningMaterialAccessibilityRequired}}
-                  <input
-                    type="checkbox"
-                    checked={{true}}
-                    {{on "click" (fn @disable "learningMaterialAccessibilityRequired")}}
-                    aria-labelledby="accessibility-required-{{templateId}}"
-                  />
-                {{else}}
-                  <input
-                    type="checkbox"
-                    {{on "click" (fn @enable "learningMaterialAccessibilityRequired")}}
-                    aria-labelledby="accessibility-required-{{templateId}}"
-                  />
-                {{/if}}
+                <input
+                  type="checkbox"
+                  checked={{@accessibilityRequired}}
+                  {{on "click" @toggle}}
+                  aria-labelledby="accessibility-required-{{templateId}}"
+                />
               </td>
             </tr>
             <tr data-test-accessibility-required-message>
@@ -52,7 +44,7 @@ export default class SchoolLearningMaterialAttributesManager extends Component {
               <td>
                 <input
                   type="text"
-                  value={{@learningMaterialAccessibilityRequiredMessage}}
+                  value={{@accessibilityRequiredMessage}}
                   {{on "input" (pick "target.value" (pipe @update))}}
                   aria-labelledby="accessibility-required-message-{{templateId}}"
                 />

--- a/packages/frontend/app/components/school-learning-material-attributes-manager.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes-manager.gjs
@@ -1,13 +1,55 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { uniqueId } from '@ember/helper';
-import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
+import t from 'ember-intl/helpers/t';
 import pick from 'ilios-common/helpers/pick';
 import pipe from 'ilios-common/helpers/pipe';
+import { string } from 'yup';
+import YupValidations from 'ilios-common/classes/yup-validations';
+import YupValidationMessage from 'ilios-common/components/yup-validation-message';
+
+const DEFAULT_URL_VALUE = 'https://';
 
 export default class SchoolLearningMaterialAttributesManager extends Component {
   @service intl;
+
+  @tracked accessibilityRequirementsLink = this.args.accessibilityRequirementsLink || '';
+  @tracked accessibilityRequirementsLinkChanged = false;
+
+  validations = new YupValidations(this, {
+    accessibilityRequirementsLink: string().ensure().trim().max(2000).url(),
+  });
+
+  get bestUrl() {
+    if (this.accessibilityRequirementsLink || this.accessibilityRequirementsLinkChanged) {
+      return this.accessibilityRequirementsLink;
+    }
+
+    return DEFAULT_URL_VALUE;
+  }
+
+  @action
+  selectAllText({ target }) {
+    if (target.value === DEFAULT_URL_VALUE) {
+      target.select();
+    }
+  }
+
+  @action
+  changeURL(value) {
+    // console.log('changeUrl', value);
+    this.validations.addErrorDisplayFor('accessibilityRequirementsLink');
+    value = value.trim();
+    const regex = RegExp('https://http[s]?:');
+    if (regex.test(value)) {
+      value = value.substring(8);
+    }
+    this.accessibilityRequirementsLink = value;
+    this.accessibilityRequirementsLinkChanged = true;
+  }
 
   <template>
     {{#let (uniqueId) as |templateId|}}
@@ -37,16 +79,27 @@ export default class SchoolLearningMaterialAttributesManager extends Component {
                 />
               </td>
             </tr>
-            <tr data-test-accessibility-required-message>
-              <td id="accessibility-required-message-{{templateId}}">
-                {{t "general.accessibilityRequiredMessage"}}
+            <tr data-test-accessibility-requirements-link>
+              <td id="accessibility-requirements-link-{{templateId}}">
+                {{t "general.accessibilityRequirementsLink"}}
               </td>
               <td>
+                {{! template-lint-disable no-bare-strings}}
                 <input
                   type="text"
-                  value={{@accessibilityRequiredMessage}}
-                  {{on "input" (pick "target.value" (pipe @update))}}
-                  aria-labelledby="accessibility-required-message-{{templateId}}"
+                  placeholder="https://example.com"
+                  value={{this.bestUrl}}
+                  inputmode="url"
+                  {{on "input" (pick "target.value" this.changeUrl)}}
+                  {{on "focus" this.selectAllText}}
+                  {{on "keydown" (pick "target.value" (pipe @update))}}
+                  aria-labelledby="accessibility-requirements-link-{{templateId}}"
+                  {{this.validations.attach "accessibilityRequirementsLink"}}
+                />
+                <YupValidationMessage
+                  @description={{t "general.accessibilityRequirementsLink"}}
+                  @validationErrors={{this.validations.errors.accessibilityRequirementsLink}}
+                  data-test-accessibility-requirements-link-validation-error-message
                 />
               </td>
             </tr>

--- a/packages/frontend/app/components/school-learning-material-attributes.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes.gjs
@@ -26,9 +26,9 @@ export default class SchoolLearningMaterialAttributesComponent extends Component
     const rhett = new Map();
     if (this.schoolConfigsData.isResolved) {
       this.schoolConfigsData.value.forEach((config) => {
-        try {
-          rhett.set(config.name, JSON.parse(config.value));
-        } catch {
+        if (config.value == 'false') {
+          rhett.set(config.name, false);
+        } else {
           rhett.set(config.name, config.value);
         }
       });
@@ -74,8 +74,8 @@ export default class SchoolLearningMaterialAttributesComponent extends Component
         {{#if @details}}
           <SchoolLearningMaterialAttributesExpanded
             @canUpdate={{@canUpdate}}
-            @learningMaterialAccessibilityRequired={{this.learningMaterialAccessibilityRequired}}
-            @learningMaterialAccessibilityRequiredMessage={{this.learningMaterialAccessibilityRequiredMessage}}
+            @accessibilityRequired={{this.learningMaterialAccessibilityRequired}}
+            @accessibilityRequiredMessage={{this.learningMaterialAccessibilityRequiredMessage}}
             @collapse={{@collapse}}
             @isManaging={{@isManaging}}
             @manage={{@manage}}
@@ -83,8 +83,8 @@ export default class SchoolLearningMaterialAttributesComponent extends Component
           />
         {{else}}
           <SchoolLearningMaterialAttributesCollapsed
-            @learningMaterialAccessibilityRequired={{this.learningMaterialAccessibilityRequired}}
-            @learningMaterialAccessibilityRequiredMessage={{this.learningMaterialAccessibilityRequiredMessage}}
+            @accessibilityRequired={{this.learningMaterialAccessibilityRequired}}
+            @accessibilityRequiredMessage={{this.learningMaterialAccessibilityRequiredMessage}}
             @expand={{@expand}}
           />
         {{/if}}

--- a/packages/frontend/app/components/school-learning-material-attributes.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes.gjs
@@ -1,0 +1,75 @@
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+import { TrackedAsyncData } from 'ember-async-data';
+import { or } from 'ember-truth-helpers';
+import perform from 'ember-concurrency/helpers/perform';
+import SchoolLearningMaterialAttributesCollapsed from 'frontend/components/school-learning-material-attributes-collapsed';
+import SchoolLearningMaterialAttributesExpanded from 'frontend/components/school-learning-material-attributes-expanded';
+
+export default class SchoolLearningMaterialAttributesComponent extends Component {
+  schoolConfigNames = ['showLearningMaterialAccessibilityRequired'];
+
+  @cached
+  get schoolConfigsData() {
+    return new TrackedAsyncData(this.args.school.configurations);
+  }
+
+  @cached
+  get schoolConfigs() {
+    const rhett = new Map();
+    if (this.schoolConfigsData.isResolved) {
+      this.schoolConfigsData.value.forEach((config) => {
+        rhett.set(config.name, JSON.parse(config.value));
+      });
+    }
+    return rhett;
+  }
+
+  get showLearningMaterialAccessibilityRequired() {
+    return this.schoolConfigs.get('showLearningMaterialAccessibilityRequired') || null;
+  }
+
+  save = task({ drop: true }, async (newValues) => {
+    try {
+      const needToSave = await Promise.all(
+        this.schoolConfigNames.map((name) => {
+          const value = newValues[name];
+          if (value !== null) {
+            return this.args.school.setConfigValue(name, value);
+          }
+        }),
+      );
+
+      const toSave = needToSave.filter(Boolean);
+      await Promise.all(toSave.map((o) => o.save()));
+    } finally {
+      this.args.manage(false);
+    }
+  });
+  <template>
+    <div
+      class="school-learning-material-attributes"
+      data-test-school-learning-material-attributes
+      ...attributes
+    >
+      {{#if (or this.schoolConfigsData.isResolved this.save.isRunning)}}
+        {{#if @details}}
+          <SchoolLearningMaterialAttributesExpanded
+            @canUpdate={{@canUpdate}}
+            @showLearningMaterialAccessibilityRequired={{this.showLearningMaterialAccessibilityRequired}}
+            @collapse={{@collapse}}
+            @isManaging={{@isManaging}}
+            @manage={{@manage}}
+            @saveAll={{perform this.save}}
+          />
+        {{else}}
+          <SchoolLearningMaterialAttributesCollapsed
+            @showLearningMaterialAccessibilityRequired={{this.showLearningMaterialAccessibilityRequired}}
+            @expand={{@expand}}
+          />
+        {{/if}}
+      {{/if}}
+    </div>
+  </template>
+}

--- a/packages/frontend/app/components/school-learning-material-attributes.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes.gjs
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { TrackedAsyncData } from 'ember-async-data';
 import { or } from 'ember-truth-helpers';
@@ -8,7 +9,12 @@ import SchoolLearningMaterialAttributesCollapsed from 'frontend/components/schoo
 import SchoolLearningMaterialAttributesExpanded from 'frontend/components/school-learning-material-attributes-expanded';
 
 export default class SchoolLearningMaterialAttributesComponent extends Component {
-  schoolConfigNames = ['showLearningMaterialAccessibilityRequired'];
+  @service intl;
+
+  schoolConfigNames = [
+    'learningMaterialAccessibilityRequired',
+    'learningMaterialAccessibilityRequiredMessage',
+  ];
 
   @cached
   get schoolConfigsData() {
@@ -26,8 +32,15 @@ export default class SchoolLearningMaterialAttributesComponent extends Component
     return rhett;
   }
 
-  get showLearningMaterialAccessibilityRequired() {
-    return this.schoolConfigs.get('showLearningMaterialAccessibilityRequired') || null;
+  get learningMaterialAccessibilityRequired() {
+    return this.schoolConfigs.get('learningMaterialAccessibilityRequired') || false;
+  }
+
+  get learningMaterialAccessibilityRequiredMessage() {
+    return (
+      this.schoolConfigs.get('learningMaterialAccessibilityRequiredMessage') ||
+      this.intl.t('general.accessibilityAgreement')
+    );
   }
 
   save = task({ drop: true }, async (newValues) => {
@@ -57,7 +70,8 @@ export default class SchoolLearningMaterialAttributesComponent extends Component
         {{#if @details}}
           <SchoolLearningMaterialAttributesExpanded
             @canUpdate={{@canUpdate}}
-            @showLearningMaterialAccessibilityRequired={{this.showLearningMaterialAccessibilityRequired}}
+            @learningMaterialAccessibilityRequired={{this.learningMaterialAccessibilityRequired}}
+            @learningMaterialAccessibilityRequiredMessage={{this.learningMaterialAccessibilityRequiredMessage}}
             @collapse={{@collapse}}
             @isManaging={{@isManaging}}
             @manage={{@manage}}
@@ -65,7 +79,8 @@ export default class SchoolLearningMaterialAttributesComponent extends Component
           />
         {{else}}
           <SchoolLearningMaterialAttributesCollapsed
-            @showLearningMaterialAccessibilityRequired={{this.showLearningMaterialAccessibilityRequired}}
+            @learningMaterialAccessibilityRequired={{this.learningMaterialAccessibilityRequired}}
+            @learningMaterialAccessibilityRequiredMessage={{this.learningMaterialAccessibilityRequiredMessage}}
             @expand={{@expand}}
           />
         {{/if}}

--- a/packages/frontend/app/components/school-learning-material-attributes.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes.gjs
@@ -26,7 +26,11 @@ export default class SchoolLearningMaterialAttributesComponent extends Component
     const rhett = new Map();
     if (this.schoolConfigsData.isResolved) {
       this.schoolConfigsData.value.forEach((config) => {
-        rhett.set(config.name, JSON.parse(config.value));
+        try {
+          rhett.set(config.name, JSON.parse(config.value));
+        } catch {
+          rhett.set(config.name, config.value);
+        }
       });
     }
     return rhett;

--- a/packages/frontend/app/components/school-learning-material-attributes.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes.gjs
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
-import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { TrackedAsyncData } from 'ember-async-data';
 import { or } from 'ember-truth-helpers';
@@ -9,11 +8,9 @@ import SchoolLearningMaterialAttributesCollapsed from 'frontend/components/schoo
 import SchoolLearningMaterialAttributesExpanded from 'frontend/components/school-learning-material-attributes-expanded';
 
 export default class SchoolLearningMaterialAttributesComponent extends Component {
-  @service intl;
-
   schoolConfigNames = [
     'learningMaterialAccessibilityRequired',
-    'learningMaterialAccessibilityRequiredMessage',
+    'learningMaterialAccessibilityRequirementsLink',
   ];
 
   @cached
@@ -40,11 +37,8 @@ export default class SchoolLearningMaterialAttributesComponent extends Component
     return this.schoolConfigs.get('learningMaterialAccessibilityRequired') || false;
   }
 
-  get learningMaterialAccessibilityRequiredMessage() {
-    return (
-      this.schoolConfigs.get('learningMaterialAccessibilityRequiredMessage') ||
-      this.intl.t('general.accessibilityAgreement')
-    );
+  get learningMaterialAccessibilityRequirementsLink() {
+    return this.schoolConfigs.get('learningMaterialAccessibilityRequirementsLink') || '';
   }
 
   save = task({ drop: true }, async (newValues) => {
@@ -75,7 +69,7 @@ export default class SchoolLearningMaterialAttributesComponent extends Component
           <SchoolLearningMaterialAttributesExpanded
             @canUpdate={{@canUpdate}}
             @accessibilityRequired={{this.learningMaterialAccessibilityRequired}}
-            @accessibilityRequiredMessage={{this.learningMaterialAccessibilityRequiredMessage}}
+            @accessibilityRequirementsLink={{this.learningMaterialAccessibilityRequirementsLink}}
             @collapse={{@collapse}}
             @isManaging={{@isManaging}}
             @manage={{@manage}}
@@ -84,7 +78,7 @@ export default class SchoolLearningMaterialAttributesComponent extends Component
         {{else}}
           <SchoolLearningMaterialAttributesCollapsed
             @accessibilityRequired={{this.learningMaterialAccessibilityRequired}}
-            @accessibilityRequiredMessage={{this.learningMaterialAccessibilityRequiredMessage}}
+            @accessibilityRequirementsLink={{this.learningMaterialAccessibilityRequirementsLink}}
             @expand={{@expand}}
           />
         {{/if}}

--- a/packages/frontend/app/components/school-learning-material-attributes.gjs
+++ b/packages/frontend/app/components/school-learning-material-attributes.gjs
@@ -23,11 +23,7 @@ export default class SchoolLearningMaterialAttributesComponent extends Component
     const rhett = new Map();
     if (this.schoolConfigsData.isResolved) {
       this.schoolConfigsData.value.forEach((config) => {
-        if (config.value == 'false') {
-          rhett.set(config.name, false);
-        } else {
-          rhett.set(config.name, config.value);
-        }
+        rhett.set(config.name, config.parsedValue);
       });
     }
     return rhett;

--- a/packages/frontend/app/components/school-manager.gjs
+++ b/packages/frontend/app/components/school-manager.gjs
@@ -27,6 +27,7 @@ import SchoolVocabulariesCollapsed from 'frontend/components/school-vocabularies
 import SchoolSessionTypesExpanded from 'frontend/components/school-session-types-expanded';
 import SchoolSessionTypesCollapsed from 'frontend/components/school-session-types-collapsed';
 import SchoolSessionAttributes from 'frontend/components/school-session-attributes';
+import SchoolLearningMaterialAttributes from 'frontend/components/school-learning-material-attributes';
 import EmailsEditor from 'frontend/components/school/emails-editor';
 import Emails from 'frontend/components/school/emails';
 import SchoolInstitutionalInformationManager from 'frontend/components/school-institutional-information-manager';
@@ -243,6 +244,15 @@ export default class SchoolManagerComponent extends Component {
             />
           {{/if}}
         {{/if}}
+        <SchoolLearningMaterialAttributes
+          @school={{@school}}
+          @canUpdate={{@canUpdateSchoolConfig}}
+          @collapse={{fn @setSchoolLearningMaterialAttributesDetails false}}
+          @expand={{fn @setSchoolLearningMaterialAttributesDetails true}}
+          @details={{@schoolLearningMaterialAttributesDetails}}
+          @isManaging={{@schoolManageLearningMaterialAttributes}}
+          @manage={{@setSchoolManageLearningMaterialAttributes}}
+        />
         <SchoolSessionAttributes
           @school={{@school}}
           @canUpdate={{@canUpdateSchoolConfig}}

--- a/packages/frontend/app/components/school-session-attributes.gjs
+++ b/packages/frontend/app/components/school-session-attributes.gjs
@@ -25,11 +25,7 @@ export default class SchoolSessionAttributesComponent extends Component {
     const rhett = new Map();
     if (this.schoolConfigsData.isResolved) {
       this.schoolConfigsData.value.forEach((config) => {
-        if (config.value == 'false') {
-          rhett.set(config.name, false);
-        } else {
-          rhett.set(config.name, config.value);
-        }
+        rhett.set(config.name, config.parsedValue);
       });
     }
     return rhett;

--- a/packages/frontend/app/components/school-session-attributes.gjs
+++ b/packages/frontend/app/components/school-session-attributes.gjs
@@ -25,7 +25,11 @@ export default class SchoolSessionAttributesComponent extends Component {
     const rhett = new Map();
     if (this.schoolConfigsData.isResolved) {
       this.schoolConfigsData.value.forEach((config) => {
-        rhett.set(config.name, JSON.parse(config.value));
+        try {
+          rhett.set(config.name, JSON.parse(config.value));
+        } catch {
+          rhett.set(config.name, config.value);
+        }
       });
     }
     return rhett;

--- a/packages/frontend/app/components/school-session-attributes.gjs
+++ b/packages/frontend/app/components/school-session-attributes.gjs
@@ -25,9 +25,9 @@ export default class SchoolSessionAttributesComponent extends Component {
     const rhett = new Map();
     if (this.schoolConfigsData.isResolved) {
       this.schoolConfigsData.value.forEach((config) => {
-        try {
-          rhett.set(config.name, JSON.parse(config.value));
-        } catch {
+        if (config.value == 'false') {
+          rhett.set(config.name, false);
+        } else {
           rhett.set(config.name, config.value);
         }
       });

--- a/packages/frontend/app/controllers/school.js
+++ b/packages/frontend/app/controllers/school.js
@@ -11,7 +11,9 @@ export default class SchoolController extends Controller {
     'schoolLeadershipDetails',
     'schoolManageLeadership',
     'schoolManageSessionAttributes',
+    'schoolManageLearningMaterialAttributes',
     'schoolSessionAttributesDetails',
+    'schoolLearningMaterialAttributesDetails',
     'schoolSessionTypeDetails',
     'schoolManagedSessionType',
     'schoolNewSessionType',
@@ -29,6 +31,8 @@ export default class SchoolController extends Controller {
   @tracked schoolManageLeadership = false;
   @tracked schoolManageSessionAttributes = false;
   @tracked schoolSessionAttributesDetails = false;
+  @tracked schoolManageLearningMaterialAttributes = false;
+  @tracked schoolLearningMaterialAttributesDetails = false;
   @tracked schoolNewSessionType = false;
   @tracked schoolSessionTypeDetails = false;
   @tracked schoolManagedSessionType = null;

--- a/packages/frontend/app/styles/components.scss
+++ b/packages/frontend/app/styles/components.scss
@@ -32,6 +32,8 @@
 @forward "components/school-new-vocabulary-form";
 @forward "components/school-institutional-information-details";
 @forward "components/school-institutional-information-manager";
+@forward "components/school-learning-material-attributes-collapsed";
+@forward "components/school-learning-material-attributes-expanded";
 @forward "components/school-session-attributes-collapsed";
 @forward "components/school-session-attributes-expanded";
 @forward "components/school-session-type-form";

--- a/packages/frontend/app/styles/components/school-learning-material-attributes-collapsed.scss
+++ b/packages/frontend/app/styles/components/school-learning-material-attributes-collapsed.scss
@@ -1,0 +1,17 @@
+@use "../ilios-common/mixins" as m;
+
+.school-learning-material-attributes-collapsed {
+  @include m.collapsed-container(var(--orange));
+
+  .title {
+    @include m.collapsed-container-title;
+  }
+
+  .content {
+    @include m.collapsed-container-content;
+
+    table {
+      @include m.collapsed-container-table;
+    }
+  }
+}

--- a/packages/frontend/app/styles/components/school-learning-material-attributes-expanded.scss
+++ b/packages/frontend/app/styles/components/school-learning-material-attributes-expanded.scss
@@ -1,0 +1,21 @@
+@use "../ilios-common/mixins" as m;
+
+.school-learning-material-attributes-expanded {
+  @include m.detail-container(var(--orange));
+
+  .school-learning-material-attributes-expanded-header {
+    @include m.detail-container-header;
+
+    .title {
+      @include m.detail-container-title;
+    }
+
+    .actions {
+      @include m.detail-container-actions;
+    }
+  }
+
+  .school-session-attributes-expanded-content {
+    @include m.detail-container-content;
+  }
+}

--- a/packages/frontend/app/styles/components/school-learning-material-attributes-expanded.scss
+++ b/packages/frontend/app/styles/components/school-learning-material-attributes-expanded.scss
@@ -15,7 +15,19 @@
     }
   }
 
-  .school-session-attributes-expanded-content {
+  .school-learning-material-attributes-expanded-content {
     @include m.detail-container-content;
+
+    .form {
+      @include m.ilios-form;
+    }
+
+    .validation-error-message {
+      color: var(--red);
+      display: block;
+      @include m.font-size("small");
+      font-style: italic;
+      margin-top: 0.25rem;
+    }
   }
 }

--- a/packages/frontend/app/templates/school.gjs
+++ b/packages/frontend/app/templates/school.gjs
@@ -40,6 +40,16 @@ import set from 'ember-set-helper/helpers/set';
     @setSchoolSessionAttributesDetails={{set @controller "schoolSessionAttributesDetails"}}
     @schoolManageSessionAttributes={{@controller.schoolManageSessionAttributes}}
     @setSchoolManageSessionAttributes={{set @controller "schoolManageSessionAttributes"}}
+    @schoolLearningMaterialAttributesDetails={{@controller.schoolLearningMaterialAttributesDetails}}
+    @setSchoolLearningMaterialAttributesDetails={{set
+      @controller
+      "schoolLearningMaterialAttributesDetails"
+    }}
+    @schoolManageLearningMaterialAttributes={{@controller.schoolManageLearningMaterialAttributes}}
+    @setSchoolManageLearningMaterialAttributes={{set
+      @controller
+      "schoolManageLearningMaterialAttributes"
+    }}
     @schoolSessionTypeDetails={{@controller.schoolSessionTypeDetails}}
     @setSchoolSessionTypeDetails={{set @controller "schoolSessionTypeDetails"}}
     @schoolManagedSessionType={{@controller.schoolManagedSessionType}}

--- a/packages/frontend/tests/acceptance/course/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/learningmaterials-test.js
@@ -16,20 +16,18 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     this.user = await setupAuthentication({ school: this.school }, true);
     this.user2 = this.server.create('user', { displayName: 'Clem Chowder' });
     this.server.create('academic-year');
+
     const statuses = this.server.createList('learningMaterialStatus', 5);
     const roles = this.server.createList('learningMaterialUserRole', 3);
     const descriptors = this.server.createList('mesh-descriptor', 6);
 
-    this.course = this.server.create('course', {
-      year: 2013,
-      school: this.school,
-    });
     this.material1 = this.server.create('learning-material', {
       originalAuthor: 'Jennifer Johnson',
       owningUser: this.user,
       status: statuses[0],
       userRole: roles[0],
       copyrightPermission: true,
+      accessibilityPermission: false,
       filename: 'something.pdf',
       absoluteFileUri: 'http://somethingsomething.com/something.pdf',
       uploadDate: DateTime.fromObject({ year: 2015, month: 2, day: 12, hour: 8 }).toJSDate(),
@@ -41,6 +39,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       userRole: roles[0],
       copyrightPermission: false,
       copyrightRationale: 'reason is thus',
+      accessibilityPermission: true,
       filename: 'filename',
       absoluteFileUri: 'http://example.com/file',
       uploadDate: DateTime.fromObject({ year: 2011, month: 3, day: 14, hour: 8 }).toJSDate(),
@@ -72,6 +71,12 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       filename: 'letter.txt',
       absoluteFileUri: 'http://bttf.com/letter.txt',
     });
+
+    this.course = this.server.create('course', {
+      year: 2013,
+      school: this.school,
+    });
+
     this.server.create('courseLearningMaterial', {
       learningMaterial: this.material1,
       course: this.course,
@@ -300,6 +305,116 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     assert.strictEqual(page.details.learningMaterials.manager.copyrightRationale, 'reason is thus');
     assert.notOk(page.details.learningMaterials.manager.hasLink);
     assert.notOk(page.details.learningMaterials.manager.hasCitation);
+  });
+
+  test('view accessibility file learning material details', async function (assert) {
+    this.user.update({ administeredSchools: [this.school] });
+    await page.visit({ courseId: this.course.id, details: true });
+    assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
+    await page.details.learningMaterials.current[0].details();
+
+    assert.strictEqual(
+      page.details.learningMaterials.manager.name.value,
+      'learning material 0',
+      'lm name correct',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.manager.author,
+      'Jennifer Johnson',
+      'lm author correct',
+    );
+    assert.strictEqual(
+      await page.details.learningMaterials.manager.description.editorValue(),
+      '<p>0 lm description</p>',
+      'lm description is correct',
+    );
+    assert.ok(page.details.learningMaterials.manager.hasFile, 'lm has a file');
+    assert.ok(
+      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      'lm has an a11y toggle',
+    );
+    assert.notOk(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      'lm a11y toggle is not set to yes',
+    );
+    assert.ok(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      'lm a11y toggle is set to no',
+    );
+    assert.notOk(page.details.learningMaterials.manager.hasLink, 'lm does not have link');
+    assert.notOk(page.details.learningMaterials.manager.hasCitation, 'lm does not have citation');
+
+    await page.details.learningMaterials.manager.cancel();
+    await page.details.learningMaterials.current[1].details();
+
+    assert.strictEqual(
+      page.details.learningMaterials.manager.name.value,
+      'learning material 1',
+      'lm name correct',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.manager.author,
+      'Jennifer Johnson',
+      'lm author correct',
+    );
+    assert.strictEqual(
+      await page.details.learningMaterials.manager.description.editorValue(),
+      '<p>1 lm description</p>',
+      'lm description is correct',
+    );
+    assert.ok(page.details.learningMaterials.manager.hasFile, 'lm has a file');
+    assert.ok(
+      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      'lm has an a11y toggle',
+    );
+    assert.ok(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      'lm a11y toggle is set to yes',
+    );
+    assert.notOk(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      'lm a11y toggle is not set to no',
+    );
+    assert.notOk(page.details.learningMaterials.manager.hasLink, 'lm does not have link');
+    assert.notOk(page.details.learningMaterials.manager.hasCitation, 'lm does not have citation');
+  });
+
+  test('toggling accessibility file learning material', async function (assert) {
+    this.user.update({ administeredSchools: [this.school] });
+    await page.visit({ courseId: this.course.id, details: true });
+    assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
+    await page.details.learningMaterials.current[0].details();
+
+    assert.ok(
+      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      'lm has an a11y toggle',
+    );
+    assert.notOk(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      'lm a11y toggle is not set to yes',
+    );
+    assert.ok(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      'lm a11y toggle is set to no',
+    );
+
+    await page.details.learningMaterials.manager.accessibilityPermissionToggle();
+    await page.details.learningMaterials.manager.save();
+
+    await page.details.learningMaterials.current[0].details();
+
+    assert.ok(
+      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      'lm has an a11y toggle',
+    );
+    assert.ok(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      'lm a11y toggle is set to yes',
+    );
+    assert.notOk(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      'lm a11y toggle is not set to no',
+    );
   });
 
   test('view url file learning material details', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/learningmaterials-test.js
@@ -27,7 +27,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       status: statuses[0],
       userRole: roles[0],
       copyrightPermission: true,
-      accessibilityPermission: false,
+      markedAccessible: false,
       filename: 'something.pdf',
       absoluteFileUri: 'http://somethingsomething.com/something.pdf',
       uploadDate: DateTime.fromObject({ year: 2015, month: 2, day: 12, hour: 8 }).toJSDate(),
@@ -39,7 +39,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       userRole: roles[0],
       copyrightPermission: false,
       copyrightRationale: 'reason is thus',
-      accessibilityPermission: true,
+      markedAccessible: true,
       filename: 'filename',
       absoluteFileUri: 'http://example.com/file',
       uploadDate: DateTime.fromObject({ year: 2011, month: 3, day: 14, hour: 8 }).toJSDate(),
@@ -330,15 +330,15 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     );
     assert.ok(page.details.learningMaterials.manager.hasFile, 'lm has a file');
     assert.ok(
-      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
       'lm has an a11y toggle',
     );
     assert.notOk(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      page.details.learningMaterials.manager.markedAccessibleToggleYes,
       'lm a11y toggle is not set to yes',
     );
     assert.ok(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      page.details.learningMaterials.manager.markedAccessibleToggleNo,
       'lm a11y toggle is set to no',
     );
     assert.notOk(page.details.learningMaterials.manager.hasLink, 'lm does not have link');
@@ -364,15 +364,15 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     );
     assert.ok(page.details.learningMaterials.manager.hasFile, 'lm has a file');
     assert.ok(
-      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
       'lm has an a11y toggle',
     );
     assert.ok(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      page.details.learningMaterials.manager.markedAccessibleToggleYes,
       'lm a11y toggle is set to yes',
     );
     assert.notOk(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      page.details.learningMaterials.manager.markedAccessibleToggleNo,
       'lm a11y toggle is not set to no',
     );
     assert.notOk(page.details.learningMaterials.manager.hasLink, 'lm does not have link');
@@ -386,33 +386,33 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     await page.details.learningMaterials.current[0].details();
 
     assert.ok(
-      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
       'lm has an a11y toggle',
     );
     assert.notOk(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      page.details.learningMaterials.manager.markedAccessibleToggleYes,
       'lm a11y toggle is not set to yes',
     );
     assert.ok(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      page.details.learningMaterials.manager.markedAccessibleToggleNo,
       'lm a11y toggle is set to no',
     );
 
-    await page.details.learningMaterials.manager.accessibilityPermissionToggle();
+    await page.details.learningMaterials.manager.markedAccessibleToggle();
     await page.details.learningMaterials.manager.save();
 
     await page.details.learningMaterials.current[0].details();
 
     assert.ok(
-      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
       'lm has an a11y toggle',
     );
     assert.ok(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      page.details.learningMaterials.manager.markedAccessibleToggleYes,
       'lm a11y toggle is set to yes',
     );
     assert.notOk(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      page.details.learningMaterials.manager.markedAccessibleToggleNo,
       'lm a11y toggle is not set to no',
     );
   });

--- a/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
@@ -9,6 +9,7 @@ const today = DateTime.fromObject({ hour: 8 });
 
 module('Acceptance | Session - Learning Materials', function (hooks) {
   setupApplicationTest(hooks);
+
   hooks.beforeEach(async function () {
     this.intl = this.owner.lookup('service:intl');
     this.school = this.server.create('school');
@@ -26,6 +27,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       status: statuses[0],
       userRole: roles[0],
       copyrightPermission: true,
+      accessibilityPermission: false,
       filename: 'something.pdf',
       absoluteFileUri: 'http://somethingsomething.com/something.pdf',
       uploadDate: DateTime.fromObject({ year: 2015, month: 2, day: 12, hour: 8 }).toJSDate(),
@@ -37,6 +39,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       userRole: roles[0],
       copyrightPermission: false,
       copyrightRationale: 'reason is thus',
+      accessibilityPermission: true,
       filename: 'filename',
       title: 'http://example.com/subdir1/subdir2/long_file_name.pdf',
       absoluteFileUri: 'http://example.com/subdir1/subdir2/long_file_name.pdf',
@@ -69,15 +72,18 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       copyrightPermission: true,
       uploadDate: DateTime.fromObject({ year: 2016, month: 3, day: 3, hour: 8 }).toJSDate(),
     });
+
     this.course = this.server.create('course', {
       year: 2013,
       school: this.school,
     });
+
     const sessionType = this.server.create('session-type', { school: this.school });
     const session = this.server.create('session', {
       course: this.course,
       sessionType,
     });
+
     this.server.create('session-learning-material', {
       learningMaterial: this.material1,
       session,
@@ -310,6 +316,114 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     assert.strictEqual(page.details.learningMaterials.manager.copyrightRationale, 'reason is thus');
     assert.notOk(page.details.learningMaterials.manager.hasLink);
     assert.notOk(page.details.learningMaterials.manager.hasCitation);
+  });
+
+  test('view accessibility file learning material details', async function (assert) {
+    await page.visit({ courseId: this.course.id, sessionId: 1 });
+    assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
+    await page.details.learningMaterials.current[0].details();
+
+    assert.strictEqual(
+      page.details.learningMaterials.manager.name.value,
+      'learning material 0',
+      'lm name correct',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.manager.author,
+      'Jennifer Johnson',
+      'lm author correct',
+    );
+    assert.strictEqual(
+      await page.details.learningMaterials.manager.description.editorValue(),
+      '<p>0 lm description</p>',
+      'lm description is correct',
+    );
+    assert.ok(page.details.learningMaterials.manager.hasFile, 'lm has a file');
+    assert.ok(
+      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      'lm has an a11y toggle',
+    );
+    assert.notOk(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      'lm a11y toggle is not set to yes',
+    );
+    assert.ok(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      'lm a11y toggle is set to no',
+    );
+    assert.notOk(page.details.learningMaterials.manager.hasLink, 'lm does not have link');
+    assert.notOk(page.details.learningMaterials.manager.hasCitation, 'lm does not have citation');
+
+    await page.details.learningMaterials.manager.cancel();
+    await page.details.learningMaterials.current[1].details();
+
+    assert.strictEqual(
+      page.details.learningMaterials.manager.name.value,
+      'learning material 1',
+      'lm name correct',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.manager.author,
+      'Jennifer Johnson',
+      'lm author correct',
+    );
+    assert.strictEqual(
+      await page.details.learningMaterials.manager.description.editorValue(),
+      '<p>1 lm description</p>',
+      'lm description is correct',
+    );
+    assert.ok(page.details.learningMaterials.manager.hasFile, 'lm has a file');
+    assert.ok(
+      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      'lm has an a11y toggle',
+    );
+    assert.ok(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      'lm a11y toggle is set to yes',
+    );
+    assert.notOk(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      'lm a11y toggle is not set to no',
+    );
+    assert.notOk(page.details.learningMaterials.manager.hasLink, 'lm does not have link');
+    assert.notOk(page.details.learningMaterials.manager.hasCitation, 'lm does not have citation');
+  });
+
+  test('toggling accessibility file learning material', async function (assert) {
+    await page.visit({ courseId: this.course.id, sessionId: 1 });
+    assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
+    await page.details.learningMaterials.current[0].details();
+
+    assert.ok(
+      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      'lm has an a11y toggle',
+    );
+    assert.notOk(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      'lm a11y toggle is not set to yes',
+    );
+    assert.ok(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      'lm a11y toggle is set to no',
+    );
+
+    await page.details.learningMaterials.manager.accessibilityPermissionToggle();
+    await page.details.learningMaterials.manager.save();
+
+    await page.details.learningMaterials.current[0].details();
+
+    assert.ok(
+      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      'lm has an a11y toggle',
+    );
+    assert.ok(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      'lm a11y toggle is set to yes',
+    );
+    assert.notOk(
+      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      'lm a11y toggle is not set to no',
+    );
   });
 
   test('view url file learning material details', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
@@ -27,7 +27,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       status: statuses[0],
       userRole: roles[0],
       copyrightPermission: true,
-      accessibilityPermission: false,
+      markedAccessible: false,
       filename: 'something.pdf',
       absoluteFileUri: 'http://somethingsomething.com/something.pdf',
       uploadDate: DateTime.fromObject({ year: 2015, month: 2, day: 12, hour: 8 }).toJSDate(),
@@ -39,7 +39,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       userRole: roles[0],
       copyrightPermission: false,
       copyrightRationale: 'reason is thus',
-      accessibilityPermission: true,
+      markedAccessible: true,
       filename: 'filename',
       title: 'http://example.com/subdir1/subdir2/long_file_name.pdf',
       absoluteFileUri: 'http://example.com/subdir1/subdir2/long_file_name.pdf',
@@ -319,6 +319,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('view accessibility file learning material details', async function (assert) {
+    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
     await page.details.learningMaterials.current[0].details();
@@ -328,6 +329,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       'learning material 0',
       'lm name correct',
     );
+
     assert.strictEqual(
       page.details.learningMaterials.manager.author,
       'Jennifer Johnson',
@@ -340,15 +342,15 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     );
     assert.ok(page.details.learningMaterials.manager.hasFile, 'lm has a file');
     assert.ok(
-      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
       'lm has an a11y toggle',
     );
     assert.notOk(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      page.details.learningMaterials.manager.markedAccessibleToggleYes,
       'lm a11y toggle is not set to yes',
     );
     assert.ok(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      page.details.learningMaterials.manager.markedAccessibleToggleNo,
       'lm a11y toggle is set to no',
     );
     assert.notOk(page.details.learningMaterials.manager.hasLink, 'lm does not have link');
@@ -359,7 +361,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
     assert.strictEqual(
       page.details.learningMaterials.manager.name.value,
-      'learning material 1',
+      'http://example.com/subdir1/subdir2/long_file_name.pdf',
       'lm name correct',
     );
     assert.strictEqual(
@@ -374,15 +376,15 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     );
     assert.ok(page.details.learningMaterials.manager.hasFile, 'lm has a file');
     assert.ok(
-      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
       'lm has an a11y toggle',
     );
     assert.ok(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      page.details.learningMaterials.manager.markedAccessibleToggleYes,
       'lm a11y toggle is set to yes',
     );
     assert.notOk(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      page.details.learningMaterials.manager.markedAccessibleToggleNo,
       'lm a11y toggle is not set to no',
     );
     assert.notOk(page.details.learningMaterials.manager.hasLink, 'lm does not have link');
@@ -390,38 +392,39 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('toggling accessibility file learning material', async function (assert) {
+    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
     await page.details.learningMaterials.current[0].details();
 
     assert.ok(
-      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
       'lm has an a11y toggle',
     );
     assert.notOk(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      page.details.learningMaterials.manager.markedAccessibleToggleYes,
       'lm a11y toggle is not set to yes',
     );
     assert.ok(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      page.details.learningMaterials.manager.markedAccessibleToggleNo,
       'lm a11y toggle is set to no',
     );
 
-    await page.details.learningMaterials.manager.accessibilityPermissionToggle();
+    await page.details.learningMaterials.manager.markedAccessibleToggle();
     await page.details.learningMaterials.manager.save();
 
     await page.details.learningMaterials.current[0].details();
 
     assert.ok(
-      page.details.learningMaterials.manager.hasAccessibilityPermissionToggle,
+      page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
       'lm has an a11y toggle',
     );
     assert.ok(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleYes,
+      page.details.learningMaterials.manager.markedAccessibleToggleYes,
       'lm a11y toggle is set to yes',
     );
     assert.notOk(
-      page.details.learningMaterials.manager.accessibilityPermissionToggleNo,
+      page.details.learningMaterials.manager.markedAccessibleToggleNo,
       'lm a11y toggle is not set to no',
     );
   });

--- a/packages/frontend/tests/acceptance/school/learning-material-attributes-test.js
+++ b/packages/frontend/tests/acceptance/school/learning-material-attributes-test.js
@@ -1,0 +1,141 @@
+import { module, test } from 'qunit';
+import { setupAuthentication } from 'ilios-common';
+import { setupApplicationTest, takeScreenshot } from 'frontend/tests/helpers';
+import page from 'frontend/tests/pages/school';
+
+module('Acceptance | School - Learning Material Attributes', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(async function () {
+    this.school = this.server.create('school');
+    await setupAuthentication({ school: this.school }, true);
+  });
+
+  test('check fields collapsed', async function (assert) {
+    this.server.create('schoolConfig', {
+      school: this.school,
+      name: 'learningMaterialAccessibilityRequired',
+      value: false,
+    });
+    this.server.create('schoolConfig', {
+      school: this.school,
+      name: 'learningMaterialAccessibilityRequirementsLink',
+      value: '',
+    });
+    await page.visit({ schoolId: this.school.id });
+    await takeScreenshot(assert);
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.collapsed.accessibilityRequired.label,
+      'Accessibility Required',
+    );
+    assert.ok(
+      page.manager.schoolLearningMaterialAttributes.collapsed.accessibilityRequired.isDisabled,
+    );
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.collapsed.accessibilityRequirementsLink.label,
+      'Accessibility Requirements Link',
+    );
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.collapsed.accessibilityRequirementsLink.link,
+      '',
+    );
+  });
+
+  test('check fields expanded', async function (assert) {
+    this.server.create('schoolConfig', {
+      school: this.school,
+      name: 'learningMaterialAccessibilityRequired',
+      value: false,
+    });
+    this.server.create('schoolConfig', {
+      school: this.school,
+      name: 'learningMaterialAccessibilityRequirementsLink',
+      value: '',
+    });
+    await page.visit({ schoolId: this.school.id, schoolLearningMaterialAttributesDetails: true });
+    await takeScreenshot(assert);
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.expanded.attributes.accessibilityRequired.label,
+      'Accessibility Required',
+    );
+    assert.ok(
+      page.manager.schoolLearningMaterialAttributes.expanded.attributes.accessibilityRequired
+        .isDisabled,
+    );
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.expanded.attributes
+        .accessibilityRequirementsLink.label,
+      'Accessibility Requirements Link',
+    );
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.expanded.attributes
+        .accessibilityRequirementsLink.link,
+      '',
+    );
+  });
+
+  test('manage learning material attributes', async function (assert) {
+    this.server.create('schoolConfig', {
+      school: this.school,
+      name: 'learningMaterialAccessibilityRequired',
+      value: false,
+    });
+    this.server.create('schoolConfig', {
+      school: this.school,
+      name: 'learningMaterialAccessibilityRequirementLink',
+      value: '',
+    });
+    await page.visit({
+      schoolId: this.school.id,
+      schoolLearningMaterialAttributesDetails: true,
+      schoolManageLearningMaterialAttributes: true,
+    });
+    await takeScreenshot(assert, 'default');
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.expanded.manager.accessibilityRequired.label,
+      'Accessibility Required',
+      'required attribute label correct',
+    );
+    assert.notOk(
+      page.manager.schoolLearningMaterialAttributes.expanded.manager.accessibilityRequired
+        .isChecked,
+      'required attribute value is not checked',
+    );
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.expanded.manager.accessibilityRequirementsLink
+        .label,
+      'Accessibility Requirements Link',
+      'requirements link attribute label correct',
+    );
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.expanded.manager.accessibilityRequirementsLink
+        .link,
+      undefined,
+      'requirements link is empty',
+    );
+    await page.manager.schoolLearningMaterialAttributes.expanded.manager.accessibilityRequired.check();
+    await page.manager.schoolLearningMaterialAttributes.expanded.manager.accessibilityRequirementsLink.update(
+      'https://iliosproject.org',
+    );
+    await takeScreenshot(assert, 'learning material attributes checked and filled out');
+    await page.manager.schoolLearningMaterialAttributes.expanded.save();
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.expanded.attributes.accessibilityRequired.label,
+      'Accessibility Required',
+    );
+    assert.notOk(
+      page.manager.schoolLearningMaterialAttributes.expanded.attributes.accessibilityRequired
+        .isDisabled,
+    );
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.expanded.attributes
+        .accessibilityRequirementsLink.label,
+      'Accessibility Requirements Link',
+    );
+    assert.strictEqual(
+      page.manager.schoolLearningMaterialAttributes.expanded.attributes
+        .accessibilityRequirementsLink.link,
+      'https://iliosproject.org',
+    );
+  });
+});

--- a/packages/frontend/tests/pages/components/school-learning-material-attributes-collapsed.js
+++ b/packages/frontend/tests/pages/components/school-learning-material-attributes-collapsed.js
@@ -1,0 +1,20 @@
+import { clickable, create, hasClass, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-school-learning-material-attributes-collapsed]',
+  expand: clickable('[data-test-title]'),
+  accessibilityRequired: {
+    scope: '[data-test-accessibility-required]',
+    label: text('td:nth-of-type(1)'),
+    isEnabled: hasClass('fa-check', 'td:nth-of-type(2) svg'),
+    isDisabled: hasClass('fa-ban', 'td:nth-of-type(2) svg'),
+  },
+  accessibilityRequirementsLink: {
+    scope: '[data-test-accessibility-requirements-link]',
+    label: text('td:nth-of-type(1)'),
+    link: text('td:nth-of-type(2) span'),
+  },
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/frontend/tests/pages/components/school-learning-material-attributes-expanded.js
+++ b/packages/frontend/tests/pages/components/school-learning-material-attributes-expanded.js
@@ -1,0 +1,28 @@
+import { clickable, create, hasClass, text } from 'ember-cli-page-object';
+import manager from './school-learning-material-attributes-manager';
+
+const definition = {
+  scope: '[data-test-school-learning-material-attributes-expanded]',
+  collapse: clickable('[data-test-title]'),
+  manage: clickable('[data-test-manage]'),
+  save: clickable('[data-test-save]'),
+  cancel: clickable('[data-test-cancel]'),
+  attributes: {
+    scope: '[data-test-attributes]',
+    accessibilityRequired: {
+      scope: '[data-test-accessibility-required]',
+      label: text('td:nth-of-type(1)'),
+      isEnabled: hasClass('fa-check', 'td:nth-of-type(2) svg'),
+      isDisabled: hasClass('fa-ban', 'td:nth-of-type(2) svg'),
+    },
+    accessibilityRequirementsLink: {
+      scope: '[data-test-accessibility-requirements-link]',
+      label: text('td:nth-of-type(1)'),
+      link: text('td:nth-of-type(2) span'),
+    },
+  },
+  manager,
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/frontend/tests/pages/components/school-learning-material-attributes-manager.js
+++ b/packages/frontend/tests/pages/components/school-learning-material-attributes-manager.js
@@ -1,0 +1,20 @@
+import { clickable, create, fillable, property, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-school-learning-material-attributes-manager]',
+  accessibilityRequired: {
+    scope: '[data-test-accessibility-required]',
+    label: text('td:nth-of-type(1)'),
+    isChecked: property('checked', 'input'),
+    check: clickable('input'),
+  },
+  accessibilityRequirementsLink: {
+    scope: '[data-test-accessibility-requirements-link]',
+    label: text('td:nth-of-type(1)'),
+    isEmpty: property('value', ''),
+    update: fillable('input'),
+  },
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/frontend/tests/pages/components/school-learning-material-attributes.js
+++ b/packages/frontend/tests/pages/components/school-learning-material-attributes.js
@@ -1,0 +1,12 @@
+import { create } from 'ember-cli-page-object';
+import collapsed from './school-learning-material-attributes-collapsed';
+import expanded from './school-learning-material-attributes-expanded';
+
+const definition = {
+  scope: '[data-test-school-learning-material-attributes]',
+  collapsed,
+  expanded,
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/frontend/tests/pages/components/school-manager.js
+++ b/packages/frontend/tests/pages/components/school-manager.js
@@ -6,6 +6,7 @@ import schoolVocabulariesCollapsed from './school-vocabularies-collapsed';
 import schoolSessionTypesExpanded from './school-session-types-expanded';
 import schoolSessionTypesCollapsed from './school-session-types-collapsed';
 import schoolSessionAttributes from './school-session-attributes';
+import schoolLearningMaterialAttributes from './school-learning-material-attributes';
 import schoolInstitutionalInformationManager from './school-institutional-information-manager';
 import schoolInstitutionalInformationDetails from './school-institutional-information-details';
 import schoolLeadershipCollapsed from 'ilios-common/page-objects/components/leadership-collapsed';
@@ -33,6 +34,7 @@ const definition = {
   schoolSessionTypesExpanded,
   schoolSessionTypesCollapsed,
   schoolSessionAttributes,
+  schoolLearningMaterialAttributes,
   schoolInstitutionalInformationDetails,
   schoolInstitutionalInformationManager,
   emails,

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -4,6 +4,7 @@ general:
   aamcSchoolId: 'AAMC School ID (e.g. "Institution ID")'
   academicYear: Academic Year
   academicYears: Academic Years
+  accessibilityRequired: Accessibility Required
   accommodationIsRequiredForLearnersInThisGroup: Accommodation is required for learners in this group
   accommodationIsRequiredForLearnersInSubgroups: "Accommodation is required for learners in the following subgroups: {groups}"
   accountEnabled: Account Enabled
@@ -186,6 +187,7 @@ general:
   learnerGroupTitleFilterPlaceholder: Filter by Learner Group Title
   learnerGroupTitlePlaceholder: Enter a title for this learner group
   learningMaterial: Learning Material
+  learningMaterialAttributes: Learning Material Attributes
   linkedCompetencies: Linked Competencies
   linkedCompetencyCount: "{count, plural, =1 {1 has a linked competency} other {# have linked competencies}}"
   lock: Lock
@@ -200,6 +202,7 @@ general:
   manageEmails: Manage Emails
   manageGroupMembership: Manage Group Membership
   manageInstitutionalInformation: Manage Institutional Information
+  manageLearningMaterialAttributes: Manage Learning Material Attributes
   manageSessionAttributes: Manage Session Attributes
   manageUsersSummaryTitle: Ilios Users
   matchGroups: Match Groups

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -5,6 +5,7 @@ general:
   academicYear: Academic Year
   academicYears: Academic Years
   accessibilityRequired: Accessibility Required
+  accessibilityRequiredMessage: Accessibility Required Message
   accommodationIsRequiredForLearnersInThisGroup: Accommodation is required for learners in this group
   accommodationIsRequiredForLearnersInSubgroups: "Accommodation is required for learners in the following subgroups: {groups}"
   accountEnabled: Account Enabled

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -5,7 +5,6 @@ general:
   academicYear: Academic Year
   academicYears: Academic Years
   accessibilityRequired: Accessibility Required
-  accessibilityRequirementsLink: Accessibility Requirements Link
   accommodationIsRequiredForLearnersInThisGroup: Accommodation is required for learners in this group
   accommodationIsRequiredForLearnersInSubgroups: "Accommodation is required for learners in the following subgroups: {groups}"
   accountEnabled: Account Enabled

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -5,7 +5,7 @@ general:
   academicYear: Academic Year
   academicYears: Academic Years
   accessibilityRequired: Accessibility Required
-  accessibilityRequiredMessage: Accessibility Required Message
+  accessibilityRequirementsLink: Accessibility Requirements Link
   accommodationIsRequiredForLearnersInThisGroup: Accommodation is required for learners in this group
   accommodationIsRequiredForLearnersInSubgroups: "Accommodation is required for learners in the following subgroups: {groups}"
   accountEnabled: Account Enabled

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -5,7 +5,7 @@ general:
   academicYear: Año Academico
   academicYears: Años Academicos
   accessibilityRequired: Accesibilidad Requerida
-  accessibilityRequiredMessage: Mensaje de Accesibilidad Requerida
+  accessibilityRequirementsLink: Enlace a los Requisitos de Accesibilidad
   accommodationIsRequiredForLearnersInThisGroup: Se requiere alojamiento para los estudiantes de este grupo
   accommodationIsRequiredForLearnersInSubgroups: "Se requiere alojamiento para los estudiantes de los siguientes subgrupos: {groups}"
   accountEnabled: Cuenta Activa

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -4,7 +4,8 @@ general:
   aamcSchoolId: 'Identificación de la escuela AAMC ("ID de la institución")'
   academicYear: Año Academico
   academicYears: Años Academicos
-  accessibilityRequired: Se Requiere Accesibilidad
+  accessibilityRequired: Accesibilidad Requerida
+  accessibilityRequiredMessage: Mensaje de Accesibilidad Requerida
   accommodationIsRequiredForLearnersInThisGroup: Se requiere alojamiento para los estudiantes de este grupo
   accommodationIsRequiredForLearnersInSubgroups: "Se requiere alojamiento para los estudiantes de los siguientes subgrupos: {groups}"
   accountEnabled: Cuenta Activa

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -4,6 +4,7 @@ general:
   aamcSchoolId: 'Identificación de la escuela AAMC ("ID de la institución")'
   academicYear: Año Academico
   academicYears: Años Academicos
+  accessibilityRequired: Se Requiere Accesibilidad
   accommodationIsRequiredForLearnersInThisGroup: Se requiere alojamiento para los estudiantes de este grupo
   accommodationIsRequiredForLearnersInSubgroups: "Se requiere alojamiento para los estudiantes de los siguientes subgrupos: {groups}"
   accountEnabled: Cuenta Activa
@@ -186,6 +187,7 @@ general:
   learnerGroupTitleFilterPlaceholder: Aplicar un Filtro por Título de Grupo de Aprendedor
   learnerGroupTitlePlaceholder: Entre en un Título para este grupo de aprendedores
   learningMaterial: Material de Aprendizaje
+  learningMaterialAttributes: Atributos del Materiales de Aprendizaje
   linkedCompetencies: Competencias Vinculadas
   linkedCompetencyCount: "{count, plural, =1 {1 tiene una competencia vinculada} other {# tienen competencias vinculadas}}"
   lock: Bloquear
@@ -200,6 +202,7 @@ general:
   manageEmails: Administrar correos electrónicos
   manageGroupMembership: Administrar membresía de grupo
   manageInstitutionalInformation: Administrar información institucional
+  manageLearningMaterialAttributes: Maneje Atributos del Material de Aprendizaje
   manageSessionAttributes: Maneje Atributos de la Sesión
   manageUsersSummaryTitle: Usuarios de Ilios
   matchGroups: Igualar Grupos

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -5,7 +5,6 @@ general:
   academicYear: Año Academico
   academicYears: Años Academicos
   accessibilityRequired: Accesibilidad Requerida
-  accessibilityRequirementsLink: Enlace a los Requisitos de Accesibilidad
   accommodationIsRequiredForLearnersInThisGroup: Se requiere alojamiento para los estudiantes de este grupo
   accommodationIsRequiredForLearnersInSubgroups: "Se requiere alojamiento para los estudiantes de los siguientes subgrupos: {groups}"
   accountEnabled: Cuenta Activa

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -5,7 +5,6 @@ general:
   academicYear: Année Scolaire
   academicYears: Années Scolaire
   accessibilityRequired: Accessibilité requise
-  accessibilityRequirementsLink: Lien vers les exigences d'accessibilité
   accommodationIsRequiredForLearnersInThisGroup: Des aménagements sont nécessaires pour les apprenants de ce groupe
   accommodationIsRequiredForLearnersInSubgroups: "Des aménagements sont nécessaires pour les apprenants des sous-groupes suivants: {groups}"
   accountEnabled: Compte Activé

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -5,7 +5,7 @@ general:
   academicYear: Année Scolaire
   academicYears: Années Scolaire
   accessibilityRequired: Accessibilité requise
-  accessibilityRequiredMessage: Message d'accessibilité requis
+  accessibilityRequirementsLink: Lien vers les exigences d'accessibilité
   accommodationIsRequiredForLearnersInThisGroup: Des aménagements sont nécessaires pour les apprenants de ce groupe
   accommodationIsRequiredForLearnersInSubgroups: "Des aménagements sont nécessaires pour les apprenants des sous-groupes suivants: {groups}"
   accountEnabled: Compte Activé

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -4,6 +4,7 @@ general:
   aamcSchoolId: 'Identifiant d''école AAMC ("Identifiant d''institution")'
   academicYear: Année Scolaire
   academicYears: Années Scolaire
+  accessibilityRequired: Accessibilité requise
   accommodationIsRequiredForLearnersInThisGroup: Des aménagements sont nécessaires pour les apprenants de ce groupe
   accommodationIsRequiredForLearnersInSubgroups: "Des aménagements sont nécessaires pour les apprenants des sous-groupes suivants: {groups}"
   accountEnabled: Compte Activé
@@ -186,6 +187,7 @@ general:
   learnerGroupTitleFilterPlaceholder: "Filtre par titre de groupe d'apprenants"
   learnerGroupTitlePlaceholder: "Ajoutez une titre pour cette groupe d'apprenants"
   learningMaterial: "Matériel d'Étude"
+  learningMaterialAttributes: "Attributs du Matériels d'Étude"
   linkedCompetencies: Compétences Liés
   linkedCompetencyCount: "{count, plural, =1 {1 présente un compétence líé} other {# présentes des compétences líés}}"
   lock: Verrouiller
@@ -200,6 +202,7 @@ general:
   manageEmails: Gérer les emails
   manageGroupMembership: "Gérer l'appartenance au groupe"
   manageInstitutionalInformation: Manager les informations institutionnelles
+  manageLearningMaterialAttributes: "Gérer Attributs du Matériel d'Étude"
   manageSessionAttributes: Gérer Attributs de Séance
   manageUsersSummaryTitle: "utilisateurs d'Ilios"
   matchGroups: "Départagez les Groupes "

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -5,6 +5,7 @@ general:
   academicYear: Année Scolaire
   academicYears: Années Scolaire
   accessibilityRequired: Accessibilité requise
+  accessibilityRequiredMessage: Message d'accessibilité requis
   accommodationIsRequiredForLearnersInThisGroup: Des aménagements sont nécessaires pour les apprenants de ce groupe
   accommodationIsRequiredForLearnersInSubgroups: "Des aménagements sont nécessaires pour les apprenants des sous-groupes suivants: {groups}"
   accountEnabled: Compte Activé

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials.js
@@ -49,16 +49,12 @@ const definition = {
     },
     copyrightPermission: text('.copyrightpermission'),
     copyrightRationale: text('.copyrightrationale'),
-    accessibilityPermission: text('.accessibilitypermission'),
-    accessibilityPermissionToggle: clickable(
-      '.accessibility-permission-toggle button.toggle-yesno .switch-handle',
+    markedAccessible: text('.markedaccessible'),
+    markedAccessibleToggle: clickable(
+      '.marked-accessible-toggle button.toggle-yesno .switch-handle',
     ),
-    accessibilityPermissionToggleYes: isVisible(
-      '.accessibility-permission-toggle button.toggle-yesno.yes',
-    ),
-    accessibilityPermissionToggleNo: isVisible(
-      '.accessibility-permission-toggle button.toggle-yesno.no',
-    ),
+    markedAccessibleToggleYes: isVisible('.marked-accessible-toggle button.toggle-yesno.yes'),
+    markedAccessibleToggleNo: isVisible('.marked-accessible-toggle button.toggle-yesno.no'),
     uploadDate: text('.upload-date'),
     downloadText: text('.downloadurl a'),
     downloadUrl: attribute('href', '.downloadurl a'),
@@ -66,9 +62,7 @@ const definition = {
     citation: text('.citation'),
     hasCopyrightPermission: isVisible('.copyrightpermission'),
     hasCopyrightRationale: isVisible('.copyrightrationale'),
-    hasAccessibilityPermissionToggle: isVisible(
-      '.accessibility-permission-toggle button.toggle-yesno',
-    ),
+    hasMarkedAccessibleToggle: isVisible('.marked-accessible-toggle button.toggle-yesno'),
     hasLink: isVisible('.link'),
     hasCitation: isVisible('.citation'),
     hasFile: isVisible('.downloadurl'),

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials.js
@@ -49,6 +49,16 @@ const definition = {
     },
     copyrightPermission: text('.copyrightpermission'),
     copyrightRationale: text('.copyrightrationale'),
+    accessibilityPermission: text('.accessibilitypermission'),
+    accessibilityPermissionToggle: clickable(
+      '.accessibility-permission-toggle button.toggle-yesno .switch-handle',
+    ),
+    accessibilityPermissionToggleYes: isVisible(
+      '.accessibility-permission-toggle button.toggle-yesno.yes',
+    ),
+    accessibilityPermissionToggleNo: isVisible(
+      '.accessibility-permission-toggle button.toggle-yesno.no',
+    ),
     uploadDate: text('.upload-date'),
     downloadText: text('.downloadurl a'),
     downloadUrl: attribute('href', '.downloadurl a'),
@@ -56,6 +66,9 @@ const definition = {
     citation: text('.citation'),
     hasCopyrightPermission: isVisible('.copyrightpermission'),
     hasCopyrightRationale: isVisible('.copyrightrationale'),
+    hasAccessibilityPermissionToggle: isVisible(
+      '.accessibility-permission-toggle button.toggle-yesno',
+    ),
     hasLink: isVisible('.link'),
     hasCitation: isVisible('.citation'),
     hasFile: isVisible('.downloadurl'),

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials.js
@@ -49,7 +49,7 @@ const definition = {
     },
     copyrightPermission: text('.copyrightpermission'),
     copyrightRationale: text('.copyrightrationale'),
-    markedAccessible: text('.markedaccessible'),
+    markedAccessible: text('[data-test-marked-accessible-value]'),
     markedAccessibleToggle: clickable(
       '.marked-accessible-toggle button.toggle-yesno .switch-handle',
     ),

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/new-learningmaterial.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/new-learningmaterial.js
@@ -88,6 +88,9 @@ const definition = {
       scope: '[data-test-marked-accessible-validation-error-message]',
     },
   },
+  accessibilityRequirementsLink: {
+    scope: '[data-test-accessibility-requirements-link]',
+  },
   fileUpload: {
     scope: '[data-test-file]',
     errorMessage: {

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/new-learningmaterial.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/new-learningmaterial.js
@@ -78,6 +78,16 @@ const definition = {
       scope: '[data-test-copyright-rationale-validation-error-message]',
     },
   },
+  accessibilityPermission: {
+    scope: '[data-test-accessibility-permission]',
+    toggle: clickable('input'),
+    ariaInvalid: attribute('aria-invalid', 'input'),
+    ariaErrorMessage: attribute('aria-errormessage', 'input'),
+    errorMessage: {
+      id: attribute('id'),
+      scope: '[data-test-accessibility-permission-validation-error-message]',
+    },
+  },
   fileUpload: {
     scope: '[data-test-file]',
     errorMessage: {

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/new-learningmaterial.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/new-learningmaterial.js
@@ -78,14 +78,14 @@ const definition = {
       scope: '[data-test-copyright-rationale-validation-error-message]',
     },
   },
-  accessibilityPermission: {
-    scope: '[data-test-accessibility-permission]',
+  markedAccessible: {
+    scope: '[data-test-marked-accessible]',
     toggle: clickable('input'),
     ariaInvalid: attribute('aria-invalid', 'input'),
     ariaErrorMessage: attribute('aria-errormessage', 'input'),
     errorMessage: {
       id: attribute('id'),
-      scope: '[data-test-accessibility-permission-validation-error-message]',
+      scope: '[data-test-marked-accessible-validation-error-message]',
     },
   },
   fileUpload: {

--- a/packages/ilios-common/addon/components/detail-learning-materials.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials.gjs
@@ -74,9 +74,6 @@ export default class DetailLearningMaterialsComponent extends Component {
     return !!this.managingMaterial;
   }
 
-  get isSession() {
-    return !this.args.isCourse;
-  }
   get displaySearchBox() {
     return !this.isManaging && !this.displayAddNewForm && !this.isSorting && this.args.editable;
   }

--- a/packages/ilios-common/addon/components/detail-learning-materials.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials.gjs
@@ -248,6 +248,7 @@ export default class DetailLearningMaterialsComponent extends Component {
         {{else if this.displayAddNewForm}}
           <NewLearningmaterial
             @type={{this.type}}
+            @subject={{@subject}}
             @learningMaterialStatuses={{this.learningMaterialStatuses}}
             @learningMaterialUserRoles={{this.learningMaterialUserRoles}}
             @save={{perform this.saveNewLearningMaterial}}

--- a/packages/ilios-common/addon/components/detail-learning-materials.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials.gjs
@@ -232,6 +232,8 @@ export default class DetailLearningMaterialsComponent extends Component {
         {{#if this.isManaging}}
           <LearningmaterialManager
             @learningMaterial={{this.managingMaterial}}
+            @isCourse={{@isCourse}}
+            @subject={{@subject}}
             @editable={{@editable}}
             @closeManager={{this.closeLearningmaterialManager}}
             @learningMaterialStatuses={{this.learningMaterialStatuses}}

--- a/packages/ilios-common/addon/components/detail-learning-materials.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials.gjs
@@ -245,6 +245,7 @@ export default class DetailLearningMaterialsComponent extends Component {
         {{else if this.displayAddNewForm}}
           <NewLearningmaterial
             @type={{this.type}}
+            @isCourse={{@isCourse}}
             @subject={{@subject}}
             @learningMaterialStatuses={{this.learningMaterialStatuses}}
             @learningMaterialUserRoles={{this.learningMaterialUserRoles}}

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -10,11 +10,10 @@ import YupValidations from 'ilios-common/classes/yup-validations';
 import { date, string } from 'yup';
 import { uniqueId, fn } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
-import { and, eq, not } from 'ember-truth-helpers';
+import { and, eq } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 import pick from 'ilios-common/helpers/pick';
 import set from 'ember-set-helper/helpers/set';
-import isEmpty from 'ember-truth-helpers/helpers/is-empty';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import ToggleYesno from 'ilios-common/components/toggle-yesno';
 import HtmlEditor from 'ilios-common/components/html-editor';
@@ -579,7 +578,7 @@ export default class LearningmaterialManagerComponent extends Component {
                   <label>
                     {{t "general.accessibilityAgreement"}}:
                   </label>
-                  {{#if (not (isEmpty this.accessibilityRequirementsLink))}}
+                  {{#if this.accessibilityRequirementsLink}}
                     <a
                       href="{{this.accessibilityRequirementsLink}}"
                       target="_blank"

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -1,10 +1,11 @@
 import Component from '@glimmer/component';
 import { task } from 'ember-concurrency';
 import { service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
+import { cached, tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { DateTime } from 'luxon';
 import { findById } from 'ilios-common/utils/array-helpers';
+import { TrackedAsyncData } from 'ember-async-data';
 import YupValidations from 'ilios-common/classes/yup-validations';
 import { date, string } from 'yup';
 import { uniqueId, fn } from '@ember/helper';
@@ -26,7 +27,7 @@ import DatePicker from 'ilios-common/components/date-picker';
 import TimePicker from 'ilios-common/components/time-picker';
 import MeshManager from 'ilios-common/components/mesh-manager';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
-import { faCopy, faDownload } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUpRightFromSquare, faCopy, faDownload } from '@fortawesome/free-solid-svg-icons';
 
 export default class LearningmaterialManagerComponent extends Component {
   @service store;
@@ -36,6 +37,50 @@ export default class LearningmaterialManagerComponent extends Component {
   constructor() {
     super(...arguments);
     this.loadExistingData();
+  }
+
+  @cached
+  get subjectData() {
+    return new TrackedAsyncData(this.args.subject);
+  }
+
+  @cached
+  get courseData() {
+    if (this.subjectData.isResolved) {
+      if (!this.args.isCourse) {
+        return new TrackedAsyncData(this.subjectData.value.course);
+      } else {
+        return new TrackedAsyncData(this.subjectData.value);
+      }
+    }
+
+    return new TrackedAsyncData(null);
+  }
+
+  @cached
+  get schoolData() {
+    if (this.courseData.isResolved) {
+      return new TrackedAsyncData(this.courseData.value.school);
+    }
+
+    return new TrackedAsyncData(null);
+  }
+
+  @cached
+  get accessibilityRequirementsLinkData() {
+    if (this.schoolData.isResolved) {
+      return new TrackedAsyncData(
+        this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequirementsLink'),
+      );
+    }
+
+    return new TrackedAsyncData(null);
+  }
+
+  get accessibilityRequirementsLink() {
+    return this.accessibilityRequirementsLinkData.isResolved
+      ? this.accessibilityRequirementsLinkData.value
+      : null;
   }
 
   validations = new YupValidations(this, {
@@ -528,16 +573,26 @@ export default class LearningmaterialManagerComponent extends Component {
 
           <div class="item">
             {{#if @editable}}
-              <div class="marked-accessible-toggle">
-                <label>
-                  {{t "general.markedAccessible"}}:
-                </label>
-                <ToggleYesno
-                  @yes={{this.markedAccessible}}
-                  @toggle={{set this "markedAccessible"}}
-                />
-              </div>
-              <span>{{t "general.accessibilityAgreement"}}</span>
+              {{#if this.accessibilityRequirementsLinkData.isResolved}}
+                <div class="marked-accessible-toggle">
+                  <label>
+                    {{t "general.accessibilityAgreement"}}:
+                  </label>
+                  {{#if this.accessibilityRequirementsLink}}
+                    <a
+                      href="{{this.accessibilityRequirementsLink}}"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <FaIcon @icon={{faArrowUpRightFromSquare}} />
+                    </a>
+                  {{/if}}
+                  <ToggleYesno
+                    @yes={{this.markedAccessible}}
+                    @toggle={{set this "markedAccessible"}}
+                  />
+                </div>
+              {{/if}}
             {{else if this.markedAccessible}}
               <label>
                 {{t "general.markedAccessible"}}:

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -81,6 +81,8 @@ export default class LearningmaterialManagerComponent extends Component {
   @tracked description;
   @tracked copyrightPermission;
   @tracked copyrightRationale;
+  @tracked accessibilityPermission;
+  @tracked accessibilityRationale;
   @tracked citation;
   @tracked link;
   @tracked mimetype;
@@ -245,6 +247,8 @@ export default class LearningmaterialManagerComponent extends Component {
     this.description = parentMaterial.description;
     this.copyrightPermission = parentMaterial.copyrightPermission;
     this.copyrightRationale = parentMaterial.copyrightRationale;
+    this.accessibilityPermission = parentMaterial.accessibilityPermission;
+    this.accessibilityRationale = parentMaterial.accessibilityRationale;
     this.citation = parentMaterial.citation;
     this.link = parentMaterial.link;
     this.mimetype = parentMaterial.mimetype;
@@ -519,6 +523,33 @@ export default class LearningmaterialManagerComponent extends Component {
               </label>
               <span class="copyrightrationale">
                 {{this.copyrightRationale}}
+              </span>
+            </div>
+          {{/if}}
+
+          {{#if this.accessibilityPermission}}
+            <div class="item">
+              <label>
+                {{t "general.accessibilityPermission"}}:
+              </label>
+              {{#if this.accessibilityPermission}}
+                <span class="accessibilityPermission add">
+                  {{t "general.yes"}}
+                </span>
+              {{else}}
+                <span class="accessibilityPermission remove">
+                  {{t "general.no"}}
+                </span>
+              {{/if}}
+            </div>
+          {{/if}}
+          {{#if this.accessibilityRationale}}
+            <div class="item">
+              <label>
+                {{t "general.accessibilityRationale"}}:
+              </label>
+              <span class="accessibilityRationale">
+                {{this.accessibilityRationale}}
               </span>
             </div>
           {{/if}}

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -10,10 +10,11 @@ import YupValidations from 'ilios-common/classes/yup-validations';
 import { date, string } from 'yup';
 import { uniqueId, fn } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
-import { and, eq } from 'ember-truth-helpers';
+import { and, eq, not } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 import pick from 'ilios-common/helpers/pick';
 import set from 'ember-set-helper/helpers/set';
+import isEmpty from 'ember-truth-helpers/helpers/is-empty';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import ToggleYesno from 'ilios-common/components/toggle-yesno';
 import HtmlEditor from 'ilios-common/components/html-editor';
@@ -578,12 +579,13 @@ export default class LearningmaterialManagerComponent extends Component {
                   <label>
                     {{t "general.accessibilityAgreement"}}:
                   </label>
-                  {{#if this.accessibilityRequirementsLink}}
+                  {{#if (not (isEmpty this.accessibilityRequirementsLink))}}
                     <a
                       href="{{this.accessibilityRequirementsLink}}"
                       target="_blank"
                       rel="noopener noreferrer"
                       title={{t "general.accessibilityRequirementsLink"}}
+                      data-test-accessibility-requirements-link
                     >
                       <FaIcon @icon={{faArrowUpRightFromSquare}} />
                     </a>

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -527,19 +527,28 @@ export default class LearningmaterialManagerComponent extends Component {
           {{/if}}
 
           <div class="item">
-            <label>
-              {{t "general.accessibilityPermission"}}:
-            </label>
             {{#if @editable}}
-              <ToggleYesno
-                @yes={{this.accessibilityPermission}}
-                @toggle={{set this "accessibilityPermission"}}
-              />
+              <div class="accessibility-permission-toggle">
+                <label>
+                  {{t "general.accessibilityPermission"}}:
+                </label>
+                <ToggleYesno
+                  @yes={{this.accessibilityPermission}}
+                  @toggle={{set this "accessibilityPermission"}}
+                />
+              </div>
+              <span>{{t "general.accessibilityAgreement"}}</span>
             {{else}}{{#this.accessibilityPermission}}
+                <label>
+                  {{t "general.accessibilityPermission"}}:
+                </label>
                 <span class="accessibilityPermission add">
                   {{t "general.yes"}}
                 </span>
               {{else}}
+                <label>
+                  {{t "general.accessibilityPermission"}}:
+                </label>
                 <span class="accessibilityPermission remove">
                   {{t "general.no"}}
                 </span>

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -542,14 +542,14 @@ export default class LearningmaterialManagerComponent extends Component {
               <label>
                 {{t "general.markedAccessible"}}:
               </label>
-              <span class="markedaccessible add">
+              <span class="markedaccessible add" data-test-marked-accessible-value>
                 {{t "general.yes"}}
               </span>
             {{else}}
               <label>
                 {{t "general.markedAccessible"}}:
               </label>
-              <span class="markedaccessible remove">
+              <span class="markedaccessible remove" data-test-marked-accessible-value>
                 {{t "general.no"}}
               </span>
             {{/if}}

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -538,21 +538,21 @@ export default class LearningmaterialManagerComponent extends Component {
                 />
               </div>
               <span>{{t "general.accessibilityAgreement"}}</span>
-            {{else}}{{#this.accessibilityPermission}}
-                <label>
-                  {{t "general.accessibilityPermission"}}:
-                </label>
-                <span class="accessibilityPermission add">
-                  {{t "general.yes"}}
-                </span>
-              {{else}}
-                <label>
-                  {{t "general.accessibilityPermission"}}:
-                </label>
-                <span class="accessibilityPermission remove">
-                  {{t "general.no"}}
-                </span>
-              {{/this.accessibilityPermission}}{{/if}}
+            {{else if this.accessibilityPermission}}
+              <label>
+                {{t "general.accessibilityPermission"}}:
+              </label>
+              <span class="accessibilitypermission add">
+                {{t "general.yes"}}
+              </span>
+            {{else}}
+              <label>
+                {{t "general.accessibilityPermission"}}:
+              </label>
+              <span class="accessibilitypermission remove">
+                {{t "general.no"}}
+              </span>
+            {{/if}}
           </div>
 
           <div class="item timed-release">

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -583,6 +583,7 @@ export default class LearningmaterialManagerComponent extends Component {
                       href="{{this.accessibilityRequirementsLink}}"
                       target="_blank"
                       rel="noopener noreferrer"
+                      title={{t "general.accessibilityRequirementsLink"}}
                     >
                       <FaIcon @icon={{faArrowUpRightFromSquare}} />
                     </a>

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -280,6 +280,7 @@ export default class LearningmaterialManagerComponent extends Component {
     this.parentMaterial.set('status', this.currentStatus);
     this.parentMaterial.set('title', this.title);
     this.parentMaterial.set('description', this.description);
+    this.parentMaterial.set('accessibilityPermission', this.accessibilityPermission);
 
     this.args.learningMaterial.set('meshDescriptors', this.terms);
     await this.args.learningMaterial.save();
@@ -529,15 +530,20 @@ export default class LearningmaterialManagerComponent extends Component {
             <label>
               {{t "general.accessibilityPermission"}}:
             </label>
-            {{#if this.accessibilityPermission}}
-              <span class="accessibilityPermission add">
-                {{t "general.yes"}}
-              </span>
-            {{else}}
-              <span class="accessibilityPermission remove">
-                {{t "general.no"}}
-              </span>
-            {{/if}}
+            {{#if @editable}}
+              <ToggleYesno
+                @yes={{this.accessibilityPermission}}
+                @toggle={{set this "accessibilityPermission"}}
+              />
+            {{else}}{{#this.accessibilityPermission}}
+                <span class="accessibilityPermission add">
+                  {{t "general.yes"}}
+                </span>
+              {{else}}
+                <span class="accessibilityPermission remove">
+                  {{t "general.no"}}
+                </span>
+              {{/this.accessibilityPermission}}{{/if}}
           </div>
 
           <div class="item timed-release">

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -82,7 +82,6 @@ export default class LearningmaterialManagerComponent extends Component {
   @tracked copyrightPermission;
   @tracked copyrightRationale;
   @tracked accessibilityPermission;
-  @tracked accessibilityRationale;
   @tracked citation;
   @tracked link;
   @tracked mimetype;
@@ -248,7 +247,6 @@ export default class LearningmaterialManagerComponent extends Component {
     this.copyrightPermission = parentMaterial.copyrightPermission;
     this.copyrightRationale = parentMaterial.copyrightRationale;
     this.accessibilityPermission = parentMaterial.accessibilityPermission;
-    this.accessibilityRationale = parentMaterial.accessibilityRationale;
     this.citation = parentMaterial.citation;
     this.link = parentMaterial.link;
     this.mimetype = parentMaterial.mimetype;
@@ -527,32 +525,20 @@ export default class LearningmaterialManagerComponent extends Component {
             </div>
           {{/if}}
 
-          {{#if this.accessibilityPermission}}
-            <div class="item">
-              <label>
-                {{t "general.accessibilityPermission"}}:
-              </label>
-              {{#if this.accessibilityPermission}}
-                <span class="accessibilityPermission add">
-                  {{t "general.yes"}}
-                </span>
-              {{else}}
-                <span class="accessibilityPermission remove">
-                  {{t "general.no"}}
-                </span>
-              {{/if}}
-            </div>
-          {{/if}}
-          {{#if this.accessibilityRationale}}
-            <div class="item">
-              <label>
-                {{t "general.accessibilityRationale"}}:
-              </label>
-              <span class="accessibilityRationale">
-                {{this.accessibilityRationale}}
+          <div class="item">
+            <label>
+              {{t "general.accessibilityPermission"}}:
+            </label>
+            {{#if this.accessibilityPermission}}
+              <span class="accessibilityPermission add">
+                {{t "general.yes"}}
               </span>
-            </div>
-          {{/if}}
+            {{else}}
+              <span class="accessibilityPermission remove">
+                {{t "general.no"}}
+              </span>
+            {{/if}}
+          </div>
 
           <div class="item timed-release">
             <label>

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -81,7 +81,7 @@ export default class LearningmaterialManagerComponent extends Component {
   @tracked description;
   @tracked copyrightPermission;
   @tracked copyrightRationale;
-  @tracked accessibilityPermission;
+  @tracked markedAccessible;
   @tracked citation;
   @tracked link;
   @tracked mimetype;
@@ -246,7 +246,7 @@ export default class LearningmaterialManagerComponent extends Component {
     this.description = parentMaterial.description;
     this.copyrightPermission = parentMaterial.copyrightPermission;
     this.copyrightRationale = parentMaterial.copyrightRationale;
-    this.accessibilityPermission = parentMaterial.accessibilityPermission;
+    this.markedAccessible = parentMaterial.markedAccessible;
     this.citation = parentMaterial.citation;
     this.link = parentMaterial.link;
     this.mimetype = parentMaterial.mimetype;
@@ -280,7 +280,7 @@ export default class LearningmaterialManagerComponent extends Component {
     this.parentMaterial.set('status', this.currentStatus);
     this.parentMaterial.set('title', this.title);
     this.parentMaterial.set('description', this.description);
-    this.parentMaterial.set('accessibilityPermission', this.accessibilityPermission);
+    this.parentMaterial.set('markedAccessible', this.markedAccessible);
 
     this.args.learningMaterial.set('meshDescriptors', this.terms);
     await this.args.learningMaterial.save();
@@ -528,28 +528,28 @@ export default class LearningmaterialManagerComponent extends Component {
 
           <div class="item">
             {{#if @editable}}
-              <div class="accessibility-permission-toggle">
+              <div class="marked-accessible-toggle">
                 <label>
-                  {{t "general.accessibilityPermission"}}:
+                  {{t "general.markedAccessible"}}:
                 </label>
                 <ToggleYesno
-                  @yes={{this.accessibilityPermission}}
-                  @toggle={{set this "accessibilityPermission"}}
+                  @yes={{this.markedAccessible}}
+                  @toggle={{set this "markedAccessible"}}
                 />
               </div>
               <span>{{t "general.accessibilityAgreement"}}</span>
-            {{else if this.accessibilityPermission}}
+            {{else if this.markedAccessible}}
               <label>
-                {{t "general.accessibilityPermission"}}:
+                {{t "general.markedAccessible"}}:
               </label>
-              <span class="accessibilitypermission add">
+              <span class="markedaccessible add">
                 {{t "general.yes"}}
               </span>
             {{else}}
               <label>
-                {{t "general.accessibilityPermission"}}:
+                {{t "general.markedAccessible"}}:
               </label>
-              <span class="accessibilitypermission remove">
+              <span class="markedaccessible remove">
                 {{t "general.no"}}
               </span>
             {{/if}}

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -126,8 +126,21 @@ export default class NewLearningmaterialComponent extends Component {
   userModel = new TrackedAsyncData(this.currentUser.getModel());
 
   @cached
+  get subjectData() {
+    return new TrackedAsyncData(this.args.subject);
+  }
+
+  @cached
   get schoolData() {
-    return new TrackedAsyncData(this.args.subject.school);
+    if (this.subjectData.isResolved) {
+      if (!this.args.isCourse) {
+        return new TrackedAsyncData(this.subjectData.value.course.get('school'));
+      } else {
+        return new TrackedAsyncData(this.subjectData.value.school);
+      }
+    } else {
+      return [];
+    }
   }
 
   // https://www.ada.gov/law-and-regs/regulations/title-ii-2010-regulations/#-35200-requirements-for-web-and-mobile-accessibility
@@ -503,7 +516,7 @@ export default class NewLearningmaterialComponent extends Component {
             </span>
           </div>
         {{/unless}}
-        {{#if this.accessibilityRequired}}
+        {{#if this.accessibilityRequiredData.isResolved}}
           <div class="item accessibility" data-test-accessibility-permission>
             <label for="accessibility-permission-{{this.uniqueId}}">
               {{t "general.accessibilityPermission"}}:
@@ -536,30 +549,30 @@ export default class NewLearningmaterialComponent extends Component {
               </p>
             </span>
           </div>
+          {{#unless this.accessibilityPermission}}
+            <div class="item accessibility-rationale" data-test-accessibility-permission>
+              <label for="accessibility-rationale-{{this.uniqueId}}">
+                {{t "general.accessibilityRationale"}}:
+              </label>
+              <span>
+                <textarea
+                  id="accessibility-rationale-{{this.uniqueId}}"
+                  aria-invalid={{if this.validations.errors.accessibilityRationale "true" "false"}}
+                  aria-errormessage="accessibility-rationale-error-{{this.uniqueId}}"
+                  class={{if this.validations.errors.accessibilityRationale "error"}}
+                  {{on "input" (pick "target.value" (set this "accessibilityRationale"))}}
+                  {{this.validations.attach "accessibilityRationale"}}
+                >{{this.accessibilityRationale}}</textarea>
+                <YupValidationMessage
+                  id="accessibility-rationale-error-{{this.uniqueId}}"
+                  @description={{t "general.accessibilityRationale"}}
+                  @validationErrors={{this.validations.errors.accessibilityRationale}}
+                  data-test-accessibility-rationale-validation-error-message
+                />
+              </span>
+            </div>
+          {{/unless}}
         {{/if}}
-        {{#unless this.accessibilityPermission}}
-          <div class="item accessibility-rationale" data-test-accessibility-permission>
-            <label for="accessibility-rationale-{{this.uniqueId}}">
-              {{t "general.accessibilityRationale"}}:
-            </label>
-            <span>
-              <textarea
-                id="accessibility-rationale-{{this.uniqueId}}"
-                aria-invalid={{if this.validations.errors.accessibilityRationale "true" "false"}}
-                aria-errormessage="accessibility-rationale-error-{{this.uniqueId}}"
-                class={{if this.validations.errors.accessibilityRationale "error"}}
-                {{on "input" (pick "target.value" (set this "accessibilityRationale"))}}
-                {{this.validations.attach "accessibilityRationale"}}
-              >{{this.accessibilityRationale}}</textarea>
-              <YupValidationMessage
-                id="accessibility-rationale-error-{{this.uniqueId}}"
-                @description={{t "general.accessibilityRationale"}}
-                @validationErrors={{this.validations.errors.accessibilityRationale}}
-                data-test-accessibility-rationale-validation-error-message
-              />
-            </span>
-          </div>
-        {{/unless}}
       {{/if}}
 
       <div class="buttons">

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -88,7 +88,7 @@ export default class NewLearningmaterialComponent extends Component {
           (d) => {
             return {
               path: d.path,
-              messageKey: 'errors.agreementRequired',
+              messageKey: 'errors.agreementRequiredOrRationale',
             };
           },
           (value) => this.copyrightRationale || value === true,

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -148,13 +148,28 @@ export default class NewLearningmaterialComponent extends Component {
   get accessibilityRequiredData() {
     return new TrackedAsyncData(
       this.schoolData.isResolved
-        ? this.schoolData.value?.getConfigValue('showLearningMaterialAccessibilityRequired')
+        ? this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequired')
         : false,
     );
   }
 
   get accessibilityRequired() {
     return this.accessibilityRequiredData.isResolved ? this.accessibilityRequiredData.value : false;
+  }
+
+  @cached
+  get accessibilityRequiredMessageData() {
+    return new TrackedAsyncData(
+      this.schoolData.isResolved
+        ? this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequiredMessage')
+        : false,
+    );
+  }
+
+  get accessibilityRequiredMessage() {
+    return this.accessibilityRequiredMessageData.isResolved
+      ? this.accessibilityRequiredMessageData.value
+      : false;
   }
 
   get uniqueId() {
@@ -537,7 +552,11 @@ export default class NewLearningmaterialComponent extends Component {
                   {{on "change" (perform this.validations.runValidator)}}
                   data-test-accessibility-permission
                 />
-                {{t "general.accessibilityAgreement"}}
+                {{#if this.accessibilityRequiredMessage}}
+                  {{this.accessibilityRequiredMessage}}
+                {{else}}
+                  {{t "general.accessibilityAgreement"}}
+                {{/if}}
                 {{#if this.validations.errors.accessibilityPermission}}
                   <br />
                 {{/if}}

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -149,9 +149,13 @@ export default class NewLearningmaterialComponent extends Component {
   // https://www.ada.gov/law-and-regs/regulations/title-ii-2010-regulations/#-35200-requirements-for-web-and-mobile-accessibility
   @cached
   get accessibilityRequiredData() {
-    return new TrackedAsyncData(
-      this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequired'),
-    );
+    if (this.schoolData.isResolved) {
+      return new TrackedAsyncData(
+        this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequired'),
+      );
+    }
+
+    return new TrackedAsyncData(null);
   }
 
   get accessibilityRequired() {
@@ -160,7 +164,11 @@ export default class NewLearningmaterialComponent extends Component {
 
   @cached
   get accessibilityRequirementsLinkData() {
-    return new TrackedAsyncData('learningMaterialAccessibilityRequirementsLink');
+    if (this.schoolData.isResolved) {
+      return new TrackedAsyncData('learningMaterialAccessibilityRequirementsLink');
+    }
+
+    return new TrackedAsyncData(null);
   }
 
   get accessibilityRequirementsLink() {

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -17,6 +17,7 @@ import YupValidationMessage from 'ilios-common/components/yup-validation-message
 import isEqual from 'ember-truth-helpers/helpers/is-equal';
 import UserNameInfo from 'ilios-common/components/user-name-info';
 import HtmlEditor from 'ilios-common/components/html-editor';
+import isEmpty from 'ember-truth-helpers/helpers/is-empty';
 import { not } from 'ember-truth-helpers';
 import perform from 'ember-concurrency/helpers/perform';
 import LearningMaterialUploader from 'ilios-common/components/learning-material-uploader';
@@ -165,7 +166,9 @@ export default class NewLearningmaterialComponent extends Component {
   @cached
   get accessibilityRequirementsLinkData() {
     if (this.schoolData.isResolved) {
-      return new TrackedAsyncData('learningMaterialAccessibilityRequirementsLink');
+      return new TrackedAsyncData(
+        this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequirementsLink'),
+      );
     }
 
     return new TrackedAsyncData(null);
@@ -174,7 +177,7 @@ export default class NewLearningmaterialComponent extends Component {
   get accessibilityRequirementsLink() {
     return this.accessibilityRequirementsLinkData.isResolved
       ? this.accessibilityRequirementsLinkData.value
-      : this.intl.t('general.accessibilityAgreement');
+      : '';
   }
 
   get uniqueId() {
@@ -555,12 +558,13 @@ export default class NewLearningmaterialComponent extends Component {
                 <label for="marked-accessible-{{this.uniqueId}}">
                   {{t "general.accessibilityAgreement"}}
                 </label>
-                {{#if this.accessibilityRequirementsLink}}
+                {{#if (not (isEmpty this.accessibilityRequirementsLink))}}
                   <a
                     href="{{this.accessibilityRequirementsLink}}"
                     target="_blank"
                     rel="noopener noreferrer"
                     title={{t "general.accessibilityRequirementsLink"}}
+                    data-test-accessibility-requirements-link
                   >
                     <FaIcon @icon={{faArrowUpRightFromSquare}} />
                   </a>

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -95,14 +95,14 @@ export default class NewLearningmaterialComponent extends Component {
         ),
     }),
     accessibilityRationale: string().when(
-      ['$isFile', 'accessibilityPermission', '$afterGovtCutoff'],
-      ([isFile, accessibilityPermission, afterGovtCutoff], schema) => {
-        if (isFile && !accessibilityPermission && afterGovtCutoff) {
+      ['$isFile', 'accessibilityPermission', '$accessibilityRequired'],
+      ([isFile, accessibilityPermission, accessibilityRequired], schema) => {
+        if (isFile && !accessibilityPermission && accessibilityRequired) {
           return schema.required().min(2).max(65000);
         }
       },
     ),
-    accessibilityPermission: boolean().when(['$isFile', '$afterGovtCutoff'], {
+    accessibilityPermission: boolean().when(['$isFile', '$accessibilityRequired'], {
       is: true,
       then: (schema) =>
         schema.test(
@@ -125,9 +125,23 @@ export default class NewLearningmaterialComponent extends Component {
   });
   userModel = new TrackedAsyncData(this.currentUser.getModel());
 
+  @cached
+  get schoolData() {
+    return new TrackedAsyncData(this.args.subject.school);
+  }
+
   // https://www.ada.gov/law-and-regs/regulations/title-ii-2010-regulations/#-35200-requirements-for-web-and-mobile-accessibility
-  get afterGovtCutoff() {
-    return new Date() >= new Date('April 24, 2026');
+  @cached
+  get accessibilityRequiredData() {
+    return new TrackedAsyncData(
+      this.schoolData.isResolved
+        ? this.schoolData.value?.getConfigValue('showLearningMaterialAccessibilityRequired')
+        : false,
+    );
+  }
+
+  get accessibilityRequired() {
+    return this.accessibilityRequiredData.isResolved ? this.accessibilityRequiredData.value : false;
   }
 
   get uniqueId() {
@@ -489,38 +503,40 @@ export default class NewLearningmaterialComponent extends Component {
             </span>
           </div>
         {{/unless}}
-        <div class="item accessibility" data-test-accessibility-permission>
-          <label for="accessibility-permission-{{this.uniqueId}}">
-            {{t "general.accessibilityPermission"}}:
-          </label>
-          <span>
-            <p id="lm-accessibility-permissions-text">
-              <input
-                id="accessibility-permission-{{this.uniqueId}}"
-                aria-invalid={{if this.validations.errors.accessibilityPermission "true" "false"}}
-                aria-errormessage="accessibility-permission-error-{{this.uniqueId}}"
-                class={{if this.validations.errors.accessibilityPermission "error"}}
-                type="checkbox"
-                checked={{this.accessibilityPermission}}
-                {{on
-                  "click"
-                  (set this "accessibilityPermission" (not this.accessibilityPermission))
-                }}
-                {{on "change" (perform this.validations.runValidator)}}
-                data-test-accessibility-permission
-              />
-              {{t "general.accessibilityAgreement"}}
-              {{#if this.validations.errors.accessibilityPermission}}
-                <br />
-              {{/if}}
-              <YupValidationMessage
-                id="accessibility-permission-error-{{this.uniqueId}}"
-                @validationErrors={{this.validations.errors.accessibilityPermission}}
-                data-test-accessibility-permission-validation-error-message
-              />
-            </p>
-          </span>
-        </div>
+        {{#if this.accessibilityRequired}}
+          <div class="item accessibility" data-test-accessibility-permission>
+            <label for="accessibility-permission-{{this.uniqueId}}">
+              {{t "general.accessibilityPermission"}}:
+            </label>
+            <span>
+              <p id="lm-accessibility-permissions-text">
+                <input
+                  id="accessibility-permission-{{this.uniqueId}}"
+                  aria-invalid={{if this.validations.errors.accessibilityPermission "true" "false"}}
+                  aria-errormessage="accessibility-permission-error-{{this.uniqueId}}"
+                  class={{if this.validations.errors.accessibilityPermission "error"}}
+                  type="checkbox"
+                  checked={{this.accessibilityPermission}}
+                  {{on
+                    "click"
+                    (set this "accessibilityPermission" (not this.accessibilityPermission))
+                  }}
+                  {{on "change" (perform this.validations.runValidator)}}
+                  data-test-accessibility-permission
+                />
+                {{t "general.accessibilityAgreement"}}
+                {{#if this.validations.errors.accessibilityPermission}}
+                  <br />
+                {{/if}}
+                <YupValidationMessage
+                  id="accessibility-permission-error-{{this.uniqueId}}"
+                  @validationErrors={{this.validations.errors.accessibilityPermission}}
+                  data-test-accessibility-permission-validation-error-message
+                />
+              </p>
+            </span>
+          </div>
+        {{/if}}
         {{#unless this.accessibilityPermission}}
           <div class="item accessibility-rationale" data-test-accessibility-permission>
             <label for="accessibility-rationale-{{this.uniqueId}}">

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -123,16 +123,25 @@ export default class NewLearningmaterialComponent extends Component {
   }
 
   @cached
-  get schoolData() {
+  get courseData() {
     if (this.subjectData.isResolved) {
       if (!this.args.isCourse) {
-        return new TrackedAsyncData(this.subjectData.value.course.get('school'));
+        return new TrackedAsyncData(this.subjectData.value.course);
       } else {
-        return new TrackedAsyncData(this.subjectData.value.school);
+        return new TrackedAsyncData(this.subjectData.value);
       }
-    } else {
-      return new TrackedAsyncData(null);
     }
+
+    return null;
+  }
+
+  @cached
+  get schoolData() {
+    if (this.courseData.isResolved) {
+      return new TrackedAsyncData(this.courseData.value.school);
+    }
+
+    return null;
   }
 
   // https://www.ada.gov/law-and-regs/regulations/title-ii-2010-regulations/#-35200-requirements-for-web-and-mobile-accessibility
@@ -161,7 +170,7 @@ export default class NewLearningmaterialComponent extends Component {
   get accessibilityRequiredMessage() {
     return this.accessibilityRequiredMessageData.isResolved
       ? this.accessibilityRequiredMessageData.value
-      : '';
+      : this.intl.t('general.accessibilityAgreement');
   }
 
   get uniqueId() {

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -150,9 +150,7 @@ export default class NewLearningmaterialComponent extends Component {
   @cached
   get accessibilityRequiredData() {
     return new TrackedAsyncData(
-      this.schoolData.isResolved && this.schoolData.value
-        ? this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequired')
-        : null,
+      this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequired'),
     );
   }
 
@@ -162,11 +160,7 @@ export default class NewLearningmaterialComponent extends Component {
 
   @cached
   get accessibilityRequirementsLinkData() {
-    return new TrackedAsyncData(
-      this.schoolData.isResolved && this.schoolData.value
-        ? this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequirementsLink')
-        : null,
-    );
+    return new TrackedAsyncData('learningMaterialAccessibilityRequirementsLink');
   }
 
   get accessibilityRequirementsLink() {

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -21,6 +21,8 @@ import { not } from 'ember-truth-helpers';
 import perform from 'ember-concurrency/helpers/perform';
 import LearningMaterialUploader from 'ilios-common/components/learning-material-uploader';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 
 const DEFAULT_URL_VALUE = 'https://';
 
@@ -159,17 +161,17 @@ export default class NewLearningmaterialComponent extends Component {
   }
 
   @cached
-  get accessibilityRequiredMessageData() {
+  get accessibilityRequirementsLinkData() {
     return new TrackedAsyncData(
       this.schoolData.isResolved && this.schoolData.value
-        ? this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequiredMessage')
+        ? this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequirementsLink')
         : null,
     );
   }
 
-  get accessibilityRequiredMessage() {
-    return this.accessibilityRequiredMessageData.isResolved
-      ? this.accessibilityRequiredMessageData.value
+  get accessibilityRequirementsLink() {
+    return this.accessibilityRequirementsLinkData.isResolved
+      ? this.accessibilityRequirementsLinkData.value
       : this.intl.t('general.accessibilityAgreement');
   }
 
@@ -535,9 +537,6 @@ export default class NewLearningmaterialComponent extends Component {
         {{/unless}}
         {{#if this.accessibilityRequiredData.isResolved}}
           <div class="item accessibility" data-test-marked-accessible>
-            <label for="marked-accessible-{{this.uniqueId}}">
-              {{t "general.markedAccessible"}}:
-            </label>
             <span>
               <p id="lm-accessibility-permissions-text">
                 <input
@@ -551,13 +550,17 @@ export default class NewLearningmaterialComponent extends Component {
                   {{on "change" (perform this.validations.runValidator)}}
                   data-test-marked-accessible
                 />
-                {{#if this.accessibilityRequiredMessage}}
-                  {{this.accessibilityRequiredMessage}}
-                {{else}}
+                <label for="marked-accessible-{{this.uniqueId}}">
                   {{t "general.accessibilityAgreement"}}
-                {{/if}}
-                {{#if this.validations.errors.markedAccessible}}
-                  <br />
+                </label>
+                {{#if this.accessibilityRequirementsLink}}
+                  <a
+                    href="{{this.accessibilityRequirementsLink}}"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <FaIcon @icon={{faArrowUpRightFromSquare}} />
+                  </a>
                 {{/if}}
                 <YupValidationMessage
                   id="marked-accessible-error-{{this.uniqueId}}"

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -94,7 +94,7 @@ export default class NewLearningmaterialComponent extends Component {
           (value) => this.copyrightRationale || value === true,
         ),
     }),
-    accessibilityPermission: boolean().when(['$isFile', '$accessibilityRequired'], {
+    markedAccessible: boolean().when(['$isFile', '$accessibilityRequired'], {
       is: true,
       then: (schema) =>
         schema.test(
@@ -264,7 +264,7 @@ export default class NewLearningmaterialComponent extends Component {
         learningMaterial.setProperties({
           copyrightRationale: this.copyrightRationale,
           copyrightPermission: this.copyrightPermission,
-          accessibilityPermission: this.accessibilityPermission,
+          markedAccessible: this.markedAccessible,
           filename: this.filename,
           fileHash: this.fileHash,
         });
@@ -534,38 +534,35 @@ export default class NewLearningmaterialComponent extends Component {
           </div>
         {{/unless}}
         {{#if this.accessibilityRequiredData.isResolved}}
-          <div class="item accessibility" data-test-accessibility-permission>
-            <label for="accessibility-permission-{{this.uniqueId}}">
-              {{t "general.accessibilityPermission"}}:
+          <div class="item accessibility" data-test-marked-accessible>
+            <label for="marked-accessible-{{this.uniqueId}}">
+              {{t "general.markedAccessible"}}:
             </label>
             <span>
               <p id="lm-accessibility-permissions-text">
                 <input
-                  id="accessibility-permission-{{this.uniqueId}}"
-                  aria-invalid={{if this.validations.errors.accessibilityPermission "true" "false"}}
-                  aria-errormessage="accessibility-permission-error-{{this.uniqueId}}"
-                  class={{if this.validations.errors.accessibilityPermission "error"}}
+                  id="marked-accessible-{{this.uniqueId}}"
+                  aria-invalid={{if this.validations.errors.markedAccessible "true" "false"}}
+                  aria-errormessage="marked-accessible-error-{{this.uniqueId}}"
+                  class={{if this.validations.errors.markedAccessible "error"}}
                   type="checkbox"
-                  checked={{this.accessibilityPermission}}
-                  {{on
-                    "click"
-                    (set this "accessibilityPermission" (not this.accessibilityPermission))
-                  }}
+                  checked={{this.markedAccessible}}
+                  {{on "click" (set this "markedAccessible" (not this.markedAccessible))}}
                   {{on "change" (perform this.validations.runValidator)}}
-                  data-test-accessibility-permission
+                  data-test-marked-accessible
                 />
                 {{#if this.accessibilityRequiredMessage}}
                   {{this.accessibilityRequiredMessage}}
                 {{else}}
                   {{t "general.accessibilityAgreement"}}
                 {{/if}}
-                {{#if this.validations.errors.accessibilityPermission}}
+                {{#if this.validations.errors.markedAccessible}}
                   <br />
                 {{/if}}
                 <YupValidationMessage
-                  id="accessibility-permission-error-{{this.uniqueId}}"
-                  @validationErrors={{this.validations.errors.accessibilityPermission}}
-                  data-test-accessibility-permission-validation-error-message
+                  id="marked-accessible-error-{{this.uniqueId}}"
+                  @validationErrors={{this.validations.errors.markedAccessible}}
+                  data-test-marked-accessible-validation-error-message
                 />
               </p>
             </span>

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -17,7 +17,6 @@ import YupValidationMessage from 'ilios-common/components/yup-validation-message
 import isEqual from 'ember-truth-helpers/helpers/is-equal';
 import UserNameInfo from 'ilios-common/components/user-name-info';
 import HtmlEditor from 'ilios-common/components/html-editor';
-import isEmpty from 'ember-truth-helpers/helpers/is-empty';
 import { not } from 'ember-truth-helpers';
 import perform from 'ember-concurrency/helpers/perform';
 import LearningMaterialUploader from 'ilios-common/components/learning-material-uploader';
@@ -558,7 +557,7 @@ export default class NewLearningmaterialComponent extends Component {
                 <label for="marked-accessible-{{this.uniqueId}}">
                   {{t "general.accessibilityAgreement"}}
                 </label>
-                {{#if (not (isEmpty this.accessibilityRequirementsLink))}}
+                {{#if this.accessibilityRequirementsLink}}
                   <a
                     href="{{this.accessibilityRequirementsLink}}"
                     target="_blank"

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -560,6 +560,7 @@ export default class NewLearningmaterialComponent extends Component {
                     href="{{this.accessibilityRequirementsLink}}"
                     target="_blank"
                     rel="noopener noreferrer"
+                    title={{t "general.accessibilityRequirementsLink"}}
                   >
                     <FaIcon @icon={{faArrowUpRightFromSquare}} />
                   </a>

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -105,7 +105,7 @@ export default class NewLearningmaterialComponent extends Component {
               messageKey: 'errors.agreementRequired',
             };
           },
-          (value) => this.accessibilityRationale || value === true,
+          (value) => value === true,
         ),
     }),
     fileHash: string()

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -94,14 +94,6 @@ export default class NewLearningmaterialComponent extends Component {
           (value) => this.copyrightRationale || value === true,
         ),
     }),
-    accessibilityRationale: string().when(
-      ['$isFile', 'accessibilityPermission', '$accessibilityRequired'],
-      ([isFile, accessibilityPermission, accessibilityRequired], schema) => {
-        if (isFile && !accessibilityPermission && accessibilityRequired) {
-          return schema.required().min(2).max(65000);
-        }
-      },
-    ),
     accessibilityPermission: boolean().when(['$isFile', '$accessibilityRequired'], {
       is: true,
       then: (schema) =>
@@ -568,29 +560,6 @@ export default class NewLearningmaterialComponent extends Component {
               </p>
             </span>
           </div>
-          {{#unless this.accessibilityPermission}}
-            <div class="item accessibility-rationale" data-test-accessibility-permission>
-              <label for="accessibility-rationale-{{this.uniqueId}}">
-                {{t "general.accessibilityRationale"}}:
-              </label>
-              <span>
-                <textarea
-                  id="accessibility-rationale-{{this.uniqueId}}"
-                  aria-invalid={{if this.validations.errors.accessibilityRationale "true" "false"}}
-                  aria-errormessage="accessibility-rationale-error-{{this.uniqueId}}"
-                  class={{if this.validations.errors.accessibilityRationale "error"}}
-                  {{on "input" (pick "target.value" (set this "accessibilityRationale"))}}
-                  {{this.validations.attach "accessibilityRationale"}}
-                >{{this.accessibilityRationale}}</textarea>
-                <YupValidationMessage
-                  id="accessibility-rationale-error-{{this.uniqueId}}"
-                  @description={{t "general.accessibilityRationale"}}
-                  @validationErrors={{this.validations.errors.accessibilityRationale}}
-                  data-test-accessibility-rationale-validation-error-message
-                />
-              </span>
-            </div>
-          {{/unless}}
         {{/if}}
       {{/if}}
 

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -255,6 +255,7 @@ export default class NewLearningmaterialComponent extends Component {
         learningMaterial.setProperties({
           copyrightRationale: this.copyrightRationale,
           copyrightPermission: this.copyrightPermission,
+          accessibilityPermission: this.accessibilityPermission,
           filename: this.filename,
           fileHash: this.fileHash,
         });

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -131,7 +131,7 @@ export default class NewLearningmaterialComponent extends Component {
         return new TrackedAsyncData(this.subjectData.value.school);
       }
     } else {
-      return null;
+      return new TrackedAsyncData(null);
     }
   }
 
@@ -139,9 +139,9 @@ export default class NewLearningmaterialComponent extends Component {
   @cached
   get accessibilityRequiredData() {
     return new TrackedAsyncData(
-      this.schoolData && this.schoolData.isResolved
+      this.schoolData.isResolved && this.schoolData.value
         ? this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequired')
-        : false,
+        : null,
     );
   }
 
@@ -152,16 +152,16 @@ export default class NewLearningmaterialComponent extends Component {
   @cached
   get accessibilityRequiredMessageData() {
     return new TrackedAsyncData(
-      this.schoolData && this.schoolData.isResolved
+      this.schoolData.isResolved && this.schoolData.value
         ? this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequiredMessage')
-        : false,
+        : null,
     );
   }
 
   get accessibilityRequiredMessage() {
     return this.accessibilityRequiredMessageData.isResolved
       ? this.accessibilityRequiredMessageData.value
-      : false;
+      : '';
   }
 
   get uniqueId() {

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -132,7 +132,7 @@ export default class NewLearningmaterialComponent extends Component {
       }
     }
 
-    return null;
+    return new TrackedAsyncData(null);
   }
 
   @cached
@@ -141,7 +141,7 @@ export default class NewLearningmaterialComponent extends Component {
       return new TrackedAsyncData(this.courseData.value.school);
     }
 
-    return null;
+    return new TrackedAsyncData(null);
   }
 
   // https://www.ada.gov/law-and-regs/regulations/title-ii-2010-regulations/#-35200-requirements-for-web-and-mobile-accessibility

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -131,7 +131,7 @@ export default class NewLearningmaterialComponent extends Component {
         return new TrackedAsyncData(this.subjectData.value.school);
       }
     } else {
-      return [];
+      return null;
     }
   }
 
@@ -139,7 +139,7 @@ export default class NewLearningmaterialComponent extends Component {
   @cached
   get accessibilityRequiredData() {
     return new TrackedAsyncData(
-      this.schoolData.isResolved
+      this.schoolData && this.schoolData.isResolved
         ? this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequired')
         : false,
     );
@@ -152,7 +152,7 @@ export default class NewLearningmaterialComponent extends Component {
   @cached
   get accessibilityRequiredMessageData() {
     return new TrackedAsyncData(
-      this.schoolData.isResolved
+      this.schoolData && this.schoolData.isResolved
         ? this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequiredMessage')
         : false,
     );

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -94,6 +94,28 @@ export default class NewLearningmaterialComponent extends Component {
           (value) => this.copyrightRationale || value === true,
         ),
     }),
+    accessibilityRationale: string().when(
+      ['$isFile', 'accessibilityPermission', '$afterGovtCutoff'],
+      ([isFile, accessibilityPermission, afterGovtCutoff], schema) => {
+        if (isFile && !accessibilityPermission && afterGovtCutoff) {
+          return schema.required().min(2).max(65000);
+        }
+      },
+    ),
+    accessibilityPermission: boolean().when(['$isFile', '$afterGovtCutoff'], {
+      is: true,
+      then: (schema) =>
+        schema.test(
+          'is-true',
+          (d) => {
+            return {
+              path: d.path,
+              messageKey: 'errors.agreementRequired',
+            };
+          },
+          (value) => this.accessibilityRationale || value === true,
+        ),
+    }),
     fileHash: string()
       .nullable()
       .when('$isFile', {
@@ -102,6 +124,11 @@ export default class NewLearningmaterialComponent extends Component {
       }),
   });
   userModel = new TrackedAsyncData(this.currentUser.getModel());
+
+  // https://www.ada.gov/law-and-regs/regulations/title-ii-2010-regulations/#-35200-requirements-for-web-and-mobile-accessibility
+  get afterGovtCutoff() {
+    return new Date() >= new Date('April 24, 2026');
+  }
 
   get uniqueId() {
     return guidFor(this);
@@ -440,7 +467,7 @@ export default class NewLearningmaterialComponent extends Component {
           </span>
         </div>
         {{#unless this.copyrightPermission}}
-          <div class="item" data-test-copyright-rationale>
+          <div class="item copyright-rationale" data-test-copyright-rationale>
             <label for="copyright-rationale-{{this.uniqueId}}">
               {{t "general.copyrightRationale"}}:
             </label>
@@ -458,6 +485,61 @@ export default class NewLearningmaterialComponent extends Component {
                 @description={{t "general.copyrightRationale"}}
                 @validationErrors={{this.validations.errors.copyrightRationale}}
                 data-test-copyright-rationale-validation-error-message
+              />
+            </span>
+          </div>
+        {{/unless}}
+        <div class="item accessibility" data-test-accessibility-permission>
+          <label for="accessibility-permission-{{this.uniqueId}}">
+            {{t "general.accessibilityPermission"}}:
+          </label>
+          <span>
+            <p id="lm-accessibility-permissions-text">
+              <input
+                id="accessibility-permission-{{this.uniqueId}}"
+                aria-invalid={{if this.validations.errors.accessibilityPermission "true" "false"}}
+                aria-errormessage="accessibility-permission-error-{{this.uniqueId}}"
+                class={{if this.validations.errors.accessibilityPermission "error"}}
+                type="checkbox"
+                checked={{this.accessibilityPermission}}
+                {{on
+                  "click"
+                  (set this "accessibilityPermission" (not this.accessibilityPermission))
+                }}
+                {{on "change" (perform this.validations.runValidator)}}
+                data-test-accessibility-permission
+              />
+              {{t "general.accessibilityAgreement"}}
+              {{#if this.validations.errors.accessibilityPermission}}
+                <br />
+              {{/if}}
+              <YupValidationMessage
+                id="accessibility-permission-error-{{this.uniqueId}}"
+                @validationErrors={{this.validations.errors.accessibilityPermission}}
+                data-test-accessibility-permission-validation-error-message
+              />
+            </p>
+          </span>
+        </div>
+        {{#unless this.accessibilityPermission}}
+          <div class="item accessibility-rationale" data-test-accessibility-permission>
+            <label for="accessibility-rationale-{{this.uniqueId}}">
+              {{t "general.accessibilityRationale"}}:
+            </label>
+            <span>
+              <textarea
+                id="accessibility-rationale-{{this.uniqueId}}"
+                aria-invalid={{if this.validations.errors.accessibilityRationale "true" "false"}}
+                aria-errormessage="accessibility-rationale-error-{{this.uniqueId}}"
+                class={{if this.validations.errors.accessibilityRationale "error"}}
+                {{on "input" (pick "target.value" (set this "accessibilityRationale"))}}
+                {{this.validations.attach "accessibilityRationale"}}
+              >{{this.accessibilityRationale}}</textarea>
+              <YupValidationMessage
+                id="accessibility-rationale-error-{{this.uniqueId}}"
+                @description={{t "general.accessibilityRationale"}}
+                @validationErrors={{this.validations.errors.accessibilityRationale}}
+                data-test-accessibility-rationale-validation-error-message
               />
             </span>
           </div>

--- a/packages/ilios-common/addon/models/learning-material.js
+++ b/packages/ilios-common/addon/models/learning-material.js
@@ -16,7 +16,7 @@ export default class LearningMaterial extends Model {
   @attr('string')
   copyrightRationale;
   @attr('boolean')
-  accessibilityPermission;
+  markedAccessible;
   @attr('string')
   filename;
   @attr('string')

--- a/packages/ilios-common/addon/models/learning-material.js
+++ b/packages/ilios-common/addon/models/learning-material.js
@@ -15,6 +15,10 @@ export default class LearningMaterial extends Model {
   copyrightPermission;
   @attr('string')
   copyrightRationale;
+  @attr('boolean')
+  accessibilityPermission;
+  @attr('string')
+  accessibilityRationale;
   @attr('string')
   filename;
   @attr('string')

--- a/packages/ilios-common/addon/models/learning-material.js
+++ b/packages/ilios-common/addon/models/learning-material.js
@@ -18,8 +18,6 @@ export default class LearningMaterial extends Model {
   @attr('boolean')
   accessibilityPermission;
   @attr('string')
-  accessibilityRationale;
-  @attr('string')
   filename;
   @attr('string')
   mimetype;

--- a/packages/ilios-common/addon/models/school-config.js
+++ b/packages/ilios-common/addon/models/school-config.js
@@ -11,6 +11,10 @@ export default class SchoolConfig extends Model {
   school;
 
   get parsedValue() {
-    return JSON.parse(this.value ?? null);
+    try {
+      return JSON.parse(this.value ?? null);
+    } catch {
+      return this.value ?? null;
+    }
   }
 }

--- a/packages/ilios-common/addon/models/school-config.js
+++ b/packages/ilios-common/addon/models/school-config.js
@@ -11,10 +11,13 @@ export default class SchoolConfig extends Model {
   school;
 
   get parsedValue() {
-    try {
-      return JSON.parse(this.value ?? null);
-    } catch {
-      return this.value ?? null;
+    switch (this.value) {
+      case 'false':
+        return false;
+      case 'true':
+        return true;
+      default:
+        return this.value;
     }
   }
 }

--- a/packages/ilios-common/addon/models/school.js
+++ b/packages/ilios-common/addon/models/school.js
@@ -84,8 +84,6 @@ export default class School extends Model {
       school: this,
       name,
     });
-    const configurations = await this.configurations;
-    configurations.push(config);
 
     return config;
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
@@ -30,7 +30,7 @@
       padding: 0.25em 0 1em;
     }
 
-    .accessibility-permission-toggle {
+    .marked-accessible-toggle {
       display: flex;
       gap: 0.5em;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
@@ -30,6 +30,15 @@
       padding: 0.25em 0 1em;
     }
 
+    .accessibility-permission-toggle {
+      display: flex;
+      gap: 0.5em;
+
+      & + span {
+        font-style: italic;
+      }
+    }
+
     .downloadurl {
       align-items: center;
       display: flex;

--- a/packages/ilios-common/app/styles/ilios-common/components/new-learningmaterial.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/new-learningmaterial.scss
@@ -19,8 +19,14 @@
       }
     }
 
-    &.copyright {
-      #lm-copyright-permissions-text {
+    &.copyright,
+    &.copyright-rationale,
+    &.accessibility,
+    &.accessibility-rationale {
+      margin-top: 1em;
+
+      #lm-copyright-permissions-text,
+      #lm-accessibility-permissions-text {
         margin: 0;
       }
     }

--- a/packages/ilios-common/config/api-version.js
+++ b/packages/ilios-common/config/api-version.js
@@ -1,1 +1,1 @@
-module.exports = 'v3.13';
+module.exports = 'v3.14';

--- a/packages/ilios-common/ember-intl.config.mjs
+++ b/packages/ilios-common/ember-intl.config.mjs
@@ -6,6 +6,7 @@ export default {
         'errors.accepted',
         'errors.after',
         'errors.agreementRequired',
+        'errors.agreementRequiredOrRationale',
         'errors.before',
         'errors.blank',
         'errors.collection',

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -212,8 +212,8 @@ general:
   makeRecurring: Make Recurring
   manageLeadership: Manage Leadership
   manageLearners: Manage Learners
-  markedAccessible: Accessible
   markAsScheduled: Mark as Scheduled
+  markedAccessible: Accessible
   materials: Materials
   mesh: MeSH
   meshCount: "{count, plural, =1 {1 has MeSH} other {# have MesH}}"

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -1,6 +1,6 @@
 general:
   accessAllMaterialsForThisCourse: Access All Materials for this Course
-  accessibilityAgreement: "The file upload is accessible."
+  accessibilityAgreement: "This file meets accessibility requirements"
   accommodationIsRequiredForLearnersInThisGroup: Accommodation is required for learners in this group
   actions: Actions
   activeFilters: Active Filters

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -1,6 +1,7 @@
 general:
   accessAllMaterialsForThisCourse: Access All Materials for this Course
   accessibilityAgreement: "This file meets accessibility requirements"
+  accessibilityRequirementsLink: Accessibility Requirements Link
   accommodationIsRequiredForLearnersInThisGroup: Accommodation is required for learners in this group
   actions: Actions
   activeFilters: Active Filters

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -212,7 +212,7 @@ general:
   makeRecurring: Make Recurring
   manageLeadership: Manage Leadership
   manageLearners: Manage Learners
-  markedAccessible: Accessibile
+  markedAccessible: Accessible
   markAsScheduled: Mark as Scheduled
   materials: Materials
   mesh: MeSH

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -1,7 +1,7 @@
 general:
   accessAllMaterialsForThisCourse: Access All Materials for this Course
-  accessibilityAgreement: "The file I am uploading is accessible."
-  accessibilityPermission: Accessibility Permission
+  accessibilityAgreement: "The file upload is accessible."
+  accessibilityPermission: Accessibility
   accommodationIsRequiredForLearnersInThisGroup: Accommodation is required for learners in this group
   actions: Actions
   activeFilters: Active Filters

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -1,5 +1,8 @@
 general:
   accessAllMaterialsForThisCourse: Access All Materials for this Course
+  accessibilityAgreement: "The file I am uploading is accessible."
+  accessibilityPermission: Accessibility Permission
+  accessibilityRationale: Accessibility Rationale
   accommodationIsRequiredForLearnersInThisGroup: Accommodation is required for learners in this group
   actions: Actions
   activeFilters: Active Filters

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -415,7 +415,8 @@ general:
 errors:
   accepted: "{description} must be accepted"
   after: "{description} must be after {after}"
-  agreementRequired: Agreement or alternate rationale is required for upload
+  agreementRequired: Agreement is required for upload
+  agreementRequiredOrRationale: Agreement or alternate rationale is required for upload
   before: "{description} must be before {before}"
   blank: "{description} can not be blank"
   collection: "{description} must be a collection"

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -1,7 +1,6 @@
 general:
   accessAllMaterialsForThisCourse: Access All Materials for this Course
   accessibilityAgreement: "The file upload is accessible."
-  accessibilityPermission: Accessibility
   accommodationIsRequiredForLearnersInThisGroup: Accommodation is required for learners in this group
   actions: Actions
   activeFilters: Active Filters
@@ -213,6 +212,7 @@ general:
   makeRecurring: Make Recurring
   manageLeadership: Manage Leadership
   manageLearners: Manage Learners
+  markedAccessible: Accessibile
   markAsScheduled: Mark as Scheduled
   materials: Materials
   mesh: MeSH

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -2,7 +2,6 @@ general:
   accessAllMaterialsForThisCourse: Access All Materials for this Course
   accessibilityAgreement: "The file I am uploading is accessible."
   accessibilityPermission: Accessibility Permission
-  accessibilityRationale: Accessibility Rationale
   accommodationIsRequiredForLearnersInThisGroup: Accommodation is required for learners in this group
   actions: Actions
   activeFilters: Active Filters

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -1,7 +1,6 @@
 general:
   accessAllMaterialsForThisCourse: Acceso Todos los Materiales para este Curso
   accessibilityAgreement: "El archivo es accesible."
-  accessibilityPermission: Accesibilidad
   accommodationIsRequiredForLearnersInThisGroup: Se requiere alojamiento para los estudiantes de este grupo
   actions: Acciones
   activeFilters: Filtros Activos
@@ -213,6 +212,7 @@ general:
   makeRecurring: Hacer Recurrente
   manageLeadership: Maneje el Liderazgo
   manageLearners: Administrar Aprendedores
+  markedAccessible: Accesibile
   markAsScheduled: Marque Como Programado
   materials: Materiales
   mesh: MeSH

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -1,7 +1,7 @@
 general:
   accessAllMaterialsForThisCourse: Acceso Todos los Materiales para este Curso
-  accessibilityAgreement: "El archivo que estoy cargando es accesible."
-  accessibilityPermission: Permiso de Accesibilidad
+  accessibilityAgreement: "El archivo es accesible."
+  accessibilityPermission: Accesibilidad
   accommodationIsRequiredForLearnersInThisGroup: Se requiere alojamiento para los estudiantes de este grupo
   actions: Acciones
   activeFilters: Filtros Activos

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -1,5 +1,8 @@
 general:
   accessAllMaterialsForThisCourse: Acceso Todos los Materiales para este Curso
+  accessibilityAgreement: "El archivo que estoy cargando es accesible."
+  accessibilityPermission: Permiso de Accesibilidad
+  accessibilityRationale: Justificación para Accesibilidad
   accommodationIsRequiredForLearnersInThisGroup: Se requiere alojamiento para los estudiantes de este grupo
   actions: Acciones
   activeFilters: Filtros Activos

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -212,7 +212,7 @@ general:
   makeRecurring: Hacer Recurrente
   manageLeadership: Maneje el Liderazgo
   manageLearners: Administrar Aprendedores
-  markedAccessible: Accesibile
+  markedAccessible: Accesible
   markAsScheduled: Marque Como Programado
   materials: Materiales
   mesh: MeSH

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -2,7 +2,6 @@ general:
   accessAllMaterialsForThisCourse: Acceso Todos los Materiales para este Curso
   accessibilityAgreement: "El archivo que estoy cargando es accesible."
   accessibilityPermission: Permiso de Accesibilidad
-  accessibilityRationale: Justificación para Accesibilidad
   accommodationIsRequiredForLearnersInThisGroup: Se requiere alojamiento para los estudiantes de este grupo
   actions: Acciones
   activeFilters: Filtros Activos

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -415,7 +415,8 @@ general:
 errors:
   accepted: "{description} debe ser aceptado"
   after: "{description} necesita estar después de {after}"
-  agreementRequired: Acuerdo o se requiere una justificación alternativa para cargar
+  agreementRequired: Acuerdo se requiere para cargar
+  agreementRequiredOrRationale: Acuerdo o se requiere una justificación alternativa para cargar
   before: "{description} necesita estar antes de {before}"
   blank: "{description} no puede estar en blanco"
   collection: "{description} necesita ser una colección"

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -212,8 +212,8 @@ general:
   makeRecurring: Hacer Recurrente
   manageLeadership: Maneje el Liderazgo
   manageLearners: Administrar Aprendedores
-  markedAccessible: Accesible
   markAsScheduled: Marque Como Programado
+  markedAccessible: Accesible
   materials: Materiales
   mesh: MeSH
   meshCount: "{count, plural, =1 {1 tiene MeSH} other {# tienen MeSH}}"

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -1,6 +1,7 @@
 general:
   accessAllMaterialsForThisCourse: Acceso Todos los Materiales para este Curso
   accessibilityAgreement: "Este archivo cumple con los requisitos de accesibilidad"
+  accessibilityRequirementsLink: Enlace a los Requisitos de Accesibilidad
   accommodationIsRequiredForLearnersInThisGroup: Se requiere alojamiento para los estudiantes de este grupo
   actions: Acciones
   activeFilters: Filtros Activos

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -1,6 +1,6 @@
 general:
   accessAllMaterialsForThisCourse: Acceso Todos los Materiales para este Curso
-  accessibilityAgreement: "El archivo es accesible."
+  accessibilityAgreement: "Este archivo cumple con los requisitos de accesibilidad"
   accommodationIsRequiredForLearnersInThisGroup: Se requiere alojamiento para los estudiantes de este grupo
   actions: Acciones
   activeFilters: Filtros Activos

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -2,7 +2,6 @@ general:
   accessAllMaterialsForThisCourse: "Accéder à tout le matériel d'étude pour ce cours"
   accessibilityAgreement: "Le fichier que je télécharge est accessible."
   accessibilityPermission: Autorisation d'accessibilité
-  accessibilityRationale: Justification de l'accessibilité
   accommodationIsRequiredForLearnersInThisGroup: Des aménagements sont nécessaires pour les apprenants de ce groupe
   actions: Actions
   activeFilters: Filtres actifs

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -1,6 +1,7 @@
 general:
   accessAllMaterialsForThisCourse: "Accéder à tout le matériel d'étude pour ce cours"
   accessibilityAgreement: "Ce fichier conforme aux exigences d'accessibilité"
+  accessibilityRequirementsLink: Lien vers les exigences d'accessibilité
   accommodationIsRequiredForLearnersInThisGroup: Des aménagements sont nécessaires pour les apprenants de ce groupe
   actions: Actions
   activeFilters: Filtres actifs

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -1,7 +1,6 @@
 general:
   accessAllMaterialsForThisCourse: "Accéder à tout le matériel d'étude pour ce cours"
   accessibilityAgreement: "Le fichier est accessible."
-  accessibilityPermission: Accessibilité
   accommodationIsRequiredForLearnersInThisGroup: Des aménagements sont nécessaires pour les apprenants de ce groupe
   actions: Actions
   activeFilters: Filtres actifs
@@ -214,6 +213,7 @@ general:
   manageLeadership: Gérer Dirigeants
   manageLearners: Manager Étudiants
   markAsScheduled: Faire à prévu
+  markedAccessible: Accessibile
   materials: Matériels
   mesh: MeSH
   meshCount: "{count, plural, =1 {1 a des MeSH} other {# ont MeSH}}"

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -415,7 +415,8 @@ general:
 errors:
   accepted: "{description} doit être accepté"
   after: "{description} doit être après {after}"
-  agreementRequired: Entente ou autre justification requise pour le téléchargement
+  agreementRequired: Entente requise pour le téléchargement
+  agreementRequiredOrRationale: Entente ou autre justification requise pour le téléchargement
   before: "{description} doit être avant {before}"
   blank: "{description} ne doit pas être blanc"
   collection: "{description} doit être un collection"

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -1,5 +1,8 @@
 general:
   accessAllMaterialsForThisCourse: "Accéder à tout le matériel d'étude pour ce cours"
+  accessibilityAgreement: "Le fichier que je télécharge est accessible."
+  accessibilityPermission: Autorisation d'accessibilité
+  accessibilityRationale: Justification de l'accessibilité
   accommodationIsRequiredForLearnersInThisGroup: Des aménagements sont nécessaires pour les apprenants de ce groupe
   actions: Actions
   activeFilters: Filtres actifs

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -1,6 +1,6 @@
 general:
   accessAllMaterialsForThisCourse: "Accéder à tout le matériel d'étude pour ce cours"
-  accessibilityAgreement: "Le fichier est accessible."
+  accessibilityAgreement: "Ce fichier conforme aux exigences d'accessibilité"
   accommodationIsRequiredForLearnersInThisGroup: Des aménagements sont nécessaires pour les apprenants de ce groupe
   actions: Actions
   activeFilters: Filtres actifs

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -213,7 +213,7 @@ general:
   manageLeadership: Gérer Dirigeants
   manageLearners: Manager Étudiants
   markAsScheduled: Faire à prévu
-  markedAccessible: Accessibile
+  markedAccessible: Accessible
   materials: Matériels
   mesh: MeSH
   meshCount: "{count, plural, =1 {1 a des MeSH} other {# ont MeSH}}"

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -1,7 +1,7 @@
 general:
   accessAllMaterialsForThisCourse: "Accéder à tout le matériel d'étude pour ce cours"
-  accessibilityAgreement: "Le fichier que je télécharge est accessible."
-  accessibilityPermission: Autorisation d'accessibilité
+  accessibilityAgreement: "Le fichier est accessible."
+  accessibilityPermission: Accessibilité
   accommodationIsRequiredForLearnersInThisGroup: Des aménagements sont nécessaires pour les apprenants de ce groupe
   actions: Actions
   activeFilters: Filtres actifs

--- a/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
+++ b/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
@@ -1,4 +1,4 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 import { setupAuthentication } from 'ilios-common';
 import { render } from '@ember/test-helpers';
@@ -193,10 +193,7 @@ module('Integration | Component | new learningmaterial', function (hooks) {
     assert.strictEqual(component.copyrightRationale.ariaInvalid, 'false');
   });
 
-  skip('validate accessibility permission enabled', async function (assert) {
-    // global failure: TypeError: this.schoolData.value?.getConfigValue is not a function
-    // are my data getters in new-learningmaterial.gjs correct?
-
+  test('validate accessibility permission enabled', async function (assert) {
     this.schoolConfig = this.store.createRecord('school-config', {
       name: 'learningMaterialAccessibilityRequired',
       value: true,
@@ -209,7 +206,7 @@ module('Integration | Component | new learningmaterial', function (hooks) {
         <NewLearningmaterial
           @type={{this.type}}
           @isCourse={{true}}
-          @subject={{this.course}}
+          @subject={{this.courseModel}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}
@@ -251,7 +248,51 @@ module('Integration | Component | new learningmaterial', function (hooks) {
     );
     assert.strictEqual(
       component.accessibilityPermission.ariaInvalid,
+      'false',
       'link aria no longer invalid',
+    );
+  });
+
+  test('validate accessibility permission disabled', async function (assert) {
+    this.schoolConfig = this.store.createRecord('school-config', {
+      name: 'learningMaterialAccessibilityRequired',
+      value: false,
+      school: this.schoolModel,
+    });
+
+    this.set('type', 'file');
+    await render(
+      <template>
+        <NewLearningmaterial
+          @type={{this.type}}
+          @isCourse={{true}}
+          @subject={{this.courseModel}}
+          @learningMaterialStatuses={{(array)}}
+          @learningMaterialUserRoles={{(array)}}
+          @save={{(noop)}}
+          @cancel={{(noop)}}
+        />
+      </template>,
+    );
+    assert.notOk(
+      component.accessibilityPermission.errorMessage.isPresent,
+      'error message not present',
+    );
+    assert.strictEqual(
+      component.accessibilityPermission.ariaInvalid,
+      'false',
+      'link aria not invalid',
+    );
+
+    await component.save();
+    assert.notOk(
+      component.accessibilityPermission.errorMessage.isPresent,
+      'error message still not present',
+    );
+    assert.strictEqual(
+      component.accessibilityPermission.ariaInvalid,
+      'false',
+      'link aria still invalid',
     );
   });
 

--- a/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
+++ b/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 import { setupAuthentication } from 'ilios-common';
 import { render } from '@ember/test-helpers';
@@ -14,13 +14,16 @@ module('Integration | Component | new learningmaterial', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const school = this.server.create('school');
+    this.store = this.owner.lookup('service:store');
+    this.school = this.server.create('school');
+    this.schoolModel = await this.store.findRecord('school', this.school.id);
     this.course = this.server.create('course', {
       published: true,
       year: 2026,
+      school: this.school,
     });
     await setupAuthentication({
-      school,
+      school: this.school,
       displayName: 'Clem Chowder',
     });
   });
@@ -187,6 +190,68 @@ module('Integration | Component | new learningmaterial', function (hooks) {
     assert.notOk(component.copyrightPermission.errorMessage.isPresent);
     assert.notOk(component.copyrightRationale.errorMessage.isPresent);
     assert.strictEqual(component.copyrightRationale.ariaInvalid, 'false');
+  });
+
+  skip('validate accessibility permission enabled', async function (assert) {
+    // global failure: TypeError: this.schoolData.value?.getConfigValue is not a function
+    // are my data getters in new-learningmaterial.gjs correct?
+
+    this.schoolConfig = this.store.createRecord('school-config', {
+      name: 'learningMaterialAccessibilityRequired',
+      value: true,
+      school: this.schoolModel,
+    });
+
+    this.set('type', 'file');
+    await render(
+      <template>
+        <NewLearningmaterial
+          @type={{this.type}}
+          @isCourse={{true}}
+          @subject={{this.course}}
+          @learningMaterialStatuses={{(array)}}
+          @learningMaterialUserRoles={{(array)}}
+          @save={{(noop)}}
+          @cancel={{(noop)}}
+        />
+      </template>,
+    );
+    assert.notOk(
+      component.accessibilityPermission.errorMessage.isPresent,
+      'error message not present',
+    );
+    assert.strictEqual(
+      component.accessibilityPermission.ariaInvalid,
+      'false',
+      'link aria not invalid',
+    );
+
+    await component.save();
+    assert.strictEqual(
+      component.accessibilityPermission.ariaErrorMessage,
+      component.accessibilityPermission.errorMessage.id,
+      'error message id is correct',
+    );
+    assert.strictEqual(
+      component.accessibilityPermission.errorMessage.text,
+      'Agreement is required for upload',
+      'error message text is correct',
+    );
+    assert.strictEqual(
+      component.accessibilityPermission.ariaInvalid,
+      'true',
+      'link aria is invalid',
+    );
+
+    await component.accessibilityPermission.toggle();
+    assert.notOk(
+      component.accessibilityPermission.errorMessage.isPresent,
+      'error message no longer present',
+    );
+    assert.strictEqual(
+      component.accessibilityPermission.ariaInvalid,
+      'link aria no longer invalid',
+    );
   });
 
   test('validate original author', async function (assert) {

--- a/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
+++ b/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
@@ -15,6 +15,10 @@ module('Integration | Component | new learningmaterial', function (hooks) {
 
   hooks.beforeEach(async function () {
     const school = this.server.create('school');
+    this.course = this.server.create('course', {
+      published: true,
+      year: 2026,
+    });
     await setupAuthentication({
       school,
       displayName: 'Clem Chowder',
@@ -53,6 +57,8 @@ module('Integration | Component | new learningmaterial', function (hooks) {
       <template>
         <NewLearningmaterial
           @type={{this.type}}
+          @isCourse={{true}}
+          @subject={{this.course}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}
@@ -60,8 +66,8 @@ module('Integration | Component | new learningmaterial', function (hooks) {
         />
       </template>,
     );
-    assert.notOk(component.url.errorMessage.isPresent);
-    assert.strictEqual(component.url.ariaInvalid, 'false');
+    assert.notOk(component.url.errorMessage.isPresent, 'no error message present');
+    assert.strictEqual(component.url.ariaInvalid, 'false', 'link aria not invalid');
 
     await component.save();
     assert.strictEqual(component.url.ariaErrorMessage, component.url.errorMessage.id);
@@ -86,6 +92,8 @@ module('Integration | Component | new learningmaterial', function (hooks) {
       <template>
         <NewLearningmaterial
           @type={{this.type}}
+          @isCourse={{true}}
+          @subject={{this.course}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}
@@ -104,6 +112,8 @@ module('Integration | Component | new learningmaterial', function (hooks) {
       <template>
         <NewLearningmaterial
           @type={{this.type}}
+          @isCourse={{true}}
+          @subject={{this.course}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}
@@ -144,6 +154,8 @@ module('Integration | Component | new learningmaterial', function (hooks) {
       <template>
         <NewLearningmaterial
           @type={{this.type}}
+          @isCourse={{true}}
+          @subject={{this.course}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}
@@ -183,6 +195,8 @@ module('Integration | Component | new learningmaterial', function (hooks) {
       <template>
         <NewLearningmaterial
           @type={{this.type}}
+          @isCourse={{true}}
+          @subject={{this.course}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}
@@ -223,6 +237,8 @@ module('Integration | Component | new learningmaterial', function (hooks) {
       <template>
         <NewLearningmaterial
           @type={{this.type}}
+          @isCourse={{true}}
+          @subject={{this.course}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}

--- a/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
+++ b/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
@@ -274,6 +274,60 @@ module('Integration | Component | new learningmaterial', function (hooks) {
     assert.strictEqual(component.markedAccessible.ariaInvalid, 'false', 'link aria still invalid');
   });
 
+  test('validate accessibility requirements link blank', async function (assert) {
+    this.schoolConfig = this.store.createRecord('school-config', {
+      name: 'learningMaterialAccessibilityRequirementsLink',
+      value: '',
+      school: this.schoolModel,
+    });
+
+    this.set('type', 'file');
+    await render(
+      <template>
+        <NewLearningmaterial
+          @type={{this.type}}
+          @isCourse={{true}}
+          @subject={{this.courseModel}}
+          @learningMaterialStatuses={{(array)}}
+          @learningMaterialUserRoles={{(array)}}
+          @save={{(noop)}}
+          @cancel={{(noop)}}
+        />
+      </template>,
+    );
+    assert.notOk(
+      component.accessibilityRequirementsLink.isPresent,
+      'accessibility requirements link not visible',
+    );
+  });
+
+  test('validate accessibility requirements link', async function (assert) {
+    this.schoolConfig = this.store.createRecord('school-config', {
+      name: 'learningMaterialAccessibilityRequirementsLink',
+      value: 'https://iliosproject.org',
+      school: this.schoolModel,
+    });
+
+    this.set('type', 'file');
+    await render(
+      <template>
+        <NewLearningmaterial
+          @type={{this.type}}
+          @isCourse={{true}}
+          @subject={{this.courseModel}}
+          @learningMaterialStatuses={{(array)}}
+          @learningMaterialUserRoles={{(array)}}
+          @save={{(noop)}}
+          @cancel={{(noop)}}
+        />
+      </template>,
+    );
+    assert.ok(
+      component.accessibilityRequirementsLink.isPresent,
+      'accessibility requirements link visible',
+    );
+  });
+
   test('validate original author', async function (assert) {
     this.set('type', 'file');
     await render(

--- a/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
+++ b/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
@@ -22,6 +22,7 @@ module('Integration | Component | new learningmaterial', function (hooks) {
       year: 2026,
       school: this.school,
     });
+    this.courseModel = await this.store.findRecord('course', this.course.id);
     await setupAuthentication({
       school: this.school,
       displayName: 'Clem Chowder',
@@ -61,7 +62,7 @@ module('Integration | Component | new learningmaterial', function (hooks) {
         <NewLearningmaterial
           @type={{this.type}}
           @isCourse={{true}}
-          @subject={{this.course}}
+          @subject={{this.courseModel}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}
@@ -96,7 +97,7 @@ module('Integration | Component | new learningmaterial', function (hooks) {
         <NewLearningmaterial
           @type={{this.type}}
           @isCourse={{true}}
-          @subject={{this.course}}
+          @subject={{this.courseModel}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}
@@ -116,7 +117,7 @@ module('Integration | Component | new learningmaterial', function (hooks) {
         <NewLearningmaterial
           @type={{this.type}}
           @isCourse={{true}}
-          @subject={{this.course}}
+          @subject={{this.courseModel}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}
@@ -158,7 +159,7 @@ module('Integration | Component | new learningmaterial', function (hooks) {
         <NewLearningmaterial
           @type={{this.type}}
           @isCourse={{true}}
-          @subject={{this.course}}
+          @subject={{this.courseModel}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}
@@ -261,7 +262,7 @@ module('Integration | Component | new learningmaterial', function (hooks) {
         <NewLearningmaterial
           @type={{this.type}}
           @isCourse={{true}}
-          @subject={{this.course}}
+          @subject={{this.courseModel}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}
@@ -303,7 +304,7 @@ module('Integration | Component | new learningmaterial', function (hooks) {
         <NewLearningmaterial
           @type={{this.type}}
           @isCourse={{true}}
-          @subject={{this.course}}
+          @subject={{this.courseModel}}
           @learningMaterialStatuses={{(array)}}
           @learningMaterialUserRoles={{(array)}}
           @save={{(noop)}}

--- a/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
+++ b/packages/test-app/tests/integration/components/new-learningmaterial-test.gjs
@@ -214,40 +214,29 @@ module('Integration | Component | new learningmaterial', function (hooks) {
         />
       </template>,
     );
-    assert.notOk(
-      component.accessibilityPermission.errorMessage.isPresent,
-      'error message not present',
-    );
-    assert.strictEqual(
-      component.accessibilityPermission.ariaInvalid,
-      'false',
-      'link aria not invalid',
-    );
+    assert.notOk(component.markedAccessible.errorMessage.isPresent, 'error message not present');
+    assert.strictEqual(component.markedAccessible.ariaInvalid, 'false', 'link aria not invalid');
 
     await component.save();
     assert.strictEqual(
-      component.accessibilityPermission.ariaErrorMessage,
-      component.accessibilityPermission.errorMessage.id,
+      component.markedAccessible.ariaErrorMessage,
+      component.markedAccessible.errorMessage.id,
       'error message id is correct',
     );
     assert.strictEqual(
-      component.accessibilityPermission.errorMessage.text,
+      component.markedAccessible.errorMessage.text,
       'Agreement is required for upload',
       'error message text is correct',
     );
-    assert.strictEqual(
-      component.accessibilityPermission.ariaInvalid,
-      'true',
-      'link aria is invalid',
-    );
+    assert.strictEqual(component.markedAccessible.ariaInvalid, 'true', 'link aria is invalid');
 
-    await component.accessibilityPermission.toggle();
+    await component.markedAccessible.toggle();
     assert.notOk(
-      component.accessibilityPermission.errorMessage.isPresent,
+      component.markedAccessible.errorMessage.isPresent,
       'error message no longer present',
     );
     assert.strictEqual(
-      component.accessibilityPermission.ariaInvalid,
+      component.markedAccessible.ariaInvalid,
       'false',
       'link aria no longer invalid',
     );
@@ -274,26 +263,15 @@ module('Integration | Component | new learningmaterial', function (hooks) {
         />
       </template>,
     );
-    assert.notOk(
-      component.accessibilityPermission.errorMessage.isPresent,
-      'error message not present',
-    );
-    assert.strictEqual(
-      component.accessibilityPermission.ariaInvalid,
-      'false',
-      'link aria not invalid',
-    );
+    assert.notOk(component.markedAccessible.errorMessage.isPresent, 'error message not present');
+    assert.strictEqual(component.markedAccessible.ariaInvalid, 'false', 'link aria not invalid');
 
     await component.save();
     assert.notOk(
-      component.accessibilityPermission.errorMessage.isPresent,
+      component.markedAccessible.errorMessage.isPresent,
       'error message still not present',
     );
-    assert.strictEqual(
-      component.accessibilityPermission.ariaInvalid,
-      'false',
-      'link aria still invalid',
-    );
+    assert.strictEqual(component.markedAccessible.ariaInvalid, 'false', 'link aria still invalid');
   });
 
   test('validate original author', async function (assert) {

--- a/packages/test-app/tests/unit/models/school-config-test.js
+++ b/packages/test-app/tests/unit/models/school-config-test.js
@@ -28,4 +28,12 @@ module('Unit | Model | School Config', function (hooks) {
     });
     assert.true(model.parsedValue);
   });
+
+  test('getParsedValue empty string', async function (assert) {
+    const model = this.store.createRecord('school-config', {
+      name: 'test-empty-string',
+      value: '',
+    });
+    assert.strictEqual(model.parsedValue, '');
+  });
 });

--- a/packages/test-app/tests/unit/models/school-test.js
+++ b/packages/test-app/tests/unit/models/school-test.js
@@ -34,11 +34,22 @@ module('Unit | Model | School', function (hooks) {
     assert.deepEqual(testNull, null);
   });
 
+  test('getConfigValue empty string', async function (assert) {
+    const school = this.store.createRecord('school');
+    this.store.createRecord('school-config', {
+      name: 'test-empty-string',
+      value: '',
+      school,
+    });
+    const testEmptyString = await school.getConfigValue('test-empty-string');
+    assert.strictEqual(testEmptyString, '');
+  });
+
   test('getConfigValue null', async function (assert) {
     const school = this.store.createRecord('school');
     this.store.createRecord('school-config', {
       name: 'test-null',
-      value: 'null',
+      value: null,
       school,
     });
     const testNull = await school.getConfigValue('test-null');


### PR DESCRIPTION
Requires https://github.com/ilios/ilios/pull/6984
Fixes ilios/ilios#6902

Much like the Copyright Permission and Rationale section, there is now an Accessibility Permission ~~and Rationale~~ section. The one major difference is it only requires them if it is after the government cutoff date. This can be removed entirely, if needed, and just never required. The translations need to be updated, as well.

- [x] Remove date cutoff
- [x] Create School Learning Material Attributes components
- [x] Create Accessibility Required attribute
- [x] Create Accessibility Required Message attribute (to override default message)
- [x] Course->New LM: load and use required attribute or not
- [x] Course->New LM: load and use message override attribute
- [x] Session->New LM: load and use required attribute or not
- [x] Session->New LM: load and use message override attribute
- [x] Add all this to existing LMs
- [x] Remove Rationale option
- [x] Tests
- [x] Validation on Accessibility Required Message