### PR TITLE
Remember expanded years in Curriculum Reports

### DIFF
--- a/packages/frontend/app/components/reports/curriculum.gjs
+++ b/packages/frontend/app/components/reports/curriculum.gjs
@@ -134,6 +134,8 @@ export default class ReportsCurriculumComponent extends Component {
         />
         <ChooseCourse
           @selectedCourseIds={{@selectedCourseIds}}
+          @expandedYears={{@expandedYears}}
+          @setExpandedYears={{@setExpandedYears}}
           @schools={{@schools}}
           @add={{this.pickCourse}}
           @remove={{this.removeCourse}}

--- a/packages/frontend/app/components/reports/curriculum/choose-course.gjs
+++ b/packages/frontend/app/components/reports/curriculum/choose-course.gjs
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { cached, tracked } from '@glimmer/tracking';
 import { TrackedAsyncData } from 'ember-async-data';
-import currentAcademicYear from 'ilios-common/utils/current-academic-year';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { eq, gt } from 'ember-truth-helpers';
 import t from 'ember-intl/helpers/t';
@@ -20,12 +19,6 @@ export default class ReportsCurriculumChooseCourseComponent extends Component {
   @service currentUser;
 
   @tracked selectedSchoolId = null;
-  @tracked expandedYears = [];
-
-  constructor() {
-    super(...arguments);
-    this.expandedYears.push(currentAcademicYear());
-  }
 
   userModel = new TrackedAsyncData(this.currentUser.getModel());
 
@@ -82,7 +75,7 @@ export default class ReportsCurriculumChooseCourseComponent extends Component {
       const hasAllSelectedCourses = selectedCourses.length === courses.length;
       const hasSomeSelectedCourses = selectedCourses.length > 0 && !hasAllSelectedCourses;
       return {
-        isExpanded: this.expandedYears.includes(year),
+        isExpanded: this.args.expandedYears.includes(year),
         year,
         courses,
         selectedCourses,
@@ -94,9 +87,9 @@ export default class ReportsCurriculumChooseCourseComponent extends Component {
 
   toggleYear = (year, isExpanded) => {
     if (isExpanded) {
-      this.expandedYears = this.expandedYears.filter((y) => y !== year);
+      this.args.setExpandedYears(this.args.expandedYears.filter((y) => Number(y) !== year));
     } else {
-      this.expandedYears = [...this.expandedYears, year];
+      this.args.setExpandedYears([...this.args.expandedYears, Number(year)].sort());
     }
   };
 

--- a/packages/frontend/app/components/reports/curriculum/choose-course.gjs
+++ b/packages/frontend/app/components/reports/curriculum/choose-course.gjs
@@ -75,7 +75,7 @@ export default class ReportsCurriculumChooseCourseComponent extends Component {
       const hasAllSelectedCourses = selectedCourses.length === courses.length;
       const hasSomeSelectedCourses = selectedCourses.length > 0 && !hasAllSelectedCourses;
       return {
-        isExpanded: this.args.expandedYears.includes(year),
+        isExpanded: this.args.expandedYears?.includes(year),
         year,
         courses,
         selectedCourses,

--- a/packages/frontend/app/controllers/reports/curriculum.js
+++ b/packages/frontend/app/controllers/reports/curriculum.js
@@ -1,10 +1,12 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import currentAcademicYear from 'ilios-common/utils/current-academic-year';
 
 export default class ReportsCurriculumController extends Controller {
-  queryParams = [{ courses: 'courses' }, { report: 'report' }, { run: 'run' }];
+  queryParams = [{ courses: 'courses' }, { years: 'years' }, { report: 'report' }, { run: 'run' }];
 
   @tracked courses = null;
+  @tracked years = String(currentAcademicYear());
   @tracked report = null;
   @tracked run = false;
 
@@ -18,6 +20,18 @@ export default class ReportsCurriculumController extends Controller {
     } else {
       //use a Set to remove duplicates
       this.courses = [...new Set(ids)].join('-');
+    }
+  };
+
+  get expandedYears() {
+    return this.years?.split('-').map((year) => Number(year)) ?? [];
+  }
+
+  setExpandedYears = (years) => {
+    if (!years || !years.length) {
+      this.years = null;
+    } else {
+      this.years = years.join('-');
     }
   };
 }

--- a/packages/frontend/app/routes/reports/curriculum.js
+++ b/packages/frontend/app/routes/reports/curriculum.js
@@ -13,6 +13,9 @@ export default class ReportsCurriculumRoute extends Route {
     courses: {
       replace: true,
     },
+    years: {
+      replace: true,
+    },
   };
 
   beforeModel(transition) {

--- a/packages/frontend/app/templates/reports/curriculum.gjs
+++ b/packages/frontend/app/templates/reports/curriculum.gjs
@@ -8,6 +8,8 @@ import { fn } from '@ember/helper';
   <Curriculum
     @selectedCourseIds={{@controller.selectedCourseIds}}
     @setSelectedCourseIds={{@controller.setSelectedCourseIds}}
+    @expandedYears={{@controller.expandedYears}}
+    @setExpandedYears={{@controller.setExpandedYears}}
     @report={{@controller.report}}
     @setReport={{set @controller "report"}}
     @schools={{@model}}

--- a/packages/frontend/tests/acceptance/reports/curriculum-test.js
+++ b/packages/frontend/tests/acceptance/reports/curriculum-test.js
@@ -622,4 +622,44 @@ module('Acceptance | Reports - Curriculum Reports', function (hooks) {
     assert.notOk(page.curriculum.chooseCourse.years[2].isExpanded);
     assert.strictEqual(currentURL(), `/reports/curriculum${years}`, 'current URL is correct');
   });
+
+  test('querystring toggles years', async function (assert) {
+    await this.server.createList('course', 2, {
+      school: this.school,
+      year: currentAcademicYear(),
+    });
+    await this.server.createList('course', 2, {
+      school: this.school,
+      year: currentAcademicYear() - 1,
+    });
+    await this.server.createList('course', 2, {
+      school: this.school,
+      year: currentAcademicYear() - 2,
+    });
+    await page.visitCurriculumReports();
+
+    assert.strictEqual(currentRouteName(), 'reports.curriculum');
+
+    assert.ok(page.curriculum.chooseCourse.years[0].isExpanded);
+    assert.notOk(page.curriculum.chooseCourse.years[1].isExpanded);
+    assert.notOk(page.curriculum.chooseCourse.years[2].isExpanded);
+
+    await page.visitCurriculumReports2025();
+
+    assert.notOk(page.curriculum.chooseCourse.years[0].isExpanded);
+    assert.ok(page.curriculum.chooseCourse.years[1].isExpanded);
+    assert.notOk(page.curriculum.chooseCourse.years[2].isExpanded);
+
+    await page.visitCurriculumReports2024_2025();
+
+    assert.notOk(page.curriculum.chooseCourse.years[0].isExpanded);
+    assert.ok(page.curriculum.chooseCourse.years[1].isExpanded);
+    assert.ok(page.curriculum.chooseCourse.years[2].isExpanded);
+
+    await page.visitCurriculumReports2026();
+
+    assert.ok(page.curriculum.chooseCourse.years[0].isExpanded);
+    assert.notOk(page.curriculum.chooseCourse.years[1].isExpanded);
+    assert.notOk(page.curriculum.chooseCourse.years[2].isExpanded);
+  });
 });

--- a/packages/frontend/tests/acceptance/reports/curriculum-test.js
+++ b/packages/frontend/tests/acceptance/reports/curriculum-test.js
@@ -565,4 +565,61 @@ module('Acceptance | Reports - Curriculum Reports', function (hooks) {
     navigator.clipboard.writeText = writeText;
     assert.verifySteps(['API called', ...Array(3).fill('navigator.clipboard.writeText called')]);
   });
+
+  test('toggling years updates url', async function (assert) {
+    let years = '';
+
+    await this.server.createList('course', 2, {
+      school: this.school,
+      year: currentAcademicYear(),
+    });
+    await this.server.createList('course', 2, {
+      school: this.school,
+      year: currentAcademicYear() - 1,
+    });
+    await this.server.createList('course', 2, {
+      school: this.school,
+      year: currentAcademicYear() - 2,
+    });
+    await page.visitCurriculumReports();
+
+    assert.strictEqual(currentRouteName(), 'reports.curriculum');
+    assert.strictEqual(currentURL(), `/reports/curriculum`, 'current URL is correct');
+
+    assert.ok(page.curriculum.chooseCourse.years[0].isExpanded);
+    assert.notOk(page.curriculum.chooseCourse.years[1].isExpanded);
+    assert.notOk(page.curriculum.chooseCourse.years[2].isExpanded);
+
+    years = `?years=${currentAcademicYear() - 1}-${currentAcademicYear()}`;
+
+    await page.curriculum.chooseCourse.years[1].toggle();
+    assert.ok(page.curriculum.chooseCourse.years[0].isExpanded);
+    assert.ok(page.curriculum.chooseCourse.years[1].isExpanded);
+    assert.notOk(page.curriculum.chooseCourse.years[2].isExpanded);
+    assert.strictEqual(currentURL(), `/reports/curriculum${years}`, 'current URL is correct');
+
+    years = `?years=${currentAcademicYear() - 2}-${currentAcademicYear() - 1}-${currentAcademicYear()}`;
+
+    await page.curriculum.chooseCourse.years[2].toggle();
+    assert.ok(page.curriculum.chooseCourse.years[0].isExpanded);
+    assert.ok(page.curriculum.chooseCourse.years[1].isExpanded);
+    assert.ok(page.curriculum.chooseCourse.years[2].isExpanded);
+    assert.strictEqual(currentURL(), `/reports/curriculum${years}`, 'current URL is correct');
+
+    years = `?years=${currentAcademicYear() - 2}-${currentAcademicYear()}`;
+
+    await page.curriculum.chooseCourse.years[1].toggle();
+    assert.ok(page.curriculum.chooseCourse.years[0].isExpanded);
+    assert.notOk(page.curriculum.chooseCourse.years[1].isExpanded);
+    assert.ok(page.curriculum.chooseCourse.years[2].isExpanded);
+    assert.strictEqual(currentURL(), `/reports/curriculum${years}`, 'current URL is correct');
+
+    years = '';
+
+    await page.curriculum.chooseCourse.years[2].toggle();
+    assert.ok(page.curriculum.chooseCourse.years[0].isExpanded);
+    assert.notOk(page.curriculum.chooseCourse.years[1].isExpanded);
+    assert.notOk(page.curriculum.chooseCourse.years[2].isExpanded);
+    assert.strictEqual(currentURL(), `/reports/curriculum${years}`, 'current URL is correct');
+  });
 });

--- a/packages/frontend/tests/integration/components/reports/curriculum-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/curriculum-test.gjs
@@ -43,8 +43,12 @@ module('Integration | Component | reports/curriculum', function (hooks) {
         />
       </template>,
     );
-    assert.notOk(component.header.reportSelector.isPresent);
-    assert.strictEqual(component.header.runSummaryText, 'Select Courses to Run Report');
+    assert.notOk(component.header.reportSelector.isPresent, 'report selector is present');
+    assert.strictEqual(
+      component.header.runSummaryText,
+      'Select Courses to Run Report',
+      'report header text correct',
+    );
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -129,11 +133,13 @@ module('Integration | Component | reports/curriculum', function (hooks) {
       assert.step('setSelectedCourseIds called');
       assert.deepEqual(selectedCourseIds, [1, 2]);
     });
+    this.set('year', currentAcademicYear());
     await render(
       <template>
         <Curriculum
           @selectedCourseIds={{array "1"}}
           @setSelectedCourseIds={{this.setSelectedCourseIds}}
+          @expandedYears={{array this.year}}
           @report="sessionObjectives"
           @setReport={{(noop)}}
           @schools={{this.schools}}
@@ -143,6 +149,7 @@ module('Integration | Component | reports/curriculum', function (hooks) {
         />
       </template>,
     );
+
     await component.chooseCourse.years[0].courses[1].pick();
     assert.verifySteps(['setSelectedCourseIds called']);
   });
@@ -153,11 +160,13 @@ module('Integration | Component | reports/curriculum', function (hooks) {
       assert.step('setSelectedCourseIds called');
       assert.deepEqual(selectedCourseIds, [1]);
     });
+    this.set('year', currentAcademicYear());
     await render(
       <template>
         <Curriculum
           @selectedCourseIds={{array "1" "2"}}
           @setSelectedCourseIds={{this.setSelectedCourseIds}}
+          @expandedYears={{array this.year}}
           @report="sessionObjectives"
           @setReport={{(noop)}}
           @schools={{this.schools}}

--- a/packages/frontend/tests/integration/components/reports/curriculum/choose-course-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/curriculum/choose-course-test.gjs
@@ -56,11 +56,13 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
     });
     await setupAuthentication({ school });
     this.set('selectedCourseIds', ['2']);
+    this.set('expandedYears', [1984]);
     this.set('schools', buildSchoolsFromData(this.server));
     await render(
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{(noop)}}
@@ -69,14 +71,14 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       </template>,
     );
 
-    assert.notOk(component.hasMultipleSchools);
-    assert.strictEqual(component.years.length, 3);
-    assert.strictEqual(component.years[0].title, '1985');
-    assert.notOk(component.years[0].isExpanded);
-    assert.strictEqual(component.years[1].title, '1984');
-    assert.ok(component.years[1].isExpanded);
-    assert.strictEqual(component.years[2].title, '1983');
-    assert.notOk(component.years[2].isExpanded);
+    assert.notOk(component.hasMultipleSchools, 'only one school selected');
+    assert.strictEqual(component.years.length, 3, 'year length correct');
+    assert.strictEqual(component.years[0].title, '1985', 'first year value correct');
+    assert.notOk(component.years[0].isExpanded, 'first year collapsed');
+    assert.strictEqual(component.years[1].title, '1984', 'second year value correct');
+    assert.ok(component.years[1].isExpanded, 'second year expanded');
+    assert.strictEqual(component.years[2].title, '1983', 'third year value correct');
+    assert.notOk(component.years[2].isExpanded, 'third year collapsed');
 
     assert.ok(component.years[1].toggleAll.isPartiallySelected);
     assert.notOk(component.years[1].toggleAll.isFullySelected);
@@ -110,10 +112,12 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
     });
     this.set('schools', buildSchoolsFromData(this.server));
     this.set('selectedCourseIds', []);
