### PR TITLE
Make all manual instances of `faSpinner` use `LoadingSpinner` component

### DIFF
--- a/packages/frontend/app/components/curriculum-inventory/report-header.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-header.gjs
@@ -11,10 +11,11 @@ import { on } from '@ember/modifier';
 import pick from 'ilios-common/helpers/pick';
 import set from 'ember-set-helper/helpers/set';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { not } from 'ember-truth-helpers';
 import focus from 'ilios-common/modifiers/focus';
-import { faLock, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faLock } from '@fortawesome/free-solid-svg-icons';
 
 export default class CurriculumInventoryReportHeaderComponent extends Component {
   @tracked name;
@@ -102,7 +103,7 @@ export default class CurriculumInventoryReportHeaderComponent extends Component 
         >
           {{t "general.finalize"}}
           {{#if @isFinalizing}}
-            <FaIcon @icon={{faSpinner}} @spin={{true}} />
+            <LoadingSpinner />
           {{/if}}
         </button>
       </div>

--- a/packages/frontend/app/components/global-search.gjs
+++ b/packages/frontend/app/components/global-search.gjs
@@ -4,7 +4,6 @@ import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 import GlobalSearchBox from './global-search-box';
 import { and, gt, not } from 'ember-truth-helpers';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import t from 'ember-intl/helpers/t';
 import CourseSearchResult from './course-search-result';
 import { on } from '@ember/modifier';
@@ -14,7 +13,7 @@ import includes from 'ilios-common/helpers/includes';
 import PaginationLinks from './pagination-links';
 import { htmlSafe } from '@ember/template';
 import { modifier } from 'ember-modifier';
-import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 
 const COURSES_PER_PAGE = 10;
 
@@ -141,7 +140,7 @@ export default class GlobalSearchComponent extends Component {
       >
         {{#if this.resultsData.isPending}}
           <li class="searching" data-test-searching>
-            <FaIcon @icon={{faSpinner}} class="orange" @spin={{true}} />
+            <LoadingSpinner @class="orange" />
             {{t "general.currentlySearchingPrompt"}}
           </li>
         {{else}}

--- a/packages/frontend/app/components/program-year/objective-list-item-competency.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item-competency.gjs
@@ -1,7 +1,8 @@
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
-import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { faArrowRotateLeft, faCheck } from '@fortawesome/free-solid-svg-icons';
 <template>
   <div
     class="program-year-objective-list-item-competency grid-item"
@@ -17,7 +18,7 @@ import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-s
         data-test-save
       >
         {{#if @isSaving}}
-          <FaIcon @icon={{faSpinner}} @spin={{true}} />
+          <LoadingSpinner />
         {{else}}
           <FaIcon @icon={{faCheck}} />
         {{/if}}

--- a/packages/frontend/app/components/program-year/objective-list-item-descriptors.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item-descriptors.gjs
@@ -1,8 +1,9 @@
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import sortBy from 'ilios-common/helpers/sort-by';
-import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faArrowRotateLeft, faCheck } from '@fortawesome/free-solid-svg-icons';
 <template>
   <div
     class="program-year-objective-list-item-descriptors grid-item"
@@ -18,7 +19,7 @@ import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-s
         data-test-save
       >
         {{#if @isSaving}}
-          <FaIcon @icon={{faSpinner}} @spin={{true}} />
+          <LoadingSpinner />
         {{else}}
           <FaIcon @icon={{faCheck}} />
         {{/if}}

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -8,7 +8,7 @@ import { findById, sortBy } from 'ilios-common/utils/array-helpers';
 import { on } from '@ember/modifier';
 import set from 'ember-set-helper/helpers/set';
 import { and, not } from 'ember-truth-helpers';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import t from 'ember-intl/helpers/t';
 import EditableField from 'ilios-common/components/editable-field';
 import perform from 'ember-concurrency/helpers/perform';
@@ -16,7 +16,6 @@ import HtmlEditor from 'ilios-common/components/html-editor';
 import ObjectiveListItemCompetency from './objective-list-item-competency';
 import ObjectiveListItemTerms from 'ilios-common/components/objective-list-item-terms';
 import ObjectiveListItemDescriptors from './objective-list-item-descriptors';
-import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import ManageObjectiveCompetency from './manage-objective-competency';
 import ManageObjectiveDescriptors from './manage-objective-descriptors';
 import ObjectiveListItemExpanded from './objective-list-item-expanded';
@@ -26,10 +25,10 @@ import YupValidationMessage from 'ilios-common/components/yup-validation-message
 import { string } from 'yup';
 import striptags from 'striptags';
 import FadeText from 'ilios-common/components/fade-text';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import {
   faCaretDown,
   faCaretRight,
-  faSpinner,
   faToggleOff,
   faToggleOn,
   faTrash,
@@ -433,7 +432,7 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
             {{on "click" (perform this.deleteObjective)}}
           >
             {{#if this.deleteObjective.isRunning}}
-              <FaIcon @icon={{faSpinner}} @spin={{true}} />
+              <LoadingSpinner />
             {{else}}
               {{t "general.yes"}}
             {{/if}}

--- a/packages/frontend/app/components/reports/curriculum/header.gjs
+++ b/packages/frontend/app/components/reports/curriculum/header.gjs
@@ -9,9 +9,10 @@ import CopyButton from 'ilios-common/components/copy-button';
 import perform from 'ember-concurrency/helpers/perform';
 import mouseHoverToggle from 'ilios-common/modifiers/mouse-hover-toggle';
 import set from 'ember-set-helper/helpers/set';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import IliosTooltip from 'ilios-common/components/ilios-tooltip';
-import { faCheck, faCopy, faDownload, faPlay, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faCheck, faCopy, faDownload, faPlay } from '@fortawesome/free-solid-svg-icons';
 
 export default class ReportsCurriculumHeaderComponent extends Component {
   @service flashMessages;
@@ -207,7 +208,7 @@ export default class ReportsCurriculumHeaderComponent extends Component {
         {{#if @showReportResults}}
           {{#if @loading}}
             <div class="loading-results">
-              <FaIcon @icon={{faSpinner}} @spin={{true}} />
+              <LoadingSpinner />
             </div>
           {{else}}
             <button type="button" {{on "click" @download}} data-test-download>

--- a/packages/frontend/app/components/school/competencies-list-item-pcrs.gjs
+++ b/packages/frontend/app/components/school/competencies-list-item-pcrs.gjs
@@ -5,11 +5,12 @@ import { TrackedAsyncData } from 'ember-async-data';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import perform from 'ember-concurrency/helpers/perform';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import sortBy from 'ilios-common/helpers/sort-by';
 import { fn } from '@ember/helper';
 import pcrsUriToNumber from '../../helpers/pcrs-uri-to-number';
-import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faArrowRotateLeft, faCheck } from '@fortawesome/free-solid-svg-icons';
 
 export default class SchoolCompetenciesListItemPcrsComponent extends Component {
   save = task({ drop: true }, async () => {
@@ -40,7 +41,7 @@ export default class SchoolCompetenciesListItemPcrsComponent extends Component {
           data-test-save
         >
           {{#if this.save.isRunning}}
-            <FaIcon @icon={{faSpinner}} @spin={{true}} />
+            <LoadingSpinner />
           {{else}}
             <FaIcon @icon={{faCheck}} />
           {{/if}}

--- a/packages/frontend/app/components/school/visualize-session-type-vocabularies-graph.gjs
+++ b/packages/frontend/app/components/school/visualize-session-type-vocabularies-graph.gjs
@@ -13,12 +13,13 @@ import SimpleChart from 'ember-simple-charts/components/simple-chart';
 import perform from 'ember-concurrency/helpers/perform';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import SortableTh from 'ilios-common/components/sortable-th';
 import { fn, array } from '@ember/helper';
 import sortBy from 'ilios-common/helpers/sort-by';
 import { LinkTo } from '@ember/routing';
-import { faDownload, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faDownload } from '@fortawesome/free-solid-svg-icons';
 
 export default class SchoolVisualizeSessionTypeVocabulariesGraphComponent extends Component {
   @service router;
@@ -285,7 +286,7 @@ export default class SchoolVisualizeSessionTypeVocabulariesGraphComponent extend
           </div>
         {{/if}}
       {{else}}
-        <FaIcon @icon={{faSpinner}} @spin={{true}} />
+        <LoadingSpinner />
       {{/if}}
     </div>
   </template>

--- a/packages/frontend/app/components/school/visualize-session-type-vocabulary-graph.gjs
+++ b/packages/frontend/app/components/school/visualize-session-type-vocabulary-graph.gjs
@@ -13,11 +13,12 @@ import SimpleChart from 'ember-simple-charts/components/simple-chart';
 import perform from 'ember-concurrency/helpers/perform';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import SortableTh from 'ilios-common/components/sortable-th';
 import { fn } from '@ember/helper';
 import sortBy from 'ilios-common/helpers/sort-by';
-import { faDownload, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faDownload } from '@fortawesome/free-solid-svg-icons';
 
 export default class SchoolVisualizeSessionTypeVocabularyGraphComponent extends Component {
   @service router;
@@ -235,7 +236,7 @@ export default class SchoolVisualizeSessionTypeVocabularyGraphComponent extends 
           </div>
         {{/if}}
       {{else}}
-        <FaIcon @icon={{faSpinner}} @spin={{true}} />
+        <LoadingSpinner />
       {{/if}}
     </div>
   </template>

--- a/packages/ilios-common/addon/components/course/materials.gjs
+++ b/packages/ilios-common/addon/components/course/materials.gjs
@@ -17,6 +17,7 @@ import includes from 'ilios-common/helpers/includes';
 import capitalize from 'ilios-common/helpers/capitalize';
 import formatDate from 'ember-intl/helpers/format-date';
 import { pageTitle } from 'ember-page-title';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 const DEBOUNCE_DELAY = 250;
@@ -352,7 +353,8 @@ export default class CourseMaterialsComponent extends Component {
             {{#if this.isLoading}}
               <tr>
                 <td colspan="9" align="center">
-                  <FaIcon @icon={{faSpinner}} class="orange" @size="2x" @spin={{true}} />
+                  <LoadingSpinner @class="orange" @size="2x" />
+
                 </td>
               </tr>
             {{else}}

--- a/packages/ilios-common/addon/components/course/objective-list-item-descriptors.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item-descriptors.gjs
@@ -1,8 +1,9 @@
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import sortBy from 'ilios-common/helpers/sort-by';
-import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faArrowRotateLeft, faCheck } from '@fortawesome/free-solid-svg-icons';
 <template>
   <div
     class="course-objective-list-item-descriptors grid-item"
@@ -18,7 +19,7 @@ import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-s
         data-test-save
       >
         {{#if @isSaving}}
-          <FaIcon @icon={{faSpinner}} @spin={{true}} />
+          <LoadingSpinner />
         {{else}}
           <FaIcon @icon={{faCheck}} />
         {{/if}}

--- a/packages/ilios-common/addon/components/course/objective-list-item-parents.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item-parents.gjs
@@ -2,9 +2,10 @@ import Component from '@glimmer/component';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import FadeText from 'ilios-common/components/fade-text';
-import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faArrowRotateLeft, faCheck } from '@fortawesome/free-solid-svg-icons';
 
 export default class CourseObjectiveListItemParentsComponent extends Component {
   get parentTitles() {
@@ -30,7 +31,7 @@ export default class CourseObjectiveListItemParentsComponent extends Component {
           data-test-save
         >
           {{#if @isSaving}}
-            <FaIcon @icon={{faSpinner}} @spin={{true}} />
+            <LoadingSpinner />
           {{else}}
             <FaIcon @icon={{faCheck}} />
           {{/if}}

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -16,7 +16,7 @@ import ObjectiveListItemDescriptors from 'ilios-common/components/course/objecti
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import set from 'ember-set-helper/helpers/set';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import ManageObjectiveParents from 'ilios-common/components/course/manage-objective-parents';
 import ManageObjectiveDescriptors from 'ilios-common/components/course/manage-objective-descriptors';
 import TaxonomyManager from 'ilios-common/components/taxonomy-manager';
@@ -24,7 +24,8 @@ import YupValidations from 'ilios-common/classes/yup-validations';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import { string } from 'yup';
 import striptags from 'striptags';
-import { faSpinner, faTrash } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export default class CourseObjectiveListItemComponent extends Component {
   @service store;
@@ -310,7 +311,7 @@ export default class CourseObjectiveListItemComponent extends Component {
               {{on "click" (perform this.deleteObjective)}}
             >
               {{#if this.deleteObjective.isRunning}}
-                <FaIcon @icon={{faSpinner}} @spin={{true}} />
+                <LoadingSpinner />
               {{else}}
                 {{t "general.yes"}}
               {{/if}}

--- a/packages/ilios-common/addon/components/daily-calendar.gjs
+++ b/packages/ilios-common/addon/components/daily-calendar.gjs
@@ -3,12 +3,11 @@ import { service } from '@ember/service';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 import { modifier } from 'ember-modifier';
 import { DateTime } from 'luxon';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
 import DailyCalendarEvent from 'ilios-common/components/daily-calendar-event';
 import { fn } from '@ember/helper';
-import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 export default class DailyCalendarComponent extends Component {
   @service intl;
@@ -66,7 +65,7 @@ export default class DailyCalendarComponent extends Component {
     >
       <h2 class="day-of-week" data-test-day-of-week>
         {{#if @isLoadingEvents}}
-          <FaIcon @icon={{faSpinner}} @spin={{true}} />
+          <LoadingSpinner />
           {{t "general.loadingEvents"}}
           ...
         {{else}}

--- a/packages/ilios-common/addon/components/dashboard/calendar-filters.gjs
+++ b/packages/ilios-common/addon/components/dashboard/calendar-filters.gjs
@@ -8,10 +8,9 @@ import t from 'ember-intl/helpers/t';
 import FilterCheckbox from 'ilios-common/components/dashboard/filter-checkbox';
 import includes from 'ilios-common/helpers/includes';
 import { fn } from '@ember/helper';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import CohortCalendarFilter from 'ilios-common/components/dashboard/cohort-calendar-filter';
 import TermsCalendarFilter from 'ilios-common/components/dashboard/terms-calendar-filter';
-import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 export default class DashboardCalendarFiltersComponent extends Component {
   @service dataLoader;
@@ -90,7 +89,7 @@ export default class DashboardCalendarFiltersComponent extends Component {
                 {{/each}}
               </ul>
             {{else}}
-              <FaIcon @icon={{faSpinner}} @spin={{true}} />
+              <LoadingSpinner />
             {{/if}}
           </div>
         </div>
@@ -126,7 +125,7 @@ export default class DashboardCalendarFiltersComponent extends Component {
                 {{/each}}
               </ul>
             {{else}}
-              <FaIcon @icon={{faSpinner}} @spin={{true}} />
+              <LoadingSpinner />
             {{/if}}
           </div>
         </div>

--- a/packages/ilios-common/addon/components/dashboard/materials.gjs
+++ b/packages/ilios-common/addon/components/dashboard/materials.gjs
@@ -18,8 +18,7 @@ import PagedlistControls from 'ilios-common/components/pagedlist-controls';
 import SortableTh from 'ilios-common/components/sortable-th';
 import { fn } from '@ember/helper';
 import MaterialListItem from 'ilios-common/components/dashboard/material-list-item';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
-import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 
 const DEBOUNCE_DELAY = 250;
 
@@ -373,7 +372,7 @@ export default class DashboardMaterialsComponent extends Component {
             <p>{{t "general.none"}}</p>
           {{/if}}
         {{else}}
-          <FaIcon @icon={{faSpinner}} class="orange" @size="2x" @spin={{true}} />
+          <LoadingSpinner @class="orange" @size="2x" />
         {{/if}}
       </div>
     </div>

--- a/packages/ilios-common/addon/components/loading-spinner.gjs
+++ b/packages/ilios-common/addon/components/loading-spinner.gjs
@@ -2,6 +2,6 @@ import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 <template>
   <span class="loading-spinner">
-    <FaIcon @icon={{faSpinner}} @spin={{true}} />
+    <FaIcon @icon={{faSpinner}} @spin={{true}} class={{@class}} @size={{@size}} />
   </span>
 </template>

--- a/packages/ilios-common/addon/components/mesh-manager.gjs
+++ b/packages/ilios-common/addon/components/mesh-manager.gjs
@@ -8,14 +8,15 @@ import { uniqueId, fn } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import MeshDescriptorLastTreeNumber from 'ilios-common/components/mesh-descriptor-last-tree-number';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
 import { and, lte } from 'ember-truth-helpers';
 import includes from 'ilios-common/helpers/includes';
 import mapBy0 from 'ilios-common/helpers/map-by';
 import perform from 'ember-concurrency/helpers/perform';
 import focus from 'ilios-common/modifiers/focus';
-import { faXmark, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
 
 const DEBOUNCE_TIMEOUT = 250;
 const MIN_INPUT = 3;
@@ -234,7 +235,7 @@ export default class MeshManagerComponent extends Component {
                 data-test-show-more
               >
                 {{#if this.searchMore.isRunning}}
-                  <FaIcon @icon={{faSpinner}} @spin={{true}} />
+                  <LoadingSpinner />
                 {{/if}}
                 {{t "general.showMore"}}
               </button>

--- a/packages/ilios-common/addon/components/monthly-calendar.gjs
+++ b/packages/ilios-common/addon/components/monthly-calendar.gjs
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 import { DateTime } from 'luxon';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
 import { concat, fn } from '@ember/helper';
@@ -11,7 +11,8 @@ import { on } from '@ember/modifier';
 import slice from 'ilios-common/helpers/slice';
 import IliosCalendarEventMonth from 'ilios-common/components/ilios-calendar-event-month';
 import { gt } from 'ember-truth-helpers';
-import { faAnglesDown, faEllipsis, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faAnglesDown, faEllipsis } from '@fortawesome/free-solid-svg-icons';
 
 export default class MonthlyCalendarComponent extends Component {
   @service intl;
@@ -83,7 +84,7 @@ export default class MonthlyCalendarComponent extends Component {
     >
       <h2 class="month-year" data-test-month-year>
         {{#if @isLoadingEvents}}
-          <FaIcon @icon={{faSpinner}} @spin={{true}} />
+          <LoadingSpinner />
           {{t "general.loadingEvents"}}
           ...
         {{else}}

--- a/packages/ilios-common/addon/components/objective-list-item-terms.gjs
+++ b/packages/ilios-common/addon/components/objective-list-item-terms.gjs
@@ -3,11 +3,12 @@ import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import DetailTermsList from 'ilios-common/components/detail-terms-list';
 import noop from 'ilios-common/helpers/noop';
 import { fn } from '@ember/helper';
-import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faArrowRotateLeft, faCheck } from '@fortawesome/free-solid-svg-icons';
 
 export default class ObjectiveListItemTermsComponent extends Component {
   @cached
@@ -30,7 +31,7 @@ export default class ObjectiveListItemTermsComponent extends Component {
           {{on "click" @save}}
         >
           {{#if @isSaving}}
-            <FaIcon @icon={{faSpinner}} @spin={{true}} />
+            <LoadingSpinner />
           {{else}}
             <FaIcon @icon={{faCheck}} />
           {{/if}}

--- a/packages/ilios-common/addon/components/objective-sort-manager.gjs
+++ b/packages/ilios-common/addon/components/objective-sort-manager.gjs
@@ -7,17 +7,13 @@ import { action } from '@ember/object';
 import { TrackedAsyncData } from 'ember-async-data';
 import { on } from '@ember/modifier';
 import perform from 'ember-concurrency/helpers/perform';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import { eq } from 'ember-truth-helpers';
 import { fn } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import FadeText from 'ilios-common/components/fade-text';
-import {
-  faArrowRotateLeft,
-  faCheck,
-  faSpinner,
-  faUpDownLeftRight,
-} from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faArrowRotateLeft, faCheck, faUpDownLeftRight } from '@fortawesome/free-solid-svg-icons';
 
 export default class ObjectiveSortManagerComponent extends Component {
   @tracked totalObjectivesToSave;
@@ -123,7 +119,7 @@ export default class ObjectiveSortManagerComponent extends Component {
           {{on "click" (perform this.saveSortOrder)}}
         >
           {{#if this.saveSortOrder.isRunning}}
-            <FaIcon @icon={{faSpinner}} @spin={{true}} />
+            <LoadingSpinner />
             {{this.saveProgress}}%
           {{else}}
             <FaIcon @icon={{faCheck}} />

--- a/packages/ilios-common/addon/components/save-button.gjs
+++ b/packages/ilios-common/addon/components/save-button.gjs
@@ -1,13 +1,14 @@
 import { eq } from 'ember-truth-helpers';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
-import { faCheck, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
 <template>
   <button type="button" disabled={{@isSaving}} ...attributes>
     {{#if @isSaving}}
       {{#if (eq @saveProgressPercent 100)}}
         <FaIcon @icon={{faCheck}} />
       {{else}}
-        <FaIcon @icon={{faSpinner}} @spin={{true}} />
+        <LoadingSpinner />
       {{/if}}
       {{#if @saveProgressPercent}}
         {{@saveProgressPercent}}%

--- a/packages/ilios-common/addon/components/session/objective-list-item-descriptors.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item-descriptors.gjs
@@ -1,8 +1,9 @@
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import sortBy from 'ilios-common/helpers/sort-by';
-import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faArrowRotateLeft, faCheck } from '@fortawesome/free-solid-svg-icons';
 <template>
   <div
     class="session-objective-list-item-descriptors grid-item"
@@ -18,7 +19,7 @@ import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-s
         data-test-save
       >
         {{#if @isSaving}}
-          <FaIcon @icon={{faSpinner}} @spin={{true}} />
+          <LoadingSpinner />
         {{else}}
           <FaIcon @icon={{faCheck}} />
         {{/if}}

--- a/packages/ilios-common/addon/components/session/objective-list-item-parents.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item-parents.gjs
@@ -2,9 +2,10 @@ import Component from '@glimmer/component';
 import sortableByPosition from 'ilios-common/utils/sortable-by-position';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import FadeText from 'ilios-common/components/fade-text';
-import { faArrowRotateLeft, faCheck, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faArrowRotateLeft, faCheck } from '@fortawesome/free-solid-svg-icons';
 
 export default class SessionObjectiveListItemParentsComponent extends Component {
   get parentTitles() {
@@ -34,7 +35,7 @@ export default class SessionObjectiveListItemParentsComponent extends Component 
           data-test-save
         >
           {{#if @isSaving}}
-            <FaIcon @icon={{faSpinner}} @spin={{true}} />
+            <LoadingSpinner />
           {{else}}
             <FaIcon @icon={{faCheck}} />
           {{/if}}

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -15,7 +15,7 @@ import ObjectiveListItemDescriptors from 'ilios-common/components/session/object
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import set from 'ember-set-helper/helpers/set';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import ManageObjectiveParents from 'ilios-common/components/session/manage-objective-parents';
 import ManageObjectiveDescriptors from 'ilios-common/components/session/manage-objective-descriptors';
 import TaxonomyManager from 'ilios-common/components/taxonomy-manager';
@@ -23,7 +23,8 @@ import YupValidations from 'ilios-common/classes/yup-validations';
 import YupValidationMessage from 'ilios-common/components/yup-validation-message';
 import { string } from 'yup';
 import striptags from 'striptags';
-import { faSpinner, faTrash } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
 export default class SessionObjectiveListItemComponent extends Component {
   @service store;
@@ -293,7 +294,7 @@ export default class SessionObjectiveListItemComponent extends Component {
               {{on "click" (perform this.deleteObjective)}}
             >
               {{#if this.deleteObjective.isRunning}}
-                <FaIcon @icon={{faSpinner}} @spin={{true}} />
+                <LoadingSpinner />
               {{else}}
                 {{t "general.yes"}}
               {{/if}}

--- a/packages/ilios-common/addon/components/week-glance.gjs
+++ b/packages/ilios-common/addon/components/week-glance.gjs
@@ -10,10 +10,11 @@ import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import optional from 'ilios-common/helpers/optional';
 import t from 'ember-intl/helpers/t';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import WeekGlanceEvent from 'ilios-common/components/week-glance-event';
 import formatDate from 'ember-intl/helpers/format-date';
-import { faSpinner, faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons';
+import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import { faCaretRight, faCaretDown } from '@fortawesome/free-solid-svg-icons';
 
 export default class WeeklyGlanceComponent extends Component {
   @service userEvents;
@@ -189,7 +190,7 @@ export default class WeeklyGlanceComponent extends Component {
           {{/if}}
         {{else}}
           <p>
-            <FaIcon @icon={{faSpinner}} @spin={{true}} />
+            <LoadingSpinner />
             {{t "general.loadingEvents"}}
           </p>
         {{/if}}

--- a/packages/ilios-common/addon/components/weekly-calendar.gjs
+++ b/packages/ilios-common/addon/components/weekly-calendar.gjs
@@ -4,14 +4,13 @@ import { action } from '@ember/object';
 import { sortBy } from 'ilios-common/utils/array-helpers';
 import { modifier } from 'ember-modifier';
 import { DateTime } from 'luxon';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import t from 'ember-intl/helpers/t';
 import formatDate from 'ember-intl/helpers/format-date';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import WeeklyCalendarEvent from 'ilios-common/components/weekly-calendar-event';
 import Event from 'ilios-common/classes/event';
-import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 export default class WeeklyCalendarComponent extends Component {
   @service intl;
@@ -145,7 +144,7 @@ export default class WeeklyCalendarComponent extends Component {
     >
       <h2 class="week-of-year" data-test-week-of-year>
         {{#if @isLoadingEvents}}
-          <FaIcon @icon={{faSpinner}} @spin={{true}} />
+          <LoadingSpinner />
           {{t "general.loadingEvents"}}
           ...
         {{else}}

--- a/packages/test-app/app/templates/login.gjs
+++ b/packages/test-app/app/templates/login.gjs
@@ -4,8 +4,7 @@ import { on } from '@ember/modifier';
 import pick from 'ilios-common/helpers/pick';
 import set from 'ember-set-helper/helpers/set';
 import perform from 'ember-concurrency/helpers/perform';
-import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
-import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+import LoadingSpinner from 'ilios-common/components/loading-spinner';
 <template>
   <div class="token-login main-section">
     {{#let (uniqueId) as |templateId|}}
@@ -24,7 +23,7 @@ import { faSpinner } from '@fortawesome/free-solid-svg-icons';
         {{on "click" (perform @controller.login)}}
       >
         {{#if @controller.login.isRunning}}
-          <FaIcon @icon={{faSpinner}} @spin={{true}} />
+          <LoadingSpinner />
         {{/if}}
         {{t "general.login"}}
       </button>

--- a/packages/test-app/tests/integration/components/loading-spinner-test.gjs
+++ b/packages/test-app/tests/integration/components/loading-spinner-test.gjs
@@ -11,5 +11,16 @@ module('Integration | Component | loading-spinner', function (hooks) {
 
     assert.dom(this.element).hasText('');
     assert.dom('svg').hasClass('fa-spinner');
+    assert.dom('svg').hasClass('fa-spin');
+  });
+
+  test('it supports custom options', async function (assert) {
+    await render(<template><LoadingSpinner @class="orange" @size="2x" /></template>);
+
+    assert.dom(this.element).hasText('');
+    assert.dom('svg').hasClass('fa-spinner');
+    assert.dom('svg').hasClass('fa-spin');
+    assert.dom('svg').hasClass('orange');
+    assert.dom('svg').hasClass('fa-2x');
   });
 });


### PR DESCRIPTION
Fixes ilios/ilios#7085

There should be no visual change or difference in rendered templates. This PR merely replaces all manual instances of `<FaIcon @icon={{faSpinner}} @spin={{true}} />` with `<LoadingSpinner />`, which does the same thing.

The `LoadingSpinner` component, however, now takes `@class` and `@size` arguments, since Ilios has a couple non-standard uses of the `faSpinner` icon, and now they can be replaced, too.