### PR TITLE
School->SessionType-Visualization->Vocab by SessionType breadcrumb replacement

### DIFF
--- a/packages/frontend/app/components/school/session-type-visualize-vocabularies.gjs
+++ b/packages/frontend/app/components/school/session-type-visualize-vocabularies.gjs
@@ -1,5 +1,6 @@
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
+import { hash } from '@ember/helper';
 import { pageTitle } from 'ember-page-title';
 import VisualizeSessionTypeVocabulariesGraph from './visualize-session-type-vocabularies-graph';
 <template>
@@ -21,8 +22,12 @@ import VisualizeSessionTypeVocabulariesGraph from './visualize-session-type-voca
     data-test-school-session-type-visualize-vocabularies
     ...attributes
   >
-    <div class="backtolink">
-      <LinkTo @route="school" @model={{@model.school}}>
+    <div class="backtolink" data-test-back-to-school>
+      <LinkTo
+        @route="school"
+        @model={{@model.school}}
+        @query={{hash schoolSessionTypeDetails=true}}
+      >
         {{t "general.backToSchool"}}
       </LinkTo>
     </div>

--- a/packages/frontend/app/components/school/session-type-visualize-vocabularies.gjs
+++ b/packages/frontend/app/components/school/session-type-visualize-vocabularies.gjs
@@ -1,5 +1,4 @@
 import { LinkTo } from '@ember/routing';
-import { hash } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import { pageTitle } from 'ember-page-title';
 import VisualizeSessionTypeVocabulariesGraph from './visualize-session-type-vocabularies-graph';
@@ -22,28 +21,10 @@ import VisualizeSessionTypeVocabulariesGraph from './visualize-session-type-voca
     data-test-school-session-type-visualize-vocabularies
     ...attributes
   >
-    <div class="breadcrumbs" data-test-breadcrumb>
-      <span>
-        <LinkTo
-          @route="school"
-          @model={{@model.school}}
-          @query={{hash schoolSessionTypeDetails=true}}
-        >
-          {{@model.school.title}}
-        </LinkTo>
-      </span>
-      <span>
-        {{t "general.visualizations"}}
-      </span>
-      <span>
-        {{t "general.sessionTypes"}}
-      </span>
-      <span>
-        {{@model.title}}
-      </span>
-      <span>
-        {{t "general.vocabularies"}}
-      </span>
+    <div class="backtolink">
+      <LinkTo @route="school" @model={{@model.school}}>
+        {{t "general.backToSchool"}}
+      </LinkTo>
     </div>
     <h2 data-test-primary-title>{{t "general.vocabulariesBySessionType"}}</h2>
     <h3 data-test-secondary-title>

--- a/packages/frontend/app/components/school/session-type-visualize-vocabulary.gjs
+++ b/packages/frontend/app/components/school/session-type-visualize-vocabulary.gjs
@@ -1,5 +1,4 @@
 import { LinkTo } from '@ember/routing';
-import { hash } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import { pageTitle } from 'ember-page-title';
 import VisualizeSessionTypeVocabularyGraph from './visualize-session-type-vocabulary-graph';
@@ -24,33 +23,10 @@ import VisualizeSessionTypeVocabularyGraph from './visualize-session-type-vocabu
     data-test-school-session-type-visualize-vocabulary
     ...attributes
   >
-    <div class="breadcrumbs" data-test-breadcrumb>
-      <span>
-        <LinkTo
-          @route="school"
-          @model={{@model.vocabulary.school}}
-          @query={{hash schoolSessionTypeDetails=true}}
-        >
-          {{@model.vocabulary.school.title}}
-        </LinkTo>
-      </span>
-      <span>
-        {{t "general.visualizations"}}
-      </span>
-      <span>
-        {{t "general.sessionTypes"}}
-      </span>
-      <span>
-        {{@model.sessionType.title}}
-      </span>
-      <span>
-        <LinkTo @route="session-type-visualize-vocabularies" @model={{@model.sessionType}}>
-          {{t "general.vocabularies"}}
-        </LinkTo>
-      </span>
-      <span>
-        {{@model.vocabulary.title}}
-      </span>
+    <div class="backtolink" data-test-back-to-vocabularies>
+      <LinkTo @route="session-type-visualize-vocabularies" @model={{@model.sessionType}}>
+        {{t "general.backToVocabularies"}}
+      </LinkTo>
     </div>
     <h2 data-test-primary-title>{{t "general.termsBySessionType"}}</h2>
     <h3 data-test-secondary-title>

