### PR TITLE
added a period to admin console full sentence captions

### DIFF
--- a/packages/frontend/tests/integration/components/pending-updates-summary-test.gjs
+++ b/packages/frontend/tests/integration/components/pending-updates-summary-test.gjs
@@ -32,7 +32,7 @@ module('Integration | Component | pending updates summary', function (hooks) {
     this.set('schools', schools);
     await render(<template><PendingUpdatesSummary @schools={{this.schools}} /></template>);
     assert.strictEqual(component.title, 'Updates from the Campus Directory');
-    assert.strictEqual(component.summary, 'There are 5 users needing attention');
+    assert.strictEqual(component.summary, 'There are 5 users needing attention.');
     assert.ok(component.schoolFilter.hasMultiple);
     assert.strictEqual(component.schoolFilter.options.length, 2);
     assert.strictEqual(component.schoolFilter.selected, '1');
@@ -62,7 +62,7 @@ module('Integration | Component | pending updates summary', function (hooks) {
     this.set('schools', schools);
     await render(<template><PendingUpdatesSummary @schools={{this.schools}} /></template>);
     assert.strictEqual(component.title, 'Updates from the Campus Directory');
-    assert.strictEqual(component.summary, 'There are 5 users needing attention');
+    assert.strictEqual(component.summary, 'There are 5 users needing attention.');
     assert.notOk(component.schoolFilter.hasMultiple);
     assert.strictEqual(component.schoolFilter.text, 'School school 0');
     assert.ok(component.hasAlert);
@@ -89,7 +89,7 @@ module('Integration | Component | pending updates summary', function (hooks) {
     await render(<template><PendingUpdatesSummary @schools={{this.schools}} /></template>);
 
     assert.strictEqual(component.title, 'Updates from the Campus Directory');
-    assert.strictEqual(component.summary, 'There are 0 users needing attention');
+    assert.strictEqual(component.summary, 'There are 0 users needing attention.');
     assert.ok(component.schoolFilter.hasMultiple);
     assert.strictEqual(component.schoolFilter.options.length, 2);
     assert.strictEqual(component.schoolFilter.selected, '1');
@@ -123,7 +123,7 @@ module('Integration | Component | pending updates summary', function (hooks) {
     await render(<template><PendingUpdatesSummary @schools={{this.schools}} /></template>);
 
     assert.strictEqual(component.title, 'Updates from the Campus Directory');
-    assert.strictEqual(component.summary, 'There are 2 users needing attention');
+    assert.strictEqual(component.summary, 'There are 2 users needing attention.');
     assert.ok(component.schoolFilter.hasMultiple);
     assert.strictEqual(component.schoolFilter.options.length, 3);
     assert.strictEqual(component.schoolFilter.selected, '2');
@@ -131,13 +131,13 @@ module('Integration | Component | pending updates summary', function (hooks) {
     assert.strictEqual(component.manage.link, '/admin/userupdates?school=2');
 
     await component.schoolFilter.set('1');
-    assert.strictEqual(component.summary, 'There is one user needing attention');
+    assert.strictEqual(component.summary, 'There is one user needing attention.');
     assert.strictEqual(component.schoolFilter.selected, '1');
     assert.ok(component.hasAlert);
     assert.strictEqual(component.manage.link, '/admin/userupdates?school=1');
 
     await component.schoolFilter.set('3');
-    assert.strictEqual(component.summary, 'There are 0 users needing attention');
+    assert.strictEqual(component.summary, 'There are 0 users needing attention.');
     assert.strictEqual(component.schoolFilter.selected, '3');
     assert.notOk(component.hasAlert);
     assert.notOk(component.manage.isVisible);

--- a/packages/frontend/tests/integration/components/unassigned-students-summary-test.gjs
+++ b/packages/frontend/tests/integration/components/unassigned-students-summary-test.gjs
@@ -52,7 +52,7 @@ module('Integration | Component | unassigned students summary', function (hooks)
     assert.strictEqual(component.selectedSchool, '1');
     assert.strictEqual(
       component.summaryText,
-      'There are 5 students needing assignment to a cohort',
+      'There are 5 students needing assignment to a cohort.',
     );
     assert.ok(component.hasManageLink);
     assert.ok(component.hasAlert);
@@ -76,7 +76,7 @@ module('Integration | Component | unassigned students summary', function (hooks)
     assert.notOk(component.hasMultipleSchools);
     assert.strictEqual(
       component.summaryText,
-      'There are 0 students needing assignment to a cohort',
+      'There are 0 students needing assignment to a cohort.',
     );
 
     assert.notOk(component.hasManageLink);

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -292,7 +292,7 @@ general:
   otherId: Other ID
   parallel: Parallel
   password: Password
-  pendingUpdatesSummary: "{count, plural, =1 {There is one user needing attention} other {There are # users needing attention}}"
+  pendingUpdatesSummary: "{count, plural, =1 {There is one user needing attention.} other {There are # users needing attention.}}"
   pendingUpdatesSummaryTitle: Updates from the Campus Directory
   pendingUserUpdates:
     filterBy: Filter by user name
@@ -424,7 +424,7 @@ general:
   unableToSyncUser: "Unable to sync user from directory, please ensure the Campus ID is correct."
   unassigned: Unassigned
   unassignedStudentsConfirmation: "{count, plural, =1 {Assign 1 selected user to} other {Assign # selected users to}}"
-  unassignedStudentsSummary: "{count, plural, =1 {There is one student needing assignment to a cohort} other {There are # students needing assignment to a cohort}}"
+  unassignedStudentsSummary: "{count, plural, =1 {There is one student needing assignment to a cohort.} other {There are # students needing assignment to a cohort.}}"
   unassignedStudentsSummaryTitle: Students Requiring Cohort Assignment
   unlock: Unlock
   unlockCourse: Unlock course

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -292,7 +292,7 @@ general:
   otherId: Otro ID
   parallel: Paralelo
   password: Contraseña
-  pendingUpdatesSummary: "{count, plural, =1 {Hay un usuario que necesita atención} other {Hay # usuarios que necesitan atención}}"
+  pendingUpdatesSummary: "{count, plural, =1 {Hay un usuario que necesita atención.} other {Hay # usuarios que necesitan atención.}}"
   pendingUpdatesSummaryTitle: Actualizaciones del Directorio del Campus
   pendingUserUpdates:
     filterBy: Filtro por nombre de uauario
@@ -424,7 +424,7 @@ general:
   unableToSyncUser: "Incapaz de sincronizar al usuario del directorio, por favor asegure el Campus ID es correcto."
   unassigned: No asignado
   unassignedStudentsConfirmation: "{count, plural, =1 {Asignar 1 el usuario seleccionado a} other {Asignar # usuarios seleccionados a}}"
-  unassignedStudentsSummary: "{count, plural, =1 {Hay un estudiante que requiere asignación de cohorte} other {Hay # estudiantes que requieren asignación de cohorte}}"
+  unassignedStudentsSummary: "{count, plural, =1 {Hay un estudiante que requiere asignación de cohorte.} other {Hay # estudiantes que requieren asignación de cohorte.}}"
   unassignedStudentsSummaryTitle: Estudiantes que Requieren Asignación de Cohorte
   unlock: Desbloquea
   unlockCourse: Desbloquea el curso

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -292,7 +292,7 @@ general:
   otherId: Autre ID
   parallel: Parallèle
   password: Mot de passe
-  pendingUpdatesSummary: "{count, plural, =1 {Il y a un utilisateur nécessitant une attention particulière} other {Il y a des # utilisateurs nécessitants une attention particulière}}"
+  pendingUpdatesSummary: "{count, plural, =1 {Il y a un utilisateur nécessitant une attention particulière.} other {Il y a des # utilisateurs nécessitants une attention particulière.}}"
   pendingUpdatesSummaryTitle: Mises du répertoire de Campus
   pendingUserUpdates:
     filterBy: Filtre par nom d’utilisateur
@@ -424,7 +424,7 @@ general:
   unableToSyncUser: "Incapable de syncroniser le utilisateur de répertoire, veuillez vous assurer le campus ID soit exacte."
   unassigned: Non attribuée
   unassignedStudentsConfirmation: "{count, plural, =1 {Attribuez 1 l’utilisateur sélectionné à} other {Attribuez # utilisateurs sélectionnés à}}"
-  unassignedStudentsSummary: "{count, plural, =1 {Il y a un étudiant qui a besoin affectation à une cohorte} other {Il y a # étudiants qui ont besoin affectation à une cohorte}}"
+  unassignedStudentsSummary: "{count, plural, =1 {Il y a un étudiant qui a besoin affectation à une cohorte.} other {Il y a # étudiants qui ont besoin affectation à une cohorte.}}"
   unassignedStudentsSummaryTitle: Étudiants qui ont besoin affectation à une cohorte
   unlock: Débloquer
   unlockCourse: Débloquer le cours


### PR DESCRIPTION
Fixes https://github.com/ilios/ilios/issues/5591

This is what I normally do in the user guide. I added periods "." to the admin console messages regarding user assignment. 

If there is something wrong with the way I have done this ...

- I apologize.
- Please terminate my effort however it is necessary to do. 
- Let me know how I can fix this - if that is even possible. 

I only updated the translation files with the period where I thought it was applicable. That's why they call them pull "requests" I guess. I am asking if this is cool ... or not.