### PR TITLE
rm unnecessary root user creation in the mock current session.

### DIFF
--- a/packages/frontend/tests/acceptance/course/objectiveparents-description-sync-test.js
+++ b/packages/frontend/tests/acceptance/course/objectiveparents-description-sync-test.js
@@ -13,7 +13,6 @@ module('Acceptance | Course - Objective Parents - Faded Status Sync', function (
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam placerat tempor neque ut egestas. In cursus dignissim erat, sed porttitor mauris tincidunt at. Nunc et tortor in purus facilisis molestie. Phasellus in ligula nisi. Nam nec mi in urna mollis pharetra. Suspendisse in nibh ex. Curabitur maximus diam in condimentum pulvinar. Phasellus sit amet metus interdum, molestie turpis vel, bibendum eros. In fermentum elit in odio cursus cursus. Nullam ipsum ipsum, fringilla a efficitur non, vehicula vitae enim. Duis ultrices vitae neque in pulvinar. Nulla molestie vitae quam eu faucibus. Vestibulum tempor, tellus in dapibus sagittis, velit purus maximus lectus, quis ullamcorper sem neque quis sem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed commodo risus sed tellus imperdiet, ac suscipit justo scelerisque. Quisque sit amet nulla efficitur, sollicitudin sem in, venenatis mi. Quisque sit amet neque varius, interdum quam id, condimentum ipsum. Quisque tincidunt efficitur diam ut feugiat. Duis vehicula mauris elit, vel vehicula eros commodo rhoncus. Phasellus ac eros vel turpis egestas aliquet. Nam id dolor rutrum, imperdiet purus ac, faucibus nisi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nam aliquam leo eget quam varius ultricies. Suspendisse pellentesque varius mi eu luctus. Integer lacinia ornare magna, in egestas quam molestie non.';
     this.fadedSelector = '.faded';
 
-    this.user = await setupAuthentication({ root: true });
     this.school = await this.server.create('school');
     const program = await this.server.create('program', { school: this.school });
     const programYear = await this.server.create('program-year', { program });
@@ -63,6 +62,7 @@ module('Acceptance | Course - Objective Parents - Faded Status Sync', function (
       programYearObjectives: [parent3],
       title: this.longObjDescription,
     });
+    this.user = await setupAuthentication({ directedCourses: [this.course] });
   });
 
   test('objective description and parent objectives faded statuses are synced', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/printcourse-test.js
+++ b/packages/frontend/tests/acceptance/course/printcourse-test.js
@@ -8,7 +8,6 @@ module('Acceptance | Course - Print Course', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
     this.school = await this.server.create('school');
-    await setupAuthentication({ school: this.school, root: true });
     const program = await this.server.create('program', { school: this.school });
     const programYear = await this.server.create('program-year', { program });
     await this.server.create('academic-year');
@@ -61,6 +60,7 @@ module('Acceptance | Course - Print Course', function (hooks) {
       courses: [this.course],
       name: 'Flux Capacitor',
     });
+    await setupAuthentication({ directedCourses: [this.course] });
   });
 
   test('print course header', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/publicationcheck-test.js
+++ b/packages/frontend/tests/acceptance/course/publicationcheck-test.js
@@ -7,7 +7,6 @@ import page from 'ilios-common/page-objects/course-publication-check';
 module('Acceptance | Course - Publication Check', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    await setupAuthentication({ root: true });
     const school = await this.server.create('school');
     const vocabulary = await this.server.create('vocabulary', {
       school,
@@ -35,6 +34,7 @@ module('Acceptance | Course - Publication Check', function (hooks) {
       year: 2013,
       school,
     });
+    await setupAuthentication({ directedCourses: [this.fullCourse, this.emptyCourse] });
   });
 
   test('full course count', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/session/objectiveparents-description-sync-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectiveparents-description-sync-test.js
@@ -14,7 +14,6 @@ module('Acceptance | Session - Objective Parents - Faded Status Sync', function 
     this.fadedSelector = '.faded';
 
     this.school = await this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school, root: true });
     const program = await this.server.create('program', { school: this.school });
     const programYear = await this.server.create('program-year', { program });
     const cohort = await this.server.create('cohort', { programYear });
@@ -79,6 +78,7 @@ module('Acceptance | Session - Objective Parents - Faded Status Sync', function 
       courseObjectives: [courseObjective3],
       title: this.longObjDescription,
     });
+    this.user = await setupAuthentication({ school: this.school, directedCourses: [course] });
   });
 
   test('objective description and parent objectives faded statuses are synced', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/session/offerings-test.js
+++ b/packages/frontend/tests/acceptance/course/session/offerings-test.js
@@ -16,14 +16,12 @@ module('Acceptance | Session - Offerings', function (hooks) {
     );
     this.intl = this.owner.lookup('service:intl');
     this.school = await this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school, root: true });
     const program = await this.server.create('program', { school: this.school });
     const programYear = await this.server.create('program-year', { program });
     const cohort = await this.server.create('cohort', { programYear });
     this.course = await this.server.create('course', {
       cohorts: [cohort],
       school: this.school,
-      directors: [this.user],
     });
     const sessionType = await this.server.create('session-type', {
       school: this.school,
@@ -40,6 +38,9 @@ module('Acceptance | Session - Offerings', function (hooks) {
       users: [users[2], users[3]],
       school: this.school,
     });
+
+    this.user = await setupAuthentication({ school: this.school, directedCourses: [this.course] });
+
     const learnerGroup1 = await this.server.create('learner-group', {
       users: [users[0], users[1]],
       cohort,
@@ -198,7 +199,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.strictEqual(blocks[0].timeBlockOfferings.offerings[0].instructors.length, 8);
     assert.strictEqual(
       blocks[0].timeBlockOfferings.offerings[0].instructors[0].userNameInfo.fullName,
-      '1 guy M. Mc1son',
+      '0 guy M. Mc0son',
     );
     assert.notOk(
       blocks[0].timeBlockOfferings.offerings[0].instructors[0].userStatus.accountIsDisabled,
@@ -206,7 +207,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
     assert.strictEqual(
       blocks[0].timeBlockOfferings.offerings[0].instructors[1].userNameInfo.fullName,
-      '2 guy M. Mc2son',
+      '1 guy M. Mc1son',
     );
     assert.notOk(
       blocks[0].timeBlockOfferings.offerings[0].instructors[1].userStatus.accountIsDisabled,
@@ -214,7 +215,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
     assert.strictEqual(
       blocks[0].timeBlockOfferings.offerings[0].instructors[2].userNameInfo.fullName,
-      '3 guy M. Mc3son',
+      '2 guy M. Mc2son',
     );
     assert.notOk(
       blocks[0].timeBlockOfferings.offerings[0].instructors[2].userStatus.accountIsDisabled,
@@ -222,7 +223,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
     assert.strictEqual(
       blocks[0].timeBlockOfferings.offerings[0].instructors[3].userNameInfo.fullName,
-      '4 guy M. Mc4son',
+      '3 guy M. Mc3son',
     );
     assert.notOk(
       blocks[0].timeBlockOfferings.offerings[0].instructors[3].userStatus.accountIsDisabled,
@@ -230,28 +231,28 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
     assert.strictEqual(
       blocks[0].timeBlockOfferings.offerings[0].instructors[4].userNameInfo.fullName,
-      '5 guy M. Mc5son',
+      '4 guy M. Mc4son',
     );
     assert.notOk(
       blocks[0].timeBlockOfferings.offerings[0].instructors[4].userStatus.accountIsDisabled,
     );
     assert.strictEqual(
       blocks[0].timeBlockOfferings.offerings[0].instructors[5].userNameInfo.fullName,
-      '6 guy M. Mc6son',
+      '5 guy M. Mc5son',
     );
     assert.notOk(
       blocks[0].timeBlockOfferings.offerings[0].instructors[5].userStatus.accountIsDisabled,
     );
     assert.strictEqual(
       blocks[0].timeBlockOfferings.offerings[0].instructors[6].userNameInfo.fullName,
-      '7 guy M. Mc7son',
+      '6 guy M. Mc6son',
     );
     assert.notOk(
       blocks[0].timeBlockOfferings.offerings[0].instructors[6].userStatus.accountIsDisabled,
     );
     assert.strictEqual(
       blocks[0].timeBlockOfferings.offerings[0].instructors[7].userNameInfo.fullName,
-      '8 guy M. Mc8son',
+      '7 guy M. Mc7son',
     );
     assert.ok(
       blocks[0].timeBlockOfferings.offerings[0].instructors[7].userStatus.accountIsDisabled,
@@ -266,19 +267,19 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.strictEqual(blocks[1].timeBlockOfferings.offerings[0].instructors.length, 4);
     assert.strictEqual(
       blocks[1].timeBlockOfferings.offerings[0].instructors[0].userNameInfo.fullName,
-      '3 guy M. Mc3son',
+      '2 guy M. Mc2son',
     );
     assert.strictEqual(
       blocks[1].timeBlockOfferings.offerings[0].instructors[1].userNameInfo.fullName,
-      '4 guy M. Mc4son',
+      '3 guy M. Mc3son',
     );
     assert.strictEqual(
       blocks[1].timeBlockOfferings.offerings[0].instructors[2].userNameInfo.fullName,
-      '7 guy M. Mc7son',
+      '6 guy M. Mc6son',
     );
     assert.strictEqual(
       blocks[1].timeBlockOfferings.offerings[0].instructors[3].userNameInfo.fullName,
-      '8 guy M. Mc8son',
+      '7 guy M. Mc7son',
     );
 
     assert.strictEqual(blocks[2].timeBlockOfferings.offerings[0].learnerGroups.length, 1);
@@ -291,11 +292,11 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.strictEqual(blocks[2].timeBlockOfferings.offerings[0].instructors.length, 2);
     assert.strictEqual(
       blocks[2].timeBlockOfferings.offerings[0].instructors[0].userNameInfo.fullName,
-      '3 guy M. Mc3son',
+      '2 guy M. Mc2son',
     );
     assert.strictEqual(
       blocks[2].timeBlockOfferings.offerings[0].instructors[1].userNameInfo.fullName,
-      '4 guy M. Mc4son',
+      '3 guy M. Mc3son',
     );
   });
 
@@ -476,7 +477,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.strictEqual(block.timeBlockOfferings.offerings[0].instructors.length, 1);
     assert.strictEqual(
       block.timeBlockOfferings.offerings[0].instructors[0].userNameInfo.fullName,
-      '0 guy M. Mc0son',
+      '8 guy M. Mc8son',
     );
     assert.strictEqual(block.timeBlockOfferings.offerings[0].url, 'https://iliosproject.org/');
 
@@ -488,19 +489,19 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.strictEqual(block.timeBlockOfferings.offerings[1].instructors.length, 4);
     assert.strictEqual(
       block.timeBlockOfferings.offerings[1].instructors[0].userNameInfo.fullName,
-      '1 guy M. Mc1son',
+      '0 guy M. Mc0son',
     );
     assert.strictEqual(
       block.timeBlockOfferings.offerings[1].instructors[1].userNameInfo.fullName,
-      '2 guy M. Mc2son',
+      '1 guy M. Mc1son',
     );
     assert.strictEqual(
       block.timeBlockOfferings.offerings[1].instructors[2].userNameInfo.fullName,
-      '5 guy M. Mc5son',
+      '4 guy M. Mc4son',
     );
     assert.strictEqual(
       block.timeBlockOfferings.offerings[1].instructors[3].userNameInfo.fullName,
-      '6 guy M. Mc6son',
+      '5 guy M. Mc5son',
     );
     assert.notOk(block.timeBlockOfferings.offerings[1].hasUrl);
   });
@@ -546,11 +547,11 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.strictEqual(offering.learnerGroups.length, 1);
     assert.strictEqual(offering.learnerGroups[0].title, 'learner group 1');
     assert.strictEqual(offering.instructors.length, 5);
-    assert.strictEqual(offering.instructors[0].userNameInfo.fullName, '3 guy M. Mc3son');
-    assert.strictEqual(offering.instructors[1].userNameInfo.fullName, '4 guy M. Mc4son');
-    assert.strictEqual(offering.instructors[2].userNameInfo.fullName, '6 guy M. Mc6son');
-    assert.strictEqual(offering.instructors[3].userNameInfo.fullName, '7 guy M. Mc7son');
-    assert.strictEqual(offering.instructors[4].userNameInfo.fullName, '8 guy M. Mc8son');
+    assert.strictEqual(offering.instructors[0].userNameInfo.fullName, '2 guy M. Mc2son');
+    assert.strictEqual(offering.instructors[1].userNameInfo.fullName, '3 guy M. Mc3son');
+    assert.strictEqual(offering.instructors[2].userNameInfo.fullName, '5 guy M. Mc5son');
+    assert.strictEqual(offering.instructors[3].userNameInfo.fullName, '6 guy M. Mc6son');
+    assert.strictEqual(offering.instructors[4].userNameInfo.fullName, '7 guy M. Mc7son');
     assert.strictEqual(offering.location, 'Rm. 111');
     assert.strictEqual(offering.url, 'https://example.org/');
   });
@@ -574,14 +575,14 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.strictEqual(offering.learnerGroups.length, 2);
     assert.strictEqual(offering.learnerGroups[0].title, 'learner group 0');
     assert.strictEqual(offering.instructors.length, 8);
-    assert.strictEqual(offering.instructors[0].userNameInfo.fullName, '1 guy M. Mc1son');
-    assert.strictEqual(offering.instructors[1].userNameInfo.fullName, '2 guy M. Mc2son');
-    assert.strictEqual(offering.instructors[2].userNameInfo.fullName, '3 guy M. Mc3son');
-    assert.strictEqual(offering.instructors[3].userNameInfo.fullName, '4 guy M. Mc4son');
-    assert.strictEqual(offering.instructors[4].userNameInfo.fullName, '5 guy M. Mc5son');
-    assert.strictEqual(offering.instructors[5].userNameInfo.fullName, '6 guy M. Mc6son');
-    assert.strictEqual(offering.instructors[6].userNameInfo.fullName, '7 guy M. Mc7son');
-    assert.strictEqual(offering.instructors[7].userNameInfo.fullName, '8 guy M. Mc8son');
+    assert.strictEqual(offering.instructors[0].userNameInfo.fullName, '0 guy M. Mc0son');
+    assert.strictEqual(offering.instructors[1].userNameInfo.fullName, '1 guy M. Mc1son');
+    assert.strictEqual(offering.instructors[2].userNameInfo.fullName, '2 guy M. Mc2son');
+    assert.strictEqual(offering.instructors[3].userNameInfo.fullName, '3 guy M. Mc3son');
+    assert.strictEqual(offering.instructors[4].userNameInfo.fullName, '4 guy M. Mc4son');
+    assert.strictEqual(offering.instructors[5].userNameInfo.fullName, '5 guy M. Mc5son');
+    assert.strictEqual(offering.instructors[6].userNameInfo.fullName, '6 guy M. Mc6son');
+    assert.strictEqual(offering.instructors[7].userNameInfo.fullName, '7 guy M. Mc7son');
     assert.strictEqual(offering.location, 'room 0');
     assert.strictEqual(offering.url, 'https://ucsf.edu/');
     await page.details.offerings.dateBlocks[0].timeBlockOfferings.offerings[0].edit();
@@ -622,14 +623,14 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.strictEqual(offering.learnerGroups.length, 2);
     assert.strictEqual(offering.learnerGroups[0].title, 'learner group 0');
     assert.strictEqual(offering.instructors.length, 8);
-    assert.strictEqual(offering.instructors[0].userNameInfo.fullName, '1 guy M. Mc1son');
-    assert.strictEqual(offering.instructors[1].userNameInfo.fullName, '2 guy M. Mc2son');
-    assert.strictEqual(offering.instructors[2].userNameInfo.fullName, '3 guy M. Mc3son');
-    assert.strictEqual(offering.instructors[3].userNameInfo.fullName, '4 guy M. Mc4son');
-    assert.strictEqual(offering.instructors[4].userNameInfo.fullName, '5 guy M. Mc5son');
-    assert.strictEqual(offering.instructors[5].userNameInfo.fullName, '6 guy M. Mc6son');
-    assert.strictEqual(offering.instructors[6].userNameInfo.fullName, '7 guy M. Mc7son');
-    assert.strictEqual(offering.instructors[7].userNameInfo.fullName, '8 guy M. Mc8son');
+    assert.strictEqual(offering.instructors[0].userNameInfo.fullName, '0 guy M. Mc0son');
+    assert.strictEqual(offering.instructors[1].userNameInfo.fullName, '1 guy M. Mc1son');
+    assert.strictEqual(offering.instructors[2].userNameInfo.fullName, '2 guy M. Mc2son');
+    assert.strictEqual(offering.instructors[3].userNameInfo.fullName, '3 guy M. Mc3son');
+    assert.strictEqual(offering.instructors[4].userNameInfo.fullName, '4 guy M. Mc4son');
+    assert.strictEqual(offering.instructors[5].userNameInfo.fullName, '5 guy M. Mc5son');
+    assert.strictEqual(offering.instructors[6].userNameInfo.fullName, '6 guy M. Mc6son');
+    assert.strictEqual(offering.instructors[7].userNameInfo.fullName, '7 guy M. Mc7son');
     assert.strictEqual(offering.location, 'room 0');
     assert.strictEqual(offering.url, 'https://ucsf.edu/');
   });
@@ -678,7 +679,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       assert.strictEqual(block.timeBlockOfferings.offerings[0].instructors.length, 1);
       assert.strictEqual(
         block.timeBlockOfferings.offerings[0].instructors[0].userNameInfo.fullName,
-        '0 guy M. Mc0son',
+        '8 guy M. Mc8son',
       );
 
       assert.strictEqual(block.timeBlockOfferings.offerings[1].learnerGroups.length, 1);
@@ -689,19 +690,19 @@ module('Acceptance | Session - Offerings', function (hooks) {
       assert.strictEqual(block.timeBlockOfferings.offerings[1].instructors.length, 4);
       assert.strictEqual(
         block.timeBlockOfferings.offerings[1].instructors[0].userNameInfo.fullName,
-        '1 guy M. Mc1son',
+        '0 guy M. Mc0son',
       );
       assert.strictEqual(
         block.timeBlockOfferings.offerings[1].instructors[1].userNameInfo.fullName,
-        '2 guy M. Mc2son',
+        '1 guy M. Mc1son',
       );
       assert.strictEqual(
         block.timeBlockOfferings.offerings[1].instructors[2].userNameInfo.fullName,
-        '5 guy M. Mc5son',
+        '4 guy M. Mc4son',
       );
       assert.strictEqual(
         block.timeBlockOfferings.offerings[1].instructors[3].userNameInfo.fullName,
-        '6 guy M. Mc6son',
+        '5 guy M. Mc5son',
       );
     }
   });

