### PR TITLE
indicate inactive ancestors on selected taxonomy terms.

### DIFF
--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-terms-list-item.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-terms-list-item.js
@@ -1,0 +1,12 @@
+import { clickable, create, isPresent, hasClass, text } from 'ember-cli-page-object';
+
+const definition = {
+  scope: '[data-test-detail-terms-list-item]',
+  name: text(),
+  remove: clickable('button'),
+  isSelected: hasClass('selected'),
+  hasDeleteIcon: isPresent('.fa-xmark'),
+};
+
+export default definition;
+export const component = create(definition);

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-terms-list.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-terms-list.js
@@ -1,16 +1,12 @@
-import { clickable, collection, create, isPresent, hasClass, text } from 'ember-cli-page-object';
+import { clickable, collection, create, text } from 'ember-cli-page-object';
+import listItem from './detail-terms-list-item';
 
 const definition = {
   scope: '[data-test-detail-terms-list]',
   vocabularyName: text('strong'),
   title: text('[data-test-title]'),
   manage: clickable('[data-test-manage]'),
-  terms: collection('.selected-taxonomy-terms li', {
-    name: text(),
-    remove: clickable('button'),
-    isSelected: hasClass('selected'),
-    hasDeleteIcon: isPresent('.fa-xmark'),
-  }),
+  terms: collection('[data-test-detail-terms-list-item]', listItem),
 };
 
 export default definition;

