### PR TITLE
Hide 'skip to main content' link from visual users in Safari

### DIFF
--- a/packages/frontend/app/components/ilios-header.gjs
+++ b/packages/frontend/app/components/ilios-header.gjs
@@ -74,8 +74,12 @@ export default class IliosHeaderComponent extends Component {
       <NavigationNarrator
         @navigationText={{t "general.navigationCompleteText"}}
         @skipText={{t "general.skipToMainContent"}}
+        @skipLink={{false}}
         @routeChangeValidator={{this.checkRouteChange}}
       />
+      <a href="#main" class="visually-hidden">
+        {{t "general.skipToMainContent"}}
+      </a>
       <h1 class="visually-hidden" data-test-title>
         {{this.pageTitle.title}}
       </h1>

--- a/packages/frontend/app/components/ilios-header.gjs
+++ b/packages/frontend/app/components/ilios-header.gjs
@@ -76,7 +76,7 @@ export default class IliosHeaderComponent extends Component {
         @skipLink={{false}}
         @routeChangeValidator={{this.checkRouteChange}}
       />
-      <a href="#main" class="visually-hidden">
+      <a href="#main" id="ember-a11y-refocus-skip-link" class="visually-hidden">
         {{t "general.skipToMainContent"}}
       </a>
       <h1 class="visually-hidden" data-test-title>

--- a/packages/frontend/app/components/ilios-header.gjs
+++ b/packages/frontend/app/components/ilios-header.gjs
@@ -73,7 +73,6 @@ export default class IliosHeaderComponent extends Component {
     <header class="ilios-header" data-test-ilios-header ...attributes>
       <NavigationNarrator
         @navigationText={{t "general.navigationCompleteText"}}
-        @skipText={{t "general.skipToMainContent"}}
         @skipLink={{false}}
         @routeChangeValidator={{this.checkRouteChange}}
       />

--- a/packages/frontend/app/styles/layout/_layout.scss
+++ b/packages/frontend/app/styles/layout/_layout.scss
@@ -23,6 +23,11 @@
 
   & > header {
     grid-area: header;
+
+    // make sure "Skip to main content" link is not visible on Safari
+    .ember-a11y-refocus-skip-link {
+      clip-path: inset(100%);
+    }
   }
 
   & > nav {

--- a/packages/frontend/app/styles/layout/_layout.scss
+++ b/packages/frontend/app/styles/layout/_layout.scss
@@ -23,11 +23,6 @@
 
   & > header {
     grid-area: header;
-
-    // make sure "Skip to main content" link is not visible on Safari
-    .ember-a11y-refocus-skip-link {
-      clip-path: inset(100%);
-    }
   }
 
   & > nav {


### PR DESCRIPTION
Fixes ilios/ilios#7095

Safari needs the `ember-a11y-skip-link` element to be hidden by either `clip` (deprecated) or `clip-path` to be truly hidden. Also, there may be some kind of issue with the focus-ring applied to the element when clicking the page, which causes it to "drift" down the page.