### PR TITLE
Remove all Overview headers

### DIFF
--- a/packages/frontend/app/components/curriculum-inventory/report-overview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/report-overview.gjs
@@ -231,9 +231,6 @@ export default class CurriculumInventoryReportOverviewComponent extends Componen
     >
       {{#let (uniqueId) as |templateId|}}
         <div class="report-overview-header">
-          <div class="title" data-test-title>
-            {{t "general.overview"}}
-          </div>
           <div class="report-overview-actions">
             <LinkTo
               @route="verification-preview"

--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.gjs
@@ -658,7 +658,6 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
     >
       {{#let (uniqueId) as |templateId|}}
         <div class="curriculum-inventory-sequence-block-overview-wrapper" data-test-overview>
-          <div class="title" data-test-title>{{t "general.overview"}}</div>
           <div class="curriculum-inventory-sequence-block-overview-content">
             <div class="block course" data-test-course>
               <span>

--- a/packages/frontend/app/components/program-year/overview.gjs
+++ b/packages/frontend/app/components/program-year/overview.gjs
@@ -5,9 +5,6 @@ import { faChartColumn } from '@fortawesome/free-solid-svg-icons';
 <template>
   <div class="ilios-overview programyear-overview" data-test-program-year-overview ...attributes>
     <div class="overview-header">
-      <h4 class="overview-title" data-test-title>
-        {{t "general.overview"}}
-      </h4>
       <div class="overview-actions" data-test-actions>
         <LinkTo
           @route="program-year-visualize-objectives"

--- a/packages/frontend/app/components/program/overview.gjs
+++ b/packages/frontend/app/components/program/overview.gjs
@@ -64,11 +64,6 @@ export default class ProgramOverviewComponent extends Component {
   }
   <template>
     <div class="ilios-overview program-overview" data-test-program-overview ...attributes>
-      <div class="overview-header">
-        <h2 class="overview-title">
-          {{t "general.overview"}}
-        </h2>
-      </div>
       <div class="overview-content">
         <div class="overview-block" data-test-short-title>
           <label for={{concat this.id "short-title"}}>

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-details.scss
@@ -2,6 +2,7 @@
 
 .curriculum-inventory-report-details {
   @include m.detail-container(var(--orange));
+  border-bottom: none;
   margin: 0 0.5rem;
 
   .title {

--- a/packages/frontend/app/styles/components/curriculum-inventory/report-overview.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/report-overview.scss
@@ -31,6 +31,7 @@
   .curriculum-inventory-report-overview-content {
     @include m.ilios-overview-content;
     @include m.ilios-form-error;
+    padding-top: 0;
   }
 
   .description {

--- a/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-overview.scss
+++ b/packages/frontend/app/styles/components/curriculum-inventory/sequence-block-overview.scss
@@ -58,6 +58,7 @@
 
     .curriculum-inventory-sequence-block-overview-content {
       @include m.ilios-overview-content;
+      padding-top: 0;
     }
   }
 

--- a/packages/frontend/app/styles/components/programyear-details.scss
+++ b/packages/frontend/app/styles/components/programyear-details.scss
@@ -1,5 +1,5 @@
 .programyear-details {
   background-color: var(--white);
   margin: 0;
-  padding: 0.5rem;
+  padding: 0 0.5rem;
 }

--- a/packages/frontend/app/styles/components/programyear-overview.scss
+++ b/packages/frontend/app/styles/components/programyear-overview.scss
@@ -5,7 +5,7 @@
   border-top: 1px dotted var(--orange);
   border-bottom: 0;
   margin: 0 0.5rem;
-  padding: 0 0 1rem 0;
+  padding: 0;
 
   .actions {
     a {

--- a/packages/frontend/tests/acceptance/course/overview-test.js
+++ b/packages/frontend/tests/acceptance/course/overview-test.js
@@ -108,15 +108,15 @@ module('Acceptance | Course - Overview', function (hooks) {
         .lookup('service:store')
         .findRecord('course', this.course.id);
       await page.visit({ courseId: courseModel.id });
-      assert.strictEqual(page.details.titles, 2);
+      assert.strictEqual(page.details.titles, 1);
       assert.strictEqual(currentURL(), '/courses/1');
       await page.details.collapseControl();
       await takeScreenshot(assert, '/courses/1');
-      assert.ok(page.details.titles > 2);
+      assert.ok(page.details.titles > 1);
       assert.strictEqual(currentURL(), '/courses/1?details=true');
       await page.details.collapseControl();
       await takeScreenshot(assert, '/courses/1?details=true');
-      assert.strictEqual(page.details.titles, 2);
+      assert.strictEqual(page.details.titles, 1);
       assert.strictEqual(currentURL(), '/courses/1');
     });
   });

--- a/packages/frontend/tests/integration/components/curriculum-inventory/report-overview-test.gjs
+++ b/packages/frontend/tests/integration/components/curriculum-inventory/report-overview-test.gjs
@@ -50,7 +50,6 @@ module('Integration | Component | curriculum-inventory/report-overview', functio
     await render(
       <template><ReportOverview @report={{this.report}} @canUpdate={{true}} /></template>,
     );
-    assert.strictEqual(component.title, 'Overview', 'Component title is visible.');
     assert.ok(component.rolloverLink.isVisible, 'Rollover course button is visible.');
     assert.ok(component.verificationPreviewLink.isVisible, 'Verification preview link is visible.');
     assert.strictEqual(component.startDate.label, 'Start Date:', 'Start date label is correct.');

--- a/packages/frontend/tests/integration/components/program-year/overview-test.gjs
+++ b/packages/frontend/tests/integration/components/program-year/overview-test.gjs
@@ -18,7 +18,6 @@ module('Integration | Component | program-year/overview', function (hooks) {
       .findRecord('program-year', programYear.id);
     this.set('program', programYearModel);
     await render(<template><Overview @programYear={{this.programYear}} /></template>);
-    assert.strictEqual(component.title, 'Overview');
     assert.ok(component.actions.visualizations.isPresent);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');

--- a/packages/frontend/tests/pages/components/curriculum-inventory/report-overview.js
+++ b/packages/frontend/tests/pages/components/curriculum-inventory/report-overview.js
@@ -12,7 +12,6 @@ import { flatpickrDatePicker } from 'ilios-common';
 
 const definition = {
   scope: '[data-test-curriculum-inventory-report-overview]',
-  title: text('[data-test-title]'),
   verificationPreviewLink: {
     scope: '[data-test-transition-to-verification-preview]',
   },

--- a/packages/frontend/tests/pages/components/program-year/overview.js
+++ b/packages/frontend/tests/pages/components/program-year/overview.js
@@ -1,8 +1,7 @@
-import { attribute, create, text } from 'ember-cli-page-object';
+import { attribute, create } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-program-year-overview]',
-  title: text('[data-test-title]'),
   actions: {
     scope: '[data-test-actions]',
     visualizations: {

--- a/packages/ilios-common/addon/components/course/loading.gjs
+++ b/packages/ilios-common/addon/components/course/loading.gjs
@@ -13,9 +13,6 @@ import { faSquarePlus } from '@fortawesome/free-solid-svg-icons';
       </div>
       <div class="ilios-overview">
         <div class="overview-header">
-          <div class="overview-title loading-text">
-            {{t "general.overview"}}
-          </div>
           <div class="overview-actions"></div>
         </div>
         <div class="overview-content">

--- a/packages/ilios-common/addon/components/course/overview.gjs
+++ b/packages/ilios-common/addon/components/course/overview.gjs
@@ -237,9 +237,6 @@ export default class CourseOverview extends Component {
     <section class="ilios-overview" data-test-course-overview>
       {{#let (uniqueId) as |templateId|}}
         <div class="overview-header">
-          <div class="overview-title" data-test-title>
-            {{t "general.overview"}}
-          </div>
           <div class="overview-actions">
             <LinkTo
               @route="course-materials"

--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -152,9 +152,6 @@ export default class PrintCourseSessionComponent extends Component {
         <PublicationStatus @item={{@session}} @showText={{true}} />
       </div>
       <section class="overview block">
-        <div class="title">
-          {{t "general.overview"}}
-        </div>
         <div class="last-update" data-test-last-update>
           {{t "general.lastUpdate"}}:
           {{formatDate

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -132,9 +132,6 @@ export default class PrintCourseComponent extends Component {
         <PublicationStatus @item={{@course}} @showText={{true}} />
       </div>
       <section class="overview block" data-test-course-overview>
-        <div class="title">
-          {{t "general.overview"}}
-        </div>
         <div class="content">
           <div class="inline-label-data-block">
             <label>

--- a/packages/ilios-common/addon/components/session/overview.gjs
+++ b/packages/ilios-common/addon/components/session/overview.gjs
@@ -393,11 +393,6 @@ export default class SessionOverviewComponent extends Component {
             </div>
 
             <div class="overview-header">
-
-              <div class="overview-title">
-                {{t "general.overview"}}
-              </div>
-
               <div class="overview-actions">
                 {{#if this.showCopy}}
                   <LinkTo

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
@@ -24,7 +24,7 @@
 @mixin ilios-overview-header() {
   align-items: baseline;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   margin-top: 1rem;
   height: 1.5em;
 }
@@ -38,7 +38,7 @@
 @mixin ilios-overview-actions() {
   align-items: baseline;
   display: flex;
-  justify-content: space-around;
+  justify-content: flex-end;
   text-align: right;
   vertical-align: middle;
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/ilios-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/ilios-overview.scss
@@ -13,13 +13,13 @@
   }
 
   .overview-header {
-    justify-content: space-between;
+    justify-content: flex-end;
     margin-top: 1rem;
     height: 1.5em;
   }
 
   .overview-actions {
-    justify-content: space-around;
+    justify-content: flex-end;
     text-align: right;
     vertical-align: middle;
 

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -265,7 +265,6 @@ general:
   objectives: Objectives
   offering: Offering
   offerings: Offerings
-  overview: Overview
   ownedBy: "owned by {owner}"
   owner: Owner
   pagedResultsCount: "Showing {start} - {end} of {total}"

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -265,7 +265,6 @@ general:
   objectives: Objetivos
   offering: Ofrecimiento
   offerings: Ofrecimientos
-  overview: Visión Amplia
   ownedBy: "propiedad de {owner}"
   owner: Dueño
   pagedResultsCount: "Mostrando {start} - {end} de {total}"

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -265,7 +265,6 @@ general:
   objectives: Objectifs
   offering: Offre
   offerings: Offres
-  overview: Conception Général
   ownedBy: "Possédé par {owner}"
   owner: Propriétaire
   pagedResultsCount: "Montrant {start} - {end} de {total}"


### PR DESCRIPTION
As it was discussed recently that having the word "Overview" at the top of certain routes was unnecessary, this PR removes all instances of "Overview" across the board where it was found. The translation was removed, as well. Some minor spacing reductions were also applied to make up for the missing text.