### PR TITLE
Remove message if Course has no Program Cohorts

### DIFF
--- a/packages/ilios-common/addon/components/detail-cohort-list.gjs
+++ b/packages/ilios-common/addon/components/detail-cohort-list.gjs
@@ -83,8 +83,6 @@ export default class DetailCohortListComponent extends Component {
               {{/each}}
             </tbody>
           </table>
-        {{else}}
-          {{t "general.noCohorts"}}
         {{/if}}
       {{else}}
         <LoadingSpinner />

--- a/packages/ilios-common/addon/components/detail-cohorts.gjs
+++ b/packages/ilios-common/addon/components/detail-cohorts.gjs
@@ -137,7 +137,7 @@ export default class DetailCohortsComponent extends Component {
           {{/if}}
         </div>
       </div>
-      <div class="detail-cohorts-content">
+      <div class="detail-cohorts-content{{unless this.cohorts.length ' empty'}}">
         {{#if this.isManaging}}
           <DetailCohortManager
             @course={{@course}}

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-cohorts.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-cohorts.scss
@@ -17,5 +17,9 @@
 
   .detail-cohorts-content {
     @include m.detail-container-content;
+
+    &.empty {
+      padding: 0 0.5em;
+    }
   }
 }

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -243,7 +243,6 @@ general:
   no: No
   noAssociatedCompetencies: No Associated Competencies
   noAssociatedCompetency: No Associated Competency
-  noCohorts: There are no cohorts in this course
   noCourseLearningMaterialsAvailable: No Course Learning Materials Available
   noEvents: No Events
   none: None

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -243,7 +243,6 @@ general:
   no: No
   noAssociatedCompetencies: No Competencias Asociadas
   noAssociatedCompetency: No Competencia Asociada
-  noCohorts: No hay ningún clase de la graduación en este curso
   noCourseLearningMaterialsAvailable: Ningunos Materiales Didácticos del Curso Disponibles
   noEvents: no eventos
   none: Ningún

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -243,7 +243,6 @@ general:
   no: Non
   noAssociatedCompetencies: Nul compétences associées
   noAssociatedCompetency: Nul compétence associée
-  noCohorts: "Il n'y a aucun des cohortes dans ce cours"
   noCourseLearningMaterialsAvailable: "Aucun Matériels D'étude de Cours"
   noEvents: aucuns événements
   none: Nul


### PR DESCRIPTION
Fixes ilios/ilios#7052

I also added a conditional `empty` class to make the spacing consistent with other Course sections when there are no cohorts.

<img width="1500" height="129" alt="image" src="https://github.com/user-attachments/assets/4c0e5b95-0071-4d14-8d2b-54522b5c6a71" />
