### PR TITLE
grants write perms on PRs to deploy PR commenting job.

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -42,6 +42,7 @@ jobs:
   comment:
     permissions:
       issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     needs: deploy
     steps:


### PR DESCRIPTION
allow the "deploy PR" workflow to comment on the PR being deployed.