### PR TITLE
Offering shows year next to Day of Week and Month if offerings span multiple years

### DIFF
--- a/packages/frontend/tests/acceptance/course/session/offerings-test.js
+++ b/packages/frontend/tests/acceptance/course/session/offerings-test.js
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon';
 import { module, test } from 'qunit';
 import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
 import { setupApplicationTest, takeScreenshot } from 'frontend/tests/helpers';
+import currentAcademicYear from 'ilios-common/utils/current-academic-year';
 import page from 'ilios-common/page-objects/session';
 
 module('Acceptance | Session - Offerings', function (hooks) {
@@ -103,11 +104,13 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
   test('offering dates', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
+    await takeScreenshot(assert);
 
     const blocks = page.details.offerings.dateBlocks;
     assert.ok(blocks[0].hasStartTime);
     assert.ok(blocks[0].hasEndTime);
     assert.notOk(blocks[0].hasMultiDay);
+
     assert.strictEqual(
       blocks[0].dayOfWeek,
       DateTime.fromISO(this.offering1.startDate).toFormat('cccc'),
@@ -116,6 +119,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       blocks[0].dayOfMonth,
       DateTime.fromISO(this.offering1.startDate).toFormat('MMMM d'),
     );
+    assert.strictEqual(blocks[0].year, DateTime.fromISO(this.offering1.startDate).toFormat('y'));
     assert.strictEqual(
       blocks[0].startTime,
       'Starts: ' + DateTime.fromISO(this.offering1.startDate).toFormat('hh:mm a'),
@@ -136,6 +140,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       blocks[1].dayOfMonth,
       DateTime.fromISO(this.offering2.startDate).toFormat('MMMM d'),
     );
+    assert.strictEqual(blocks[1].year, DateTime.fromISO(this.offering2.startDate).toFormat('y'));
     assert.strictEqual(
       blocks[1].startTime,
       'Starts: ' + DateTime.fromISO(this.offering2.startDate).toFormat('hh:mm a'),
@@ -156,6 +161,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       blocks[2].dayOfMonth,
       DateTime.fromISO(this.offering3.startDate).toFormat('MMMM d'),
     );
+    assert.strictEqual(blocks[2].year, DateTime.fromISO(this.offering3.startDate).toFormat('y'));
     assert.strictEqual(blocks[2].timeBlockOfferings.offerings.length, 1);
     assert.strictEqual(
       blocks[2].multiDayStart,
@@ -354,6 +360,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasMultiDay);
     assert.strictEqual(block.dayOfWeek, 'Sunday');
     assert.strictEqual(block.dayOfMonth, 'September 11');
+    assert.strictEqual(block.year, '2011');
     assert.strictEqual(block.startTime, 'Starts: 02:15 AM');
     assert.strictEqual(block.endTime, 'Ends: 05:30 PM');
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 1);
@@ -401,6 +408,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasEndTime);
     assert.strictEqual(block.dayOfWeek, 'Sunday');
     assert.strictEqual(block.dayOfMonth, 'September 11');
+    assert.strictEqual(block.year, '2011');
     assert.strictEqual(
       block.multiDayStart,
       'Starts: ' +
@@ -465,6 +473,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasMultiDay);
     assert.strictEqual(block.dayOfWeek, 'Sunday');
     assert.strictEqual(block.dayOfMonth, 'September 11');
+    assert.strictEqual(block.year, '2011');
     assert.strictEqual(block.startTime, 'Starts: 02:15 AM');
     assert.strictEqual(block.endTime, 'Ends: 05:30 PM');
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 2);
@@ -538,6 +547,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasMultiDay);
     assert.strictEqual(block.dayOfWeek, 'Wednesday');
     assert.strictEqual(block.dayOfMonth, 'October 5');
+    assert.strictEqual(block.year, '2011');
     assert.strictEqual(block.startTime, 'Starts: 11:45 AM');
     assert.strictEqual(block.endTime, 'Ends: 05:55 PM');
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 1);
@@ -566,6 +576,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasMultiDay);
     assert.strictEqual(block.dayOfWeek, 'Friday');
     assert.strictEqual(block.dayOfMonth, 'December 11');
