### PR TITLE
rm redundant dependency.

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,6 @@
     "@embroider/macros": "^1.19.6",
     "@embroider/webpack": "~4.1.0",
     "@eslint/js": "^9.39.2",
-    "@fortawesome/free-solid-svg-icons": "6.7.2",
     "@glimmer/component": "^2.0.0",
     "@glimmer/tracking": "^1.1.2",
     "@sentry/ember": "^10.45.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,9 +81,6 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.4
-      '@fortawesome/free-solid-svg-icons':
-        specifier: 6.7.2
-        version: 6.7.2
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0


### PR DESCRIPTION
we're getting this via ilios-common already, no need to re-declare this in frontend explicitly.