### PR TITLE
Session Publication workflow improvement

### DIFF
--- a/packages/frontend/tests/acceptance/course/session/publicationcheck-test.js
+++ b/packages/frontend/tests/acceptance/course/session/publicationcheck-test.js
@@ -30,10 +30,10 @@ module('Acceptance | Session - Publication Check', function (hooks) {
     await page.visit({ courseId: this.course.id, sessionId: session.id });
     await takeScreenshot(assert);
     assert.strictEqual(currentRouteName(), 'session.publication-check');
-    assert.strictEqual(page.sessionTitle, 'session 0');
-    assert.strictEqual(page.offerings, 'Yes (1)');
-    assert.strictEqual(page.terms, 'Yes (1)');
-    assert.strictEqual(page.objectives, 'Yes (1)');
+    assert.strictEqual(page.publicationcheck.sessionTitle, 'session 0');
+    assert.strictEqual(page.publicationcheck.offerings, 'Yes (1)');
+    assert.strictEqual(page.publicationcheck.terms, 'Yes (1)');
+    assert.strictEqual(page.publicationcheck.objectives, 'Yes (1)');
   });
 
   test('empty session count', async function (assert) {
@@ -41,10 +41,11 @@ module('Acceptance | Session - Publication Check', function (hooks) {
       course: this.course,
     });
     await page.visit({ courseId: this.course.id, sessionId: session.id });
-    assert.strictEqual(page.sessionTitle, 'session 0');
-    assert.strictEqual(page.offerings, 'No');
-    assert.strictEqual(page.terms, 'No');
-    assert.strictEqual(page.objectives, 'No');
+    await takeScreenshot(assert);
+    assert.strictEqual(page.publicationcheck.sessionTitle, 'session 0');
+    assert.strictEqual(page.publicationcheck.offerings, 'No');
+    assert.strictEqual(page.publicationcheck.terms, 'No');
+    assert.strictEqual(page.publicationcheck.objectives, 'No');
   });
 
   test('unlink icon transitions properly', async function (assert) {
@@ -54,7 +55,7 @@ module('Acceptance | Session - Publication Check', function (hooks) {
     });
     await this.server.create('session-objective', { session });
     await page.visit({ courseId: this.course.id, sessionId: session.id });
-    await page.unlink.click();
+    await page.publicationcheck.unlink.click();
     assert.ok(currentURL().startsWith('/courses/1/sessions/1'));
     assert.ok(currentURL().includes('sessionObjectiveDetails=true'));
   });

--- a/packages/frontend/tests/acceptance/course/session/publish-test.js
+++ b/packages/frontend/tests/acceptance/course/session/publish-test.js
@@ -1,9 +1,10 @@
-import { currentRouteName } from '@ember/test-helpers';
+import { currentRouteName, currentURL } from '@ember/test-helpers';
 import { DateTime } from 'luxon';
 import { module, test } from 'qunit';
 import { setupAuthentication, freezeDateAt, unfreezeDate } from 'ilios-common';
 import { setupApplicationTest } from 'frontend/tests/helpers';
 import page from 'ilios-common/page-objects/session';
