### PR TITLE
Fix incorrect spacing between Session Term lists

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/detail-taxonomies.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-taxonomies.scss
@@ -22,7 +22,7 @@
       padding: 0 0.5em;
     }
 
-    .detail-terms-list {
+    .detail-terms-list:last-of-type {
       margin-bottom: 0;
     }
   }


### PR DESCRIPTION
Fixes ilios/ilios#7091

The fix was to _only_ remove margin from the last session terms list, not all of them.