--- a/packages/frontend/tests/integration/components/school/session-type-visualize-vocabularies-test.gjs
+++ b/packages/frontend/tests/integration/components/school/session-type-visualize-vocabularies-test.gjs
@@ -33,18 +33,10 @@ module('Integration | Component | school/session-type-visualize-vocabularies', f
 
     await render(<template><SessionTypeVisualizeVocabularies @model={{this.model}} /></template>);
 
+    assert.strictEqual(component.backToSchool.text, 'Back to School');
+    assert.strictEqual(component.backToSchool.url, '/schools/1?schoolSessionTypeDetails=true');
     assert.strictEqual(component.primaryTitle, 'Vocabularies by Session Type');
     assert.strictEqual(component.secondaryTitle, 'session type 0');
-    assert.strictEqual(component.breadcrumb.crumbs.length, 5);
-    assert.strictEqual(component.breadcrumb.crumbs[0].text, 'school 0');
-    assert.strictEqual(
-      component.breadcrumb.crumbs[0].link,
-      '/schools/1?schoolSessionTypeDetails=true',
-    );
-    assert.strictEqual(component.breadcrumb.crumbs[1].text, 'Visualizations');
-    assert.strictEqual(component.breadcrumb.crumbs[2].text, 'Session Types');
-    assert.strictEqual(component.breadcrumb.crumbs[3].text, 'session type 0');
-    assert.strictEqual(component.breadcrumb.crumbs[4].text, 'Vocabularies');
 
     await waitFor('.loaded');
     await waitFor('svg .slice');

--- a/packages/frontend/tests/integration/components/school/session-type-visualize-vocabulary-test.gjs
+++ b/packages/frontend/tests/integration/components/school/session-type-visualize-vocabulary-test.gjs
@@ -34,20 +34,10 @@ module('Integration | Component | school/session-type-visualize-vocabulary', fun
 
     await render(<template><SessionTypeVisualizeVocabulary @model={{this.model}} /></template>);
 
+    assert.strictEqual(component.backToVocabularies.text, 'Back to Vocabularies');
+    assert.strictEqual(component.backToVocabularies.url, '/data/sessiontype/1/vocabularies');
     assert.strictEqual(component.primaryTitle, 'Terms by Session Type');
     assert.strictEqual(component.secondaryTitle, 'session type 0 (Vocabulary 1)');
-    assert.strictEqual(component.breadcrumb.crumbs.length, 6);
-    assert.strictEqual(component.breadcrumb.crumbs[0].text, 'school 0');
-    assert.strictEqual(
-      component.breadcrumb.crumbs[0].link,
-      '/schools/1?schoolSessionTypeDetails=true',
-    );
-    assert.strictEqual(component.breadcrumb.crumbs[1].text, 'Visualizations');
-    assert.strictEqual(component.breadcrumb.crumbs[2].text, 'Session Types');
-    assert.strictEqual(component.breadcrumb.crumbs[3].text, 'session type 0');
-    assert.strictEqual(component.breadcrumb.crumbs[4].text, 'Vocabularies');
-    assert.strictEqual(component.breadcrumb.crumbs[4].link, '/data/sessiontype/1/vocabularies');
-    assert.strictEqual(component.breadcrumb.crumbs[5].text, 'Vocabulary 1');
 
     await waitFor('.loaded');
     await waitFor('svg .slice');

--- a/packages/frontend/tests/pages/components/school/session-type-visualize-vocabularies.js
+++ b/packages/frontend/tests/pages/components/school/session-type-visualize-vocabularies.js
@@ -1,16 +1,14 @@
-import { attribute, collection, create, text } from 'ember-cli-page-object';
+import { attribute, create, text } from 'ember-cli-page-object';
 import vocabulariesChart from './visualize-session-type-vocabularies-graph';
 
 const definition = create({
   scope: '[data-test-school-session-type-visualize-vocabularies]',
+  backToSchool: {
+    scope: '[data-test-back-to-school]',
+    url: attribute('href', 'a'),
+  },
   primaryTitle: text('[data-test-primary-title]'),
   secondaryTitle: text('[data-test-secondary-title]'),
-  breadcrumb: {
-    scope: '[data-test-breadcrumb]',
-    crumbs: collection('span', {
-      link: attribute('href', 'a'),
-    }),
-  },
   vocabulariesChart,
 });
 

--- a/packages/frontend/tests/pages/components/school/session-type-visualize-vocabulary.js
+++ b/packages/frontend/tests/pages/components/school/session-type-visualize-vocabulary.js
@@ -3,6 +3,10 @@ import termsChart from './visualize-session-type-vocabulary-graph';
 
 const definition = create({
   scope: '[data-test-school-session-type-visualize-vocabulary]',
+  backToVocabularies: {
+    scope: '[data-test-back-to-vocabularies]',
+    url: attribute('href', 'a'),
+  },
   primaryTitle: text('[data-test-primary-title]'),
   secondaryTitle: text('[data-test-secondary-title]'),
   breadcrumb: {

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -37,6 +37,7 @@ general:
   backToProgramYears: Back to Program Years
   backToReport: Back to Report
   backToReports: Back to Reports
+  backToSchool: Back to School
   backToSchools: Back to Schools
   backToTableOfContents: Back to Table of Contents
   bad: Bad

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -40,6 +40,7 @@ general:
   backToSchool: Back to School
   backToSchools: Back to Schools
   backToTableOfContents: Back to Table of Contents
+  backToVocabularies: Back to Vocabularies
   bad: Bad
   badCredentials: Incorrect username or password
   campusId: Campus ID

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -37,6 +37,7 @@ general:
   backToProgramYears: Atrás a Años de Programas
   backToReport: Atrás a Reporte
   backToReports: Atrás a Reportes
+  backToSchool: Atrás a Escuela
   backToSchools: Atrás a Escuelas
   backToTableOfContents: Atrás a la tabla de contenido
   bad: Malo

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -40,6 +40,7 @@ general:
   backToSchool: Atrás a Escuela
   backToSchools: Atrás a Escuelas
   backToTableOfContents: Atrás a la tabla de contenido
+  backToVocabularies: Atrás a Vocabularios
   bad: Malo
   badCredentials: Incorrecta contraseña o nombre de usuario
   campusId: Campus ID

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -37,6 +37,7 @@ general:
   backToProgramYears: Retour à Années de Diplôme
   backToReport: Retour à rapport
   backToReports: Retour à rapports
+  backToSchool: Retour à école
   backToSchools: Retour aux écoles
   backToTableOfContents: Retour à la table des matières
   bad: Mal

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -40,6 +40,7 @@ general:
   backToSchool: Retour à école
   backToSchools: Retour aux écoles
   backToTableOfContents: Retour à la table des matières
+  backToVocabularies: Retour à Vocabulaires
   bad: Mal
   badCredentials: "Nom d'utilisateur ou mot de passe incorrect"
   campusId: Campus ID


### PR DESCRIPTION
Fixes ilios/ilios#6895

The breadcrumbs on the two routes `school/session-type-visualize-vocabularies` and `school/session-type-visualize-vocabulary` are confusing because they contain links that go nowhere and so I replaced them with simpler `Back to School` on the former and `Back to Vocabularies` on the latter.

To test: go to https://demo.iliosproject.org/schools/1?schoolSessionTypeDetails=true, choose a Visualization icon link, and then click into one of the vocabularies. You can then click `Back to Vocabularies` and then `Back to School` to get all the way back to the School.


<img width="1256" height="464" alt="image" src="https://github.com/user-attachments/assets/4ad3b4de-2ff6-411e-8748-d5da6eb4dc19" />
