### PR TITLE
weekly calendar: prevent unclickable events and day headers from appearing clickable

### DIFF
--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/weekly-calendar.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/weekly-calendar.js
@@ -4,6 +4,7 @@ import {
   create,
   collection,
   hasClass,
+  property,
   text,
   isPresent,
 } from 'ember-cli-page-object';
@@ -28,7 +29,11 @@ const definition = {
     isSixthDayOfWeek: hasClass('day-6'),
     isSeventhDayOfWeek: hasClass('day-7'),
     hasNoEvents: isPresent('[data-test-no-events]'),
-    isClickable: hasClass('clickable', '[data-test-day]'),
+    button: {
+      scope: 'button',
+      cssClasses: attribute('class'),
+      isDisabled: property('disabled'),
+    },
   }),
   days: collection('[data-test-events-day]', {
     events: collection('[data-test-weekly-calendar-event]'),

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/weekly-calendar.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/weekly-calendar.js
@@ -28,6 +28,7 @@ const definition = {
     isSixthDayOfWeek: hasClass('day-6'),
     isSeventhDayOfWeek: hasClass('day-7'),
     hasNoEvents: isPresent('[data-test-no-events]'),
+    isClickable: hasClass('clickable', '[data-test-day]'),
   }),
   days: collection('[data-test-events-day]', {
     events: collection('[data-test-weekly-calendar-event]'),

--- a/packages/ilios-common/addon/components/ilios-calendar-week.gjs
+++ b/packages/ilios-common/addon/components/ilios-calendar-week.gjs
@@ -62,11 +62,14 @@ export default class IliosCalendarWeekComponent extends Component {
 
   @action
   changeToDayView(date) {
-    if (this.args.areDaysSelectable && this.args.changeDate && this.args.changeView) {
-      this.args.changeDate(date);
-      this.args.changeView('day');
-    }
+    this.args.changeDate(date);
+    this.args.changeView('day');
   }
+
+  get canChangeToDayView() {
+    return this.args.areDaysSelectable && this.args.changeDate && this.args.changeView;
+  }
+
   <template>
     {{#if (isArray @calendarEvents)}}
       <div class="ilios-calendar-week" data-test-ilios-calendar-week>
@@ -74,9 +77,10 @@ export default class IliosCalendarWeekComponent extends Component {
           @isLoadingEvents={{@isLoadingEvents}}
           @date={{this.date}}
           @events={{this.singleDayEvents}}
-          @changeToDayView={{if @areDaysSelectable this.changeToDayView (noop)}}
+          @changeToDayView={{if this.canChangeToDayView this.changeToDayView false}}
           @selectEvent={{if @areEventsSelectable @selectEvent (noop)}}
           @isUserProfileCalendar={{@isUserProfileCalendar}}
+          @areEventsSelectable={{@areEventsSelectable}}
         />
         <IliosCalendarMultidayEvents
           @events={{this.multiDayEventsList}}

--- a/packages/ilios-common/addon/components/weekly-calendar-event.gjs
+++ b/packages/ilios-common/addon/components/weekly-calendar-event.gjs
@@ -74,7 +74,7 @@ export default class WeeklyCalendarEventComponent extends Component {
   }
 
   get clickable() {
-    return this.isIlm || this.isOffering;
+    return this.args.isEventSelectable && (this.isIlm || this.isOffering);
   }
 
   get tooltipContent() {

--- a/packages/ilios-common/addon/components/weekly-calendar.gjs
+++ b/packages/ilios-common/addon/components/weekly-calendar.gjs
@@ -207,6 +207,7 @@ export default class WeeklyCalendarComponent extends Component {
           <div class="day-heading day-{{day.dayOfWeek}}">
             <button
               class="link-button{{if @changeToDayView ' clickable'}}"
+              disabled={{unless @changeToDayView "disabled"}}
               type="button"
               {{on "click" (fn this.changeToDayView day.date)}}
               tabindex="-1"

--- a/packages/ilios-common/addon/components/weekly-calendar.gjs
+++ b/packages/ilios-common/addon/components/weekly-calendar.gjs
@@ -122,7 +122,9 @@ export default class WeeklyCalendarComponent extends Component {
   @action
   selectEvent(event) {
     if (event.isMulti) {
-      this.args.changeToDayView(event.startDate);
+      if (this.args.changeToDayView) {
+        this.args.changeToDayView(event.startDate);
+      }
     } else {
       this.args.selectEvent(event);
     }
@@ -130,7 +132,9 @@ export default class WeeklyCalendarComponent extends Component {
 
   @action
   changeToDayView(date) {
-    this.args.changeToDayView(DateTime.fromJSDate(date).toFormat('yyyy-MM-dd'));
+    if (this.args.changeToDayView) {
+      this.args.changeToDayView(DateTime.fromJSDate(date).toFormat('yyyy-MM-dd'));
+    }
   }
   <template>
     <section
@@ -184,6 +188,7 @@ export default class WeeklyCalendarComponent extends Component {
                 @day={{day.dayOfWeek}}
                 @allDayEvents={{day.events}}
                 @selectEvent={{fn this.selectEvent event}}
+                @isEventSelectable={{@areEventsSelectable}}
               />
             {{else}}
               <span class="no-events visually-hidden" data-test-no-events>{{t
@@ -201,7 +206,7 @@ export default class WeeklyCalendarComponent extends Component {
         {{#each this.week as |day|}}
           <div class="day-heading day-{{day.dayOfWeek}}">
             <button
-              class="link-button"
+              class="link-button{{if @changeToDayView ' clickable'}}"
               type="button"
               {{on "click" (fn this.changeToDayView day.date)}}
               tabindex="-1"

--- a/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar.scss
@@ -126,9 +126,14 @@
       }
 
       button {
+        cursor: default;
         display: flex;
         flex-direction: column;
         text-align: center;
+
+        &.clickable {
+          cursor: pointer;
+        }
       }
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/shared/button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/button.scss
@@ -9,5 +9,9 @@ button {
     font: inherit;
     text-align: left;
     white-space: normal;
+
+    &.inactive {
+      color: var(--black);
+    }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/button.scss
@@ -10,7 +10,7 @@ button {
     text-align: left;
     white-space: normal;
 
-    &.inactive {
+    &:disabled {
       color: var(--black);
     }
   }

--- a/packages/test-app/tests/integration/components/ilios-calendar-week-test.gjs
+++ b/packages/test-app/tests/integration/components/ilios-calendar-week-test.gjs
@@ -57,6 +57,7 @@ module('Integration | Component | ilios calendar week', function (hooks) {
         />
       </template>,
     );
+    assert.ok(component.calendar.dayHeadings[0].isClickable);
     await component.calendar.dayHeadings[0].selectDay();
     assert.verifySteps(['changeDate called', 'changeView called']);
   });
@@ -85,6 +86,7 @@ module('Integration | Component | ilios calendar week', function (hooks) {
         />
       </template>,
     );
+    assert.notOk(component.calendar.dayHeadings[0].isClickable);
     await component.calendar.dayHeadings[0].selectDay();
     assert.verifySteps([]);
   });

--- a/packages/test-app/tests/integration/components/ilios-calendar-week-test.gjs
+++ b/packages/test-app/tests/integration/components/ilios-calendar-week-test.gjs
@@ -57,12 +57,12 @@ module('Integration | Component | ilios calendar week', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.calendar.dayHeadings[0].isClickable);
+    assert.notOk(component.calendar.dayHeadings[0].button.isDisabled);
     await component.calendar.dayHeadings[0].selectDay();
     assert.verifySteps(['changeDate called', 'changeView called']);
   });
 
-  test('clicking on a day header does nothing when areDaysSelectable is false', async function (assert) {
+  test('day header is disabled when areDaysSelectable is false', async function (assert) {
     const date = DateTime.fromObject({
       year: 2015,
       month: 9,
@@ -72,22 +72,17 @@ module('Integration | Component | ilios calendar week', function (hooks) {
       second: 0,
     });
     this.set('date', date.toJSDate());
-    this.set('changeDate', () => {
-      assert.step('changeDate called');
-    });
     await render(
       <template>
         <IliosCalendarWeek
           @date={{this.date}}
           @calendarEvents={{(array)}}
           @areDaysSelectable={{false}}
-          @changeDate={{this.changeDate}}
+          @changeDate={{(noop)}}
           @changeView={{(noop)}}
         />
       </template>,
     );
-    assert.notOk(component.calendar.dayHeadings[0].isClickable);
-    await component.calendar.dayHeadings[0].selectDay();
-    assert.verifySteps([]);
+    assert.ok(component.calendar.dayHeadings[0].button.isDisabled);
   });
 });

--- a/packages/test-app/tests/integration/components/weekly-calendar-event-test.gjs
+++ b/packages/test-app/tests/integration/components/weekly-calendar-event-test.gjs
@@ -6,6 +6,7 @@ import { DateTime } from 'luxon';
 import { component } from 'ilios-common/page-objects/components/weekly-calendar-event';
 import WeeklyCalendarEvent from 'ilios-common/components/weekly-calendar-event';
 import Event from 'ilios-common/classes/event';
+import noop from 'ilios-common/helpers/noop';
 import { array } from '@ember/helper';
 
 module('Integration | Component | weekly-calendar-event', function (hooks) {
@@ -34,6 +35,7 @@ module('Integration | Component | weekly-calendar-event', function (hooks) {
         isScheduled,
         postrequisites: [],
         prerequisites,
+        offering: 1,
       },
       false,
       showAsBlockedTime,
@@ -616,5 +618,56 @@ module('Integration | Component | weekly-calendar-event', function (hooks) {
     assert.ok(component.cssClasses.includes(' blocked-time'));
     assert.notOk(component.style.includes(' background-color:'));
     assert.notOk(component.style.includes('; color:'));
+  });
+
+  test('selectable event', async function (assert) {
+    const event = this.createEvent(
+      'event 0',
+      '2020-02-10 10:40:00',
+      '2020-02-10 12:30:00',
+      '2012-01-09 08:00:00',
+      false,
+      true,
+      [],
+      true,
+    );
+    this.set('event', event);
+    this.set('events', [event]);
+    await render(
+      <template>
+        <WeeklyCalendarEvent
+          @event={{this.event}}
+          @allDayEvents={{this.events}}
+          @isEventSelectable={{true}}
+          @selectEvent={{(noop)}}
+        />
+      </template>,
+    );
+    assert.ok(component.cssClasses.includes('clickable'));
+  });
+
+  test('unselectable event', async function (assert) {
+    const event = this.createEvent(
+      'event 0',
+      '2020-02-10 10:40:00',
+      '2020-02-10 12:30:00',
+      '2012-01-09 08:00:00',
+      false,
+      true,
+      [],
+      true,
+    );
+    this.set('event', event);
+    this.set('events', [event]);
+    await render(
+      <template>
+        <WeeklyCalendarEvent
+          @event={{this.event}}
+          @allDayEvents={{this.events}}
+          @isEventSelectable={{false}}
+        />
+      </template>,
+    );
+    assert.notOk(component.cssClasses.includes('clickable'));
   });
 });

--- a/packages/test-app/tests/integration/components/weekly-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/weekly-calendar-test.gjs
@@ -185,6 +185,58 @@ module('Integration | Component | weekly-calendar', function (hooks) {
     assert.ok(true, 'no a11y errors found!');
   });
 
+  test('day headings appear not-clickable if click handler is false', async function (assert) {
+    const january9th2019 = DateTime.fromObject({
+      year: 2019,
+      month: 1,
+      day: 9,
+      hour: 8,
+      minute: 0,
+      second: 0,
+    });
+    this.set('date', january9th2019.toJSDate());
+    await render(
+      <template>
+        <WeeklyCalendar
+          @date={{this.date}}
+          @events={{(array)}}
+          @changeToDayView={{false}}
+          @selectEvent={{(noop)}}
+        />
+      </template>,
+    );
+    assert.strictEqual(component.dayHeadings.length, 7);
+    component.dayHeadings.forEach((heading) => {
+      assert.notOk(heading.isClickable);
+    });
+  });
+
+  test('day headings appear clickable if click handler is given', async function (assert) {
+    const january9th2019 = DateTime.fromObject({
+      year: 2019,
+      month: 1,
+      day: 9,
+      hour: 8,
+      minute: 0,
+      second: 0,
+    });
+    this.set('date', january9th2019.toJSDate());
+    await render(
+      <template>
+        <WeeklyCalendar
+          @date={{this.date}}
+          @events={{(array)}}
+          @changeToDayView={{this.changeToDayView}}
+          @selectEvent={{(noop)}}
+        />
+      </template>,
+    );
+    assert.strictEqual(component.dayHeadings.length, 7);
+    component.dayHeadings.forEach((heading) => {
+      assert.notOk(heading.isClickable);
+    });
+  });
+
   test('click on day', async function (assert) {
     const january9th2019 = DateTime.fromObject({
       year: 2019,
@@ -205,6 +257,7 @@ module('Integration | Component | weekly-calendar', function (hooks) {
           @events={{(array)}}
           @changeToDayView={{this.changeToDayView}}
           @selectEvent={{(noop)}}
+          @areEventsSelectable={{true}}
         />
       </template>,
     );
@@ -244,6 +297,7 @@ module('Integration | Component | weekly-calendar', function (hooks) {
           @events={{this.events}}
           @changeToDayView={{(noop)}}
           @selectEvent={{this.selectEvent}}
+          @areEventsSelectable={{true}}
         />
       </template>,
     );
@@ -284,6 +338,7 @@ module('Integration | Component | weekly-calendar', function (hooks) {
           @events={{this.events}}
           @changeToDayView={{this.changeToDayView}}
           @selectEvent={{(noop)}}
+          @areEventsSelectable={{true}}
         />
       </template>,
     );

--- a/packages/test-app/tests/integration/components/weekly-calendar-test.gjs
+++ b/packages/test-app/tests/integration/components/weekly-calendar-test.gjs
@@ -207,7 +207,8 @@ module('Integration | Component | weekly-calendar', function (hooks) {
     );
     assert.strictEqual(component.dayHeadings.length, 7);
     component.dayHeadings.forEach((heading) => {
-      assert.notOk(heading.isClickable);
+      assert.notOk(heading.button.cssClasses.includes('clickable'));
+      assert.ok(heading.button.isDisabled);
     });
   });
 
@@ -233,7 +234,8 @@ module('Integration | Component | weekly-calendar', function (hooks) {
     );
     assert.strictEqual(component.dayHeadings.length, 7);
     component.dayHeadings.forEach((heading) => {
-      assert.notOk(heading.isClickable);
+      assert.notOk(heading.button.cssClasses.includes('clickable'));
+      assert.ok(heading.button.isDisabled);
     });
   });
 


### PR DESCRIPTION
fixes ilios/ilios#7037

<img width="660" height="346" alt="image" src="https://github.com/user-attachments/assets/9e0288cc-1590-4d4a-b6d6-3f3c0875c610" />

<img width="660" height="346" alt="image" src="https://github.com/user-attachments/assets/fa066ca3-9ca2-4e88-ac6a-5cd2f561426a" />


since the weekly calendar is a reused component, this change applies to the user-profile and learner-group calendars as well.