+    assert.strictEqual(block.year, `${currentAcademicYear()}`);
     assert.strictEqual(block.startTime, 'Starts: 09:00 AM');
     assert.strictEqual(block.endTime, 'Ends: 10:00 AM');
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 1);
@@ -614,6 +625,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasMultiDay);
     assert.strictEqual(block.dayOfWeek, 'Friday');
     assert.strictEqual(block.dayOfMonth, 'December 11');
+    assert.strictEqual(block.year, `${currentAcademicYear()}`);
     assert.strictEqual(block.startTime, 'Starts: 09:00 AM');
     assert.strictEqual(block.endTime, 'Ends: 10:00 AM');
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 1);

--- a/packages/frontend/tests/acceptance/course/session/offerings-test.js
+++ b/packages/frontend/tests/acceptance/course/session/offerings-test.js
@@ -692,7 +692,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.ok(block.hasStartTime);
     assert.ok(block.hasEndTime);
     assert.notOk(block.hasMultiDay);
-    assert.strictEqual(block.dayOfWeek, 'Friday');
+    assert.strictEqual(block.dayOfWeek, 'Sunday');
     assert.strictEqual(block.dayOfMonth, 'December 11');
     assert.strictEqual(block.startTime, 'Starts: 09:00 AM');
     assert.strictEqual(block.endTime, 'Ends: 10:00 AM');
@@ -740,7 +740,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.ok(block.hasStartTime);
     assert.ok(block.hasEndTime);
     assert.notOk(block.hasMultiDay);
-    assert.strictEqual(block.dayOfWeek, 'Friday');
+    assert.strictEqual(block.dayOfWeek, 'Sunday');
     assert.strictEqual(block.dayOfMonth, 'December 11');
     assert.strictEqual(block.startTime, 'Starts: 09:00 AM');
     assert.strictEqual(block.endTime, 'Ends: 10:00 AM');

--- a/packages/frontend/tests/acceptance/course/session/offerings-test.js
+++ b/packages/frontend/tests/acceptance/course/session/offerings-test.js
@@ -12,6 +12,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       DateTime.fromObject({
         month: 12,
         day: 11,
+        year: 2011,
       }).toJSDate(),
     );
     this.intl = this.owner.lookup('service:intl');
@@ -118,7 +119,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       blocks[0].dayOfMonth,
       DateTime.fromISO(this.offering1.startDate).toFormat('MMMM d'),
     );
-    assert.notOk(blocks[0].year.isVisible);
+    assert.notOk(blocks[0].hasDayMonthYear);
     assert.strictEqual(
       blocks[0].startTime,
       'Starts: ' + DateTime.fromISO(this.offering1.startDate).toFormat('hh:mm a'),
@@ -139,7 +140,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       blocks[1].dayOfMonth,
       DateTime.fromISO(this.offering2.startDate).toFormat('MMMM d'),
     );
