### PR TITLE
Fix diverging File Structure->Class names

### DIFF
--- a/packages/frontend/app/components/courses/loading.gjs
+++ b/packages/frontend/app/components/courses/loading.gjs
@@ -8,7 +8,7 @@ import sortBy from 'ilios-common/helpers/sort-by';
 import LoadingList from 'frontend/components/courses/loading-list';
 import { faBuildingColumns, faCalendar } from '@fortawesome/free-solid-svg-icons';
 
-export default class CoursesLoading extends Component {
+export default class CoursesLoadingComponent extends Component {
   @service store;
 
   today = new Date();

--- a/packages/frontend/app/components/curriculum-inventory/new-sequence-block.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/new-sequence-block.gjs
@@ -24,7 +24,7 @@ import DatePicker from 'ilios-common/components/date-picker';
 import perform from 'ember-concurrency/helpers/perform';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 
-export default class CurriculumInventoryNewSequenceBlock extends Component {
+export default class CurriculumInventoryNewSequenceBlockComponent extends Component {
   @service intl;
   @service store;
 

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-list.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-list.gjs
@@ -13,7 +13,7 @@ import sortBy from 'ilios-common/helpers/sort-by';
 import SequenceBlockListItem from 'frontend/components/curriculum-inventory/sequence-block-list-item';
 import { faSquareUpRight } from '@fortawesome/free-solid-svg-icons';
 
-export default class SequenceBlockListComponent extends Component {
+export default class CurriculumInventorySequenceBlockListComponent extends Component {
   @service store;
 
   @tracked editorOn = false;

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-session-list.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-session-list.gjs
@@ -9,7 +9,7 @@ import { eq, or } from 'ember-truth-helpers';
 import sortBy from 'ilios-common/helpers/sort-by';
 import includes from 'ilios-common/helpers/includes';
 
-export default class SequenceBlockSessionListComponent extends Component {
+export default class CurriculumInventorySequenceBlockSessionListComponent extends Component {
   @cached
   get sessionsData() {
     return new TrackedAsyncData(this.args.sequenceBlock.sessions);

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-session-manager.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-session-manager.gjs
@@ -13,7 +13,7 @@ import sortBy from 'ilios-common/helpers/sort-by';
 import includes from 'ilios-common/helpers/includes';
 import { faArrowRotateLeft, faCheck } from '@fortawesome/free-solid-svg-icons';
 
-export default class SequenceBlockSessionManagerComponent extends Component {
+export default class CurriculumInventorySequenceBlockSessionManagerComponent extends Component {
   @service store;
   @tracked excludedSessions = [];
   @tracked linkedSessions = [];

--- a/packages/frontend/app/components/global-search-box.gjs
+++ b/packages/frontend/app/components/global-search-box.gjs
@@ -11,7 +11,7 @@ import onKey from 'ember-keyboard/modifiers/on-key';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 
-export default class GlobalSearchBox extends Component {
+export default class GlobalSearchBoxComponent extends Component {
   @service router;
 
   @tracked internalQuery;

--- a/packages/frontend/app/components/ilios-navigation.gjs
+++ b/packages/frontend/app/components/ilios-navigation.gjs
@@ -23,7 +23,7 @@ import {
   faUserDoctor,
 } from '@fortawesome/free-solid-svg-icons';
 
-export default class IliosNavigation extends Component {
+export default class IliosNavigationComponent extends Component {
   @service currentUser;
   @tracked expanded = false;
   <template>

--- a/packages/frontend/app/components/learner-group/bulk-finalize-users.gjs
+++ b/packages/frontend/app/components/learner-group/bulk-finalize-users.gjs
@@ -9,7 +9,7 @@ import { on } from '@ember/modifier';
 import perform from 'ember-concurrency/helpers/perform';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 
-export default class LearnergroupBulkFinalizeUsersComponent extends Component {
+export default class LearnerGroupBulkFinalizeUsersComponent extends Component {
   @service flashMessages;
   @service intl;
 

--- a/packages/frontend/app/components/program-year/new.gjs
+++ b/packages/frontend/app/components/program-year/new.gjs
@@ -14,7 +14,7 @@ import { eq } from 'ember-truth-helpers';
 import perform from 'ember-concurrency/helpers/perform';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 
-export default class NewProgramYearComponent extends Component {
+export default class ProgramYearNewComponent extends Component {
   allYears = [];
   @tracked year;
 

--- a/packages/frontend/app/components/program/new.gjs
+++ b/packages/frontend/app/components/program/new.gjs
@@ -15,7 +15,7 @@ import YupValidationMessage from 'ilios-common/components/yup-validation-message
 import perform from 'ember-concurrency/helpers/perform';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 
-export default class NewProgramComponent extends Component {
+export default class ProgramNewComponent extends Component {
   @service store;
 
   @tracked title;

--- a/packages/frontend/app/components/reports/curriculum/choose-course.gjs
+++ b/packages/frontend/app/components/reports/curriculum/choose-course.gjs
@@ -15,7 +15,7 @@ import { fn } from '@ember/helper';
 import includes from 'ilios-common/helpers/includes';
 import { faBuildingColumns, faCaretDown, faCaretRight } from '@fortawesome/free-solid-svg-icons';
 
-export default class ReportsCurriculumChooseCourse extends Component {
+export default class ReportsCurriculumChooseCourseComponent extends Component {
   @service iliosConfig;
   @service currentUser;
 

--- a/packages/frontend/app/components/reports/curriculum/header.gjs
+++ b/packages/frontend/app/components/reports/curriculum/header.gjs
@@ -13,7 +13,7 @@ import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import IliosTooltip from 'ilios-common/components/ilios-tooltip';
 import { faCheck, faCopy, faDownload, faPlay, faSpinner } from '@fortawesome/free-solid-svg-icons';
 
-export default class ReportsCurriculumHeader extends Component {
+export default class ReportsCurriculumHeaderComponent extends Component {
   @service flashMessages;
   @service intl;
   @service store;

--- a/packages/frontend/app/components/reports/curriculum/loading.gjs
+++ b/packages/frontend/app/components/reports/curriculum/loading.gjs
@@ -11,7 +11,7 @@ import truncate from 'ilios-common/helpers/truncate';
 import random from 'ember-math-helpers/helpers/random';
 import { faBuildingColumns, faCaretDown, faCaretRight } from '@fortawesome/free-solid-svg-icons';
 
-export default class ReportsCurriculumLoading extends Component {
+export default class ReportsCurriculumLoadingComponent extends Component {
   @service router;
   @service intl;
   @service store;

--- a/packages/frontend/app/components/reports/subject-copy.gjs
+++ b/packages/frontend/app/components/reports/subject-copy.gjs
@@ -7,7 +7,7 @@ import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import t from 'ember-intl/helpers/t';
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 
-export default class ReportsSubjectCopy extends Component {
+export default class ReportsSubjectCopyComponent extends Component {
   @service reporting;
   @service intl;
 

--- a/packages/frontend/app/components/reports/subject-download.gjs
+++ b/packages/frontend/app/components/reports/subject-download.gjs
@@ -12,7 +12,7 @@ import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import t from 'ember-intl/helpers/t';
 import { faCheck, faDownload } from '@fortawesome/free-solid-svg-icons';
 
-export default class ReportsSubjectDownload extends Component {
+export default class ReportsSubjectDownloadComponent extends Component {
   @service reporting;
   @tracked finishedBuildingReport = false;
 

--- a/packages/frontend/app/components/reports/subject-header.gjs
+++ b/packages/frontend/app/components/reports/subject-header.gjs
@@ -21,7 +21,7 @@ import SubjectYearFilter from 'frontend/components/reports/subject-year-filter';
 import SubjectDescription from 'frontend/components/reports/subject-description';
 import focus from 'ilios-common/modifiers/focus';
 
-export default class ReportsSubjectHeader extends Component {
+export default class ReportsSubjectHeaderComponent extends Component {
   @service router;
   @service reporting;
   @tracked title = this.args.report?.title ?? '';

--- a/packages/frontend/app/components/reports/subject-year-filter.gjs
+++ b/packages/frontend/app/components/reports/subject-year-filter.gjs
@@ -9,7 +9,7 @@ import isEmpty from 'ember-truth-helpers/helpers/is-empty';
 import sortBy from 'ilios-common/helpers/sort-by';
 import { eq } from 'ember-truth-helpers';
 
-export default class ReportsSubjectYearFilter extends Component {
+export default class ReportsSubjectYearFilterComponent extends Component {
   @service store;
 
   @cached

--- a/packages/frontend/app/components/reports/subject/new/mesh-term.gjs
+++ b/packages/frontend/app/components/reports/subject/new/mesh-term.gjs
@@ -11,7 +11,7 @@ import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import MeshManager from 'ilios-common/components/mesh-manager';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 
-export default class ReportsSubjectNewProgramComponent extends Component {
+export default class ReportsSubjectNewMeshTermComponent extends Component {
   @service store;
 
   @cached

--- a/packages/frontend/app/components/reports/subject/new/term.gjs
+++ b/packages/frontend/app/components/reports/subject/new/term.gjs
@@ -11,7 +11,7 @@ import isEmpty from 'ember-truth-helpers/helpers/is-empty';
 import { eq } from 'ember-truth-helpers';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 
-export default class ReportsSubjectNewProgramYearComponent extends Component {
+export default class ReportsSubjectNewTermComponent extends Component {
   @service store;
 
   @cached

--- a/packages/frontend/app/components/reports/table-row.gjs
+++ b/packages/frontend/app/components/reports/table-row.gjs
@@ -6,7 +6,7 @@ import { fn } from '@ember/helper';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
-export default class ReportsListRowComponent extends Component {
+export default class ReportsTableRowComponent extends Component {
   get showRemoveConfirmation() {
     return this.args.reportsForRemovalConfirmation.includes(this.args.decoratedReport.report.id);
   }

--- a/packages/frontend/app/components/reports/table.gjs
+++ b/packages/frontend/app/components/reports/table.gjs
@@ -10,7 +10,7 @@ import TableRow from 'frontend/components/reports/table-row';
 import includes from 'ilios-common/helpers/includes';
 import { on } from '@ember/modifier';
 
-export default class ReportsListComponent extends Component {
+export default class ReportsTableComponent extends Component {
   @tracked reportsForRemovalConfirmation = [];
 
   get sortedAscending() {

--- a/packages/frontend/app/components/school-session-types-collapsed.gjs
+++ b/packages/frontend/app/components/school-session-types-collapsed.gjs
@@ -7,7 +7,7 @@ import t from 'ember-intl/helpers/t';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faCaretRight } from '@fortawesome/free-solid-svg-icons';
 
-export default class SchoolSessionTypesCollapseComponent extends Component {
+export default class SchoolSessionTypesCollapsedComponent extends Component {
   @cached
   get sessionTypesData() {
     return new TrackedAsyncData(this.args.school.sessionTypes);

--- a/packages/frontend/app/components/user-list.gjs
+++ b/packages/frontend/app/components/user-list.gjs
@@ -11,7 +11,7 @@ import UserNameInfo from 'ilios-common/components/user-name-info';
 import SortableTh from 'ilios-common/components/sortable-th';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 
-export default class UserList extends Component {
+export default class UserListComponent extends Component {
   get sortedAscending() {
     return this.args.sortBy.search(/desc/) === -1;
   }

--- a/packages/frontend/app/components/user-profile-calendar.gjs
+++ b/packages/frontend/app/components/user-profile-calendar.gjs
@@ -12,7 +12,7 @@ import IliosCalendarWeek from 'ilios-common/components/ilios-calendar-week';
 import Event from 'ilios-common/classes/event';
 import { faBackward, faForward } from '@fortawesome/free-solid-svg-icons';
 
-export default class UserProfileCalendar extends Component {
+export default class UserProfileCalendarComponent extends Component {
   @service fetch;
   @service router;
   @service iliosConfig;

--- a/packages/ilios-common/addon/components/course/objective-list.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list.gjs
@@ -13,6 +13,7 @@ import t from 'ember-intl/helpers/t';
 import isArray from 'ember-truth-helpers/helpers/is-array';
 import ObjectiveListItem from 'ilios-common/components/course/objective-list-item';
 import ObjectiveListLoading from 'ilios-common/components/course/objective-list-loading';
+
 export default class CourseObjectiveListComponent extends Component {
   @service store;
   @service intl;

--- a/packages/ilios-common/addon/components/course/visualize-instructor-session-type-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-instructor-session-type-graph.gjs
@@ -24,7 +24,7 @@ import sub_ from 'ember-math-helpers/helpers/sub';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 
-export default class CourseVisualizeInstructorSessionTypeGraph extends Component {
+export default class CourseVisualizeInstructorSessionTypeGraphComponent extends Component {
   @service router;
   @service intl;
   @tracked tooltipContent = null;

--- a/packages/ilios-common/addon/components/course/visualize-instructor-term-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-instructor-term-graph.gjs
@@ -25,7 +25,7 @@ import sub_ from 'ember-math-helpers/helpers/sub';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 
-export default class CourseVisualizeInstructorTermGraph extends Component {
+export default class CourseVisualizeInstructorTermGraphComponent extends Component {
   @service router;
   @service intl;
   @tracked tooltipContent = null;

--- a/packages/ilios-common/addon/components/course/visualize-instructors-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-instructors-graph.gjs
@@ -26,7 +26,7 @@ import sub_ from 'ember-math-helpers/helpers/sub';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 
-export default class CourseVisualizeInstructorsGraph extends Component {
+export default class CourseVisualizeInstructorsGraphComponent extends Component {
   @service router;
   @service intl;
   @tracked tooltipContent = null;

--- a/packages/ilios-common/addon/components/course/visualize-objectives-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-objectives-graph.gjs
@@ -25,7 +25,7 @@ import sub_ from 'ember-math-helpers/helpers/sub';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { faDownload, faFaceMeh, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 
-export default class CourseVisualizeObjectivesGraph extends Component {
+export default class CourseVisualizeObjectivesGraphComponent extends Component {
   @service router;
   @service intl;
   @service dataLoader;

--- a/packages/ilios-common/addon/components/course/visualize-session-type-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-session-type-graph.gjs
@@ -26,7 +26,7 @@ import sub_ from 'ember-math-helpers/helpers/sub';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 
-export default class CourseVisualizeSessionTypeGraph extends Component {
+export default class CourseVisualizeSessionTypeGraphComponent extends Component {
   @service router;
   @service intl;
   @tracked tooltipContent = null;

--- a/packages/ilios-common/addon/components/course/visualize-session-types-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-session-types-graph.gjs
@@ -25,7 +25,7 @@ import sub_ from 'ember-math-helpers/helpers/sub';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 
-export default class CourseVisualizeSessionTypesGraph extends Component {
+export default class CourseVisualizeSessionTypesGraphComponent extends Component {
   @service router;
   @service intl;
   @tracked tooltipContent = null;

--- a/packages/ilios-common/addon/components/course/visualize-term-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-term-graph.gjs
@@ -24,7 +24,7 @@ import sub_ from 'ember-math-helpers/helpers/sub';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 
-export default class CourseVisualizeTermGraph extends Component {
+export default class CourseVisualizeTermGraphComponent extends Component {
   @service router;
   @service intl;
   @tracked tooltipContent = null;

--- a/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.gjs
@@ -24,7 +24,7 @@ import sub_ from 'ember-math-helpers/helpers/sub';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 
-export default class CourseVisualizeVocabulariesGraph extends Component {
+export default class CourseVisualizeVocabulariesGraphComponent extends Component {
   @service router;
   @service intl;
   @tracked tooltipContent = null;

--- a/packages/ilios-common/addon/components/course/visualize-vocabulary-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-vocabulary-graph.gjs
@@ -24,7 +24,7 @@ import sub_ from 'ember-math-helpers/helpers/sub';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 
-export default class CourseVisualizeVocabularyGraph extends Component {
+export default class CourseVisualizeVocabularyGraphComponent extends Component {
   @service router;
   @service intl;
   @tracked tooltipContent = null;

--- a/packages/ilios-common/addon/components/dashboard/navigation.gjs
+++ b/packages/ilios-common/addon/components/dashboard/navigation.gjs
@@ -6,7 +6,7 @@ import t from 'ember-intl/helpers/t';
 import { LinkTo } from '@ember/routing';
 import IcsFeed from 'ilios-common/components/ics-feed';
 
-export default class NavigationComponent extends Component {
+export default class DashboardNavigationComponent extends Component {
   @service currentUser;
   @service iliosConfig;
   @service intl;

--- a/packages/ilios-common/addon/components/detail-learning-materials.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials.gjs
@@ -24,7 +24,7 @@ import NewLearningmaterial from 'ilios-common/components/new-learningmaterial';
 import DetailLearningMaterialsItem from 'ilios-common/components/detail-learning-materials-item';
 import { faMinus } from '@fortawesome/free-solid-svg-icons';
 
-export default class DetailCohortsComponent extends Component {
+export default class DetailLearningMaterialsComponent extends Component {
   @service currentUser;
   @service store;
   @service intl;

--- a/packages/ilios-common/addon/components/ilios-tooltip.gjs
+++ b/packages/ilios-common/addon/components/ilios-tooltip.gjs
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import popperTooltip from 'ember-popper-modifier/modifiers/popper-tooltip';
 
-export default class TooltipComponent extends Component {
+export default class IliosTooltipComponent extends Component {
   get applicationElement() {
     return document.querySelector('.ember-application');
   }

--- a/packages/ilios-common/addon/components/leadership-collapsed.gjs
+++ b/packages/ilios-common/addon/components/leadership-collapsed.gjs
@@ -4,7 +4,7 @@ import t from 'ember-intl/helpers/t';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faCaretRight } from '@fortawesome/free-solid-svg-icons';
 
-export default class LeadershipCollapsed extends Component {
+export default class LeadershipCollapsedComponent extends Component {
   get count() {
     const administratorsCount = this.args.showAdministrators
       ? (this.args.administratorsCount ?? 0)

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -28,7 +28,7 @@ import MeshManager from 'ilios-common/components/mesh-manager';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { faCopy, faDownload } from '@fortawesome/free-solid-svg-icons';
 
-export default class LearningMaterialManagerComponent extends Component {
+export default class LearningmaterialManagerComponent extends Component {
   @service store;
   @service flashMessages;
   @service intl;

--- a/packages/ilios-common/addon/components/learningmaterial-search.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-search.gjs
@@ -13,7 +13,7 @@ import LmTypeIcon from 'ilios-common/components/lm-type-icon';
 import formatDate from 'ember-intl/helpers/format-date';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 
-export default class LearningMaterialSearchComponent extends Component {
+export default class LearningmaterialSearchComponent extends Component {
   @service store;
   @service intl;
   @tracked query = '';

--- a/packages/ilios-common/addon/components/new-offering.gjs
+++ b/packages/ilios-common/addon/components/new-offering.gjs
@@ -9,7 +9,7 @@ import set from 'ember-set-helper/helpers/set';
 import OfferingForm from 'ilios-common/components/offering-form';
 import { not } from 'ember-truth-helpers';
 
-export default class NewObjectiveComponent extends Component {
+export default class NewOfferingComponent extends Component {
   @service store;
   @tracked smallGroupMode = true;
 

--- a/packages/ilios-common/addon/components/offering-calendar.gjs
+++ b/packages/ilios-common/addon/components/offering-calendar.gjs
@@ -14,7 +14,7 @@ import IliosCalendarWeek from 'ilios-common/components/ilios-calendar-week';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import Event from 'ilios-common/classes/event';
 
-export default class OfferingCalendar extends Component {
+export default class OfferingCalendarComponent extends Component {
   @tracked showLearnerGroupEvents = true;
   @tracked showSessionEvents = true;
   @tracked learnerGroupEvents = [];

--- a/packages/ilios-common/addon/components/offering-form.gjs
+++ b/packages/ilios-common/addon/components/offering-form.gjs
@@ -39,7 +39,7 @@ import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 const DEBOUNCE_DELAY = 600;
 const DEFAULT_URL_VALUE = 'https://';
 
-export default class OfferingForm extends Component {
+export default class OfferingFormComponent extends Component {
   @service currentUser;
   @service timezone;
   @service intl;

--- a/packages/ilios-common/addon/components/search-box.gjs
+++ b/packages/ilios-common/addon/components/search-box.gjs
@@ -12,7 +12,7 @@ import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 const DEBOUNCE_TIMEOUT = 250;
 
-export default class SearchBox extends Component {
+export default class SearchBoxComponent extends Component {
   @service intl;
   @tracked value = '';
 

--- a/packages/ilios-common/addon/components/selectable-terms-list-item.gjs
+++ b/packages/ilios-common/addon/components/selectable-terms-list-item.gjs
@@ -9,7 +9,7 @@ import IliosTooltip from 'ilios-common/components/ilios-tooltip';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faPlus, faXmark } from '@fortawesome/free-solid-svg-icons';
 
-export default class SelectableTermsListItem extends Component {
+export default class SelectableTermsListItemComponent extends Component {
   @tracked isHovering;
 
   get selectableTermsListItemButtonId() {

--- a/packages/ilios-common/addon/components/selectable-terms-list.gjs
+++ b/packages/ilios-common/addon/components/selectable-terms-list.gjs
@@ -7,7 +7,7 @@ import SelectableTermsListItem from 'ilios-common/components/selectable-terms-li
 import SelectableTermsList0 from 'ilios-common/components/selectable-terms-list';
 import add from 'ember-math-helpers/helpers/add';
 
-export default class SelectableTermsList extends Component {
+export default class SelectableTermsListComponent extends Component {
   @cached
   get termsData() {
     return new TrackedAsyncData(this.getFilteredTerms(this.args.parent, this.args.termFilter));

--- a/packages/ilios-common/addon/components/session/overview.gjs
+++ b/packages/ilios-common/addon/components/session/overview.gjs
@@ -30,7 +30,7 @@ import FadeText from 'ilios-common/components/fade-text';
 import focus from 'ilios-common/modifiers/focus';
 import { faClockRotateLeft, faCopy, faSquareUpRight } from '@fortawesome/free-solid-svg-icons';
 
-export default class SessionOverview extends Component {
+export default class SessionOverviewComponent extends Component {
   @service currentUser;
   @service router;
   @service permissionChecker;

--- a/packages/ilios-common/addon/components/sessions-grid-loading.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-loading.gjs
@@ -7,7 +7,7 @@ import formatDate from 'ember-intl/helpers/format-date';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faStarHalfStroke } from '@fortawesome/free-solid-svg-icons';
 
-export default class SessionsGridLoading extends Component {
+export default class SessionsGridLoadingComponent extends Component {
   now = new Date();
   <template>
     <div

--- a/packages/ilios-common/addon/components/sessions-grid-offering-table.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-offering-table.gjs
@@ -8,7 +8,7 @@ import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
 import SessionsGridOfferingTableOfferings from 'ilios-common/components/sessions-grid-offering-table-offerings';
 
-export default class SessionsGridOfferingTable extends Component {
+export default class SessionsGridOfferingTableComponent extends Component {
   @service permissionChecker;
 
   @cached

--- a/packages/ilios-common/addon/components/sessions-grid-offering.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-offering.gjs
@@ -24,7 +24,7 @@ import { string } from 'yup';
 import focus from 'ilios-common/modifiers/focus';
 import { faPencil } from '@fortawesome/free-solid-svg-icons';
 
-export default class SessionsGridOffering extends Component {
+export default class SessionsGridOfferingComponent extends Component {
   @tracked roomBuffer;
   @tracked isEditing = false;
   @tracked wasUpdated = false;

--- a/packages/ilios-common/addon/components/sessions-grid.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid.gjs
@@ -20,7 +20,7 @@ import { fn } from '@ember/helper';
 import SessionsGridLastUpdated from 'ilios-common/components/sessions-grid-last-updated';
 import SessionsGridOfferingTable from 'ilios-common/components/sessions-grid-offering-table';
 
-export default class SessionsGrid extends Component {
+export default class SessionsGridComponent extends Component {
   @service router;
   @service preserveScroll;
   @service intl;

--- a/packages/ilios-common/addon/components/single-event-objective-list.gjs
+++ b/packages/ilios-common/addon/components/single-event-objective-list.gjs
@@ -8,7 +8,7 @@ import { not } from 'ember-truth-helpers';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faIndent, faList, faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons';
 
-export default class SingleEventObjectiveList extends Component {
+export default class SingleEventObjectiveListComponent extends Component {
   @tracked groupByCompetencies = true;
   @tracked isExpanded = !!this.args.isExpandedByDefault;
 

--- a/packages/ilios-common/addon/components/single-event.gjs
+++ b/packages/ilios-common/addon/components/single-event.gjs
@@ -36,7 +36,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { faBlackTie } from '@fortawesome/free-brands-svg-icons';
 
-export default class SingleEvent extends Component {
+export default class SingleEventComponent extends Component {
   @service currentUser;
   @service intl;
   @service store;

--- a/packages/ilios-common/addon/components/sortable-heading.gjs
+++ b/packages/ilios-common/addon/components/sortable-heading.gjs
@@ -10,7 +10,7 @@ import {
   faSort,
 } from '@fortawesome/free-solid-svg-icons';
 
-export default class SortableHeading extends Component {
+export default class SortableHeadingComponent extends Component {
   get align() {
     return this.args.align || 'left';
   }

--- a/packages/ilios-common/addon/components/sortable-th.gjs
+++ b/packages/ilios-common/addon/components/sortable-th.gjs
@@ -10,7 +10,7 @@ import {
   faSort,
 } from '@fortawesome/free-solid-svg-icons';
 
-export default class SortableTh extends Component {
+export default class SortableThComponent extends Component {
   get align() {
     return this.args.align || 'left';
   }

--- a/packages/ilios-common/addon/components/taxonomy-manager.gjs
+++ b/packages/ilios-common/addon/components/taxonomy-manager.gjs
@@ -17,7 +17,7 @@ import sortBy from 'ilios-common/helpers/sort-by';
 import SelectableTermsListItem from 'ilios-common/components/selectable-terms-list-item';
 import SelectableTermsList from 'ilios-common/components/selectable-terms-list';
 
-export default class TaxonomyManager extends Component {
+export default class TaxonomyManagerComponent extends Component {
   @service store;
   @service intl;
   @service flashMessages;

--- a/packages/ilios-common/addon/components/time-picker.gjs
+++ b/packages/ilios-common/addon/components/time-picker.gjs
@@ -6,7 +6,7 @@ import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import isEqual from 'ember-truth-helpers/helpers/is-equal';
 
-export default class TimePicker extends Component {
+export default class TimePickerComponent extends Component {
   constructor() {
     super(...arguments);
     this.now = new Date();

--- a/packages/ilios-common/addon/components/timed-release-schedule.gjs
+++ b/packages/ilios-common/addon/components/timed-release-schedule.gjs
@@ -4,7 +4,7 @@ import { and, not } from 'ember-truth-helpers';
 import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
 
-export default class TimedReleaseSchedule extends Component {
+export default class TimedReleaseScheduleComponent extends Component {
   get show() {
     return this.showNoSchedule || this.args.endDate || this.startDateInTheFuture;
   }

--- a/packages/ilios-common/addon/components/toggle-buttons.gjs
+++ b/packages/ilios-common/addon/components/toggle-buttons.gjs
@@ -5,7 +5,7 @@ import { concat } from '@ember/helper';
 import { eq } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 
-export default class ToggleButtons extends Component {
+export default class ToggleButtonsComponent extends Component {
   get uniqueId() {
     return guidFor(this);
   }

--- a/packages/ilios-common/addon/components/toggle-yesno.gjs
+++ b/packages/ilios-common/addon/components/toggle-yesno.gjs
@@ -5,7 +5,7 @@ import { on } from '@ember/modifier';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
 
-export default class ToggleYesno extends Component {
+export default class ToggleYesnoComponent extends Component {
   get yes() {
     return !!this.args.yes;
   }

--- a/packages/ilios-common/addon/components/user-search-result-user.gjs
+++ b/packages/ilios-common/addon/components/user-search-result-user.gjs
@@ -5,7 +5,7 @@ import { fn } from '@ember/helper';
 import Component from '@glimmer/component';
 import UserStatus from 'ilios-common/components/user-status';
 
-export default class UserSearchResultUser extends Component {
+export default class UserSearchResultUserComponent extends Component {
   get canAddUser() {
     return this.args.user.enabled || this.args.canAddDisabledUser;
   }

--- a/packages/ilios-common/addon/components/user-search.gjs
+++ b/packages/ilios-common/addon/components/user-search.gjs
@@ -11,7 +11,7 @@ import { and, eq, gt } from 'ember-truth-helpers';
 import UserSearchResultUser from 'ilios-common/components/user-search-result-user';
 import UserSearchResultInstructorGroup from 'ilios-common/components/user-search-result-instructor-group';
 
-export default class UserSearch extends Component {
+export default class UserSearchComponent extends Component {
   @service store;
   @service intl;
   @tracked showMoreInputPrompt = false;

--- a/packages/ilios-common/addon/components/wait-saving.gjs
+++ b/packages/ilios-common/addon/components/wait-saving.gjs
@@ -6,7 +6,7 @@ import PulseLoader from 'ilios-common/components/pulse-loader';
 import t from 'ember-intl/helpers/t';
 import ProgressBar from 'ilios-common/components/progress-bar';
 
-export default class WaitSaving extends Component {
+export default class WaitSavingComponent extends Component {
   get contentId() {
     return `wait-saving-${guidFor(this)}`;
   }

--- a/packages/ilios-common/addon/components/week-glance-event.gjs
+++ b/packages/ilios-common/addon/components/week-glance-event.gjs
@@ -16,7 +16,7 @@ import LearningMaterialList from 'ilios-common/components/week-glance/learning-m
 import { faBlackTie } from '@fortawesome/free-brands-svg-icons';
 import { faCalendarCheck, faCalendarMinus, faFlask } from '@fortawesome/free-solid-svg-icons';
 
-export default class WeekGlanceEvent extends Component {
+export default class WeekGlanceEventComponent extends Component {
   @service intl;
 
   sortString(a, b) {

--- a/packages/ilios-common/addon/components/week-glance.gjs
+++ b/packages/ilios-common/addon/components/week-glance.gjs
@@ -15,7 +15,7 @@ import WeekGlanceEvent from 'ilios-common/components/week-glance-event';
 import formatDate from 'ember-intl/helpers/format-date';
 import { faSpinner, faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons';
 
-export default class WeeklyGlance extends Component {
+export default class WeeklyGlanceComponent extends Component {
   @service userEvents;
   @service intl;
   @service localeDays;

--- a/packages/ilios-common/addon/components/weekly-events.gjs
+++ b/packages/ilios-common/addon/components/weekly-events.gjs
@@ -10,7 +10,7 @@ import includes from 'ilios-common/helpers/includes';
 import { fn } from '@ember/helper';
 import { faBackward, faForward } from '@fortawesome/free-solid-svg-icons';
 
-export default class WeeklyEvents extends Component {
+export default class WeeklyEventsComponent extends Component {
   get weeksInYear() {
     const { weeksInWeekYear } = DateTime.fromObject({ weekYear: this.args.year });
     const weeks = [];

--- a/packages/ilios-common/addon/components/yup-validation-message.gjs
+++ b/packages/ilios-common/addon/components/yup-validation-message.gjs
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 
-export default class YupValidationMessage extends Component {
+export default class YupValidationMessageComponent extends Component {
   @service intl;
 
   get messages() {


### PR DESCRIPTION
## SO!

This is an _extremely_ nit-picky PR, because the class name you give to a Javascript file _literally_ doesn't matter (I tested this with @stopfstedt once and realized you can just write `export default class extends Component` and it works fine).

## HOWEVER!

When you're programming, seeing a class name that doesn't match the filename or doesn't follow the same naming structure as the established convention, then it can be distracting.

### Established Convention

1. `if (componentInRoot) then file-name.gjs -> FileNameComponent`
2. `if (componentInSubdir) then subdir/file-name.gjs -> SubdirFileNameComponent`)

## THUS!

I went through both `/packages/frontend/` and `/packages/ilios-common` and normalized all the class names.

## END!