### PR TITLE
removes link to course objectives viz from bulk session publishing summary.

### DIFF
--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/publish-all-sessions.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/publish-all-sessions.js
@@ -90,9 +90,6 @@ const definition = {
     transitionToCourse: {
       scope: '[data-test-course-link]',
     },
-    visualize: {
-      scope: '[data-test-visualize]',
-    },
     confirmation: text('[data-test-confirmation]'),
     save: clickable('[data-test-save]'),
   },

--- a/packages/ilios-common/addon/components/publish-all-sessions.gjs
+++ b/packages/ilios-common/addon/components/publish-all-sessions.gjs
@@ -17,12 +17,7 @@ import includes from 'ilios-common/helpers/includes';
 import mapBy from 'ilios-common/helpers/map-by';
 import SaveButton from 'ilios-common/components/save-button';
 import perform from 'ember-concurrency/helpers/perform';
-import {
-  faChartColumn,
-  faLinkSlash,
-  faCaretRight,
-  faCaretDown,
-} from '@fortawesome/free-solid-svg-icons';
+import { faLinkSlash, faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons';
 
 export default class PublishAllSessionsComponent extends Component {
   @service store;
@@ -526,14 +521,6 @@ export default class PublishAllSessionsComponent extends Component {
             data-test-course-link
           >
             <FaIcon @icon={{faLinkSlash}} />
-          </LinkTo>
-          <LinkTo
-            @route="course-visualize-objectives"
-            @model={{@course}}
-            title={{t "general.courseVisualizations"}}
-            data-test-visualize
-          >
-            <FaIcon @icon={{faChartColumn}} />
           </LinkTo>
         {{/if}}
         <p data-test-confirmation>

--- a/packages/test-app/tests/integration/components/publish-all-sessions-test.gjs
+++ b/packages/test-app/tests/integration/components/publish-all-sessions-test.gjs
@@ -157,7 +157,6 @@ module('Integration | Component | publish all sessions', function (hooks) {
       'This course has unlinked objective(s)',
     );
     assert.ok(component.review.transitionToCourse.isVisible);
-    assert.ok(component.review.visualize.isVisible);
   });
 
   test('publish all overridable #2478', async function (assert) {


### PR DESCRIPTION
fixes ilios/ilios#7029

<img width="1472" height="231" alt="image" src="https://github.com/user-attachments/assets/3067f7b2-b737-4e29-86e7-c1ae01cae84a" />