+    this.set('expandedYears', [1984]);
     await render(
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{(noop)}}
@@ -161,10 +165,12 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
     });
     this.set('schools', buildSchoolsFromData(this.server));
     this.set('selectedCourseIds', [course1.id, course2.id]);
+    this.set('expandedYears', [1984]);
     await render(
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{(noop)}}
@@ -206,10 +212,18 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
     });
     this.set('schools', buildSchoolsFromData(this.server));
     this.set('selectedCourseIds', []);
+    this.set('expandedYears', [1984]);
+    this.set('setExpandedYears', (year) => {
+      assert.step('setExpandedYears called');
+      assert.ok(year);
+      this.set('expandedYears', year);
+    });
     await render(
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
+          @setExpandedYears={{this.setExpandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{(noop)}}
@@ -235,6 +249,12 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
     await component.years[1].toggle();
     assert.notOk(component.years[0].isExpanded);
     assert.ok(component.years[1].isExpanded);
+    assert.verifySteps([
+      'setExpandedYears called',
+      'setExpandedYears called',
+      'setExpandedYears called',
+      'setExpandedYears called',
+    ]);
   });
 
   test('select course fires action', async function (assert) {
@@ -246,6 +266,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       year: 1984,
     });
     this.set('selectedCourseIds', []);