+import pubcheckPage from 'ilios-common/page-objects/session-publication-check';
 
 module('Acceptance | Session - Publish', function (hooks) {
   setupApplicationTest(hooks);
@@ -68,46 +69,64 @@ module('Acceptance | Session - Publish', function (hooks) {
     assert.strictEqual(currentRouteName(), 'session.index');
     assert.strictEqual(page.details.overview.publicationMenu.toggle.text, 'Published');
     await page.details.overview.publicationMenu.toggle.click();
-    assert.strictEqual(page.details.overview.publicationMenu.buttons.length, 3);
-    assert.strictEqual(
-      page.details.overview.publicationMenu.buttons[0].text,
-      'Review 2 Missing Items',
-    );
-    assert.strictEqual(page.details.overview.publicationMenu.buttons[1].text, 'Mark as Scheduled');
-    assert.strictEqual(page.details.overview.publicationMenu.buttons[2].text, 'UnPublish Session');
+    assert.strictEqual(page.details.overview.publicationMenu.buttons.length, 2);
+    assert.strictEqual(page.details.overview.publicationMenu.buttons[0].text, 'Mark as Scheduled');
+    assert.strictEqual(page.details.overview.publicationMenu.buttons[1].text, 'UnPublish Session');
   });
 
   test('check scheduled session', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.scheduledSession.id });
     assert.strictEqual(page.details.overview.publicationMenu.toggle.text, 'Scheduled');
     await page.details.overview.publicationMenu.toggle.click();
-    assert.strictEqual(page.details.overview.publicationMenu.buttons.length, 3);
+    assert.strictEqual(page.details.overview.publicationMenu.buttons.length, 2);
     assert.strictEqual(page.details.overview.publicationMenu.buttons[0].text, 'Publish As-is');
-    assert.strictEqual(
-      page.details.overview.publicationMenu.buttons[1].text,
-      'Review 2 Missing Items',
-    );
-    assert.strictEqual(page.details.overview.publicationMenu.buttons[2].text, 'UnPublish Session');
+    assert.strictEqual(page.details.overview.publicationMenu.buttons[1].text, 'UnPublish Session');
   });
 
   test('check draft session', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.draftSession.id });
     assert.strictEqual(page.details.overview.publicationMenu.toggle.text, 'Not Published');
     await page.details.overview.publicationMenu.toggle.click();
-    assert.strictEqual(page.details.overview.publicationMenu.buttons.length, 3);
+    assert.strictEqual(page.details.overview.publicationMenu.buttons.length, 2);
     assert.strictEqual(page.details.overview.publicationMenu.buttons[0].text, 'Publish As-is');
-    assert.strictEqual(
-      page.details.overview.publicationMenu.buttons[1].text,
-      'Review 2 Missing Items',
-    );
-    assert.strictEqual(page.details.overview.publicationMenu.buttons[2].text, 'Mark as Scheduled');
+    assert.strictEqual(page.details.overview.publicationMenu.buttons[1].text, 'Mark as Scheduled');
   });
 
   test('check publish draft session', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.draftSession.id });
-    assert.strictEqual(page.details.overview.publicationMenu.toggle.text, 'Not Published');
+
+    assert.strictEqual(currentURL(), '/courses/1/sessions/3', 'session page url is correct');
+    assert.strictEqual(
+      page.details.overview.publicationMenu.toggle.text,
+      'Not Published',
+      'session published status is correct',
+    );
+
     await page.details.overview.publicationMenu.toggle.click();
     await page.details.overview.publicationMenu.publishAsIs();
+
+    assert.strictEqual(
+      currentURL(),
+      '/courses/1/sessions/3/publicationcheck',
+      'session publicationcheck url is correct',
+    );
+
+    const pubcheck = pubcheckPage.publicationcheck;
+
+    assert.strictEqual(pubcheck.title, 'Publication Review');
+    assert.strictEqual(pubcheck.missingItemsTitle, 'Missing Items (2)');
+    assert.strictEqual(pubcheck.sessionTitle, 'session 2');
+    assert.strictEqual(pubcheck.offerings, 'Yes (1)');
+    assert.strictEqual(pubcheck.terms, 'No');
+    assert.strictEqual(pubcheck.objectives, 'No');
+    assert.strictEqual(
+      pubcheck.publishWithMissingItems.text,
+      'Publish Session, with 2 items missing',
+    );
+
+    await pubcheckPage.publicationcheck.publishWithMissingItems.click();
+
+    assert.strictEqual(currentURL(), '/courses/1/sessions/3', 'session page url is correct');
     assert.strictEqual(page.details.overview.publicationMenu.toggle.text, 'Published');
   });
 
