### PR TITLE
remove nav link to curriculum inventory manager from side-menu.

### DIFF
--- a/packages/frontend/app/components/ilios-navigation.gjs
+++ b/packages/frontend/app/components/ilios-navigation.gjs
@@ -13,7 +13,6 @@ import {
   faBars,
   faBook,
   faBuildingColumns,
-  faChartColumn,
   faChevronRight,
   faFileLines,
   faGears,
@@ -167,29 +166,6 @@ export default class IliosNavigationComponent extends Component {
                 <FaIcon @icon={{faGears}} @fixedWidth={{true}} />
                 <span class="text">
                   {{t "general.admin"}}
-                </span>
-                <FaIcon class="if-active" @icon={{faChevronRight}} @fixedWidth={{true}} />
-              </LinkTo>
-            </li>
-          {{/if}}
-          {{#if this.currentUser.performsNonLearnerFunction}}
-            <li>
-              <LinkTo
-                @route="curriculum-inventory-reports"
-                title={{t "general.curriculumInventory"}}
-                @current-when={{join
-                  " "
-                  (array
-                    "curriculum-inventory-report"
-                    "curriculum-inventory-reports"
-                    "curriculum-inventory-sequence-block"
-                    "verification-preview"
-                  )
-                }}
-              >
-                <FaIcon @icon={{faChartColumn}} @fixedWidth={{true}} />
-                <span class="text">
-                  {{t "general.curriculumInventory"}}
                 </span>
                 <FaIcon class="if-active" @icon={{faChevronRight}} @fixedWidth={{true}} />
               </LinkTo>

--- a/packages/frontend/tests/integration/components/ilios-navigation-test.gjs
+++ b/packages/frontend/tests/integration/components/ilios-navigation-test.gjs
@@ -19,7 +19,7 @@ module('Integration | Component | ilios-navigation', function (hooks) {
     await a11yAudit(this.element);
 
     assert.ok(component.expandCollapse.isPresent);
-    assert.strictEqual(component.links.length, 8);
+    assert.strictEqual(component.links.length, 7);
     assert.strictEqual(component.links[0].text, 'Dashboard');
     assert.strictEqual(component.links[1].text, 'Courses and Sessions');
     assert.strictEqual(component.links[2].text, 'Learner Groups');
@@ -27,7 +27,6 @@ module('Integration | Component | ilios-navigation', function (hooks) {
     assert.strictEqual(component.links[4].text, 'Schools');
     assert.strictEqual(component.links[5].text, 'Programs');
     assert.strictEqual(component.links[6].text, 'Reports');
-    assert.strictEqual(component.links[7].text, 'Curriculum Inventory');
   });
 
   test('navigation does not render for non-privileged user', async function (assert) {
@@ -53,7 +52,7 @@ module('Integration | Component | ilios-navigation', function (hooks) {
     await render(<template><IliosNavigation /></template>);
     await a11yAudit(this.element);
 
-    assert.strictEqual(component.links.length, 9);
+    assert.strictEqual(component.links.length, 8);
     assert.strictEqual(component.links[0].text, 'Dashboard');
     assert.strictEqual(component.links[1].text, 'Courses and Sessions');
     assert.strictEqual(component.links[2].text, 'Learner Groups');
@@ -62,6 +61,5 @@ module('Integration | Component | ilios-navigation', function (hooks) {
     assert.strictEqual(component.links[5].text, 'Programs');
     assert.strictEqual(component.links[6].text, 'Reports');
     assert.strictEqual(component.links[7].text, 'Admin');
-    assert.strictEqual(component.links[8].text, 'Curriculum Inventory');
   });
 });

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -111,7 +111,6 @@ general:
   createBulk: Upload Multiple Users
   createNew: Create New
   createNewGroup: Create This Group
-  curriculumInventory: Curriculum Inventory
   curriculumInventoryReport: Curriculum Inventory Report
   curriculumInventoryReportRollover: Rollover Report
   curriculumInventoryReportRolloverSummary: "This action will copy the structure of this report to be used in your target year. It will not copy course information, only the higher level sequence block structure. You will need to add the appropriate course information and modify the sequence block start and end dates once you have rolled over the existing report structure."

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -112,7 +112,6 @@ general:
   createNew: Crear Nuevo
   createNewGroup: Crear Este Grupo
   curriculumReports: Informes Curriculares
-  curriculumInventory: Inventario de plan de Estudios
   curriculumInventoryReport: Informe de Inventario de Plan de Estudios
   curriculumInventoryReportRollover: Copiar Inventario de plan de Estudios
   curriculumInventoryReportRolloverSummary: "Esta acción copiará la estructura de este informe que se utilizará en su año objetivo. No copiará la información del curso, solo la estructura del bloque de secuencia de nivel superior. Deberá agregar la información del curso adecuada y modificar las fechas de inicio y finalización del bloque de secuencia una vez que haya cambiado la estructura del informe existente."

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -112,7 +112,6 @@ general:
   createNew: Créer Neuf
   createNewGroup: Créez Ce Groupe
   curriculumReports: "Rapports des programmes d'études"
-  curriculumInventory: "Inventaire des programmes d'études"
   curriculumInventoryReport: "Rapport d'inventaire des programmes d'études"
   curriculumInventoryReportRollover: "Roulement Rapport d'inventaire des programmes d'études"
   curriculumInventoryReportRolloverSummary: "Cette action copiera la structure de ce rapport à utiliser dans votre année cible. Il ne copiera pas les informations de cours, uniquement la structure de bloc de séquence de niveau supérieur. Vous devrez ajouter les informations de cours appropriées et modifier les dates de début et de fin du bloc de séquence une fois que vous aurez reconduit la structure de rapport existante."


### PR DESCRIPTION
the curr inv manager is deprecated, we're phasing it out. removing the nav link is a first step towards this.