+    this.set('expandedYears', [1984]);
     this.set('schools', buildSchoolsFromData(this.server));
     this.set('add', (courseId) => {
       assert.step('add called');
@@ -255,6 +276,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{this.add}}
           @remove={{(noop)}}
@@ -277,6 +299,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       year: 1984,
     });
     this.set('selectedCourseIds', [course.id]);
+    this.set('expandedYears', [1984]);
     this.set('schools', buildSchoolsFromData(this.server));
     this.set('remove', (courseId) => {
       assert.step('remove called');
@@ -286,6 +309,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{this.remove}}
@@ -308,6 +332,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       year: 1984,
     });
     this.set('selectedCourseIds', [course.id]);
+    this.set('expandedYears', [1984]);
     this.set('schools', buildSchoolsFromData(this.server));
     this.set('add', (courseId) => {
       assert.step('add called');
@@ -328,6 +353,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{this.add}}
           @remove={{this.remove}}
@@ -357,6 +383,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       year: 1985,
     });
     this.set('selectedCourseIds', [course1.id, course2.id]);
+    this.set('expandedYears', [1984]);
     this.set('schools', buildSchoolsFromData(this.server));
     this.set('removeAll', () => {
       assert.step('removeAll called');
@@ -366,6 +393,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{noop}}
@@ -396,6 +424,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       year: 1984,
     });
     this.set('selectedCourseIds', [courses[0].id]);
