### PR TITLE
Improve Mobile Hamburger Icon Alignment

### DIFF
--- a/packages/frontend/app/styles/components/ilios-navigation.scss
+++ b/packages/frontend/app/styles/components/ilios-navigation.scss
@@ -56,13 +56,17 @@
         &:hover {
           background-color: var(--light-blue);
         }
+
+        svg {
+          width: 100%;
+        }
       }
     }
   }
 
   &.expanded {
     @include m.for-smaller-than-laptop {
-      ul {
+      ul.navigation-links {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
 


### PR DESCRIPTION
The mobile hamburger image was always hugging the left side of its container, which kinda bugged me, especially as the viewport gets smaller. I fixed it by removing an erroneous `display: grid` being applied to it, and stretching the `svg` used for its icon to the full width of its container.

Olded and Scolded:
https://github.com/user-attachments/assets/88435503-5185-43d4-a1e1-dbb949a0ea95

Bolded and Golded:
https://github.com/user-attachments/assets/fc9b3718-6b97-4136-9dd5-9d21864cc2a2

