### PR TITLE
reduce mock user updates in acceptance tests.

### DIFF
--- a/packages/frontend/tests/acceptance/course/competencies-test.js
+++ b/packages/frontend/tests/acceptance/course/competencies-test.js
@@ -50,7 +50,6 @@ module('Acceptance | Course - Competencies', function (hooks) {
   });
 
   test('collapsed competencies renders', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     await takeScreenshot(assert);
     assert.strictEqual(page.details.collapsedCompetencies.title, 'Competencies (1)');
@@ -61,7 +60,6 @@ module('Acceptance | Course - Competencies', function (hooks) {
   });
 
   test('changing objective parent changes summary', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: this.course.id,
       details: true,

--- a/packages/frontend/tests/acceptance/course/competencies-test.js
+++ b/packages/frontend/tests/acceptance/course/competencies-test.js
@@ -7,9 +7,9 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Competencies', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
-    this.school = this.server.create('school');
-    const program = this.server.create('program', { school: this.school });
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
+    const program = this.server.create('program', { school });
     const programYear = this.server.create('program-year', {
       program,
     });
@@ -17,11 +17,11 @@ module('Acceptance | Course - Competencies', function (hooks) {
       programYear,
     });
     const competency1 = this.server.create('competency', {
-      school: this.school,
+      school,
       programYears: [programYear],
     });
     const competency2 = this.server.create('competency', {
-      school: this.school,
+      school,
       programYears: [programYear],
     });
 
@@ -36,7 +36,7 @@ module('Acceptance | Course - Competencies', function (hooks) {
 
     this.course = this.server.create('course', {
       year: 2013,
-      school: this.school,
+      school,
       cohorts: [cohort],
     });
     this.server.create('course-objective', {

--- a/packages/frontend/tests/acceptance/course/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/learningmaterials-test.js
@@ -13,7 +13,10 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   hooks.beforeEach(async function () {
     this.intl = this.owner.lookup('service:intl');
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    this.user = await setupAuthentication(
+      { school: this.school, administeredSchools: [this.school] },
+      true,
+    );
     this.user2 = this.server.create('user', { displayName: 'Clem Chowder' });
     this.server.create('academic-year');
 

--- a/packages/frontend/tests/acceptance/course/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/learningmaterials-test.js
@@ -105,7 +105,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('list learning materials', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(currentRouteName(), 'course.index');
 
@@ -171,7 +170,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('create new link learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const testTitle = 'testsome title';
     const testAuthor = 'testsome author';
     const testDescription = 'testsome description';
@@ -207,7 +205,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('create new citation learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const testTitle = 'testsome title';
     const testAuthor = 'testsome author';
     const testDescription = 'testsome description';
@@ -244,7 +241,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('can only add one learning-material at a time', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     assert.ok(page.details.learningMaterials.canCreateNew);
@@ -256,7 +252,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('cancel new learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     assert.ok(page.details.learningMaterials.search.isVisible);
@@ -268,7 +263,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('view copyright file learning material details', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[0].details();
@@ -288,7 +282,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('view rationale file learning material details', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[1].details();
@@ -308,7 +301,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('view accessibility file learning material details', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
     await page.details.learningMaterials.current[0].details();
@@ -380,7 +372,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('toggling accessibility file learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
     await page.details.learningMaterials.current[0].details();
@@ -418,7 +409,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('view url file learning material details', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[1].details();
@@ -441,7 +431,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('view link learning material details', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[2].details();
@@ -470,7 +459,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('view citation learning material details', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[3].details();
@@ -492,7 +480,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('edit learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newNote = 'text text. Woo hoo!';
     const newDescription = "i'll sleep when i'm dead.";
 
@@ -530,8 +517,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('change from required to not required #1249', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[2].details();
@@ -544,7 +529,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('cancel editing learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newNote = 'text text. Woo hoo!';
     const newDescription = 'counting sheep';
 
@@ -580,7 +564,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('manage terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[0].details();
@@ -625,7 +608,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('save terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[0].details();
@@ -646,7 +628,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('cancel term changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[0].details();
@@ -667,7 +648,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('find and add learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.search.search.set('doc');
@@ -696,7 +676,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('add timed release start date', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
     await page.details.learningMaterials.current[0].details();
@@ -724,7 +703,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('add timed release start and end date', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newStartDate = DateTime.fromObject({ hour: 10, minute: 10 }).plus({
       days: 1,
       month: 1,
@@ -771,7 +749,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('add timed release end date', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
     await page.details.learningMaterials.current[0].details();
@@ -799,7 +776,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('end date is after start date', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newDate = DateTime.fromObject({ hour: 10, minute: 10 }).plus({ days: 1, month: 1 });
 
     await page.visit({ courseId: this.course.id, details: true });
@@ -835,7 +811,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('edit learning material with no other links #3617', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newTitle = 'text text. Woo hoo!';
 
     await page.visit({ courseId: this.course.id, details: true });
@@ -853,7 +828,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('title too short', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
     await page.details.learningMaterials.current[0].details();
@@ -864,7 +838,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('title too long', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
     await page.details.learningMaterials.current[0].details();
@@ -875,7 +848,6 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('missing copyright info #1204', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     await page.details.learningMaterials.createNew();
     await page.details.learningMaterials.pickNew('File');
@@ -914,7 +886,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       required: false,
       position: 1,
     });
-    this.user.update({ administeredSchools: [this.school] });
+
     await page.visit({ courseId: course.id, details: true });
     await takeScreenshot(assert);
     assert.strictEqual(currentRouteName(), 'course.index');
@@ -944,7 +916,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       required: false,
       position: 1,
     });
-    this.user.update({ administeredSchools: [this.school] });
+
     await page.visit({ courseId: course.id, details: true });
     assert.strictEqual(page.details.learningMaterials.current.length, 1);
     await page.details.learningMaterials.current[0].details();

--- a/packages/frontend/tests/acceptance/course/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/mesh-test.js
@@ -7,8 +7,8 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Mesh Terms', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
-    this.school = this.server.create('school');
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
     this.server.create('academic-year');
     this.server.createList('meshTree', 3);
     this.server.createList('meshConcept', 3);
@@ -28,7 +28,7 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
 
     this.course = this.server.create('course', {
       year: 2014,
-      school: this.school,
+      school,
       meshDescriptorIds: [1, 2, 3],
     });
   });

--- a/packages/frontend/tests/acceptance/course/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/mesh-test.js
@@ -42,7 +42,6 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
   });
 
   test('manage terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     await page.details.meshTerms.manage();
@@ -74,7 +73,6 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
   });
 
   test('save terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     await page.details.meshTerms.manage();
@@ -96,7 +94,6 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
   });
 
   test('cancel term changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');

--- a/packages/frontend/tests/acceptance/course/objectivecreate-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivecreate-test.js
@@ -6,8 +6,8 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Objective Create', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [this.school] }, true);
     this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);

--- a/packages/frontend/tests/acceptance/course/objectivecreate-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivecreate-test.js
@@ -20,7 +20,7 @@ module('Acceptance | Course - Objective Create', function (hooks) {
       school: this.school,
     });
     this.server.create('course-objective', { course });
-    this.user.update({ administeredSchools: [this.school] });
+
     const newObjectiveDescription = 'Test junk 123';
 
     await page.visit({
@@ -58,7 +58,7 @@ module('Acceptance | Course - Objective Create', function (hooks) {
       school: this.school,
     });
     this.server.create('course-objective', { course });
-    this.user.update({ administeredSchools: [this.school] });
+
     await page.visit({
       courseId: course.id,
       details: true,
@@ -88,7 +88,7 @@ module('Acceptance | Course - Objective Create', function (hooks) {
       school: this.school,
     });
     this.server.create('course-objective', { course });
-    this.user.update({ administeredSchools: [this.school] });
+
     await page.visit({
       courseId: course.id,
       details: true,
@@ -117,7 +117,7 @@ module('Acceptance | Course - Objective Create', function (hooks) {
       year: 2013,
       school: this.school,
     });
-    this.user.update({ administeredSchools: [this.school] });
+
     const newObjectiveDescription = 'Test junk 123';
 
     await page.visit({

--- a/packages/frontend/tests/acceptance/course/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivelist-test.js
@@ -6,8 +6,8 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Objective List', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [this.school] }, true);
     this.server.create('academic-year', { id: 2013 });
   });
 

--- a/packages/frontend/tests/acceptance/course/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivelist-test.js
@@ -12,7 +12,6 @@ module('Acceptance | Course - Objective List', function (hooks) {
   });
 
   test('list objectives', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const competencies = this.server.createList('competency', 2, {
       school: this.school,
     });
@@ -136,7 +135,6 @@ module('Acceptance | Course - Objective List', function (hooks) {
   });
 
   test('long objective', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const longTitle =
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam placerat tempor neque ut egestas. In cursus dignissim erat, sed porttitor mauris tincidunt at. Nunc et tortor in purus facilisis molestie. Phasellus in ligula nisi. Nam nec mi in urna mollis pharetra. Suspendisse in nibh ex. Curabitur maximus diam in condimentum pulvinar. Phasellus sit amet metus interdum, molestie turpis vel, bibendum eros. In fermentum elit in odio cursus cursus. Nullam ipsum ipsum, fringilla a efficitur non, vehicula vitae enim. Duis ultrices vitae neque in pulvinar. Nulla molestie vitae quam eu faucibus. Vestibulum tempor, tellus in dapibus sagittis, velit purus maximus lectus, quis ullamcorper sem neque quis sem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed commodo risus sed tellus imperdiet, ac suscipit justo scelerisque. Quisque sit amet nulla efficitur, sollicitudin sem in, venenatis mi. Quisque sit amet neque varius, interdum quam id, condimentum ipsum. Quisque tincidunt efficitur diam ut feugiat. Duis vehicula mauris elit, vel vehicula eros commodo rhoncus. Phasellus ac eros vel turpis egestas aliquet. Nam id dolor rutrum, imperdiet purus ac, faucibus nisi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nam aliquam leo eget quam varius ultricies. Suspendisse pellentesque varius mi eu luctus. Integer lacinia ornare magna, in egestas quam molestie non.';
     const course = this.server.create('course', {
@@ -163,7 +161,6 @@ module('Acceptance | Course - Objective List', function (hooks) {
   });
 
   test('edit objective title', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newDescription = 'test new title';
     const course = this.server.create('course', {
       year: 2013,
@@ -191,7 +188,6 @@ module('Acceptance | Course - Objective List', function (hooks) {
   });
 
   test('empty objective title can not be saved', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,

--- a/packages/frontend/tests/acceptance/course/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivemesh-test.js
@@ -6,8 +6,8 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
-    this.school = this.server.create('school');
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
     this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);
@@ -15,7 +15,7 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
 
     this.course = this.server.create('course', {
       year: 2013,
-      school: this.school,
+      school,
     });
 
     const meshDescriptors = this.server.createList('mesh-descriptor', 6);

--- a/packages/frontend/tests/acceptance/course/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivemesh-test.js
@@ -37,8 +37,6 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
   });
 
   test('manage terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: this.course.id,
       details: true,
@@ -113,8 +111,6 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
   });
 
   test('save terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: this.course.id,
       details: true,
@@ -177,8 +173,6 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
   });
 
   test('cancel changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: this.course.id,
       details: true,

--- a/packages/frontend/tests/acceptance/course/objectiveparents-allow-multiple-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-allow-multiple-test.js
@@ -14,7 +14,6 @@ module('Acceptance | Course - Multiple Objective Parents', function (hooks) {
       name: 'allowMultipleCourseObjectiveParents',
       value: true,
     });
-    this.user.update({ administeredSchools: [this.school] });
 
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
@@ -79,7 +78,6 @@ module('Acceptance | Course - Multiple Objective Parents', function (hooks) {
   });
 
   test('can select multiple parents', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: this.course.id,
       details: true,

--- a/packages/frontend/tests/acceptance/course/objectiveparents-allow-multiple-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-allow-multiple-test.js
@@ -7,19 +7,19 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Multiple Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
-    this.school = this.server.create('school');
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
     this.server.create('schoolConfig', {
-      school: this.school,
+      school,
       name: 'allowMultipleCourseObjectiveParents',
       value: true,
     });
 
-    const program = this.server.create('program', { school: this.school });
+    const program = this.server.create('program', { school });
     const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
     const competency = this.server.create('competency', {
-      school: this.school,
+      school,
       programYears: [programYear],
     });
     const programYearObjectives = this.server.createList('program-year-objective', 3, {
@@ -28,7 +28,7 @@ module('Acceptance | Course - Multiple Objective Parents', function (hooks) {
     });
 
     this.course = this.server.create('course', {
-      school: this.school,
+      school,
       cohorts: [cohort],
     });
 

--- a/packages/frontend/tests/acceptance/course/objectiveparents-description-sync-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-description-sync-test.js
@@ -66,8 +66,6 @@ module('Acceptance | Course - Objective Parents - Faded Status Sync', function (
   });
 
   test('objective description and parent objectives faded statuses are synced', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: this.course.id,
       details: true,

--- a/packages/frontend/tests/acceptance/course/objectiveparents-inactive-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-inactive-test.js
@@ -7,8 +7,8 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Objective Inactive Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [this.school] }, true);
   });
 
   test('inactive program year objectives are hidden unless they are selected', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/objectiveparents-inactive-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-inactive-test.js
@@ -51,7 +51,6 @@ module('Acceptance | Course - Objective Inactive Parents', function (hooks) {
       programYearObjectives: [parent],
     });
 
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: course.id,
       details: true,

--- a/packages/frontend/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -6,9 +6,9 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course with multiple Cohorts - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
-    this.school = this.server.create('school');
-    const program = this.server.create('program', { school: this.school });
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
+    const program = this.server.create('program', { school });
 
     const programYears = this.server.createList('programYear', 2, {
       program,
@@ -20,7 +20,7 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
       programYear: programYears[1],
     });
     const competencies = this.server.createList('competency', 2, {
-      school: this.school,
+      school,
       programYears,
     });
 
@@ -43,7 +43,7 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
 
     this.course = this.server.create('course', {
       year: 2013,
-      school: this.school,
+      school,
       cohorts: [cohort1, cohort2],
     });
     this.server.create('course-objective', {

--- a/packages/frontend/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-multiplecohorts-test.js
@@ -54,7 +54,6 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
   });
 
   test('list parent objectives by competency', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: this.course.id,
       details: true,
@@ -116,7 +115,6 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
   });
 
   test('save changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: this.course.id,
       details: true,
@@ -166,7 +164,6 @@ module('Acceptance | Course with multiple Cohorts - Objective Parents', function
   });
 
   test('cancel changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: this.course.id,
       details: true,

--- a/packages/frontend/tests/acceptance/course/objectiveparents-nocohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-nocohorts-test.js
@@ -30,7 +30,6 @@ module('Acceptance | Course with no cohorts - Objective Parents', function (hook
   });
 
   test('add and remove a new cohort', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: this.course.id,
       details: true,

--- a/packages/frontend/tests/acceptance/course/objectiveparents-nocohorts-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-nocohorts-test.js
@@ -7,9 +7,9 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course with no cohorts - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
-    this.school = this.server.create('school');
-    const program = this.server.create('program', { school: this.school });
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
+    const program = this.server.create('program', { school });
 
     const year = new Date().getFullYear();
     const programYear = this.server.create('program-year', {
@@ -18,13 +18,13 @@ module('Acceptance | Course with no cohorts - Objective Parents', function (hook
     });
     this.server.create('cohort', { programYear });
     const competency = this.server.create('competency', {
-      school: this.school,
+      school,
       programYears: [programYear],
     });
     this.server.create('program-year-objective', { programYear, competency });
     this.course = this.server.create('course', {
       year: 2013,
-      school: this.school,
+      school,
     });
     this.server.create('course-objective', { course: this.course });
   });

--- a/packages/frontend/tests/acceptance/course/objectiveparents-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-test.js
@@ -44,8 +44,6 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
   });
 
   test('list parent objectives by competency', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: this.course.id,
       details: true,
@@ -84,8 +82,6 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
   });
 
   test('save changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: this.course.id,
       details: true,
@@ -126,8 +122,6 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
   });
 
   test('cancel changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: this.course.id,
       details: true,

--- a/packages/frontend/tests/acceptance/course/objectiveparents-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-test.js
@@ -6,17 +6,17 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
-    this.school = this.server.create('school');
-    const program = this.server.create('program', { school: this.school });
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
+    const program = this.server.create('program', { school });
     const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
     const competency1 = this.server.create('competency', {
-      school: this.school,
+      school,
       programYears: [programYear],
     });
     const competency2 = this.server.create('competency', {
-      school: this.school,
+      school,
       programYears: [programYear],
     });
     const parent = this.server.create('program-year-objective', {
@@ -33,7 +33,7 @@ module('Acceptance | Course - Objective Parents', function (hooks) {
     });
     this.course = this.server.create('course', {
       year: 2013,
-      school: this.school,
+      school,
       cohorts: [cohort],
     });
     this.server.create('course-objective', {

--- a/packages/frontend/tests/acceptance/course/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveterms-test.js
@@ -7,8 +7,8 @@ module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
     const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
     this.server.create('academic-year', { id: 2013 });
     const program = this.server.create('program', { school });
     const programYear = this.server.create('program-year', { program });
@@ -21,7 +21,6 @@ module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
     this.server.createList('term', 3, { vocabulary, active: true });
     this.course = this.server.create('course', { school });
     this.server.create('course-objective', { course: this.course, terms: [term] });
-    this.school = school;
   });
 
   test('manage and save terms', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveterms-test.js
@@ -25,7 +25,6 @@ module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
   });
 
   test('manage and save terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: this.course.id,
       details: true,
@@ -133,7 +132,6 @@ module('Acceptance | Course - Objective Vocabulary Terms', function (hooks) {
   });
 
   test('manage and cancel terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: this.course.id,
       details: true,

--- a/packages/frontend/tests/acceptance/course/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/overview-test.js
@@ -9,8 +9,8 @@ module('Acceptance | Course - Overview', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.intl = this.owner.lookup('service:intl');
-    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [this.school] }, true);
     this.server.createList('course-clerkship-type', 2);
   });
 
@@ -344,6 +344,7 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('rollover hidden from unprivileged users', async function (assert) {
+    this.user.update({ administeredSchools: [] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,

--- a/packages/frontend/tests/acceptance/course/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/overview-test.js
@@ -16,7 +16,6 @@ module('Acceptance | Course - Overview', function (hooks) {
 
   module('check fields', function (hooks2) {
     hooks2.beforeEach(function () {
-      this.user.update({ administeredSchools: [this.school] });
       this.clerkshipType = this.server.create('course-clerkship-type');
       this.course = this.server.create('course', {
         year: 2013,
@@ -123,7 +122,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('back to courses link contains year of given course as query param', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const year = 2013;
     const course = this.server.create('course', {
       year,
@@ -135,7 +133,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('pick clerkship type', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -157,7 +154,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('remove clerkship type', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const clerkshipType = this.server.create('course-clerkship-type');
     const course = this.server.create('course', {
       year: 2013,
@@ -181,7 +177,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('change title', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -196,7 +191,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('change start date', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       startDate: '2013-03-23',
@@ -214,7 +208,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('start date validation', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       startDate: '2013-03-23',
@@ -233,7 +226,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('change end date', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       startDate: '2013-03-23',
@@ -251,7 +243,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('end date validation', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       startDate: '2013-03-23',
@@ -271,7 +262,7 @@ module('Acceptance | Course - Overview', function (hooks) {
 
   test('change externalId', async function (assert) {
     const externalId = 'abc123';
-    this.user.update({ administeredSchools: [this.school] });
+
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -289,7 +280,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('change to empty externalId', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -311,7 +301,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('renders with empty externalId', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -325,7 +314,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('change level', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -343,7 +331,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('click rollover', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -367,7 +354,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('rollover hidden from privileged users if course is locked', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -379,7 +365,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('rollover visible to privileged users', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -390,7 +375,6 @@ module('Acceptance | Course - Overview', function (hooks) {
   });
 
   test('rollover hidden on rollover route', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,

--- a/packages/frontend/tests/acceptance/course/publish-test.js
+++ b/packages/frontend/tests/acceptance/course/publish-test.js
@@ -6,8 +6,8 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Publish', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [this.school] }, true);
     this.cohort = this.server.create('cohort');
   });
 

--- a/packages/frontend/tests/acceptance/course/publish-test.js
+++ b/packages/frontend/tests/acceptance/course/publish-test.js
@@ -12,7 +12,6 @@ module('Acceptance | Course - Publish', function (hooks) {
   });
 
   test('check publish draft course', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -26,7 +25,6 @@ module('Acceptance | Course - Publish', function (hooks) {
   });
 
   test('check schedule draft course', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -40,7 +38,6 @@ module('Acceptance | Course - Publish', function (hooks) {
   });
 
   test('check publish scheduled course', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -56,7 +53,6 @@ module('Acceptance | Course - Publish', function (hooks) {
   });
 
   test('check unpublish scheduled course', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -72,7 +68,6 @@ module('Acceptance | Course - Publish', function (hooks) {
   });
 
   test('check schedule published course', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -87,7 +82,6 @@ module('Acceptance | Course - Publish', function (hooks) {
   });
 
   test('check unpublish published course', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       school: this.school,

--- a/packages/frontend/tests/acceptance/course/publishall-test.js
+++ b/packages/frontend/tests/acceptance/course/publishall-test.js
@@ -122,7 +122,6 @@ module('Acceptance | Course - Publish All Sessions', function (hooks) {
   });
 
   test('Updating course objectives updates the unlinked objective warning', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', {
       cohort: this.cohort,
     });

--- a/packages/frontend/tests/acceptance/course/publishall-test.js
+++ b/packages/frontend/tests/acceptance/course/publishall-test.js
@@ -8,8 +8,8 @@ import page from 'ilios-common/page-objects/course-publish-all';
 module('Acceptance | Course - Publish All Sessions', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
     this.school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [this.school] }, true);
     this.cohort = this.server.create('cohort');
   });
 

--- a/packages/frontend/tests/acceptance/course/session/ilm-test.js
+++ b/packages/frontend/tests/acceptance/course/session/ilm-test.js
@@ -7,15 +7,15 @@ import page from 'ilios-common/page-objects/session';
 module('Acceptance | Session - Independent Learning', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ school, administeredSchools: [school] }, true);
     this.server.createList('user', 6);
     this.server.create('academic-year');
-    this.course = this.server.create('course', { school: this.school });
-    this.server.createList('instructor-group', 5, { school: this.school });
+    this.course = this.server.create('course', { school });
+    this.server.createList('instructor-group', 5, { school });
     this.server.createList('user', 2, { instructorGroupIds: [1] });
     this.server.createList('user', 3, { instructorGroupIds: [2] });
-    const sessionType = this.server.create('session-type', { school: this.school });
+    const sessionType = this.server.create('session-type', { school });
     const ilmSession = this.server.create('ilm-session', {
       instructorGroupIds: [1, 2, 3],
       instructorIds: [2, 3, 4],

--- a/packages/frontend/tests/acceptance/course/session/ilm-test.js
+++ b/packages/frontend/tests/acceptance/course/session/ilm-test.js
@@ -102,7 +102,6 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
   });
 
   test('manage instructors lists', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -173,7 +172,6 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
   });
 
   test('manage instructors search users', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -212,7 +210,6 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
   });
 
   test('manage instructors search groups', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -237,7 +234,6 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
   });
 
   test('add instructor group', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -319,7 +315,6 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
   });
 
   test('add instructor', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -401,7 +396,6 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
   });
 
   test('remove instructor group', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -466,7 +460,6 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
   });
 
   test('remove instructor', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -531,7 +524,6 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
   });
 
   test('undo instructor/group changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -600,7 +592,6 @@ module('Acceptance | Session - Independent Learning', function (hooks) {
   });
 
   test('ilm-only subcomponents disappear/reappear if ilm gets toggled off/on', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,

--- a/packages/frontend/tests/acceptance/course/session/learner-groups-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learner-groups-test.js
@@ -88,7 +88,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('manager display', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
@@ -211,7 +210,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('learner group manager display with no selected groups or learners', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [],
@@ -299,7 +297,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('filter learner groups by top group should include all subgroups', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
@@ -350,7 +347,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('filter learner groups by subgroup should include top group', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
@@ -401,7 +397,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('add learner group', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
@@ -530,7 +525,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('add learner sub group', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
@@ -645,7 +639,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('add learner group with children', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2],
@@ -777,7 +770,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('add learner group with children and remove one child', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2],
@@ -926,7 +918,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('undo learner group change', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerGroupIds: [1, 2, 4],
@@ -1005,7 +996,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('add learner', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerIds: [2, 3],
@@ -1056,7 +1046,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('remove learner', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerIds: [2, 3],
@@ -1090,7 +1079,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
     });
 
     test('undo learner change', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('ilm-session', {
         sessionId: 1,
         learnerIds: [2, 3],
@@ -1125,7 +1113,6 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
   });
 
   test('initial state with save works as expected #1773', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const sessionType = this.server.create('session-type', { school: this.school });
     this.server.create('program', {
       school: this.school,

--- a/packages/frontend/tests/acceptance/course/session/learner-groups-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learner-groups-test.js
@@ -9,7 +9,10 @@ module('Acceptance | Session - Learner Groups', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    this.user = await setupAuthentication(
+      { school: this.school, administeredSchools: [this.school] },
+      true,
+    );
   });
 
   module('With Fixtures', function (hooks2) {

--- a/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
@@ -276,12 +276,11 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[0].details();
-
-    assert.strictEqual(page.details.learningMaterials.manager.nameValue, 'learning material 0');
+    assert.strictEqual(page.details.learningMaterials.manager.name.value, 'learning material 0');
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Jennifer Johnson');
     assert.strictEqual(
-      page.details.learningMaterials.manager.description.value,
-      '0 lm description',
+      await page.details.learningMaterials.manager.description.editorValue(),
+      '<p>0 lm description</p>',
     );
     assert.ok(page.details.learningMaterials.manager.hasFile);
     assert.ok(page.details.learningMaterials.manager.hasCopyrightPermission);
@@ -297,13 +296,13 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     await page.details.learningMaterials.current[1].details();
 
     assert.strictEqual(
-      page.details.learningMaterials.manager.nameValue,
+      page.details.learningMaterials.manager.name.value,
       'http://example.com/subdir1/subdir2/long_file_name.pdf',
     );
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Jennifer Johnson');
     assert.strictEqual(
-      page.details.learningMaterials.manager.description.value,
-      '1 lm description',
+      await page.details.learningMaterials.manager.description.editorValue(),
+      '<p>1 lm description</p>',
     );
     assert.ok(page.details.learningMaterials.manager.hasFile);
     assert.notOk(page.details.learningMaterials.manager.hasCopyrightPermission);
@@ -428,13 +427,13 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     await page.details.learningMaterials.current[1].details();
 
     assert.strictEqual(
-      page.details.learningMaterials.manager.nameValue,
+      page.details.learningMaterials.manager.name.value,
       'http://example.com/subdir1/subdir2/long_file_name.pdf',
     );
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Jennifer Johnson');
     assert.strictEqual(
-      page.details.learningMaterials.manager.description.value,
-      '1 lm description',
+      await page.details.learningMaterials.manager.description.editorValue(),
+      '<p>1 lm description</p>',
     );
     assert.strictEqual(page.details.learningMaterials.manager.uploadDate, '03/14/2011');
     assert.ok(page.details.learningMaterials.manager.hasFile);
@@ -452,11 +451,11 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[2].details();
 
-    assert.strictEqual(page.details.learningMaterials.manager.nameValue, 'learning material 2');
+    assert.strictEqual(page.details.learningMaterials.manager.name.value, 'learning material 2');
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Hunter Pence');
     assert.strictEqual(
-      page.details.learningMaterials.manager.description.value,
-      '2 lm description',
+      await page.details.learningMaterials.manager.description.editorValue(),
+      '<p>2 lm description</p>',
     );
     assert.strictEqual(
       page.details.learningMaterials.manager.uploadDate,
@@ -480,11 +479,11 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[3].details();
 
-    assert.strictEqual(page.details.learningMaterials.manager.nameValue, 'learning material 3');
+    assert.strictEqual(page.details.learningMaterials.manager.name.value, 'learning material 3');
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Willie Mays');
     assert.strictEqual(
-      page.details.learningMaterials.manager.description.value,
-      '3 lm description',
+      await page.details.learningMaterials.manager.description.editorValue(),
+      '<p>3 lm description</p>',
     );
     assert.strictEqual(page.details.learningMaterials.manager.uploadDate, '12/12/2016');
     assert.ok(page.details.learningMaterials.manager.hasCitation);

--- a/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
@@ -78,10 +78,10 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       school,
     });
 
-    const sessionType = this.server.create('session-type', { school });
+    this.sessionType = this.server.create('session-type', { school });
     const session = this.server.create('session', {
       course: this.course,
-      sessionType,
+      sessionType: this.sessionType,
     });
 
     this.server.create('session-learning-material', {
@@ -899,6 +899,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   test('list double linked learning materials', async function (assert) {
     const session = this.server.create('session', {
       course: this.course,
+      sessionType: this.sessionType,
     });
     this.server.create('session-learning-material', {
       learningMaterial: this.material1,
@@ -927,6 +928,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   test('view double linked learning material details', async function (assert) {
     const session = this.server.create('session', {
       course: this.course,
+      sessionType: this.sessionType,
     });
     this.server.create('session-learning-material', {
       learningMaterial: this.material1,

--- a/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
@@ -12,8 +12,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.intl = this.owner.lookup('service:intl');
-    this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ school, administeredSchools: [school] }, true);
     this.user2 = this.server.create('user', { displayName: 'Clem Chowder' });
     this.server.create('academic-year');
 
@@ -75,10 +75,10 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
     this.course = this.server.create('course', {
       year: 2013,
-      school: this.school,
+      school,
     });
 
-    const sessionType = this.server.create('session-type', { school: this.school });
+    const sessionType = this.server.create('session-type', { school });
     const session = this.server.create('session', {
       course: this.course,
       sessionType,

--- a/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
@@ -181,7 +181,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('create new link learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const testTitle = 'testsome title';
     const testAuthor = 'testsome author';
     const testDescription = 'testsome description';
@@ -217,7 +216,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('create new citation learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const testTitle = 'testsome title';
     const testAuthor = 'testsome author';
     const testDescription = 'testsome description';
@@ -253,7 +251,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('can only add one learning-material at a time', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     assert.ok(page.details.learningMaterials.canCreateNew);
@@ -265,8 +262,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('cancel new learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     assert.ok(page.details.learningMaterials.search.isVisible);
@@ -319,7 +314,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('view accessibility file learning material details', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
     await page.details.learningMaterials.current[0].details();
@@ -392,7 +386,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('toggling accessibility file learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
     await page.details.learningMaterials.current[0].details();
@@ -504,7 +497,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('edit learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newNote = 'text text. Woo hoo!';
     const newDescription = 'high altitude training';
 
@@ -543,8 +535,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('change from required to not required #1249', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[2].details();
@@ -557,7 +547,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('cancel editing learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newNote = 'text text. Woo hoo!';
     const newDescription = 'the sun is shining.';
 
@@ -593,7 +582,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('manage terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[0].details();
@@ -638,7 +626,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('save terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[0].details();
@@ -661,7 +648,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('cancel term changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.current[0].details();
@@ -684,7 +670,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('find and add learning material', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.strictEqual(page.details.learningMaterials.current.length, 4);
     await page.details.learningMaterials.search.search.set('doc');
@@ -713,7 +698,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('add timed release start date', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
     await page.details.learningMaterials.current[0].details();
@@ -741,7 +725,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('add timed release start and end date', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newStartDate = DateTime.fromObject({ hour: 10, minute: 10 }).plus({
       days: 1,
       month: 1,
@@ -788,7 +771,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('add timed release end date', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
     await page.details.learningMaterials.current[0].details();
@@ -816,7 +798,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('end date is after start date', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newDate = DateTime.fromObject({ hour: 10, minute: 10 }).plus({ days: 1, month: 1 });
 
     await page.visit({ courseId: this.course.id, sessionId: 1 });
@@ -852,7 +833,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('edit learning material with no other links #3617', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newTitle = 'text text. Woo hoo!';
 
     await page.visit({ courseId: this.course.id, sessionId: 1 });
@@ -870,7 +850,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('title too short', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
     await page.details.learningMaterials.current[0].details();
@@ -881,7 +860,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('title too long', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
     await page.details.learningMaterials.current[0].details();
@@ -892,7 +870,6 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('missing copyright info #1204', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: this.course.id, sessionId: 1 });
     await page.details.learningMaterials.createNew();
     await page.details.learningMaterials.pickNew('File');

--- a/packages/frontend/tests/acceptance/course/session/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/mesh-test.js
@@ -47,7 +47,6 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
   });
 
   test('manage terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, sessionId: 1 });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     await page.details.meshTerms.manage();
@@ -79,7 +78,6 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
   });
 
   test('save terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, sessionId: 1 });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     await page.details.meshTerms.manage();
@@ -101,7 +99,6 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
   });
 
   test('cancel term changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, sessionId: 1 });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');

--- a/packages/frontend/tests/acceptance/course/session/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/mesh-test.js
@@ -7,8 +7,8 @@ import page from 'ilios-common/page-objects/session';
 module('Acceptance | Session - Mesh Terms', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ school, administeredSchools: [school] }, true);
     this.server.create('academic-year');
     this.server.createList('meshTree', 3);
     this.server.createList('meshConcept', 3);
@@ -28,9 +28,9 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
 
     const course = this.server.create('course', {
       year: 2014,
-      school: this.school,
+      school,
     });
-    const sessionType = this.server.create('session-type', { school: this.school });
+    const sessionType = this.server.create('session-type', { school });
     this.server.create('session', {
       course,
       meshDescriptorIds: [1, 2, 3],

--- a/packages/frontend/tests/acceptance/course/session/objectivecreate-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivecreate-test.js
@@ -26,7 +26,6 @@ module('Acceptance | Session - Objective Create', function (hooks) {
   });
 
   test('save new objective', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newObjectiveDescription = 'Test junk 123';
 
     await page.visit({
@@ -59,7 +58,6 @@ module('Acceptance | Session - Objective Create', function (hooks) {
   });
 
   test('cancel new objective', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -84,7 +82,6 @@ module('Acceptance | Session - Objective Create', function (hooks) {
   });
 
   test('empty objective title can not be created', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,

--- a/packages/frontend/tests/acceptance/course/session/objectivecreate-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivecreate-test.js
@@ -7,17 +7,17 @@ import page from 'ilios-common/page-objects/session';
 module('Acceptance | Session - Objective Create', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ school, administeredSchools: [school] }, true);
     this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);
     this.server.createList('cohort', 2);
     this.course = this.server.create('course', {
       year: 2013,
-      school: this.school,
+      school,
     });
-    const sessionType = this.server.create('session-type', { school: this.school });
+    const sessionType = this.server.create('session-type', { school });
     const session = this.server.create('session', {
       course: this.course,
       sessionType,

--- a/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
@@ -18,7 +18,6 @@ module('Acceptance | Session - Objective List', function (hooks) {
   });
 
   test('list objectives', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', {
       year: 2013,
       schoolId: 1,
@@ -135,7 +134,6 @@ module('Acceptance | Session - Objective List', function (hooks) {
   });
 
   test('long objective', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     var longTitle =
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam placerat tempor neque ut egestas. In cursus dignissim erat, sed porttitor mauris tincidunt at. Nunc et tortor in purus facilisis molestie. Phasellus in ligula nisi. Nam nec mi in urna mollis pharetra. Suspendisse in nibh ex. Curabitur maximus diam in condimentum pulvinar. Phasellus sit amet metus interdum, molestie turpis vel, bibendum eros. In fermentum elit in odio cursus cursus. Nullam ipsum ipsum, fringilla a efficitur non, vehicula vitae enim. Duis ultrices vitae neque in pulvinar. Nulla molestie vitae quam eu faucibus. Vestibulum tempor, tellus in dapibus sagittis, velit purus maximus lectus, quis ullamcorper sem neque quis sem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed commodo risus sed tellus imperdiet, ac suscipit justo scelerisque. Quisque sit amet nulla efficitur, sollicitudin sem in, venenatis mi. Quisque sit amet neque varius, interdum quam id, condimentum ipsum. Quisque tincidunt efficitur diam ut feugiat. Duis vehicula mauris elit, vel vehicula eros commodo rhoncus. Phasellus ac eros vel turpis egestas aliquet. Nam id dolor rutrum, imperdiet purus ac, faucibus nisi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nam aliquam leo eget quam varius ultricies. Suspendisse pellentesque varius mi eu luctus. Integer lacinia ornare magna, in egestas quam molestie non.';
     const course = this.server.create('course', { year: 2013, schoolId: 1 });
@@ -159,7 +157,6 @@ module('Acceptance | Session - Objective List', function (hooks) {
   });
 
   test('edit objective title', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const newDescription = 'test new title';
     const course = this.server.create('course', { year: 2013, schoolId: 1 });
     const session = this.server.create('session', { course, sessionType: this.sessionType });
@@ -185,7 +182,6 @@ module('Acceptance | Session - Objective List', function (hooks) {
   });
 
   test('empty objective title can not be saved', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const course = this.server.create('course', { year: 2013, schoolId: 1 });
     const session = this.server.create('session', { course, sessionType: this.sessionType });
     this.server.create('session-objective', { session });

--- a/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
@@ -8,7 +8,10 @@ module('Acceptance | Session - Objective List', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    this.user = await setupAuthentication(
+      { school: this.school, administeredSchools: [this.school] },
+      true,
+    );
 
     this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);

--- a/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
@@ -6,17 +6,17 @@ import page from 'ilios-common/page-objects/session';
 module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.school = this.server.create('school');
-    this.user = await setupAuthentication({}, true);
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
     this.server.create('academic-year', { id: 2013 });
     this.server.createList('program', 2);
     this.server.createList('programYear', 2);
     this.server.createList('cohort', 2);
     const course = this.server.create('course', {
       year: 2013,
-      school: this.school,
+      school,
     });
-    const sessionType = this.server.create('session-type', { school: this.school });
+    const sessionType = this.server.create('session-type', { school });
     const session = this.server.create('session', { course, sessionType });
     const meshDescriptors = this.server.createList('mesh-descriptor', 6);
     this.server.create('session-objective', {

--- a/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
@@ -34,8 +34,6 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
   });
 
   test('manage terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -110,8 +108,6 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
   });
 
   test('save terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -173,8 +169,6 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
   });
 
   test('cancel changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: 1,
       sessionId: 1,

--- a/packages/frontend/tests/acceptance/course/session/objectiveparents-description-sync-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveparents-description-sync-test.js
@@ -82,8 +82,6 @@ module('Acceptance | Session - Objective Parents - Faded Status Sync', function 
   });
 
   test('objective description and parent objectives faded statuses are synced', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: 1,
       sessionId: 1,

--- a/packages/frontend/tests/acceptance/course/session/objectiveparents-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveparents-test.js
@@ -25,8 +25,6 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
   });
 
   test('list parent objectives', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -64,8 +62,6 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
   });
 
   test('save changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -115,8 +111,6 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
   });
 
   test('cancel changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -166,8 +160,6 @@ module('Acceptance | Session - Objective Parents', function (hooks) {
   });
 
   test('deselect all parents for session objective', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({
       courseId: 1,
       sessionId: 1,

--- a/packages/frontend/tests/acceptance/course/session/objectiveparents-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveparents-test.js
@@ -6,16 +6,16 @@ import page from 'ilios-common/page-objects/session';
 module('Acceptance | Session - Objective Parents', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ school, administeredSchools: [school] }, true);
     const course = this.server.create('course', {
       year: 2013,
-      school: this.school,
+      school,
     });
     const courseObjectives = this.server.createList('course-objective', 3, {
       course,
     });
-    const sessionType = this.server.create('session-type', { school: this.school });
+    const sessionType = this.server.create('session-type', { school });
     const session = this.server.create('session', { course, sessionType });
     this.server.create('session-objective', {
       session,

--- a/packages/frontend/tests/acceptance/course/session/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveterms-test.js
@@ -7,8 +7,8 @@ module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
     const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
     this.server.create('academic-year', { id: 2013 });
     const program = this.server.create('program', { school });
     const programYear = this.server.create('program-year', { program });
@@ -23,7 +23,6 @@ module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
     const sessionType = this.server.create('session-type', { school });
     const session = this.server.create('session', { course, sessionType });
     this.server.create('session-objective', { session, terms: [term] });
-    this.school = school;
   });
 
   test('manage and save terms', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/session/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveterms-test.js
@@ -27,7 +27,6 @@ module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
   });
 
   test('manage and save terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -135,7 +134,6 @@ module('Acceptance | Session - Objective Vocabulary Terms', function (hooks) {
   });
 
   test('manage and cancel terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,

--- a/packages/frontend/tests/acceptance/course/session/offerings-test.js
+++ b/packages/frontend/tests/acceptance/course/session/offerings-test.js
@@ -299,7 +299,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('confirm removal message', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.details.offerings.dateBlocks[0].timeBlockOfferings.offerings[0].remove();
     assert.ok(
@@ -312,7 +311,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('remove offering', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.details.offerings.dateBlocks[0].timeBlockOfferings.offerings[0].remove();
     await page.details.offerings.dateBlocks[0].timeBlockOfferings.offerings[0].confirmRemoval();
@@ -321,7 +319,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('cancel remove offering', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.details.offerings.dateBlocks[0].timeBlockOfferings.offerings[0].remove();
     await page.details.offerings.dateBlocks[0].timeBlockOfferings.offerings[0].cancelRemoval();
@@ -330,7 +327,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('users can create a new offering single day', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.details.offerings.top.createNew();
     const { offeringForm: form } = page.details.offerings;
@@ -378,7 +374,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('users can create a new offering multi-day', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const sep112011 = DateTime.fromObject({ year: 2011, month: 9, day: 11, hour: 2, minute: 15 });
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.details.offerings.top.createNew();
@@ -446,7 +441,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('users can create a new small group offering', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.details.offerings.top.createNew();
     const { offeringForm: form } = page.details.offerings;
@@ -511,7 +505,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('users can edit existing offerings', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, sessionId: 1 });
     assert.ok(page.details.offerings.header.isVisible);
     await page.details.offerings.dateBlocks[0].timeBlockOfferings.offerings[0].edit();
@@ -562,7 +555,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('user can cancel offering edits', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ courseId: 1, sessionId: 1 });
 
     assert.ok(page.details.offerings.header.isVisible);
@@ -642,8 +634,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('users can create recurring small groups', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.details.offerings.top.createNew();
     const { offeringForm: form } = page.details.offerings;
@@ -716,8 +706,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('users can create recurring single offerings', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit({ courseId: 1, sessionId: 1 });
     await page.details.offerings.top.createNew();
     const { offeringForm: form } = page.details.offerings;
@@ -771,7 +759,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
   });
 
   test('edit offerings twice #2850', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     this.server.create('learner-group', {
       cohortId: 1,
     });

--- a/packages/frontend/tests/acceptance/course/session/terms-test.js
+++ b/packages/frontend/tests/acceptance/course/session/terms-test.js
@@ -63,7 +63,6 @@ module('Acceptance | Session - Terms', function (hooks) {
   });
 
   test('manage terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -88,7 +87,6 @@ module('Acceptance | Session - Terms', function (hooks) {
   });
 
   test('save term changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,
@@ -107,7 +105,6 @@ module('Acceptance | Session - Terms', function (hooks) {
   });
 
   test('cancel term changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: 1,
       sessionId: 1,

--- a/packages/frontend/tests/acceptance/course/session/terms-test.js
+++ b/packages/frontend/tests/acceptance/course/session/terms-test.js
@@ -7,10 +7,10 @@ import page from 'ilios-common/page-objects/session';
 module('Acceptance | Session - Terms', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ school, administeredSchools: [school] }, true);
     const vocabulary = this.server.create('vocabulary', {
-      school: this.school,
+      school,
       active: true,
     });
     this.server.create('academic-year', { id: 2013 });
@@ -26,9 +26,9 @@ module('Acceptance | Session - Terms', function (hooks) {
 
     const course = this.server.create('course', {
       year: 2013,
-      school: this.school,
+      school,
     });
-    const sessionType = this.server.create('session-type', { school: this.school });
+    const sessionType = this.server.create('session-type', { school });
     this.server.create('session', {
       course,
       sessionType,

--- a/packages/frontend/tests/acceptance/course/terms-test.js
+++ b/packages/frontend/tests/acceptance/course/terms-test.js
@@ -64,7 +64,6 @@ module('Acceptance | Course - Terms', function (hooks) {
   });
 
   test('manage terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: this.course.id,
       details: true,
@@ -88,7 +87,6 @@ module('Acceptance | Course - Terms', function (hooks) {
   });
 
   test('save term changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: this.course.id,
       details: true,
@@ -107,7 +105,6 @@ module('Acceptance | Course - Terms', function (hooks) {
   });
 
   test('cancel term changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       courseId: this.course.id,
       details: true,

--- a/packages/frontend/tests/acceptance/course/terms-test.js
+++ b/packages/frontend/tests/acceptance/course/terms-test.js
@@ -7,10 +7,10 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Terms', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
-    this.school = this.server.create('school');
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
     this.server.create('vocabulary', {
-      school: this.school,
+      school,
       active: true,
     });
     this.server.create('academic-year', { id: 2013 });
@@ -26,7 +26,7 @@ module('Acceptance | Course - Terms', function (hooks) {
 
     this.course = this.server.create('course', {
       year: 2013,
-      school: this.school,
+      school,
       termIds: [1],
     });
   });

--- a/packages/frontend/tests/acceptance/courses-test.js
+++ b/packages/frontend/tests/acceptance/courses-test.js
@@ -250,7 +250,6 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('privileged users can only delete unpublished courses', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     this.server.create('academic-year', { id: 2014 });
     this.server.create('course', {
       year: 2014,
@@ -272,7 +271,6 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('new course', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const year = DateTime.now().year;
     this.server.create('academic-year', { id: year });
     await page.visit({ year });
@@ -312,7 +310,6 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('new course link hides after changing year', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const year1 = DateTime.now().year;
     const year2 = DateTime.now().year + 1;
     this.server.create('academic-year', { id: year1 });
@@ -344,7 +341,6 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('new course in another year does not display in list', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     this.server.create('academic-year', { id: 2012 });
     this.server.create('academic-year', { id: 2013 });
 
@@ -360,7 +356,6 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('new course does not appear twice when navigating back', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const year = DateTime.now().year;
     this.server.create('academic-year', { id: year });
 
@@ -381,7 +376,6 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('new course can be deleted', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const year = DateTime.now().year;
     this.server.create('academic-year', { id: year });
     this.server.create('userRole', {
@@ -442,8 +436,6 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('no academic years exist', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit();
     await page.root.toggleNewCourseForm();
 
@@ -592,7 +584,6 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('privileged users can lock and unlock course', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     this.server.create('academic-year', { id: 2014 });
     this.server.create('course', {
       year: 2014,
@@ -663,7 +654,6 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('can not delete course with descendants #3620', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const year = DateTime.now().year.toString();
     this.server.create('academic-year', { id: year });
     const course1 = this.server.create('course', {
@@ -690,7 +680,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('academic year pre-selects last year with calendar-year-boundary-crossing config turned on', async function (assert) {
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
-    this.user.update({ administeredSchools: [this.school] });
+
     freezeDateAt(new Date('1/1/2021'));
     const year = DateTime.now().year;
     this.server.create('academic-year', { id: year - 1 });
@@ -713,7 +703,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('academic year pre-selects this year with calendar-year-boundary-crossing config turned on', async function (assert) {
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
-    this.user.update({ administeredSchools: [this.school] });
+
     freezeDateAt(new Date('10/10/2021'));
     const year = DateTime.now().year;
     this.server.create('academic-year', { id: year - 1 });
@@ -736,7 +726,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('academic year always pre-selects this year with calendar-year-boundary-crossing config turned off', async function (assert) {
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
-    this.user.update({ administeredSchools: [this.school] });
+
     freezeDateAt(new Date('1/1/2021'));
     const year = DateTime.now().year;
     this.server.create('academic-year', { id: year - 1 });
@@ -759,7 +749,7 @@ module('Acceptance | Courses', function (hooks) {
 
   test('academic STILL always year pre-selects this year with calendar-year-boundary-crossing config turned off', async function (assert) {
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
-    this.user.update({ administeredSchools: [this.school] });
+
     freezeDateAt(new Date('10/10/2021'));
     const year = DateTime.now().year;
     this.server.create('academic-year', { id: year - 1 });

--- a/packages/frontend/tests/acceptance/courses-test.js
+++ b/packages/frontend/tests/acceptance/courses-test.js
@@ -10,7 +10,10 @@ module('Acceptance | Courses', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    this.user = await setupAuthentication(
+      { school: this.school, administeredSchools: [this.school] },
+      true,
+    );
     this.server.create('school');
   });
 
@@ -226,6 +229,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('unprivileged users can not delete courses', async function (assert) {
+    this.user.update({ administeredSchools: [] });
     this.server.create('academic-year', { id: 2014 });
     this.server.create('course', {
       year: 2014,
@@ -334,6 +338,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('new course toggle does not show up for unprivileged users', async function (assert) {
+    this.user.update({ administeredSchools: [] });
     const year = DateTime.now().year;
     this.server.create('academic-year', { id: year });
     await page.visit({ year });

--- a/packages/frontend/tests/acceptance/instructorgroup-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroup-test.js
@@ -11,11 +11,11 @@ module('Acceptance | Instructor Group', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    const school = this.server.create('school');
+    await setupAuthentication({ school, administeredSchools: [school] }, true);
     const users = this.server.createList('user', 4);
     const courses = this.server.createList('course', 2, {
-      school: this.school,
+      school,
     });
     const sessionType = this.server.create('session-type');
     const session1 = this.server.create('session', {
@@ -27,14 +27,14 @@ module('Acceptance | Instructor Group', function (hooks) {
       sessionType,
     });
     const instructorGroup1 = this.server.create('instructor-group', {
-      school: this.school,
+      school,
       users: [users[0], users[1]],
     });
     const instructorGroup2 = this.server.create('instructor-group', {
-      school: this.school,
+      school,
     });
     this.server.create('instructor-group', {
-      school: this.school,
+      school,
     });
     this.server.create('offering', {
       session: session1,

--- a/packages/frontend/tests/acceptance/instructorgroup-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroup-test.js
@@ -73,7 +73,6 @@ module('Acceptance | Instructor Group', function (hooks) {
   });
 
   test('change title', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await visit(url);
     assert.strictEqual(page.root.header.title.text, 'instructor group 0');
     await page.root.header.title.edit();
@@ -84,7 +83,6 @@ module('Acceptance | Instructor Group', function (hooks) {
   });
 
   test('add instructor', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await visit(url);
     assert.strictEqual(page.root.users.users.length, 2);
     assert.strictEqual(page.root.users.users[0].userNameInfo.fullName, '1 guy M. Mc1son');
@@ -148,7 +146,6 @@ module('Acceptance | Instructor Group', function (hooks) {
   });
 
   test('remove instructor', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await visit(url);
     assert.strictEqual(page.root.users.users.length, 2);
     assert.strictEqual(page.root.users.users[0].userNameInfo.fullName, '1 guy M. Mc1son');

--- a/packages/frontend/tests/acceptance/instructorgroups-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroups-test.js
@@ -11,7 +11,10 @@ module('Acceptance | Instructor Groups', function (hooks) {
   module('User in single school', function (hooks) {
     hooks.beforeEach(async function () {
       this.school = this.server.create('school');
-      this.user = await setupAuthentication({ school: this.school }, true);
+      this.user = await setupAuthentication(
+        { school: this.school, administeredSchools: [this.school] },
+        true,
+      );
     });
 
     test('visiting /instructorgroups', async function (assert) {

--- a/packages/frontend/tests/acceptance/instructorgroups-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroups-test.js
@@ -119,7 +119,6 @@ module('Acceptance | Instructor Groups', function (hooks) {
     });
 
     test('add new instructorgroup', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       await page.visit();
       assert.strictEqual(page.headerTitle, 'Instructor Groups (0)');
       const newTitle = 'new test title';
@@ -135,7 +134,6 @@ module('Acceptance | Instructor Groups', function (hooks) {
     });
 
     test('cancel adding new instructor group', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('instructor-group', {
         school: this.school,
       });
@@ -151,7 +149,6 @@ module('Acceptance | Instructor Groups', function (hooks) {
     });
 
     test('remove instructor group', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('instructor-group', {
         school: this.school,
       });
@@ -167,7 +164,6 @@ module('Acceptance | Instructor Groups', function (hooks) {
     });
 
     test('cancel remove instructor group', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('instructor-group', {
         school: this.school,
       });
@@ -181,7 +177,6 @@ module('Acceptance | Instructor Groups', function (hooks) {
     });
 
     test('confirmation of remove message', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       const users = this.server.createList('user', 5);
       this.server.create('instructor-group', {
         school: this.school,
@@ -221,7 +216,6 @@ module('Acceptance | Instructor Groups', function (hooks) {
     });
 
     test('cannot delete instructor group with attached courses #3767', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       const group1 = this.server.create('instructor-group', {
         school: this.school,
       });

--- a/packages/frontend/tests/acceptance/learnergroup-test.js
+++ b/packages/frontend/tests/acceptance/learnergroup-test.js
@@ -16,7 +16,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('move learners individually from cohort to group', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     this.server.create('learner-group', { cohort });
@@ -71,7 +70,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('remove learners individually from group', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     const learnerGroup = this.server.create('learner-group', { cohort });
@@ -103,7 +101,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('generate new subgroups', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     this.server.createList('user', 2);
@@ -168,7 +165,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('copy learnergroup without learners', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', {
       programYear,
@@ -222,7 +218,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('cannot copy learnergroup with learners', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const users = this.server.createList('user', 3);
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', {
@@ -252,7 +247,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('cannot copy learnergroup with learners in subgroup', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const users = this.server.createList('user', 3);
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', {
@@ -421,7 +415,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('Learners with missing parent group affiliation still appear in subgroup manager #3476', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', {
       programYearId: 1,
@@ -451,7 +444,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('moving learners to group updates count #3570', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     const learnerGroup = this.server.create('learner-group', { cohort });
@@ -473,7 +465,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('moving learners out of group updates count #3570', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     const learnerGroup = this.server.create('learner-group', { cohort });
@@ -496,7 +487,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('manage subgroup members does not duplicate members #3936', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     const parent = this.server.create('learner-group', { cohort });
@@ -512,7 +502,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('move learners individually from subgroup to subgroup #4953', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     const parent = this.server.create('learner-group', { cohort });
@@ -604,7 +593,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('expand and collapse course associations', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     const learnerGroup = this.server.create('learner-group', { cohort });
@@ -631,7 +619,6 @@ module('Acceptance | Learner Group', function (hooks) {
   });
 
   test('course associations are expanded if URL contains corresponding parameter', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', { program: this.program });
     const cohort = this.server.create('cohort', { programYear });
     const learnerGroup = this.server.create('learner-group', { cohort });

--- a/packages/frontend/tests/acceptance/learnergroup-test.js
+++ b/packages/frontend/tests/acceptance/learnergroup-test.js
@@ -11,7 +11,10 @@ module('Acceptance | Learner Group', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    this.user = await setupAuthentication(
+      { school: this.school, administeredSchools: [this.school] },
+      true,
+    );
     this.program = this.server.create('program', { school: this.school });
   });
 

--- a/packages/frontend/tests/acceptance/learnergroups-test.js
+++ b/packages/frontend/tests/acceptance/learnergroups-test.js
@@ -185,8 +185,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('add new learnergroup', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
     this.server.create('cohort', { programYear });
@@ -213,7 +211,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('cancel adding new learnergroup', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
@@ -233,8 +230,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('remove learnergroup', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
@@ -255,8 +250,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('cancel remove learnergroup', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
@@ -273,8 +266,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('confirmation of remove message', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     this.server.createList('user', 5);
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
@@ -294,8 +285,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('populated learner groups are deletable', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     this.server.createList('user', 5);
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
@@ -312,7 +301,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('learner groups linked to offerings or ILMs cannot be deleted', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
@@ -377,7 +365,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('add new learnergroup with full cohort', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
@@ -403,8 +390,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('no add button when there is no cohort', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     await page.visit();
     assert.strictEqual(currentRouteName(), 'learner-groups');
     assert.notOk(page.hasNewGroupToggle);
@@ -430,8 +415,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('copy learnergroup without learners', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });
     const cohort = this.server.create('cohort', { programYear });
@@ -487,8 +470,6 @@ module('Acceptance | Learner Groups', function (hooks) {
   });
 
   test('copy learnergroup with learners', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
-
     this.server.createList('user', 10);
     const program = this.server.create('program', { school: this.school });
     const programYear = this.server.create('program-year', { program });

--- a/packages/frontend/tests/acceptance/learnergroups-test.js
+++ b/packages/frontend/tests/acceptance/learnergroups-test.js
@@ -10,7 +10,10 @@ module('Acceptance | Learner Groups', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    this.user = await setupAuthentication(
+      { school: this.school, administeredSchools: [this.school] },
+      true,
+    );
     this.sessionType = this.server.create('session-type', { school: this.school });
   });
 

--- a/packages/frontend/tests/acceptance/program-year/competencies-test.js
+++ b/packages/frontend/tests/acceptance/program-year/competencies-test.js
@@ -7,10 +7,10 @@ module('Acceptance | Program Year - Competencies', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ school, administeredSchools: [school] }, true);
     this.server.create('program', {
-      school: this.school,
+      school,
     });
     this.server.create('program-year', {
       programId: 1,
@@ -19,18 +19,18 @@ module('Acceptance | Program Year - Competencies', function (hooks) {
       programYearId: 1,
     });
     this.server.create('competency', {
-      school: this.school,
+      school,
     });
     this.server.createList('competency', 2, {
       parentId: 1,
-      school: this.school,
+      school,
       programYearIds: [1],
     });
     this.server.create('competency', {
-      school: this.school,
+      school,
     });
     this.server.createList('competency', 2, {
-      school: this.school,
+      school,
       parentId: 4,
     });
   });

--- a/packages/frontend/tests/acceptance/program-year/competencies-test.js
+++ b/packages/frontend/tests/acceptance/program-year/competencies-test.js
@@ -53,7 +53,6 @@ module('Acceptance | Program Year - Competencies', function (hooks) {
   });
 
   test('list with permission to edit', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyCompetencyDetails: true });
     await takeScreenshot(assert);
     assert.strictEqual(page.details.competencies.title, 'Competencies (2)');
@@ -71,7 +70,6 @@ module('Acceptance | Program Year - Competencies', function (hooks) {
   });
 
   test('manager list', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyCompetencyDetails: true });
     await page.details.competencies.manage();
 
@@ -88,7 +86,6 @@ module('Acceptance | Program Year - Competencies', function (hooks) {
   });
 
   test('change and save', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyCompetencyDetails: true });
     await page.details.competencies.manage();
 
@@ -124,7 +121,6 @@ module('Acceptance | Program Year - Competencies', function (hooks) {
   });
 
   test('change and cancel', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyCompetencyDetails: true });
     await page.details.competencies.manage();
 

--- a/packages/frontend/tests/acceptance/program-year/objectives-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectives-test.js
@@ -7,12 +7,12 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ school, administeredSchools: [school] }, true);
     const program = this.server.create('program', {
-      school: this.school,
+      school,
     });
-    const vocabulary = this.server.create('vocabulary', { school: this.school });
+    const vocabulary = this.server.create('vocabulary', { school });
     const term1 = this.server.create('term', { vocabulary, active: true });
     const term2 = this.server.create('term', { vocabulary });
     const programYear = this.server.create('program-year', {
@@ -22,28 +22,28 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
       programYear,
     });
     const parent = this.server.create('competency', {
-      school: this.school,
+      school,
       programYears: [programYear],
     });
     const competency1 = this.server.create('competency', {
       parent,
-      school: this.school,
+      school,
       programYears: [programYear],
     });
     this.server.create('competency', {
       parent,
-      school: this.school,
+      school,
       programYears: [programYear],
     });
     const competency4 = this.server.create('competency', {
-      school: this.school,
+      school,
       programYears: [programYear],
     });
     this.server.create('competency', {
-      school: this.school,
+      school,
       programYears: [programYear],
     });
-    this.server.createList('competency', 3, { school: this.school });
+    this.server.createList('competency', 3, { school });
     const meshDescriptors = this.server.createList('mesh-descriptor', 4);
     const programYearObjective = this.server.create('program-year-objective', {
       programYear,

--- a/packages/frontend/tests/acceptance/program-year/objectives-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectives-test.js
@@ -66,7 +66,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('list editable', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     await takeScreenshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
@@ -196,7 +195,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('manage MeSH terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
@@ -246,7 +244,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('save MeSH terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
@@ -288,7 +285,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('cancel changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
@@ -329,7 +325,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('manage competency', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     await page.details.objectives.objectiveList.objectives[0].competency.manage();
     const m = page.details.objectives.objectiveList.objectives[0].competencyManager;
@@ -351,7 +346,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('save competency', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     await page.details.objectives.objectiveList.objectives[0].competency.manage();
     const m = page.details.objectives.objectiveList.objectives[0].competencyManager;
@@ -378,7 +372,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('save no competency', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     await page.details.objectives.objectiveList.objectives[0].competency.manage();
     const m = page.details.objectives.objectiveList.objectives[0].competencyManager;
@@ -395,7 +388,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('cancel competency change', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     await page.details.objectives.objectiveList.objectives[0].competency.manage();
     const m = page.details.objectives.objectiveList.objectives[0].competencyManager;
@@ -422,7 +414,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('cancel remove competency change', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     await page.details.objectives.objectiveList.objectives[0].competency.manage();
     const m = page.details.objectives.objectiveList.objectives[0].competencyManager;
@@ -449,7 +440,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('add competency', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(
       page.details.objectives.objectiveList.objectives[2].description.text,
@@ -482,7 +472,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('empty objective title can not be saved', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
     assert.strictEqual(
@@ -520,7 +509,6 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('activate and deactivate', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 

--- a/packages/frontend/tests/acceptance/program-year/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectiveterms-test.js
@@ -7,8 +7,8 @@ module('Acceptance | Program Year - Objective Vocabulary Terms', function (hooks
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({}, true);
     const school = this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [school] }, true);
     this.server.create('academic-year', { id: 2013 });
     const program = this.server.create('program', { school });
     const programYear = this.server.create('program-year', { program });
@@ -23,7 +23,6 @@ module('Acceptance | Program Year - Objective Vocabulary Terms', function (hooks
     this.server.createList('term', 3, { vocabulary, active: true });
     this.server.create('term', { vocabulary: vocabulary2, active: true });
     this.server.create('program-year-objective', { programYear, terms: [term] });
-    this.school = school;
   });
 
   test('manage and save terms', async function (assert) {

--- a/packages/frontend/tests/acceptance/program-year/objectiveterms-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectiveterms-test.js
@@ -27,7 +27,6 @@ module('Acceptance | Program Year - Objective Vocabulary Terms', function (hooks
   });
 
   test('manage and save terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     await takeScreenshot(assert);
     assert.strictEqual(
@@ -146,7 +145,6 @@ module('Acceptance | Program Year - Objective Vocabulary Terms', function (hooks
   });
 
   test('manage and cancel terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(
       page.details.objectives.objectiveList.objectives[0].selectedTerms.list.length,

--- a/packages/frontend/tests/acceptance/program-year/terms-test.js
+++ b/packages/frontend/tests/acceptance/program-year/terms-test.js
@@ -7,14 +7,14 @@ module('Acceptance | Program Year - Terms', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    const school = this.server.create('school');
+    this.user = await setupAuthentication({ school, administeredSchools: [school] }, true);
     const vocabulary = this.server.create('vocabulary', {
-      school: this.school,
+      school,
       active: true,
     });
     const program = this.server.create('program', {
-      school: this.school,
+      school,
     });
     const programYear = this.server.create('program-year', {
       program,

--- a/packages/frontend/tests/acceptance/program-year/terms-test.js
+++ b/packages/frontend/tests/acceptance/program-year/terms-test.js
@@ -46,7 +46,6 @@ module('Acceptance | Program Year - Terms', function (hooks) {
   });
 
   test('manage terms', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       programId: this.program.id,
       programYearId: this.programYear.id,
@@ -70,7 +69,6 @@ module('Acceptance | Program Year - Terms', function (hooks) {
   });
 
   test('save term changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       programId: this.program.id,
       programYearId: this.programYear.id,
@@ -87,7 +85,6 @@ module('Acceptance | Program Year - Terms', function (hooks) {
   });
 
   test('cancel term changes', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({
       programId: this.program.id,
       programYearId: this.programYear.id,

--- a/packages/frontend/tests/acceptance/program/overview-test.js
+++ b/packages/frontend/tests/acceptance/program/overview-test.js
@@ -9,7 +9,10 @@ module('Acceptance | Program - Overview', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    this.user = await setupAuthentication(
+      { school: this.school, administeredSchools: [this.school] },
+      true,
+    );
   });
 
   test('non editable fields', async function (assert) {

--- a/packages/frontend/tests/acceptance/program/overview-test.js
+++ b/packages/frontend/tests/acceptance/program/overview-test.js
@@ -24,7 +24,6 @@ module('Acceptance | Program - Overview', function (hooks) {
   });
 
   test('editable fields', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     this.server.create('program', {
       school: this.school,
     });
@@ -36,7 +35,6 @@ module('Acceptance | Program - Overview', function (hooks) {
   });
 
   test('change title', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     this.server.create('program', {
       school: this.school,
     });
@@ -54,7 +52,6 @@ module('Acceptance | Program - Overview', function (hooks) {
   });
 
   test('change short title', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     this.server.create('program', {
       school: this.school,
     });
@@ -72,7 +69,6 @@ module('Acceptance | Program - Overview', function (hooks) {
   });
 
   test('change duration', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     this.server.create('program', {
       school: this.school,
     });
@@ -90,7 +86,6 @@ module('Acceptance | Program - Overview', function (hooks) {
   });
 
   test('leave duration at 1', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     this.server.create('program', {
       school: this.school,
       duration: 1,

--- a/packages/frontend/tests/acceptance/program/programyear-list-test.js
+++ b/packages/frontend/tests/acceptance/program/programyear-list-test.js
@@ -15,7 +15,6 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
   });
 
   test('check list', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const thisYear = new Date().getFullYear();
     const cohorts = this.server.createList('cohort', 4);
     this.server.create('program-year', {
@@ -54,7 +53,6 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
   });
 
   test('sort list', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const thisYear = new Date().getFullYear();
     const cohorts = this.server.createList('cohort', 4);
     this.server.create('program-year', {
@@ -175,7 +173,6 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
   });
 
   test('can delete a program-year', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYear = this.server.create('program-year', {
       program: this.program,
     });
@@ -188,7 +185,6 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
   });
 
   test('canceling adding new program-year collapses new program year form', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     await page.visit({ programId: this.program.id });
     assert.notOk(page.programYears.newProgramYear.isVisible);
     await page.programYears.expandCollapse.toggle();
@@ -199,7 +195,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
 
   test('can add a program-year (with no pre-existing program-years)', async function (assert) {
     const thisYear = new Date().getFullYear();
-    this.user.update({ administeredSchools: [this.school] });
+
     await page.visit({ programId: this.program.id });
     assert.strictEqual(page.programYears.items.length, 0);
     await page.programYears.expandCollapse.toggle();
@@ -215,7 +211,7 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
 
   test('can add a program-year (with pre-existing program-year)', async function (assert) {
     const thisYear = new Date().getFullYear();
-    this.user.update({ administeredSchools: [this.school] });
+
     const directors = this.server.createList('user', 3);
     const competencies = this.server.createList('competency', 3);
     const vocabulary = this.server.create('vocabulary', { school: this.school });
@@ -269,7 +265,6 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
   });
 
   test('privileged users can lock and unlock program-year', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const cohorts = this.server.createList('cohort', 2);
     this.server.create('program-year', {
       program: this.program,
@@ -297,7 +292,6 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
   });
 
   test('delete-button is not visible for program years with populated cohorts', async function (assert) {
-    this.user.update({ administeredSchools: [this.school] });
     const programYears = this.server.createList('programYear', 2, {
       program: this.program,
     });

--- a/packages/frontend/tests/acceptance/program/programyear-list-test.js
+++ b/packages/frontend/tests/acceptance/program/programyear-list-test.js
@@ -10,7 +10,10 @@ module('Acceptance | Program - ProgramYear List', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school }, true);
+    this.user = await setupAuthentication(
+      { school: this.school, administeredSchools: [this.school] },
+      true,
+    );
     this.program = this.server.create('program', { school: this.school });
   });
 

--- a/packages/frontend/tests/acceptance/programs-test.js
+++ b/packages/frontend/tests/acceptance/programs-test.js
@@ -21,7 +21,6 @@ module('Acceptance | Programs', function (hooks) {
     });
 
     test('add new program', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       await page.visit();
 
       assert.ok(page.root.toggleNewProgramFormExists);
@@ -38,7 +37,6 @@ module('Acceptance | Programs', function (hooks) {
     });
 
     test('remove program', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('program', {
         school: this.school,
       });
@@ -54,7 +52,6 @@ module('Acceptance | Programs', function (hooks) {
     });
 
     test('cancel remove program', async function (assert) {
-      this.user.update({ administeredSchools: [this.school] });
       this.server.create('program', {
         school: this.school,
       });

--- a/packages/frontend/tests/acceptance/programs-test.js
+++ b/packages/frontend/tests/acceptance/programs-test.js
@@ -11,7 +11,10 @@ module('Acceptance | Programs', function (hooks) {
   module('User in single school with no special permissions', function (hooks) {
     hooks.beforeEach(async function () {
       this.school = this.server.create('school');
-      this.user = await setupAuthentication({ school: this.school }, true);
+      this.user = await setupAuthentication(
+        { school: this.school, administeredSchools: [this.school] },
+        true,
+      );
     });
 
     test('visiting /programs', async function (assert) {


### PR DESCRIPTION
this is cleanup.
by doing it this way, we drastically slim down the work that needs to go into our transition to msw backed tests.