### PR TITLE
Breadcrumb sections above and below link text now clickable

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
@@ -9,6 +9,8 @@
   text-align: left;
 
   a {
+    display: block;
+
     &:focus,
     &:hover {
       color: var(--white);


### PR DESCRIPTION
Fixes ilios/ilios#7129

This should make the text, and the area above and below the text, clickable. The area to the left and right (i.e. the > parts) are not currently clickable because they are created by `span::before` and `span::after` CSS attributes.

Will follow this up with a re-write of breadcrumbs as a proper component so future accommodations are much easier.