### PR TITLE
pre-filter events by date range in offering calendar.

### DIFF
--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/offering-calendar.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/offering-calendar.js
@@ -1,0 +1,25 @@
+import { create, text } from 'ember-cli-page-object';
+import weeklyCalendar from './ilios-calendar-week';
+import toggle from './toggle-yesno';
+
+const definition = {
+  scope: '[data-test-offering-calendar]',
+  title: text('[data-test-offering-calendar-title]'),
+  filters: {
+    scope: '[data-test-filters]',
+    learnerGroupEvents: {
+      scope: '[data-test-learner-group-events-filter]',
+      toggle,
+      label: text('label'),
+    },
+    sessionEvents: {
+      scope: '[data-test-session-events-filter]',
+      toggle,
+      label: text('label'),
+    },
+  },
+  weeklyCalendar,
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/ilios-common/addon/components/offering-calendar.gjs
+++ b/packages/ilios-common/addon/components/offering-calendar.gjs
@@ -7,6 +7,7 @@ import t from 'ember-intl/helpers/t';
 import ToggleYesno from 'ilios-common/components/toggle-yesno';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
+import { service } from '@ember/service';
 import set from 'ember-set-helper/helpers/set';
 import { not } from 'ember-truth-helpers';
 import toggle from 'ilios-common/helpers/toggle';
@@ -16,6 +17,8 @@ import Event from 'ilios-common/classes/event';
 import { uniqueBy } from 'ilios-common/utils/array-helpers';
 
 export default class OfferingCalendarComponent extends Component {
+  @service localeDays;
+
   @tracked showLearnerGroupEvents = true;
   @tracked showSessionEvents = true;
   @tracked learnerGroupEvents = [];
@@ -116,6 +119,18 @@ export default class OfferingCalendarComponent extends Component {
     }
   }
 
+  get fromTimeStamp() {
+    return DateTime.fromJSDate(this.localeDays.firstDayOfDateWeek(this.args.startDate))
+      .set({ hour: 0, minute: 0, second: 0 })
+      .toUnixInteger();
+  }
+
+  get toTimeStamp() {
+    return DateTime.fromJSDate(this.localeDays.lastDayOfDateWeek(this.args.startDate))
+      .set({ hour: 23, minute: 59, second: 59 })
+      .toUnixInteger();
+  }
+
   get calendarEvents() {
     if (!this.currentEvent) {
       return [];
@@ -144,7 +159,10 @@ export default class OfferingCalendarComponent extends Component {
       return eventIdentifier !== currentEventIdentifier;
     });
 
-    return [...filteredEvents, this.currentEvent];
+    return [...filteredEvents, this.currentEvent].filter((event) => {
+      const ts = DateTime.fromISO(event.startDate).toUnixInteger();
+      return this.fromTimeStamp <= ts && ts <= this.toTimeStamp;
+    });
   }
   <template>
     <div class="offering-calendar">

--- a/packages/ilios-common/addon/components/offering-calendar.gjs
+++ b/packages/ilios-common/addon/components/offering-calendar.gjs
@@ -165,13 +165,13 @@ export default class OfferingCalendarComponent extends Component {
     });
   }
   <template>