--- a/packages/frontend/tests/acceptance/course/session/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/session/overview-test.js
@@ -17,10 +17,10 @@ module('Acceptance | Session - Overview', function (hooks) {
     this.sessionTypes = await this.server.createList('session-type', 2, {
       school: this.school,
     });
+    await setupAuthentication({ school: this.school, directedCourses: [this.course] });
   });
 
   test('check fields', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -34,7 +34,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('check remove ilm', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const ilmSession = await this.server.create('ilm-session');
     const session = await this.server.create('session', {
       course: this.course,
@@ -66,7 +65,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('check add ilm', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -96,7 +94,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change ilm hours', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const ilmSession = await this.server.create('ilm-session', {
       hours: 3,
     });
@@ -116,7 +113,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change ilm due date and time', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const dueDate = DateTime.fromObject({
       year: 2021,
       month: 5,
@@ -174,7 +170,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change title', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -221,7 +216,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change type', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -237,7 +231,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('session attributes are shown by school config', async function (assert) {
-    await setupAuthentication({ school: this.school, root: true });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -275,7 +268,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('session attributes are hidden by school config', async function (assert) {
-    await setupAuthentication({ school: this.school, root: true });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -310,7 +302,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('session attributes are hidden when there is no school config', async function (assert) {
-    await setupAuthentication({ school: this.school, root: true });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -325,7 +316,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change supplemental', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[1],
@@ -345,7 +335,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change special attire', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[1],
@@ -365,7 +354,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change special equipment', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[1],
@@ -385,7 +373,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change attendance required', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[1],
@@ -405,7 +392,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change description', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -422,7 +408,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('add description', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -440,7 +425,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('empty description removes description', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -457,7 +441,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('remove description', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -473,7 +456,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('cancel editing empty description #3210', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -490,7 +472,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('click copy', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -503,7 +484,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('copy button is visible', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -514,7 +494,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('copy hidden on copy route', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -528,7 +507,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change instructionalNotes', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     let session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -560,7 +538,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('add instructionalNotes', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     let session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -591,7 +568,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('empty instructionalNotes removes instructionalNotes', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     let session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -609,7 +585,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('remove instructionalNotes', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -626,7 +601,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('cancel editing empty instructionalNotes #3210', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -642,7 +616,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('has no pre-requisite', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -652,7 +625,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('has pre-requisites', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -673,7 +645,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('has no post-requisite', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const ilmSession = await this.server.create('ilm-session');
     const session = await this.server.create('session', {
       course: this.course,
@@ -690,7 +661,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('has post-requisite', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const ilmSession = await this.server.create('ilm-session');
     const postrequisite = await this.server.create('session', {
       course: this.course,
@@ -712,7 +682,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('change post-requisite', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -729,7 +698,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('shows expanded objectives if no objectives exist', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -740,7 +708,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('shows collapsed objectives if objectives exist', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],
@@ -752,7 +719,6 @@ module('Acceptance | Session - Overview', function (hooks) {
   });
 
   test('shows associated learner groups', async function (assert) {
-    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
     const session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionTypes[0],

--- a/packages/frontend/tests/acceptance/course/session/publicationcheck-test.js
+++ b/packages/frontend/tests/acceptance/course/session/publicationcheck-test.js
@@ -7,7 +7,6 @@ import page from 'ilios-common/page-objects/session-publication-check';
 module('Acceptance | Session - Publication Check', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    await setupAuthentication({ root: true });
     const school = await this.server.create('school');
     const vocabulary = await this.server.create('vocabulary', {
       school,
@@ -17,6 +16,7 @@ module('Acceptance | Session - Publication Check', function (hooks) {
       school,
     });
     this.term = await this.server.create('term', { vocabulary });
+    await setupAuthentication({ directedCourses: [this.course] });
   });
 
   test('full session count', async function (assert) {
@@ -48,7 +48,10 @@ module('Acceptance | Session - Publication Check', function (hooks) {
   });
 
   test('unlink icon transitions properly', async function (assert) {
-    const session = await this.server.create('session', { course: this.course });
+    const session = await this.server.create('session', {
+      course: this.course,
+      sessionType: this.sessionTypes[0],
+    });
     await this.server.create('session-objective', { session });
     await page.visit({ courseId: this.course.id, sessionId: session.id });
     await page.unlink.click();

--- a/packages/frontend/tests/acceptance/course/sessionlist-test.js
+++ b/packages/frontend/tests/acceptance/course/sessionlist-test.js
@@ -18,7 +18,6 @@ module('Acceptance | Course - Session List', function (hooks) {
     this.intl = this.owner.lookup('service:intl');
     this.today = DateTime.fromObject({ hour: 8 });
     this.school = await this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school, root: true });
     this.sessionType = await this.server.create('session-type', {
       school: this.school,
     });
@@ -37,7 +36,6 @@ module('Acceptance | Course - Session List', function (hooks) {
     });
     this.course = await this.server.create('course', {
       school: this.school,
-      directors: [this.user],
     });
     this.session1 = await this.server.create('session', {
       course: this.course,
@@ -78,6 +76,7 @@ module('Acceptance | Course - Session List', function (hooks) {
       startDate: this.today.plus({ day: 2 }).toISO(),
       endDate: this.today.plus({ day: 3 }).toISO(),
     });
+    this.user = await setupAuthentication({ school: this.school, directedCourses: [this.course] });
   });
 
   hooks.afterEach(() => {
@@ -165,9 +164,9 @@ module('Acceptance | Course - Session List', function (hooks) {
     assert.strictEqual(offerings.offerings.length, 3);
     assert.strictEqual(offerings.offerings[0].startTime, offering1StartDate.toFormat('hh:mm a'));
     assert.strictEqual(offerings.offerings[0].location, 'room 0');
-    assert.strictEqual(offerings.offerings[0].learners, '(2) 1 guy M. Mc1son, 2 guy...');
+    assert.strictEqual(offerings.offerings[0].learners, '(2) 0 guy M. Mc0son, 1 guy...');
     assert.strictEqual(offerings.offerings[0].learnerGroups, '(2) learner group 0, learn...');
-    assert.strictEqual(offerings.offerings[0].instructors, '(3) 3 guy M. Mc3son, 4 guy...');
+    assert.strictEqual(offerings.offerings[0].instructors, '(3) 2 guy M. Mc2son, 3 guy...');
 
     assert.strictEqual(offerings.offerings[1].startTime, offering2StartDate.toFormat('hh:mm a'));
     assert.strictEqual(offerings.offerings[1].location, 'room 1');

--- a/packages/frontend/tests/acceptance/course/visualizations-instructor-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-instructor-test.js
@@ -6,9 +6,6 @@ import { setupAuthentication } from 'ilios-common';
 
 module('Acceptance | course visualizations - instructor', function (hooks) {
   setupApplicationTest(hooks);
-  hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({ root: true });
-  });
 
   test('it renders', async function (assert) {
     const instructor = await this.server.create('user');
@@ -58,10 +55,13 @@ module('Acceptance | course visualizations - instructor', function (hooks) {
       sessions: [session1, session2, session3],
       year: 2022,
     });
+
+    await setupAuthentication({ directedCourses: [course] });
+
     await page.visit({ courseId: course.id, userId: instructor.id });
-    assert.strictEqual(currentURL(), '/data/courses/1/instructors/2');
+    assert.strictEqual(currentURL(), '/data/courses/1/instructors/1');
     assert.strictEqual(page.root.title, 'course 0 2022');
-    assert.strictEqual(page.root.instructorName, '1 guy M. Mc1son');
+    assert.strictEqual(page.root.instructorName, '0 guy M. Mc0son');
     assert.strictEqual(page.root.totalOfferingsTime, 'Total Instructional Time 90 Minutes');
     assert.strictEqual(page.root.totalIlmTime, 'Total ILM Time 120 Minutes');
     assert.strictEqual(page.root.breadcrumbs.crumbs.length, 4);
@@ -71,7 +71,7 @@ module('Acceptance | course visualizations - instructor', function (hooks) {
     assert.strictEqual(page.root.breadcrumbs.crumbs[1].link, '/data/courses/1');
     assert.strictEqual(page.root.breadcrumbs.crumbs[2].text, 'Instructors');
     assert.strictEqual(page.root.breadcrumbs.crumbs[2].link, '/data/courses/1/instructors');
-    assert.strictEqual(page.root.breadcrumbs.crumbs[3].text, '1 guy M. Mc1son');
+    assert.strictEqual(page.root.breadcrumbs.crumbs[3].text, '0 guy M. Mc0son');
     // wait for charts to load
     await waitFor('.loaded', { count: 2 });
     await waitFor('svg .bars');

--- a/packages/frontend/tests/acceptance/course/visualizations-instructors-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-instructors-test.js
@@ -7,7 +7,6 @@ import { setupAuthentication } from 'ilios-common';
 module('Acceptance | course visualizations - instructors', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({ root: true });
     const instructor1 = await this.server.create('user');
     const instructor2 = await this.server.create('user');
     const vocabulary1 = await this.server.create('vocabulary');
@@ -60,6 +59,7 @@ module('Acceptance | course visualizations - instructors', function (hooks) {
       sessions: [session1, session2, session3],
       year: 2022,
     });
+    this.user = await setupAuthentication({ directedCourses: [this.course] });
   });
 
   test('it renders', async function (assert) {
@@ -79,15 +79,15 @@ module('Acceptance | course visualizations - instructors', function (hooks) {
     assert.strictEqual(page.root.instructorsChart.chart.bars.length, 2);
     assert.strictEqual(
       page.root.instructorsChart.chart.bars[0].description,
-      '1 guy M. Mc1son - 75 Minutes',
+      '0 guy M. Mc0son - 75 Minutes',
     );
     assert.strictEqual(
       page.root.instructorsChart.chart.bars[1].description,
-      '2 guy M. Mc2son - 90 Minutes',
+      '1 guy M. Mc1son - 90 Minutes',
     );
     assert.strictEqual(page.root.instructorsChart.chart.labels.length, 2);
-    assert.strictEqual(page.root.instructorsChart.chart.labels[0].text, '1 guy M. Mc1son\u200b');
-    assert.strictEqual(page.root.instructorsChart.chart.labels[1].text, '2 guy M. Mc2son\u200b');
+    assert.strictEqual(page.root.instructorsChart.chart.labels[0].text, '0 guy M. Mc0son\u200b');
+    assert.strictEqual(page.root.instructorsChart.chart.labels[1].text, '1 guy M. Mc1son\u200b');
     assert.strictEqual(page.root.instructorsChart.dataTable.rows.length, 2);
   });
 
@@ -96,8 +96,8 @@ module('Acceptance | course visualizations - instructors', function (hooks) {
     // wait for charts to load
     await waitFor('.loaded');
     await waitFor('svg .bars');
-    assert.strictEqual(page.root.instructorsChart.chart.labels[0].text, '1 guy M. Mc1son\u200b');
+    assert.strictEqual(page.root.instructorsChart.chart.labels[0].text, '0 guy M. Mc0son\u200b');
     await page.root.instructorsChart.chart.bars[0].click();
-    assert.strictEqual(currentURL(), '/data/courses/1/instructors/2');
+    assert.strictEqual(currentURL(), '/data/courses/1/instructors/1');
   });
 });

--- a/packages/frontend/tests/acceptance/course/visualizations-objectives-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-objectives-test.js
@@ -6,9 +6,6 @@ import { setupAuthentication } from 'ilios-common';
 
 module('Acceptance | course visualizations - objectives', function (hooks) {
   setupApplicationTest(hooks);
-  hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({ root: true });
-  });
 
   test('it renders', async function (assert) {
     const school = await this.server.create('school');
@@ -56,6 +53,7 @@ module('Acceptance | course visualizations - objectives', function (hooks) {
       startDate: '2019-12-05T18:00:00',
       endDate: '2019-12-05T21:00:00',
     });
+    await setupAuthentication({ directedCourses: [course] });
     await page.visit({ courseId: course.id });
     assert.strictEqual(currentURL(), '/data/courses/1/objectives');
     assert.strictEqual(page.root.title, 'course 0 2021');

--- a/packages/frontend/tests/acceptance/course/visualizations-session-type-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-session-type-test.js
@@ -6,9 +6,6 @@ import { setupAuthentication } from 'ilios-common';
 
 module('Acceptance | course visualizations - session-type', function (hooks) {
   setupApplicationTest(hooks);
-  hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({ root: true });
-  });
 
   test('it renders', async function (assert) {
     const sessionType = await this.server.create('session-type');
@@ -51,6 +48,7 @@ module('Acceptance | course visualizations - session-type', function (hooks) {
       endDate: '2022-07-20T09:30:00',
       session: session2,
     });
+    await setupAuthentication({ directedCourses: [course] });
     await page.visit({ courseId: course.id, sessionTypeId: sessionType.id });
     assert.strictEqual(currentURL(), '/data/courses/1/session-types/1');
     assert.strictEqual(page.root.title, 'course 0 2022');

--- a/packages/frontend/tests/acceptance/course/visualizations-session-types-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-session-types-test.js
@@ -6,9 +6,6 @@ import { setupAuthentication } from 'ilios-common';
 
 module('Acceptance | course visualizations - session-types', function (hooks) {
   setupApplicationTest(hooks);
-  hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({ root: true });
-  });
 
   test('it renders', async function (assert) {
     const sessionType1 = await this.server.create('session-type');
@@ -54,6 +51,7 @@ module('Acceptance | course visualizations - session-types', function (hooks) {
       sessions: [session1, session2, session3],
       year: 2022,
     });
+    await setupAuthentication({ directedCourses: [course] });
     await page.visit({ courseId: course.id });
     assert.strictEqual(currentURL(), '/data/courses/1/session-types');
     assert.strictEqual(page.root.title, 'course 0 2022');

--- a/packages/frontend/tests/acceptance/course/visualizations-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-test.js
@@ -7,13 +7,13 @@ import { setupAuthentication } from 'ilios-common';
 module('Acceptance | course visualizations', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({ root: true });
     this.school = await this.server.create('school');
 
-    await this.server.create('course', {
+    const course = await this.server.create('course', {
       year: 2021,
       school: this.school,
     });
+    this.user = await setupAuthentication({ directedCourses: [course] });
   });
 
   test('visiting /data/courses/1', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/visualizations-vocabularies-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-vocabularies-test.js
@@ -6,9 +6,6 @@ import { setupAuthentication } from 'ilios-common';
 
 module('Acceptance | course visualizations - vocabularies', function (hooks) {
   setupApplicationTest(hooks);
-  hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({ root: true });
-  });
 
   test('it renders', async function (assert) {
     const sessionType = await this.server.create('session-type');
@@ -52,6 +49,7 @@ module('Acceptance | course visualizations - vocabularies', function (hooks) {
       sessions: [session1, session2, session3],
       year: 2022,
     });
+    await setupAuthentication({ directedCourses: [course] });
     await page.visit({ courseId: course.id });
     assert.strictEqual(currentURL(), '/data/courses/1/vocabularies');
     assert.strictEqual(page.root.courseTitle.text, 'course 0 2022');

--- a/packages/frontend/tests/acceptance/course/visualizations-vocabulary-test.js
+++ b/packages/frontend/tests/acceptance/course/visualizations-vocabulary-test.js
@@ -7,7 +7,6 @@ import { setupAuthentication } from 'ilios-common';
 module('Acceptance | course visualizations - vocabulary', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    this.user = await setupAuthentication({ root: true });
     this.vocabulary = await this.server.create('vocabulary');
     const term1 = await this.server.create('term', {
       vocabulary: this.vocabulary,
@@ -49,6 +48,7 @@ module('Acceptance | course visualizations - vocabulary', function (hooks) {
       sessions: [session1, session2, session3],
       year: 2022,
     });
+    this.user = await setupAuthentication({ directedCourses: [this.course] });
   });
 
   test('it renders', async function (assert) {

--- a/packages/frontend/tests/acceptance/courses-test.js
+++ b/packages/frontend/tests/acceptance/courses-test.js
@@ -637,7 +637,7 @@ module('Acceptance | Courses', function (hooks) {
   });
 
   test('non-privileged users cannot lock and unlock course but can see the icon', async function (assert) {
-    await setupAuthentication({ school: this.school, root: true });
+    await setupAuthentication({ school: this.school, directedSchools: [this.school2] });
     await this.server.create('academic-year', { id: 2014 });
     await this.server.create('course', {
       year: 2014,

--- a/packages/frontend/tests/acceptance/dashboard/calendar-test.js
+++ b/packages/frontend/tests/acceptance/dashboard/calendar-test.js
@@ -550,14 +550,16 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('user context filters are present on user calendar for privileged users', async function (assert) {
-    await setupAuthentication({ school: this.school, root: true });
+    // Any user relationship that results in the current user 'performing non-learner function' will do here,
+    // including making the user a school director.
+    await setupAuthentication({ school: this.school, directedSchools: [this.school] });
     await page.visit({ show: 'calendar' });
     await takeScreenshot(assert);
     assert.ok(page.calendar.controls.userContextFilter.isPresent);
   });
 
   test('user context filters are not present on school calendar', async function (assert) {
-    await setupAuthentication({ school: this.school, root: true });
+    await setupAuthentication({ school: this.school, directedSchools: [this.school] });
     await page.visit({ show: 'calendar' });
     assert.ok(page.calendar.controls.userContextFilter.isPresent);
     await page.calendar.controls.mySchedule.toggle.secondLabel.click();
@@ -566,7 +568,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('user context filters do not apply to school calendar', async function (assert) {
-    this.user = await setupAuthentication({ school: this.school, root: true });
+    this.user = await setupAuthentication({ school: this.school, directedSchools: [this.school] });
     const day = DateTime.fromObject({
       month: 7,
       day: 7,
@@ -601,7 +603,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('test user context filters', async function (assert) {
-    this.user = await setupAuthentication({ school: this.school, root: true });
+    this.user = await setupAuthentication({ school: this.school, directedSchools: [this.school] });
     const day = DateTime.fromObject({
       month: 4,
       day: 4,
@@ -651,7 +653,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('user context filter selections persist across page reloads', async function (assert) {
-    this.user = await setupAuthentication({ school: this.school, root: true });
+    this.user = await setupAuthentication({ school: this.school, directedSchools: [this.school] });
     const day = DateTime.fromObject({
       month: 4,
       day: 4,
@@ -729,7 +731,7 @@ module('Acceptance | Dashboard Calendar', function (hooks) {
   });
 
   test('filter toggle not present on my-schedule', async function (assert) {
-    await setupAuthentication({ school: this.school, root: true });
+    await setupAuthentication({ school: this.school, directedSchools: [this.school] });
     await page.visit({ show: 'calendar' });
     assert.notOk(page.calendar.controls.showFilters.isPresent);
     await page.calendar.controls.mySchedule.toggle.secondLabel.click();

--- a/packages/frontend/tests/acceptance/four-oh-four-test.js
+++ b/packages/frontend/tests/acceptance/four-oh-four-test.js
@@ -6,11 +6,8 @@ import { setupApplicationTest, takeScreenshot } from 'frontend/tests/helpers';
 module('Acceptance | FourOhFour', function (hooks) {
   setupApplicationTest(hooks);
 
-  hooks.beforeEach(async function () {
-    await setupAuthentication({ root: true });
-  });
-
   test('visiting /four-oh-four', async function (assert) {
+    await setupAuthentication();
     await visit('/four-oh-four');
     await takeScreenshot(assert);
 
@@ -23,11 +20,14 @@ module('Acceptance | FourOhFour', function (hooks) {
   });
 
   test('visiting /nothing', async function (assert) {
+    await setupAuthentication();
     await visit('/nothing');
     assert.strictEqual(currentRouteName(), 'four-oh-four');
   });
 
   test('visiting missing course', async function (assert) {
+    const school = await this.server.create('school');
+    await setupAuthentication({ directedSchools: [school] });
     await visit('/courses/1337');
     assert.strictEqual(currentURL(), '/courses/1337');
     assert
@@ -38,8 +38,9 @@ module('Acceptance | FourOhFour', function (hooks) {
   });
 
   test('visiting existing course does NOT trigger 404', async function (assert) {
-    this.school = await this.server.create('school');
-    this.course = await this.server.create('course', { school: this.school });
+    const school = await this.server.create('school');
+    const course = await this.server.create('course', { school });
+    await setupAuthentication({ directedCourses: [course] });
 
     await visit('/courses/1');
     assert.strictEqual(currentURL(), '/courses/1');
@@ -47,6 +48,8 @@ module('Acceptance | FourOhFour', function (hooks) {
   });
 
   test('visiting missing session', async function (assert) {
+    const school = await this.server.create('school');
+    await setupAuthentication({ directedSchools: [school] });
     await visit('/courses/1337/sessions/99999');
     assert.strictEqual(currentURL(), '/courses/1337/sessions/99999');
     assert
@@ -57,6 +60,8 @@ module('Acceptance | FourOhFour', function (hooks) {
   });
 
   test('visiting missing learner group', async function (assert) {
+    const school = await this.server.create('school');
+    await setupAuthentication({ directedSchools: [school] });
     await visit('/learnergroups/1776');
     assert.strictEqual(currentURL(), '/learnergroups/1776');
     assert
@@ -67,6 +72,8 @@ module('Acceptance | FourOhFour', function (hooks) {
   });
 
   test('visiting missing instructor group', async function (assert) {
+    const school = await this.server.create('school');
+    await setupAuthentication({ directedSchools: [school] });
     await visit('/instructorgroups/9001');
     assert.strictEqual(currentURL(), '/instructorgroups/9001');
     assert
@@ -77,6 +84,8 @@ module('Acceptance | FourOhFour', function (hooks) {
   });
 
   test('visiting missing school', async function (assert) {
+    const school = await this.server.create('school');
+    await setupAuthentication({ directedSchools: [school] });
     await visit('/schools/99');
     assert.strictEqual(currentURL(), '/schools/99');
     assert
@@ -87,6 +96,8 @@ module('Acceptance | FourOhFour', function (hooks) {
   });
 
   test('visiting missing program', async function (assert) {
+    const school = await this.server.create('school');
+    await setupAuthentication({ directedSchools: [school] });
     await visit('/programs/135');
     assert.strictEqual(currentURL(), '/programs/135');
     assert
@@ -97,6 +108,8 @@ module('Acceptance | FourOhFour', function (hooks) {
   });
 
   test('visiting missing report #5127', async function (assert) {
+    const school = await this.server.create('school');
+    await setupAuthentication({ directedSchools: [school] });
     await visit('/reports/subjects/1989');
     assert.strictEqual(currentURL(), '/reports/subjects/1989');
     assert
@@ -107,6 +120,8 @@ module('Acceptance | FourOhFour', function (hooks) {
   });
 
   test('visiting missing user #1111', async function (assert) {
+    const school = await this.server.create('school');
+    await setupAuthentication({ directedSchools: [school] });
     await visit('/users/1111');
     assert.strictEqual(currentURL(), '/users/1111');
     assert
@@ -117,6 +132,8 @@ module('Acceptance | FourOhFour', function (hooks) {
   });
 
   test('visiting missing curriculum inventory report #6324', async function (assert) {
+    const school = await this.server.create('school');
+    await setupAuthentication({ directedSchools: [school] });
     await visit('/reports/subjects/2525');
     assert.strictEqual(currentURL(), '/reports/subjects/2525');
     assert

--- a/packages/frontend/tests/acceptance/header-test.js
+++ b/packages/frontend/tests/acceptance/header-test.js
@@ -25,6 +25,9 @@ module('Acceptance | header', function (hooks) {
         },
       };
     });
+    // Global search requires the current user to perform a non-learner function.
+    // Creating the current user as root gives us the necessary permissions.
+    // Please see the `ilios-header` component for details.
     await setupAuthentication({ root: true });
     await visit('/');
     await takeScreenshot(assert);
@@ -43,7 +46,10 @@ module('Acceptance | header', function (hooks) {
         },
       };
     });
-    await setupAuthentication();
+    // Global search requires the current user to perform a non-learner function.
+    // Creating the current user as root gives us the necessary permissions.
+    // Please see the `ilios-header` component for details.
+    await setupAuthentication({ root: true });
     await visit('/');
     await takeScreenshot(assert);
     assert.dom('.global-search-box').doesNotExist();

--- a/packages/frontend/tests/acceptance/instructorgroups-test.js
+++ b/packages/frontend/tests/acceptance/instructorgroups-test.js
@@ -241,7 +241,7 @@ module('Acceptance | Instructor Groups', function (hooks) {
 
   test('filters options', async function (assert) {
     const schools = await this.server.createList('school', 2);
-    await setupAuthentication({ school: schools[1], root: true });
+    await setupAuthentication({ school: schools[1], directedSchools: schools });
 
     await page.visit();
     await takeScreenshot(assert);

--- a/packages/frontend/tests/acceptance/program-year/course-associations-test.js
+++ b/packages/frontend/tests/acceptance/program-year/course-associations-test.js
@@ -9,8 +9,8 @@ module('Acceptance | Program Year - Course associations', function (hooks) {
 
   hooks.beforeEach(async function () {
     const school = await this.server.create('school');
-    await setupAuthentication({ school, root: true });
     const program = await this.server.create('program', { school });
+    await setupAuthentication({ school, directedPrograms: [program] });
     const programYear = await this.server.create('program-year', { program });
     const cohort = await this.server.create('cohort', { programYear });
     await this.server.create('course', { school, cohorts: [cohort] });

--- a/packages/frontend/tests/acceptance/programs-test.js
+++ b/packages/frontend/tests/acceptance/programs-test.js
@@ -84,11 +84,10 @@ module('Acceptance | Programs', function (hooks) {
       this.school2 = await this.server.create('school');
       this.program1 = await this.server.create('program', { school: this.school1 });
       this.program2 = await this.server.create('program', { school: this.school2 });
-      this.user = await setupAuthentication();
     });
 
     test('remember non-default school filter choice', async function (assert) {
-      await setupAuthentication({ root: true });
+      await setupAuthentication({ school: this.school1, directedSchools: [this.school1] });
       await page.visit();
 
       assert.strictEqual(currentURL(), '/programs');
@@ -112,7 +111,7 @@ module('Acceptance | Programs', function (hooks) {
 
   test('filters options', async function (assert) {
     const schools = await this.server.createList('school', 2);
-    await setupAuthentication({ school: schools[1], root: true });
+    await setupAuthentication({ school: schools[1], directedSchools: schools });
     await page.visit();
     assert.strictEqual(page.root.schoolFilter.schools.length, 2);
     assert.strictEqual(page.root.schoolFilter.schools[0].text, 'school 0');

--- a/packages/frontend/tests/acceptance/reports/curriculum-test.js
+++ b/packages/frontend/tests/acceptance/reports/curriculum-test.js
@@ -11,7 +11,7 @@ module('Acceptance | Reports - Curriculum Reports', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = await this.server.create('school');
-    await setupAuthentication({ school: this.school, root: true });
+    await setupAuthentication({ school: this.school, directedSchools: [this.school] });
     await this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
       if (query.includes('courses(academicYears:')) {

--- a/packages/frontend/tests/acceptance/reports/subject-test.js
+++ b/packages/frontend/tests/acceptance/reports/subject-test.js
@@ -9,7 +9,7 @@ module('Acceptance | Reports - Subject Report', function (hooks) {
 
   hooks.beforeEach(async function () {
     const school = await this.server.create('school');
-    const user = await setupAuthentication({ school, root: true });
+    const user = await setupAuthentication({ school, directedSchools: [school] });
     const vocabulary = await this.server.create('vocabulary', {
       school,
     });

--- a/packages/frontend/tests/acceptance/reports/subjects-test.js
+++ b/packages/frontend/tests/acceptance/reports/subjects-test.js
@@ -10,7 +10,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = await this.server.create('school');
-    const user = await setupAuthentication({ school: this.school, root: true });
+    const user = await setupAuthentication({ school: this.school, directedSchools: [this.school] });
     this.vocabulary = await this.server.create('vocabulary', {
       school: this.school,
     });

--- a/packages/frontend/tests/acceptance/route-performance-test.js
+++ b/packages/frontend/tests/acceptance/route-performance-test.js
@@ -11,7 +11,7 @@ module('Acceptance | performance', function (hooks) {
     this.set('maxDuration', 10000);
 
     this.school = await this.server.create('school');
-    this.user = await setupAuthentication({ school: this.school, root: true });
+    this.user = await setupAuthentication({ school: this.school, directedSchools: [this.school] });
   });
 
   test('/dashboard/week', async function (assert) {

--- a/packages/frontend/tests/acceptance/school/learning-material-attributes-test.js
+++ b/packages/frontend/tests/acceptance/school/learning-material-attributes-test.js
@@ -8,7 +8,7 @@ module('Acceptance | School - Learning Material Attributes', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = await this.server.create('school');
-    await setupAuthentication({ school: this.school, root: true });
+    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
   });
 
   test('check fields collapsed', async function (assert) {

--- a/packages/frontend/tests/acceptance/school/session-attributes-test.js
+++ b/packages/frontend/tests/acceptance/school/session-attributes-test.js
@@ -8,7 +8,7 @@ module('Acceptance | School - Session Attributes', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.school = await this.server.create('school');
-    await setupAuthentication({ school: this.school, root: true });
+    await setupAuthentication({ school: this.school, administeredSchools: [this.school] });
   });
 
   test('check fields collapsed', async function (assert) {

--- a/packages/frontend/tests/acceptance/search-test.js
+++ b/packages/frontend/tests/acceptance/search-test.js
@@ -11,6 +11,9 @@ module('Acceptance | search', function (hooks) {
 
   hooks.beforeEach(async function () {
     const school = await this.server.create('school');
+    // Global search requires the current user to perform a non-learner function.
+    // Creating the current user as root gives us the necessary permissions.
+    // Please see the `ilios-header` component for details.
     await setupAuthentication({ school, root: true });
     const { apiVersion } = this.owner.resolveRegistration('config:environment');
     this.server.get('/application/config', function () {

--- a/packages/frontend/tests/integration/components/reports/subject/course-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/subject/course-test.gjs
@@ -26,6 +26,9 @@ module('Integration | Component | reports/subject/course', function (hooks) {
   };
 
   test('it renders for user with permissions', async function (assert) {
+    // The component checks permissions against the "performs non-learner function" of the current user,
+    // and not against user relationships in the curriculum.
+    // Making the current user a root user makes that perms check pass.
     await setupAuthentication({ root: true });
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
@@ -87,7 +90,6 @@ module('Integration | Component | reports/subject/course', function (hooks) {
   });
 
   test('it renders for user with no permissions', async function (assert) {
-    await setupAuthentication();
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
       assert.step('API called');
@@ -122,8 +124,6 @@ module('Integration | Component | reports/subject/course', function (hooks) {
   });
 
   test('it renders all results when resultsLengthMax is not reached', async function (assert) {
-    await setupAuthentication({ root: true });
-
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
       assert.step('API called');
@@ -153,8 +153,6 @@ module('Integration | Component | reports/subject/course', function (hooks) {
   });
 
   test('it renders limited results and an extra download button when resultsLengthMax is eclipsed', async function (assert) {
-    await setupAuthentication({ root: true });
-
     const years = [2020, 2021, 2022, 2023, 2024, 2025];
     const responseDataLarge = {
       data: {
@@ -203,7 +201,6 @@ module('Integration | Component | reports/subject/course', function (hooks) {
   });
 
   test('it renders school link if all schools is chosen', async function (assert) {
-    await setupAuthentication({ root: true });
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
       assert.step('API called');
@@ -504,7 +501,6 @@ module('Integration | Component | reports/subject/course', function (hooks) {
   });
 
   test('download', async function (assert) {
-    await setupAuthentication({ root: true });
     this.server.post('/api/graphql', () => {
       assert.step('API called');
       return responseData;

--- a/packages/frontend/tests/integration/components/reports/subject/program-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/subject/program-test.gjs
@@ -20,6 +20,9 @@ module('Integration | Component | reports/subject/program', function (hooks) {
   };
 
   test('it renders for user with permissions', async function (assert) {
+    // The component checks permissions against the "performs non-learner function" of the current user,
+    // and not against user relationships in the curriculum.
+    // Making the current user a root user makes that perms check pass.
     await setupAuthentication({ root: true });
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
@@ -54,7 +57,6 @@ module('Integration | Component | reports/subject/program', function (hooks) {
   });
 
   test('it renders for user with no permissions', async function (assert) {
-    await setupAuthentication();
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
       assert.step('API called');
@@ -86,8 +88,6 @@ module('Integration | Component | reports/subject/program', function (hooks) {
   });
 
   test('it renders all results when resultsLengthMax is not reached', async function (assert) {
-    await setupAuthentication({ root: true });
-
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
       assert.step('API called');
@@ -114,8 +114,6 @@ module('Integration | Component | reports/subject/program', function (hooks) {
   });
 
   test('it renders limited results and an extra download button when resultsLengthMax is eclipsed', async function (assert) {
-    await setupAuthentication({ root: true });
-
     const alphabet = [...Array(26).keys()].map((i) => String.fromCharCode(i + 65));
     const responseDataLarge = {
       data: {

--- a/packages/frontend/tests/integration/components/reports/subject/program-year-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/subject/program-year-test.gjs
@@ -32,6 +32,9 @@ module('Integration | Component | reports/subject/program-year', function (hooks
   };
 
   test('it renders for user with permissions', async function (assert) {
+    // The component checks permissions against the "performs non-learner function" of the current user,
+    // and not against user relationships in the curriculum.
+    // Making the current user a root user makes that perms check pass.
     await setupAuthentication({ root: true });
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
@@ -79,7 +82,6 @@ module('Integration | Component | reports/subject/program-year', function (hooks
   });
 
   test('it renders for user with no permissions', async function (assert) {
-    await setupAuthentication();
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
       assert.step('API called');
@@ -123,8 +125,6 @@ module('Integration | Component | reports/subject/program-year', function (hooks
   });
 
   test('it renders all results when resultsLengthMax is not reached', async function (assert) {
-    await setupAuthentication({ root: true });
-
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
       assert.step('API called');
@@ -154,8 +154,6 @@ module('Integration | Component | reports/subject/program-year', function (hooks
   });
 
   test('it renders limited results and an extra download button when resultsLengthMax is eclipsed', async function (assert) {
-    await setupAuthentication({ root: true });
-
     const years = [2020, 2021, 2022, 2023, 2024, 2025];
     const alphabet = [...Array(26).keys()].map((i) => String.fromCharCode(i + 65));
     const responseDataLarge = {

--- a/packages/frontend/tests/integration/components/reports/subject/session-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/subject/session-test.gjs
@@ -78,6 +78,9 @@ module('Integration | Component | reports/subject/session', function (hooks) {
   };
 
   test('it renders for user with permissions', async function (assert) {
+    // The component checks permissions against the "performs non-learner function" of the current user,
+    // and not against user relationships in the curriculum.
+    // Making the current user a root user makes that perms check pass.
     await setupAuthentication({ root: true });
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
@@ -177,7 +180,6 @@ module('Integration | Component | reports/subject/session', function (hooks) {
   });
 
   test('it renders for user with no permissions', async function (assert) {
-    await setupAuthentication();
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
       assert.step('API called');
@@ -246,7 +248,6 @@ module('Integration | Component | reports/subject/session', function (hooks) {
   });
 
   test('it renders all results when resultsLengthMax is not reached', async function (assert) {
-    await setupAuthentication({ root: true });
     this.server.post('/api/graphql', async ({ request }) => {
       const { query } = await request.json();
       assert.step('API called');
@@ -276,8 +277,6 @@ module('Integration | Component | reports/subject/session', function (hooks) {
   });
 
   test('it renders limited results and an extra download button when resultsLengthMax is eclipsed', async function (assert) {
-    await setupAuthentication({ root: true });
-
     const years = [2020, 2021, 2022, 2023, 2024, 2025];
     const responseDataLarge = {
       data: {
@@ -618,7 +617,6 @@ module('Integration | Component | reports/subject/session', function (hooks) {
   });
 
   test('download', async function (assert) {
-    await setupAuthentication({ root: true });
     this.server.post('/api/graphql', () => {
       assert.step('API called');
       return responseData;


### PR DESCRIPTION
This either removes the root flag altogether without replacement if possible,
or scopes this down to the perms granted by providing user relationships instead.

I elaborated on the remaining root flags in code comments.

In some cases, additional data massaging was necessary due to changes in
fixture creation order.

fixes ilios/ilios#7179