### PR TITLE
Restrict Token Creation to 90 Days

### DIFF
--- a/packages/frontend/app/components/my-profile.gjs
+++ b/packages/frontend/app/components/my-profile.gjs
@@ -65,9 +65,9 @@ export default class MyProfileComponent extends Component {
       second: 59,
     });
     const twoWeeksFromNow = midnightToday.plus({ weeks: 2 });
-    const oneYearFromNow = midnightToday.plus({ years: 1 });
+    const nintyDaysFromNow = midnightToday.plus({ days: 90 });
     this.minDate = midnightToday.toJSDate();
-    this.maxDate = oneYearFromNow.toJSDate();
+    this.maxDate = nintyDaysFromNow.toJSDate();
     this.expiresAt = twoWeeksFromNow.toJSDate();
     this.generatedJwt = null;
   }


### PR DESCRIPTION
This matches our upcoming change to the maximum TTL on the API and ensures users can't create tokens in the UI that are longer than allowed by the backend.