-    <div class="offering-calendar">
+    <div class="offering-calendar" data-test-offering-calendar>
       {{#if this.calendarEventsData.isResolved}}
-        <h2 class="offering-calendar-title">
+        <h2 class="offering-calendar-title" data-test-offering-calendar-title>
           {{t "general.calendar"}}
         </h2>
-        <p class="offering-calendar-filter-options">
-          <span class="filter">
+        <p class="offering-calendar-filter-options" data-test-filters>
+          <span class="filter" data-test-learner-group-events-filter>
             <ToggleYesno
               @yes={{this.showLearnerGroupEvents}}
               @toggle={{fn (mut this.showLearnerGroupEvents)}}
@@ -182,7 +182,7 @@ export default class OfferingCalendarComponent extends Component {
               {{t "general.showLearnerGroupEvents"}}
             </label>
           </span>
-          <span class="filter">
+          <span class="filter" data-test-session-events-filter>
             <ToggleYesno
               @yes={{this.showSessionEvents}}
               @toggle={{fn (mut this.showSessionEvents)}}

--- a/packages/test-app/tests/integration/components/offering-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/offering-calendar-test.gjs
@@ -57,8 +57,8 @@ module('Integration | Component | offering-calendar', function (hooks) {
   });
 
   test('shows events', async function (assert) {
-    const today = DateTime.fromObject({ hour: 8 });
-    const tomorrow = today.plus({ day: 1 });
+    const startDate = DateTime.fromISO('2026-03-31T08:00:00');
+    const endDate = startDate.plus({ day: 1 });
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
     const sessionType = this.server.create('session-type');
@@ -71,20 +71,20 @@ module('Integration | Component | offering-calendar', function (hooks) {
       sessionType,
     });
     const offering1 = this.server.create('offering', {
-      startDate: today.toJSDate(),
-      endDate: today.plus({ hour: 1 }).toJSDate(),
+      startDate: startDate.toJSDate(),
+      endDate: startDate.plus({ hour: 1 }).toJSDate(),
       location: 123,
       session,
     });
     const offering2 = this.server.create('offering', {
-      startDate: today.toJSDate(),
-      endDate: today.plus({ hour: 1 }).toJSDate(),
+      startDate: startDate.toJSDate(),
+      endDate: startDate.plus({ hour: 1 }).toJSDate(),
       location: 123,
       session,
     });
     const offering3 = this.server.create('offering', {
-      startDate: today.toJSDate(),
-      endDate: today.plus({ hour: 1 }).toJSDate(),
+      startDate: startDate.toJSDate(),
+      endDate: startDate.plus({ hour: 1 }).toJSDate(),
       location: 123,
       session: session2,
     });
@@ -103,8 +103,8 @@ module('Integration | Component | offering-calendar', function (hooks) {
       .lookup('service:store')
       .findRecord('learner-group', learnerGroup2.id);
 
-    this.set('startDate', today.toJSDate());
-    this.set('endDate', tomorrow.toJSDate());
+    this.set('startDate', startDate.toJSDate());
+    this.set('endDate', endDate.toJSDate());
     this.set('session', sessionModel);
     this.set('learnerGroups', [learnerGroupModel, learnerGroupModel2]);
     await render(

--- a/packages/test-app/tests/integration/components/offering-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/offering-calendar-test.gjs
@@ -58,7 +58,7 @@ module('Integration | Component | offering-calendar', function (hooks) {
 
   test('shows events', async function (assert) {
     const startDate = DateTime.fromISO('2026-03-31T08:00:00');
-    const endDate = startDate.plus({ day: 1 });
+    const endDate = startDate.plus({ hours: 8 });
     const startOfWeek = startDate.minus({ day: 2 }).set({ hour: 0, minute: 0, second: 0 });
     const endOfWeek = startDate.plus({ day: 4 }).set({ hour: 22, minute: 59, second: 59 });
     const school = this.server.create('school');
@@ -119,12 +119,14 @@ module('Integration | Component | offering-calendar', function (hooks) {
         />
       </template>,
     );
-    assert.strictEqual(component.weeklyCalendar.calendar.events.length, 3);
+    assert.strictEqual(component.weeklyCalendar.calendar.events.length, 4);
     assert.ok(component.weeklyCalendar.calendar.events[0].isFirstDayOfWeek);
     assert.strictEqual(component.weeklyCalendar.calendar.events[0].time, '12:00 AM');
     assert.ok(component.weeklyCalendar.calendar.events[1].isThirdDayOfWeek);
     assert.strictEqual(component.weeklyCalendar.calendar.events[1].time, '08:00 AM');
-    assert.ok(component.weeklyCalendar.calendar.events[2].isSeventhDayOfWeek);
-    assert.strictEqual(component.weeklyCalendar.calendar.events[2].time, '10:59 PM');
+    assert.ok(component.weeklyCalendar.calendar.events[2].isThirdDayOfWeek);
+    assert.strictEqual(component.weeklyCalendar.calendar.events[2].time, '08:00 AM');
+    assert.ok(component.weeklyCalendar.calendar.events[3].isSeventhDayOfWeek);
+    assert.strictEqual(component.weeklyCalendar.calendar.events[3].time, '10:59 PM');
   });
 });

--- a/packages/test-app/tests/integration/components/offering-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/offering-calendar-test.gjs
@@ -59,6 +59,8 @@ module('Integration | Component | offering-calendar', function (hooks) {
   test('shows events', async function (assert) {
     const startDate = DateTime.fromISO('2026-03-31T08:00:00');
     const endDate = startDate.plus({ day: 1 });
+    const startOfWeek = startDate.minus({ day: 2 }).set({ hour: 0, minute: 0, second: 0 });
+    const endOfWeek = startDate.plus({ day: 4 }).set({ hour: 22, minute: 59, second: 59 });
     const school = this.server.create('school');
     const course = this.server.create('course', { school });
     const sessionType = this.server.create('session-type');
@@ -71,14 +73,14 @@ module('Integration | Component | offering-calendar', function (hooks) {
       sessionType,
     });
     const offering1 = this.server.create('offering', {
-      startDate: startDate.toJSDate(),
-      endDate: startDate.plus({ hour: 1 }).toJSDate(),
+      startDate: startOfWeek.toJSDate(),
+      endDate: startOfWeek.plus({ hour: 1 }).toJSDate(),
       location: 123,
       session,
     });
     const offering2 = this.server.create('offering', {
-      startDate: startDate.toJSDate(),
-      endDate: startDate.plus({ hour: 1 }).toJSDate(),
+      startDate: endOfWeek.toJSDate(),
+      endDate: endOfWeek.plus({ hour: 1 }).toJSDate(),
       location: 123,
       session,
     });
@@ -118,8 +120,11 @@ module('Integration | Component | offering-calendar', function (hooks) {
       </template>,
     );
     assert.strictEqual(component.weeklyCalendar.calendar.events.length, 3);
-    assert.ok(component.weeklyCalendar.calendar.events[0].isThirdDayOfWeek);
+    assert.ok(component.weeklyCalendar.calendar.events[0].isFirstDayOfWeek);
+    assert.strictEqual(component.weeklyCalendar.calendar.events[0].time, '12:00 AM');
     assert.ok(component.weeklyCalendar.calendar.events[1].isThirdDayOfWeek);
-    assert.ok(component.weeklyCalendar.calendar.events[2].isThirdDayOfWeek);
+    assert.strictEqual(component.weeklyCalendar.calendar.events[1].time, '08:00 AM');
+    assert.ok(component.weeklyCalendar.calendar.events[2].isSeventhDayOfWeek);
+    assert.strictEqual(component.weeklyCalendar.calendar.events[2].time, '10:59 PM');
   });
 });

--- a/packages/test-app/tests/integration/components/offering-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/offering-calendar-test.gjs
@@ -1,13 +1,60 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
 import { render } from '@ember/test-helpers';
+import { array } from '@ember/helper';
 import { setupMirage } from 'test-app/tests/test-support/mirage';
 import { DateTime } from 'luxon';
 import OfferingCalendar from 'ilios-common/components/offering-calendar';
+import { component } from 'ilios-common/page-objects/components/offering-calendar';
 
 module('Integration | Component | offering-calendar', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
+
+  test('it renders', async function (assert) {
+    const startDate = DateTime.fromISO('2026-03-31T09:00:00');
+    const endDate = startDate.plus({ hour: 8 });
+    const school = this.server.create('school');
+    const course = this.server.create('course', { school });
+    const sessionType = this.server.create('session-type');
+    const session = this.server.create('session', {
+      course,
+      sessionType,
+    });
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+
+    this.set('startDate', startDate.toJSDate());
+    this.set('endDate', endDate.toJSDate());
+    this.set('session', sessionModel);
+    await render(
+      <template>
+        <OfferingCalendar
+          @learnerGroups={{(array)}}
+          @session={{this.session}}
+          @startDate={{this.startDate}}
+          @endDate={{this.endDate}}
+        />
+      </template>,
+    );
+    assert.strictEqual(component.title, 'Calendar');
+    assert.ok(
+      component.filters.learnerGroupEvents.toggle.checked,
+      'learner group events filter is on by default',
+    );
+    assert.strictEqual(
+      component.filters.learnerGroupEvents.label,
+      'Show all events for assigned learner groups',
+    );
+    assert.ok(
+      component.filters.sessionEvents.toggle.checked,
+      'session events filter is on by default',
+    );
+    assert.strictEqual(component.filters.sessionEvents.label, 'Show all other session 0 events');
+    assert.strictEqual(
+      component.weeklyCalendar.calendar.title.longWeekOfYear,
+      'Week of March 29, 2026',
+    );
+  });
 
   test('shows events', async function (assert) {
     const today = DateTime.fromObject({ hour: 8 });
@@ -70,7 +117,6 @@ module('Integration | Component | offering-calendar', function (hooks) {
         />
       </template>,
     );
-    const events = '[data-test-calendar-event]';
-    assert.dom(events).exists({ count: 3 });
+    assert.strictEqual(component.weeklyCalendar.calendar.events.length, 3);
   });
 });

--- a/packages/test-app/tests/integration/components/offering-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/offering-calendar-test.gjs
@@ -118,5 +118,8 @@ module('Integration | Component | offering-calendar', function (hooks) {
       </template>,
     );
     assert.strictEqual(component.weeklyCalendar.calendar.events.length, 3);
+    assert.ok(component.weeklyCalendar.calendar.events[0].isThirdDayOfWeek);
+    assert.ok(component.weeklyCalendar.calendar.events[1].isThirdDayOfWeek);
+    assert.ok(component.weeklyCalendar.calendar.events[2].isThirdDayOfWeek);
   });
 });

--- a/packages/test-app/tests/integration/components/offering-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/offering-calendar-test.gjs
@@ -85,8 +85,8 @@ module('Integration | Component | offering-calendar', function (hooks) {
       session,
     });
     const offering3 = this.server.create('offering', {
-      startDate: startDate.toJSDate(),
-      endDate: startDate.plus({ hour: 1 }).toJSDate(),
+      startDate: startDate.plus({ day: 1, hour: 1}).toJSDate(),
+      endDate: startDate.plus({ day: 1, hour: 2 }).toJSDate(),
       location: 123,
       session: session2,
     });
@@ -124,8 +124,8 @@ module('Integration | Component | offering-calendar', function (hooks) {
     assert.strictEqual(component.weeklyCalendar.calendar.events[0].time, '12:00 AM');
     assert.ok(component.weeklyCalendar.calendar.events[1].isThirdDayOfWeek);
     assert.strictEqual(component.weeklyCalendar.calendar.events[1].time, '08:00 AM');
-    assert.ok(component.weeklyCalendar.calendar.events[2].isThirdDayOfWeek);
-    assert.strictEqual(component.weeklyCalendar.calendar.events[2].time, '08:00 AM');
+    assert.ok(component.weeklyCalendar.calendar.events[2].isFourthDayOfWeek);
+    assert.strictEqual(component.weeklyCalendar.calendar.events[2].time, '09:00 AM');
     assert.ok(component.weeklyCalendar.calendar.events[3].isSeventhDayOfWeek);
     assert.strictEqual(component.weeklyCalendar.calendar.events[3].time, '10:59 PM');
   });

--- a/packages/test-app/tests/integration/components/offering-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/offering-calendar-test.gjs
@@ -85,7 +85,7 @@ module('Integration | Component | offering-calendar', function (hooks) {
       session,
     });
     const offering3 = this.server.create('offering', {
-      startDate: startDate.plus({ day: 1, hour: 1}).toJSDate(),
+      startDate: startDate.plus({ day: 1, hour: 1 }).toJSDate(),
       endDate: startDate.plus({ day: 1, hour: 2 }).toJSDate(),
       location: 123,
       session: session2,
@@ -128,5 +128,25 @@ module('Integration | Component | offering-calendar', function (hooks) {
     assert.strictEqual(component.weeklyCalendar.calendar.events[2].time, '09:00 AM');
     assert.ok(component.weeklyCalendar.calendar.events[3].isSeventhDayOfWeek);
     assert.strictEqual(component.weeklyCalendar.calendar.events[3].time, '10:59 PM');
+
+    await component.filters.learnerGroupEvents.toggle.handle.click();
+    assert.strictEqual(component.weeklyCalendar.calendar.events.length, 3);
+    assert.ok(component.weeklyCalendar.calendar.events[0].isFirstDayOfWeek);
+    assert.strictEqual(component.weeklyCalendar.calendar.events[0].time, '12:00 AM');
+    assert.ok(component.weeklyCalendar.calendar.events[1].isThirdDayOfWeek);
+    assert.strictEqual(component.weeklyCalendar.calendar.events[1].time, '08:00 AM');
+    assert.ok(component.weeklyCalendar.calendar.events[2].isSeventhDayOfWeek);
+    assert.strictEqual(component.weeklyCalendar.calendar.events[2].time, '10:59 PM');
+
+    await component.filters.sessionEvents.toggle.handle.click();
+    assert.strictEqual(component.weeklyCalendar.calendar.events.length, 1);
+    assert.ok(component.weeklyCalendar.calendar.events[0].isThirdDayOfWeek);
+    assert.strictEqual(component.weeklyCalendar.calendar.events[0].time, '08:00 AM');
+
+    await component.filters.sessionEvents.toggle.handle.click();
+    assert.strictEqual(component.weeklyCalendar.calendar.events.length, 3);
+
+    await component.filters.learnerGroupEvents.toggle.handle.click();
+    assert.strictEqual(component.weeklyCalendar.calendar.events.length, 4);
   });
 });


### PR DESCRIPTION
fixes https://github.com/ilios/ilios/issues/7019

while at it, i substantially fleshed out the integration test for the offering-calendar component.