### PR TITLE
Publication Review Buttons and Checkboxes now using Radio Button Groups

### DIFF
--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/publish-all-sessions.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/publish-all-sessions.js
@@ -137,11 +137,11 @@ const definition = {
     title: text('> [data-test-title]'),
     publishAllAsIs: {
       scope: '[data-test-publish-all-as-is]',
-      isDisabled: property('disabled'),
+      isChecked: property('checked'),
     },
     markAllAsScheduled: {
       scope: '[data-test-mark-all-as-scheduled]',
-      isDisabled: property('disabled'),
+      isChecked: property('checked'),
     },
     table: {
       scope: 'table',

--- a/packages/ilios-common/addon/components/publish-all-sessions.gjs
+++ b/packages/ilios-common/addon/components/publish-all-sessions.gjs
@@ -27,6 +27,7 @@ export default class PublishAllSessionsComponent extends Component {
 
   @tracked totalSessionsToSave;
   @tracked currentSessionsSaved;
+  @tracked userSelectedAction = 'scheduleAll';
 
   @tracked userSelectedSessionsToPublish = [];
   @tracked userSelectedSessionsToSchedule = [];
@@ -245,12 +246,14 @@ export default class PublishAllSessionsComponent extends Component {
   publishAllAsIs() {
     this.userSelectedSessionsToSchedule = [];
     this.userSelectedSessionsToPublish = [...this.overridableSessions];
+    this.userSelectedAction = 'publishAllAsIs';
   }
 
   @action
   scheduleAll() {
     this.userSelectedSessionsToPublish = [];
     this.userSelectedSessionsToSchedule = [...this.overridableSessions];
+    this.userSelectedAction = 'scheduleAll';
   }
 
   @action
@@ -561,22 +564,49 @@ export default class PublishAllSessionsComponent extends Component {
         </div>
         <div class="content">
           {{#if this.overridableSessions.length}}
-            <button
-              type="button"
-              disabled={{this.allSessionsPublished}}
-              {{on "click" this.publishAllAsIs}}
-              data-test-publish-all-as-is
-            >
-              {{t "general.publishAsIs"}}
-            </button>
-            <button
-              type="button"
-              disabled={{this.allSessionsScheduled}}
-              {{on "click" this.scheduleAll}}
-              data-test-mark-all-as-scheduled
-            >
-              {{t "general.markAsScheduled"}}
-            </button>
+
+            {{#if (eq this.userSelectedAction "publishAllAsIs")}}
+              <label class="publish-all-as-is">
+                <input
+                  type="radio"
+                  checked="checked"
+                  {{on "click" this.publishAllAsIs}}
+                  data-test-publish-all-as-is
+                />
+                {{t "general.publishAsIs"}}
+              </label>
+            {{else}}
+              <label class="publish-all-as-is">
+                <input
+                  type="radio"
+                  {{on "click" this.publishAllAsIs}}
+                  data-test-publish-all-as-is
+                />
+                {{t "general.publishAsIs"}}
+              </label>
+            {{/if}}
+
+            {{#if (eq this.userSelectedAction "scheduleAll")}}
+              <label class="mark-all-as-scheduled">
+                <input
+                  type="radio"
+                  checked="checked"
+                  {{on "click" this.scheduleAll}}
+                  data-test-mark-all-as-scheduled
+                />
+                {{t "general.markAsScheduled"}}
+              </label>
+            {{else}}
+              <label class="mark-all-as-scheduled">
+                <input
+                  type="radio"
+                  {{on "click" this.scheduleAll}}
+                  data-test-mark-all-as-scheduled
+                />
+                {{t "general.markAsScheduled"}}
+              </label>
+            {{/if}}
+
             <table class="ilios-table ilios-table-colors sticky-header">
               <thead>
                 <tr>

--- a/packages/ilios-common/addon/components/publish-all-sessions.gjs
+++ b/packages/ilios-common/addon/components/publish-all-sessions.gjs
@@ -240,6 +240,8 @@ export default class PublishAllSessionsComponent extends Component {
       );
       this.userSelectedSessionsToPublish = [...this.userSelectedSessionsToPublish, session];
     }
+
+    this.userSelectedAction = '';
   }
 
   @action
@@ -565,47 +567,28 @@ export default class PublishAllSessionsComponent extends Component {
         <div class="content">
           {{#if this.overridableSessions.length}}
 
-            {{#if (eq this.userSelectedAction "publishAllAsIs")}}
+            <fieldset data-bulk-selection-action>
               <label class="publish-all-as-is">
                 <input
                   type="radio"
-                  checked="checked"
+                  name="bulk-selection-action"
+                  checked={{eq this.userSelectedAction "publishAllAsIs"}}
                   {{on "click" this.publishAllAsIs}}
                   data-test-publish-all-as-is
                 />
                 {{t "general.publishAsIs"}}
               </label>
-            {{else}}
-              <label class="publish-all-as-is">
-                <input
-                  type="radio"
-                  {{on "click" this.publishAllAsIs}}
-                  data-test-publish-all-as-is
-                />
-                {{t "general.publishAsIs"}}
-              </label>
-            {{/if}}
-
-            {{#if (eq this.userSelectedAction "scheduleAll")}}
               <label class="mark-all-as-scheduled">
                 <input
                   type="radio"
-                  checked="checked"
+                  name="bulk-selection-action"
+                  checked={{eq this.userSelectedAction "scheduleAll"}}
                   {{on "click" this.scheduleAll}}
                   data-test-mark-all-as-scheduled
                 />
                 {{t "general.markAsScheduled"}}
               </label>
-            {{else}}
-              <label class="mark-all-as-scheduled">
-                <input
-                  type="radio"
-                  {{on "click" this.scheduleAll}}
-                  data-test-mark-all-as-scheduled
-                />
-                {{t "general.markAsScheduled"}}
-              </label>
-            {{/if}}
+            </fieldset>
 
             <table class="ilios-table ilios-table-colors sticky-header">
               <thead>
@@ -663,30 +646,28 @@ export default class PublishAllSessionsComponent extends Component {
                 {{#each this.orderedOverridableSessions as |session|}}
                   <tr>
                     <td>
-                      <ul>
-                        <li>
-                          <label>
-                            <input
-                              type="checkbox"
-                              checked={{includes session.id (mapBy "id" this.sessionsToPublish)}}
-                              {{on "click" (fn this.toggleSession session)}}
-                              data-test-publish-as-is
-                            />
-                            {{t "general.publishAsIs"}}
-                          </label>
-                        </li>
-                        <li>
-                          <label>
-                            <input
-                              type="checkbox"
-                              checked={{includes session.id (mapBy "id" this.sessionsToSchedule)}}
-                              {{on "click" (fn this.toggleSession session)}}
-                              data-test-mark-as-scheduled
-                            />
-                            {{t "general.markAsScheduled"}}
-                          </label>
-                        </li>
-                      </ul>
+                      <fieldset data-test-session-action>
+                        <label>
+                          <input
+                            type="radio"
+                            name="session-action{{session.id}}"
+                            checked={{includes session.id (mapBy "id" this.sessionsToPublish)}}
+                            {{on "click" (fn this.toggleSession session)}}
+                            data-test-publish-as-is
+                          />
+                          {{t "general.publishAsIs"}}
+                        </label>
+                        <label>
+                          <input
+                            type="radio"
+                            name="session-action{{session.id}}"
+                            checked={{includes session.id (mapBy "id" this.sessionsToSchedule)}}
+                            {{on "click" (fn this.toggleSession session)}}
+                            data-test-mark-as-scheduled
+                          />
+                          {{t "general.markAsScheduled"}}
+                        </label>
+                      </fieldset>
                     </td>
                     <td colspan="2" data-test-title>
                       <LinkTo @route="session" @model={{session}}>

--- a/packages/ilios-common/addon/components/publish-all-sessions.gjs
+++ b/packages/ilios-common/addon/components/publish-all-sessions.gjs
@@ -27,7 +27,7 @@ export default class PublishAllSessionsComponent extends Component {
 
   @tracked totalSessionsToSave;
   @tracked currentSessionsSaved;
-  @tracked userSelectedAction = '';
+  @tracked bulkSelectedAction = '';
 
   @tracked userSelectedSessionsToPublish = [];
   @tracked userSelectedSessionsToSchedule = [];
@@ -74,6 +74,22 @@ export default class PublishAllSessionsComponent extends Component {
     return uniqueValues(
       sessionsToPublish.filter((s) => !this.userSelectedSessionsToPublish.includes(s)),
     );
+  }
+
+  get sessionsToAllBePublished() {
+    if (this.sessionsToPublish?.length) {
+      return !this.sessionsToSchedule?.length ? true : false;
+    }
+
+    return false;
+  }
+
+  get sessionsToAllBeScheduled() {
+    if (this.sessionsToSchedule?.length) {
+      return !this.sessionsToPublish?.length ? true : false;
+    }
+
+    return false;
   }
 
   get allSessionsScheduled() {
@@ -241,21 +257,21 @@ export default class PublishAllSessionsComponent extends Component {
       this.userSelectedSessionsToPublish = [...this.userSelectedSessionsToPublish, session];
     }
 
-    this.userSelectedAction = '';
+    this.bulkSelectedAction = '';
   }
 
   @action
   publishAllAsIs() {
     this.userSelectedSessionsToSchedule = [];
     this.userSelectedSessionsToPublish = [...this.overridableSessions];
-    this.userSelectedAction = 'publishAllAsIs';
+    this.bulkSelectedAction = 'publishAllAsIs';
   }
 
   @action
   scheduleAll() {
     this.userSelectedSessionsToPublish = [];
     this.userSelectedSessionsToSchedule = [...this.overridableSessions];
-    this.userSelectedAction = 'scheduleAll';
+    this.bulkSelectedAction = 'scheduleAll';
   }
 
   @action
@@ -571,7 +587,10 @@ export default class PublishAllSessionsComponent extends Component {
                 <input
                   type="radio"
                   name="bulk-selection-action"
-                  checked={{eq this.userSelectedAction "publishAllAsIs"}}
+                  checked={{or
+                    (eq this.bulkSelectedAction "publishAllAsIs")
+                    this.sessionsToAllBePublished
+                  }}
                   {{on "click" this.publishAllAsIs}}
                   data-test-publish-all-as-is
                 />
@@ -581,7 +600,10 @@ export default class PublishAllSessionsComponent extends Component {
                 <input
                   type="radio"
                   name="bulk-selection-action"
-                  checked={{eq this.userSelectedAction "scheduleAll"}}
+                  checked={{or
+                    (eq this.bulkSelectedAction "scheduleAll")
+                    this.sessionsToAllBeScheduled
+                  }}
                   {{on "click" this.scheduleAll}}
                   data-test-mark-all-as-scheduled
                 />

--- a/packages/ilios-common/addon/components/publish-all-sessions.gjs
+++ b/packages/ilios-common/addon/components/publish-all-sessions.gjs
@@ -77,19 +77,11 @@ export default class PublishAllSessionsComponent extends Component {
   }
 
   get sessionsToAllBePublished() {
-    if (this.sessionsToPublish?.length) {
-      return !this.sessionsToSchedule?.length ? true : false;
-    }
-
-    return false;
+    return !this.sessionsToSchedule?.length;
   }
 
   get sessionsToAllBeScheduled() {
-    if (this.sessionsToSchedule?.length) {
-      return !this.sessionsToPublish?.length ? true : false;
-    }
-
-    return false;
+    return !this.sessionsToPublish?.length;
   }
 
   get allSessionsScheduled() {

--- a/packages/ilios-common/addon/components/publish-all-sessions.gjs
+++ b/packages/ilios-common/addon/components/publish-all-sessions.gjs
@@ -27,7 +27,7 @@ export default class PublishAllSessionsComponent extends Component {
 
   @tracked totalSessionsToSave;
   @tracked currentSessionsSaved;
-  @tracked userSelectedAction = 'scheduleAll';
+  @tracked userSelectedAction = '';
 
   @tracked userSelectedSessionsToPublish = [];
   @tracked userSelectedSessionsToSchedule = [];
@@ -566,8 +566,7 @@ export default class PublishAllSessionsComponent extends Component {
         </div>
         <div class="content">
           {{#if this.overridableSessions.length}}
-
-            <fieldset data-bulk-selection-action>
+            <fieldset data-test-bulk-selection-actions>
               <label class="publish-all-as-is">
                 <input
                   type="radio"

--- a/packages/ilios-common/addon/components/publish-all-sessions.gjs
+++ b/packages/ilios-common/addon/components/publish-all-sessions.gjs
@@ -594,7 +594,7 @@ export default class PublishAllSessionsComponent extends Component {
                   {{on "click" this.publishAllAsIs}}
                   data-test-publish-all-as-is
                 />
-                {{t "general.publishAsIs"}}
+                {{t "general.publishAllAsIs"}}
               </label>
               <label class="mark-all-as-scheduled">
                 <input
@@ -607,7 +607,7 @@ export default class PublishAllSessionsComponent extends Component {
                   {{on "click" this.scheduleAll}}
                   data-test-mark-all-as-scheduled
                 />
-                {{t "general.markAsScheduled"}}
+                {{t "general.markAllAsScheduled"}}
               </label>
             </fieldset>
 

--- a/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
@@ -46,8 +46,14 @@
         td {
           vertical-align: top;
 
-          @include m.for-tablet-and-up {
-            padding-right: 0.5em;
+          fieldset {
+            border: none;
+            padding: 0;
+
+            label {
+              display: block;
+              padding-bottom: 0.5em;
+            }
           }
         }
       }
@@ -65,10 +71,13 @@
     border-bottom: none;
     padding-bottom: 0;
 
-    ul {
-      list-style-type: none;
-      margin: 0;
+    fieldset {
+      border: none;
       padding: 0;
+
+      label {
+        padding-right: 0.5em;
+      }
     }
   }
 

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -218,6 +218,7 @@ general:
   makeRecurring: Make Recurring
   manageLeadership: Manage Leadership
   manageLearners: Manage Learners
+  markAllAsScheduled: Mark All as Scheduled
   markAsScheduled: Mark as Scheduled
   markedAccessible: Accessible
   materials: Materials
@@ -286,6 +287,7 @@ general:
   publicationReview: Publication Review
   publicationStatus: Publication Status
   publishAllConfirmation: "Publish {publishCount}, schedule {scheduleCount}, and ignore {ignoreCount} sessions"
+  publishAllAsIs: Publish All As-is
   publishAsIs: Publish As-is
   publishCourse: Publish Course
   published: Published

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -218,6 +218,7 @@ general:
   makeRecurring: Hacer Recurrente
   manageLeadership: Maneje el Liderazgo
   manageLearners: Administrar Aprendedores
+  markAllAsScheduled: Marque Todo Como Programado
   markAsScheduled: Marque Como Programado
   markedAccessible: Accesible
   materials: Materiales
@@ -286,6 +287,7 @@ general:
   publicationReview: Revisión de Publicación
   publicationStatus: Estado de Publicación
   publishAllConfirmation: "Publique {publishCount}, Programe {scheduleCount}, y ignore {ignoreCount} sesiónes"
+  publishAllAsIs: Publique Todo Como Es
   publishAsIs: Publique Como Es
   publishCourse: Publique Curso
   published: Publicado

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -218,6 +218,7 @@ general:
   makeRecurring: Activité Récurrente
   manageLeadership: Gérer Dirigeants
   manageLearners: Manager Étudiants
+  markAllAsScheduled: Faire tout à prévu
   markAsScheduled: Faire à prévu
   markedAccessible: Accessible
   materials: Matériels
@@ -286,6 +287,7 @@ general:
   publicationReview: Revue de Publication
   publicationStatus: Statut de Publication
   publishAllConfirmation: "Publier {publishCount}, réserver {scheduleCount}, et ignorer des {ignoreCount} séances"
+  publishAllAsIs: 'Publier tout "as-is"'
   publishAsIs: 'Publier "as-is"'
   publishCourse: Publier Cours
   published: Publié

--- a/packages/test-app/tests/integration/components/publish-all-sessions-test.gjs
+++ b/packages/test-app/tests/integration/components/publish-all-sessions-test.gjs
@@ -405,17 +405,24 @@ module('Integration | Component | publish all sessions', function (hooks) {
     assert.ok(list[0].markAsScheduled.isChecked);
     assert.ok(list[1].publishAsIs.isChecked);
     assert.notOk(list[1].markAsScheduled.isChecked);
-    await component.overridableSessions.markAllAsScheduled.click();
+    await list[1].markAsScheduled.click();
     assert.notOk(component.overridableSessions.publishAllAsIs.isChecked);
     assert.ok(component.overridableSessions.markAllAsScheduled.isChecked);
     assert.notOk(list[0].publishAsIs.isChecked);
     assert.ok(list[0].markAsScheduled.isChecked);
     assert.notOk(list[1].publishAsIs.isChecked);
     assert.ok(list[1].markAsScheduled.isChecked);
+    await component.overridableSessions.publishAllAsIs.click();
+    assert.ok(component.overridableSessions.publishAllAsIs.isChecked);
+    assert.notOk(component.overridableSessions.markAllAsScheduled.isChecked);
+    assert.ok(list[0].publishAsIs.isChecked);
+    assert.notOk(list[0].markAsScheduled.isChecked);
+    assert.ok(list[1].publishAsIs.isChecked);
+    assert.notOk(list[1].markAsScheduled.isChecked);
 
     assert.strictEqual(
       component.review.confirmation,
-      'Publish 1, schedule 2, and ignore 1 sessions',
+      'Publish 3, schedule 0, and ignore 1 sessions',
     );
   });
 });

--- a/packages/test-app/tests/integration/components/publish-all-sessions-test.gjs
+++ b/packages/test-app/tests/integration/components/publish-all-sessions-test.gjs
@@ -372,6 +372,12 @@ module('Integration | Component | publish all sessions', function (hooks) {
           @course={{this.course}}
           @setExpandCompleteSessions={{(noop)}}
           @setExpandIncompleteSessions={{(noop)}}
+          @sortIncompleteBy={{this.sortColumn}}
+          @setSortIncompleteBy={{(noop)}}
+          @sortCompleteBy={{this.sortColumn}}
+          @setSortCompleteBy={{(noop)}}
+          @sortUnpublishedBy={{this.sortColumn}}
+          @setSortUnpublishedBy={{(noop)}}
         />
       </template>,
     );
@@ -379,7 +385,7 @@ module('Integration | Component | publish all sessions', function (hooks) {
       component.review.confirmation,
       'Publish 2, schedule 1, and ignore 1 sessions',
     );
-    assert.strictEqual(component.overridableSessions.title, 'Sessions Requiring Review (2)');
+    assert.strictEqual(component.overridableSessions.title, 'Unpublished Sessions: for review (2)');
     assert.ok(component.overridableSessions.markAllAsScheduled.isVisible);
     assert.ok(component.overridableSessions.publishAllAsIs.isVisible);
     const { sessions: list } = component.overridableSessions;

--- a/packages/test-app/tests/integration/components/publish-all-sessions-test.gjs
+++ b/packages/test-app/tests/integration/components/publish-all-sessions-test.gjs
@@ -362,4 +362,60 @@ module('Integration | Component | publish all sessions', function (hooks) {
       'Publish 1, schedule 2, and ignore 1 sessions',
     );
   });
+
+  test('publish/schedule individual sessions', async function (assert) {
+    this.set('course', this.course);
+
+    await render(
+      <template>
+        <PublishAllSessions
+          @course={{this.course}}
+          @setExpandCompleteSessions={{(noop)}}
+          @setExpandIncompleteSessions={{(noop)}}
+        />
+      </template>,
+    );
+    assert.strictEqual(
+      component.review.confirmation,
+      'Publish 2, schedule 1, and ignore 1 sessions',
+    );
+    assert.strictEqual(component.overridableSessions.title, 'Sessions Requiring Review (2)');
+    assert.ok(component.overridableSessions.markAllAsScheduled.isVisible);
+    assert.ok(component.overridableSessions.publishAllAsIs.isVisible);
+    const { sessions: list } = component.overridableSessions;
+
+    assert.strictEqual(list.length, 2);
+    assert.notOk(component.overridableSessions.publishAllAsIs.isChecked);
+    assert.notOk(component.overridableSessions.markAllAsScheduled.isChecked);
+    assert.notOk(list[0].publishAsIs.isChecked);
+    assert.ok(list[0].markAsScheduled.isChecked);
+    assert.ok(list[1].publishAsIs.isChecked);
+    assert.notOk(list[1].markAsScheduled.isChecked);
+    await component.overridableSessions.publishAllAsIs.click();
+    assert.ok(component.overridableSessions.publishAllAsIs.isChecked);
+    assert.notOk(component.overridableSessions.markAllAsScheduled.isChecked);
+    assert.ok(list[0].publishAsIs.isChecked);
+    assert.notOk(list[0].markAsScheduled.isChecked);
+    assert.ok(list[1].publishAsIs.isChecked);
+    assert.notOk(list[1].markAsScheduled.isChecked);
+    await list[0].markAsScheduled.click();
+    assert.notOk(component.overridableSessions.publishAllAsIs.isChecked);
+    assert.notOk(component.overridableSessions.markAllAsScheduled.isChecked);
+    assert.notOk(list[0].publishAsIs.isChecked);
+    assert.ok(list[0].markAsScheduled.isChecked);
+    assert.ok(list[1].publishAsIs.isChecked);
+    assert.notOk(list[1].markAsScheduled.isChecked);
+    await component.overridableSessions.markAllAsScheduled.click();
+    assert.notOk(component.overridableSessions.publishAllAsIs.isChecked);
+    assert.ok(component.overridableSessions.markAllAsScheduled.isChecked);
+    assert.notOk(list[0].publishAsIs.isChecked);
+    assert.ok(list[0].markAsScheduled.isChecked);
+    assert.notOk(list[1].publishAsIs.isChecked);
+    assert.ok(list[1].markAsScheduled.isChecked);
+
+    assert.strictEqual(
+      component.review.confirmation,
+      'Publish 1, schedule 2, and ignore 1 sessions',
+    );
+  });
 });


### PR DESCRIPTION
Fixes ilios/ilios#6854

This changes the "Publish All As-Is" and "Mark All As Scheduled" bulk action buttons for Publication Review into a semantically clearer radio button group. It also changes individual session row checkboxes into radio button groups.