### PR TITLE
Normalize event session descriptions

### DIFF
--- a/packages/ilios-common/addon/components/single-event.gjs
+++ b/packages/ilios-common/addon/components/single-event.gjs
@@ -8,6 +8,7 @@ import { findById } from 'ilios-common/utils/array-helpers';
 import createTypedLearningMaterialProxy from 'ilios-common/utils/create-typed-learning-material-proxy';
 import { TrackedAsyncData } from 'ember-async-data';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
+import TruncateText from 'ilios-common/components/truncate-text';
 import t from 'ember-intl/helpers/t';
 import { and, eq, gt, not } from 'ember-truth-helpers';
 import { LinkTo } from '@ember/routing';
@@ -448,8 +449,13 @@ export default class SingleEventComponent extends Component {
             </div>
           {{/if}}
           {{#if @event.sessionDescription}}
-            <div class="single-event-session-description">
-              {{this.sessionDescription}}
+            <div class="single-event-session-description text-wrap">
+              <TruncateText
+                @text={{this.sessionDescription}}
+                @length={{50}}
+                @slippage={{200}}
+                @renderHtml={{true}}
+              />
             </div>
           {{/if}}
         </div>

--- a/packages/ilios-common/addon/components/single-event.gjs
+++ b/packages/ilios-common/addon/components/single-event.gjs
@@ -8,7 +8,6 @@ import { findById } from 'ilios-common/utils/array-helpers';
 import createTypedLearningMaterialProxy from 'ilios-common/utils/create-typed-learning-material-proxy';
 import { TrackedAsyncData } from 'ember-async-data';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
-import TruncateText from 'ilios-common/components/truncate-text';
 import t from 'ember-intl/helpers/t';
 import { and, eq, gt, not } from 'ember-truth-helpers';
 import { LinkTo } from '@ember/routing';
@@ -450,12 +449,7 @@ export default class SingleEventComponent extends Component {
           {{/if}}
           {{#if @event.sessionDescription}}
             <div class="single-event-session-description text-wrap normalize-external-editor">
-              <TruncateText
-                @text={{this.sessionDescription}}
-                @length={{50}}
-                @slippage={{200}}
-                @renderHtml={{true}}
-              />
+              {{this.sessionDescription}}
             </div>
           {{/if}}
         </div>

--- a/packages/ilios-common/addon/components/single-event.gjs
+++ b/packages/ilios-common/addon/components/single-event.gjs
@@ -449,7 +449,7 @@ export default class SingleEventComponent extends Component {
             </div>
           {{/if}}
           {{#if @event.sessionDescription}}
-            <div class="single-event-session-description text-wrap">
+            <div class="single-event-session-description text-wrap normalize-external-editor">
               <TruncateText
                 @text={{this.sessionDescription}}
                 @length={{50}}

--- a/packages/ilios-common/addon/components/truncate-text.gjs
+++ b/packages/ilios-common/addon/components/truncate-text.gjs
@@ -34,7 +34,7 @@ export default class TruncateTextComponent extends Component {
     return this.length + this.slippage;
   }
   get displayText() {
-    if (this.expanded || this.cleanText.length < this.totalLength) {
+    if (this.expanded || (this.cleanText.length < this.totalLength && this.lineBreakCount < 5)) {
       if (this.args.renderHtml) {
         return new htmlSafe(this.text);
       } else {
@@ -50,6 +50,16 @@ export default class TruncateTextComponent extends Component {
     } else {
       return this.displayText.toString() !== this.cleanText;
     }
+  }
+  get lineBreakCount() {
+    const regex = /(<p>|<br>|<br\/>|<br \/>|<li>)/gi;
+    const matches = this.text.match(regex);
+
+    if (matches) {
+      return matches.length;
+    }
+
+    return 0;
   }
 
   @action

--- a/packages/ilios-common/addon/components/truncate-text.gjs
+++ b/packages/ilios-common/addon/components/truncate-text.gjs
@@ -34,7 +34,7 @@ export default class TruncateTextComponent extends Component {
     return this.length + this.slippage;
   }
   get displayText() {
-    if (this.expanded || (this.cleanText.length < this.totalLength && this.lineBreakCount < 5)) {
+    if (this.expanded || this.cleanText.length < this.totalLength) {
       if (this.args.renderHtml) {
         return new htmlSafe(this.text);
       } else {
@@ -50,16 +50,6 @@ export default class TruncateTextComponent extends Component {
     } else {
       return this.displayText.toString() !== this.cleanText;
     }
-  }
-  get lineBreakCount() {
-    const regex = /(<p>|<br>|<br\/>|<br \/>|<li>)/gi;
-    const matches = this.text.match(regex);
-
-    if (matches) {
-      return matches.length;
-    }
-
-    return 0;
   }
 
   @action

--- a/packages/ilios-common/addon/components/week-glance-event.gjs
+++ b/packages/ilios-common/addon/components/week-glance-event.gjs
@@ -163,7 +163,7 @@ export default class WeekGlanceEventComponent extends Component {
         </div>
       {{/if}}
       {{#if @event.sessionDescription.length}}
-        <p class="description" data-test-description>
+        <p class="description normalize-external-editor" data-test-description>
           <TruncateText
             @text={{@event.sessionDescription}}
             @length={{50}}

--- a/packages/ilios-common/addon/components/week-glance.gjs
+++ b/packages/ilios-common/addon/components/week-glance.gjs
@@ -176,7 +176,7 @@ export default class WeeklyGlanceComponent extends Component {
                     date.startDate
                     weekday="narrow"
                   }}</h3>
-                <ul>
+                <ul class="events">
                   {{#each date.events as |event|}}
                     <WeekGlanceEvent @event={{event}} />
                   {{/each}}

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
@@ -85,5 +85,10 @@
 
   .single-event-session-description {
     margin-bottom: 1rem;
+
+    p {
+      margin: 0;
+      padding: 0;
+    }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
@@ -84,7 +84,7 @@
   }
 
   .single-event-session-description {
-    margin-bottom: 1rem;
+    margin: 1rem 0;
 
     p {
       margin: 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -78,13 +78,14 @@
       margin-top: 0;
     }
 
-    .description ul,
-    .description ol {
-      /* stylelint-disable-next-line property-disallowed-list */
-      line-height: 0.7; // match Session description view
-      list-style-position: inside;
-      margin-block-start: 1em;
-      margin-block-end: 1em;
+    .description {
+      ul,
+      ol {
+        /* stylelint-disable-next-line property-disallowed-list */
+        line-height: 0.7; // match Session description view
+        margin-block-start: 1em;
+        margin-block-end: 1em;
+      }
     }
 
     p {

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -82,7 +82,7 @@
       ul,
       ol {
         /* stylelint-disable-next-line property-disallowed-list */
-        line-height: 0.7; // match Session description view
+        line-height: calc(4px + 1ex); // match Session description view
         margin-block-start: 1em;
         margin-block-end: 1em;
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -20,6 +20,7 @@
     display: flex;
     flex-direction: row-reverse;
     justify-content: space-between;
+
     .day {
       @include m.ilios-heading-h4;
       align-self: flex-start;
@@ -57,9 +58,10 @@
       }
     }
 
-    ul {
-      @include m.ilios-list-reset;
+    ul.events {
+      list-style-type: none;
       margin-top: 0.25rem;
+      padding: 0;
     }
   }
 
@@ -74,6 +76,15 @@
 
     &:first-of-type {
       margin-top: 0;
+    }
+
+    .description ul,
+    .description ol {
+      /* stylelint-disable-next-line property-disallowed-list */
+      line-height: 0.7; // match Session description view
+      list-style-position: inside;
+      margin-block-start: 1em;
+      margin-block-end: 1em;
     }
 
     p {

--- a/packages/ilios-common/app/styles/ilios-common/shared/normalize-external-editor.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/normalize-external-editor.scss
@@ -1,8 +1,10 @@
 .normalize-external-editor {
   ul,
   ol {
+    list-style-position: inside;
     margin-block-start: 1em;
     margin-block-end: 1em;
+    padding-inline-start: 1em;
 
     li {
       margin-bottom: 0.5em;
@@ -10,31 +12,31 @@
   }
 
   ul {
-    list-style-position: inside;
     list-style-type: disc;
   }
 
   ol {
-    list-style-position: inside;
     list-style-type: decimal;
   }
 
   ul ul,
+  ul ol,
+  ol ol,
   ol ul {
     list-style-position: inside;
-    list-style-type: circle;
     margin-block-start: 0.5em;
     margin-block-end: 0.5em;
     margin-left: 15px;
   }
 
+  ul ul,
+  ol ul {
+    list-style-type: circle;
+  }
+
   ol ol,
   ul ol {
-    list-style-position: inside;
     list-style-type: lower-latin;
-    margin-block-start: 0.5em;
-    margin-block-end: 0.5em;
-    margin-left: 15px;
   }
 
   p {

--- a/packages/ilios-common/app/styles/ilios-common/shared/normalize-external-editor.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/normalize-external-editor.scss
@@ -1,4 +1,14 @@
 .normalize-external-editor {
+  ul,
+  ol {
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+
+    li {
+      margin-bottom: 0.5em;
+    }
+  }
+
   ul {
     list-style-position: inside;
     list-style-type: disc;
@@ -13,6 +23,8 @@
   ol ul {
     list-style-position: inside;
     list-style-type: circle;
+    margin-block-start: 0.5em;
+    margin-block-end: 0.5em;
     margin-left: 15px;
   }
 
@@ -20,6 +32,8 @@
   ul ol {
     list-style-position: inside;
     list-style-type: lower-latin;
+    margin-block-start: 0.5em;
+    margin-block-end: 0.5em;
     margin-left: 15px;
   }
 


### PR DESCRIPTION
Fixes ilios/ilios#6656

After much work trying to get `TruncateText`'s "character count" algo to work more like `FadeText`'s "vertical space" algo, I gave up as I was essentially turning one component into the other for no reason.

In the end, just putting `TruncateText` on session descriptions when shown on the WaaG and/or Single Event routes feels like enough. If it's overly tall, it still won't truncate unless the character count is long enough, which feels like an edge cases most of the time.

This also squares up the presentation of session descriptions across WaaG, Single Event, Session, and editing Session, as they were not normalized (mainly in how they displayed lists).

Here's an example of various description "lengths" on the dashboard and how they'd now be handled.
<img width="858" height="751" alt="Screenshot 2026-08-06 at 1 15 48 PM" src="https://github.com/user-attachments/assets/e962a8e0-6cd1-4b2b-a8f5-8723a8aa889f" />

The preview, logged in as dev, also currently has a course with a session and a wacky description to check all this again.

