### PR TITLE
Choose our Session Store Dynamically

### DIFF
--- a/packages/frontend/app/routes/application.js
+++ b/packages/frontend/app/routes/application.js
@@ -16,9 +16,9 @@ export default class AuthenticatedRoute extends Route {
 
   @tracked event;
 
-  async beforeModel() {
+  async beforeModel(transition) {
     await launchWorker();
-    await this.session.setup();
+    await this.session.setup(transition.targetName === 'lti-login');
     this.intl.setFormats(formats);
     // Set the default locale.
     this.intl.setLocale(this.initialLocale());

--- a/packages/frontend/app/services/session.js
+++ b/packages/frontend/app/services/session.js
@@ -2,12 +2,24 @@ import ESASessionService from 'ember-simple-auth/services/session';
 import config from 'frontend/config/environment';
 import * as Sentry from '@sentry/ember';
 import { service } from '@ember/service';
+import { isTesting } from '@embroider/macros';
 
 export default class SessionService extends ESASessionService {
   @service fetch;
   @service currentUser;
   @service store;
   @service router;
+
+  setup(useTheEphemeralStore) {
+    if (!isTesting()) {
+      if (useTheEphemeralStore) {
+        this.session.store.useTheEphemeralStore();
+      } else {
+        this.session.store.useTheCookieStore();
+      }
+    }
+    return super.setup();
+  }
 
   async handleAuthentication() {
     super.handleAuthentication(...arguments);

--- a/packages/frontend/app/session-stores/application.js
+++ b/packages/frontend/app/session-stores/application.js
@@ -1,6 +1,70 @@
-import Cookie from 'ember-simple-auth/session-stores/cookie';
+import BaseStore from 'ember-simple-auth/session-stores/base';
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
+import EphemeralStore from 'ember-simple-auth/session-stores/ephemeral';
+import { assert } from '@ember/debug';
 
-export default class ApplicationSessionStore extends Cookie {
+/**
+ * Custom Ember Simple Auth Store
+ * In order to support the different authentication requirements of our LTI and regular
+ * frontend this store dynamically chooses between our cookie store and an ephermeral
+ * store that keeps no data.
+ * Ref: https://github.com/mainmatter/ember-simple-auth#implementing-a-custom-store
+ */
+export default class ApplicationSessionStore extends BaseStore {
+  #activeStore;
+
+  constructor(owner) {
+    super(owner);
+    this.cookieStore = new IliosCookieStore(owner);
+    this.ephemeralStore = new EphemeralStore(owner);
+  }
+
+  useTheEphemeralStore() {
+    this.#activeStore = this.ephemeralStore;
+  }
+
+  useTheCookieStore() {
+    this.#activeStore = this.cookieStore;
+  }
+
+  clear() {
+    assert('active store must exist before calling clear', Boolean(this.#activeStore));
+    return this.#activeStore.clear();
+  }
+
+  clearRedirectTarget() {
+    assert(
+      'active store must exist before calling clearRedirectTarget',
+      Boolean(this.#activeStore),
+    );
+    return this.#activeStore.clearRedirectTarget();
+  }
+
+  getRedirectTarget() {
+    assert('active store must exist before calling getRedirectTarget', Boolean(this.#activeStore));
+    return this.#activeStore.getRedirectTarget();
+  }
+
+  restore() {
+    assert('active store must exist before calling restore', Boolean(this.#activeStore));
+    return this.#activeStore.restore();
+  }
+
+  setRedirectTarget(url) {
+    assert('active store must exist before calling setRedirectTarget', Boolean(this.#activeStore));
+    return this.#activeStore.setRedirectTarget(url);
+  }
+
+  persist(data) {
+    assert('active store must exist before calling persist', Boolean(this.#activeStore));
+    return this.#activeStore.persist(data);
+  }
+}
+
+/**
+ * Setup the attributes we want in our cookies
+ */
+class IliosCookieStore extends CookieStore {
   cookieName = 'ilios-session';
   sameSite = 'Strict';
 }

--- a/packages/frontend/tests/unit/session-stores/application-test.js
+++ b/packages/frontend/tests/unit/session-stores/application-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Session Store | application', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let store = this.owner.lookup('session-store:application');
+    assert.ok(store);
+  });
+
+  test.each(
+    'methods fail when no store is set',
+    [
+      'clear',
+      'clearRedirectTarget',
+      'getRedirectTarget',
+      'restore',
+      'setRedirectTarget',
+      'persist',
+    ],
+    async function (assert, method) {
+      let store = this.owner.lookup('session-store:application');
+      assert.throws(
+        () => store[method](),
+        new RegExp(`active store must exist before calling ${method}`),
+        'works as expected',
+      );
+    },
+  );
+});


### PR DESCRIPTION
We keep the cookie based session store for our regular frontend, but also allow LTI auth to use a memory only store that doesn't persist anywhere. This allows users to use the LTI as we have been, but not cause their authentication to carry over into the frontend if they visit it directly.