### PR TITLE
Make Loading Less Random in Tests

### DIFF
--- a/packages/frontend/app/components/courses/loading-list.gjs
+++ b/packages/frontend/app/components/courses/loading-list.gjs
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import t from 'ember-intl/helpers/t';
 import repeat from 'ilios-common/helpers/repeat';
-import random from 'ember-math-helpers/helpers/random';
 import truncate from 'ilios-common/helpers/truncate';
 import formatDate from 'ember-intl/helpers/format-date';
 import { isTesting } from '@embroider/macros';
@@ -16,6 +15,13 @@ export default class CourseLoadingListComponent extends Component {
     const max = 10;
     return Math.floor(Math.random() * (max - min) + min);
   }
+
+  random = (min, max) => {
+    if (isTesting()) {
+      return 4;
+    }
+    return Math.floor(Math.random() * (max - min) + min);
+  };
   <template>
     <table
       class="ilios-table ilios-table-colors ilios-zebra-table courses-loading-list loading-shimmer loading-text"
@@ -44,19 +50,19 @@ export default class CourseLoadingListComponent extends Component {
         {{#each (repeat this.rows)}}
           <tr class="is-loading">
             <td class="text-left" colspan="8">{{truncate
-                (repeat (random 3 10) "ilios rocks")
+                (repeat (this.random 3 10) "ilios rocks")
                 25
               }}</td>
-            <td class="text-center hide-from-small-screen">{{random 1 9}}</td>
-            <td class="text-center hide-from-small-screen">{{random 1 9}}</td>
+            <td class="text-center hide-from-small-screen">{{this.random 1 9}}</td>
+            <td class="text-center hide-from-small-screen">{{this.random 1 9}}</td>
             <td class="text-right"></td>
           </tr>
           <tr class="courses-list-item">
             <td class="text-left" colspan="8">
-              {{truncate (repeat (random 3 10) "ilios rocks") 100}}
+              {{truncate (repeat (this.random 3 10) "ilios rocks") 100}}
             </td>
             <td class="text-center hide-from-small-screen" colspan="1">
-              {{random 1 9}}
+              {{this.random 1 9}}
             </td>
             <td class="text-center hide-from-small-screen" colspan="2">
               {{formatDate this.today day="2-digit" month="2-digit" year="numeric"}}

--- a/packages/frontend/tests/integration/components/courses/loading-list-test.gjs
+++ b/packages/frontend/tests/integration/components/courses/loading-list-test.gjs
@@ -10,5 +10,11 @@ module('Integration | Component | courses/loading-list', function (hooks) {
     await render(<template><LoadingList /></template>);
     assert.dom('table').hasAttribute('aria-hidden', 'true');
     assert.dom('tbody').exists();
+    assert.dom('tbody tr').exists({ count: 8 });
+    assert
+      .dom('tbody tr:nth-of-type(1) td:nth-of-type(1)')
+      .hasText('ilios rocks,ilios rocks,ilios rocks,ilios rocks');
+    assert.dom('tbody tr:nth-of-type(1) td:nth-of-type(2)').hasText('4');
+    assert.dom('tbody tr:nth-of-type(1) td:nth-of-type(3)').hasText('4');
   });
 });


### PR DESCRIPTION
We'd already locked down the number of rows, but sometimes the random characters wrap onto a new line making these screenshots unstable.