@@ -124,6 +143,28 @@ module('Acceptance | Session - Publish', function (hooks) {
     assert.strictEqual(page.details.overview.publicationMenu.toggle.text, 'Scheduled');
     await page.details.overview.publicationMenu.toggle.click();
     await page.details.overview.publicationMenu.publishAsIs();
+
+    assert.strictEqual(
+      currentURL(),
+      '/courses/1/sessions/2/publicationcheck',
+      'session publicationcheck url is correct',
+    );
+
+    const pubcheck = pubcheckPage.publicationcheck;
+
+    assert.strictEqual(pubcheck.title, 'Publication Review');
+    assert.strictEqual(pubcheck.missingItemsTitle, 'Missing Items (2)');
+    assert.strictEqual(pubcheck.sessionTitle, 'session 1');
+    assert.strictEqual(pubcheck.offerings, 'Yes (1)');
+    assert.strictEqual(pubcheck.terms, 'No');
+    assert.strictEqual(pubcheck.objectives, 'No');
+    assert.strictEqual(
+      pubcheck.publishWithMissingItems.text,
+      'Publish Session, with 2 items missing',
+    );
+
+    await pubcheckPage.publicationcheck.publishWithMissingItems.click();
+
     assert.strictEqual(page.details.overview.publicationMenu.toggle.text, 'Published');
   });
 
@@ -155,12 +196,8 @@ module('Acceptance | Session - Publish', function (hooks) {
     await page.visit({ courseId: this.course.id, sessionId: this.ilmSession.id });
     assert.strictEqual(page.details.overview.publicationMenu.toggle.text, 'Not Published');
     await page.details.overview.publicationMenu.toggle.click();
-    assert.strictEqual(page.details.overview.publicationMenu.buttons.length, 3);
+    assert.strictEqual(page.details.overview.publicationMenu.buttons.length, 2);
     assert.strictEqual(page.details.overview.publicationMenu.buttons[0].text, 'Publish As-is');
-    assert.strictEqual(
-      page.details.overview.publicationMenu.buttons[1].text,
-      'Review 2 Missing Items',
-    );
-    assert.strictEqual(page.details.overview.publicationMenu.buttons[2].text, 'Mark as Scheduled');
+    assert.strictEqual(page.details.overview.publicationMenu.buttons[1].text, 'Mark as Scheduled');
   });
 });

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session-publicationcheck.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session-publicationcheck.js
@@ -1,17 +1,23 @@
-import { create, text } from 'ember-cli-page-object';
+import { clickable, create, text } from 'ember-cli-page-object';
 
 const definition = {
   scope: '[data-test-session-publicationcheck]',
-  title: text('[data-test-title]'),
   backToSession: {
     scope: '[data-test-back-to-session]',
   },
+  title: text('.results [data-test-title]'),
+  missingItemsTitle: text('[data-test-missing-items]'),
   sessionTitle: text('[data-test-session-title]'),
   offerings: text('[data-test-offerings]'),
   terms: text('[data-test-terms]'),
   objectives: text('[data-test-objectives]'),
   unlink: {
     scope: '[data-test-unlink]',
+  },
+  publishWithMissingItems: {
+    scope: '[data-test-publish-with-missing-items]',
+    text: text(),
+    click: clickable(),
   },
 };
 

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/session-publication-check.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/session-publication-check.js
@@ -1,20 +1,10 @@
-import { create, text, visitable } from 'ember-cli-page-object';
+import { create, visitable } from 'ember-cli-page-object';
 
 import overview from './components/session/overview';
+import publicationcheck from './components/session-publicationcheck';
 
 export default create({
   visit: visitable('/courses/:courseId/sessions/:sessionId/publicationcheck'),
   overview,
-  backToSession: {
-    scope: '[data-test-back-to-session]',
-  },
-  title: text('[data-test-title]'),
-  sessionTitle: text('[data-test-session-title]'),
-  offerings: text('[data-test-offerings]'),
-  terms: text('[data-test-terms]'),
-  objectives: text('[data-test-objectives]'),
-  unlink: {
-    scope: '[data-test-unlink]',
-  },
-  mesh: text('[data-test-mesh]'),
+  publicationcheck,
 });

--- a/packages/ilios-common/addon/components/course/publicationcheck.gjs
+++ b/packages/ilios-common/addon/components/course/publicationcheck.gjs
@@ -39,8 +39,8 @@ export default class CoursePublicationCheckComponent extends Component {
     this.args.course.set('publishedAsTbd', false);
     this.args.course.set('published', true);
     await this.args.course.save();
-    this.router.transitionTo('course', this.args.course);
     this.flashMessages.success(this.intl.t('general.publishedSuccessfully'));
+    this.router.transitionTo('course', this.args.course);
   }
 
   <template>

