### PR TITLE
Quick and Dirty Test Fix

### DIFF
--- a/packages/frontend/tests/integration/components/reports/new-subject-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/new-subject-test.gjs
@@ -199,6 +199,8 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     assert.notOk(component.meshTerm.hasSelectedTerm, 'no mesh term selected');
     await component.meshTerm.meshManager.search.set('descriptor 0');
     await takeComponentScreenshot(assert, 'with descriptor');
+    //reset the search because the screenshot steals focus
+    await component.meshTerm.meshManager.search.set('descriptor 0');
     await component.meshTerm.meshManager.searchResults[0].add();
     await takeComponentScreenshot(assert, 'with term selected');
     assert.strictEqual(


### PR DESCRIPTION
Taking the screenshot steals focus and closes the mesh search results. We probable need a better solution, but this fixes the problem and restores our ability to take screenshots in tests.