+    this.set('expandedYears', [1984]);
     this.set('schools', buildSchoolsFromData(this.server));
     this.set('add', (courseId) => {
       this.set('selectedCourseIds', [...this.selectedCourseIds, courseId]);
@@ -404,6 +433,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{this.add}}
           @remove={{(noop)}}
@@ -437,6 +467,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       courses.map(({ id }) => id),
     );
     this.set('schools', buildSchoolsFromData(this.server));
+    this.set('expandedYears', [1984]);
     this.set('remove', (courseId) => {
       this.set(
         'selectedCourseIds',
@@ -447,6 +478,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{this.remove}}

--- a/packages/frontend/tests/integration/components/reports/curriculum/choose-course-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/curriculum/choose-course-test.gjs
@@ -56,11 +56,13 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
     });
     await setupAuthentication({ school });
     this.set('selectedCourseIds', ['2']);
-    this.set('schools', buildSchoolsFromData(this.server.db));
+    this.set('expandedYears', [1984]);
+    this.set('schools', buildSchoolsFromData(this.server));
     await render(
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{(noop)}}
@@ -69,14 +71,14 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       </template>,
     );
 
-    assert.notOk(component.hasMultipleSchools);
-    assert.strictEqual(component.years.length, 3);
-    assert.strictEqual(component.years[0].title, '1985');
-    assert.notOk(component.years[0].isExpanded);
-    assert.strictEqual(component.years[1].title, '1984');
-    assert.ok(component.years[1].isExpanded);
-    assert.strictEqual(component.years[2].title, '1983');
-    assert.notOk(component.years[2].isExpanded);
+    assert.notOk(component.hasMultipleSchools, 'only one school selected');
+    assert.strictEqual(component.years.length, 3, 'year length correct');
+    assert.strictEqual(component.years[0].title, '1985', 'first year value correct');
+    assert.notOk(component.years[0].isExpanded, 'first year collapsed');
+    assert.strictEqual(component.years[1].title, '1984', 'second year value correct');
+    assert.ok(component.years[1].isExpanded, 'second year expanded');
+    assert.strictEqual(component.years[2].title, '1983', 'third year value correct');
+    assert.notOk(component.years[2].isExpanded, 'third year collapsed');
 
     assert.ok(component.years[1].toggleAll.isPartiallySelected);
     assert.notOk(component.years[1].toggleAll.isFullySelected);