--- a/packages/ilios-common/addon/components/session-publicationcheck.gjs
+++ b/packages/ilios-common/addon/components/session-publicationcheck.gjs
@@ -1,9 +1,12 @@
 import Component from '@glimmer/component';
+import { service } from '@ember/service';
 import { TrackedAsyncData } from 'ember-async-data';
 import { cached } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import Overview from 'ilios-common/components/session/overview';
 import { LinkTo } from '@ember/routing';
 import { array, hash } from '@ember/helper';
+import { on } from '@ember/modifier';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import t from 'ember-intl/helpers/t';
 import scrollIntoView from 'ilios-common/modifiers/scroll-into-view';
@@ -11,6 +14,10 @@ import hasManyLength from 'ilios-common/helpers/has-many-length';
 import { faArrowRotateLeft, faLinkSlash } from '@fortawesome/free-solid-svg-icons';
 
 export default class SessionPublicationCheckComponent extends Component {
+  @service router;
+  @service intl;
+  @service flashMessages;
+
   @cached
   get courseData() {
     return new TrackedAsyncData(this.args.session.course);
@@ -55,6 +62,14 @@ export default class SessionPublicationCheckComponent extends Component {
     return objectivesWithoutParents.length > 0;
   }
 
+  @action
+  async publish() {
+    this.args.session.set('publishedAsTbd', false);
+    this.args.session.set('published', true);
+    await this.args.session.save();
+    this.router.transitionTo('session', this.args.session);
+    this.flashMessages.success(this.intl.t('general.publishedSuccessfully'));
+  }
   <template>
     <div class="session-publicationcheck" data-test-session-publicationcheck>
       <Overview @session={{@session}} @hideCheckLink={{true}} @sessionTypes={{this.sessionTypes}} />
@@ -141,6 +156,14 @@ export default class SessionPublicationCheckComponent extends Component {
               </tr>
             </tbody>
           </table>
+        </div>
+        <div data-test-session-publicationcheck-actions>
+          <button type="button" {{on "click" this.publish}} data-test-publish-with-missing-items>
+            {{t
+              "general.publishSessionWithMissingItems"
+              missingItemCount=@session.allPublicationIssuesLength
+            }}
+          </button>
         </div>
       </div>
     </div>

--- a/packages/ilios-common/addon/components/session/publication-menu.gjs
+++ b/packages/ilios-common/addon/components/session/publication-menu.gjs
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
-import { uniqueId, get } from '@ember/helper';
+import { uniqueId } from '@ember/helper';
 import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
 import set from 'ember-set-helper/helpers/set';
 import { on } from '@ember/modifier';
@@ -50,18 +50,15 @@ export default class SessionPublicationMenuComponent extends Component {
   get showTbd() {
     return !this.args.session.publishedAsTbd;
   }
-  get showAsIs() {
+  get showReviewAsIs() {
+    if (this.router.currentRouteName === 'session.publication-check') {
+      return false;
+    }
     return (
       (!this.args.session.published || this.args.session.publishedAsTbd) &&
       this.args.session.requiredPublicationIssues.length === 0 &&
       this.args.session.allPublicationIssuesLength !== 0
     );
-  }
-  get showReview() {
-    if (this.router.currentRouteName === 'session.publication-check') {
-      return false;
-    }
-    return !this.hideCheckLink && this.args.session.allPublicationIssuesLength > 0;
   }
   get showPublish() {
     return (
@@ -205,13 +202,13 @@ export default class SessionPublicationMenuComponent extends Component {
         </button>
         {{#if this.isOpen}}
           <div class="menu" role="menu" data-test-menu {{focus}}>
-            {{#if this.showAsIs}}
+            {{#if this.showReviewAsIs}}
               <button
                 class="alert"
                 role="menuitem"
                 tabindex="-1"
                 type="button"
-                {{on "click" this.publish}}
+                {{on "click" this.scrollToSessionPublication}}
                 {{on "keydown" this.keyDown}}
                 {{on "mouseenter" this.clearFocus}}
                 data-test-publish-as-is
@@ -231,20 +228,6 @@ export default class SessionPublicationMenuComponent extends Component {
                 data-test-publish
               >
                 {{t "general.publishSession"}}
-              </button>
-            {{/if}}
-            {{#if this.showReview}}
-              <button
-                class="good"
-                role="menuitem"
-                tabindex="-1"
-                type="button"
-                {{on "click" this.scrollToSessionPublication}}
-                {{on "keydown" this.keyDown}}
-                {{on "mouseenter" this.clearFocus}}
-                data-test-review
-              >
-                {{t "general.reviewMissingItems" count=(get @session "allPublicationIssuesLength")}}
               </button>
             {{/if}}
             {{#if this.showTbd}}

--- a/packages/ilios-common/app/styles/ilios-common/components/session-publicationcheck.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-publicationcheck.scss
@@ -37,6 +37,10 @@
         background-color: var(--lightest-grey);
       }
     }
+
+    button {
+      margin-bottom: 0.5em;
+    }
   }
 
   .fa-link-slash {

--- a/packages/ilios-common/translations/en-us.yaml
+++ b/packages/ilios-common/translations/en-us.yaml
@@ -290,6 +290,7 @@ general:
   publishAsIs: Publish As-is
   publishCourse: Publish Course
   publishCourseWithMissingItems: Publish Course, with {missingItemCount, plural, =1 {1 item missing} other {# items missing}}
+  publishSessionWithMissingItems: Publish Session, with {missingItemCount, plural, =1 {1 item missing} other {# items missing}}
   published: Published
   publishedSessions: Published Sessions
   publishedSuccessfully: Published successfully
@@ -299,7 +300,6 @@ general:
   results: Results
   resultsCount: "{count, plural, =1 {1 result} other {# results}}"
   returnToPreviousPage: Return to Previous Page
-  reviewMissingItems: "Review {count} Missing Items"
   saturday: Saturday
   save: Save
   savedSuccessfully: saved successfully

--- a/packages/ilios-common/translations/es.yaml
+++ b/packages/ilios-common/translations/es.yaml
@@ -290,6 +290,7 @@ general:
   publishAsIs: Publique Como Es
   publishCourse: Publique Curso
   publishCourseWithMissingItems: Publique Curso, con {missingItemCount, plural, =1 {1 artículo faltante} other {# artículos faltantes}}
+  publishSessionWithMissingItems: Publique Sesión, con {missingItemCount, plural, =1 {1 artículo faltante} other {# artículos faltantes}}
   published: Publicado
   publishedSessions: Sesiones Publicadas
   publishedSuccessfully: Publicado con éxito
@@ -299,7 +300,6 @@ general:
   results: Resultados
   resultsCount: "{count, plural, =1 {1 resultado} other {# resultados}}"
   returnToPreviousPage: Volver a la Página Anterior
-  reviewMissingItems: "Revisar {count} Artículos Faltantes"
   saturday: Sábado
   save: Guardar
   savedSuccessfully: ahorrado con éxito

--- a/packages/ilios-common/translations/fr.yaml
+++ b/packages/ilios-common/translations/fr.yaml
@@ -290,6 +290,7 @@ general:
   publishAsIs: 'Publier "as-is"'
   publishCourse: Publier Cours
   publishCourseWithMissingItems: Publier Cours, avec {missingItemCount, plural, =1 {1 objet manquant} other {# objets manquants}}
+  publishSessionWithMissingItems: Publier Session, avec {missingItemCount, plural, =1 {1 objet manquant} other {# objets manquants}}
   published: Publié
   publishedSessions: Sessions Publiées
   publishedSuccessfully: Publié réussi
@@ -299,7 +300,6 @@ general:
   results: Resultats
   resultsCount: "{count, plural, =1 {1 résultat} other {# résultats}}"
   returnToPreviousPage: Retour à la page précédente
-  reviewMissingItems: "Examiner {count} objets manquants"
   saturday: Samedi
   save: Enregistrer
   savedSuccessfully: enregistré avec succès

--- a/packages/test-app/tests/integration/components/session/publication-menu-test.gjs
+++ b/packages/test-app/tests/integration/components/session/publication-menu-test.gjs
@@ -86,7 +86,6 @@ module('Integration | Component | session/publication-menu', function (hooks) {
     assert.ok(component.menuOpen);
     assert.notOk(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
     assert.ok(component.hasTbd);
     assert.notOk(component.hasUnPublish);
   });
@@ -103,7 +102,6 @@ module('Integration | Component | session/publication-menu', function (hooks) {
     assert.ok(component.menuOpen);
     assert.notOk(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
     assert.notOk(component.hasTbd);
     assert.ok(component.hasUnPublish);
   });
@@ -120,7 +118,6 @@ module('Integration | Component | session/publication-menu', function (hooks) {
     assert.ok(component.menuOpen);
     assert.notOk(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
     assert.ok(component.hasTbd);
     assert.ok(component.hasUnPublish);
   });
@@ -158,24 +155,19 @@ module('Integration | Component | session/publication-menu', function (hooks) {
     this.set('session', sessionModel);
     await render(<template><PublicationMenu @session={{this.session}} /></template>);
     await component.toggle.click();
-    assert.ok(component.menuOpen);
-    assert.ok(component.hasPublishAsIs);
-    assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
-    assert.ok(component.hasTbd);
-    assert.notOk(component.hasUnPublish);
 
-    assert.strictEqual(component.selectedMenuItem, 'Review 2 Missing Items');
+    assert.ok(component.menuOpen, 'menu is open');
+    assert.ok(component.hasPublishAsIs, 'menu has publish as-is');
+    assert.notOk(component.hasPublish, 'menu does not have publish');
+    assert.ok(component.hasTbd, 'menu has scheduled option');
+    assert.notOk(component.hasUnPublish, 'menu does not have unpublish');
+
+    assert.strictEqual(component.selectedMenuItem, 'Mark as Scheduled');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
 
     await component.menu.up();
     assert.strictEqual(component.selectedMenuItem, 'Publish As-is');
-    await a11yAudit(this.element);
-    assert.ok(true, 'no a11y errors found!');
-
-    await component.menu.up();
-    assert.strictEqual(component.selectedMenuItem, 'Mark as Scheduled');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -193,21 +185,15 @@ module('Integration | Component | session/publication-menu', function (hooks) {
     assert.ok(component.menuOpen);
     assert.notOk(component.hasPublishAsIs);
     assert.notOk(component.hasPublish);
-    assert.ok(component.hasReview);
     assert.ok(component.hasTbd);
     assert.ok(component.hasUnPublish);
 
-    assert.strictEqual(component.selectedMenuItem, 'Review 2 Missing Items');
+    assert.strictEqual(component.selectedMenuItem, 'Mark as Scheduled');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
 
     await component.menu.up();
     assert.strictEqual(component.selectedMenuItem, 'UnPublish Session');
-    await a11yAudit(this.element);
-    assert.ok(true, 'no a11y errors found!');
-
-    await component.menu.up();
-    assert.strictEqual(component.selectedMenuItem, 'Mark as Scheduled');
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });


### PR DESCRIPTION
Fixes https://github.com/ilios/ilios/issues/6850
Follows [ilios/ilios#9400](https://github.com/ilios/frontend/pull/9400)

This simplifies the Session Publication Menu by removing the 'Review X Items' option and having that feature as part of the "Publish As-is". You now publish the session at the `/publicationcheck` route.

- [x] Remove "Review # items" option in Session Publication button
- [x] Publish remains the same (no missing items)
- [x] Publish As-Is now incorporates the old "Review # items" if there are missing items and requires a "Yes, publish, despite these missing items"

Potential followup items:

- [ ] Missing items should be links to edit them instead of just text (in-page anchors? double-up function of on-page buttons?)
- [ ] Loosening menu option visibility logic so that "Publish As-Is" shows even if required element (offering) is not present