### PR TITLE
Split Pushing Tags and Commit

### DIFF
--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -47,8 +47,10 @@ jobs:
           git add packages/frontend/package.json packages/lti-dashboard/package.json
           git commit -m "${{env.new_tag}}"
           git tag v${{env.new_tag}} -m "Tagging the v${{env.new_tag}} ${{ github.event.inputs.releaseType }} release"
-      - name: Push Changes
-        run: git push --follow-tags
+      - name: Push Changes Tag Commit
+        run: |
+          git push
+          git push v${{env.new_tag}}
       - uses: act10ns/slack@v2
         if: failure()
         env:


### PR DESCRIPTION
When something fails with pushing the commit we don't want to push the tags as well. Split these up so the work will fail when the commit can't be pushed.

Example of this issues is in https://github.com/ilios/frontend/commit/cac0e929d0596c8be083743e1b1dd855d4ef147f