### PR TITLE
Normalize scrollIntoView behavior

### DIFF
--- a/packages/frontend/app/components/courses/list.gjs
+++ b/packages/frontend/app/components/courses/list.gjs
@@ -12,6 +12,7 @@ import ListItem from './list-item';
 import perform from 'ember-concurrency/helpers/perform';
 import includes from 'ilios-common/helpers/includes';
 import ResponsiveTd from '../responsive-td';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import { on } from '@ember/modifier';
 
 export default class CoursesListComponent extends Component {
@@ -21,6 +22,11 @@ export default class CoursesListComponent extends Component {
 
   @tracked coursesForRemovalConfirmation = [];
   @tracked savingCourseIds = [];
+
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
 
   get sortedAscending() {
     return !this.args.sortBy.includes(':desc');
@@ -191,7 +197,7 @@ export default class CoursesListComponent extends Component {
                 @confirmRemoval={{this.confirmRemoval}}
               />
               {{#if (includes course.id this.coursesForRemovalConfirmation)}}
-                <tr class="confirm-removal">
+                <tr class="confirm-removal" {{scrollIntoView opts=this.scrollOpts}}>
                   <ResponsiveTd @smallScreenSpan="11" @largeScreenSpan="16">
                     <div class="confirm-message">
                       {{t

--- a/packages/frontend/app/components/courses/list.gjs
+++ b/packages/frontend/app/components/courses/list.gjs
@@ -25,7 +25,7 @@ export default class CoursesListComponent extends Component {
 
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   get sortedAscending() {

--- a/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
@@ -10,17 +10,24 @@ import { and, not } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 import set from 'ember-set-helper/helpers/set';
 import { fn } from '@ember/helper';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import ResponsiveTd from '../responsive-td';
+
 import { faDownload, faLock, faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export default class CurriculumInventoryReportListItemComponent extends Component {
   @service iliosConfig;
   @service permissionChecker;
   @tracked showConfirmRemoval;
+
   isFinalized = this.args.report.belongsTo('export').id();
   academicYearConfig = new TrackedAsyncData(
     this.iliosConfig.itemFromConfig('academicYearCrossesCalendarYearBoundaries'),
   );
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
 
   @cached
   get canDeleteData() {
@@ -115,7 +122,7 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
       </td>
     </tr>
     {{#if this.showRemoveConfirmation}}
-      <tr class="confirm-removal" data-test-confirm-removal>
+      <tr class="confirm-removal" {{scrollIntoView opts=this.scrollOpts}} data-test-confirm-removal>
         <ResponsiveTd @smallScreenSpan="8" @largeScreenSpan="16">
           <div class="confirm-message">
             {{t "general.confirmRemoveReport"}}

--- a/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
@@ -26,7 +26,7 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
   );
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   @cached

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
@@ -20,7 +20,7 @@ export default class CurriculumInventorySequenceBlockListItemComponent extends C
 
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   @cached

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
@@ -11,11 +11,17 @@ import set from 'ember-set-helper/helpers/set';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { fn } from '@ember/helper';
 import ResponsiveTd from '../responsive-td';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export default class CurriculumInventorySequenceBlockListItemComponent extends Component {
   @service intl;
   @tracked showConfirmRemoval;
+
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
 
   @cached
   get courseData() {
@@ -89,7 +95,7 @@ export default class CurriculumInventorySequenceBlockListItemComponent extends C
       </td>
     </tr>
     {{#if this.showRemoveConfirmation}}
-      <tr class="confirm-removal" data-test-confirm-removal>
+      <tr class="confirm-removal" {{scrollIntoView opts=this.scrollOpts}} data-test-confirm-removal>
         <ResponsiveTd @smallScreenSpan="9" @largeScreenSpan="15">
           <div class="confirm-message">
             {{t "general.confirmRemoveSequenceBlock"}}

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview.gjs
@@ -3,8 +3,6 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
-import { on } from '@ember/modifier';
-import { fn } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import VerificationPreviewTable1 from './verification-preview-table1';
 import VerificationPreviewTable2 from './verification-preview-table2';
@@ -45,173 +43,101 @@ export default class CurriculumInventoryVerificationPreviewComponent extends Com
       ...attributes
     >
       {{#if this.tables}}
-        <ul class="table-of-contents" data-test-table-of-contents>
+        <ul class="table-of-contents" id="toc" data-test-table-of-contents>
           <li>
-            <button
-              class="link link-button"
-              type="button"
-              {{on "click" (fn this.scrollTo "table1")}}
-            >
+            <a href="#table1">
               {{t "general.table1ProgramExpectationsMappedToPcrs"}}
-            </button>
+            </a>
           </li>
           <li>
-            <button
-              class="link link-button"
-              type="button"
-              {{on "click" (fn this.scrollTo "table2")}}
-            >
+            <a href="#table2">
               {{t "general.table2PrimaryInstructionalMethodByNonClerkshipSequenceBlock"}}
-            </button>
+            </a>
           </li>
           <li>
-            <button
-              class="link link-button"
-              type="button"
-              {{on "click" (fn this.scrollTo "table3a")}}
-            >
+            <a href="#table3a">
               {{t "general.table3aNonClerkshipSequenceBlockInstructionalTime"}}
-            </button>
+            </a>
           </li>
           <li>
-            <button
-              class="link link-button"
-              type="button"
-              {{on "click" (fn this.scrollTo "table3b")}}
-            >
+            <a href="table3b">
               {{t "general.table3bClerkshipSequenceBlockInstructionalTime"}}
-            </button>
+            </a>
           </li>
           <li>
-            <button
-              class="link link-button"
-              type="button"
-              {{on "click" (fn this.scrollTo "table4")}}
-            >
+            <a href="#table4">
               {{t "general.table4InstructionalMethodCounts"}}
-            </button>
+            </a>
           </li>
           <li>
-            <button
-              class="link link-button"
-              type="button"
-              {{on "click" (fn this.scrollTo "table5")}}
-            >
+            <a href="#table5">
               {{t "general.table5NonClerkshipSequenceBlockAssessmentMethods"}}
-            </button>
+            </a>
           </li>
           <li>
-            <button
-              class="link link-button"
-              type="button"
-              {{on "click" (fn this.scrollTo "table6")}}
-            >
+            <a href="#table6">
               {{t "general.table6ClerkshipSequenceBlockAssessmentMethods"}}
-            </button>
+            </a>
           </li>
           <li>
-            <button
-              class="link link-button"
-              type="button"
-              {{on "click" (fn this.scrollTo "table7")}}
-            >
+            <a href="#table7">
               {{t "general.table7AllEventsWithAssessmentsTaggedAsFormativeOrSummative"}}
-            </button>
+            </a>
           </li>
           <li>
-            <button
-              class="link link-button"
-              type="button"
-              {{on "click" (fn this.scrollTo "table8")}}
-            >
+            <a href="#table8">
               {{t "general.table8AllResourceTypes"}}
-            </button>
+            </a>
           </li>
         </ul>
         <VerificationPreviewTable1 @data={{this.tables.program_expectations_mapped_to_pcrs}} />
-        <button
-          class="link link-button back-to-toc"
-          type="button"
-          {{on "click" (fn this.scrollTo "toc")}}
-        >
+        <a href="#toc" class="back-to-toc">
           {{t "general.backToTableOfContents"}}
-        </button>
+        </a>
         <VerificationPreviewTable2
           @data={{this.tables.primary_instructional_methods_by_non_clerkship_sequence_blocks}}
         />
-        <button
-          class="link link-button back-to-toc"
-          type="button"
-          {{on "click" (fn this.scrollTo "toc")}}
-        >
+        <a href="#toc" class="back-to-toc">
           {{t "general.backToTableOfContents"}}
-        </button>
+        </a>
         <VerificationPreviewTable3a
           @data={{this.tables.non_clerkship_sequence_block_instructional_time}}
         />
-        <button
-          class="link link-button back-to-toc"
-          type="button"
-          {{on "click" (fn this.scrollTo "toc")}}
-        >
+        <a href="#toc" class="back-to-toc">
           {{t "general.backToTableOfContents"}}
-        </button>
+        </a>
         <VerificationPreviewTable3b
           @data={{this.tables.clerkship_sequence_block_instructional_time}}
         />
-        <button
-          class="link link-button back-to-toc"
-          type="button"
-          {{on "click" (fn this.scrollTo "toc")}}
-        >
+        <a href="#toc" class="back-to-toc">
           {{t "general.backToTableOfContents"}}
-        </button>
+        </a>
         <VerificationPreviewTable4 @data={{this.tables.instructional_method_counts}} />
-        <button
-          class="link link-button back-to-toc"
-          type="button"
-          {{on "click" (fn this.scrollTo "toc")}}
-        >
+        <a href="#toc" class="back-to-toc">
           {{t "general.backToTableOfContents"}}
-        </button>
+        </a>
         <VerificationPreviewTable5
           @data={{this.tables.non_clerkship_sequence_block_assessment_methods}}
         />
-        <button
-          class="link link-button back-to-toc"
-          type="button"
-          {{on "click" (fn this.scrollTo "toc")}}
-        >
+        <a href="#toc" class="back-to-toc">
           {{t "general.backToTableOfContents"}}
-        </button>
+        </a>
         <VerificationPreviewTable6
           @data={{this.tables.clerkship_sequence_block_assessment_methods}}
         />
-        <button
-          class="link link-button back-to-toc"
-          type="button"
-          {{on "click" (fn this.scrollTo "toc")}}
-        >
+        <a href="#toc" class="back-to-toc">
           {{t "general.backToTableOfContents"}}
-        </button>
+        </a>
         <VerificationPreviewTable7
           @data={{this.tables.all_events_with_assessments_tagged_as_formative_or_summative}}
         />
-        <button
-          class="link link-button back-to-toc"
-          type="button"
-          {{on "click" (fn this.scrollTo "toc")}}
-        >
+        <a href="#toc" class="back-to-toc">
           {{t "general.backToTableOfContents"}}
-        </button>
+        </a>
         <VerificationPreviewTable8 @data={{this.tables.all_resource_types}} />
-        <button
-          class="link link-button back-to-toc"
-          type="button"
-          {{on "click" (fn this.scrollTo "toc")}}
-        >
+        <a href="#toc" class="back-to-toc">
           {{t "general.backToTableOfContents"}}
-        </button>
+        </a>
       {{else}}
         <LoadingSpinner />
       {{/if}}

--- a/packages/frontend/app/components/curriculum-inventory/verification-preview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/verification-preview.gjs
@@ -60,7 +60,7 @@ export default class CurriculumInventoryVerificationPreviewComponent extends Com
             </a>
           </li>
           <li>
-            <a href="table3b">
+            <a href="#table3b">
               {{t "general.table3bClerkshipSequenceBlockInstructionalTime"}}
             </a>
           </li>

--- a/packages/frontend/app/components/instructor-groups/list-item.gjs
+++ b/packages/frontend/app/components/instructor-groups/list-item.gjs
@@ -19,7 +19,7 @@ export default class InstructorGroupsListItemComponent extends Component {
 
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   @cached

--- a/packages/frontend/app/components/instructor-groups/list-item.gjs
+++ b/packages/frontend/app/components/instructor-groups/list-item.gjs
@@ -10,11 +10,17 @@ import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import ResponsiveTd from '../responsive-td';
 import t from 'ember-intl/helpers/t';
 import perform from 'ember-concurrency/helpers/perform';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export default class InstructorGroupsListItemComponent extends Component {
   @service permissionChecker;
   @tracked showRemoveConfirmation = false;
+
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
 
   @cached
   get canDeleteData() {
@@ -74,7 +80,7 @@ export default class InstructorGroupsListItemComponent extends Component {
       </td>
     </tr>
     {{#if this.showRemoveConfirmation}}
-      <tr class="confirm-removal" data-test-confirm-removal>
+      <tr class="confirm-removal" {{scrollIntoView opts=this.scrollOpts}} data-test-confirm-removal>
         <ResponsiveTd @smallScreenSpan="3" @largeScreenSpan="5">
           <div class="confirm-message">
             {{t

--- a/packages/frontend/app/components/learner-group/list-item.gjs
+++ b/packages/frontend/app/components/learner-group/list-item.gjs
@@ -13,6 +13,7 @@ import { and, not } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 import perform from 'ember-concurrency/helpers/perform';
 import set from 'ember-set-helper/helpers/set';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import {
   faArrowRotateLeft,
   faCopy,
@@ -24,6 +25,11 @@ export default class LearnerGroupListItemComponent extends Component {
   @service permissionChecker;
   @tracked showRemoveConfirmation = false;
   @tracked showCopyConfirmation = false;
+
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
 
   @cached
   get sortedTitlesOfSubgroupsInNeedOfAccommodationData() {
@@ -233,7 +239,7 @@ export default class LearnerGroupListItemComponent extends Component {
       </td>
     </tr>
     {{#if this.showRemoveConfirmation}}
-      <tr class="confirm-removal" data-test-confirm-removal>
+      <tr class="confirm-removal" {{scrollIntoView opts=this.scrollOpts}} data-test-confirm-removal>
         <ResponsiveTd @smallScreenSpan="3" @largeScreenSpan="5">
           <div class="confirm-message">
             {{t "general.confirmRemoveLearnerGroup" subgroupCount=@learnerGroup.children.length}}

--- a/packages/frontend/app/components/learner-group/list-item.gjs
+++ b/packages/frontend/app/components/learner-group/list-item.gjs
@@ -28,7 +28,7 @@ export default class LearnerGroupListItemComponent extends Component {
 
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   @cached

--- a/packages/frontend/app/components/manage-users-summary.gjs
+++ b/packages/frontend/app/components/manage-users-summary.gjs
@@ -18,6 +18,7 @@ import perform from 'ember-concurrency/helpers/perform';
 import onKey from 'ember-keyboard/modifiers/on-key';
 import { eq } from 'ember-truth-helpers';
 import UserStatus from 'ilios-common/components/user-status';
+import scrollIntoView from 'ilios-common/utils/scroll-into-view';
 
 const DEBOUNCE_MS = 250;
 const MIN_INPUT = 3;
@@ -175,7 +176,7 @@ export default class ManageUsersSummaryComponent extends Component {
   }
 
   scrollToActiveElement(element) {
-    element.scrollIntoView({ block: 'nearest', behavior: 'instant' });
+    scrollIntoView(element, { opts: { block: 'nearest' } });
   }
 
   getActiveUserId(listArray) {

--- a/packages/frontend/app/components/manage-users-summary.gjs
+++ b/packages/frontend/app/components/manage-users-summary.gjs
@@ -36,6 +36,10 @@ export default class ManageUsersSummaryComponent extends Component {
 
   userSearchTypeData = new TrackedAsyncData(this.iliosConfig.getUserSearchType());
 
+  scrollOpts = {
+    block: 'nearest',
+  };
+
   @cached
   get userSearchType() {
     return this.userSearchTypeData.isResolved ? this.userSearchTypeData.value : null;
@@ -176,7 +180,7 @@ export default class ManageUsersSummaryComponent extends Component {
   }
 
   scrollToActiveElement(element) {
-    scrollIntoView(element, { opts: { block: 'nearest' } });
+    scrollIntoView(element, this.scrollOpts);
   }
 
   getActiveUserId(listArray) {

--- a/packages/frontend/app/components/program-year/list-item.gjs
+++ b/packages/frontend/app/components/program-year/list-item.gjs
@@ -21,6 +21,11 @@ export default class ProgramYearListItemComponent extends Component {
 
   @tracked showRemoveConfirmation = false;
 
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
+
   @cached
   get canLockData() {
     return new TrackedAsyncData(this.permissionChecker.canLockProgramYear(this.args.programYear));
@@ -197,7 +202,7 @@ export default class ProgramYearListItemComponent extends Component {
         </td>
       </tr>
       {{#if this.showRemoveConfirmation}}
-        <tr class="confirm-removal" {{scrollIntoView}}>
+        <tr class="confirm-removal" {{scrollIntoView opts=this.scrollOpts}}>
           <td colspan="8" class="hide-from-small-screen">
             <div class="confirm-message" data-test-message>
               {{t "general.confirmRemoveProgramYear" courseCount=this.cohort.courses.length}}

--- a/packages/frontend/app/components/program-year/list-item.gjs
+++ b/packages/frontend/app/components/program-year/list-item.gjs
@@ -23,7 +23,7 @@ export default class ProgramYearListItemComponent extends Component {
 
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   @cached

--- a/packages/frontend/app/components/programs/list-item.gjs
+++ b/packages/frontend/app/components/programs/list-item.gjs
@@ -10,11 +10,17 @@ import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import ResponsiveTd from '../responsive-td';
 import t from 'ember-intl/helpers/t';
 import perform from 'ember-concurrency/helpers/perform';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export default class ProgramListItemComponent extends Component {
   @service permissionChecker;
   @tracked showRemoveConfirmation = false;
+
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
 
   @cached
   get canDeleteData() {
@@ -63,7 +69,7 @@ export default class ProgramListItemComponent extends Component {
       </td>
     </tr>
     {{#if this.showRemoveConfirmation}}
-      <tr class="confirm-removal" data-test-confirm-removal>
+      <tr class="confirm-removal" {{scrollIntoView opts=this.scrollOpts}} data-test-confirm-removal>
         <ResponsiveTd @smallScreenSpan="5" @largeScreenSpan="7">
           <div class="confirm-message" data-test-message>
             {{t "general.confirmRemoveProgram"}}

--- a/packages/frontend/app/components/programs/list-item.gjs
+++ b/packages/frontend/app/components/programs/list-item.gjs
@@ -19,7 +19,7 @@ export default class ProgramListItemComponent extends Component {
 
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   @cached

--- a/packages/frontend/app/components/reports/table.gjs
+++ b/packages/frontend/app/components/reports/table.gjs
@@ -16,7 +16,7 @@ export default class ReportsTableComponent extends Component {
 
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   get sortedAscending() {

--- a/packages/frontend/app/components/reports/table.gjs
+++ b/packages/frontend/app/components/reports/table.gjs
@@ -8,10 +8,16 @@ import t from 'ember-intl/helpers/t';
 import sortBy from 'ilios-common/helpers/sort-by';
 import TableRow from './table-row';
 import includes from 'ilios-common/helpers/includes';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import { on } from '@ember/modifier';
 
 export default class ReportsTableComponent extends Component {
   @tracked reportsForRemovalConfirmation = [];
+
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
 
   get sortedAscending() {
     return !this.args.sortBy.includes(':desc');
@@ -64,7 +70,7 @@ export default class ReportsTableComponent extends Component {
             @confirmRemoval={{this.confirmRemoval}}
           />
           {{#if (includes decoratedReport.report.id this.reportsForRemovalConfirmation)}}
-            <tr class="confirm-removal">
+            <tr class="confirm-removal" {{scrollIntoView opts=this.scrollOpts}}>
               <td colspan="12">
                 <div class="confirm-message">
                   {{t "general.confirmRemoveReport"}}

--- a/packages/frontend/app/components/school/session-types-list-item.gjs
+++ b/packages/frontend/app/components/school/session-types-list-item.gjs
@@ -9,6 +9,7 @@ import { and, eq, not, or } from 'ember-truth-helpers';
 import set from 'ember-set-helper/helpers/set';
 import { LinkTo } from '@ember/routing';
 import perform from 'ember-concurrency/helpers/perform';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import {
   faBan,
   faChartColumn,
@@ -19,6 +20,11 @@ import {
 
 export default class SchoolSessionTypesListItemComponent extends Component {
   @tracked showRemoveConfirmation = false;
+
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
 
   remove = task({ drop: true }, async () => {
     await this.args.sessionType.destroyRecord();
@@ -116,7 +122,7 @@ export default class SchoolSessionTypesListItemComponent extends Component {
       </td>
     </tr>
     {{#if this.showRemoveConfirmation}}
-      <tr class="confirm-removal">
+      <tr class="confirm-removal" {{scrollIntoView opts=this.scrollOpts}}>
         <td colspan="11" class="hide-from-small-screen">
           <div class="confirm-message" data-test-message>
             {{t "general.confirmRemoveSessionType"}}

--- a/packages/frontend/app/components/school/session-types-list-item.gjs
+++ b/packages/frontend/app/components/school/session-types-list-item.gjs
@@ -23,7 +23,7 @@ export default class SchoolSessionTypesListItemComponent extends Component {
 
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   remove = task({ drop: true }, async () => {

--- a/packages/frontend/app/components/school/vocabularies-list.gjs
+++ b/packages/frontend/app/components/school/vocabularies-list.gjs
@@ -22,7 +22,7 @@ export default class SchoolVocabulariesListComponent extends Component {
 
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   @cached

--- a/packages/frontend/app/components/school/vocabularies-list.gjs
+++ b/packages/frontend/app/components/school/vocabularies-list.gjs
@@ -12,12 +12,18 @@ import { fn } from '@ember/helper';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import notEq from 'ember-truth-helpers/helpers/not-eq';
 import perform from 'ember-concurrency/helpers/perform';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import { faPenToSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export default class SchoolVocabulariesListComponent extends Component {
   @service store;
   @tracked newVocabulary;
   @tracked showRemovalConfirmationFor;
+
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
 
   @cached
   get vocabulariesData() {
@@ -119,7 +125,11 @@ export default class SchoolVocabulariesListComponent extends Component {
                   </td>
                 </tr>
                 {{#if (eq this.showRemovalConfirmationFor vocabulary)}}
-                  <tr class="confirm-removal" data-test-confirm-removal={{index}}>
+                  <tr
+                    class="confirm-removal"
+                    {{scrollIntoView opts=this.scrollOpts}}
+                    data-test-confirm-removal={{index}}
+                  >
                     <td colspan="5">
                       <div class="confirm-message">
                         {{t "general.confirmRemoveVocabulary"}}

--- a/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
@@ -12,10 +12,16 @@ import sortBy from 'ilios-common/helpers/sort-by';
 import { or } from 'ember-truth-helpers';
 import set from 'ember-set-helper/helpers/set';
 import perform from 'ember-concurrency/helpers/perform';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import { faClock, faEye, faPenToSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export default class DetailLearningMaterialsItemComponent extends Component {
   @tracked showRemoveConfirmation = false;
+
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
 
   @cached
   get owningUserData() {
@@ -149,7 +155,7 @@ export default class DetailLearningMaterialsItemComponent extends Component {
       </td>
     </tr>
     {{#if this.showRemoveConfirmation}}
-      <tr class="confirm-removal" data-test-confirm-removal>
+      <tr class="confirm-removal" {{scrollIntoView opts=this.scrollOpts}} data-test-confirm-removal>
         <td colspan="14">
           <div class="confirm-message">
             {{t "general.confirmRemoveLearningMaterial"}}

--- a/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
@@ -20,7 +20,7 @@ export default class DetailLearningMaterialsItemComponent extends Component {
 
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   @cached

--- a/packages/ilios-common/addon/components/publish-all-sessions.gjs
+++ b/packages/ilios-common/addon/components/publish-all-sessions.gjs
@@ -200,7 +200,7 @@ export default class PublishAllSessionsComponent extends Component {
   });
 
   <template>
-    <div class="publish-all-sessions" data-test-publish-all-sessions>
+    <div class="publish-all-sessions" {{scrollIntoView delay=10}} data-test-publish-all-sessions>
       <div class="publish-all-sessions-header" data-test-header>
         <span class="title" data-test-title>
           {{t "general.publicationReview"}}

--- a/packages/ilios-common/addon/components/publish-all-sessions.gjs
+++ b/packages/ilios-common/addon/components/publish-all-sessions.gjs
@@ -16,6 +16,7 @@ import includes from 'ilios-common/helpers/includes';
 import mapBy from 'ilios-common/helpers/map-by';
 import SaveButton from 'ilios-common/components/save-button';
 import perform from 'ember-concurrency/helpers/perform';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import { faLinkSlash, faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons';
 
 export default class PublishAllSessionsComponent extends Component {

--- a/packages/ilios-common/addon/components/sessions-grid.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid.gjs
@@ -34,7 +34,7 @@ export default class SessionsGridComponent extends Component {
 
   scrollOpts = {
     behavior: 'smooth',
-    block: 'center',
+    block: 'nearest',
   };
 
   @cached

--- a/packages/ilios-common/addon/components/sessions-grid.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid.gjs
@@ -19,6 +19,7 @@ import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { fn } from '@ember/helper';
 import SessionsGridLastUpdated from 'ilios-common/components/sessions-grid-last-updated';
 import SessionsGridOfferingTable from 'ilios-common/components/sessions-grid-offering-table';
+import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 
 export default class SessionsGridComponent extends Component {
   @service router;
@@ -30,6 +31,11 @@ export default class SessionsGridComponent extends Component {
     super(...arguments);
     this.scrollDown();
   }
+
+  scrollOpts = {
+    behavior: 'smooth',
+    block: 'center',
+  };
 
   @cached
   get sortedSessionsData() {
@@ -229,7 +235,11 @@ export default class SessionsGridComponent extends Component {
             @expandedSessionIds={{@expandedSessionIds}}
           />
           {{#if (includes session.id this.confirmDeleteSessionIds)}}
-            <div class="confirm-removal" data-test-confirm-removal>
+            <div
+              class="confirm-removal"
+              {{scrollIntoView opts=this.scrollOpts}}
+              data-test-confirm-removal
+            >
               {{t "general.confirmRemoveSession"}}
               <div class="confirm-buttons">
                 <button


### PR DESCRIPTION
Fixes ilios/ilios#7049

* Adds `scrollIntoView` to all `confirm-removal` deletion confirmations I could find
* Adds `scrollIntoView` to one place that was using a raw JS call instead
* Adds `scrollIntoView` to `PublishAllSessions`/Publication Review
* Removes `scrollIntoView` from the Curriculum Inventory Report Verification Preview since it was being used for no extra benefit and we lost any `#table1`-type anchor in the URL for saving purposes