-    assert.notOk(blocks[1].year.isVisible);
+    assert.notOk(blocks[1].hasDayMonthYear);
     assert.strictEqual(
       blocks[1].startTime,
       'Starts: ' + DateTime.fromISO(this.offering2.startDate).toFormat('hh:mm a'),
@@ -152,7 +153,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
     assert.notOk(blocks[2].hasStartTime);
     assert.notOk(blocks[2].hasEndTime);
-    assert.notOk(blocks[2].year.isVisible);
+    assert.notOk(blocks[2].hasDayMonthYear);
     assert.strictEqual(
       blocks[2].dayOfWeek,
       DateTime.fromISO(this.offering3.startDate).toFormat('cccc'),
@@ -194,8 +195,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       learnerGroups: [],
       instructors: [],
       startDate: this.today.plus({ years: 1 }).toISO(),
-      endDate: this.today.plus({ days: 3, hours: 1 }).toISO(),
-      url: 'https://example.edu/',
+      endDate: this.today.plus({ years: 1, hours: 1 }).toISO(),
     });
 
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
@@ -210,12 +210,12 @@ module('Acceptance | Session - Offerings', function (hooks) {
       blocks[0].dayOfWeek,
       DateTime.fromISO(this.offering1.startDate).toFormat('cccc'),
     );
+    assert.notOk(blocks[0].hasDayOfMonth, '1st block does not have a dayOfMonth');
+    assert.ok(blocks[0].hasDayMonthYear, '1st block has a dayMonthYear');
     assert.strictEqual(
-      blocks[0].dayOfMonth,
-      DateTime.fromISO(this.offering1.startDate).toFormat('MMMM d'),
+      blocks[0].dayMonthYear,
+      DateTime.fromISO(this.offering1.startDate).toFormat('MMMM dd, y'),
     );
-    assert.ok(blocks[0].year.isVisible);
-    assert.strictEqual(blocks[0].year, DateTime.fromISO(this.offering1.startDate).toFormat('y'));
     assert.strictEqual(
       blocks[0].startTime,
       'Starts: ' + DateTime.fromISO(this.offering1.startDate).toFormat('hh:mm a'),
@@ -232,12 +232,12 @@ module('Acceptance | Session - Offerings', function (hooks) {
       blocks[1].dayOfWeek,
       DateTime.fromISO(this.offering2.startDate).toFormat('cccc'),
     );
+    assert.notOk(blocks[1].hasDayOfMonth, '2nd block does not have a dayOfMonth');
+    assert.ok(blocks[1].hasDayMonthYear, '2nd block has a dayMonthYear');
     assert.strictEqual(
-      blocks[1].dayOfMonth,
-      DateTime.fromISO(this.offering2.startDate).toFormat('MMMM d'),
+      blocks[1].dayMonthYear,
+      DateTime.fromISO(this.offering2.startDate).toFormat('MMMM dd, y'),
     );
-    assert.ok(blocks[1].year.isVisible);
-    assert.strictEqual(blocks[1].year, DateTime.fromISO(this.offering2.startDate).toFormat('y'));
     assert.strictEqual(
       blocks[1].startTime,
       'Starts: ' + DateTime.fromISO(this.offering2.startDate).toFormat('hh:mm a'),
@@ -250,14 +250,15 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
     assert.notOk(blocks[2].hasStartTime);
     assert.notOk(blocks[2].hasEndTime);
-    assert.notOk(blocks[2].year.isVisible);
     assert.strictEqual(
       blocks[2].dayOfWeek,
       DateTime.fromISO(this.offering3.startDate).toFormat('cccc'),
     );
+    assert.notOk(blocks[2].hasDayOfMonth, '3rd block does not have a dayOfMonth');
+    assert.ok(blocks[2].hasDayMonthYear, '3rd block has a dayMonthYear');
     assert.strictEqual(
-      blocks[2].dayOfMonth,
-      DateTime.fromISO(this.offering3.startDate).toFormat('MMMM d'),
+      blocks[2].dayMonthYear,
+      DateTime.fromISO(this.offering3.startDate).toFormat('MMMM dd, y'),
     );
     assert.strictEqual(blocks[2].timeBlockOfferings.offerings.length, 1);
     assert.strictEqual(
@@ -292,12 +293,12 @@ module('Acceptance | Session - Offerings', function (hooks) {
       blocks[3].dayOfWeek,
       DateTime.fromISO(this.offering4.startDate).toFormat('cccc'),
     );
+    assert.notOk(blocks[3].hasDayOfMonth, '4th block does not have a dayOfMonth');
+    assert.ok(blocks[3].hasDayMonthYear, '4th block has a dayMonthYear');
     assert.strictEqual(
-      blocks[3].dayOfMonth,
-      DateTime.fromISO(this.offering4.startDate).toFormat('MMMM d'),
+      blocks[3].dayMonthYear,
+      DateTime.fromISO(this.offering4.startDate).toFormat('MMMM dd, y'),
     );
-    assert.ok(blocks[3].year.isVisible);
-    assert.strictEqual(blocks[3].year, DateTime.fromISO(this.offering4.startDate).toFormat('y'));
     assert.strictEqual(
       blocks[3].startTime,
       'Starts: ' + DateTime.fromISO(this.offering4.startDate).toFormat('hh:mm a'),
@@ -481,7 +482,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasMultiDay);
     assert.strictEqual(block.dayOfWeek, 'Sunday');
     assert.strictEqual(block.dayOfMonth, 'September 11');
-    assert.strictEqual(block.year, '2011');
     assert.strictEqual(block.startTime, 'Starts: 02:15 AM');
     assert.strictEqual(block.endTime, 'Ends: 05:30 PM');
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 1);
@@ -529,7 +529,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasEndTime);
     assert.strictEqual(block.dayOfWeek, 'Sunday');
     assert.strictEqual(block.dayOfMonth, 'September 11');
-    assert.strictEqual(block.year, '2011');
     assert.strictEqual(
       block.multiDayStart,
       'Starts: ' +
@@ -594,7 +593,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasMultiDay);
     assert.strictEqual(block.dayOfWeek, 'Sunday');
     assert.strictEqual(block.dayOfMonth, 'September 11');
-    assert.strictEqual(block.year, '2011');
     assert.strictEqual(block.startTime, 'Starts: 02:15 AM');
     assert.strictEqual(block.endTime, 'Ends: 05:30 PM');
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 2);
@@ -668,7 +666,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasMultiDay);
     assert.strictEqual(block.dayOfWeek, 'Wednesday');
     assert.strictEqual(block.dayOfMonth, 'October 5');
-    assert.strictEqual(block.year, '2011');
     assert.strictEqual(block.startTime, 'Starts: 11:45 AM');
     assert.strictEqual(block.endTime, 'Ends: 05:55 PM');
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 1);
@@ -771,7 +768,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     await page.details.offerings.top.createNew();
     const { offeringForm: form } = page.details.offerings;
     await page.details.offerings.smallGroup();
-    await form.startDate.datePicker.set(new Date(2015, 4, 22));
+    await form.startDate.datePicker.set(new Date(2011, 4, 22));
     await form.startTime.timePicker.hour.select('02');
     await form.startTime.timePicker.minute.select('15');
     await form.startTime.timePicker.ampm.select('AM');
@@ -797,7 +794,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       assert.ok(block.hasStartTime);
       assert.ok(block.hasEndTime);
       assert.notOk(block.hasMultiDay);
-      assert.strictEqual(block.dayOfWeek, 'Friday');
+      assert.strictEqual(block.dayOfWeek, 'Sunday');
       assert.strictEqual(block.startTime, 'Starts: 02:15 AM');
       assert.strictEqual(block.endTime, 'Ends: 03:23 PM');
       assert.strictEqual(block.timeBlockOfferings.offerings.length, 2);
@@ -843,7 +840,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
     await page.details.offerings.top.createNew();
     const { offeringForm: form } = page.details.offerings;
     await page.details.offerings.singleOffering();
-    await form.startDate.datePicker.set(new Date(2015, 4, 22));
+    await form.startDate.datePicker.set(new Date(2011, 4, 22));
     await form.startTime.timePicker.hour.select('02');
     await form.startTime.timePicker.minute.select('15');
     await form.startTime.timePicker.ampm.select('AM');
@@ -871,7 +868,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       assert.ok(block.hasStartTime);
       assert.ok(block.hasEndTime);
       assert.notOk(block.hasMultiDay);
-      assert.strictEqual(block.dayOfWeek, 'Friday');
+      assert.strictEqual(block.dayOfWeek, 'Sunday');
       assert.strictEqual(block.startTime, 'Starts: 02:15 AM');
       assert.strictEqual(block.endTime, 'Ends: 03:23 PM');
       assert.strictEqual(block.timeBlockOfferings.offerings.length, 1);

--- a/packages/frontend/tests/acceptance/course/session/offerings-test.js
+++ b/packages/frontend/tests/acceptance/course/session/offerings-test.js
@@ -2,7 +2,6 @@ import { DateTime } from 'luxon';
 import { module, test } from 'qunit';
 import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
 import { setupApplicationTest, takeScreenshot } from 'frontend/tests/helpers';
-import currentAcademicYear from 'ilios-common/utils/current-academic-year';
 import page from 'ilios-common/page-objects/session';
 
 module('Acceptance | Session - Offerings', function (hooks) {
@@ -119,7 +118,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       blocks[0].dayOfMonth,
       DateTime.fromISO(this.offering1.startDate).toFormat('MMMM d'),
     );
-    assert.strictEqual(blocks[0].year, DateTime.fromISO(this.offering1.startDate).toFormat('y'));
+    assert.notOk(blocks[0].year.isVisible);
     assert.strictEqual(
       blocks[0].startTime,
       'Starts: ' + DateTime.fromISO(this.offering1.startDate).toFormat('hh:mm a'),
@@ -140,7 +139,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
       blocks[1].dayOfMonth,
       DateTime.fromISO(this.offering2.startDate).toFormat('MMMM d'),
     );
-    assert.strictEqual(blocks[1].year, DateTime.fromISO(this.offering2.startDate).toFormat('y'));
+    assert.notOk(blocks[1].year.isVisible);
     assert.strictEqual(
       blocks[1].startTime,
       'Starts: ' + DateTime.fromISO(this.offering2.startDate).toFormat('hh:mm a'),
@@ -153,6 +152,7 @@ module('Acceptance | Session - Offerings', function (hooks) {
 
     assert.notOk(blocks[2].hasStartTime);
     assert.notOk(blocks[2].hasEndTime);
+    assert.notOk(blocks[2].year.isVisible);
     assert.strictEqual(
       blocks[2].dayOfWeek,
       DateTime.fromISO(this.offering3.startDate).toFormat('cccc'),
@@ -161,7 +161,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
       blocks[2].dayOfMonth,
       DateTime.fromISO(this.offering3.startDate).toFormat('MMMM d'),
     );
-    assert.strictEqual(blocks[2].year, DateTime.fromISO(this.offering3.startDate).toFormat('y'));
     assert.strictEqual(blocks[2].timeBlockOfferings.offerings.length, 1);
     assert.strictEqual(
       blocks[2].multiDayStart,
@@ -186,6 +185,128 @@ module('Acceptance | Session - Offerings', function (hooks) {
           minute: 'numeric',
         }),
     );
+  });
+
+  test('offering dates that span years', async function (assert) {
+    this.offering4 = await this.server.create('offering', {
+      session: this.session,
+      instructorGroups: [],
+      learnerGroups: [],
+      instructors: [],
+      startDate: this.today.plus({ years: 1 }).toISO(),
+      endDate: this.today.plus({ days: 3, hours: 1 }).toISO(),
+      url: 'https://example.edu/',
+    });
+
+    await page.visit({ courseId: this.course.id, sessionId: this.session.id });
+    await takeScreenshot(assert);
+
+    const blocks = page.details.offerings.dateBlocks;
+    assert.ok(blocks[0].hasStartTime);
+    assert.ok(blocks[0].hasEndTime);
+    assert.notOk(blocks[0].hasMultiDay);
+
+    assert.strictEqual(
+      blocks[0].dayOfWeek,
+      DateTime.fromISO(this.offering1.startDate).toFormat('cccc'),
+    );
+    assert.strictEqual(
+      blocks[0].dayOfMonth,
+      DateTime.fromISO(this.offering1.startDate).toFormat('MMMM d'),
+    );
+    assert.ok(blocks[0].year.isVisible);
+    assert.strictEqual(blocks[0].year, DateTime.fromISO(this.offering1.startDate).toFormat('y'));
+    assert.strictEqual(
+      blocks[0].startTime,
+      'Starts: ' + DateTime.fromISO(this.offering1.startDate).toFormat('hh:mm a'),
+    );
+    assert.strictEqual(
+      blocks[0].endTime,
+      'Ends: ' + DateTime.fromISO(this.offering1.endDate).toFormat('h:mm a'),
+    );
+    assert.strictEqual(blocks[0].timeBlockOfferings.offerings.length, 1);
+
+    assert.ok(blocks[1].hasStartTime);
+    assert.ok(blocks[1].hasEndTime);
+    assert.strictEqual(
+      blocks[1].dayOfWeek,
+      DateTime.fromISO(this.offering2.startDate).toFormat('cccc'),
+    );
+    assert.strictEqual(
+      blocks[1].dayOfMonth,
+      DateTime.fromISO(this.offering2.startDate).toFormat('MMMM d'),
+    );
+    assert.ok(blocks[1].year.isVisible);
+    assert.strictEqual(blocks[1].year, DateTime.fromISO(this.offering2.startDate).toFormat('y'));
+    assert.strictEqual(
+      blocks[1].startTime,
+      'Starts: ' + DateTime.fromISO(this.offering2.startDate).toFormat('hh:mm a'),
+    );
+    assert.strictEqual(
+      blocks[1].endTime,
+      'Ends: ' + DateTime.fromISO(this.offering2.endDate).toFormat('h:mm a'),
+    );
+    assert.strictEqual(blocks[1].timeBlockOfferings.offerings.length, 1);
+
+    assert.notOk(blocks[2].hasStartTime);
+    assert.notOk(blocks[2].hasEndTime);
+    assert.notOk(blocks[2].year.isVisible);
+    assert.strictEqual(
+      blocks[2].dayOfWeek,
+      DateTime.fromISO(this.offering3.startDate).toFormat('cccc'),
+    );
+    assert.strictEqual(
+      blocks[2].dayOfMonth,
+      DateTime.fromISO(this.offering3.startDate).toFormat('MMMM d'),
+    );
+    assert.strictEqual(blocks[2].timeBlockOfferings.offerings.length, 1);
+    assert.strictEqual(
+      blocks[2].multiDayStart,
+      'Starts: ' +
+        this.intl.formatDate(this.offering3.startDate, {
+          month: 'long',
+          day: 'numeric',
+          weekday: 'long',
+          hour: '2-digit',
+          minute: '2-digit',
+        }),
+    );
+
+    assert.strictEqual(
+      blocks[2].multiDayEnd,
+      'Ends: ' +
+        this.intl.formatDate(this.offering3.endDate, {
+          month: 'long',
+          day: 'numeric',
+          weekday: 'long',
+          hour: 'numeric',
+          minute: 'numeric',
+        }),
+    );
+
+    assert.ok(blocks[3].hasStartTime);
+    assert.ok(blocks[3].hasEndTime);
+    assert.notOk(blocks[3].hasMultiDay);
+
+    assert.strictEqual(
+      blocks[3].dayOfWeek,
+      DateTime.fromISO(this.offering4.startDate).toFormat('cccc'),
+    );
+    assert.strictEqual(
+      blocks[3].dayOfMonth,
+      DateTime.fromISO(this.offering4.startDate).toFormat('MMMM d'),
+    );
+    assert.ok(blocks[3].year.isVisible);
+    assert.strictEqual(blocks[3].year, DateTime.fromISO(this.offering4.startDate).toFormat('y'));
+    assert.strictEqual(
+      blocks[3].startTime,
+      'Starts: ' + DateTime.fromISO(this.offering4.startDate).toFormat('hh:mm a'),
+    );
+    assert.strictEqual(
+      blocks[3].endTime,
+      'Ends: ' + DateTime.fromISO(this.offering4.endDate).toFormat('h:mm a'),
+    );
+    assert.strictEqual(blocks[3].timeBlockOfferings.offerings.length, 1);
   });
 
   test('offering details', async function (assert) {
@@ -576,7 +697,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasMultiDay);
     assert.strictEqual(block.dayOfWeek, 'Friday');
     assert.strictEqual(block.dayOfMonth, 'December 11');
-    assert.strictEqual(block.year, `${currentAcademicYear()}`);
     assert.strictEqual(block.startTime, 'Starts: 09:00 AM');
     assert.strictEqual(block.endTime, 'Ends: 10:00 AM');
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 1);
@@ -625,7 +745,6 @@ module('Acceptance | Session - Offerings', function (hooks) {
     assert.notOk(block.hasMultiDay);
     assert.strictEqual(block.dayOfWeek, 'Friday');
     assert.strictEqual(block.dayOfMonth, 'December 11');
-    assert.strictEqual(block.year, `${currentAcademicYear()}`);
     assert.strictEqual(block.startTime, 'Starts: 09:00 AM');
     assert.strictEqual(block.endTime, 'Ends: 10:00 AM');
     assert.strictEqual(block.timeBlockOfferings.offerings.length, 1);

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session-details.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session-details.js
@@ -39,9 +39,13 @@ export default create({
       scope: '[data-test-session-offerings-header]',
     },
     dateBlocks: collection('[data-test-session-offerings-list] .offering-block', {
-      dayOfWeek: text('.offering-block-date-dayofweek'),
-      dayOfMonth: text('.offering-block-date-dayofmonth'),
-      year: text('.offering-block-date-year'),
+      dayOfWeek: text('[data-test-session-offering-dayofweek]'),
+      dayOfMonth: text('[data-test-session-offering-dayofmonth]'),
+      year: {
+        scope: '[data-test-session-offering-year]',
+        isVisible: isVisible(),
+        text: text(),
+      },
       startTime: text('.offering-block-time-time-starttime'),
       hasStartTime: isVisible('.offering-block-time-time-starttime'),
       endTime: text('.offering-block-time-time-endtime'),

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session-details.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session-details.js
@@ -41,6 +41,7 @@ export default create({
     dateBlocks: collection('[data-test-session-offerings-list] .offering-block', {
       dayOfWeek: text('.offering-block-date-dayofweek'),
       dayOfMonth: text('.offering-block-date-dayofmonth'),
+      year: text('.offering-block-date-year'),
       startTime: text('.offering-block-time-time-starttime'),
       hasStartTime: isVisible('.offering-block-time-time-starttime'),
       endTime: text('.offering-block-time-time-endtime'),

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session-details.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session-details.js
@@ -41,11 +41,9 @@ export default create({
     dateBlocks: collection('[data-test-session-offerings-list] .offering-block', {
       dayOfWeek: text('[data-test-session-offering-dayofweek]'),
       dayOfMonth: text('[data-test-session-offering-dayofmonth]'),
-      year: {
-        scope: '[data-test-session-offering-year]',
-        isVisible: isVisible(),
-        text: text(),
-      },
+      hasDayMonth: isVisible('[data-test-session-offering-dayofmonth]'),
+      dayMonthYear: text('[data-test-session-offering-daymonthyear]'),
+      hasDayMonthYear: isVisible('[data-test-session-offering-daymonthyear]'),
       startTime: text('.offering-block-time-time-starttime'),
       hasStartTime: isVisible('.offering-block-time-time-starttime'),
       endTime: text('.offering-block-time-time-endtime'),

--- a/packages/ilios-common/addon/components/session-offerings-list.gjs
+++ b/packages/ilios-common/addon/components/session-offerings-list.gjs
@@ -57,6 +57,9 @@ export default class SessionOfferingsListComponent extends Component {
               <span class="offering-block-date-dayofmonth">
                 {{formatDate block.date month="long" day="numeric"}}
               </span>
+              <span class="offering-block-date-year">
+                {{formatDate block.date year="numeric"}}
+              </span>
             </div>
             {{#each block.offeringTimeBlocks as |offeringTimeBlock|}}
               <div class="offering-block-time">

--- a/packages/ilios-common/addon/components/session-offerings-list.gjs
+++ b/packages/ilios-common/addon/components/session-offerings-list.gjs
@@ -54,12 +54,16 @@ export default class SessionOfferingsListComponent extends Component {
               <span class="offering-block-date-dayofweek" data-test-session-offering-dayofweek>
                 {{formatDate block.date weekday="long"}}
               </span>
-              <span class="offering-block-date-dayofmonth" data-test-session-offering-dayofmonth>
-                {{formatDate block.date month="long" day="numeric"}}
-              </span>
               {{#if @session.offeringsSpanYears}}
-                <span class="offering-block-date-year" data-test-session-offering-year>
-                  {{formatDate block.date year="numeric"}}
+                <span
+                  class="offering-block-date-daymonthyear"
+                  data-test-session-offering-daymonthyear
+                >
+                  {{formatDate block.date month="long" day="numeric" year="numeric"}}
+                </span>
+              {{else}}
+                <span class="offering-block-date-dayofmonth" data-test-session-offering-dayofmonth>
+                  {{formatDate block.date month="long" day="numeric"}}
                 </span>
               {{/if}}
             </div>

--- a/packages/ilios-common/addon/components/session-offerings-list.gjs
+++ b/packages/ilios-common/addon/components/session-offerings-list.gjs
@@ -51,15 +51,17 @@ export default class SessionOfferingsListComponent extends Component {
         {{#each this.offeringBlocks as |block|}}
           <div class="offering-block">
             <div class="offering-block-date">
-              <span class="offering-block-date-dayofweek">
+              <span class="offering-block-date-dayofweek" data-test-session-offering-dayofweek>
                 {{formatDate block.date weekday="long"}}
               </span>
-              <span class="offering-block-date-dayofmonth">
+              <span class="offering-block-date-dayofmonth" data-test-session-offering-dayofmonth>
                 {{formatDate block.date month="long" day="numeric"}}
               </span>
-              <span class="offering-block-date-year">
-                {{formatDate block.date year="numeric"}}
-              </span>
+              {{#if @session.offeringsSpanYears}}
+                <span class="offering-block-date-year" data-test-session-offering-year>
+                  {{formatDate block.date year="numeric"}}
+                </span>
+              {{/if}}
             </div>
             {{#each block.offeringTimeBlocks as |offeringTimeBlock|}}
               <div class="offering-block-time">

--- a/packages/ilios-common/addon/models/session.js
+++ b/packages/ilios-common/addon/models/session.js
@@ -287,6 +287,34 @@ export default class SessionModel extends Model {
   }
 
   /**
+   * The latest start date of all offerings in this session, or, if this is an ILM session, the ILM's due date.
+   */
+  get lastOfferingDate() {
+    if (this.isIndependentLearning) {
+      return this._ilmSessionData.isResolved ? this._ilmSessionData.value.dueDate : undefined;
+    }
+
+    if (!this.hasMany('offerings').ids().length) {
+      return null;
+    }
+
+    return this.sortedOfferingsByDate.length
+      ? this.sortedOfferingsByDate[this.sortedOfferingsByDate.length - 1]?.startDate
+      : null;
+  }
+
+  get offeringsSpanYears() {
+    if (!this.firstOfferingDate || !this.lastOfferingDate || this.isIndependentLearning) {
+      return false;
+    }
+
+    return (
+      DateTime.fromJSDate(this.firstOfferingDate).year !==
+      DateTime.fromJSDate(this.lastOfferingDate).year
+    );
+  }
+
+  /**
    * The maximum duration in hours (incl. fractions) of any session offerings.
    */
   get maxSingleOfferingDuration() {

--- a/packages/ilios-common/app/styles/ilios-common/components/session-offerings-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-offerings-list.scss
@@ -23,7 +23,8 @@
         width: 100%;
       }
 
-      .offering-block-date-dayofmonth {
+      .offering-block-date-dayofmonth,
+      .offering-block-date-daymonthyear {
         color: var(--grey);
       }
     }


### PR DESCRIPTION
Fixes ilios/ilios#7175

If a session's offerings span multiple years, the year will be shown. Proper `this.intl.formatDate` being used now so it should look good in all translations.
