### PR TITLE
Make Curriculum Reports dominant report type and improve course selection/report run flow

### DIFF
--- a/packages/frontend/app/components/reports/curriculum.gjs
+++ b/packages/frontend/app/components/reports/curriculum.gjs
@@ -39,7 +39,7 @@ export default class ReportsCurriculumComponent extends Component {
   }
 
   get selectedReportValue() {
-    return this.args.report ?? 'courseCompetencies';
+    return this.args.report ?? null;
   }
 
   @cached

--- a/packages/frontend/app/components/reports/curriculum/header.gjs
+++ b/packages/frontend/app/components/reports/curriculum/header.gjs
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 import { guidFor } from '@ember/object/internals';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import { eq, not, and, or } from 'ember-truth-helpers';
+import { eq, not, and } from 'ember-truth-helpers';
 import isEmpty from 'ember-truth-helpers/helpers/is-empty';
 import sortBy from 'ilios-common/helpers/sort-by';
 import CopyButton from 'ilios-common/components/copy-button';
@@ -223,7 +223,7 @@ export default class ReportsCurriculumHeaderComponent extends Component {
             type="button"
             class="done text"
             {{on "click" @runReport}}
-            disabled={{or (not @countSelectedCourses) (not this.selectedReport)}}
+            disabled={{not (and @countSelectedCourses this.selectedReport)}}
             id={{this.runButtonId}}
             {{mouseHoverToggle (set this "showRunTooltip")}}
             data-test-run

--- a/packages/frontend/app/components/reports/curriculum/header.gjs
+++ b/packages/frontend/app/components/reports/curriculum/header.gjs
@@ -4,7 +4,8 @@ import { service } from '@ember/service';
 import { guidFor } from '@ember/object/internals';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import { eq, not } from 'ember-truth-helpers';
+import { eq, not, and, or } from 'ember-truth-helpers';
+import isEmpty from 'ember-truth-helpers/helpers/is-empty';
 import sortBy from 'ilios-common/helpers/sort-by';
 import CopyButton from 'ilios-common/components/copy-button';
 import perform from 'ember-concurrency/helpers/perform';
@@ -173,35 +174,8 @@ export default class ReportsCurriculumHeaderComponent extends Component {
   };
   <template>
     <div class="reports-curriculum-header" data-test-reports-curriculum-header>
-      <div class="run">
-        <p data-test-run-summary>
-          {{#if @countSelectedCourses}}
-            {{#if @showReportResults}}
-              {{t "general.run"}}
-              {{this.selectedReport.label}}
-            {{else}}
-              <label data-test-report-selector>
-                {{t "general.run"}}
-                <select {{on "change" this.changeSelectedReport}}>
-                  {{#each (sortBy "label" this.reportList) as |report|}}
-                    <option
-                      value={{report.value}}
-                      selected={{eq report.value this.selectedReport.value}}
-                    >
-                      {{report.label}}
-                    </option>
-                  {{/each}}
-                </select>
-              </label>
-            {{/if}}
-            {{this.selectedReport.summary}}
-          {{else}}
-            {{t "general.selectCoursesToRunReport"}}
-          {{/if}}
-        </p>
-      </div>
       <div class="input-buttons">
-        {{#if @countSelectedCourses}}
+        {{#if (and @countSelectedCourses this.selectedReport)}}
           <CopyButton
             @getClipboardText={{this.getReportUrl}}
             @success={{perform this.textCopied}}
@@ -249,7 +223,7 @@ export default class ReportsCurriculumHeaderComponent extends Component {
             type="button"
             class="done text"
             {{on "click" @runReport}}
-            disabled={{not @countSelectedCourses}}
+            disabled={{or (not @countSelectedCourses) (not this.selectedReport)}}
             id={{this.runButtonId}}
             {{mouseHoverToggle (set this "showRunTooltip")}}
             data-test-run
@@ -267,6 +241,37 @@ export default class ReportsCurriculumHeaderComponent extends Component {
             </IliosTooltip>
           {{/if}}
         {{/if}}
+      </div>
+      <div class="run">
+        <p data-test-run-summary>
+          <label data-test-report-selector>
+            {{t "general.selectCurriculumReportType"}}:
+            <select {{on "change" this.changeSelectedReport}}>
+              <option selected={{isEmpty this.selectedReport}} value>
+                {{t "general.selectPolite"}}
+              </option>
+              {{#each (sortBy "label" this.reportList) as |report|}}
+                <option
+                  value={{report.value}}
+                  selected={{eq report.value this.selectedReport.value}}
+                >
+                  {{report.label}}
+                </option>
+              {{/each}}
+            </select>
+          </label>
+          {{#if this.selectedReport}}
+            {{#if @countSelectedCourses}}
+              <p>
+                {{t "general.run"}}
+                {{this.selectedReport.label}}
+                {{this.selectedReport.summary}}
+              </p>
+            {{else}}
+              <p>{{t "general.selectCoursesToRunReport"}}</p>
+            {{/if}}
+          {{/if}}
+        </p>
       </div>
     </div>
   </template>

--- a/packages/frontend/app/components/reports/curriculum/header.gjs
+++ b/packages/frontend/app/components/reports/curriculum/header.gjs
@@ -244,24 +244,26 @@ export default class ReportsCurriculumHeaderComponent extends Component {
       </div>
       <div class="run">
         <p>
-          <label data-test-report-selector>
-            <span data-test-report-selector-label>
-              {{t "general.selectCurriculumReportType"}}:
-            </span>
-            <select {{on "change" this.changeSelectedReport}}>
-              <option selected={{isEmpty this.selectedReport}} value>
-                {{t "general.selectPolite"}}
-              </option>
-              {{#each (sortBy "label" this.reportList) as |report|}}
-                <option
-                  value={{report.value}}
-                  selected={{eq report.value this.selectedReport.value}}
-                >
-                  {{report.label}}
+          {{#unless @showReportResults}}
+            <label data-test-report-selector>
+              <span data-test-report-selector-label>
+                {{t "general.selectCurriculumReportType"}}:
+              </span>
+              <select {{on "change" this.changeSelectedReport}}>
+                <option selected={{isEmpty this.selectedReport}} value>
+                  {{t "general.selectPolite"}}
                 </option>
-              {{/each}}
-            </select>
-          </label>
+                {{#each (sortBy "label" this.reportList) as |report|}}
+                  <option
+                    value={{report.value}}
+                    selected={{eq report.value this.selectedReport.value}}
+                  >
+                    {{report.label}}
+                  </option>
+                {{/each}}
+              </select>
+            </label>
+          {{/unless}}
           <div data-test-run-summary>
             {{#if this.selectedReport}}
               {{#if @countSelectedCourses}}

--- a/packages/frontend/app/components/reports/curriculum/header.gjs
+++ b/packages/frontend/app/components/reports/curriculum/header.gjs
@@ -243,9 +243,11 @@ export default class ReportsCurriculumHeaderComponent extends Component {
         {{/if}}
       </div>
       <div class="run">
-        <p data-test-run-summary>
+        <p>
           <label data-test-report-selector>
-            {{t "general.selectCurriculumReportType"}}:
+            <span data-test-report-selector-label>
+              {{t "general.selectCurriculumReportType"}}:
+            </span>
             <select {{on "change" this.changeSelectedReport}}>
               <option selected={{isEmpty this.selectedReport}} value>
                 {{t "general.selectPolite"}}
@@ -260,17 +262,21 @@ export default class ReportsCurriculumHeaderComponent extends Component {
               {{/each}}
             </select>
           </label>
-          {{#if this.selectedReport}}
-            {{#if @countSelectedCourses}}
-              <p>
-                {{t "general.run"}}
-                {{this.selectedReport.label}}
-                {{this.selectedReport.summary}}
-              </p>
-            {{else}}
-              <p>{{t "general.selectCoursesToRunReport"}}</p>
+          <div data-test-run-summary>
+            {{#if this.selectedReport}}
+              {{#if @countSelectedCourses}}
+                <div data-test-selected-report-label-summary>
+                  {{t "general.run"}}
+                  {{this.selectedReport.label}}
+                  {{this.selectedReport.summary}}
+                </div>
+              {{else}}
+                <div data-test-selected-report-label-summary>
+                  {{t "general.selectCoursesToRunReport"}}
+                </div>
+              {{/if}}
             {{/if}}
-          {{/if}}
+          </div>
         </p>
       </div>
     </div>

--- a/packages/frontend/app/components/reports/curriculum/loading.gjs
+++ b/packages/frontend/app/components/reports/curriculum/loading.gjs
@@ -42,7 +42,7 @@ export default class ReportsCurriculumLoadingComponent extends Component {
   }
 
   get selectedReportValue() {
-    return this.queryParams?.report ?? 'sessionObjectives';
+    return this.queryParams?.report ?? null;
   }
   <template>
     <div

--- a/packages/frontend/app/components/reports/switcher.gjs
+++ b/packages/frontend/app/components/reports/switcher.gjs
@@ -2,15 +2,11 @@ import { LinkTo } from '@ember/routing';
 import t from 'ember-intl/helpers/t';
 <template>
   <div class="reports-switcher" data-test-reports-switcher>
-    <LinkTo
-      @route="reports.subjects"
-      @current-when="reports.subjects reports.subject"
-      data-test-subject
-    >
-      {{t "general.subjectReports"}}
-    </LinkTo>
-    <LinkTo @route="reports.curriculum" data-test-curriculum>
+    <LinkTo @route="reports.curriculum" @current-when="reports.curriculum" data-test-curriculum>
       {{t "general.curriculumReports"}}
+    </LinkTo>
+    <LinkTo @route="reports.subjects" data-test-subject>
+      {{t "general.subjectReports"}}
     </LinkTo>
   </div>
 </template>

--- a/packages/frontend/app/routes/reports/index.js
+++ b/packages/frontend/app/routes/reports/index.js
@@ -8,7 +8,7 @@ export default class ReportsIndexRoute extends Route {
 
   beforeModel(transition) {
     if (this.currentUser.requireNonLearner(transition)) {
-      this.router.replaceWith('reports.subjects');
+      this.router.replaceWith('reports.curriculum');
     }
   }
 }

--- a/packages/frontend/app/styles/components/reports/curriculum-header.scss
+++ b/packages/frontend/app/styles/components/reports/curriculum-header.scss
@@ -15,6 +15,10 @@
   .run {
     @include cm.font-size("medium");
     min-height: 2rem;
+
+    p {
+      margin: 0;
+    }
   }
 
   .input-buttons {

--- a/packages/frontend/tests/acceptance/reports/curriculum-test.js
+++ b/packages/frontend/tests/acceptance/reports/curriculum-test.js
@@ -86,6 +86,14 @@ module('Acceptance | Reports - Curriculum Reports', function (hooks) {
     };
   });
 
+  test('visiting /reports ends up at curriculum', async function (assert) {
+    await page.visit();
+    await takeScreenshot(assert);
+    assert.strictEqual(currentRouteName(), 'reports.curriculum');
+    assert.ok(page.switcher.curriculum.isActive);
+    assert.notOk(page.switcher.subject.isActive);
+  });
+
   test('visiting reports with one school', async function (assert) {
     await this.server.createList('course', 2, {
       school: this.school,

--- a/packages/frontend/tests/acceptance/reports/subjects-test.js
+++ b/packages/frontend/tests/acceptance/reports/subjects-test.js
@@ -1,4 +1,4 @@
-import { currentRouteName, currentURL } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupAuthentication } from 'ilios-common';
 import page from 'frontend/tests/pages/reports';
@@ -63,16 +63,8 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
     });
   });
 
-  test('visiting /reports ends up at subjects', async function (assert) {
-    await page.visit();
-    assert.strictEqual(currentRouteName(), 'reports.subjects');
-    assert.ok(page.switcher.subject.isActive);
-    assert.notOk(page.switcher.curriculum.isActive);
-    assert.ok(page.subjects.isPresent);
-  });
-
   test('shows reports', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     await takeScreenshot(assert);
     assert.strictEqual(page.subjects.list.table.reports.length, 2);
     assert.strictEqual(
@@ -83,7 +75,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('create new report', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     assert.strictEqual(page.subjects.list.table.reports.length, 2, 'report count is correct');
     assert.strictEqual(
       page.subjects.list.table.reports[0].title,
@@ -185,7 +177,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('create new report with empty title', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     assert.strictEqual(page.subjects.list.table.reports.length, 2);
     assert.ok(page.subjects.list.newReportLinkIsHidden);
     await page.subjects.list.toggleNewSubjectReportForm();
@@ -199,7 +191,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('filter session by year in new report form', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     assert.strictEqual(page.subjects.list.table.reports.length, 2);
     assert.strictEqual(
       page.subjects.list.table.reports[0].title,
@@ -254,7 +246,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('get all courses associated with mesh term #3419', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     assert.strictEqual(page.subjects.list.table.reports.length, 2);
     assert.strictEqual(
       page.subjects.list.table.reports[0].title,
@@ -333,7 +325,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('Prepositional object resets when a new type is selected', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     assert.strictEqual(page.subjects.list.table.reports.length, 2);
     assert.strictEqual(
       page.subjects.list.table.reports[0].title,
@@ -362,7 +354,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('course external id in report', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     assert.strictEqual(page.subjects.list.table.reports.length, 2, 'report list count correct');
     assert.strictEqual(
       page.subjects.list.table.reports[0].title,
@@ -433,7 +425,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('delete report', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     assert.strictEqual(page.subjects.list.table.reports.length, 2);
     assert.strictEqual(
       page.subjects.list.table.reports[0].title,
@@ -447,7 +439,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('run subject report', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     await page.subjects.list.toggleNewSubjectReportForm();
     await page.subjects.list.newSubject.schools.choose('1');
     await page.subjects.list.newSubject.subjects.choose('session');
@@ -496,7 +488,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('reset year when subject report is run', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     await page.subjects.list.toggleNewSubjectReportForm();
     await page.subjects.list.newSubject.schools.choose('1');
     await page.subjects.list.newSubject.subjects.choose('course');
@@ -559,7 +551,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('remove report title', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     this.server.post('/api/graphql', () => {
       assert.step('API called');
       //send wrong data back, who cares
@@ -579,7 +571,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
       subjectReportPage.report.title.text,
       'All Sessions for Course course 0 (2015) in school 0',
     );
-    await page.visit();
+    await page.visitSubjectReports();
 
     assert.strictEqual(page.subjects.list.table.reports.length, 2);
     assert.strictEqual(
@@ -595,7 +587,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
 
   test('create new report for instructors by academic year #3594', async function (assert) {
     await this.server.createList('user', 3);
-    await page.visit();
+    await page.visitSubjectReports();
     assert.strictEqual(page.subjects.list.table.reports.length, 2);
     assert.ok(page.subjects.list.newReportLinkIsHidden);
     await page.subjects.list.toggleNewSubjectReportForm();
@@ -659,7 +651,7 @@ module('Acceptance | Reports - Subject Reports', function (hooks) {
   });
 
   test('courses by academic year hides year', async function (assert) {
-    await page.visit();
+    await page.visitSubjectReports();
     await page.subjects.list.toggleNewSubjectReportForm();
     await page.subjects.list.newSubject.schools.choose('');
     await page.subjects.list.newSubject.subjects.choose('course');

--- a/packages/frontend/tests/acceptance/route-performance-test.js
+++ b/packages/frontend/tests/acceptance/route-performance-test.js
@@ -216,7 +216,38 @@ module('Acceptance | performance', function (hooks) {
     assert.ok(duration < this.maxDuration, `route loaded in allowable time: ${duration}ms`);
   });
 
-  test('/reports', async function (assert) {
+  test('/reports/curriculum', async function (assert) {
+    await this.server.create('academic-year');
+    this.sessionTypes = await this.server.createList('session-type', 1, {
+      school: this.school,
+    });
+
+    const courses = await this.server.createList('course', 10, { school: this.school });
+    const promises = [];
+
+    for (let i = 0, n = courses.length; i < n; i++) {
+      promises.push(
+        await this.server.createList('session', 10, {
+          course: courses[i],
+          sessionType: this.sessionTypes[0],
+        }),
+      );
+    }
+
+    await Promise.all(promises);
+
+    let start = performance.now();
+
+    await visit('/reports/curriculum');
+
+    let end = performance.now();
+    let duration = end - start;
+
+    assert.strictEqual(currentRouteName(), 'reports.curriculum', 'current route name is correct');
+    assert.ok(duration < this.maxDuration, `route loaded in allowable time: ${duration}ms`);
+  });
+
+  test('/reports/subjects', async function (assert) {
     await this.server.create('academic-year');
     this.sessionTypes = await this.server.createList('session-type', 1, {
       school: this.school,
@@ -248,7 +279,7 @@ module('Acceptance | performance', function (hooks) {
 
     let start = performance.now();
 
-    await visit('/reports');
+    await visit('/reports/subjects');
 
     let end = performance.now();
     let duration = end - start;

--- a/packages/frontend/tests/acceptance/route-performance-test.js
+++ b/packages/frontend/tests/acceptance/route-performance-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
 import { setupApplicationTest } from 'frontend/tests/helpers';
 import { DateTime } from 'luxon';
+import { graphQL } from 'frontend/tests/helpers/curriculum-report';
 
 module('Acceptance | performance', function (hooks) {
   setupApplicationTest(hooks);
@@ -217,6 +218,14 @@ module('Acceptance | performance', function (hooks) {
   });
 
   test('/reports/curriculum', async function (assert) {
+    this.getCourseCompetenciesResponse = (assert) => {
+      return () => {
+        const courses = this.server.db.course.all().map((c) => graphQL.buildCourse(c));
+        assert.step('API called');
+        return { data: { courses } };
+      };
+    };
+    this.server.post('/api/graphql', this.getCourseCompetenciesResponse(assert));
     await this.server.create('academic-year');
     this.sessionTypes = await this.server.createList('session-type', 1, {
       school: this.school,
@@ -245,6 +254,7 @@ module('Acceptance | performance', function (hooks) {
 
     assert.strictEqual(currentRouteName(), 'reports.curriculum', 'current route name is correct');
     assert.ok(duration < this.maxDuration, `route loaded in allowable time: ${duration}ms`);
+    assert.verifySteps(['API called']);
   });
 
   test('/reports/subjects', async function (assert) {

--- a/packages/frontend/tests/integration/components/reports/curriculum-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/curriculum-test.gjs
@@ -27,7 +27,7 @@ module('Integration | Component | reports/curriculum', function (hooks) {
     });
   });
 
-  test('it renders and is accessible with no courses selected', async function (assert) {
+  test('it renders and is accessible with no report type or courses selected', async function (assert) {
     this.set('schools', buildSchoolsFromData(this.server.db));
     await render(
       <template>
@@ -43,11 +43,39 @@ module('Integration | Component | reports/curriculum', function (hooks) {
         />
       </template>,
     );
-    assert.notOk(component.header.reportSelector.isPresent, 'report selector is present');
+    assert.ok(component.header.reportSelector.isPresent, 'report selector is present');
+    assert.ok(component.header.reportSelector.text, '(please select one)');
     assert.strictEqual(
       component.header.runSummaryText,
-      'Select Courses to Run Report',
+      'Select Curriculum Report Type: ',
       'report header text correct',
+    );
+
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders and is accessible with report type selected', async function (assert) {
+    this.set('schools', buildSchoolsFromData(this.server.db));
+    await render(
+      <template>
+        <Curriculum
+          @selectedCourseIds={{array "1"}}
+          @setSelectedCourseIds={{(noop)}}
+          @report="sessionObjectives"
+          @setReport={{(noop)}}
+          @schools={{this.schools}}
+          @run={{(noop)}}
+          @stop={{(noop)}}
+          @showReportResults={{false}}
+        />
+      </template>,
+    );
+    assert.ok(component.header.reportSelector.isPresent, 'report selector is present');
+    assert.ok(
+      component.header.runSummaryText.includes(
+        'Each session objective is listed along with instructors and course data.',
+      ),
     );
 
     await a11yAudit(this.element);
@@ -70,7 +98,7 @@ module('Integration | Component | reports/curriculum', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.header.reportSelector.isPresent);
+    assert.ok(component.header.reportSelector.isPresent, 'report selector is present');
     assert.ok(
       component.header.runSummaryText.includes(
         'Each session objective is listed along with instructors and course data.',
@@ -178,29 +206,5 @@ module('Integration | Component | reports/curriculum', function (hooks) {
     );
     await component.chooseCourse.years[0].courses[1].pick();
     assert.verifySteps(['setSelectedCourseIds called']);
-  });
-
-  test('set report works', async function (assert) {
-    this.set('schools', buildSchoolsFromData(this.server.db));
-    this.set('setReport', (report) => {
-      assert.step('setReport called');
-      assert.strictEqual(report, 'learnerGroups');
-    });
-    await render(
-      <template>
-        <Curriculum
-          @selectedCourseIds={{array "1"}}
-          @setSelectedCourseIds={{(noop)}}
-          @report="sessionObjectives"
-          @setReport={{this.setReport}}
-          @schools={{this.schools}}
-          @run={{(noop)}}
-          @stop={{(noop)}}
-          @showReportResults={{false}}
-        />
-      </template>,
-    );
-    await component.header.reportSelector.set('learnerGroups');
-    assert.verifySteps(['setReport called']);
   });
 });

--- a/packages/frontend/tests/integration/components/reports/curriculum-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/curriculum-test.gjs
@@ -34,7 +34,7 @@ module('Integration | Component | reports/curriculum', function (hooks) {
         <Curriculum
           @selectedCourseIds={{(array)}}
           @setSelectedCourseIds={{(noop)}}
-          @report="sessionObjectives"
+          @report=""
           @setReport={{(noop)}}
           @schools={{this.schools}}
           @run={{(noop)}}
@@ -44,65 +44,88 @@ module('Integration | Component | reports/curriculum', function (hooks) {
       </template>,
     );
     assert.ok(component.header.reportSelector.isPresent, 'report selector is present');
-    assert.ok(component.header.reportSelector.text, '(please select one)');
+    assert.strictEqual(
+      component.header.reportSelector.label,
+      'Select Curriculum Report Type:',
+      'report selector label is correct',
+    );
+    assert.ok(component.header.reportSelector.options[0].isSelected, 'first option is selected');
+    assert.strictEqual(
+      component.header.reportSelector.value,
+      '',
+      'report selector value is correct',
+    );
+    assert.strictEqual(component.header.runSummaryText, '', 'report header text correct');
+
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders and is accessible with report type selected but no courses', async function (assert) {
+    this.set('schools', buildSchoolsFromData(this.server.db));
+    await render(
+      <template>
+        <Curriculum
+          @selectedCourseIds={{(array)}}
+          @setSelectedCourseIds={{(noop)}}
+          @report="courseCompetencies"
+          @setReport={{(noop)}}
+          @schools={{this.schools}}
+          @run={{(noop)}}
+          @stop={{(noop)}}
+          @showReportResults={{false}}
+        />
+      </template>,
+    );
+    assert.ok(component.header.reportSelector.isPresent, 'report selector is present');
+    assert.strictEqual(
+      component.header.reportSelector.label,
+      'Select Curriculum Report Type:',
+      'report selector label is correct',
+    );
+    assert.ok(component.header.reportSelector.options[1].isSelected, 'second option is selected');
+    assert.strictEqual(
+      component.header.reportSelector.value,
+      'courseCompetencies',
+      'report selector value is correct',
+    );
+    assert.strictEqual(component.header.runSummaryText, 'Select Courses to Run Report');
+
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders and is accessible with report type and courses selected', async function (assert) {
+    this.set('schools', buildSchoolsFromData(this.server.db));
+    await render(
+      <template>
+        <Curriculum
+          @selectedCourseIds={{array "1"}}
+          @setSelectedCourseIds={{(noop)}}
+          @report="courseCompetencies"
+          @setReport={{(noop)}}
+          @schools={{this.schools}}
+          @run={{(noop)}}
+          @stop={{(noop)}}
+          @showReportResults={{false}}
+        />
+      </template>,
+    );
+    assert.ok(component.header.reportSelector.isPresent, 'report selector is present');
+    assert.strictEqual(
+      component.header.reportSelector.label,
+      'Select Curriculum Report Type:',
+      'report selector label is correct',
+    );
+    assert.ok(component.header.reportSelector.options[1].isSelected, 'second option is selected');
+    assert.strictEqual(
+      component.header.reportSelector.value,
+      'courseCompetencies',
+      'report selector value is correct',
+    );
     assert.strictEqual(
       component.header.runSummaryText,
-      'Select Curriculum Report Type: ',
-      'report header text correct',
-    );
-
-    await a11yAudit(this.element);
-    assert.ok(true, 'no a11y errors found!');
-  });
-
-  test('it renders and is accessible with report type selected', async function (assert) {
-    this.set('schools', buildSchoolsFromData(this.server.db));
-    await render(
-      <template>
-        <Curriculum
-          @selectedCourseIds={{array "1"}}
-          @setSelectedCourseIds={{(noop)}}
-          @report="sessionObjectives"
-          @setReport={{(noop)}}
-          @schools={{this.schools}}
-          @run={{(noop)}}
-          @stop={{(noop)}}
-          @showReportResults={{false}}
-        />
-      </template>,
-    );
-    assert.ok(component.header.reportSelector.isPresent, 'report selector is present');
-    assert.ok(
-      component.header.runSummaryText.includes(
-        'Each session objective is listed along with instructors and course data.',
-      ),
-    );
-
-    await a11yAudit(this.element);
-    assert.ok(true, 'no a11y errors found!');
-  });
-
-  test('it renders and is accessible with courses selected', async function (assert) {
-    this.set('schools', buildSchoolsFromData(this.server.db));
-    await render(
-      <template>
-        <Curriculum
-          @selectedCourseIds={{array "1"}}
-          @setSelectedCourseIds={{(noop)}}
-          @report="sessionObjectives"
-          @setReport={{(noop)}}
-          @schools={{this.schools}}
-          @run={{(noop)}}
-          @stop={{(noop)}}
-          @showReportResults={{false}}
-        />
-      </template>,
-    );
-    assert.ok(component.header.reportSelector.isPresent, 'report selector is present');
-    assert.ok(
-      component.header.runSummaryText.includes(
-        'Each session objective is listed along with instructors and course data.',
-      ),
+      'Run Course Competencies report for one course. Each competency is listed along with course and program year objectives.',
     );
 
     await a11yAudit(this.element);

--- a/packages/frontend/tests/integration/components/reports/curriculum/header-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/curriculum/header-test.gjs
@@ -589,16 +589,19 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
       </template>,
     );
 
+    assert.ok(component.reportSelector.isPresent);
     assert.ok(component.runReport.isPresent);
     assert.ok(component.copy.isPresent);
     assert.notOk(component.close.isPresent);
     assert.notOk(component.download.isPresent);
     await component.runReport.click();
+    assert.notOk(component.reportSelector.isPresent);
     assert.ok(component.close.isPresent);
     assert.ok(component.copy.isPresent);
     assert.ok(component.download.isPresent);
     assert.notOk(component.runReport.isPresent);
     await component.close.click();
+    assert.ok(component.reportSelector.isPresent);
     assert.ok(component.runReport.isPresent);
     assert.ok(component.copy.isPresent);
     assert.notOk(component.close.isPresent);

--- a/packages/frontend/tests/integration/components/reports/curriculum/header-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/curriculum/header-test.gjs
@@ -26,78 +26,30 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
       </template>,
     );
 
-    assert.ok(component.reportSelector.isPresent, 'report types selector is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.ok(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option IS chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[1].isSelected,
-      'report types selector second option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[2].isSelected,
-      'report types selector third option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[3].isSelected,
-      'report types selector fourth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[4].isSelected,
-      'report types selector fifth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[5].isSelected,
-      'report types selector sixth option is not chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 7 courses'),
-      'summary includes correct number of courses',
-    );
+    assert.ok(component.reportSelector.isPresent);
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.ok(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.notOk(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.notOk(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.notOk(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.notOk(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.notOk(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 7 courses'));
     assert.ok(
       component.runSummaryText.includes(
         'Each competency is listed along with course and program year objectives.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -117,78 +69,29 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
       </template>,
     );
 
-    assert.ok(component.reportSelector.isPresent, 'report types selector is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report types selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.ok(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option IS chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[1].isSelected,
-      'report types selector second option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[2].isSelected,
-      'report types selector third option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[3].isSelected,
-      'report types selector fourth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[4].isSelected,
-      'report types selector fifth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[5].isSelected,
-      'report types selector sixth option is not chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 4 courses, across 4 schools'),
-      'summary includes correct number of courses and schools',
-    );
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.ok(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.notOk(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.notOk(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.notOk(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.notOk(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.notOk(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 4 courses, across 4 schools'));
     assert.ok(
       component.runSummaryText.includes(
         'Each competency is listed along with course and program year objectives.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
   });
 
   test('it renders for instructional time and is accessible', async function (assert) {
@@ -205,78 +108,30 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
       </template>,
     );
 
-    assert.ok(component.reportSelector.isPresent, 'report types selector is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.ok(
-      component.reportSelector.options[1].isSelected,
-      'report types selector SECOND option IS chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[2].isSelected,
-      'report types selector third option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[3].isSelected,
-      'report types selector fourth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[4].isSelected,
-      'report types selector fifth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[5].isSelected,
-      'report types selector sixth option is not chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 7 courses'),
-      'summary includes correct number of courses',
-    );
+    assert.ok(component.reportSelector.isPresent);
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.notOk(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.ok(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.notOk(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.notOk(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.notOk(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.notOk(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 7 courses'));
     assert.ok(
       component.runSummaryText.includes(
         'Each attached instructor is listed along with course data.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -296,78 +151,30 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
       </template>,
     );
 
-    assert.ok(component.reportSelector.isPresent, 'report types selector is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report types selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.ok(
-      component.reportSelector.options[1].isSelected,
-      'report types selector SECOND option IS chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[2].isSelected,
-      'report types selector third option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[3].isSelected,
-      'report types selector fourth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[4].isSelected,
-      'report types selector fifth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[5].isSelected,
-      'report types selector sixth option is not chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 4 courses, across 4 schools'),
-      'summary includes correct number of courses and schools',
-    );
+    assert.ok(component.reportSelector.isPresent);
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.notOk(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.ok(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.notOk(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.notOk(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.notOk(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.notOk(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 4 courses, across 4 schools'));
     assert.ok(
       component.runSummaryText.includes(
         'Each attached instructor is listed along with course data.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
   });
 
   test('it renders for learner groups and is accessible', async function (assert) {
@@ -383,78 +190,31 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
         />
       </template>,
     );
+
     assert.ok(component.reportSelector.isPresent, 'report types selector is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option is chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[1].isSelected,
-      'report types selector second option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.ok(
-      component.reportSelector.options[2].isSelected,
-      'report types selector THIRD option IS chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[3].isSelected,
-      'report types selector fourth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[4].isSelected,
-      'report types selector fifth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[5].isSelected,
-      'report types selector sixth option is not chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 5 courses'),
-      'summary includes correct number of courses',
-    );
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.notOk(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.notOk(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.ok(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.notOk(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.notOk(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.notOk(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 5 courses'));
     assert.ok(
       component.runSummaryText.includes(
         'Each attached learner group is listed along with instructors and course data.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -473,78 +233,31 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
         />
       </template>,
     );
+
     assert.ok(component.reportSelector.isPresent, 'report types selector is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report types selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option is chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[1].isSelected,
-      'report types selector second option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.ok(
-      component.reportSelector.options[2].isSelected,
-      'report types selector THIRD option IS chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[3].isSelected,
-      'report types selector fourth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[4].isSelected,
-      'report types selector fifth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[5].isSelected,
-      'report types selector sixth option is not chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 5 courses, across 3 schools'),
-      'summary includes correct number of courses and schools',
-    );
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.notOk(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.notOk(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.ok(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.notOk(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.notOk(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.notOk(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 5 courses, across 3 schools'));
     assert.ok(
       component.runSummaryText.includes(
         'Each attached learner group is listed along with instructors and course data.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
   });
 
   test('it renders for session objectives and is accessible', async function (assert) {
@@ -560,78 +273,31 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
         />
       </template>,
     );
+
     assert.ok(component.reportSelector.isPresent, 'report types selector component is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report types selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option is chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[1].isSelected,
-      'report types selector second option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[2].isSelected,
-      'report types selector third option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.ok(
-      component.reportSelector.options[3].isSelected,
-      'report types selector FOURTH option IS chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[4].isSelected,
-      'report types selector fifth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[5].isSelected,
-      'report types selector sixth option is not chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 3 courses'),
-      'summary includes correct number of courses',
-    );
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.notOk(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.notOk(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.notOk(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.ok(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.notOk(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.notOk(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 3 courses'));
     assert.ok(
       component.runSummaryText.includes(
         'Each session objective is listed along with instructors and course data.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -655,78 +321,31 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.reportSelector.isPresent, 'report types selector is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report types selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[1].isSelected,
-      'report types selector second option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[2].isSelected,
-      'report types selector third option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.ok(
-      component.reportSelector.options[3].isSelected,
-      'report types selector FOURTH option IS chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[4].isSelected,
-      'report types selector fifth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[5].isSelected,
-      'report types selector sixth option is not chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 2 courses, across 2 schools'),
-      'summary includes correct number of courses and schools',
-    );
+
+    assert.ok(component.reportSelector.isPresent, 'report types selector component is present');
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.notOk(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.notOk(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.notOk(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.ok(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.notOk(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.notOk(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 2 courses, across 2 schools'));
     assert.ok(
       component.runSummaryText.includes(
         'Each session objective is listed along with instructors and course data.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
   });
 
   test('it renders for session offerings and is accessible', async function (assert) {
@@ -742,78 +361,31 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
         />
       </template>,
     );
+
     assert.ok(component.reportSelector.isPresent, 'report types selector component is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report types selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[1].isSelected,
-      'report types selector second option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[2].isSelected,
-      'report types selector third option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[3].isSelected,
-      'report types selector fourth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.ok(
-      component.reportSelector.options[4].isSelected,
-      'report types selector FIFTH option IS chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[5].isSelected,
-      'report types selector sixth option is not chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 3 courses'),
-      'summary includes correct number of courses',
-    );
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.notOk(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.notOk(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.notOk(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.notOk(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.ok(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.notOk(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 3 courses'));
     assert.ok(
       component.runSummaryText.includes(
         'Each session offering is listed along with instructors, learner groups, and course data.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -837,78 +409,31 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
         />
       </template>,
     );
-    assert.ok(component.reportSelector.isPresent, 'report types selector is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report types selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[1].isSelected,
-      'report types selector second option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[2].isSelected,
-      'report types selector third option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[3].isSelected,
-      'report types selector fourth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.ok(
-      component.reportSelector.options[4].isSelected,
-      'report types selector FIFTH option IS chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[5].isSelected,
-      'report types selector sixth option is not chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 2 courses, across 2 schools'),
-      'summary includes correct number of courses and schools',
-    );
+
+    assert.ok(component.reportSelector.isPresent, 'report types selector component is present');
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.notOk(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.notOk(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.notOk(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.notOk(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.ok(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.notOk(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 2 courses, across 2 schools'));
     assert.ok(
       component.runSummaryText.includes(
         'Each session offering is listed along with instructors, learner groups, and course data.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
   });
 
   test('it renders for tagged terms and is accessible', async function (assert) {
@@ -926,77 +451,29 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
     );
 
     assert.ok(component.reportSelector.isPresent, 'report types selector is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[1].isSelected,
-      'report types selector second option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[2].isSelected,
-      'report types selector third option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[3].isSelected,
-      'report types selector fourth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[4].isSelected,
-      'report types selector fifth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.ok(
-      component.reportSelector.options[5].isSelected,
-      'report types selector SIXTH option IS chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 7 courses'),
-      'summary includes correct number of courses',
-    );
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.notOk(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.notOk(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.notOk(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.notOk(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.notOk(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.ok(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 7 courses'));
     assert.ok(
       component.runSummaryText.includes(
         'Each set of attached terms is listed along with course data.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -1017,77 +494,29 @@ module('Integration | Component | reports/curriculum/header', function (hooks) {
     );
 
     assert.ok(component.reportSelector.isPresent, 'report types selector is present');
-    assert.strictEqual(
-      component.reportSelector.options.length,
-      6,
-      'report types selector has correct number of options',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[0].text,
-      'Course Competencies',
-      'report types selector has correct first option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[0].isSelected,
-      'report types selector first option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[1].text,
-      'Instructional Time',
-      'report types selector has correct second option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[1].isSelected,
-      'report types selector second option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[2].text,
-      'Learner Groups',
-      'report types selector has correct third option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[2].isSelected,
-      'report types selector third option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[3].text,
-      'Session Objectives',
-      'report types selector has correct fourth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[3].isSelected,
-      'report types selector fourth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[4].text,
-      'Session Offerings',
-      'report types selector has correct fifth option text',
-    );
-    assert.notOk(
-      component.reportSelector.options[4].isSelected,
-      'report types selector fifth option is not chosen',
-    );
-    assert.strictEqual(
-      component.reportSelector.options[5].text,
-      'Tagged Terms',
-      'report types selector has correct sixth option text',
-    );
-    assert.ok(
-      component.reportSelector.options[5].isSelected,
-      'report types selector SIXTH option IS chosen',
-    );
-    assert.ok(
-      component.runSummaryText.includes('for 4 courses, across 4 schools'),
-      'summary includes correct number of courses and schools',
-    );
+    assert.strictEqual(component.reportSelector.options.length, 7);
+    assert.strictEqual(component.reportSelector.options[0].text, '(please select one)');
+    assert.notOk(component.reportSelector.options[0].isSelected);
+    assert.strictEqual(component.reportSelector.options[1].text, 'Course Competencies');
+    assert.notOk(component.reportSelector.options[1].isSelected);
+    assert.strictEqual(component.reportSelector.options[2].text, 'Instructional Time');
+    assert.notOk(component.reportSelector.options[2].isSelected);
+    assert.strictEqual(component.reportSelector.options[3].text, 'Learner Groups');
+    assert.notOk(component.reportSelector.options[3].isSelected);
+    assert.strictEqual(component.reportSelector.options[4].text, 'Session Objectives');
+    assert.notOk(component.reportSelector.options[4].isSelected);
+    assert.strictEqual(component.reportSelector.options[5].text, 'Session Offerings');
+    assert.notOk(component.reportSelector.options[5].isSelected);
+    assert.strictEqual(component.reportSelector.options[6].text, 'Tagged Terms');
+    assert.ok(component.reportSelector.options[6].isSelected);
+    assert.ok(component.runSummaryText.includes('for 4 courses, across 4 schools'));
     assert.ok(
       component.runSummaryText.includes(
         'Each set of attached terms is listed along with course data.',
       ),
-      'summary description is correct',
     );
-    assert.ok(component.runReport.isPresent, 'run report button is present');
-    assert.ok(component.copy.isPresent, 'copy report button is present');
+    assert.ok(component.runReport.isPresent);
+    assert.ok(component.copy.isPresent);
   });
 
   test('it changes selected report', async function (assert) {

--- a/packages/frontend/tests/integration/components/reports/switcher-test.gjs
+++ b/packages/frontend/tests/integration/components/reports/switcher-test.gjs
@@ -10,9 +10,9 @@ module('Integration | Component | reports/switcher', function (hooks) {
 
   test('it renders and is accessible', async function (assert) {
     await render(<template><Switcher /></template>);
-    assert.strictEqual(component.text, 'Subject Reports Curriculum Reports');
-    assert.strictEqual(component.subject.text, 'Subject Reports');
+    assert.strictEqual(component.text, 'Curriculum Reports Subject Reports');
     assert.strictEqual(component.curriculum.text, 'Curriculum Reports');
+    assert.strictEqual(component.subject.text, 'Subject Reports');
     assert.notOk(component.subject.isActive);
     assert.notOk(component.curriculum.isActive);
 

--- a/packages/frontend/tests/pages/components/reports/curriculum/header.js
+++ b/packages/frontend/tests/pages/components/reports/curriculum/header.js
@@ -5,6 +5,7 @@ const definition = {
   runSummaryText: text('[data-test-run-summary]'),
   reportSelector: {
     scope: '[data-test-report-selector]',
+    label: text('[data-test-report-selector-label]'),
     set: fillable('select'),
     options: collection('option', {
       isSelected: property('selected'),

--- a/packages/frontend/tests/pages/components/reports/switcher.js
+++ b/packages/frontend/tests/pages/components/reports/switcher.js
@@ -2,12 +2,12 @@ import { create, hasClass } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-reports-switcher]',
-  subject: {
-    scope: '[data-test-subject]',
-    isActive: hasClass('active'),
-  },
   curriculum: {
     scope: '[data-test-curriculum]',
+    isActive: hasClass('active'),
+  },
+  subject: {
+    scope: '[data-test-subject]',
     isActive: hasClass('active'),
   },
 };

--- a/packages/frontend/tests/pages/reports.js
+++ b/packages/frontend/tests/pages/reports.js
@@ -1,17 +1,18 @@
 import { create, visitable } from 'ember-cli-page-object';
-import subjects from './components/reports/subjects-list';
 import switcher from './components/reports/switcher';
 import curriculum from './components/reports/curriculum';
+import subjects from './components/reports/subjects-list';
 
 const page = {
   visit: visitable('/reports'),
+  visitSubjectReports: visitable('/reports/subjects'),
   visitCurriculumReports: visitable('/reports/curriculum'),
   visitCurriculumReports2026: visitable('/reports/curriculum?years=2026'),
   visitCurriculumReports2025: visitable('/reports/curriculum?years=2025'),
   visitCurriculumReports2024_2025: visitable('/reports/curriculum?years=2024-2025'),
   switcher,
-  subjects,
   curriculum,
+  subjects,
 };
 
 export default create(page);

--- a/packages/frontend/translations/en-us.yaml
+++ b/packages/frontend/translations/en-us.yaml
@@ -365,6 +365,7 @@ general:
   selectAcademicYear: Select Academic Year
   selectAllOrNone: Select All or None
   selectCoursesToRunReport: Select Courses to Run Report
+  selectCurriculumReportType: Select Curriculum Report Type
   selectPolite: (please select one)
   selectUser: Select User
   sequenceBlock: Sequence Block

--- a/packages/frontend/translations/es.yaml
+++ b/packages/frontend/translations/es.yaml
@@ -365,6 +365,7 @@ general:
   selectAcademicYear: Selecciona Año Academico
   selectAllOrNone: Seleccione Todo o Ninguno
   selectCoursesToRunReport: Seleccionar cursos para ejecutar el informe
+  selectCurriculumReportType: Seleccionar tipo de informe curricular
   selectPolite: (seleccione uno, por favor)
   selectUser: Seleccione usuario
   sequenceBlock: Bloque de Secuencia

--- a/packages/frontend/translations/fr.yaml
+++ b/packages/frontend/translations/fr.yaml
@@ -365,6 +365,7 @@ general:
   selectAcademicYear: Choisissez l’année scolaire
   selectAllOrNone: Sélectionner tout ou aucun
   selectCoursesToRunReport: Select des cours d'éxecuter rapport
+  selectCurriculumReportType: Select le type du rapport des programmes d'études
   selectPolite: (veuillez en sélectionner un)
   selectUser: "Choisi l'utilisateur"
   sequenceBlock: Bloc séquence


### PR DESCRIPTION
Fixes ilios/ilios#7220

- [x] Make Curriculum default reports type route
- [x] Force Curriculum report type selection first