### PR TITLE
Course Publication workflow improvement

### DIFF
--- a/packages/frontend/app/components/courses/list-item.gjs
+++ b/packages/frontend/app/components/courses/list-item.gjs
@@ -9,7 +9,7 @@ import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import PublicationStatus from 'ilios-common/components/publication-status';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import { fn } from '@ember/helper';
+import { fn, hash } from '@ember/helper';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faLock, faLockOpen, faTrash } from '@fortawesome/free-solid-svg-icons';
 
@@ -53,7 +53,7 @@ export default class CoursesListItemComponent extends Component {
       data-test-courses-list-item
     >
       <td class="text-left" colspan="8" data-test-course-title>
-        <LinkTo @route="course" @model={{@course}}>
+        <LinkTo @route="course" @model={{@course}} @query={{hash detailsCollapseControl=true}}>
           {{@course.title}}
           {{#if @course.externalId}}
             ({{@course.externalId}})

--- a/packages/frontend/app/components/error-display.gjs
+++ b/packages/frontend/app/components/error-display.gjs
@@ -51,7 +51,7 @@ export default class ErrorDisplayComponent extends Component {
               class="error-detail-action"
               {{on "click" (set this "showDetails" (not this.showDetails))}}
             >
-              {{t (if this.showDetails "general.collapseDetail" "general.expandDetail")}}
+              {{t (if this.showDetails "general.collapseDetails" "general.expandDetails")}}
             </button>
           </p>
 

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -282,7 +282,7 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
             class="collapse-row"
             type="button"
             {{on "click" (perform this.collapseObjective)}}
-            title={{t "general.collapseDetail"}}
+            title={{t "general.collapseDetails"}}
             data-test-toggle-collapse
           >
             <FaIcon @icon={{faCaretDown}} />

--- a/packages/frontend/tests/acceptance/course/publish-test.js
+++ b/packages/frontend/tests/acceptance/course/publish-test.js
@@ -27,6 +27,7 @@ module('Acceptance | Course - Publish', function (hooks) {
       'Not Published',
       'course published status is correct',
     );
+    assert.ok(page.details.hasCollapseControl);
 
     await page.details.header.publicationMenu.toggle.click();
     await page.details.header.publicationMenu.publishAsIs();
@@ -36,6 +37,7 @@ module('Acceptance | Course - Publish', function (hooks) {
       '/courses/1/publicationcheck?details=true&detailsCollapseControl=false',
       'course publicationcheck url is correct',
     );
+    assert.notOk(page.details.hasCollapseControl);
 
     const pubcheck = pubcheckPage.publicationcheck;
 
@@ -76,6 +78,8 @@ module('Acceptance | Course - Publish', function (hooks) {
     });
     await page.visit({ courseId: course.id });
     assert.strictEqual(page.details.header.publicationMenu.toggle.text, 'Scheduled');
+    assert.ok(page.details.hasCollapseControl);
+
     await page.details.header.publicationMenu.toggle.click();
     await page.details.header.publicationMenu.publishAsIs();
 
@@ -84,6 +88,7 @@ module('Acceptance | Course - Publish', function (hooks) {
       '/courses/1/publicationcheck?details=true&detailsCollapseControl=false',
       'course publicationcheck url is correct',
     );
+    assert.notOk(page.details.hasCollapseControl);
 
     const pubcheck = pubcheckPage.publicationcheck;
 

--- a/packages/frontend/tests/acceptance/course/publish-test.js
+++ b/packages/frontend/tests/acceptance/course/publish-test.js
@@ -1,7 +1,9 @@
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import { setupApplicationTest } from 'frontend/tests/helpers';
+import { currentURL } from '@ember/test-helpers';
 import page from 'ilios-common/page-objects/course';
+import pubcheckPage from 'ilios-common/page-objects/course-publication-check';
 
 module('Acceptance | Course - Publish', function (hooks) {
   setupApplicationTest(hooks);
@@ -18,9 +20,36 @@ module('Acceptance | Course - Publish', function (hooks) {
       cohorts: [this.cohort],
     });
     await page.visit({ courseId: course.id });
-    assert.strictEqual(page.details.header.publicationMenu.toggle.text, 'Not Published');
+
+    assert.strictEqual(currentURL(), '/courses/1', 'course page url is correct');
+    assert.strictEqual(
+      page.details.header.publicationMenu.toggle.text,
+      'Not Published',
+      'course published status is correct',
+    );
+
     await page.details.header.publicationMenu.toggle.click();
     await page.details.header.publicationMenu.publishAsIs();
+
+    assert.strictEqual(
+      currentURL(),
+      '/courses/1/publicationcheck?details=true&detailsCollapseControl=false',
+      'course publicationcheck url is correct',
+    );
+
+    const pubcheck = pubcheckPage.publicationcheck;
+
+    assert.strictEqual(pubcheck.title, 'Missing Items (2)');
+    assert.strictEqual(pubcheck.courseTitle, 'course 0');
+    assert.strictEqual(pubcheck.cohorts, 'Yes (1)');
+    assert.strictEqual(pubcheck.terms, 'No');
+    assert.strictEqual(pubcheck.objectives, 'No');
+    assert.strictEqual(
+      pubcheck.publishWithMissingItems.text,
+      'Publish Course, with 2 items missing',
+    );
+
+    await pubcheckPage.publicationcheck.publishWithMissingItems.click();
     assert.strictEqual(page.details.header.publicationMenu.toggle.text, 'Published');
   });
 
@@ -49,6 +78,27 @@ module('Acceptance | Course - Publish', function (hooks) {
     assert.strictEqual(page.details.header.publicationMenu.toggle.text, 'Scheduled');
     await page.details.header.publicationMenu.toggle.click();
     await page.details.header.publicationMenu.publishAsIs();
+
+    assert.strictEqual(
+      currentURL(),
+      '/courses/1/publicationcheck?details=true&detailsCollapseControl=false',
+      'course publicationcheck url is correct',
+    );
+
+    const pubcheck = pubcheckPage.publicationcheck;
+
+    assert.strictEqual(pubcheck.title, 'Missing Items (2)');
+    assert.strictEqual(pubcheck.courseTitle, 'course 0');
+    assert.strictEqual(pubcheck.cohorts, 'Yes (1)');
+    assert.strictEqual(pubcheck.terms, 'No');
+    assert.strictEqual(pubcheck.objectives, 'No');
+    assert.strictEqual(
+      pubcheck.publishWithMissingItems.text,
+      'Publish Course, with 2 items missing',
+    );
+
+    await pubcheckPage.publicationcheck.publishWithMissingItems.click();
+
     assert.strictEqual(page.details.header.publicationMenu.toggle.text, 'Published');
   });
 

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/details.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/details.js
@@ -1,4 +1,4 @@
-import { clickable, count, create } from 'ember-cli-page-object';
+import { clickable, count, create, isVisible } from 'ember-cli-page-object';
 import objectives from './objectives';
 import learningMaterials from '../detail-learning-materials';
 import meshTerms from '../mesh-terms';
@@ -13,6 +13,7 @@ import detailCohorts from './../detail-cohorts';
 
 export default create({
   scope: '[data-test-ilios-course-details]',
+  hasCollapseControl: isVisible('[data-test-expand-course-details]'),
   collapseControl: clickable('[data-test-expand-course-details]'),
   titles: count('[data-test-title]'),
   header,

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/publicationcheck.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/publicationcheck.js
@@ -1,4 +1,4 @@
-import { attribute, create, text } from 'ember-cli-page-object';
+import { attribute, clickable, create, text } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-course-publicationcheck]',
@@ -13,6 +13,11 @@ const definition = {
   objectives: text('[data-test-objectives]'),
   unlink: {
     scope: '[data-test-unlink]',
+  },
+  publishWithMissingItems: {
+    scope: '[data-test-publish-with-missing-items]',
+    text: text(),
+    click: clickable(),
   },
 };
 

--- a/packages/ilios-common/addon/components/course/details.gjs
+++ b/packages/ilios-common/addon/components/course/details.gjs
@@ -66,6 +66,8 @@ export default class CourseDetailsComponent extends Component {
           @course={{@course}}
           @editable={{and @editable this.notRolloverRoute}}
           @academicYear={{this.academicYearDisplay}}
+          @showDetails={{@showDetails}}
+          @setShowDetails={{@setShowDetails}}
         />
         <Overview @course={{@course}} @editable={{and @editable this.notRolloverRoute}} />
         {{#if @showDetails}}

--- a/packages/ilios-common/addon/components/course/details.gjs
+++ b/packages/ilios-common/addon/components/course/details.gjs
@@ -68,6 +68,8 @@ export default class CourseDetailsComponent extends Component {
           @academicYear={{this.academicYearDisplay}}
           @showDetails={{@showDetails}}
           @setShowDetails={{@setShowDetails}}
+          @showDetailsCollapseControl={{@showDetailsCollapseControl}}
+          @setShowDetailsCollapseControl={{@setShowDetailsCollapseControl}}
         />
         <Overview @course={{@course}} @editable={{and @editable this.notRolloverRoute}} />
         {{#if @showDetails}}
@@ -85,23 +87,27 @@ export default class CourseDetailsComponent extends Component {
             @setCourseCompetencyDetails={{@setCourseCompetencyDetails}}
             @setCourseManageLeadership={{@setCourseManageLeadership}}
           />
-          <div class="detail-collapsed-control">
-            <button type="button" data-test-expand-course-details {{on "click" this.collapse}}>
-              {{t "general.collapseDetail"}}
-              <FaIcon @icon={{faSquareMinus}} class="expand-collapse-icon" />
-            </button>
-          </div>
+          {{#if @showDetailsCollapseControl}}
+            <div class="detail-collapsed-control">
+              <button type="button" data-test-expand-course-details {{on "click" this.collapse}}>
+                {{t "general.collapseDetail"}}
+                <FaIcon @icon={{faSquareMinus}} class="expand-collapse-icon" />
+              </button>
+            </div>
+          {{/if}}
         {{else}}
-          <div class="detail-collapsed-control">
-            <button
-              type="button"
-              data-test-expand-course-details
-              {{on "click" (fn @setShowDetails true)}}
-            >
-              {{t "general.expandDetail"}}
-              <FaIcon @icon={{faSquarePlus}} class="expand-collapse-icon" />
-            </button>
-          </div>
+          {{#if @showDetailsCollapseControl}}
+            <div class="detail-collapsed-control">
+              <button
+                type="button"
+                data-test-expand-course-details
+                {{on "click" (fn @setShowDetails true)}}
+              >
+                {{t "general.expandDetail"}}
+                <FaIcon @icon={{faSquarePlus}} class="expand-collapse-icon" />
+              </button>
+            </div>
+          {{/if}}
         {{/if}}
       </section>
     {{/if}}

--- a/packages/ilios-common/addon/components/course/details.gjs
+++ b/packages/ilios-common/addon/components/course/details.gjs
@@ -88,22 +88,22 @@ export default class CourseDetailsComponent extends Component {
             @setCourseManageLeadership={{@setCourseManageLeadership}}
           />
           {{#if @showDetailsCollapseControl}}
-            <div class="detail-collapsed-control">
+            <div class="details-collapse-control">
               <button type="button" data-test-expand-course-details {{on "click" this.collapse}}>
-                {{t "general.collapseDetail"}}
+                {{t "general.collapseDetails"}}
                 <FaIcon @icon={{faSquareMinus}} class="expand-collapse-icon" />
               </button>
             </div>
           {{/if}}
         {{else}}
           {{#if @showDetailsCollapseControl}}
-            <div class="detail-collapsed-control">
+            <div class="details-collapse-control">
               <button
                 type="button"
                 data-test-expand-course-details
                 {{on "click" (fn @setShowDetails true)}}
               >
-                {{t "general.expandDetail"}}
+                {{t "general.expandDetails"}}
                 <FaIcon @icon={{faSquarePlus}} class="expand-collapse-icon" />
               </button>
             </div>

--- a/packages/ilios-common/addon/components/course/header.gjs
+++ b/packages/ilios-common/addon/components/course/header.gjs
@@ -93,7 +93,11 @@ export default class CourseHeaderComponent extends Component {
       </span>
       <div class="course-publication">
         {{#if @editable}}
-          <PublicationMenu @course={{@course}} />
+          <PublicationMenu
+            @course={{@course}}
+            @showDetails={{@showDetails}}
+            @setShowDetails={{@setShowDetails}}
+          />
         {{else}}
           <PublicationStatus @item={{@course}} @showText={{true}} />
         {{/if}}

--- a/packages/ilios-common/addon/components/course/header.gjs
+++ b/packages/ilios-common/addon/components/course/header.gjs
@@ -97,6 +97,8 @@ export default class CourseHeaderComponent extends Component {
             @course={{@course}}
             @showDetails={{@showDetails}}
             @setShowDetails={{@setShowDetails}}
+            @showDetailsCollapseControl={{@showDetailsCollapseControl}}
+            @setShowDetailsCollapseControl={{@setShowDetailsCollapseControl}}
           />
         {{else}}
           <PublicationStatus @item={{@course}} @showText={{true}} />

--- a/packages/ilios-common/addon/components/course/loader.gjs
+++ b/packages/ilios-common/addon/components/course/loader.gjs
@@ -23,6 +23,8 @@ export default class CourseLoaderComponent extends Component {
           @editable={{@editable}}
           @showDetails={{@showDetails}}
           @setShowDetails={{@setShowDetails}}
+          @showDetailsCollapseControl={{@showDetailsCollapseControl}}
+          @setShowDetailsCollapseControl={{@setShowDetailsCollapseControl}}
           @courseLeadershipDetails={{@courseLeadershipDetails}}
           @courseObjectiveDetails={{@courseObjectiveDetails}}
           @courseTaxonomyDetails={{@courseTaxonomyDetails}}

--- a/packages/ilios-common/addon/components/course/loader.gjs
+++ b/packages/ilios-common/addon/components/course/loader.gjs
@@ -49,7 +49,7 @@ export default class CourseLoaderComponent extends Component {
 
           <div class="mock-detail-box">
             <span>
-              {{t "general.expandDetail"}}
+              {{t "general.expandDetails"}}
               <FaIcon @icon={{faSquarePlus}} class="expand-collapse-icon" />
             </span>
           </div>

--- a/packages/ilios-common/addon/components/course/loading.gjs
+++ b/packages/ilios-common/addon/components/course/loading.gjs
@@ -41,7 +41,7 @@ import { faSquarePlus } from '@fortawesome/free-solid-svg-icons';
       </div>
       <div class="mock-detail-box">
         <span>
-          {{t "general.expandDetail"}}
+          {{t "general.expandDetails"}}
           <FaIcon @icon={{faSquarePlus}} class="expand-collapse-icon" />
         </span>
       </div>

--- a/packages/ilios-common/addon/components/course/publication-menu.gjs
+++ b/packages/ilios-common/addon/components/course/publication-menu.gjs
@@ -52,6 +52,7 @@ export default class CoursePublicationMenuComponent extends Component {
     }
     return (
       (!this.args.course.published || this.args.course.publishedAsTbd) &&
+      this.args.course.requiredPublicationIssues.length === 0 &&
       this.args.course.allPublicationIssuesLength !== 0
     );
   }

--- a/packages/ilios-common/addon/components/course/publication-menu.gjs
+++ b/packages/ilios-common/addon/components/course/publication-menu.gjs
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
-import { uniqueId, get } from '@ember/helper';
+import { uniqueId } from '@ember/helper';
 import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
 import set from 'ember-set-helper/helpers/set';
 import { on } from '@ember/modifier';
@@ -46,18 +46,14 @@ export default class CoursePublicationMenuComponent extends Component {
   get showTbd() {
     return !this.args.course.publishedAsTbd;
   }
-  get showAsIs() {
-    return (
-      (!this.args.course.published || this.args.course.publishedAsTbd) &&
-      this.args.course.requiredPublicationIssues.length === 0 &&
-      this.args.course.allPublicationIssuesLength !== 0
-    );
-  }
-  get showReview() {
+  get showReviewAsIs() {
     if (this.router.currentRouteName === 'course.publication-check') {
       return false;
     }
-    return this.args.course.allPublicationIssuesLength > 0;
+    return (
+      (!this.args.course.published || this.args.course.publishedAsTbd) &&
+      this.args.course.allPublicationIssuesLength !== 0
+    );
   }
   get showPublish() {
     return (
@@ -148,6 +144,9 @@ export default class CoursePublicationMenuComponent extends Component {
   scrollToCoursePublication() {
     this.isOpen = false;
     this.router.transitionTo('course.publication-check', this.args.course);
+    if (!this.args.showDetails) {
+      this.args.setShowDetails(true);
+    }
   }
   @action
   async publish() {
@@ -201,13 +200,13 @@ export default class CoursePublicationMenuComponent extends Component {
         </button>
         {{#if this.isOpen}}
           <div class="menu" role="menu" data-test-menu {{focus}}>
-            {{#if this.showAsIs}}
+            {{#if this.showReviewAsIs}}
               <button
                 class="alert"
                 role="menuitem"
                 tabindex="-1"
                 type="button"
-                {{on "click" this.publish}}
+                {{on "click" this.scrollToCoursePublication}}
                 {{on "keydown" this.keyDown}}
                 {{on "mouseenter" this.clearFocus}}
                 data-test-publish-as-is
@@ -227,20 +226,6 @@ export default class CoursePublicationMenuComponent extends Component {
                 data-test-publish
               >
                 {{t "general.publishCourse"}}
-              </button>
-            {{/if}}
-            {{#if this.showReview}}
-              <button
-                class="good"
-                role="menuitem"
-                tabindex="-1"
-                type="button"
-                {{on "click" this.scrollToCoursePublication}}
-                {{on "keydown" this.keyDown}}
-                {{on "mouseenter" this.clearFocus}}
-                data-test-review
-              >
-                {{t "general.reviewMissingItems" count=(get @course "allPublicationIssuesLength")}}
               </button>
             {{/if}}
             {{#if this.showTbd}}

--- a/packages/ilios-common/addon/components/course/publication-menu.gjs
+++ b/packages/ilios-common/addon/components/course/publication-menu.gjs
@@ -143,10 +143,9 @@ export default class CoursePublicationMenuComponent extends Component {
   @action
   scrollToCoursePublication() {
     this.isOpen = false;
-    this.router.transitionTo('course.publication-check', this.args.course);
-    if (!this.args.showDetails) {
-      this.args.setShowDetails(true);
-    }
+    this.router.transitionTo('course.publication-check', this.args.course, {
+      queryParams: { details: true, detailsCollapseControl: false },
+    });
   }
   @action
   async publish() {

--- a/packages/ilios-common/addon/components/course/publicationcheck.gjs
+++ b/packages/ilios-common/addon/components/course/publicationcheck.gjs
@@ -2,8 +2,10 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
 import { LinkTo } from '@ember/routing';
+import { on } from '@ember/modifier';
 import t from 'ember-intl/helpers/t';
 import hasManyLength from 'ilios-common/helpers/has-many-length';
 import { hash } from '@ember/helper';
@@ -12,6 +14,8 @@ import { faLinkSlash } from '@fortawesome/free-solid-svg-icons';
 
 export default class CoursePublicationCheckComponent extends Component {
   @service router;
+  @service intl;
+  @service flashMessages;
 
   @cached
   get courseObjectives() {
@@ -29,6 +33,16 @@ export default class CoursePublicationCheckComponent extends Component {
 
     return objectivesWithoutParents.length > 0;
   }
+
+  @action
+  async publish() {
+    this.args.course.set('publishedAsTbd', false);
+    this.args.course.set('published', true);
+    await this.args.course.save();
+    this.router.transitionTo('course', this.args.course);
+    this.flashMessages.success(this.intl.t('general.publishedSuccessfully'));
+  }
+
   <template>
     <div
       class="course-publicationcheck main-section"
@@ -111,6 +125,18 @@ export default class CoursePublicationCheckComponent extends Component {
               </tr>
             </tbody>
           </table>
+        </div>
+        <div data-test-course-publicationcheck-actions>
+          <button
+            type="button"
+            {{on "click" this.publish}}
+            data-test-publish-course-with-missing-items
+          >
+            {{t
+              "general.publishCourseWithMissingItems"
+              missingItemCount=@course.allPublicationIssuesLength
+            }}
+          </button>
         </div>
       </section>
     </div>

--- a/packages/ilios-common/addon/components/course/publicationcheck.gjs
+++ b/packages/ilios-common/addon/components/course/publicationcheck.gjs
@@ -59,7 +59,7 @@ export default class CoursePublicationCheckComponent extends Component {
       </LinkTo>
 
       <section class="course-publicationcheck-details">
-        <div class="title">
+        <div class="title" data-test-title>
           {{t "general.missingItems"}}
           ({{@course.allPublicationIssuesLength}})
         </div>
@@ -132,11 +132,7 @@ export default class CoursePublicationCheckComponent extends Component {
           </table>
         </div>
         <div data-test-course-publicationcheck-actions>
-          <button
-            type="button"
-            {{on "click" this.publish}}
-            data-test-publish-course-with-missing-items
-          >
+          <button type="button" {{on "click" this.publish}} data-test-publish-with-missing-items>
             {{t
               "general.publishCourseWithMissingItems"
               missingItemCount=@course.allPublicationIssuesLength

--- a/packages/ilios-common/addon/components/course/publicationcheck.gjs
+++ b/packages/ilios-common/addon/components/course/publicationcheck.gjs
@@ -47,7 +47,7 @@ export default class CoursePublicationCheckComponent extends Component {
     <div
       class="course-publicationcheck main-section"
       data-test-course-publicationcheck
-      {{scrollIntoView}}
+      {{scrollIntoView delay=10}}
     >
       <LinkTo
         @route="course"

--- a/packages/ilios-common/addon/components/course/publicationcheck.gjs
+++ b/packages/ilios-common/addon/components/course/publicationcheck.gjs
@@ -49,7 +49,12 @@ export default class CoursePublicationCheckComponent extends Component {
       data-test-course-publicationcheck
       {{scrollIntoView}}
     >
-      <LinkTo @route="course" @model={{@course}} data-test-back-to-course>
+      <LinkTo
+        @route="course"
+        @model={{@course}}
+        @query={{hash detailsCollapseControl=true}}
+        data-test-back-to-course
+      >
         {{t "general.backToTitle" title=@course.title}}
       </LinkTo>
 

--- a/packages/ilios-common/addon/controllers/course.js
+++ b/packages/ilios-common/addon/controllers/course.js
@@ -3,6 +3,7 @@ import Controller from '@ember/controller';
 export default class CourseController extends Controller {
   queryParams = [
     'details',
+    'detailsCollapseControl',
     'courseLeadershipDetails',
     'courseObjectiveDetails',
     'courseTaxonomyDetails',
@@ -11,6 +12,7 @@ export default class CourseController extends Controller {
   ];
 
   details = false;
+  detailsCollapseControl = true;
   editable = false;
   courseLeadershipDetails = false;
   courseObjectiveDetails = false;

--- a/packages/ilios-common/addon/routes/course.js
+++ b/packages/ilios-common/addon/routes/course.js
@@ -14,6 +14,9 @@ export default class CourseRoute extends Route {
     details: {
       replace: true,
     },
+    detailsCollapseControl: {
+      replace: true,
+    },
     courseLeadershipDetails: {
       replace: true,
     },

--- a/packages/ilios-common/addon/templates/course.gjs
+++ b/packages/ilios-common/addon/templates/course.gjs
@@ -6,6 +6,8 @@ import set from 'ember-set-helper/helpers/set';
     @editable={{@controller.editable}}
     @showDetails={{@controller.details}}
     @setShowDetails={{set @controller "details"}}
+    @showDetailsCollapseControl={{@controller.detailsCollapseControl}}
+    @setShowDetailsCollapseControl={{set @controller "detailsCollapseControl"}}
     @courseLeadershipDetails={{@controller.courseLeadershipDetails}}
     @courseObjectiveDetails={{@controller.courseObjectiveDetails}}
     @courseTaxonomyDetails={{@controller.courseTaxonomyDetails}}

--- a/packages/ilios-common/app/styles/ilios-common/components/course/details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/details.scss
@@ -4,7 +4,7 @@
   $collapse-control-shadow-grey: #e2e2e2;
   $collapse-control-shadow-black: var(--very-transparent-black);
 
-  .detail-collapsed-control {
+  .details-collapse-control {
     display: flex;
     justify-content: center;
     width: 100%;

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -54,7 +54,7 @@ general:
   cohorts: Cohorts
   cohortsManageTitle: Manage Cohorts
   collapse: Collapse
-  collapseDetail: Hide Details
+  collapseDetails: Hide Details
   competencies: Competencies
   complete: Complete
   confirmRemoveLearningMaterial: Are you sure you want to remove this learning material? This action cannot be undone.
@@ -129,7 +129,7 @@ general:
   eventNotFoundTitle: Event Not Found
   eventNotFoundExplanation: "The event you have tried to reach is either no longer available, or you have followed a personalized user link which is not shareable. If you continue to encounter issues, please contact your Ilios help desk."
   expand: Expand
-  expandDetail: Show Details
+  expandDetails: Show Details
   externalId: Course ID
   file: File
   file-audio: Audio file

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -290,6 +290,7 @@ general:
   publishAllAsIs: Publish All As-is
   publishAsIs: Publish As-is
   publishCourse: Publish Course
+  publishCourseWithMissingItems: Publish Course, with {missingItemCount, plural, =1 {1 item missing} other {# items missing}}
   published: Published
   publishedSessions: Published Sessions
   publishedSuccessfully: Published successfully

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -290,6 +290,7 @@ general:
   publishAllAsIs: Publique Todo Como Es
   publishAsIs: Publique Como Es
   publishCourse: Publique Curso
+  publishCourseWithMissingItems: Publique Curso, con {missingItemCount, plural, =1 {1 artículo faltante} other {# artículos faltantes}}
   published: Publicado
   publishedSessions: Sesiones Publicadas
   publishedSuccessfully: Publicado con éxito

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -54,7 +54,7 @@ general:
   cohorts: Clases de la Graduación
   cohortsManageTitle: Administrar Clases de La Graduación
   collapse: Colapsar
-  collapseDetail: Esconder Detalles
+  collapseDetails: Esconder Detalles
   competencies: Competencias
   complete: Completo
   confirmRemoveLearningMaterial: ¿Está seguro que desea eliminar este material de aprendizaje? Esta acción no se puede deshacer.
@@ -129,7 +129,7 @@ general:
   eventNotFoundTitle: Evento no encontrado
   eventNotFoundExplanation: "El evento al que ha intentado acceder ya no está disponible o ha seguido un enlace de usuario personalizado que no se puede compartir. Si sigue teniendo problemas, póngase en contacto con el servicio de asistencia de Ilios."
   expand: Expandir
-  expandDetail: Enseñar Detalles
+  expandDetails: Enseñar Detalles
   externalId: Identificación del Curso
   file: Archivo
   file-audio: Archivo de audio

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -54,7 +54,7 @@ general:
   cohorts: Cohortes
   cohortsManageTitle: Manager des Cohortes
   collapse: Réduire
-  collapseDetail: Masquer Détails
+  collapseDetails: Masquer Détails
   competencies: Compétences
   complete: Accompli
   confirmRemoveLearningMaterial: "Êtes-vous sûr vous voulez supprimer cette matériel d'étude? Ça action ne peut pas être défait."
@@ -129,7 +129,7 @@ general:
   eventNotFoundExplanation: "L'événement que vous avez essayé d'atteindre n'est plus disponible ou vous avez suivi un lien utilisateur personnalisé qui n'est pas partageable. Si vous continuez à rencontrer des problèmes, veuillez contacter votre service d'assistance Ilios."
   eventNotFoundTitle: Evénement introuvable
   expand: Étendre
-  expandDetail: Afficher Détails
+  expandDetails: Afficher Détails
   externalId: ID de Cours
   file: Fichier
   file-audio: Fichier audio

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -290,6 +290,7 @@ general:
   publishAllAsIs: 'Publier tout "as-is"'
   publishAsIs: 'Publier "as-is"'
   publishCourse: Publier Cours
+  publishCourseWithMissingItems: Publier Cours, avec {missingItemCount, plural, =1 {1 objet manquant} other {# objets manquants}}
   published: Publié
   publishedSessions: Sessions Publiées
   publishedSuccessfully: Publié réussi

--- a/packages/test-app/tests/integration/components/course/publication-menu-test.gjs
+++ b/packages/test-app/tests/integration/components/course/publication-menu-test.gjs
@@ -84,7 +84,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     await render(<template><PublicationMenu @course={{this.course}} /></template>);
     await component.toggle.click();
     assert.ok(component.menuOpen);
-    assert.ok(component.hasPublishAsIs);
+    assert.notOk(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
     assert.ok(component.hasTbd);
     assert.notOk(component.hasUnPublish);
@@ -116,7 +116,7 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     await render(<template><PublicationMenu @course={{this.course}} /></template>);
     await component.toggle.click();
     assert.ok(component.menuOpen);
-    assert.ok(component.hasPublishAsIs);
+    assert.notOk(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
     assert.notOk(component.hasTbd);
     assert.ok(component.hasUnPublish);
@@ -196,12 +196,12 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     assert.ok(component.hasTbd);
     assert.notOk(component.hasUnPublish);
 
-    assert.strictEqual(component.selectedMenuItem, 'Publish As-is');
+    assert.strictEqual(component.selectedMenuItem, 'Mark as Scheduled');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
 
     await component.menu.up();
-    assert.strictEqual(component.selectedMenuItem, 'Mark as Scheduled');
+    assert.strictEqual(component.selectedMenuItem, 'Publish As-is');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });

--- a/packages/test-app/tests/integration/components/course/publication-menu-test.gjs
+++ b/packages/test-app/tests/integration/components/course/publication-menu-test.gjs
@@ -84,9 +84,8 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     await render(<template><PublicationMenu @course={{this.course}} /></template>);
     await component.toggle.click();
     assert.ok(component.menuOpen);
-    assert.notOk(component.hasPublishAsIs);
+    assert.ok(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
     assert.ok(component.hasTbd);
     assert.notOk(component.hasUnPublish);
   });
@@ -103,7 +102,6 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     assert.ok(component.menuOpen);
     assert.ok(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
     assert.ok(component.hasTbd);
     assert.notOk(component.hasUnPublish);
   });
@@ -118,9 +116,8 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     await render(<template><PublicationMenu @course={{this.course}} /></template>);
     await component.toggle.click();
     assert.ok(component.menuOpen);
-    assert.notOk(component.hasPublishAsIs);
+    assert.ok(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
     assert.notOk(component.hasTbd);
     assert.ok(component.hasUnPublish);
   });
@@ -139,7 +136,6 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     assert.ok(component.menuOpen);
     assert.ok(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
     assert.notOk(component.hasTbd);
     assert.ok(component.hasUnPublish);
   });
@@ -156,7 +152,6 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     assert.ok(component.menuOpen);
     assert.notOk(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
     assert.ok(component.hasTbd);
     assert.ok(component.hasUnPublish);
   });
@@ -198,15 +193,9 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     assert.ok(component.menuOpen);
     assert.ok(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
     assert.ok(component.hasTbd);
     assert.notOk(component.hasUnPublish);
 
-    assert.strictEqual(component.selectedMenuItem, 'Review 2 Missing Items');
-    await a11yAudit(this.element);
-    assert.ok(true, 'no a11y errors found!');
-
-    await component.menu.up();
     assert.strictEqual(component.selectedMenuItem, 'Publish As-is');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -231,21 +220,15 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     assert.ok(component.menuOpen);
     assert.notOk(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
     assert.ok(component.hasTbd);
     assert.ok(component.hasUnPublish);
 
-    assert.strictEqual(component.selectedMenuItem, 'Review 2 Missing Items');
+    assert.strictEqual(component.selectedMenuItem, 'Mark as Scheduled');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
 
     await component.menu.up();
     assert.strictEqual(component.selectedMenuItem, 'UnPublish Course');
-    await a11yAudit(this.element);
-    assert.ok(true, 'no a11y errors found!');
-
-    await component.menu.up();
-    assert.strictEqual(component.selectedMenuItem, 'Mark as Scheduled');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });


### PR DESCRIPTION
Fixes ilios/ilios#6848

This simplifies the Course Publication Menu by removing the 'Review X Items' option and having that feature as part of the "Publish As-is". You now publish the course at the `/publicationcheck` route.

- [x] Remove "Review # items" option in Course Publication button
- [x] Publish remains the same (no missing items)
- [x] Publish As-Is now incorporates the old "Review # items" if there are missing items and requires a "Yes, publish, despite these missing items"
- [x] Expand the Course, remove collapse button

Potential followup items:
- [ ] Missing items should be links to edit them instead of just text (in-page anchors? double-up function of on-page buttons?)
- [ ] Move the Publish As-Is route to above the Course overview section (only one outlet currently and it's either above or below everything)
- [ ] Loosening menu option visibility logic so that "Publish As-Is" shows even if required element (cohort) is not present