@@ -110,10 +112,12 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
     });
     this.set('schools', buildSchoolsFromData(this.server.db));
     this.set('selectedCourseIds', []);
+    this.set('expandedYears', [1984]);
     await render(
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{(noop)}}
@@ -159,12 +163,19 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       school: school2,
       year: 1984,
     });
+<<<<<<< HEAD
     this.set('schools', buildSchoolsFromData(this.server.db));
     this.set('selectedCourseIds', [`${course1.id}`, `${course2.id}`]);
+=======
+    this.set('schools', buildSchoolsFromData(this.server));
+    this.set('selectedCourseIds', [course1.id, course2.id]);
+    this.set('expandedYears', [1984]);
+>>>>>>> c76392f0c (fixed curriculum and choose-course tests)
     await render(
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{(noop)}}
@@ -206,10 +217,18 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
     });
     this.set('schools', buildSchoolsFromData(this.server.db));
     this.set('selectedCourseIds', []);
+    this.set('expandedYears', [1984]);
+    this.set('setExpandedYears', (year) => {
+      assert.step('setExpandedYears called');
+      assert.ok(year);
+      this.set('expandedYears', year);
+    });
     await render(
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
+          @setExpandedYears={{this.setExpandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{(noop)}}
@@ -235,6 +254,12 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
     await component.years[1].toggle();
     assert.notOk(component.years[0].isExpanded);
     assert.ok(component.years[1].isExpanded);
+    assert.verifySteps([
+      'setExpandedYears called',
+      'setExpandedYears called',
+      'setExpandedYears called',
+      'setExpandedYears called',
+    ]);
   });
 
   test('select course fires action', async function (assert) {
@@ -246,7 +271,12 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       year: 1984,
     });
     this.set('selectedCourseIds', []);
