### PR TITLE
restrict search results container height.

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
@@ -13,6 +13,7 @@
     box-shadow: 0 2px 2px var(--very-transparent-black);
     color: var(--black);
     left: 0;
+    max-height: 23rem;
     overflow: scroll;
     top: 2rem;
     transition: all 0.2s ease-in-out;

--- a/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
@@ -13,7 +13,7 @@
     box-shadow: 0 2px 2px var(--very-transparent-black);
     color: var(--black);
     left: 0;
-    max-height: 23rem;
+    max-height: 33dvh;
     overflow: scroll;
     top: 2rem;
     transition: all 0.2s ease-in-out;


### PR DESCRIPTION
fixes ilios/ilios#6981

this is a global change and affects all areas where user search is in place.

examples:

#### offering form

<img width="1250" height="487" alt="image" src="https://github.com/user-attachments/assets/3add8069-fe07-4bd9-afee-4132981a93cc" />

<img width="1269" height="405" alt="image" src="https://github.com/user-attachments/assets/139262c4-1fbd-43f9-a1ca-0c8bfe8831d1" />


#### user admin

<img width="1446" height="568" alt="image" src="https://github.com/user-attachments/assets/1b156db4-9d68-429d-8974-17d18a6448c0" />

etc.