### PR TITLE
Consolidate Fetching 

### DIFF
--- a/packages/frontend/app/components/program-year/objective-list.gjs
+++ b/packages/frontend/app/components/program-year/objective-list.gjs
@@ -26,7 +26,7 @@ import {
 
 export default class ProgramYearObjectiveListComponent extends Component {
   @service iliosConfig;
-  @service session;
+  @service fetch;
 
   @tracked isSorting = false;
 
@@ -87,27 +87,10 @@ export default class ProgramYearObjectiveListComponent extends Component {
     });
   }
 
-  get authHeaders() {
-    const headers = {};
-    if (this.session?.isAuthenticated) {
-      const { jwt } = this.session.data.authenticated;
-      if (jwt) {
-        headers['X-JWT-Authorization'] = `Token ${jwt}`;
-      }
-    }
-
-    return new Headers(headers);
-  }
-
   downloadReport = task({ drop: true }, async () => {
-    const apiPath = '/' + this.iliosConfig.apiNameSpace;
     const resourcePath = `/programyears/${this.args.programYear.id}/downloadobjectivesmapping`;
-    const host = this.iliosConfig.apiHost ?? `${window.location.protocol}//${window.location.host}`;
-    const url = host + apiPath + resourcePath;
+    const response = await this.fetch.getFromApi(resourcePath);
     const { default: saveAs } = await import('file-saver');
-    const response = await fetch(url, {
-      headers: this.authHeaders,
-    });
     const blob = await response.blob();
     saveAs(blob, 'report.csv');
   });