--- a/packages/ilios-common/addon/components/detail-terms-list-item.gjs
+++ b/packages/ilios-common/addon/components/detail-terms-list-item.gjs
@@ -10,6 +10,7 @@ import IliosTooltip from 'ilios-common/components/ilios-tooltip';
 import t from 'ember-intl/helpers/t';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { eq, not, or } from 'ember-truth-helpers';
 
 export default class DetailTermsListItem extends Component {
   @tracked isHovering;
@@ -30,6 +31,10 @@ export default class DetailTermsListItem extends Component {
 
   get parent() {
     return this.parentData.isResolved ? this.parentData.value : null;
+  }
+
+  get oldestInactiveParent() {
+    return this.allParents.find((p) => !p.active);
   }
 
   get detailTermsListItemId() {
@@ -72,20 +77,22 @@ export default class DetailTermsListItem extends Component {
               <span class="muted">
                 {{parent.title}}
               </span>
-              {{#unless parent.active}}
+              {{! only show the inactive label on the oldest inactive ancestor in the hierarchy }}
+              {{#if (eq parent this.oldestInactiveParent)}}
                 <span class="inactive">
                   ({{t "general.inactive"}})
                 </span>
-              {{/unless}}
+              {{/if}}
               &raquo;&nbsp;
             {{/each}}
             {{@term.title}}
           {{/if}}
-          {{#unless @term.active}}
+          {{! only show the inactive label if the given term is inactive and all of its ancestors are active }}
+          {{#if (not (or @term.active this.oldestInactiveParent))}}
             <span class="inactive">
               ({{t "general.inactive"}})
             </span>
-          {{/unless}}
+          {{/if}}
           <FaIcon @icon={{faXmark}} class="remove" />
         </button>
       {{else}}
@@ -97,20 +104,20 @@ export default class DetailTermsListItem extends Component {
             <span class="muted">
               {{parent.title}}
             </span>
-            {{#unless parent.active}}
+            {{#if (eq parent this.oldestInactiveParent)}}
               <span class="inactive">
                 ({{t "general.inactive"}})
               </span>
-            {{/unless}}
+            {{/if}}
             &raquo;&nbsp;
           {{/each}}
           {{@term.title}}
         {{/if}}
-        {{#unless @term.active}}
+        {{#if (not (or @term.active this.oldestInactiveParent))}}
           <span class="inactive">
             ({{t "general.inactive"}})
           </span>
-        {{/unless}}
+        {{/if}}
       {{/if}}
     </li>
   </template>

--- a/packages/ilios-common/addon/components/detail-terms-list-item.gjs
+++ b/packages/ilios-common/addon/components/detail-terms-list-item.gjs
@@ -15,12 +15,12 @@ export default class DetailTermsListItem extends Component {
   @tracked isHovering;
 
   @cached
-  get allParentsTitlesData() {
-    return new TrackedAsyncData(this.args.term.getAllParentTitles(this.args.term));
+  get allParentsData() {
+    return new TrackedAsyncData(this.args.term.getAllParents());
   }
 
-  get allParentTitles() {
-    return this.allParentsTitlesData.isResolved ? this.allParentsTitlesData.value : [];
+  get allParents() {
+    return this.allParentsData.isResolved ? this.allParentsData.value : [];
   }
 
   @cached
@@ -55,6 +55,7 @@ export default class DetailTermsListItem extends Component {
       class="detail-terms-list-item"
       id={{this.detailTermsListItemId}}
       {{mouseHoverToggle (set this "isHovering")}}
+      data-test-detail-terms-list-item
     >
       {{#if @canEdit}}
         {{#if this.showTooltip}}
@@ -66,12 +67,17 @@ export default class DetailTermsListItem extends Component {
           {{#if @term.isTopLevel}}
             {{@term.title}}
           {{else}}
-            {{#each this.allParentTitles as |title|}}
+            {{#each this.allParents as |parent|}}
               {{! template-lint-disable no-bare-strings}}
               <span class="muted">
-                {{title}}
-                &raquo;&nbsp;
+                {{parent.title}}
               </span>
+              {{#unless parent.active}}
+                <span class="inactive">
+                  ({{t "general.inactive"}})
+                </span>
+              {{/unless}}
+              &raquo;&nbsp;
             {{/each}}
             {{@term.title}}
           {{/if}}
@@ -86,12 +92,17 @@ export default class DetailTermsListItem extends Component {
         {{#if @term.isTopLevel}}
           {{@term.title}}
         {{else}}
-          {{#each this.allParentTitles as |title|}}
+          {{#each this.allParents as |parent|}}
             {{! template-lint-disable no-bare-strings}}
             <span class="muted">
-              {{title}}
-              &raquo;&nbsp;
+              {{parent.title}}
             </span>
+            {{#unless parent.active}}
+              <span class="inactive">
+                ({{t "general.inactive"}})
+              </span>
+            {{/unless}}
+            &raquo;&nbsp;
           {{/each}}
           {{@term.title}}
         {{/if}}

--- a/packages/test-app/tests/integration/components/detail-terms-list-item-test.gjs
+++ b/packages/test-app/tests/integration/components/detail-terms-list-item-test.gjs
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'test-app/tests/helpers';
-import { render, click, findAll } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { setupMSW } from 'ilios-common/msw';
+import { component } from 'ilios-common/page-objects/components/detail-terms-list-item';
 import DetailTermsListItem from 'ilios-common/components/detail-terms-list-item';
 import noop from 'ilios-common/helpers/noop';
 
@@ -17,58 +18,62 @@ module('Integration | Component | detail terms list item', function (hooks) {
     const term = await this.server.create('term', {
       vocabulary: this.vocabulary,
       title: 'Foo',
+      active: true,
     });
     const termModel = await this.owner.lookup('service:store').findRecord('term', term.id);
     this.set('term', termModel);
     await render(
       <template><DetailTermsListItem @term={{this.term}} @canEdit={{false}} /></template>,
     );
-    assert.notStrictEqual(this.element.textContent.trim().indexOf('Foo'), -1);
+    assert.strictEqual(component.name, 'Foo');
   });
 
   test('nested', async function (assert) {
     const term = await this.server.create('term', {
       vocabulary: this.vocabulary,
       title: 'Lorem',
+      active: true,
     });
     const term2 = await this.server.create('term', {
       vocabulary: this.vocabulary,
       title: 'Ipsum',
       parent: term,
+      active: true,
     });
     const term3 = await this.server.create('term', {
       vocabulary: this.vocabulary,
       title: 'Foo',
       parent: term2,
+      active: true,
     });
     const termModel = await this.owner.lookup('service:store').findRecord('term', term3.id);
     this.set('term', termModel);
     await render(
       <template><DetailTermsListItem @term={{this.term}} @canEdit={{false}} /></template>,
     );
-    assert.dom('.muted').includesText('Lorem »');
-    assert.dom(findAll('.muted')[1]).includesText('Ipsum »');
-    assert.notStrictEqual(this.element.textContent.trim().indexOf('Foo'), -1);
+    assert.strictEqual(component.name, 'Lorem » Ipsum » Foo');
   });
 
   test('remove', async function (assert) {
     const term = await this.server.create('term', {
       vocabulary: this.vocabulary,
       title: 'Foo',
+      active: true,
     });
     const termModel = await this.owner.lookup('service:store').findRecord('term', term.id);
     this.set('term', termModel);
     this.set('remove', (val) => {
-      assert.step('remove called');
       assert.strictEqual(termModel, val);
+      assert.step('remove called');
     });
     await render(
       <template>
         <DetailTermsListItem @term={{this.term}} @canEdit={{true}} @remove={{this.remove}} />
       </template>,
     );
-    assert.dom('.fa-xmark').exists({ count: 1 });
-    await click('.fa-xmark');
+    assert.strictEqual(component.name, 'Foo');
+    assert.ok(component.hasDeleteIcon);
+    await component.remove();
     assert.verifySteps(['remove called']);
   });
 
@@ -84,8 +89,8 @@ module('Integration | Component | detail terms list item', function (hooks) {
         <DetailTermsListItem @term={{this.term}} @canEdit={{true}} @remove={{(noop)}} />
       </template>,
     );
-    assert.dom('.inactive').hasText('(inactive)');
-    assert.dom('.fa-xmark').exists({ count: 1 });
+    assert.strictEqual(component.name, 'Foo (inactive)');
+    assert.ok(component.hasDeleteIcon);
   });
 
   test('read-only mode', async function (assert) {
@@ -98,7 +103,36 @@ module('Integration | Component | detail terms list item', function (hooks) {
     await render(
       <template><DetailTermsListItem @term={{this.term}} @canEdit={{false}} /></template>,
     );
-    assert.dom('.inactive').exists();
-    assert.dom('.fa-xmark').doesNotExist();
+    assert.strictEqual(component.name, 'Foo (inactive)');
+    assert.notOk(component.hasDeleteIcon);
+  });
+
+  test('inactive ancestors are labeled as such', async function (assert) {
+    const term = await this.server.create('term', {
+      vocabulary: this.vocabulary,
+      title: 'Foo',
+    });
+    const term2 = await this.server.create('term', {
+      parent: term,
+      title: 'Bar',
+      active: true,
+    });
+    const term3 = await this.server.create('term', {
+      parent: term2,
+      title: 'Brat',
+    });
+    const term4 = await this.server.create('term', {
+      parent: term3,
+      title: 'Wurst',
+      active: true,
+    });
+    const termModel = await this.owner.lookup('service:store').findRecord('term', term4.id);
+    this.set('term', termModel);
+    await render(
+      <template>
+        <DetailTermsListItem @term={{this.term}} @canEdit={{true}} @remove={{(noop)}} />
+      </template>,
+    );
+    assert.strictEqual(component.name, 'Foo (inactive) » Bar » Brat (inactive) » Wurst');
   });
 });

--- a/packages/test-app/tests/integration/components/detail-terms-list-item-test.gjs
+++ b/packages/test-app/tests/integration/components/detail-terms-list-item-test.gjs
@@ -107,10 +107,39 @@ module('Integration | Component | detail terms list item', function (hooks) {
     assert.notOk(component.hasDeleteIcon);
   });
 
-  test('inactive ancestors are labeled as such', async function (assert) {
+  test('inactive ancestor is labeled as such', async function (assert) {
     const term = await this.server.create('term', {
       vocabulary: this.vocabulary,
       title: 'Foo',
+      active: true,
+    });
+    const term2 = await this.server.create('term', {
+      parent: term,
+      title: 'Bar',
+    });
+    const term3 = await this.server.create('term', {
+      parent: term2,
+      title: 'Brat',
+    });
+    const term4 = await this.server.create('term', {
+      parent: term3,
+      title: 'Wurst',
+    });
+    const termModel = await this.owner.lookup('service:store').findRecord('term', term4.id);
+    this.set('term', termModel);
+    await render(
+      <template>
+        <DetailTermsListItem @term={{this.term}} @canEdit={{true}} @remove={{(noop)}} />
+      </template>,
+    );
+    assert.strictEqual(component.name, 'Foo » Bar (inactive) » Brat » Wurst');
+  });
+
+  test('only apply inactive label to nested term if all its ancestors are active', async function (assert) {
+    const term = await this.server.create('term', {
+      vocabulary: this.vocabulary,
+      title: 'Foo',
+      active: true,
     });
     const term2 = await this.server.create('term', {
       parent: term,
@@ -120,11 +149,11 @@ module('Integration | Component | detail terms list item', function (hooks) {
     const term3 = await this.server.create('term', {
       parent: term2,
       title: 'Brat',
+      active: true,
     });
     const term4 = await this.server.create('term', {
       parent: term3,
       title: 'Wurst',
-      active: true,
     });
     const termModel = await this.owner.lookup('service:store').findRecord('term', term4.id);
     this.set('term', termModel);
@@ -133,6 +162,6 @@ module('Integration | Component | detail terms list item', function (hooks) {
         <DetailTermsListItem @term={{this.term}} @canEdit={{true}} @remove={{(noop)}} />
       </template>,
     );
-    assert.strictEqual(component.name, 'Foo (inactive) » Bar » Brat (inactive) » Wurst');
+    assert.strictEqual(component.name, 'Foo » Bar » Brat » Wurst (inactive)');
   });
 });


### PR DESCRIPTION
currently, only the selected term itself is indicated as such if it is inactive. this adds the indicator to any ancestors of the selected term if applicable.

like so:
<img width="1099" height="180" alt="image" src="https://github.com/user-attachments/assets/3413b8f0-c86d-43ef-b982-91c5bf9f2ff4" />

refs https://github.com/ilios/frontend/pull/9387#issuecomment-4772038331
