### PR TITLE
Normalize disabling actions when confirming deletion

### DIFF
--- a/packages/frontend/app/components/courses/list-item.gjs
+++ b/packages/frontend/app/components/courses/list-item.gjs
@@ -49,10 +49,7 @@ export default class CoursesListItemComponent extends Component {
   }
   <template>
     <tr
-      class="courses-list-item{{if
-          (includes @course.id @coursesForRemovalConfirmation)
-          ' confirm-removal'
-        }}"
+      class="courses-list-item{{if @showRemoveConfirmation ' confirm-removal'}}"
       data-test-courses-list-item
     >
       <td class="text-left" colspan="8" data-test-course-title>
@@ -94,12 +91,13 @@ export default class CoursesListItemComponent extends Component {
           {{else if this.canLock}}
             <button
               type="button"
-              class="link-button"
+              class="link-button{{if @showRemoveConfirmation ' disabled'}}"
               title={{t "general.lockCourse"}}
+              disabled={{@showRemoveConfirmation}}
               {{on "click" (fn @lockCourse @course)}}
               data-test-lock
             >
-              <FaIcon @icon={{faLockOpen}} />
+              <FaIcon @icon={{faLockOpen}} class="{{if @showRemoveConfirmation 'disabled'}}" />
             </button>
           {{else}}
             <FaIcon @icon={{faLockOpen}} class="disabled" />
@@ -107,12 +105,16 @@ export default class CoursesListItemComponent extends Component {
           {{#if this.canDelete}}
             <button
               type="button"
-              class="link-button"
+              class="link-button{{if @showRemoveConfirmation ' disabled'}}"
               title={{t "general.deleteCourse"}}
+              disabled={{@showRemoveConfirmation}}
               {{on "click" (fn @confirmRemoval @course)}}
               data-test-remove
             >
-              <FaIcon @icon={{faTrash}} class="enabled remove" />
+              <FaIcon
+                @icon={{faTrash}}
+                class="remove{{if @showRemoveConfirmation ' disabled' ' enabled'}}"
+              />
             </button>
           {{else}}
             <FaIcon @icon={{faTrash}} class="disabled" @title={{t "general.canNotDeleteCourse"}} />

--- a/packages/frontend/app/components/courses/list-item.gjs
+++ b/packages/frontend/app/components/courses/list-item.gjs
@@ -78,15 +78,28 @@ export default class CoursesListItemComponent extends Component {
             {{#if this.canUnlock}}
               <button
                 type="button"
-                class="link-button"
-                title={{t "general.unlockCourse"}}
+                class="link-button{{if @showRemoveConfirmation ' disabled'}}"
+                title={{if
+                  @showRemoveConfirmation
+                  (t "general.disabledByConfirmation")
+                  (t "general.unlockCourse")
+                }}
+                disabled={{@showRemoveConfirmation}}
                 {{on "click" (fn @unlockCourse @course)}}
                 data-test-unlock
               >
                 <FaIcon @icon={{faLock}} />
               </button>
             {{else}}
-              <FaIcon @icon={{faLock}} class="disabled" />
+              <button
+                type="button"
+                class="link-button disabled"
+                title={{t "general.canNotUnlockCourse"}}
+                disabled
+                data-test-unlock
+              >
+                <FaIcon @icon={{faLock}} class="disabled" />
+              </button>
             {{/if}}
           {{else if this.canLock}}
             <button
@@ -104,7 +117,15 @@ export default class CoursesListItemComponent extends Component {
               <FaIcon @icon={{faLockOpen}} class="{{if @showRemoveConfirmation 'disabled'}}" />
             </button>
           {{else}}
-            <FaIcon @icon={{faLockOpen}} class="disabled" />
+            <button
+              type="button"
+              class="link-button disabled"
+              title={{t "general.canNotLockCourse"}}
+              disabled
+              data-test-lock
+            >
+              <FaIcon @icon={{faLockOpen}} class="disabled" />
+            </button>
           {{/if}}
           {{#if this.canDelete}}
             <button
@@ -125,7 +146,15 @@ export default class CoursesListItemComponent extends Component {
               />
             </button>
           {{else}}
-            <FaIcon @icon={{faTrash}} class="disabled" @title={{t "general.canNotDeleteCourse"}} />
+            <button
+              type="button"
+              class="link-button disabled"
+              title={{t "general.canNotDeleteCourse"}}
+              disabled
+              data-test-remove
+            >
+              <FaIcon @icon={{faTrash}} class="disabled" />
+            </button>
           {{/if}}
         {{/if}}
       </td>

--- a/packages/frontend/app/components/courses/list-item.gjs
+++ b/packages/frontend/app/components/courses/list-item.gjs
@@ -92,11 +92,6 @@ export default class CoursesListItemComponent extends Component {
             <button
               type="button"
               class="link-button{{if @showRemoveConfirmation ' disabled'}}"
-              aria-label={{if
-                @showRemoveConfirmation
-                (t "general.disabledByConfirmation")
-                (t "general.lockCourse")
-              }}
               title={{if
                 @showRemoveConfirmation
                 (t "general.disabledByConfirmation")
@@ -115,11 +110,6 @@ export default class CoursesListItemComponent extends Component {
             <button
               type="button"
               class="link-button{{if @showRemoveConfirmation ' disabled'}}"
-              aria-label={{if
-                @showRemoveConfirmation
-                (t "general.disabledByConfirmation")
-                (t "general.deleteCourse")
-              }}
               title={{if
                 @showRemoveConfirmation
                 (t "general.disabledByConfirmation")

--- a/packages/frontend/app/components/courses/list-item.gjs
+++ b/packages/frontend/app/components/courses/list-item.gjs
@@ -114,7 +114,7 @@ export default class CoursesListItemComponent extends Component {
               {{on "click" (fn @lockCourse @course)}}
               data-test-lock
             >
-              <FaIcon @icon={{faLockOpen}} class="{{if @showRemoveConfirmation 'disabled'}}" />
+              <FaIcon @icon={{faLockOpen}} class={{if @showRemoveConfirmation "disabled"}} />
             </button>
           {{else}}
             <button

--- a/packages/frontend/app/components/courses/list-item.gjs
+++ b/packages/frontend/app/components/courses/list-item.gjs
@@ -92,7 +92,16 @@ export default class CoursesListItemComponent extends Component {
             <button
               type="button"
               class="link-button{{if @showRemoveConfirmation ' disabled'}}"
-              title={{t "general.lockCourse"}}
+              aria-label={{if
+                @showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.lockCourse")
+              }}
+              title={{if
+                @showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.lockCourse")
+              }}
               disabled={{@showRemoveConfirmation}}
               {{on "click" (fn @lockCourse @course)}}
               data-test-lock
@@ -106,14 +115,23 @@ export default class CoursesListItemComponent extends Component {
             <button
               type="button"
               class="link-button{{if @showRemoveConfirmation ' disabled'}}"
-              title={{t "general.deleteCourse"}}
+              aria-label={{if
+                @showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.deleteCourse")
+              }}
+              title={{if
+                @showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.deleteCourse")
+              }}
               disabled={{@showRemoveConfirmation}}
               {{on "click" (fn @confirmRemoval @course)}}
               data-test-remove
             >
               <FaIcon
                 @icon={{faTrash}}
-                class="remove{{if @showRemoveConfirmation ' disabled' ' enabled'}}"
+                class={{if @showRemoveConfirmation "disabled" "remove enabled"}}
               />
             </button>
           {{else}}

--- a/packages/frontend/app/components/courses/list.gjs
+++ b/packages/frontend/app/components/courses/list.gjs
@@ -191,6 +191,7 @@ export default class CoursesListComponent extends Component {
               <ListItem
                 @course={{course}}
                 @coursesForRemovalConfirmation={{this.coursesForRemovalConfirmation}}
+                @showRemoveConfirmation={{includes course.id this.coursesForRemovalConfirmation}}
                 @savingCourseIds={{this.savingCourseIds}}
                 @lockCourse={{fn (perform this.lockCourse)}}
                 @unlockCourse={{fn (perform this.unlockCourse)}}

--- a/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
@@ -120,11 +120,6 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
             class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
-            aria-label={{if
-              this.showRemoveConfirmation
-              (t "general.disabledByConfirmation")
-              (t "general.remove")
-            }}
             title={{if
               this.showRemoveConfirmation
               (t "general.disabledByConfirmation")

--- a/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
@@ -97,7 +97,6 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
             href={{@report.absoluteFileUri}}
             rel="noopener noreferrer"
             target="_blank"
-            disabled={{this.showRemoveConfirmation}}
             class={{if this.showRemoveConfirmation "disabled"}}
             data-test-download
           ><FaIcon

--- a/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
@@ -6,7 +6,6 @@ import { LinkTo } from '@ember/routing';
 import formatDate from 'ember-intl/helpers/format-date';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import t from 'ember-intl/helpers/t';
-import { and, not } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 import set from 'ember-set-helper/helpers/set';
 import { fn } from '@ember/helper';
@@ -99,19 +98,18 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
             rel="noopener noreferrer"
             target="_blank"
             disabled={{this.showRemoveConfirmation}}
+            class={{if this.showRemoveConfirmation "disabled"}}
             data-test-download
-          >
-            <FaIcon
+          ><FaIcon
               @icon={{faDownload}}
               @title={{t "general.download"}}
               class={{if this.showRemoveConfirmation "disabled" "enabled"}}
               aria-label={{t "general.download"}}
-            />
-          </a>
+            /></a>
         </span>
-        {{#if (and this.canDelete (not this.showRemoveConfirmation))}}
+        {{#if this.canDelete}}
           <button
-            class="link-button"
+            class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
             aria-label={{t "general.remove"}}
@@ -120,7 +118,7 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
           >
             <FaIcon
               @icon={{faTrash}}
-              class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+              class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
             />
           </button>
         {{else}}

--- a/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
@@ -117,15 +117,15 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
         </span>
         {{#if this.canDelete}}
           <button
-            class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
             type="button"
-            {{on "click" (set this "showRemoveConfirmation" true)}}
+            class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
             title={{if
               this.showRemoveConfirmation
               (t "general.disabledByConfirmation")
               (t "general.remove")
             }}
             disabled={{this.showRemoveConfirmation}}
+            {{on "click" (set this "showRemoveConfirmation" true)}}
             data-test-remove
           >
             <FaIcon
@@ -134,11 +134,15 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
             />
           </button>
         {{else}}
-          <FaIcon
-            @icon={{faTrash}}
-            class="disabled"
-            @title={{t "general.canNotDeleteCurriculumInventoryReport"}}
-          />
+          <button
+            type="button"
+            class="link-button disabled"
+            title={{t "general.canNotDeleteCurriculumInventoryReport"}}
+            disabled
+            data-test-remove
+          >
+            <FaIcon @icon={{faTrash}} class="disabled" />
+          </button>
         {{/if}}
       </td>
     </tr>

--- a/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
@@ -98,13 +98,16 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
             href={{@report.absoluteFileUri}}
             rel="noopener noreferrer"
             target="_blank"
+            disabled={{this.showRemoveConfirmation}}
             data-test-download
-          ><FaIcon
+          >
+            <FaIcon
               @icon={{faDownload}}
               @title={{t "general.download"}}
-              class="enabled"
+              class={{if this.showRemoveConfirmation "disabled" "enabled"}}
               aria-label={{t "general.download"}}
-            /></a>
+            />
+          </a>
         </span>
         {{#if (and this.canDelete (not this.showRemoveConfirmation))}}
           <button
@@ -112,9 +115,13 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
             aria-label={{t "general.remove"}}
+            disabled={{this.showRemoveConfirmation}}
             data-test-remove
           >
-            <FaIcon @icon={{faTrash}} class="enabled remove" />
+            <FaIcon
+              @icon={{faTrash}}
+              class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+            />
           </button>
         {{else}}
           <FaIcon

--- a/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-list-item.gjs
@@ -102,9 +102,17 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
             data-test-download
           ><FaIcon
               @icon={{faDownload}}
-              @title={{t "general.download"}}
+              aria-label={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.download")
+              }}
+              @title={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.download")
+              }}
               class={{if this.showRemoveConfirmation "disabled" "enabled"}}
-              aria-label={{t "general.download"}}
             /></a>
         </span>
         {{#if this.canDelete}}
@@ -112,7 +120,16 @@ export default class CurriculumInventoryReportListItemComponent extends Componen
             class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
-            aria-label={{t "general.remove"}}
+            aria-label={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
+            title={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
             disabled={{this.showRemoveConfirmation}}
             data-test-remove
           >

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
@@ -85,9 +85,13 @@ export default class CurriculumInventorySequenceBlockListItemComponent extends C
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
             aria-label={{t "general.remove"}}
+            disabled={{this.showRemoveConfirmation}}
             data-test-remove
           >
-            <FaIcon @icon={{faTrash}} class="enabled remove" />
+            <FaIcon
+              @icon={{faTrash}}
+              class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+            />
           </button>
         {{else}}
           <FaIcon

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
@@ -84,11 +84,6 @@ export default class CurriculumInventorySequenceBlockListItemComponent extends C
             class="link-button"
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
-            aria-label={{if
-              this.showRemoveConfirmation
-              (t "general.disabledByConfirmation")
-              (t "general.remove")
-            }}
             title={{if
               this.showRemoveConfirmation
               (t "general.disabledByConfirmation")

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
@@ -5,7 +5,6 @@ import { TrackedAsyncData } from 'ember-async-data';
 import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
-import { and, not } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 import set from 'ember-set-helper/helpers/set';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
@@ -79,17 +78,17 @@ export default class CurriculumInventorySequenceBlockListItemComponent extends C
         {{this.courseTitle}}
       </td>
       <td class="text-center" colspan="1">
-        {{#if (and @canUpdate (not this.showRemoveConfirmation))}}
+        {{#if @canUpdate}}
           <button
-            class="link-button"
             type="button"
-            {{on "click" (set this "showRemoveConfirmation" true)}}
+            class="link-button{{if @showRemoveConfirmation ' disabled'}}"
             title={{if
               this.showRemoveConfirmation
               (t "general.disabledByConfirmation")
               (t "general.remove")
             }}
             disabled={{this.showRemoveConfirmation}}
+            {{on "click" (set this "showRemoveConfirmation" true)}}
             data-test-remove
           >
             <FaIcon
@@ -98,11 +97,15 @@ export default class CurriculumInventorySequenceBlockListItemComponent extends C
             />
           </button>
         {{else}}
-          <FaIcon
-            @icon={{faTrash}}
-            class="disabled"
-            @title={{t "general.canNotDeleteSequenceBlock"}}
-          />
+          <button
+            type="button"
+            class="link-button disabled"
+            title={{t "general.canNotDeleteSequenceBlock"}}
+            disabled
+            data-test-remove
+          >
+            <FaIcon @icon={{faTrash}} class="disabled" />
+          </button>
         {{/if}}
       </td>
     </tr>

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-list-item.gjs
@@ -84,13 +84,22 @@ export default class CurriculumInventorySequenceBlockListItemComponent extends C
             class="link-button"
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
-            aria-label={{t "general.remove"}}
+            aria-label={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
+            title={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
             disabled={{this.showRemoveConfirmation}}
             data-test-remove
           >
             <FaIcon
               @icon={{faTrash}}
-              class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+              class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
             />
           </button>
         {{else}}

--- a/packages/frontend/app/components/instructor-groups/list-item.gjs
+++ b/packages/frontend/app/components/instructor-groups/list-item.gjs
@@ -70,9 +70,13 @@ export default class InstructorGroupsListItemComponent extends Component {
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
             title={{t "general.remove"}}
+            disabled={{this.showRemoveConfirmation}}
             data-test-remove
           >
-            <FaIcon @icon={{faTrash}} class="enabled remove" />
+            <FaIcon
+              @icon={{faTrash}}
+              class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+            />
           </button>
         {{else}}
           <FaIcon

--- a/packages/frontend/app/components/instructor-groups/list-item.gjs
+++ b/packages/frontend/app/components/instructor-groups/list-item.gjs
@@ -69,11 +69,6 @@ export default class InstructorGroupsListItemComponent extends Component {
             class="link-button"
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
-            aria-label={{if
-              this.showRemoveConfirmation
-              (t "general.disabledByConfirmation")
-              (t "general.remove")
-            }}
             title={{if
               this.showRemoveConfirmation
               (t "general.disabledByConfirmation")

--- a/packages/frontend/app/components/instructor-groups/list-item.gjs
+++ b/packages/frontend/app/components/instructor-groups/list-item.gjs
@@ -66,15 +66,15 @@ export default class InstructorGroupsListItemComponent extends Component {
       <td class="text-right">
         {{#if this.canDelete}}
           <button
-            class="link-button"
+            class="link-button{{if @showRemoveConfirmation ' disabled'}}"
             type="button"
-            {{on "click" (set this "showRemoveConfirmation" true)}}
             title={{if
               this.showRemoveConfirmation
               (t "general.disabledByConfirmation")
               (t "general.remove")
             }}
             disabled={{this.showRemoveConfirmation}}
+            {{on "click" (set this "showRemoveConfirmation" true)}}
             data-test-remove
           >
             <FaIcon
@@ -83,11 +83,13 @@ export default class InstructorGroupsListItemComponent extends Component {
             />
           </button>
         {{else}}
-          <FaIcon
-            @icon={{faTrash}}
-            class="disabled"
-            @title={{t "general.canNotDeleteInstructorGroup"}}
-          />
+          <button
+            type="button"
+            class="link-button disabled"
+            title={{t "general.canNotDeleteInstructorGroup"}}
+          >
+            <FaIcon @icon={{faTrash}} class="disabled" />
+          </button>
         {{/if}}
       </td>
     </tr>

--- a/packages/frontend/app/components/instructor-groups/list-item.gjs
+++ b/packages/frontend/app/components/instructor-groups/list-item.gjs
@@ -69,13 +69,22 @@ export default class InstructorGroupsListItemComponent extends Component {
             class="link-button"
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
-            title={{t "general.remove"}}
+            aria-label={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
+            title={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
             disabled={{this.showRemoveConfirmation}}
             data-test-remove
           >
             <FaIcon
               @icon={{faTrash}}
-              class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+              class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
             />
           </button>
         {{else}}

--- a/packages/frontend/app/components/learner-group/list-item.gjs
+++ b/packages/frontend/app/components/learner-group/list-item.gjs
@@ -206,11 +206,6 @@ export default class LearnerGroupListItemComponent extends Component {
               class="link-button"
               type="button"
               {{on "click" this.showRemove}}
-              aria-label={{if
-                this.showRemoveConfirmation
-                (t "general.disabledByConfirmation")
-                (t "general.remove")
-              }}
               title={{if
                 this.showRemoveConfirmation
                 (t "general.disabledByConfirmation")
@@ -240,11 +235,6 @@ export default class LearnerGroupListItemComponent extends Component {
               class="link-button"
               type="button"
               {{on "click" this.showCopy}}
-              aria-label={{if
-                this.showRemoveConfirmation
-                (t "general.disabledByConfirmation")
-                (t "general.copy")
-              }}
               title={{if
                 this.showRemoveConfirmation
                 (t "general.disabledByConfirmation")

--- a/packages/frontend/app/components/learner-group/list-item.gjs
+++ b/packages/frontend/app/components/learner-group/list-item.gjs
@@ -201,15 +201,19 @@ export default class LearnerGroupListItemComponent extends Component {
             @title={{t "general.canNotDeleteLearnerGroup"}}
           />
         {{else}}
-          {{#if (and this.canDelete (not this.showRemoveConfirmation))}}
+          {{#if this.canDelete}}
             <button
               class="link-button"
               type="button"
               {{on "click" this.showRemove}}
               title={{t "general.remove"}}
+              disabled={{this.showRemoveConfirmation}}
               data-test-remove
             >
-              <FaIcon @icon={{faTrash}} class="enabled remove" />
+              <FaIcon
+                @icon={{faTrash}}
+                class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+              />
             </button>
           {{else}}
             <FaIcon
@@ -228,9 +232,10 @@ export default class LearnerGroupListItemComponent extends Component {
               type="button"
               {{on "click" this.showCopy}}
               title={{t "general.copy"}}
+              disabled={{this.showRemoveConfirmation}}
               data-test-copy
             >
-              <FaIcon @icon={{faCopy}} />
+              <FaIcon @icon={{faCopy}} class="{{if this.showRemoveConfirmation 'disabled'}}" />
             </button>
           {{else}}
             <button

--- a/packages/frontend/app/components/learner-group/list-item.gjs
+++ b/packages/frontend/app/components/learner-group/list-item.gjs
@@ -245,7 +245,7 @@ export default class LearnerGroupListItemComponent extends Component {
               disabled={{this.showRemoveConfirmation}}
               data-test-copy
             >
-              <FaIcon @icon={{faCopy}} class="{{if this.showRemoveConfirmation 'disabled'}}" />
+              <FaIcon @icon={{faCopy}} class={{if this.showRemoveConfirmation "disabled"}} />
             </button>
           {{else}}
             <button

--- a/packages/frontend/app/components/learner-group/list-item.gjs
+++ b/packages/frontend/app/components/learner-group/list-item.gjs
@@ -203,15 +203,15 @@ export default class LearnerGroupListItemComponent extends Component {
         {{else}}
           {{#if this.canDelete}}
             <button
-              class="link-button"
+              class="link-button{{if @showRemoveConfirmation ' disabled'}}"
               type="button"
-              {{on "click" this.showRemove}}
               title={{if
                 this.showRemoveConfirmation
                 (t "general.disabledByConfirmation")
                 (t "general.remove")
               }}
               disabled={{this.showRemoveConfirmation}}
+              {{on "click" this.showRemove}}
               data-test-remove
             >
               <FaIcon
@@ -220,11 +220,13 @@ export default class LearnerGroupListItemComponent extends Component {
               />
             </button>
           {{else}}
-            <FaIcon
-              @icon={{faTrash}}
-              class="disabled"
-              @title={{t "general.canNotDeleteLearnerGroup"}}
-            />
+            <button
+              type="button"
+              class="link-button disabled"
+              title={{t "general.canNotDeleteLearnerGroup"}}
+            >
+              <FaIcon @icon={{faTrash}} class="disabled" />
+            </button>
           {{/if}}
         {{/if}}
         {{#if this.canCreateLoading}}
@@ -232,7 +234,7 @@ export default class LearnerGroupListItemComponent extends Component {
         {{else}}
           {{#if (and this.canCreate (not this.showCopyConfirmation))}}
             <button
-              class="link-button"
+              class="link-button{{if @showRemoveConfirmation ' disabled'}}"
               type="button"
               {{on "click" this.showCopy}}
               title={{if

--- a/packages/frontend/app/components/learner-group/list-item.gjs
+++ b/packages/frontend/app/components/learner-group/list-item.gjs
@@ -206,13 +206,22 @@ export default class LearnerGroupListItemComponent extends Component {
               class="link-button"
               type="button"
               {{on "click" this.showRemove}}
-              title={{t "general.remove"}}
+              aria-label={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.remove")
+              }}
+              title={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.remove")
+              }}
               disabled={{this.showRemoveConfirmation}}
               data-test-remove
             >
               <FaIcon
                 @icon={{faTrash}}
-                class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+                class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
               />
             </button>
           {{else}}
@@ -231,7 +240,16 @@ export default class LearnerGroupListItemComponent extends Component {
               class="link-button"
               type="button"
               {{on "click" this.showCopy}}
-              title={{t "general.copy"}}
+              aria-label={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.copy")
+              }}
+              title={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.copy")
+              }}
               disabled={{this.showRemoveConfirmation}}
               data-test-copy
             >

--- a/packages/frontend/app/components/program-year/list-item.gjs
+++ b/packages/frontend/app/components/program-year/list-item.gjs
@@ -191,9 +191,13 @@ export default class ProgramYearListItemComponent extends Component {
                 class="link-button"
                 aria-label={{t "general.remove"}}
                 {{on "click" (set this "showRemoveConfirmation" true)}}
+                disabled={{this.showRemoveConfirmation}}
                 data-test-remove
               >
-                <FaIcon @icon={{faTrash}} class="remove" />
+                <FaIcon
+                  @icon={{faTrash}}
+                  class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+                />
               </button>
             {{else}}
               <FaIcon

--- a/packages/frontend/app/components/program-year/list-item.gjs
+++ b/packages/frontend/app/components/program-year/list-item.gjs
@@ -162,15 +162,28 @@ export default class ProgramYearListItemComponent extends Component {
               {{#if this.canUnlock}}
                 <button
                   type="button"
-                  class="link-button"
-                  aria-label={{t "general.unlock"}}
+                  class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
+                  title={{if
+                    this.showRemoveConfirmation
+                    (t "general.disabledByConfirmation")
+                    (t "general.unlock")
+                  }}
+                  disabled={{this.showRemoveConfirmation}}
                   {{on "click" (perform this.unlock)}}
                   data-test-unlock
                 >
                   <FaIcon @icon={{faLock}} />
                 </button>
               {{else}}
-                <FaIcon @icon={{faLock}} />
+                <button
+                  type="button"
+                  class="link-button disabled"
+                  title={{t "general.canNotUnlockProgramYear"}}
+                  disabled
+                  data-test-unlock
+                >
+                  <FaIcon @icon={{faLock}} />
+                </button>
               {{/if}}
             {{else if this.canLock}}
               <button
@@ -188,7 +201,15 @@ export default class ProgramYearListItemComponent extends Component {
                 <FaIcon @icon={{faLockOpen}} class={{if this.showRemoveConfirmation "disabled"}} />
               </button>
             {{else}}
-              <FaIcon @icon={{faLockOpen}} />
+              <button
+                type="button"
+                class="link-button disabled"
+                title={{t "general.canNotLockProgramYear"}}
+                disabled
+                data-test-lock
+              >
+                <FaIcon @icon={{faLockOpen}} class="disabled" />
+              </button>
             {{/if}}
             {{#if this.canDelete}}
               <button
@@ -209,11 +230,15 @@ export default class ProgramYearListItemComponent extends Component {
                 />
               </button>
             {{else}}
-              <FaIcon
-                @icon={{faTrash}}
-                class="disabled"
-                @title={{t "general.canNotDeleteProgramYear"}}
-              />
+              <button
+                type="button"
+                class="link-button disabled"
+                title={{t "general.canNotDeleteProgramYear"}}
+                disabled
+                data-test-remove
+              >
+                <FaIcon @icon={{faTrash}} class="disabled" />
+              </button>
             {{/if}}
           {{/if}}
         </td>

--- a/packages/frontend/app/components/program-year/list-item.gjs
+++ b/packages/frontend/app/components/program-year/list-item.gjs
@@ -176,11 +176,6 @@ export default class ProgramYearListItemComponent extends Component {
               <button
                 type="button"
                 class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
-                aria-label={{if
-                  this.showRemoveConfirmation
-                  (t "general.disabledByConfirmation")
-                  (t "general.lock")
-                }}
                 title={{if
                   this.showRemoveConfirmation
                   (t "general.disabledByConfirmation")
@@ -199,11 +194,6 @@ export default class ProgramYearListItemComponent extends Component {
               <button
                 type="button"
                 class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
-                aria-label={{if
-                  this.showRemoveConfirmation
-                  (t "general.disabledByConfirmation")
-                  (t "general.remove")
-                }}
                 title={{if
                   this.showRemoveConfirmation
                   (t "general.disabledByConfirmation")

--- a/packages/frontend/app/components/program-year/list-item.gjs
+++ b/packages/frontend/app/components/program-year/list-item.gjs
@@ -175,12 +175,13 @@ export default class ProgramYearListItemComponent extends Component {
             {{else if this.canLock}}
               <button
                 type="button"
-                class="link-button"
+                class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
                 aria-label={{t "general.lock"}}
+                disabled={{this.showRemoveConfirmation}}
                 {{on "click" (perform this.lock)}}
                 data-test-lock
               >
-                <FaIcon @icon={{faLockOpen}} />
+                <FaIcon @icon={{faLockOpen}} class={{if this.showRemoveConfirmation "disabled"}} />
               </button>
             {{else}}
               <FaIcon @icon={{faLockOpen}} />
@@ -188,7 +189,7 @@ export default class ProgramYearListItemComponent extends Component {
             {{#if this.canDelete}}
               <button
                 type="button"
-                class="link-button"
+                class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
                 aria-label={{t "general.remove"}}
                 {{on "click" (set this "showRemoveConfirmation" true)}}
                 disabled={{this.showRemoveConfirmation}}
@@ -196,7 +197,7 @@ export default class ProgramYearListItemComponent extends Component {
               >
                 <FaIcon
                   @icon={{faTrash}}
-                  class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+                  class="{{if this.showRemoveConfirmation 'disabled' 'remove enabled'}}"
                 />
               </button>
             {{else}}

--- a/packages/frontend/app/components/program-year/list-item.gjs
+++ b/packages/frontend/app/components/program-year/list-item.gjs
@@ -176,7 +176,16 @@ export default class ProgramYearListItemComponent extends Component {
               <button
                 type="button"
                 class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
-                aria-label={{t "general.lock"}}
+                aria-label={{if
+                  this.showRemoveConfirmation
+                  (t "general.disabledByConfirmation")
+                  (t "general.lock")
+                }}
+                title={{if
+                  this.showRemoveConfirmation
+                  (t "general.disabledByConfirmation")
+                  (t "general.lock")
+                }}
                 disabled={{this.showRemoveConfirmation}}
                 {{on "click" (perform this.lock)}}
                 data-test-lock
@@ -190,14 +199,23 @@ export default class ProgramYearListItemComponent extends Component {
               <button
                 type="button"
                 class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
-                aria-label={{t "general.remove"}}
+                aria-label={{if
+                  this.showRemoveConfirmation
+                  (t "general.disabledByConfirmation")
+                  (t "general.remove")
+                }}
+                title={{if
+                  this.showRemoveConfirmation
+                  (t "general.disabledByConfirmation")
+                  (t "general.remove")
+                }}
                 {{on "click" (set this "showRemoveConfirmation" true)}}
                 disabled={{this.showRemoveConfirmation}}
                 data-test-remove
               >
                 <FaIcon
                   @icon={{faTrash}}
-                  class="{{if this.showRemoveConfirmation 'disabled' 'remove enabled'}}"
+                  class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
                 />
               </button>
             {{else}}

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -405,13 +405,13 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
           <button
             class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
             type="button"
-            {{on "click" (set this "showRemoveConfirmation" true)}}
             title={{if
               this.showRemoveConfirmation
               (t "general.disabledByConfirmation")
               (t "general.remove")
             }}
             disabled={{this.showRemoveConfirmation}}
+            {{on "click" (set this "showRemoveConfirmation" true)}}
             data-test-remove
           >
             <FaIcon
@@ -420,11 +420,15 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
             />
           </button>
         {{else}}
-          <FaIcon
-            @icon={{faTrash}}
-            class="disabled"
-            @title={{t "general.canNotDeleteProgramYearObjective"}}
-          />
+          <button
+            type="button"
+            class="link-button disabled"
+            title={{t "general.canNotDeleteProgramYearObjective"}}
+            disabled
+            data-test-remove
+          >
+            <FaIcon @icon={{faTrash}} class="disabled" />
+          </button>
         {{/if}}
       </div>
 

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -406,11 +406,6 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
             class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
-            aria-label={{if
-              this.showRemoveConfirmation
-              (t "general.disabledByConfirmation")
-              (t "general.remove")
-            }}
             title={{if
               this.showRemoveConfirmation
               (t "general.disabledByConfirmation")

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -406,7 +406,16 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
             class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
-            aria-label={{t "general.remove"}}
+            aria-label={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
+            title={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
             disabled={{this.showRemoveConfirmation}}
             data-test-remove
           >

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -401,17 +401,19 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
             <FaIcon @icon={{faToggleOff}} @title={{t "general.inactive"}} />
           {{/if}}
         {{/if}}
-        {{#if
-          (and this.canDelete @editable (not this.isManaging) (not this.showRemoveConfirmation))
-        }}
+        {{#if (and this.canDelete @editable (not this.isManaging))}}
           <button
-            class="link-button"
+            class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
             type="button"
             {{on "click" (set this "showRemoveConfirmation" true)}}
             aria-label={{t "general.remove"}}
+            disabled={{this.showRemoveConfirmation}}
             data-test-remove
           >
-            <FaIcon @icon={{faTrash}} class="enabled remove" />
+            <FaIcon
+              @icon={{faTrash}}
+              class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
+            />
           </button>
         {{else}}
           <FaIcon

--- a/packages/frontend/app/components/programs/list-item.gjs
+++ b/packages/frontend/app/components/programs/list-item.gjs
@@ -57,12 +57,13 @@ export default class ProgramListItemComponent extends Component {
         {{#if this.canDelete}}
           <button
             type="button"
+            class={{if this.showRemoveConfirmation "disabled"}}
             aria-label={{t "general.remove"}}
             {{on "click" (set this "showRemoveConfirmation" true)}}
             disabled={{this.showRemoveConfirmation}}
             data-test-remove
           >
-            <FaIcon @icon={{faTrash}} class="{{if this.showRemoveConfirmation 'disabled'}}" />
+            <FaIcon @icon={{faTrash}} class={{if this.showRemoveConfirmation "disabled"}} />
           </button>
         {{else}}
           <FaIcon @icon={{faTrash}} class="disabled" @title={{t "general.canNotDeleteProgram"}} />

--- a/packages/frontend/app/components/programs/list-item.gjs
+++ b/packages/frontend/app/components/programs/list-item.gjs
@@ -63,14 +63,22 @@ export default class ProgramListItemComponent extends Component {
               (t "general.disabledByConfirmation")
               (t "general.remove")
             }}
-            {{on "click" (set this "showRemoveConfirmation" true)}}
             disabled={{this.showRemoveConfirmation}}
+            {{on "click" (set this "showRemoveConfirmation" true)}}
             data-test-remove
           >
             <FaIcon @icon={{faTrash}} class={{if this.showRemoveConfirmation "disabled"}} />
           </button>
         {{else}}
-          <FaIcon @icon={{faTrash}} class="disabled" @title={{t "general.canNotDeleteProgram"}} />
+          <button
+            type="button"
+            class={{if this.showRemoveConfirmation "disabled"}}
+            title={{t "general.canNotDeleteProgram"}}
+            disabled
+            data-test-remove
+          >
+            <FaIcon @icon={{faTrash}} class="disabled" />
+          </button>
         {{/if}}
       </td>
     </tr>

--- a/packages/frontend/app/components/programs/list-item.gjs
+++ b/packages/frontend/app/components/programs/list-item.gjs
@@ -59,9 +59,10 @@ export default class ProgramListItemComponent extends Component {
             type="button"
             aria-label={{t "general.remove"}}
             {{on "click" (set this "showRemoveConfirmation" true)}}
+            disabled={{this.showRemoveConfirmation}}
             data-test-remove
           >
-            <FaIcon @icon={{faTrash}} />
+            <FaIcon @icon={{faTrash}} class="{{if this.showRemoveConfirmation 'disabled'}}" />
           </button>
         {{else}}
           <FaIcon @icon={{faTrash}} class="disabled" @title={{t "general.canNotDeleteProgram"}} />

--- a/packages/frontend/app/components/programs/list-item.gjs
+++ b/packages/frontend/app/components/programs/list-item.gjs
@@ -58,11 +58,6 @@ export default class ProgramListItemComponent extends Component {
           <button
             type="button"
             class={{if this.showRemoveConfirmation "disabled"}}
-            aria-label={{if
-              this.showRemoveConfirmation
-              (t "general.disabledByConfirmation")
-              (t "general.remove")
-            }}
             title={{if
               this.showRemoveConfirmation
               (t "general.disabledByConfirmation")

--- a/packages/frontend/app/components/programs/list-item.gjs
+++ b/packages/frontend/app/components/programs/list-item.gjs
@@ -58,7 +58,16 @@ export default class ProgramListItemComponent extends Component {
           <button
             type="button"
             class={{if this.showRemoveConfirmation "disabled"}}
-            aria-label={{t "general.remove"}}
+            aria-label={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
+            title={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
             {{on "click" (set this "showRemoveConfirmation" true)}}
             disabled={{this.showRemoveConfirmation}}
             data-test-remove

--- a/packages/frontend/app/components/reports/table-row.gjs
+++ b/packages/frontend/app/components/reports/table-row.gjs
@@ -30,11 +30,6 @@ export default class ReportsTableRowComponent extends Component {
         <button
           type="button"
           class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
-          aria-label={{if
-            this.showRemoveConfirmation
-            (t "general.disabledByConfirmation")
-            (t "general.delete")
-          }}
           title={{if
             this.showRemoveConfirmation
             (t "general.disabledByConfirmation")

--- a/packages/frontend/app/components/reports/table-row.gjs
+++ b/packages/frontend/app/components/reports/table-row.gjs
@@ -29,12 +29,16 @@ export default class ReportsTableRowComponent extends Component {
       <td class="text-right" colspan="1" data-test-status>
         <button
           type="button"
-          class="link-button"
+          class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
           title={{t "general.delete"}}
           {{on "click" (fn @confirmRemoval @decoratedReport.report)}}
+          disabled={{this.showRemoveConfirmation}}
           data-test-remove
         >
-          <FaIcon @icon={{faTrash}} class="enabled remove" />
+          <FaIcon
+            @icon={{faTrash}}
+            class={{if this.showRemoveConfirmation "disabled" "enabled remove"}}
+          />
         </button>
       </td>
     </tr>

--- a/packages/frontend/app/components/reports/table-row.gjs
+++ b/packages/frontend/app/components/reports/table-row.gjs
@@ -30,14 +30,23 @@ export default class ReportsTableRowComponent extends Component {
         <button
           type="button"
           class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
-          title={{t "general.delete"}}
+          aria-label={{if
+            this.showRemoveConfirmation
+            (t "general.disabledByConfirmation")
+            (t "general.delete")
+          }}
+          title={{if
+            this.showRemoveConfirmation
+            (t "general.disabledByConfirmation")
+            (t "general.delete")
+          }}
           {{on "click" (fn @confirmRemoval @decoratedReport.report)}}
           disabled={{this.showRemoveConfirmation}}
           data-test-remove
         >
           <FaIcon
             @icon={{faTrash}}
-            class={{if this.showRemoveConfirmation "disabled" "enabled remove"}}
+            class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
           />
         </button>
       </td>

--- a/packages/frontend/app/components/school/session-types-list-item.gjs
+++ b/packages/frontend/app/components/school/session-types-list-item.gjs
@@ -82,18 +82,26 @@ export default class SchoolSessionTypesListItemComponent extends Component {
       <td>
         <button
           type="button"
-          class="link-button"
+          class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
           aria-label={{t "general.manage"}}
+          disabled={{or (this.showRemoveConfirmation this.deleteSessionType.isRunning)}}
           data-test-manage
           {{on "click" (fn @manageSessionType @sessionType.id)}}
         >
-          <FaIcon @icon={{faPenToSquare}} class="edit" />
+          <FaIcon
+            @icon={{faPenToSquare}}
+            class={{if
+              (or this.showRemoveConfirmation this.deleteSessionType.isRunning)
+              "disabled"
+              "edit"
+            }}
+          />
         </button>
         {{#if (eq @sessionType.sessionCount 0)}}
           {{#if @canDelete}}
             <button
               type="button"
-              class="link-button"
+              class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
               aria-label={{t "general.remove"}}
               disabled={{or (this.showRemoveConfirmation this.deleteSessionType.isRunning)}}
               data-test-delete
@@ -103,7 +111,7 @@ export default class SchoolSessionTypesListItemComponent extends Component {
                 @icon={{faTrash}}
                 class={{if
                   (or this.showRemoveConfirmation this.deleteSessionType.isRunning)
-                  "inactive"
+                  "disabled"
                   "remove"
                 }}
               />
@@ -121,7 +129,14 @@ export default class SchoolSessionTypesListItemComponent extends Component {
           @model={{@sessionType}}
           title={{t "general.vocabularies"}}
         >
-          <FaIcon @icon={{faChartColumn}} class="enabled" />
+          <FaIcon
+            @icon={{faChartColumn}}
+            class={{if
+              (or this.showRemoveConfirmation this.deleteSessionType.isRunning)
+              "disabled"
+              "enabled"
+            }}
+          />
         </LinkTo>
       </td>
     </tr>

--- a/packages/frontend/app/components/school/session-types-list-item.gjs
+++ b/packages/frontend/app/components/school/session-types-list-item.gjs
@@ -5,7 +5,7 @@ import { on } from '@ember/modifier';
 import { fn, concat } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
-import { and, eq, not, or } from 'ember-truth-helpers';
+import { and, eq, not } from 'ember-truth-helpers';
 import set from 'ember-set-helper/helpers/set';
 import { LinkTo } from '@ember/routing';
 import perform from 'ember-concurrency/helpers/perform';
@@ -89,17 +89,13 @@ export default class SchoolSessionTypesListItemComponent extends Component {
             (t "general.disabledByConfirmation")
             (t "general.manage")
           }}
-          disabled={{or (this.showRemoveConfirmation this.deleteSessionType.isRunning)}}
+          disabled={{this.showRemoveConfirmation}}
           {{on "click" (fn @manageSessionType @sessionType.id)}}
           data-test-manage
         >
           <FaIcon
             @icon={{faPenToSquare}}
-            class={{if
-              (or this.showRemoveConfirmation this.deleteSessionType.isRunning)
-              "disabled"
-              "edit"
-            }}
+            class={{if this.showRemoveConfirmation "disabled" "edit"}}
           />
         </button>
         {{#if (eq @sessionType.sessionCount 0)}}
@@ -112,18 +108,24 @@ export default class SchoolSessionTypesListItemComponent extends Component {
                 (t "general.disabledByConfirmation")
                 (t "general.remove")
               }}
-              disabled={{or (this.showRemoveConfirmation this.deleteSessionType.isRunning)}}
+              disabled={{this.showRemoveConfirmation}}
               {{on "click" (set this "showRemoveConfirmation" true)}}
               data-test-delete
             >
               <FaIcon
                 @icon={{faTrash}}
-                class={{if
-                  (or this.showRemoveConfirmation this.deleteSessionType.isRunning)
-                  "disabled"
-                  "remove"
-                }}
+                class={{if this.showRemoveConfirmation "disabled" "remove"}}
               />
+            </button>
+          {{else}}
+            <button
+              type="button"
+              class="link-button disabled"
+              title={{t "general.canNotDeleteSchoolSessionType"}}
+              disabled
+              data-test-delete
+            >
+              <FaIcon @icon={{faTrash}} class="disabled" />
             </button>
           {{/if}}
         {{else}}
@@ -140,16 +142,16 @@ export default class SchoolSessionTypesListItemComponent extends Component {
         <LinkTo
           @route="session-type-visualize-vocabularies"
           @model={{@sessionType}}
-          title={{t "general.vocabularies"}}
-          class={{if (or this.showRemoveConfirmation this.deleteSessionType.isRunning) "disabled"}}
+          @disabled={{this.showRemoveConfirmation}}
+          title={{if
+            this.showRemoveConfirmation
+            (t "general.disabledByConfirmation")
+            (t "general.vocabularies")
+          }}
         >
           <FaIcon
             @icon={{faChartColumn}}
-            class={{if
-              (or this.showRemoveConfirmation this.deleteSessionType.isRunning)
-              "disabled"
-              "enabled"
-            }}
+            class={{if this.showRemoveConfirmation "disabled" "enabled"}}
           />
         </LinkTo>
       </td>

--- a/packages/frontend/app/components/school/session-types-list-item.gjs
+++ b/packages/frontend/app/components/school/session-types-list-item.gjs
@@ -102,7 +102,16 @@ export default class SchoolSessionTypesListItemComponent extends Component {
             <button
               type="button"
               class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
-              aria-label={{t "general.remove"}}
+              aria-label={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.remove")
+              }}
+              title={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.remove")
+              }}
               disabled={{or (this.showRemoveConfirmation this.deleteSessionType.isRunning)}}
               data-test-delete
               {{on "click" (set this "showRemoveConfirmation" true)}}

--- a/packages/frontend/app/components/school/session-types-list-item.gjs
+++ b/packages/frontend/app/components/school/session-types-list-item.gjs
@@ -84,9 +84,14 @@ export default class SchoolSessionTypesListItemComponent extends Component {
           type="button"
           class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
           aria-label={{t "general.manage"}}
+          title={{if
+            this.showRemoveConfirmation
+            (t "general.disabledByConfirmation")
+            (t "general.manage")
+          }}
           disabled={{or (this.showRemoveConfirmation this.deleteSessionType.isRunning)}}
-          data-test-manage
           {{on "click" (fn @manageSessionType @sessionType.id)}}
+          data-test-manage
         >
           <FaIcon
             @icon={{faPenToSquare}}
@@ -108,8 +113,8 @@ export default class SchoolSessionTypesListItemComponent extends Component {
                 (t "general.remove")
               }}
               disabled={{or (this.showRemoveConfirmation this.deleteSessionType.isRunning)}}
-              data-test-delete
               {{on "click" (set this "showRemoveConfirmation" true)}}
+              data-test-delete
             >
               <FaIcon
                 @icon={{faTrash}}
@@ -122,11 +127,15 @@ export default class SchoolSessionTypesListItemComponent extends Component {
             </button>
           {{/if}}
         {{else}}
-          <FaIcon
-            @icon={{faTrash}}
-            class="disabled"
-            @title={{t "general.canNotDeleteSchoolSessionType"}}
-          />
+          <button
+            type="button"
+            class="link-button disabled"
+            title={{t "general.canNotDeleteSchoolSessionType"}}
+            disabled
+            data-test-delete
+          >
+            <FaIcon @icon={{faTrash}} class="disabled" />
+          </button>
         {{/if}}
         <LinkTo
           @route="session-type-visualize-vocabularies"

--- a/packages/frontend/app/components/school/session-types-list-item.gjs
+++ b/packages/frontend/app/components/school/session-types-list-item.gjs
@@ -102,11 +102,6 @@ export default class SchoolSessionTypesListItemComponent extends Component {
             <button
               type="button"
               class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
-              aria-label={{if
-                this.showRemoveConfirmation
-                (t "general.disabledByConfirmation")
-                (t "general.remove")
-              }}
               title={{if
                 this.showRemoveConfirmation
                 (t "general.disabledByConfirmation")

--- a/packages/frontend/app/components/school/session-types-list-item.gjs
+++ b/packages/frontend/app/components/school/session-types-list-item.gjs
@@ -128,6 +128,7 @@ export default class SchoolSessionTypesListItemComponent extends Component {
           @route="session-type-visualize-vocabularies"
           @model={{@sessionType}}
           title={{t "general.vocabularies"}}
+          class={{if (or this.showRemoveConfirmation this.deleteSessionType.isRunning) "disabled"}}
         >
           <FaIcon
             @icon={{faChartColumn}}

--- a/packages/frontend/app/components/school/vocabularies-list.gjs
+++ b/packages/frontend/app/components/school/vocabularies-list.gjs
@@ -119,19 +119,19 @@ export default class SchoolVocabulariesListComponent extends Component {
                     </button>
                     {{#if (and @canDelete (eq vocabulary.termCount 0))}}
                       <button
+                        type="button"
                         class="link-button{{if
                             (eq this.showRemovalConfirmationFor vocabulary)
                             ' disabled'
                           }}"
-                        type="button"
                         title={{if
                           (eq this.showRemovalConfirmationFor vocabulary)
                           (t "general.disabledByConfirmation")
                           (t "general.remove")
                         }}
                         disabled={{eq this.showRemovalConfirmationFor vocabulary}}
-                        data-test-delete
                         {{on "click" (fn this.confirmRemoval vocabulary)}}
+                        data-test-delete
                       >
                         <FaIcon
                           @icon={{faTrash}}
@@ -143,11 +143,15 @@ export default class SchoolVocabulariesListComponent extends Component {
                         />
                       </button>
                     {{else}}
-                      <FaIcon
-                        @icon={{faTrash}}
-                        class="disabled"
-                        @title={{t "general.canNotDeleteSchoolVocabulary"}}
-                      />
+                      <button
+                        type="button"
+                        class="link-button disabled"
+                        title={{t "general.canNotDeleteSchoolVocabulary"}}
+                        disabled
+                        data-test-delete
+                      >
+                        <FaIcon @icon={{faTrash}} class="disabled" />
+                      </button>
                     {{/if}}
                   </td>
                 </tr>

--- a/packages/frontend/app/components/school/vocabularies-list.gjs
+++ b/packages/frontend/app/components/school/vocabularies-list.gjs
@@ -10,7 +10,6 @@ import { and, eq } from 'ember-truth-helpers';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
-import notEq from 'ember-truth-helpers/helpers/not-eq';
 import perform from 'ember-concurrency/helpers/perform';
 import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import { faPenToSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
@@ -100,7 +99,16 @@ export default class SchoolVocabulariesListComponent extends Component {
                           ' disabled'
                         }}"
                       type="button"
-                      aria-label={{t "general.edit"}}
+                      aria-label={{if
+                        (eq this.showRemovalConfirmationFor vocabulary)
+                        (t "general.disabledByConfirmation")
+                        (t "general.edit")
+                      }}
+                      title={{if
+                        (eq this.showRemovalConfirmationFor vocabulary)
+                        (t "general.disabledByConfirmation")
+                        (t "general.edit")
+                      }}
                       disabled={{eq this.showRemovalConfirmationFor vocabulary}}
                       data-test-manage
                       {{on "click" (fn @manageVocabulary vocabulary.id)}}
@@ -114,25 +122,35 @@ export default class SchoolVocabulariesListComponent extends Component {
                         }}
                       />
                     </button>
-                    {{#if
-                      (and
-                        @canDelete
-                        (eq vocabulary.termCount 0)
-                        (notEq this.showRemovalConfirmationFor vocabulary)
-                      )
-                    }}
+                    {{#if (and @canDelete (eq vocabulary.termCount 0))}}
                       <button
                         class="link-button{{if
                             (eq this.showRemovalConfirmationFor vocabulary)
                             ' disabled'
                           }}"
                         type="button"
-                        aria-label={{t "general.remove"}}
+                        aria-label={{if
+                          (eq this.showRemovalConfirmationFor vocabulary)
+                          (t "general.disabledByConfirmation")
+                          (t "general.remove")
+                        }}
+                        title={{if
+                          (eq this.showRemovalConfirmationFor vocabulary)
+                          (t "general.disabledByConfirmation")
+                          (t "general.remove")
+                        }}
                         disabled={{eq this.showRemovalConfirmationFor vocabulary}}
                         data-test-delete
                         {{on "click" (fn this.confirmRemoval vocabulary)}}
                       >
-                        <FaIcon @icon={{faTrash}} class="enabled remove" />
+                        <FaIcon
+                          @icon={{faTrash}}
+                          class={{if
+                            (eq this.showRemovalConfirmationFor vocabulary)
+                            "disabled"
+                            "remove enabled"
+                          }}
+                        />
                       </button>
                     {{else}}
                       <FaIcon

--- a/packages/frontend/app/components/school/vocabularies-list.gjs
+++ b/packages/frontend/app/components/school/vocabularies-list.gjs
@@ -99,11 +99,6 @@ export default class SchoolVocabulariesListComponent extends Component {
                           ' disabled'
                         }}"
                       type="button"
-                      aria-label={{if
-                        (eq this.showRemovalConfirmationFor vocabulary)
-                        (t "general.disabledByConfirmation")
-                        (t "general.edit")
-                      }}
                       title={{if
                         (eq this.showRemovalConfirmationFor vocabulary)
                         (t "general.disabledByConfirmation")
@@ -129,11 +124,6 @@ export default class SchoolVocabulariesListComponent extends Component {
                             ' disabled'
                           }}"
                         type="button"
-                        aria-label={{if
-                          (eq this.showRemovalConfirmationFor vocabulary)
-                          (t "general.disabledByConfirmation")
-                          (t "general.remove")
-                        }}
                         title={{if
                           (eq this.showRemovalConfirmationFor vocabulary)
                           (t "general.disabledByConfirmation")

--- a/packages/frontend/app/components/school/vocabularies-list.gjs
+++ b/packages/frontend/app/components/school/vocabularies-list.gjs
@@ -95,13 +95,24 @@ export default class SchoolVocabulariesListComponent extends Component {
                   </td>
                   <td class="text-left text-top" colspan="1">
                     <button
-                      class="link-button"
+                      class="link-button{{if
+                          (eq this.showRemovalConfirmationFor vocabulary)
+                          ' disabled'
+                        }}"
                       type="button"
                       aria-label={{t "general.edit"}}
+                      disabled={{eq this.showRemovalConfirmationFor vocabulary}}
                       data-test-manage
                       {{on "click" (fn @manageVocabulary vocabulary.id)}}
                     >
-                      <FaIcon @icon={{faPenToSquare}} class="enabled" />
+                      <FaIcon
+                        @icon={{faPenToSquare}}
+                        class={{if
+                          (eq this.showRemovalConfirmationFor vocabulary)
+                          "disabled"
+                          "enabled"
+                        }}
+                      />
                     </button>
                     {{#if
                       (and
@@ -111,9 +122,13 @@ export default class SchoolVocabulariesListComponent extends Component {
                       )
                     }}
                       <button
-                        class="link-button"
+                        class="link-button{{if
+                            (eq this.showRemovalConfirmationFor vocabulary)
+                            ' disabled'
+                          }}"
                         type="button"
                         aria-label={{t "general.remove"}}
+                        disabled={{eq this.showRemovalConfirmationFor vocabulary}}
                         data-test-delete
                         {{on "click" (fn this.confirmRemoval vocabulary)}}
                       >

--- a/packages/frontend/app/styles/components/programs/list-item.scss
+++ b/packages/frontend/app/styles/components/programs/list-item.scss
@@ -5,6 +5,10 @@
     button {
       @include m.ilios-button-reset;
       color: var(--red);
+
+      &.disabled {
+        cursor: default;
+      }
     }
   }
 }

--- a/packages/frontend/app/styles/components/school/session-types-list-item.scss
+++ b/packages/frontend/app/styles/components/school/session-types-list-item.scss
@@ -13,4 +13,9 @@
   .link-button {
     text-align: left;
   }
+
+  .link-button.disabled,
+  a.disabled {
+    cursor: default;
+  }
 }

--- a/packages/frontend/tests/acceptance/courses-test.js
+++ b/packages/frontend/tests/acceptance/courses-test.js
@@ -818,11 +818,6 @@ module('Acceptance | Courses', function (hooks) {
 
     assert.ok(page.root.list.courses[0].status.canRemove, 'first course can be removed');
     assert.strictEqual(
-      page.root.list.courses[0].status.lockIcon.label,
-      'Lock Course',
-      'first course lock icon aria-label correct',
-    );
-    assert.strictEqual(
       page.root.list.courses[0].status.lockIcon.title,
       'Lock Course',
       'first course lock icon title correct',
@@ -835,30 +830,21 @@ module('Acceptance | Courses', function (hooks) {
 
     assert.notOk(page.root.list.courses[1].status.canRemove, 'second course cannot be removed');
     assert.strictEqual(
-      page.root.list.courses[1].status.lockIcon.label,
-      'Lock Course',
-      'second course lock icon aria-label correct',
-    );
-    assert.strictEqual(
       page.root.list.courses[1].status.lockIcon.title,
       'Lock Course',
       'second course lock icon title correct',
     );
     assert.ok(
-      page.root.list.courses[1].status.removeDisabledIcon,
+      page.root.list.courses[1].status.removeIcon.isDisabled,
       'second course shows disabled remove icon',
     );
     assert.strictEqual(
-      page.root.list.courses[1].status.removeDisabledIcon.title,
+      page.root.list.courses[1].status.removeIcon.title,
       'This course cannot be deleted because it is published, scheduled, has been rolled over, or you do not have permission.',
+      'second course disabled remove icon tooltip correct',
     );
 
     assert.ok(page.root.list.courses[2].status.canRemove, 'third course can be removed');
-    assert.strictEqual(
-      page.root.list.courses[2].status.lockIcon.label,
-      'Lock Course',
-      'third course lock icon aria-label correct',
-    );
     assert.strictEqual(
       page.root.list.courses[2].status.lockIcon.title,
       'Lock Course',
@@ -887,11 +873,6 @@ module('Acceptance | Courses', function (hooks) {
 
     await page.root.list.cancelCourseRemoval();
 
-    assert.strictEqual(
-      page.root.list.courses[0].status.lockIcon.label,
-      'Lock Course',
-      'first course lock icon aria-label correct',
-    );
     assert.strictEqual(
       page.root.list.courses[0].status.lockIcon.title,
       'Lock Course',

--- a/packages/frontend/tests/acceptance/courses-test.js
+++ b/packages/frontend/tests/acceptance/courses-test.js
@@ -244,11 +244,11 @@ module('Acceptance | Courses', function (hooks) {
     await page.visit();
 
     assert.notOk(
-      page.root.list.courses[0].canRemove,
+      page.root.list.courses[0].status.canRemove,
       'non-privileged user cannot delete published course',
     );
     assert.notOk(
-      page.root.list.courses[1].canRemove,
+      page.root.list.courses[1].status.canRemove,
       'non-privileged user cannot delete unpublished course',
     );
   });
@@ -268,10 +268,13 @@ module('Acceptance | Courses', function (hooks) {
     await page.visit();
 
     assert.notOk(
-      page.root.list.courses[0].canRemove,
+      page.root.list.courses[0].status.canRemove,
       'privileged user cannot delete published course',
     );
-    assert.ok(page.root.list.courses[1].canRemove, 'privileged user can delete unpublished course');
+    assert.ok(
+      page.root.list.courses[1].status.canRemove,
+      'privileged user can delete unpublished course',
+    );
   });
 
   test('new course', async function (assert) {
@@ -404,7 +407,7 @@ module('Acceptance | Courses', function (hooks) {
     assert.strictEqual(page.root.list.courses.length, 1);
     assert.ok(page.root.newCourseLinkIsHidden);
 
-    await page.root.list.courses[0].remove();
+    await page.root.list.courses[0].status.remove();
     await page.root.list.confirmCourseRemoval();
     assert.strictEqual(page.root.list.courses.length, 0);
     assert.notOk(page.root.list.listIsVisible);
@@ -430,14 +433,15 @@ module('Acceptance | Courses', function (hooks) {
       'Not Published',
       'course status is correct',
     );
-    assert.notOk(page.root.list.courses[0].isLocked, 'course is not locked');
+
+    assert.notOk(page.root.list.courses[0].status.isLocked, 'course is not locked');
     assert.strictEqual(page.root.list.courses[1].title, 'course 1', 'course name is correct');
     assert.strictEqual(
       page.root.list.courses[1].publicationStatus.icon.title,
       'Not Published',
       'course status is correct',
     );
-    assert.ok(page.root.list.courses[1].isLocked, 'course is locked');
+    assert.ok(page.root.list.courses[1].status.isLocked, 'course is locked');
   });
 
   test('no academic years exist', async function (assert) {
@@ -606,13 +610,14 @@ module('Acceptance | Courses', function (hooks) {
     });
 
     await page.visit();
+
     assert.strictEqual(page.root.list.courses.length, 2);
-    assert.ok(page.root.list.courses[0].isLocked, 'first course is locked');
-    assert.ok(page.root.list.courses[1].isUnlocked, 'second course is unlocked');
-    await page.root.list.courses[0].unLock();
-    await page.root.list.courses[1].lock();
-    assert.ok(page.root.list.courses[0].isUnlocked, 'first course is now unlocked');
-    assert.ok(page.root.list.courses[1].isLocked, 'second course is now locked');
+    assert.ok(page.root.list.courses[0].status.isLocked, 'first course is locked');
+    assert.ok(page.root.list.courses[1].status.isUnlocked, 'second course is unlocked');
+    await page.root.list.courses[0].status.unLock();
+    await page.root.list.courses[1].status.lock();
+    assert.ok(page.root.list.courses[0].status.isUnlocked, 'first course is now unlocked');
+    assert.ok(page.root.list.courses[1].status.isLocked, 'second course is now locked');
   });
 
   test('non-privileged users cannot lock and unlock course but can see the icon', async function (assert) {
@@ -634,10 +639,10 @@ module('Acceptance | Courses', function (hooks) {
 
     await page.visit();
     assert.strictEqual(page.root.list.courses.length, 2);
-    assert.ok(page.root.list.courses[0].isLocked, 'first course is locked');
-    assert.ok(page.root.list.courses[1].isUnlocked, 'second course is unlocked');
-    assert.notOk(page.root.list.courses[0].canLock);
-    assert.notOk(page.root.list.courses[1].canUnlock);
+    assert.ok(page.root.list.courses[0].status.isLocked, 'first course is locked');
+    assert.ok(page.root.list.courses[1].status.isUnlocked, 'second course is unlocked');
+    assert.notOk(page.root.list.courses[0].status.canLock);
+    assert.notOk(page.root.list.courses[1].status.canUnlock);
   });
 
   test('title filter escapes regex', async function (assert) {
@@ -674,11 +679,11 @@ module('Acceptance | Courses', function (hooks) {
     await page.visit({ year });
 
     assert.notOk(
-      page.root.list.courses[0].canRemove,
+      page.root.list.courses[0].status.canRemove,
       'privileged user cannot delete course with descendants',
     );
     assert.ok(
-      page.root.list.courses[1].canRemove,
+      page.root.list.courses[1].status.canRemove,
       'privileged user can delete course with ancestors',
     );
   });
@@ -787,5 +792,115 @@ module('Acceptance | Courses', function (hooks) {
     assert.notOk(page.root.filterHasFocus);
     await page.root.filterByTitle('first');
     assert.ok(page.root.filterHasFocus);
+  });
+
+  test('course actions have proper labels and titles during deletion confirmation and non-confirmation', async function (assert) {
+    this.user.update({ administeredSchools: [this.school] });
+    const year = DateTime.now().year.toString();
+    this.server.create('academic-year', { id: year });
+    this.server.create('course', {
+      year,
+      school: this.school,
+      published: false,
+    });
+    const courseParent = this.server.create('course', {
+      year,
+      school: this.school,
+    });
+    this.server.create('course', {
+      year,
+      school: this.school,
+      ancestor: courseParent,
+    });
+    await page.visit();
+
+    assert.strictEqual(page.root.list.courses.length, 3);
+
+    assert.ok(page.root.list.courses[0].status.canRemove, 'first course can be removed');
+    assert.strictEqual(
+      page.root.list.courses[0].status.lockIcon.label,
+      'Lock Course',
+      'first course lock icon aria-label correct',
+    );
+    assert.strictEqual(
+      page.root.list.courses[0].status.lockIcon.title,
+      'Lock Course',
+      'first course lock icon title correct',
+    );
+    assert.strictEqual(
+      page.root.list.courses[0].status.removeIcon.title,
+      'Delete Course',
+      'first course remove icon title correct',
+    );
+
+    assert.notOk(page.root.list.courses[1].status.canRemove, 'second course cannot be removed');
+    assert.strictEqual(
+      page.root.list.courses[1].status.lockIcon.label,
+      'Lock Course',
+      'second course lock icon aria-label correct',
+    );
+    assert.strictEqual(
+      page.root.list.courses[1].status.lockIcon.title,
+      'Lock Course',
+      'second course lock icon title correct',
+    );
+    assert.ok(
+      page.root.list.courses[1].status.removeDisabledIcon,
+      'second course shows disabled remove icon',
+    );
+    assert.strictEqual(
+      page.root.list.courses[1].status.removeDisabledIcon.title,
+      'This course cannot be deleted because it is published, scheduled, has been rolled over, or you do not have permission.',
+    );
+
+    assert.ok(page.root.list.courses[2].status.canRemove, 'third course can be removed');
+    assert.strictEqual(
+      page.root.list.courses[2].status.lockIcon.label,
+      'Lock Course',
+      'third course lock icon aria-label correct',
+    );
+    assert.strictEqual(
+      page.root.list.courses[2].status.lockIcon.title,
+      'Lock Course',
+      'third course lock icon title correct',
+    );
+    assert.strictEqual(
+      page.root.list.courses[2].status.removeIcon.title,
+      'Delete Course',
+      'third course remove icon title correct',
+    );
+
+    await page.root.list.courses[0].status.remove();
+
+    assert.strictEqual(
+      page.root.list.courses[0].status.lockIcon.label,
+      'This cannot be used while confirming deletion.',
+    );
+    assert.strictEqual(
+      page.root.list.courses[0].status.lockIcon.title,
+      'This cannot be used while confirming deletion.',
+    );
+    assert.strictEqual(
+      page.root.list.courses[0].status.removeIcon.title,
+      'This cannot be used while confirming deletion.',
+    );
+
+    await page.root.list.cancelCourseRemoval();
+
+    assert.strictEqual(
+      page.root.list.courses[0].status.lockIcon.label,
+      'Lock Course',
+      'first course lock icon aria-label correct',
+    );
+    assert.strictEqual(
+      page.root.list.courses[0].status.lockIcon.title,
+      'Lock Course',
+      'first course lock icon title correct',
+    );
+    assert.strictEqual(
+      page.root.list.courses[0].status.removeIcon.title,
+      'Delete Course',
+      'first course remove icon title correct',
+    );
   });
 });

--- a/packages/frontend/tests/acceptance/courses-test.js
+++ b/packages/frontend/tests/acceptance/courses-test.js
@@ -614,6 +614,8 @@ module('Acceptance | Courses', function (hooks) {
     assert.strictEqual(page.root.list.courses.length, 2);
     assert.ok(page.root.list.courses[0].status.isLocked, 'first course is locked');
     assert.ok(page.root.list.courses[1].status.isUnlocked, 'second course is unlocked');
+    assert.ok(page.root.list.courses[0].status.canUnlock, 'first course can be locked');
+    assert.ok(page.root.list.courses[1].status.canLock, 'second course can be unlocked');
     await page.root.list.courses[0].status.unLock();
     await page.root.list.courses[1].status.lock();
     assert.ok(page.root.list.courses[0].status.isUnlocked, 'first course is now unlocked');
@@ -621,25 +623,26 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('non-privileged users cannot lock and unlock course but can see the icon', async function (assert) {
+    this.user.update({ administeredSchools: [] });
     this.server.create('academic-year', { id: 2014 });
     this.server.create('course', {
       year: 2014,
       schoolId: 1,
       published: true,
-      publishedAsTbd: false,
+      publishedAsTbd: true,
       locked: false,
     });
     this.server.create('course', {
       year: 2014,
       schoolId: 1,
       published: true,
-      publishedAsTbd: true,
+      publishedAsTbd: false,
       locked: true,
     });
 
     await page.visit();
 
-    assert.strictEqual(page.root.list.courses.length, 2);
+    assert.strictEqual(page.root.list.courses.length, 2, 'course count correct');
     assert.ok(page.root.list.courses[0].status.isUnlocked, 'first course is unlocked');
     assert.ok(page.root.list.courses[1].status.isLocked, 'second course is locked');
     assert.notOk(page.root.list.courses[0].status.canLock, 'first course cannot be locked');

--- a/packages/frontend/tests/acceptance/courses-test.js
+++ b/packages/frontend/tests/acceptance/courses-test.js
@@ -627,22 +627,23 @@ module('Acceptance | Courses', function (hooks) {
       schoolId: 1,
       published: true,
       publishedAsTbd: false,
-      locked: true,
+      locked: false,
     });
     this.server.create('course', {
       year: 2014,
       schoolId: 1,
       published: true,
       publishedAsTbd: true,
-      locked: false,
+      locked: true,
     });
 
     await page.visit();
+
     assert.strictEqual(page.root.list.courses.length, 2);
-    assert.ok(page.root.list.courses[0].status.isLocked, 'first course is locked');
-    assert.ok(page.root.list.courses[1].status.isUnlocked, 'second course is unlocked');
-    assert.notOk(page.root.list.courses[0].status.canLock);
-    assert.notOk(page.root.list.courses[1].status.canUnlock);
+    assert.ok(page.root.list.courses[0].status.isUnlocked, 'first course is unlocked');
+    assert.ok(page.root.list.courses[1].status.isLocked, 'second course is locked');
+    assert.notOk(page.root.list.courses[0].status.canLock, 'first course cannot be locked');
+    assert.notOk(page.root.list.courses[1].status.canUnlock, 'second course cannot be unlocked');
   });
 
   test('title filter escapes regex', async function (assert) {
@@ -858,10 +859,6 @@ module('Acceptance | Courses', function (hooks) {
 
     await page.root.list.courses[0].status.remove();
 
-    assert.strictEqual(
-      page.root.list.courses[0].status.lockIcon.label,
-      'This cannot be used while confirming deletion.',
-    );
     assert.strictEqual(
       page.root.list.courses[0].status.lockIcon.title,
       'This cannot be used while confirming deletion.',

--- a/packages/frontend/tests/acceptance/school/vocabularies-test.js
+++ b/packages/frontend/tests/acceptance/school/vocabularies-test.js
@@ -45,10 +45,12 @@ module('Acceptance | School - Vocabularies', function (hooks) {
     assert.strictEqual(c.vocabulariesList.vocabularies.length, 2);
     assert.strictEqual(c.vocabulariesList.vocabularies[0].title.text, 'Vocabulary 1');
     assert.strictEqual(c.vocabulariesList.vocabularies[0].termsCount, '2');
-    assert.notOk(c.vocabulariesList.vocabularies[0].hasDeleteButton);
+    assert.ok(c.vocabulariesList.vocabularies[0].hasDeleteButton);
+    assert.ok(c.vocabulariesList.vocabularies[0].deleteButtonIsDisabled);
     assert.strictEqual(c.vocabulariesList.vocabularies[1].title.text, 'Vocabulary 2');
     assert.strictEqual(c.vocabulariesList.vocabularies[1].termsCount, '1');
-    assert.notOk(c.vocabulariesList.vocabularies[1].hasDeleteButton);
+    assert.ok(c.vocabulariesList.vocabularies[1].hasDeleteButton);
+    assert.ok(c.vocabulariesList.vocabularies[1].deleteButtonIsDisabled);
   });
 
   test('add new vocabulary', async function (assert) {

--- a/packages/frontend/tests/integration/components/courses/list-item-test.gjs
+++ b/packages/frontend/tests/integration/components/courses/list-item-test.gjs
@@ -55,10 +55,10 @@ module('Integration | Component | courses/list-item', function (hooks) {
     assert.strictEqual(component.startDate, '04/23/2023');
     assert.strictEqual(component.endDate, '05/30/2023');
     assert.strictEqual(component.publicationStatus.icon.title, 'Not Published');
-    assert.ok(component.isUnlocked);
-    assert.notOk(component.isLocked);
-    assert.ok(component.isUnlocked);
-    assert.ok(component.isUnlocked);
+    assert.ok(component.status.isUnlocked);
+    assert.notOk(component.status.isLocked);
+    assert.ok(component.status.isUnlocked);
+    assert.ok(component.status.isUnlocked);
   });
 
   test('lock', async function (assert) {
@@ -78,10 +78,10 @@ module('Integration | Component | courses/list-item', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.isUnlocked);
-    assert.notOk(component.isLocked);
-    assert.ok(component.canLock);
-    await component.lock();
+    assert.ok(component.status.isUnlocked);
+    assert.notOk(component.status.isLocked);
+    assert.ok(component.status.canLock);
+    await component.status.lock();
     assert.verifySteps(['lock called']);
   });
 
@@ -103,10 +103,10 @@ module('Integration | Component | courses/list-item', function (hooks) {
         />
       </template>,
     );
-    assert.notOk(component.isUnlocked);
-    assert.ok(component.isLocked);
-    assert.ok(component.canUnlock);
-    await component.unLock();
+    assert.notOk(component.status.isUnlocked);
+    assert.ok(component.status.isLocked);
+    assert.ok(component.status.canUnlock);
+    await component.status.unLock();
     assert.verifySteps(['unlock called']);
   });
 
@@ -127,8 +127,8 @@ module('Integration | Component | courses/list-item', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.canRemove);
-    await component.remove();
+    assert.ok(component.status.canRemove);
+    await component.status.remove();
     assert.verifySteps(['confirmRemoval called']);
   });
 
@@ -151,8 +151,8 @@ module('Integration | Component | courses/list-item', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.isLocked);
-    assert.notOk(component.canUnlock);
+    assert.ok(component.status.isLocked);
+    assert.notOk(component.status.canUnlock);
   });
 
   test('cannot lock', async function (assert) {
@@ -173,8 +173,8 @@ module('Integration | Component | courses/list-item', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.isUnlocked);
-    assert.notOk(component.canLock);
+    assert.ok(component.status.isUnlocked);
+    assert.notOk(component.status.canLock);
   });
 
   test('cannot delete b/c course has been rolled over', async function (assert) {

--- a/packages/frontend/tests/integration/components/courses/list-test.gjs
+++ b/packages/frontend/tests/integration/components/courses/list-test.gjs
@@ -484,8 +484,8 @@ module('Integration | Component | courses/list', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.courses[0].isUnlocked);
-    await component.courses[0].lock();
+    assert.ok(component.courses[0].status.isUnlocked);
+    await component.courses[0].status.lock();
     assert.verifySteps(['lock called']);
   });
 
@@ -510,8 +510,8 @@ module('Integration | Component | courses/list', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.courses[0].isLocked);
-    await component.courses[0].unLock();
+    assert.ok(component.courses[0].status.isLocked);
+    await component.courses[0].status.unLock();
     assert.verifySteps(['unlock called']);
   });
 
@@ -536,7 +536,11 @@ module('Integration | Component | courses/list', function (hooks) {
         />
       </template>,
     );
-    await component.courses[0].remove();
+    assert.notOk(component.courses[0].status.removeIcon.isDisabled);
+    assert.strictEqual(component.courses[0].status.removeIcon.title, 'Remove Course');
+    await component.courses[0].status.remove();
+    assert.ok(component.courses[0].status.removeIcon.isDisabled);
+    assert.strictEqual(component.courses[0].status.removeIcon.title, 'This cannot be removed');
     await component.confirmCourseRemoval();
     assert.verifySteps(['remove called']);
   });

--- a/packages/frontend/tests/integration/components/courses/list-test.gjs
+++ b/packages/frontend/tests/integration/components/courses/list-test.gjs
@@ -537,10 +537,13 @@ module('Integration | Component | courses/list', function (hooks) {
       </template>,
     );
     assert.notOk(component.courses[0].status.removeIcon.isDisabled);
-    assert.strictEqual(component.courses[0].status.removeIcon.title, 'Remove Course');
+    assert.strictEqual(component.courses[0].status.removeIcon.title, 'Delete Course');
     await component.courses[0].status.remove();
     assert.ok(component.courses[0].status.removeIcon.isDisabled);
-    assert.strictEqual(component.courses[0].status.removeIcon.title, 'This cannot be removed');
+    assert.strictEqual(
+      component.courses[0].status.removeIcon.title,
+      'This cannot be used while confirming deletion.',
+    );
     await component.confirmCourseRemoval();
     assert.verifySteps(['remove called']);
   });

--- a/packages/frontend/tests/integration/components/school/vocabularies-list-test.gjs
+++ b/packages/frontend/tests/integration/components/school/vocabularies-list-test.gjs
@@ -48,9 +48,12 @@ module('Integration | Component | school/vocabularies-list', function (hooks) {
       </template>,
     );
     assert.strictEqual(component.vocabularies.length, 3);
-    assert.notOk(component.vocabularies[0].hasDeleteButton);
-    assert.notOk(component.vocabularies[1].hasDeleteButton);
+    assert.ok(component.vocabularies[0].hasDeleteButton);
+    assert.ok(component.vocabularies[0].deleteButtonIsDisabled);
+    assert.ok(component.vocabularies[1].hasDeleteButton);
+    assert.ok(component.vocabularies[1].deleteButtonIsDisabled);
     assert.ok(component.vocabularies[2].hasDeleteButton);
+    assert.notOk(component.vocabularies[2].deleteButtonIsDisabled);
   });
 
   test('clicking delete removes the vocabulary', async function (assert) {

--- a/packages/frontend/tests/pages/components/courses/list-item.js
+++ b/packages/frontend/tests/pages/components/courses/list-item.js
@@ -1,4 +1,12 @@
-import { attribute, clickable, create, hasClass, isVisible, text } from 'ember-cli-page-object';
+import {
+  attribute,
+  clickable,
+  create,
+  hasClass,
+  isVisible,
+  property,
+  text,
+} from 'ember-cli-page-object';
 import publicationStatus from 'ilios-common/page-objects/components/publication-status';
 
 const definition = {
@@ -18,6 +26,7 @@ const definition = {
       at: 1,
       label: attribute('aria-label'),
       title: attribute('title'),
+      isDisabled: property('disabled'),
     },
     isUnlocked: hasClass('fa-lock-open', 'svg', { at: 1 }),
     canUnlock: isVisible('[data-test-unlock]'),
@@ -27,6 +36,7 @@ const definition = {
       at: 1,
       label: attribute('aria-label'),
       title: attribute('title'),
+      isDisabled: hasClass('disabled'),
     },
     canRemove: isVisible('[data-test-remove]'),
     remove: clickable('[data-test-remove]'),
@@ -34,10 +44,7 @@ const definition = {
       scope: '[data-test-remove]',
       label: attribute('aria-label'),
       title: attribute('title'),
-    },
-    removeDisabledIcon: {
-      scope: '.fa-trash.disabled',
-      title: text('title'),
+      isDisabled: property('disabled'),
     },
   },
 };

--- a/packages/frontend/tests/pages/components/courses/list-item.js
+++ b/packages/frontend/tests/pages/components/courses/list-item.js
@@ -1,12 +1,6 @@
-import {
-  attribute,
-  clickable,
-  create,
-  hasClass,
-  isVisible,
-  property,
-  text,
-} from 'ember-cli-page-object';
+import { attribute, clickable, create, hasClass, property, text } from 'ember-cli-page-object';
+import { findOne } from 'ember-cli-page-object/extend';
+import { getter } from 'ember-cli-page-object/macros';
 import publicationStatus from 'ilios-common/page-objects/components/publication-status';
 
 const definition = {
@@ -19,35 +13,38 @@ const definition = {
   status: {
     scope: '[data-test-status]',
     isLocked: hasClass('fa-lock', 'svg', { at: 1 }),
-    canLock: isVisible('[data-test-lock]'),
+    canLock: isVisibleAndEnabled('[data-test-lock]'),
     lock: clickable('[data-test-lock]'),
     lockIcon: {
       scope: '[data-test-lock]',
       at: 1,
-      label: attribute('aria-label'),
       title: attribute('title'),
       isDisabled: property('disabled'),
     },
     isUnlocked: hasClass('fa-lock-open', 'svg', { at: 1 }),
-    canUnlock: isVisible('[data-test-unlock]'),
+    canUnlock: isVisibleAndEnabled('[data-test-unlock]'),
     unLock: clickable('[data-test-unlock]'),
     unlockIcon: {
       scope: '[data-test-unlock]',
       at: 1,
-      label: attribute('aria-label'),
       title: attribute('title'),
       isDisabled: hasClass('disabled'),
     },
-    canRemove: isVisible('[data-test-remove]'),
+    canRemove: isVisibleAndEnabled('[data-test-remove]'),
     remove: clickable('[data-test-remove]'),
     removeIcon: {
       scope: '[data-test-remove]',
-      label: attribute('aria-label'),
       title: attribute('title'),
       isDisabled: property('disabled'),
     },
   },
 };
+
+function isVisibleAndEnabled(selector) {
+  return getter(function (pageObjectKey) {
+    return !findOne(this, selector, { pageObjectKey }).disabled;
+  });
+}
 
 export default definition;
 export const component = create(definition);

--- a/packages/frontend/tests/pages/components/courses/list-item.js
+++ b/packages/frontend/tests/pages/components/courses/list-item.js
@@ -1,4 +1,4 @@
-import { clickable, create, hasClass, isVisible, text } from 'ember-cli-page-object';
+import { attribute, clickable, create, hasClass, isVisible, text } from 'ember-cli-page-object';
 import publicationStatus from 'ilios-common/page-objects/components/publication-status';
 
 const definition = {
@@ -8,14 +8,38 @@ const definition = {
   startDate: text('[data-test-start-date]'),
   endDate: text('[data-test-end-date]'),
   publicationStatus,
-  isLocked: hasClass('fa-lock', 'svg', { scope: '[data-test-status]', at: 1 }),
-  isUnlocked: hasClass('fa-lock-open', 'svg', { scope: '[data-test-status]', at: 1 }),
-  canLock: isVisible('[data-test-lock]', { scope: '[data-test-status]' }),
-  canUnlock: isVisible('[data-test-unlock]', { scope: '[data-test-status]' }),
-  canRemove: isVisible('[data-test-remove]', { scope: '[data-test-status]' }),
-  lock: clickable('[data-test-lock]', { scope: '[data-test-status]' }),
-  unLock: clickable('[data-test-unlock]', { scope: '[data-test-status]' }),
-  remove: clickable('[data-test-remove]', { scope: '[data-test-status]' }),
+  status: {
+    scope: '[data-test-status]',
+    isLocked: hasClass('fa-lock', 'svg', { at: 1 }),
+    canLock: isVisible('[data-test-lock]'),
+    lock: clickable('[data-test-lock]'),
+    lockIcon: {
+      scope: '[data-test-lock]',
+      at: 1,
+      label: attribute('aria-label'),
+      title: attribute('title'),
+    },
+    isUnlocked: hasClass('fa-lock-open', 'svg', { at: 1 }),
+    canUnlock: isVisible('[data-test-unlock]'),
+    unLock: clickable('[data-test-unlock]'),
+    unlockIcon: {
+      scope: '[data-test-unlock]',
+      at: 1,
+      label: attribute('aria-label'),
+      title: attribute('title'),
+    },
+    canRemove: isVisible('[data-test-remove]'),
+    remove: clickable('[data-test-remove]'),
+    removeIcon: {
+      scope: '[data-test-remove]',
+      label: attribute('aria-label'),
+      title: attribute('title'),
+    },
+    removeDisabledIcon: {
+      scope: '.fa-trash.disabled',
+      title: text('title'),
+    },
+  },
 };
 
 export default definition;

--- a/packages/frontend/tests/pages/components/courses/list.js
+++ b/packages/frontend/tests/pages/components/courses/list.js
@@ -13,6 +13,9 @@ const definition = {
   confirmCourseRemoval: clickable(
     '[data-test-courses] .confirm-removal td:nth-of-type(1) button.remove',
   ),
+  cancelCourseRemoval: clickable(
+    '[data-test-courses] .confirm-removal td:nth-of-type(1) button.done',
+  ),
   isSortedByTitleAscending: hasClass(
     'fa-arrow-down-a-z',
     '[data-test-course-headings] th:eq(0) svg',

--- a/packages/frontend/tests/pages/components/curriculum-inventory/report-list-item.js
+++ b/packages/frontend/tests/pages/components/curriculum-inventory/report-list-item.js
@@ -1,4 +1,6 @@
 import { attribute, clickable, create, isPresent, text } from 'ember-cli-page-object';
+import { findOne } from 'ember-cli-page-object/extend';
+import { getter } from 'ember-cli-page-object/macros';
 
 const definition = {
   scope: '[data-test-curriculum-inventory-report-list-item]',
@@ -11,7 +13,7 @@ const definition = {
   status: text('[data-test-status]'),
   remove: clickable('[data-test-remove]'),
   isDownloadable: isPresent('[data-test-download]'),
-  isDeletable: isPresent('[data-test-remove]'),
+  isDeletable: isVisibleAndEnabled('[data-test-remove]'),
   confirmRemoval: {
     resetScope: true,
     scope: '[data-test-confirm-removal]',
@@ -19,6 +21,12 @@ const definition = {
     cancel: clickable('[data-test-cancel]', { visible: true }),
   },
 };
+
+function isVisibleAndEnabled(selector) {
+  return getter(function (pageObjectKey) {
+    return !findOne(this, selector, { pageObjectKey }).disabled;
+  });
+}
 
 export default definition;
 export const component = create(definition);

--- a/packages/frontend/tests/pages/components/curriculum-inventory/sequence-block-list-item.js
+++ b/packages/frontend/tests/pages/components/curriculum-inventory/sequence-block-list-item.js
@@ -1,4 +1,6 @@
-import { attribute, clickable, create, isPresent, text } from 'ember-cli-page-object';
+import { attribute, clickable, create, text } from 'ember-cli-page-object';
+import { findOne } from 'ember-cli-page-object/extend';
+import { getter } from 'ember-cli-page-object/macros';
 
 const definition = {
   scope: '[data-test-curriculum-inventory-sequence-block-list-item]',
@@ -11,7 +13,7 @@ const definition = {
   endDate: text('[data-test-end-date]'),
   course: text('[data-test-course]'),
   remove: clickable('[data-test-remove]'),
-  isDeletable: isPresent('[data-test-remove]'),
+  isDeletable: isVisibleAndEnabled('[data-test-remove]'),
   confirmRemoval: {
     resetScope: true,
     scope: '[data-test-confirm-removal]',
@@ -19,6 +21,12 @@ const definition = {
     cancel: clickable('[data-test-cancel]', { visible: true }),
   },
 };
+
+function isVisibleAndEnabled(selector) {
+  return getter(function (pageObjectKey) {
+    return !findOne(this, selector, { pageObjectKey }).disabled;
+  });
+}
 
 export default definition;
 export const component = create(definition);

--- a/packages/frontend/tests/pages/components/program-year/list-item.js
+++ b/packages/frontend/tests/pages/components/program-year/list-item.js
@@ -1,4 +1,6 @@
 import { clickable, create, isVisible, text } from 'ember-cli-page-object';
+import { findOne } from 'ember-cli-page-object/extend';
+import { getter } from 'ember-cli-page-object/macros';
 
 const definition = {
   scope: '[data-test-program-year-list-item]',
@@ -18,14 +20,14 @@ const definition = {
   terms: {
     scope: '[data-test-terms]',
   },
-  canBeRemoved: isVisible('[data-test-remove]'),
+  canBeRemoved: isVisibleAndEnabled('[data-test-remove]'),
   remove: clickable('[data-test-remove]'),
   unlock: clickable('[data-test-unlock]'),
-  canBeUnlocked: isVisible('[data-test-unlock]'),
+  canBeUnlocked: isVisibleAndEnabled('[data-test-unlock]'),
   lock: clickable('[data-test-lock]'),
   isLocked: isVisible('[data-test-unlock]'),
   isUnlocked: isVisible('[data-test-lock]'),
-  canBeLocked: isVisible('[data-test-lock]'),
+  canBeLocked: isVisibleAndEnabled('[data-test-lock]'),
   confirmRemoval: {
     scope: '[data-test-confirm-removal]',
     message: text('[data-test-message]'),
@@ -34,6 +36,12 @@ const definition = {
     resetScope: true,
   },
 };
+
+function isVisibleAndEnabled(selector) {
+  return getter(function (pageObjectKey) {
+    return !findOne(this, selector, { pageObjectKey }).disabled;
+  });
+}
 
 export default definition;
 export const component = create(definition);

--- a/packages/frontend/tests/pages/components/programs/list-item.js
+++ b/packages/frontend/tests/pages/components/programs/list-item.js
@@ -1,4 +1,6 @@
-import { create, clickable, isVisible, text } from 'ember-cli-page-object';
+import { create, clickable, text } from 'ember-cli-page-object';
+import { findOne } from 'ember-cli-page-object/extend';
+import { getter } from 'ember-cli-page-object/macros';
 
 const definition = {
   scope: '[data-test-program-list-item]',
@@ -6,7 +8,7 @@ const definition = {
   school: text('[data-test-school]'),
   remove: clickable('[data-test-remove]'),
   open: clickable('[data-test-link]'),
-  canBeRemoved: isVisible('[data-test-remove]'),
+  canBeRemoved: isVisibleAndEnabled('[data-test-remove]'),
   confirmRemoval: {
     scope: '[data-test-confirm-removal] td:nth-of-type(1)',
     message: text('[data-test-message]'),
@@ -15,6 +17,12 @@ const definition = {
     resetScope: true,
   },
 };
+
+function isVisibleAndEnabled(selector) {
+  return getter(function (pageObjectKey) {
+    return !findOne(this, selector, { pageObjectKey }).disabled;
+  });
+}
 
 export default definition;
 export const component = create(definition);

--- a/packages/frontend/tests/pages/components/school/session-types-list-item.js
+++ b/packages/frontend/tests/pages/components/school/session-types-list-item.js
@@ -1,4 +1,6 @@
-import { attribute, clickable, create, hasClass, isVisible, text } from 'ember-cli-page-object';
+import { attribute, clickable, create, hasClass, text } from 'ember-cli-page-object';
+import { findOne } from 'ember-cli-page-object/extend';
+import { getter } from 'ember-cli-page-object/macros';
 
 const definition = {
   scope: '[data-test-school-session-types-list-item]',
@@ -13,7 +15,7 @@ const definition = {
   calendarColor: attribute('style', '[data-test-colorbox]'),
   manage: clickable('[data-test-manage]'),
   delete: clickable('[data-test-delete]'),
-  isDeletable: isVisible('[data-test-delete]'),
+  isDeletable: isVisibleAndEnabled('[data-test-delete]'),
   confirmRemoval: {
     scope: '[data-test-confirm-removal]',
     message: text('[data-test-message]'),
@@ -22,6 +24,12 @@ const definition = {
     resetScope: true,
   },
 };
+
+function isVisibleAndEnabled(selector) {
+  return getter(function (pageObjectKey) {
+    return !findOne(this, selector, { pageObjectKey }).disabled;
+  });
+}
 
 export default definition;
 export const component = create(definition);

--- a/packages/frontend/tests/pages/components/school/vocabularies-list.js
+++ b/packages/frontend/tests/pages/components/school/vocabularies-list.js
@@ -1,4 +1,4 @@
-import { clickable, create, collection, text, isVisible } from 'ember-cli-page-object';
+import { clickable, create, collection, isVisible, property, text } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-school-vocabularies-list]',
@@ -10,6 +10,7 @@ const definition = {
     manage: clickable('[data-test-manage]'),
     delete: clickable('[data-test-delete]'),
     hasDeleteButton: isVisible('[data-test-delete]'),
+    deleteButtonIsDisabled: property('disabled', '[data-test-delete]'),
   }),
   deletionConfirmation: {
     scope: '[data-test-confirm-removal]',

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -125,6 +125,7 @@ general:
   deselectUser: Deselect User
   didYouMean: Did you mean <a href="{href}">{suggestion}</a>?
   director: Director
+  disabledByConfirmation: This cannot be used while confirming deletion.
   disableUser: Disable User
   doesNotMatchUserRecord: 'Uploaded {description} does not match the information in Ilios, which is "{record}"'
   downloadCompetencyMap: Download Competency Map

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -59,6 +59,10 @@ general:
   canNotDeleteSchoolVocabulary: This school vocabulary cannot be deleted because it has at least one term, or you do not have permission.
   canNotDeleteSchoolVocabularyTerm: This school vocabulary term cannot be deleted because it has at least one sub-term, has an association, or you do not have permission.
   canNotDeleteSequenceBlock: This sequence block cannot be deleted because you do not have permission.
+  canNotLockCourse: This course cannot be locked because you do not have permission.
+  canNotLockProgramYear: This program year cannot be locked because you do not have permission.
+  canNotUnlockCourse: This course cannot be unlocked because you do not have permission.
+  canNotUnlockProgramYear: This program year cannot be unlocked because you do not have permission.
   changeAlertRecipients: Change-alert Recipients
   changeAlertRecipientsPlaceholder: "email1@example.edu, email2@example.edu"
   childSequenceOrder: Child Sequence Order

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -59,6 +59,10 @@ general:
   canNotDeleteSchoolVocabulary: "Este vocabulario escolar no se puede eliminar porque tiene al menos un término o no tiene permiso."
   canNotDeleteSchoolVocabularyTerm: "Este término del vocabulario escolar no se puede eliminar porque tiene al menos un término subordinado, tiene una asociación, o no tiene permiso."
   canNotDeleteSequenceBlock: "Este bloque de secuencia no se puede eliminar porque no tiene permiso."
+  canNotLockCourse: "Este curso no se puede bloquear porque no tiene permiso."
+  canNotLockProgramYear: "Este año del programa no se puede bloquear porque no tiene permiso."
+  canNotUnlockCourse: "Este curso no se puede desbloquear porque no tiene permiso."
+  canNotUnlockProgramYear: "Este año del programa no se puede desbloquear porque no tiene permiso."
   changeAlertRecipients: Destinatarios con alerta de cambio
   changeAlertRecipientsPlaceholder: "email1@example.edu, email2@example.edu"
   childSequenceOrder: Orden de Secuencia de Los Hijos

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -125,6 +125,7 @@ general:
   deselectUser: Deseleccione usuario
   didYouMean: ¿Quería decir <a href="{href}">{suggestion}</a>?
   director: Director
+  disabledByConfirmation: "Esto no se puede utilizar al confirmar la eliminación."
   disableUser: Desactivar el usuario
   doesNotMatchUserRecord: 'Cargado {description} no coincide con la información en Ilios, cuál es "{record}"'
   downloadCompetencyMap: Descargar el mapa de competencias

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -59,6 +59,10 @@ general:
   canNotDeleteSchoolVocabulary: "Ce vocabulaire ne peut pas être supprimé car il contient au moins un terme, ou vous n'en avez pas la permission."
   canNotDeleteSchoolVocabularyTerm: "Ce terme de vocabulaire ne peut pas être supprimé car il comporte au moins un sous-terme, une association, ou vous n'en avez pas la permission."
   canNotDeleteSequenceBlock: "Ce bloc de séquence ne peut pas être supprimé car vous n'en avez pas la permission."
+  canNotLockCourse: "Cette cours ne peut être verrouillée car vous n'en avez pas la permission."
+  canNotLockProgramYear: "Cette année de programme ne peut être verrouillée car vous n'en avez pas la permission."
+  canNotUnlockCourse: "Cette cours ne peut être débloqué car vous n'en avez pas la permission."
+  canNotUnlockProgramYear: "Cette année de programme ne peut être débloqué car vous n'en avez pas la permission."
   changeAlertRecipients: Destinataires des alertes de changement
   changeAlertRecipientsPlaceholder: "email1@example.edu, email2@example.edu"
   childSequenceOrder: Ordre séquentiel des enfants

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -125,6 +125,7 @@ general:
   deselectUser: "Désélectionner l'utilisateur "
   didYouMean: Confirmez-vous <a href="{href}">{suggestion}</a>?
   director: Directeur
+  disabledByConfirmation: "Cette fonction ne peut pas être utilisée lors de la confirmation d'une suppression."
   disableUser: Désactiver compte d’utilisateur
   doesNotMatchUserRecord: 'Téléchargé {description} ne correspond pas aux informations dans Ilios, qui est "{record}"'
   downloadCompetencyMap: Télécharger la tableau de compétences

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials-item.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials-item.js
@@ -1,4 +1,4 @@
-import { clickable, create, isVisible, text } from 'ember-cli-page-object';
+import { clickable, create, isVisible, property, text } from 'ember-cli-page-object';
 import userNameInfo from './user-name-info';
 import typeIcon from './lm-type-icon';
 
@@ -22,6 +22,7 @@ const definition = {
     },
     remove: {
       scope: '[data-test-remove]',
+      isDisabled: property('disabled'),
     },
   },
   confirmRemoval: {

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -289,11 +289,6 @@ export default class CourseObjectiveListItemComponent extends Component {
             <button
               class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
               type="button"
-              aria-label={{if
-                this.showRemoveConfirmation
-                (t "general.disabledByConfirmation")
-                (t "general.remove")
-              }}
               title={{if
                 this.showRemoveConfirmation
                 (t "general.disabledByConfirmation")

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -280,11 +280,15 @@ export default class CourseObjectiveListItemComponent extends Component {
       {{#if @editable}}
         <div class="actions grid-item" data-test-actions>
           {{#if this.isManaging}}
-            <FaIcon
-              @icon={{faTrash}}
-              class="disabled"
-              @title={{t "general.canNotDeleteCourseObjective"}}
-            />
+            <button
+              type="button"
+              class="link-button disabled"
+              title={{t "general.canNotDeleteCourseObjective"}}
+              disabled
+              data-test-remove
+            >
+              <FaIcon @icon={{faTrash}} class="disabled" />
+            </button>
           {{else}}
             <button
               class="link-button{{if this.showRemoveConfirmation ' disabled'}}"

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -279,11 +279,26 @@ export default class CourseObjectiveListItemComponent extends Component {
 
       {{#if @editable}}
         <div class="actions grid-item" data-test-actions>
-          {{#if (not this.isManaging)}}
+          {{#if this.isManaging}}
+            <FaIcon
+              @icon={{faTrash}}
+              class="disabled"
+              @title={{t "general.canNotDeleteCourseObjective"}}
+            />
+          {{else}}
             <button
               class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
               type="button"
-              aria-label={{t "general.remove"}}
+              aria-label={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.remove")
+              }}
+              title={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.remove")
+              }}
               disabled={{this.showRemoveConfirmation}}
               {{on "click" (set this "showRemoveConfirmation" true)}}
               data-test-remove
@@ -293,12 +308,6 @@ export default class CourseObjectiveListItemComponent extends Component {
                 class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
               />
             </button>
-          {{else}}
-            <FaIcon
-              @icon={{faTrash}}
-              class="disabled"
-              @title={{t "general.canNotDeleteCourseObjective"}}
-            />
           {{/if}}
         </div>
       {{/if}}

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -279,15 +279,19 @@ export default class CourseObjectiveListItemComponent extends Component {
 
       {{#if @editable}}
         <div class="actions grid-item" data-test-actions>
-          {{#if (and (not this.isManaging) (not this.showRemoveConfirmation))}}
+          {{#if (not this.isManaging)}}
             <button
-              class="link-button"
+              class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
               type="button"
               aria-label={{t "general.remove"}}
+              disabled={{this.showRemoveConfirmation}}
               {{on "click" (set this "showRemoveConfirmation" true)}}
               data-test-remove
             >
-              <FaIcon @icon={{faTrash}} class="enabled remove" />
+              <FaIcon
+                @icon={{faTrash}}
+                class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
+              />
             </button>
           {{else}}
             <FaIcon

--- a/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
@@ -134,11 +134,6 @@ export default class DetailLearningMaterialsItemComponent extends Component {
           <button
             type="button"
             class="icon-button{{if this.showRemoveConfirmation ' disabled'}}"
-            aria-label={{if
-              this.showRemoveConfirmation
-              (t "general.disabledByConfirmation")
-              (t "general.edit")
-            }}
             title={{if
               this.showRemoveConfirmation
               (t "general.disabledByConfirmation")
@@ -153,11 +148,6 @@ export default class DetailLearningMaterialsItemComponent extends Component {
           <button
             type="button"
             class="icon-button{{if this.showRemoveConfirmation ' disabled' ' remove'}}"
-            aria-label={{if
-              this.showRemoveConfirmation
-              (t "general.disabledByConfirmation")
-              (t "general.remove")
-            }}
             title={{if
               this.showRemoveConfirmation
               (t "general.disabledByConfirmation")

--- a/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
@@ -153,8 +153,8 @@ export default class DetailLearningMaterialsItemComponent extends Component {
               (t "general.disabledByConfirmation")
               (t "general.remove")
             }}
-            {{on "click" (set this "showRemoveConfirmation" true)}}
             disabled={{this.showRemoveConfirmation}}
+            {{on "click" (set this "showRemoveConfirmation" true)}}
             data-test-remove
           >
             <FaIcon
@@ -163,11 +163,15 @@ export default class DetailLearningMaterialsItemComponent extends Component {
             />
           </button>
         {{else}}
-          <FaIcon
-            @icon={{faTrash}}
-            class="disabled"
-            @title={{t "general.canNotDeleteLearningMaterial"}}
-          />
+          <button
+            type="button"
+            class="icon-button disabled"
+            title={{t "general.canNotDeleteLearningMaterial"}}
+            disabled
+            data-test-remove
+          >
+            <FaIcon @icon={{faTrash}} class="disabled" />
+          </button>
         {{/if}}
       </td>
     </tr>

--- a/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
@@ -133,8 +133,17 @@ export default class DetailLearningMaterialsItemComponent extends Component {
         {{#if @editable}}
           <button
             type="button"
-            class="icon-button"
-            aria-label={{t "general.edit"}}
+            class="icon-button{{if this.showRemoveConfirmation ' disabled'}}"
+            aria-label={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.edit")
+            }}
+            title={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.edit")
+            }}
             {{on "click" (fn @setManagedMaterial @lm)}}
             disabled={{this.showRemoveConfirmation}}
             data-test-edit
@@ -144,7 +153,16 @@ export default class DetailLearningMaterialsItemComponent extends Component {
           <button
             type="button"
             class="icon-button{{if this.showRemoveConfirmation ' disabled' ' remove'}}"
-            aria-label={{t "general.remove"}}
+            aria-label={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
+            title={{if
+              this.showRemoveConfirmation
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
             {{on "click" (set this "showRemoveConfirmation" true)}}
             disabled={{this.showRemoveConfirmation}}
             data-test-remove

--- a/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
@@ -136,18 +136,23 @@ export default class DetailLearningMaterialsItemComponent extends Component {
             class="icon-button"
             aria-label={{t "general.edit"}}
             {{on "click" (fn @setManagedMaterial @lm)}}
+            disabled={{this.showRemoveConfirmation}}
             data-test-edit
           >
-            <FaIcon @icon={{faPenToSquare}} />
+            <FaIcon @icon={{faPenToSquare}} class={{if this.showRemoveConfirmation "disabled"}} />
           </button>
           <button
             type="button"
-            class="icon-button remove"
+            class="icon-button{{if this.showRemoveConfirmation ' disabled' ' remove'}}"
             aria-label={{t "general.remove"}}
             {{on "click" (set this "showRemoveConfirmation" true)}}
+            disabled={{this.showRemoveConfirmation}}
             data-test-remove
           >
-            <FaIcon @icon={{faTrash}} class="enabled remove" />
+            <FaIcon
+              @icon={{faTrash}}
+              class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
+            />
           </button>
         {{else}}
           <FaIcon

--- a/packages/ilios-common/addon/components/offering-manager.gjs
+++ b/packages/ilios-common/addon/components/offering-manager.gjs
@@ -261,7 +261,7 @@ export default class OfferingManagerComponent extends Component {
               >
                 <FaIcon
                   @icon={{faPenToSquare}}
-                  class="{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+                  class={{if this.showRemoveConfirmation "disabled" "enabled"}}
                 />
               </button>
               {{#if @editable}}

--- a/packages/ilios-common/addon/components/offering-manager.gjs
+++ b/packages/ilios-common/addon/components/offering-manager.gjs
@@ -11,7 +11,7 @@ import mouseHoverToggle from 'ilios-common/modifiers/mouse-hover-toggle';
 import { fn, get, concat } from '@ember/helper';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import t from 'ember-intl/helpers/t';
-import { and, eq, not } from 'ember-truth-helpers';
+import { and, eq } from 'ember-truth-helpers';
 import includes from 'ilios-common/helpers/includes';
 import IliosTooltip from 'ilios-common/components/ilios-tooltip';
 import mapBy0 from 'ilios-common/helpers/map-by';
@@ -245,26 +245,34 @@ export default class OfferingManagerComponent extends Component {
               {{/each}}
             </ul>
           </div>
-          {{#if (and @editable (not this.showRemoveConfirmation))}}
+          {{#if @editable}}
             <div class="offering-manager-actions">
               <button
                 class="link-button edit"
                 type="button"
                 title={{t "general.edit"}}
+                disabled={{this.showRemoveConfirmation}}
                 {{on "click" this.toggleIsEditing}}
                 data-test-edit
               >
-                <FaIcon @icon={{faPenToSquare}} class="enabled" />
+                <FaIcon
+                  @icon={{faPenToSquare}}
+                  class="{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+                />
               </button>
               {{#if @editable}}
                 <button
                   class="link-button remove"
                   type="button"
                   title={{t "general.remove"}}
+                  disabled={{this.showRemoveConfirmation}}
                   {{on "click" (set0 this "showRemoveConfirmation" true)}}
                   data-test-remove
                 >
-                  <FaIcon @icon={{faTrash}} class="enabled remove" />
+                  <FaIcon
+                    @icon={{faTrash}}
+                    class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+                  />
                 </button>
               {{else}}
                 <FaIcon

--- a/packages/ilios-common/addon/components/offering-manager.gjs
+++ b/packages/ilios-common/addon/components/offering-manager.gjs
@@ -250,11 +250,6 @@ export default class OfferingManagerComponent extends Component {
               <button
                 class="link-button edit"
                 type="button"
-                aria-label={{if
-                  this.showRemoveConfirmation
-                  (t "general.disabledByConfirmation")
-                  (t "general.edit")
-                }}
                 title={{if
                   this.showRemoveConfirmation
                   (t "general.disabledByConfirmation")
@@ -273,11 +268,6 @@ export default class OfferingManagerComponent extends Component {
                 <button
                   class="link-button remove"
                   type="button"
-                  aria-label={{if
-                    this.showRemoveConfirmation
-                    (t "general.disabledByConfirmation")
-                    (t "general.remove")
-                  }}
                   title={{if
                     this.showRemoveConfirmation
                     (t "general.disabledByConfirmation")

--- a/packages/ilios-common/addon/components/offering-manager.gjs
+++ b/packages/ilios-common/addon/components/offering-manager.gjs
@@ -250,7 +250,16 @@ export default class OfferingManagerComponent extends Component {
               <button
                 class="link-button edit"
                 type="button"
-                title={{t "general.edit"}}
+                aria-label={{if
+                  this.showRemoveConfirmation
+                  (t "general.disabledByConfirmation")
+                  (t "general.edit")
+                }}
+                title={{if
+                  this.showRemoveConfirmation
+                  (t "general.disabledByConfirmation")
+                  (t "general.edit")
+                }}
                 disabled={{this.showRemoveConfirmation}}
                 {{on "click" this.toggleIsEditing}}
                 data-test-edit
@@ -264,14 +273,23 @@ export default class OfferingManagerComponent extends Component {
                 <button
                   class="link-button remove"
                   type="button"
-                  title={{t "general.remove"}}
+                  aria-label={{if
+                    this.showRemoveConfirmation
+                    (t "general.disabledByConfirmation")
+                    (t "general.remove")
+                  }}
+                  title={{if
+                    this.showRemoveConfirmation
+                    (t "general.disabledByConfirmation")
+                    (t "general.remove")
+                  }}
                   disabled={{this.showRemoveConfirmation}}
                   {{on "click" (set0 this "showRemoveConfirmation" true)}}
                   data-test-remove
                 >
                   <FaIcon
                     @icon={{faTrash}}
-                    class="remove{{if this.showRemoveConfirmation ' disabled' ' enabled'}}"
+                    class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
                   />
                 </button>
               {{else}}

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -272,11 +272,6 @@ export default class SessionObjectiveListItemComponent extends Component {
             <button
               class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
               type="button"
-              aria-label={{if
-                this.showRemoveConfirmation
-                (t "general.disabledByConfirmation")
-                (t "general.remove")
-              }}
               title={{if
                 this.showRemoveConfirmation
                 (t "general.disabledByConfirmation")

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -262,15 +262,19 @@ export default class SessionObjectiveListItemComponent extends Component {
 
       {{#if @editable}}
         <div class="actions grid-item" data-test-actions>
-          {{#if (and (not this.isManaging) (not this.showRemoveConfirmation))}}
+          {{#if (not this.isManaging)}}
             <button
-              class="link-button"
+              class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
               type="button"
               aria-label={{t "general.remove"}}
+              disabled={{this.showRemoveConfirmation}}
               {{on "click" (set this "showRemoveConfirmation" true)}}
               data-test-remove
             >
-              <FaIcon @icon={{faTrash}} class="enabled remove" />
+              <FaIcon
+                @icon={{faTrash}}
+                class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
+              />
             </button>
           {{else}}
             <FaIcon

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -263,11 +263,15 @@ export default class SessionObjectiveListItemComponent extends Component {
       {{#if @editable}}
         <div class="actions grid-item" data-test-actions>
           {{#if this.isManaging}}
-            <FaIcon
-              @icon={{faTrash}}
-              class="disabled"
-              @title={{t "general.canNotDeleteSessionObjective"}}
-            />
+            <button
+              type="button"
+              class="link-button disabled"
+              title={{t "general.canNotDeleteSessionObjective"}}
+              disabled
+              data-test-remove
+            >
+              <FaIcon @icon={{faTrash}} class="disabled" />
+            </button>
           {{else}}
             <button
               class="link-button{{if this.showRemoveConfirmation ' disabled'}}"

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -262,11 +262,26 @@ export default class SessionObjectiveListItemComponent extends Component {
 
       {{#if @editable}}
         <div class="actions grid-item" data-test-actions>
-          {{#if (not this.isManaging)}}
+          {{#if this.isManaging}}
+            <FaIcon
+              @icon={{faTrash}}
+              class="disabled"
+              @title={{t "general.canNotDeleteSessionObjective"}}
+            />
+          {{else}}
             <button
               class="link-button{{if this.showRemoveConfirmation ' disabled'}}"
               type="button"
-              aria-label={{t "general.remove"}}
+              aria-label={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.remove")
+              }}
+              title={{if
+                this.showRemoveConfirmation
+                (t "general.disabledByConfirmation")
+                (t "general.remove")
+              }}
               disabled={{this.showRemoveConfirmation}}
               {{on "click" (set this "showRemoveConfirmation" true)}}
               data-test-remove
@@ -276,12 +291,6 @@ export default class SessionObjectiveListItemComponent extends Component {
                 class={{if this.showRemoveConfirmation "disabled" "remove enabled"}}
               />
             </button>
-          {{else}}
-            <FaIcon
-              @icon={{faTrash}}
-              class="disabled"
-              @title={{t "general.canNotDeleteSessionObjective"}}
-            />
           {{/if}}
         </div>
       {{/if}}

--- a/packages/ilios-common/addon/components/sessions-grid-session-row.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-session-row.gjs
@@ -195,11 +195,6 @@ export default class SessionsGridSessionRowComponent extends Component {
             class="link-button{{if @showConfirmDelete ' disabled'}}"
             type="button"
             {{on "click" (fn @confirmDelete @session.id)}}
-            aria-label={{if
-              @showConfirmDelete
-              (t "general.disabledByConfirmation")
-              (t "general.remove")
-            }}
             title={{if
               @showConfirmDelete
               (t "general.disabledByConfirmation")

--- a/packages/ilios-common/addon/components/sessions-grid-session-row.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-session-row.gjs
@@ -192,13 +192,18 @@ export default class SessionsGridSessionRowComponent extends Component {
       <span class="session-grid-actions" data-test-actions>
         {{#if (and this.canUpdate (not @session.prerequisiteCount))}}
           <button
-            class="link-button"
+            class="link-button{{if @showConfirmDelete ' disabled'}}"
             type="button"
             {{on "click" (fn @confirmDelete @session.id)}}
             title={{t "general.remove"}}
+            disabled={{@showConfirmDelete}}
             data-test-delete
           >
-            <FaIcon @icon={{faTrash}} @ariaHidden={{false}} class="remove enabled" />
+            <FaIcon
+              @icon={{faTrash}}
+              @ariaHidden={{false}}
+              class="remove{{if @showConfirmDelete ' disabled' ' enabled'}}"
+            />
           </button>
         {{else}}
           <FaIcon

--- a/packages/ilios-common/addon/components/sessions-grid-session-row.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-session-row.gjs
@@ -195,14 +195,23 @@ export default class SessionsGridSessionRowComponent extends Component {
             class="link-button{{if @showConfirmDelete ' disabled'}}"
             type="button"
             {{on "click" (fn @confirmDelete @session.id)}}
-            title={{t "general.remove"}}
+            aria-label={{if
+              @showConfirmDelete
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
+            title={{if
+              @showConfirmDelete
+              (t "general.disabledByConfirmation")
+              (t "general.remove")
+            }}
             disabled={{@showConfirmDelete}}
             data-test-delete
           >
             <FaIcon
               @icon={{faTrash}}
               @ariaHidden={{false}}
-              class="remove{{if @showConfirmDelete ' disabled' ' enabled'}}"
+              class={{if @showConfirmDelete " disabled" "remove enabled"}}
             />
           </button>
         {{else}}

--- a/packages/ilios-common/addon/components/sessions-grid.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid.gjs
@@ -230,6 +230,7 @@ export default class SessionsGridComponent extends Component {
             @session={{session}}
             @sessionsForRemovalConfirmation={{this.confirmDeleteSessionIds}}
             @confirmDelete={{this.confirmDelete}}
+            @showConfirmDelete={{includes session.id this.confirmDeleteSessionIds}}
             @closeSession={{@closeSession}}
             @expandSession={{this.expandSession}}
             @expandedSessionIds={{@expandedSessionIds}}

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -23,8 +23,8 @@ a,
 .link {
   @include m.ilios-link;
 
-  &.disabled {
-    cursor: default;
+  &.disabled:active {
+    pointer-events: none;
   }
 }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -22,6 +22,10 @@ body {
 a,
 .link {
   @include m.ilios-link;
+
+  &.disabled {
+    cursor: default;
+  }
 }
 
 button {

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -114,6 +114,10 @@
     .icon-button {
       @include m.ilios-button-reset;
       color: var(--light-blue);
+
+      &.disabled {
+        cursor: default;
+      }
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/button.scss
@@ -12,6 +12,7 @@ button {
 
     &:disabled {
       color: var(--black);
+      cursor: default;
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/icons.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/icons.scss
@@ -10,5 +10,6 @@
 
   &.disabled {
     color: var(--grey);
+    cursor: default;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/ilios-removable-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/ilios-removable-table.scss
@@ -34,7 +34,7 @@
         padding-top: 1.1em;
       }
 
-      .remove {
+      .remove:not(.disabled) {
         background-color: var(--white);
         color: var(--red);
 

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -109,6 +109,7 @@ general:
   description: Description
   directorCount: "There {count, plural, =1 {is 1 director} other {are # directors}}"
   directors: Directors
+  disabledByConfirmation: This cannot be used while confirming deletion.
   disabledUserAccount: disabled user account
   displayName: Display Name
   done: Done

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -109,6 +109,7 @@ general:
   description: Descripción
   directorCount: "Hay {count, plural, =1 {1 director} other {# directores}}"
   directors: Directores
+  disabledByConfirmation: "Esto no se puede utilizar al confirmar la eliminación."
   disabledUserAccount: cuenta de usuario deshabilitada
   displayName: Nombre de Mostrar
   done: Acabado

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -109,6 +109,7 @@ general:
   description: Description
   directorCount: "Il y a {count, plural, =1 {un directeur} other {# directeurs}}"
   directors: Directeurs
+  disabledByConfirmation: "Cette fonction ne peut pas être utilisée lors de la confirmation d'une suppression."
   disabledUserAccount: compte utilisateur désactivé
   displayName: Nom d’Affichage
   done: Fini

--- a/packages/test-app/tests/integration/components/detail-learning-materials-item-test.gjs
+++ b/packages/test-app/tests/integration/components/detail-learning-materials-item-test.gjs
@@ -54,6 +54,7 @@ module('Integration | Component | detail-learning-materials-item', function (hoo
     assert.ok(component.isNotePublic);
     assert.ok(component.actions.edit.isVisible);
     assert.ok(component.actions.remove.isVisible);
+    assert.notOk(component.actions.remove.isDisabled);
   });
 
   test('read-only', async function (assert) {
@@ -75,8 +76,9 @@ module('Integration | Component | detail-learning-materials-item', function (hoo
     assert.strictEqual(component.mesh, 'descriptor 0 descriptor 1');
     assert.strictEqual(component.status, 'status 1');
     assert.ok(component.isNotePublic);
-    assert.notOk(component.actions.edit.isVisible);
-    assert.notOk(component.actions.remove.isVisible);
+    assert.notOk(component.actions.edit.isVisible, 'edit icon is not visible');
+    assert.ok(component.actions.remove.isVisible, 'remove icon is visible');
+    assert.ok(component.actions.remove.isDisabled, 'remove icon is disabled');
   });
 
   test('click to delete and cancel', async function (assert) {


### PR DESCRIPTION
Fixes ilios/ilios#7072
Fixes ilios/ilios#7073

Relies on https://github.com/ilios/frontend/pull/9281 going through first

Sections to check
- [x] Course
- [x] Course Objective
- [x] Session
- [x] Session Objective
- [x] Session Offering
- [x] Course/Session Learning Material
- [x] Learner Group
- [x] Instructor Group
- [x] School Vocabulary
- [x] School Session Type
- [x] Program
- [x] Program Year
- [x] Program Year Objective
- [x] Curricular Inventory Report
- [x] Sequence Block

Additional things
- [x] Add/update tests