--- a/packages/frontend/app/routes/lti-login.js
+++ b/packages/frontend/app/routes/lti-login.js
@@ -6,7 +6,7 @@ export default class LtiLoginRoute extends Route {
   @service serverVariables;
   @service session;
   @service router;
-  @service iliosConfig;
+  @service fetch;
 
   async model({ token }) {
     const decodedJwt = jwtDecode(token);
@@ -19,9 +19,7 @@ export default class LtiLoginRoute extends Route {
   }
 
   async getNewToken(ltiToken) {
-    const apiHost = this.iliosConfig.apiHost;
-    const url = `${apiHost}/auth/token`;
-    const response = await fetch(url, {
+    const response = await this.fetch.fetchFromApiHost('/auth/token', {
       headers: {
         'X-JWT-Authorization': `Token ${ltiToken}`,
       },

--- a/packages/frontend/app/services/graphql.js
+++ b/packages/frontend/app/services/graphql.js
@@ -1,49 +1,18 @@
 import Service, { service } from '@ember/service';
-import { waitForFetch } from '@ember/test-waiters';
 
 export default class GraphqlService extends Service {
-  @service flashMessages;
-  @service intl;
-  @service session;
-  @service router;
-  @service iliosConfig;
-
-  get authHeaders() {
-    const headers = {};
-    if (this.session && this.session.isAuthenticated) {
-      const { jwt } = this.session.data.authenticated;
-      if (jwt) {
-        headers['X-JWT-Authorization'] = `Token ${jwt}`;
-      }
-    }
-
-    return headers;
-  }
-
-  get host() {
-    return this.iliosConfig.apiHost
-      ? this.iliosConfig.apiHost
-      : window.location.protocol + '//' + window.location.host;
-  }
+  @service fetch;
 
   async #query(q) {
-    const url = `${this.host}/api/graphql`;
-    const headers = this.authHeaders;
+    const url = `/api/graphql`;
+    const headers = this.fetch.authHeaders;
     headers['Content-Type'] = 'application/json';
     headers['Accept'] = 'application/json';
-    const response = await waitForFetch(
-      fetch(url, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({ query: q }),
-      }),
-    );
-
-    // if invalid auth, invalidate session
-    if (response.status == 401) {
-      this.flashMessages.alert(this.intl.t('errors.invalidAuthentication'));
-      this.session.invalidate();
-    }
+    const response = await this.fetch.fetchFromApiHost(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query: q }),
+    });
 
     return response.json();
   }

--- a/packages/ilios-common/addon/authenticators/ilios-jwt.js
+++ b/packages/ilios-common/addon/authenticators/ilios-jwt.js
@@ -5,7 +5,7 @@ import { cancel, later } from '@ember/runloop';
 import { DateTime } from 'luxon';
 
 export default class IliosJWT extends Base {
-  @service iliosConfig;
+  @service fetch;
   #tokenExpirationTimeout = null;
 
   async authenticate(credentials, headers) {
@@ -62,8 +62,7 @@ export default class IliosJWT extends Base {
   }
 
   async loginWithCredentials(data, loginHeaders) {
-    const host = this.iliosConfig.apiHost ? this.iliosConfig.apiHost : '';
-    const response = await fetch(`${host}/auth/login`, {
+    const response = await this.fetch.fetchFromApiHost('/auth/login', {
       method: 'POST',
       headers: {
         Accept: 'application/json',

--- a/packages/ilios-common/addon/services/fetch.js
+++ b/packages/ilios-common/addon/services/fetch.js
@@ -27,19 +27,10 @@ export default class Fetch extends Service {
       : window.location.protocol + '//' + window.location.host;
   }
 
-  apiHostUrlFromPath(relativePath) {
+  async fetchFromApiHost(relativePath, options) {
     const trimmedPath = relativePath.replace(/^\//, '');
-    return `${this.host}/${trimmedPath}`;
-  }
-
-  async getJsonFromApiHost(relativePath) {
-    const url = this.apiHostUrlFromPath(relativePath);
-
-    const response = await waitForFetch(
-      fetch(url, {
-        headers: this.authHeaders,
-      }),
-    );
+    const path = `${this.host}/${trimmedPath}`;
+    const response = await waitForFetch(fetch(path, options));
 
     // if invalid auth, invalidate session
     if (response.status == 401) {
@@ -47,43 +38,55 @@ export default class Fetch extends Service {
       this.session.invalidate();
     }
 
+    return response;
+  }
+
+  async getFromApiHost(relativePath) {
+    return this.fetchFromApiHost(relativePath, {
+      headers: this.authHeaders,
+    });
+  }
+
+  async getJsonFromApiHost(relativePath) {
+    const response = await this.getFromApiHost(relativePath);
     return response.json();
   }
 
-  async postToApiHost(relativePath, body, contentType) {
-    const url = this.apiHostUrlFromPath(relativePath);
+  async getFromApi(endpoint) {
+    const path = this.#apiPathFromEndpoint(endpoint);
+    return this.getFromApiHost(path);
+  }
+
+  async postQueryToApi(path, data) {
+    const apiPath = this.#apiPathFromEndpoint(path);
+    const body = queryString.stringify(data, {
+      arrayFormat: 'bracket',
+    });
+    return this.#postToApiHost(apiPath, body, 'application/x-www-form-urlencoded');
+  }
+
+  async postManyToApi(path, items) {
+    const apiPath = this.#apiPathFromEndpoint(path);
+    const body = JSON.stringify({ data: items });
+    return this.#postToApiHost(apiPath, body, 'application/vnd.api+json');
+  }
+
+  #apiPathFromEndpoint(endpoint) {
+    const trimmedPath = endpoint.replace(/^\//, '');
+    return `/${this.iliosConfig.apiNameSpace}/${trimmedPath}`;
+  }
+
+  async #postToApiHost(relativePath, body, contentType) {
     const headers = this.authHeaders;
     headers['Content-Type'] = contentType;
     headers['Accept'] = 'application/vnd.api+json';
 
-    const response = await waitForFetch(
-      fetch(url, {
-        method: 'POST',
-        headers,
-        body,
-      }),
-    );
-
-    // if invalid auth, invalidate session
-    if (response.status == 401) {
-      this.flashMessages.alert(this.intl.t('errors.invalidAuthentication'));
-      this.session.invalidate();
-    }
+    const response = await this.fetchFromApiHost(relativePath, {
+      method: 'POST',
+      headers,
+      body,
+    });
 
     return response.json();
-  }
-
-  async postQueryToApi(path, data) {
-    const apiPath = `/${this.iliosConfig.apiNameSpace}/${path}`;
-    const body = queryString.stringify(data, {
-      arrayFormat: 'bracket',
-    });
-    return this.postToApiHost(apiPath, body, 'application/x-www-form-urlencoded');
-  }
-
-  async postManyToApi(path, items) {
-    const apiPath = `/${this.iliosConfig.apiNameSpace}/${path}`;
-    const body = JSON.stringify({ data: items });
-    return this.postToApiHost(apiPath, body, 'application/vnd.api+json');
   }
 }

--- a/packages/ilios-common/addon/services/search.js
+++ b/packages/ilios-common/addon/services/search.js
@@ -1,26 +1,7 @@
 import Service, { service } from '@ember/service';
-import { waitForFetch } from '@ember/test-waiters';
 
 export default class SearchService extends Service {
-  @service iliosConfig;
-  @service session;
-
-  get authHeaders() {
-    const session = this.session;
-    const { jwt } = session.data.authenticated;
-    const headers = {};
-    if (jwt) {
-      headers['X-JWT-Authorization'] = `Token ${jwt}`;
-    }
-
-    return new Headers(headers);
-  }
-
-  get host() {
-    return this.iliosConfig.apiHost
-      ? this.iliosConfig.apiHost
-      : window.location.protocol + '//' + window.location.host;
-  }
+  @service fetch;
 
   /**
    * Find courses
@@ -28,13 +9,9 @@ export default class SearchService extends Service {
   async forCurriculum(q, size, from, schools, years) {
     const schoolQuery = schools ? `&schools=${schools.join('-')}` : '';
     const yearQuery = years ? `&years=${years.join('-')}` : '';
-    const url = `${this.host}/api/search/v2/curriculum?q=${q}&size=${size}&from=${from}${schoolQuery}${yearQuery}`;
+    const url = `/api/search/v2/curriculum?q=${q}&size=${size}&from=${from}${schoolQuery}${yearQuery}`;
 
-    const response = await waitForFetch(
-      fetch(url, {
-        headers: this.authHeaders,
-      }),
-    );
+    const response = await this.fetch.getFromApiHost(url);
     const { results } = await response.json();
 
     return results;
@@ -45,13 +22,9 @@ export default class SearchService extends Service {
    */
   async forUsers(q, size = 100, onlySuggestEnabled = false) {
     const onlySuggest = onlySuggestEnabled ? '&onlySuggest=true' : '';
-    const url = `${this.host}/api/search/v1/users?q=${q}&size=${size}${onlySuggest}`;
+    const url = `/api/search/v1/users?q=${q}&size=${size}${onlySuggest}`;
 
-    const response = await waitForFetch(
-      fetch(url, {
-        headers: this.authHeaders,
-      }),
-    );
+    const response = await this.fetch.getFromApiHost(url);
     const { results } = await response.json();
 
     const { users, autocomplete } = results;

--- a/packages/test-app/app/controllers/login.js
+++ b/packages/test-app/app/controllers/login.js
@@ -4,8 +4,8 @@ import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 
 export default class LoginController extends Controller {
-  @service iliosConfig;
   @service session;
+  @service fetch;
   @tracked jwt = null;
   @tracked error = null;
 
@@ -13,9 +13,7 @@ export default class LoginController extends Controller {
     this.error = null;
 
     if (this.jwt) {
-      const apiHost = this.iliosConfig.get('apiHost');
-      const url = `${apiHost}/auth/token`;
-      const response = await fetch(url, {
+      const response = await this.fetch.fetchFromApiHost('/auth/token', {
         headers: {
           'X-JWT-Authorization': `Token ${this.jwt}`,
         },


### PR DESCRIPTION
We have several calls to fetch around and about. Most of which also call on the session for auth data and the config to get the path correct. I've refactored them all to run through the fetch service. Which will make changes to the session easier to control.