### PR TITLE
LearnerGroup can now be deleted without confirmation if there are no members or subgroups

### DIFF
--- a/packages/frontend/app/components/learner-group/list-item.gjs
+++ b/packages/frontend/app/components/learner-group/list-item.gjs
@@ -9,7 +9,7 @@ import { LinkTo } from '@ember/routing';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import ResponsiveTd from '../responsive-td';
 import t from 'ember-intl/helpers/t';
-import { and, not } from 'ember-truth-helpers';
+import { and, or, not } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 import perform from 'ember-concurrency/helpers/perform';
 import set from 'ember-set-helper/helpers/set';
@@ -191,16 +191,30 @@ export default class LearnerGroupListItemComponent extends Component {
         {{#if this.canDeleteLoading}}
           <FaIcon @icon={{faTrash}} class="disabled" />
         {{else}}
-          {{#if (and this.canDelete (not this.showRemoveConfirmation))}}
-            <button
-              class="link-button"
-              type="button"
-              {{on "click" this.showRemove}}
-              title={{t "general.remove"}}
-              data-test-remove
-            >
-              <FaIcon @icon={{faTrash}} class="enabled remove" />
-            </button>
+          {{#if this.canDelete}}
+            {{#if (or @learnerGroup.usersCount @learnerGroup.childrenCount)}}
+              {{#unless this.showRemoveConfirmation}}
+                <button
+                  class="link-button"
+                  type="button"
+                  {{on "click" this.showRemove}}
+                  title={{t "general.remove"}}
+                  data-test-remove
+                >
+                  <FaIcon @icon={{faTrash}} class="enabled remove" />
+                </button>
+              {{/unless}}
+            {{else}}
+              <button
+                class="link-button"
+                type="button"
+                {{on "click" (perform this.remove)}}
+                title={{t "general.remove"}}
+                data-test-remove
+              >
+                <FaIcon @icon={{faTrash}} class="enabled remove" />
+              </button>
+            {{/if}}
           {{else}}
             <FaIcon @icon={{faTrash}} class="disabled" />
           {{/if}}
@@ -236,7 +250,11 @@ export default class LearnerGroupListItemComponent extends Component {
       <tr class="confirm-removal" data-test-confirm-removal>
         <ResponsiveTd @smallScreenSpan="3" @largeScreenSpan="5">
           <div class="confirm-message">
-            {{t "general.confirmRemoveLearnerGroup" subgroupCount=@learnerGroup.children.length}}
+            {{t
+              "general.confirmRemoveLearnerGroup"
+              memberCount=@learnerGroup.usersCount
+              subgroupCount=@learnerGroup.children.length
+            }}
             <br />
             <div class="confirm-buttons">
               <button

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -60,7 +60,7 @@ general:
   competencyDomain: Competency Domain
   confirmRemoveCourse: "Are you sure you want to delete this course, with {publishedOfferingCount} published offerings? This action will remove all sessions and offerings for this course, and cannot be undone."
   confirmRemoveInstructorGroup: "Are you sure you want to delete this instructor group, with {instructorCount} instructors? This action cannot be undone."
-  confirmRemoveLearnerGroup: "Are you sure you want to delete this learner group, with {subgroupCount} subgroups? This action cannot be undone."
+  confirmRemoveLearnerGroup: "Are you sure you want to delete this learner group, with {memberCount} member(s) and {subgroupCount} subgroup(s)? This action cannot be undone."
   confirmRemoveProgram: Are you sure you want to delete this program? This action cannot be undone.
   confirmRemoveProgramYear: "Are you sure you want to delete this program year? Doing so will also remove its associated student cohort and groups, and associations with {courseCount} course(s), and cannot be undone."
   confirmRemoveReport: Are you sure you want to delete this report? This action cannot be undone.

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -60,7 +60,7 @@ general:
   competencyDomain: Dominio de Dompetencia
   confirmRemoveCourse: " ¿Estás seguro que quieres borrar este curso, con {publishedOfferingCount} ofrecimientos publicados? Esta acción borrará todas las sesiones y ofrecimientos para este curso y no se puede deshacer."
   confirmRemoveInstructorGroup: "¿Estás seguro que quieres remover este grupo de instructores, con {instructorCount} instructores? Esta acción no se puede deshacer."
-  confirmRemoveLearnerGroup: "¿Estás seguro que quieres borrar este grupo de aprendedores, con {subgroupCount} grupos subordinados? Esta acción no se puede deshacer."
+  confirmRemoveLearnerGroup: "¿Estás seguro que quieres borrar este grupo de aprendedores, con {memberCount} miembro(s) y {subgroupCount} grupo(s) subordinado(s)? Esta acción no se puede deshacer."
   confirmRemoveProgram: ¿Estás seguro que quieres borrar este programa? Esta accion no se puede deshacer.
   confirmRemoveProgramYear: "¿Está seguro de que desea eliminar este año del programa?   Hacer tan también quitará su cohorte estudiantil asociada y grupos y asociaciones con {courseCount} curso(s), y no se puede deshacer."
   confirmRemoveReport: ¿Está seguro que desea eliminar este informe? Esta acción no se puede deshacer.

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -60,7 +60,7 @@ general:
   competencyDomain: Domaine de Compétence
   confirmRemoveCourse: "Êtes-vous sûr vous voulez supprimer ce cours, avec {publishedOfferingCount} offres publié? Cela supprimera toutes sessions et offres pour ce cours, et ne peut pas être défait."
   confirmRemoveInstructorGroup: "Êtes-vous sûr vous voulez supprimer cette groupe des instructeurs, avec {instructorCount} membres? Ça action ne peut pas être défait."
-  confirmRemoveLearnerGroup: "Êtes-vous sûr vous voulez supprimer cette groupe d'apprenants, avec {subgroupCount} sous-groupes? Ça action ne peut pas être défait."
+  confirmRemoveLearnerGroup: "Êtes-vous sûr vous voulez supprimer cette groupe d'apprenants, avec {memberCount} membre(s) et {subgroupCount} sous-groupe(s)? Ça action ne peut pas être défait."
   confirmRemoveProgram: Êtes-vous certain que vous voulez supprimer ce diplôme? Cette action ne peut être annulée.
   confirmRemoveProgramYear: "Êtes-vous certain que vous voulez supprimer cette année de diplôme? Cette action va supprimer tous les cohortes et groupes des étudiants associées, et liaisons avec {courseCount} des cours, et ne peut être annulée."
   confirmRemoveReport: Êtes-vous sûrs que vous voulez supprimer ce rapport? Cette action ne peut pas être défaite.


### PR DESCRIPTION
Fixes ilios/ilios#6870

This PR does what was requested, but I'm not sure I like it ;P Maybe if there's no confirmation, some kind of flash message needs to pop up upon deletion? Also, the inconsistency between "just does it" vs. "needs extra step to do it" is odd.