+<<<<<<< HEAD
     this.set('schools', buildSchoolsFromData(this.server.db));
+=======
+    this.set('expandedYears', [1984]);
+    this.set('schools', buildSchoolsFromData(this.server));
+>>>>>>> c76392f0c (fixed curriculum and choose-course tests)
     this.set('add', (courseId) => {
       assert.step('add called');
       assert.strictEqual(Number(courseId), course.id);
@@ -255,6 +285,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{this.add}}
           @remove={{(noop)}}
@@ -276,8 +307,14 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       school,
       year: 1984,
     });
+<<<<<<< HEAD
     this.set('selectedCourseIds', [`${course.id}`]);
     this.set('schools', buildSchoolsFromData(this.server.db));
+=======
+    this.set('selectedCourseIds', [course.id]);
+    this.set('expandedYears', [1984]);
+    this.set('schools', buildSchoolsFromData(this.server));
+>>>>>>> c76392f0c (fixed curriculum and choose-course tests)
     this.set('remove', (courseId) => {
       assert.step('remove called');
       assert.strictEqual(Number(courseId), course.id);
@@ -286,6 +323,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{this.remove}}
@@ -307,8 +345,14 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       school,
       year: 1984,
     });
+<<<<<<< HEAD
     this.set('selectedCourseIds', [`${course.id}`]);
     this.set('schools', buildSchoolsFromData(this.server.db));
+=======
+    this.set('selectedCourseIds', [course.id]);
+    this.set('expandedYears', [1984]);
+    this.set('schools', buildSchoolsFromData(this.server));
+>>>>>>> c76392f0c (fixed curriculum and choose-course tests)
     this.set('add', (courseId) => {
       assert.step('add called');
       this.set('selectedCourseIds', [...this.selectedCourseIds, courseId]);
@@ -328,6 +372,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{this.add}}
           @remove={{this.remove}}
@@ -356,8 +401,14 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       school,
       year: 1985,
     });
+<<<<<<< HEAD
     this.set('selectedCourseIds', [`${course1.id}`, `${course2.id}`]);
     this.set('schools', buildSchoolsFromData(this.server.db));
