### PR TITLE
Improve Screenshot Capture 

### DIFF
--- a/.github/workflows/visual_diff.yml
+++ b/.github/workflows/visual_diff.yml
@@ -53,6 +53,7 @@ jobs:
         if: steps.screenshot-cache.outputs.cache-hit != 'true'
         run: pnpm install
       - name: Capture Screenshots
+        continue-on-error: true
         if: steps.screenshot-cache.outputs.cache-hit != 'true'
         run: pnpm --filter frontend exec ember exam --parallel=3 --load-balance --config-file=testem.screenshots.js
       - name: Rename screenshots
@@ -106,6 +107,7 @@ jobs:
         if: steps.screenshot-cache.outputs.cache-hit != 'true'
         run: pnpm install
       - name: Capture Screenshots
+        continue-on-error: true
         if: steps.screenshot-cache.outputs.cache-hit != 'true'
         run: pnpm --filter frontend exec ember exam --parallel=3 --load-balance --config-file=testem.screenshots.js
       - name: Rename screenshots

--- a/packages/frontend/testem.screenshots.js
+++ b/packages/frontend/testem.screenshots.js
@@ -3,6 +3,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const FailureOnlyReporter = require('testem-failure-only-reporter');
 
 const buildDir = process.env.BUILD_DIR || path.resolve(__dirname, '../../build');
 const downloadDir = `${buildDir}/screenshots`;
@@ -43,4 +44,5 @@ module.exports = {
     Firefox: ['--headless'],
   },
   firefox_user_js: firefoxUserJsPath,
+  reporter: FailureOnlyReporter,
 };

--- a/packages/frontend/tests/integration/components/reports/new-subject-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/new-subject-test.gjs
@@ -199,8 +199,6 @@ module('Integration | Component | reports/new-subject', function (hooks) {
     assert.notOk(component.meshTerm.hasSelectedTerm, 'no mesh term selected');
     await component.meshTerm.meshManager.search.set('descriptor 0');
     await takeComponentScreenshot(assert, 'with descriptor');
-    //reset the search because the screenshot steals focus
-    await component.meshTerm.meshManager.search.set('descriptor 0');
     await component.meshTerm.meshManager.searchResults[0].add();
     await takeComponentScreenshot(assert, 'with term selected');
     assert.strictEqual(


### PR DESCRIPTION
When an individual test fails we don't really want screenshots capture and comparison to fail without reaching the comparison step.

Also reverts #9310 as, hopefully, no longer needed now that test failure won't cause screenshot failure.