+=======
+    this.set('selectedCourseIds', [course1.id, course2.id]);
+    this.set('expandedYears', [1984]);
+    this.set('schools', buildSchoolsFromData(this.server));
+>>>>>>> c76392f0c (fixed curriculum and choose-course tests)
     this.set('removeAll', () => {
       assert.step('removeAll called');
       this.set('selectedCourseIds', []);
@@ -366,6 +417,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{noop}}
@@ -395,8 +447,14 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       school,
       year: 1984,
     });
+<<<<<<< HEAD
     this.set('selectedCourseIds', [`${courses[0].id}`]);
     this.set('schools', buildSchoolsFromData(this.server.db));
+=======
+    this.set('selectedCourseIds', [courses[0].id]);
+    this.set('expandedYears', [1984]);
+    this.set('schools', buildSchoolsFromData(this.server));
+>>>>>>> c76392f0c (fixed curriculum and choose-course tests)
     this.set('add', (courseId) => {
       this.set('selectedCourseIds', [...this.selectedCourseIds, courseId]);
     });
@@ -404,6 +462,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{this.add}}
           @remove={{(noop)}}
@@ -436,7 +495,12 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       'selectedCourseIds',
       courses.map(({ id }) => `${id}`),
     );
+<<<<<<< HEAD
     this.set('schools', buildSchoolsFromData(this.server.db));
+=======
+    this.set('schools', buildSchoolsFromData(this.server));
+    this.set('expandedYears', [1984]);
+>>>>>>> c76392f0c (fixed curriculum and choose-course tests)
     this.set('remove', (courseId) => {
       this.set(
         'selectedCourseIds',
@@ -447,6 +511,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       <template>
         <ChooseCourse
           @selectedCourseIds={{this.selectedCourseIds}}
+          @expandedYears={{this.expandedYears}}
           @schools={{this.schools}}
           @add={{(noop)}}
           @remove={{this.remove}}

--- a/packages/frontend/tests/integration/components/reports/curriculum/choose-course-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/curriculum/choose-course-test.gjs
@@ -57,7 +57,7 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
     await setupAuthentication({ school });
     this.set('selectedCourseIds', ['2']);
     this.set('expandedYears', [1984]);
-    this.set('schools', buildSchoolsFromData(this.server));
+    this.set('schools', buildSchoolsFromData(this.server.db));
     await render(
       <template>
         <ChooseCourse
@@ -163,14 +163,9 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       school: school2,
       year: 1984,
     });
-<<<<<<< HEAD
     this.set('schools', buildSchoolsFromData(this.server.db));
     this.set('selectedCourseIds', [`${course1.id}`, `${course2.id}`]);
-=======
-    this.set('schools', buildSchoolsFromData(this.server));
-    this.set('selectedCourseIds', [course1.id, course2.id]);
     this.set('expandedYears', [1984]);
->>>>>>> c76392f0c (fixed curriculum and choose-course tests)
     await render(
       <template>
         <ChooseCourse
@@ -271,12 +266,8 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       year: 1984,
     });
     this.set('selectedCourseIds', []);
-<<<<<<< HEAD
-    this.set('schools', buildSchoolsFromData(this.server.db));
-=======
     this.set('expandedYears', [1984]);
-    this.set('schools', buildSchoolsFromData(this.server));
->>>>>>> c76392f0c (fixed curriculum and choose-course tests)
+    this.set('schools', buildSchoolsFromData(this.server.db));
     this.set('add', (courseId) => {
       assert.step('add called');
       assert.strictEqual(Number(courseId), course.id);
@@ -307,14 +298,9 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       school,
       year: 1984,
     });
-<<<<<<< HEAD
     this.set('selectedCourseIds', [`${course.id}`]);
-    this.set('schools', buildSchoolsFromData(this.server.db));
-=======
-    this.set('selectedCourseIds', [course.id]);
     this.set('expandedYears', [1984]);
-    this.set('schools', buildSchoolsFromData(this.server));
->>>>>>> c76392f0c (fixed curriculum and choose-course tests)
+    this.set('schools', buildSchoolsFromData(this.server.db));
     this.set('remove', (courseId) => {
       assert.step('remove called');
       assert.strictEqual(Number(courseId), course.id);
@@ -345,14 +331,9 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       school,
       year: 1984,
     });
-<<<<<<< HEAD
     this.set('selectedCourseIds', [`${course.id}`]);
-    this.set('schools', buildSchoolsFromData(this.server.db));
-=======
-    this.set('selectedCourseIds', [course.id]);
     this.set('expandedYears', [1984]);
-    this.set('schools', buildSchoolsFromData(this.server));
->>>>>>> c76392f0c (fixed curriculum and choose-course tests)
+    this.set('schools', buildSchoolsFromData(this.server.db));
     this.set('add', (courseId) => {
       assert.step('add called');
       this.set('selectedCourseIds', [...this.selectedCourseIds, courseId]);
@@ -401,14 +382,9 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       school,
       year: 1985,
     });
-<<<<<<< HEAD
     this.set('selectedCourseIds', [`${course1.id}`, `${course2.id}`]);
-    this.set('schools', buildSchoolsFromData(this.server.db));
-=======
-    this.set('selectedCourseIds', [course1.id, course2.id]);
     this.set('expandedYears', [1984]);
-    this.set('schools', buildSchoolsFromData(this.server));
->>>>>>> c76392f0c (fixed curriculum and choose-course tests)
+    this.set('schools', buildSchoolsFromData(this.server.db));
     this.set('removeAll', () => {
       assert.step('removeAll called');
       this.set('selectedCourseIds', []);
@@ -447,14 +423,9 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       school,
       year: 1984,
     });
-<<<<<<< HEAD
     this.set('selectedCourseIds', [`${courses[0].id}`]);
-    this.set('schools', buildSchoolsFromData(this.server.db));
-=======
-    this.set('selectedCourseIds', [courses[0].id]);
     this.set('expandedYears', [1984]);
-    this.set('schools', buildSchoolsFromData(this.server));
->>>>>>> c76392f0c (fixed curriculum and choose-course tests)
+    this.set('schools', buildSchoolsFromData(this.server.db));
     this.set('add', (courseId) => {
       this.set('selectedCourseIds', [...this.selectedCourseIds, courseId]);
     });
@@ -495,12 +466,8 @@ module('Integration | Component | reports/curriculum/choose-course', function (h
       'selectedCourseIds',
       courses.map(({ id }) => `${id}`),
     );
-<<<<<<< HEAD
     this.set('schools', buildSchoolsFromData(this.server.db));
-=======
-    this.set('schools', buildSchoolsFromData(this.server));
     this.set('expandedYears', [1984]);
->>>>>>> c76392f0c (fixed curriculum and choose-course tests)
     this.set('remove', (courseId) => {
       this.set(
         'selectedCourseIds',

--- a/packages/frontend/tests/pages/reports.js
+++ b/packages/frontend/tests/pages/reports.js
@@ -6,6 +6,9 @@ import curriculum from './components/reports/curriculum';
 const page = {
   visit: visitable('/reports'),
   visitCurriculumReports: visitable('/reports/curriculum'),
+  visitCurriculumReports2026: visitable('/reports/curriculum?years=2026'),
+  visitCurriculumReports2025: visitable('/reports/curriculum?years=2025'),
+  visitCurriculumReports2024_2025: visitable('/reports/curriculum?years=2024-2025'),
   switcher,
   subjects,
   curriculum,


### PR DESCRIPTION
Fixes ilios/ilios#7121

This PR moves the `expandedYears` variable out of the component and into the route so it can be kept track of in the URL and properly expand/collapse when refreshing or sharing a link.

~~TODO: fix tests~~
TODO: Add more tests