### PR TITLE
Fix `class` attribute conditional values that can leave trailing spaces (or worse!)

### DIFF
--- a/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.gjs
+++ b/packages/frontend/app/components/curriculum-inventory/sequence-block-overview.gjs
@@ -1099,7 +1099,7 @@ export default class CurriculumInventorySequenceBlockOverviewComponent extends C
               {{/if}}
             </div>
             <div
-              class="block is-selective {{unless this.isSelective 'hidden'}}"
+              class="block is-selective{{unless this.isSelective ' hidden'}}"
               data-test-is-selective
             >
               <label>{{t "general.sequenceBlockIsSelective"}}</label>

--- a/packages/frontend/app/components/global-search.gjs
+++ b/packages/frontend/app/components/global-search.gjs
@@ -136,7 +136,7 @@ export default class GlobalSearchComponent extends Component {
       />
       {{#if @query.length}}
         <ul
-          class="results {{if (and this.resultsData.isPending (not this.hasResults)) 'hidden'}}"
+          class="results{{if (and this.resultsData.isPending (not this.hasResults)) ' hidden'}}"
           data-test-results
         >
           {{#if this.resultsData.isPending}}

--- a/packages/frontend/app/components/ilios-navigation.gjs
+++ b/packages/frontend/app/components/ilios-navigation.gjs
@@ -28,7 +28,7 @@ export default class IliosNavigationComponent extends Component {
   <template>
     <nav
       aria-label={{t "general.primary"}}
-      class="ilios-navigation {{if this.expanded 'expanded'}}"
+      class="ilios-navigation{{if this.expanded ' expanded'}}"
       data-test-ilios-navigation
       ...attributes
     >

--- a/packages/frontend/app/components/learner-group/calendar.gjs
+++ b/packages/frontend/app/components/learner-group/calendar.gjs
@@ -164,7 +164,7 @@ export default class LearnerGroupCalendarComponent extends Component {
           @areDaysSelectable={{false}}
         />
       </div>
-      <span class="loading-indicator {{unless this.load.isRunning 'loaded'}}">
+      <span class="loading-indicator{{unless this.load.isRunning ' loaded'}}">
         <LoadingSpinner />
         {{t "general.loadingEvents"}}
         ...

--- a/packages/frontend/app/components/login-form.gjs
+++ b/packages/frontend/app/components/login-form.gjs
@@ -147,7 +147,7 @@ export default class LoginFormComponent extends Component {
             <div class="buttons">
               <button
                 type="button"
-                class="done {{if this.authenticate.isRunning 'active'}}"
+                class="done{{if this.authenticate.isRunning ' active'}}"
                 disabled={{if this.authenticate.isRunning "disabled"}}
                 {{on "click" (perform this.authenticate)}}
                 data-test-login

--- a/packages/frontend/app/components/pending-updates-summary.gjs
+++ b/packages/frontend/app/components/pending-updates-summary.gjs
@@ -89,7 +89,7 @@ export default class PendingUpdatesSummaryComponent extends Component {
   }
   <template>
     <div
-      class="pending-updates-summary small-component {{if this.haveUpdates 'alert'}}"
+      class="pending-updates-summary small-component{{if this.haveUpdates ' alert'}}"
       data-test-pending-updates-summary
       ...attributes
     >

--- a/packages/frontend/app/components/program-year/manage-objective-competency.gjs
+++ b/packages/frontend/app/components/program-year/manage-objective-competency.gjs
@@ -14,13 +14,12 @@ import t from 'ember-intl/helpers/t';
       <ul class="parent-picker" data-test-parent-picker>
         {{#each (sortBy "title" @domainTrees) as |domain|}}
           <li
-            class="domain
-              {{if
+            class="domain{{if
                 (or
                   (eq @selected.id domain.id)
                   (includes @selected.id (mapBy 'id' domain.competencies))
                 )
-                'selected'
+                ' selected'
               }}"
             data-test-domain
           >

--- a/packages/frontend/app/components/programs/list-item.gjs
+++ b/packages/frontend/app/components/programs/list-item.gjs
@@ -41,7 +41,7 @@ export default class ProgramListItemComponent extends Component {
   });
   <template>
     <tr
-      class="list-item {{if this.showRemoveConfirmation 'confirm-removal'}}"
+      class="list-item{{if this.showRemoveConfirmation ' confirm-removal'}}"
       data-test-active-row
       data-test-program-list-item
     >

--- a/packages/frontend/app/components/reports/curriculum/choose-course.gjs
+++ b/packages/frontend/app/components/reports/curriculum/choose-course.gjs
@@ -131,7 +131,7 @@ export default class ReportsCurriculumChooseCourseComponent extends Component {
         {{/if}}
       </div>
       {{#each this.selectedSchoolYears as |y|}}
-        <ul class="year {{if y.isExpanded 'expanded' 'collapsed'}}" data-test-year>
+        <ul class="year{{if y.isExpanded ' expanded' ' collapsed'}}" data-test-year>
           <li>
             <input
               type="checkbox"

--- a/packages/frontend/app/components/school/competencies-list-item.gjs
+++ b/packages/frontend/app/components/school/competencies-list-item.gjs
@@ -89,11 +89,11 @@ export default class SchoolCompetenciesListItemComponent extends Component {
   <template>
     <div
       id="competency-{{@competency.id}}"
-      class="competency-row grid-row {{if this.isManaging 'is-managing'}}"
+      class="competency-row grid-row{{if this.isManaging ' is-managing'}}"
       data-test-school-competencies-list-item
       ...attributes
     >
-      <div class="grid-item {{if this.isDomain 'domain' 'competency'}}" data-test-title>
+      <div class="grid-item{{if this.isDomain ' domain' ' competency'}}" data-test-title>
         {{@competency.title}}
       </div>
       <CompetenciesListItemPcrs

--- a/packages/frontend/app/components/school/session-type-form.gjs
+++ b/packages/frontend/app/components/school/session-type-form.gjs
@@ -196,7 +196,7 @@ export default class SchoolSessionTypeFormComponent extends Component {
             {{#if @canEditActive}}
               <ToggleYesno @yes={{this.isActive}} @toggle={{set this "isActive"}} />
             {{else}}
-              <span class="value {{if this.isActive 'yes' 'no'}}">
+              <span class="value{{if this.isActive ' yes' ' no'}}">
                 {{#if this.isActive}}
                   {{t "general.yes"}}
                 {{else}}
@@ -212,7 +212,7 @@ export default class SchoolSessionTypeFormComponent extends Component {
             {{#if @canEditAssessment}}
               <ToggleYesno @yes={{this.assessment}} @toggle={{this.updateAssessment}} />
             {{else}}
-              <span class="value {{if this.assessment 'yes' 'no'}}">
+              <span class="value{{if this.assessment ' yes' ' no'}}">
                 {{#if this.assessment}}
                   {{t "general.yes"}}
                 {{else}}

--- a/packages/frontend/app/components/school/visualize-session-type-vocabulary-graph.gjs
+++ b/packages/frontend/app/components/school/visualize-session-type-vocabulary-graph.gjs
@@ -161,7 +161,7 @@ export default class SchoolVisualizeSessionTypeVocabularyGraphComponent extends 
   });
   <template>
     <div
-      class="{{unless @isIcon 'not-icon'}} graph-with-data-table"
+      class="graph-with-data-table{{unless @isIcon ' not-icon'}}"
       data-test-school-visualize-session-type-vocabulary-graph
       ...attributes
     >

--- a/packages/frontend/app/components/unassigned-students-summary.gjs
+++ b/packages/frontend/app/components/unassigned-students-summary.gjs
@@ -77,8 +77,10 @@ export default class UnassignedStudentsSummaryComponent extends Component {
   <template>
     {{#let (uniqueId) as |templateId|}}
       <div
-        class="unassigned-students-summary small-component
-          {{if this.hasUnassignedStudents 'alert'}}"
+        class="unassigned-students-summary small-component{{if
+            this.hasUnassignedStudents
+            ' alert'
+          }}"
         data-test-unassigned-students-summary
       >
         <h3 data-test-title>

--- a/packages/frontend/app/components/user-list.gjs
+++ b/packages/frontend/app/components/user-list.gjs
@@ -50,8 +50,10 @@ export default class UserListComponent extends Component {
   }
   <template>
     <table
-      class="ilios-table ilios-table-colors ilios-zebra-table user-list
-        {{if @headerIsLocked ' sticky-header'}}"
+      class="ilios-table ilios-table-colors ilios-zebra-table user-list{{if
+          @headerIsLocked
+          ' sticky-header'
+        }}"
       data-test-user-list
       ...attributes
     >

--- a/packages/frontend/app/components/user-profile-roles.gjs
+++ b/packages/frontend/app/components/user-profile-roles.gjs
@@ -153,7 +153,7 @@ export default class UserProfileRolesComponent extends Component {
           <label>
             {{t "general.student"}}:
           </label>
-          <span class="value {{if this.isStudent 'yes' 'no'}}">
+          <span class="value{{if this.isStudent ' yes' ' no'}}">
             {{#if this.isStudent}}
               {{t "general.yes"}}
             {{else}}
@@ -173,7 +173,7 @@ export default class UserProfileRolesComponent extends Component {
               {{on "click" (set this "isFormerStudentFlipped" (not this.isFormerStudentFlipped))}}
             />
           {{else}}
-            <span class="value {{if this.isFormerStudent 'yes' 'no'}}">
+            <span class="value{{if this.isFormerStudent ' yes' ' no'}}">
               {{#if this.isFormerStudent}}
                 {{t "general.yes"}}
               {{else}}
@@ -196,7 +196,7 @@ export default class UserProfileRolesComponent extends Component {
               disabled={{if (eq @user.id this.currentUser.currentUserId) true}}
             />
           {{else}}
-            <span class="value {{if this.isEnabled 'yes' 'no'}}">
+            <span class="value{{if this.isEnabled ' yes' ' no'}}">
               {{#if this.isEnabled}}
                 {{t "general.yes"}}
               {{else}}
@@ -220,7 +220,7 @@ export default class UserProfileRolesComponent extends Component {
               }}
             />
           {{else}}
-            <span class="value {{if this.isUserSyncIgnored 'yes' 'no'}}">
+            <span class="value{{if this.isUserSyncIgnored ' yes' ' no'}}">
               {{#if this.isUserSyncIgnored}}
                 {{t "general.yes"}}
               {{else}}

--- a/packages/frontend/app/components/visualizer-program-year-objectives.gjs
+++ b/packages/frontend/app/components/visualizer-program-year-objectives.gjs
@@ -154,7 +154,7 @@ export default class VisualizerProgramYearObjectivesComponent extends Component 
     this.tooltipSessions = uniqueValues(allSessionTitles);
   });
   <template>
-    <div class="{{unless @isIcon 'not-icon'}} visualizer-program-year-objectives" ...attributes>
+    <div class="visualizer-program-year-objectives{{unless @isIcon ' not-icon'}}" ...attributes>
       {{#if this.chartOutputData.isResolved}}
         {{#if (or @isIcon this.chartOutput)}}
           <SimpleChart

--- a/packages/ilios-common/addon/components/click-choice-buttons.gjs
+++ b/packages/ilios-common/addon/components/click-choice-buttons.gjs
@@ -4,7 +4,7 @@ import { fn } from '@ember/helper';
 <template>
   <div class="click-choice-buttons" data-test-click-choice-buttons>
     <button
-      class="first-button {{if @firstChoicePicked 'active'}}"
+      class="first-button{{if @firstChoicePicked ' active'}}"
       type="button"
       data-test-first-button
       {{on "click" (if @firstChoicePicked (noop) (fn @toggle true))}}
@@ -12,7 +12,7 @@ import { fn } from '@ember/helper';
       {{@buttonContent1}}
     </button>
     <button
-      class="second-button {{unless @firstChoicePicked 'active'}}"
+      class="second-button{{unless @firstChoicePicked ' active'}}"
       type="button"
       data-test-second-button
       {{on "click" (if @firstChoicePicked (fn @toggle false) (noop))}}

--- a/packages/ilios-common/addon/components/course/visualize-instructor-session-type-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-instructor-session-type-graph.gjs
@@ -172,7 +172,7 @@ export default class CourseVisualizeInstructorSessionTypeGraphComponent extends 
   });
   <template>
     <div
-      class="graph-with-data-table {{unless @isIcon 'not-icon'}}"
+      class="graph-with-data-table{{unless @isIcon ' not-icon'}}"
       data-test-course-visualize-instructor-session-type-graph
       ...attributes
     >

--- a/packages/ilios-common/addon/components/course/visualize-instructor-term-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-instructor-term-graph.gjs
@@ -193,7 +193,7 @@ export default class CourseVisualizeInstructorTermGraphComponent extends Compone
   });
   <template>
     <div
-      class="graph-with-data-table {{unless @isIcon 'not-icon'}}"
+      class="graph-with-data-table{{unless @isIcon ' not-icon'}}"
       data-test-course-visualize-instructor-term-graph
       ...attributes
     >

--- a/packages/ilios-common/addon/components/course/visualize-instructors-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-instructors-graph.gjs
@@ -188,7 +188,7 @@ export default class CourseVisualizeInstructorsGraphComponent extends Component 
   });
   <template>
     <div
-      class="graph-with-data-table {{unless @isIcon 'not-icon'}}"
+      class="graph-with-data-table{{unless @isIcon ' not-icon'}}"
       data-test-course-visualize-instructors-graph
       ...attributes
     >

--- a/packages/ilios-common/addon/components/course/visualize-objectives-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-objectives-graph.gjs
@@ -230,7 +230,7 @@ export default class CourseVisualizeObjectivesGraphComponent extends Component {
   });
   <template>
     <div
-      class="course-visualize-objectives-graph graph-with-data-table {{unless @isIcon 'not-icon'}}"
+      class="course-visualize-objectives-graph graph-with-data-table{{unless @isIcon ' not-icon'}}"
       data-test-course-visualize-objectives-graph
       ...attributes
     >

--- a/packages/ilios-common/addon/components/course/visualize-session-type-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-session-type-graph.gjs
@@ -207,7 +207,7 @@ export default class CourseVisualizeSessionTypeGraphComponent extends Component 
   });
   <template>
     <div
-      class="graph-with-data-table {{unless @isIcon 'not-icon'}}"
+      class="graph-with-data-table{{unless @isIcon ' not-icon'}}"
       data-test-course-visualize-session-type-graph
       ...attributes
     >

--- a/packages/ilios-common/addon/components/course/visualize-session-types-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-session-types-graph.gjs
@@ -189,7 +189,7 @@ export default class CourseVisualizeSessionTypesGraphComponent extends Component
   });
   <template>
     <div
-      class="graph-with-data-table {{unless @isIcon 'not-icon'}}"
+      class="graph-with-data-table{{unless @isIcon ' not-icon'}}"
       data-test-course-visualize-session-types-graph
       ...attributes
     >

--- a/packages/ilios-common/addon/components/course/visualize-term-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-term-graph.gjs
@@ -158,7 +158,7 @@ export default class CourseVisualizeTermGraphComponent extends Component {
   });
   <template>
     <div
-      class="graph-with-data-table {{unless @isIcon 'not-icon'}}"
+      class="graph-with-data-table{{unless @isIcon ' not-icon'}}"
       data-test-course-visualize-term-graph
       ...attributes
     >

--- a/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-vocabularies-graph.gjs
@@ -182,7 +182,7 @@ export default class CourseVisualizeVocabulariesGraphComponent extends Component
   });
   <template>
     <div
-      class="graph-with-data-table {{unless @isIcon 'not-icon'}}"
+      class="graph-with-data-table{{unless @isIcon ' not-icon'}}"
       data-test-course-visualize-vocabularies-graph
       ...attributes
     >

--- a/packages/ilios-common/addon/components/course/visualize-vocabulary-graph.gjs
+++ b/packages/ilios-common/addon/components/course/visualize-vocabulary-graph.gjs
@@ -183,7 +183,7 @@ export default class CourseVisualizeVocabularyGraphComponent extends Component {
   });
   <template>
     <div
-      class="graph-with-data-table {{unless @isIcon 'not-icon'}}"
+      class="graph-with-data-table{{unless @isIcon ' not-icon'}}"
       data-test-course-visualize-vocabulary-graph
       ...attributes
     >

--- a/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.gjs
+++ b/packages/ilios-common/addon/components/dashboard/courses-calendar-filter.gjs
@@ -169,7 +169,7 @@ export default class DashboardCoursesCalendarFilterComponent extends Component {
         {{#if this.coursesRelationshipData.isResolved}}
           {{#each this.courseYears as |year|}}
             <div
-              class="year {{if (includes year.year this.expandedYears) 'expanded' 'collapsed'}}"
+              class="year{{if (includes year.year this.expandedYears) ' expanded' ' collapsed'}}"
               {{this.scrollToDefaultExpandedYear year.year}}
               {{inViewport
                 onEnter=(fn this.addYearInView year.year)

--- a/packages/ilios-common/addon/components/leadership-search.gjs
+++ b/packages/ilios-common/addon/components/leadership-search.gjs
@@ -105,10 +105,9 @@ export default class LeadershipSearchComponent extends Component {
         data-test-search-input
       />
       <ul
-        class="results user-search-results
-          {{unless
+        class="results user-search-results{{unless
             (or this.searchForUsers.isRunning this.searchForUsers.lastSuccessful.value.length)
-            'hidden'
+            ' hidden'
           }}"
       >
         {{#if this.searchForUsers.isRunning}}

--- a/packages/ilios-common/addon/components/learning-materials-sort-manager.gjs
+++ b/packages/ilios-common/addon/components/learning-materials-sort-manager.gjs
@@ -117,11 +117,10 @@ export default class LearningMaterialsSortManagerComponent extends Component {
           <ul class="sortable-items">
             {{#each this.items as |item|}}
               <li
-                class="item
-                  {{if (eq this.draggingItem item) 'dragging-item'}}
-                  {{if (eq this.draggedAboveItem item) 'dragged-above'}}
-                  {{if (eq this.draggedBelowItem item) 'dragged-below'}}
-                  "
+                class="item{{if (eq this.draggingItem item) ' dragging-item'}}{{if
+                    (eq this.draggedAboveItem item)
+                    ' dragged-above'
+                  }}{{if (eq this.draggedBelowItem item) ' dragged-below'}}"
                 draggable="true"
                 {{on "drag" (fn this.drag item)}}
                 {{on "dragend" this.dragEnd}}

--- a/packages/ilios-common/addon/components/mesh-manager.gjs
+++ b/packages/ilios-common/addon/components/mesh-manager.gjs
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { mapBy, sortBy } from 'ilios-common/utils/array-helpers';
-import { uniqueId, fn } from '@ember/helper';
+import { uniqueId, fn, array } from '@ember/helper';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import MeshDescriptorLastTreeNumber from 'ilios-common/components/mesh-descriptor-last-tree-number';
@@ -12,6 +12,7 @@ import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { and, lte } from 'ember-truth-helpers';
 import includes from 'ilios-common/helpers/includes';
+import join from 'ilios-common/helpers/join';
 import mapBy0 from 'ilios-common/helpers/map-by';
 import perform from 'ember-concurrency/helpers/perform';
 import focus from 'ilios-common/modifiers/focus';
@@ -214,8 +215,13 @@ export default class MeshManagerComponent extends Component {
                       {{#each term.concepts as |concept|}}
                         {{#if concept.scopeNote}}
                           <li
-                            class="{{if (includes term.id (mapBy0 'id' this.terms)) 'disabled'}}
-                              {{if concept.hasTruncatedScopeNote 'truncated'}}"
+                            class={{join
+                              " "
+                              (array
+                                (if (includes term.id (mapBy0 "id" this.terms)) "disabled")
+                                (if concept.hasTruncatedScopeNote "truncated")
+                              )
+                            }}
                           >
                             {{concept.truncatedScopeNote}}
                           </li>

--- a/packages/ilios-common/addon/components/sessions-grid-session-row.gjs
+++ b/packages/ilios-common/addon/components/sessions-grid-session-row.gjs
@@ -80,7 +80,7 @@ export default class SessionsGridSessionRowComponent extends Component {
           </button>
         {{else}}
           <button
-            class="link-button {{if (eq @session.offeringCount 0) 'disabled'}}"
+            class="link-button{{if (eq @session.offeringCount 0) ' disabled'}}"
             disabled={{if (eq @session.offeringCount 0) "disabled"}}
             type="button"
             aria-label={{t "general.close"}}
@@ -206,7 +206,7 @@ export default class SessionsGridSessionRowComponent extends Component {
             <FaIcon
               @icon={{faTrash}}
               @ariaHidden={{false}}
-              class={{if @showConfirmDelete " disabled" "remove enabled"}}
+              class={{if @showConfirmDelete "disabled" "remove enabled"}}
             />
           </button>
         {{else}}

--- a/packages/ilios-common/addon/components/sortable-heading.gjs
+++ b/packages/ilios-common/addon/components/sortable-heading.gjs
@@ -60,8 +60,10 @@ export default class SortableHeadingComponent extends Component {
   <template>
     <button
       type="button"
-      class="sortable-heading sortable text-{{this.align}}
-        {{if this.hideFromSmallScreen 'hide-from-small-screen'}}"
+      class="sortable-heading sortable text-{{this.align}}{{if
+          this.hideFromSmallScreen
+          ' hide-from-small-screen'
+        }}"
       colspan={{this.colspan}}
       title={{this.title}}
       {{on "click" this.click}}

--- a/packages/ilios-common/addon/components/taxonomy-manager-terms-list-item.gjs
+++ b/packages/ilios-common/addon/components/taxonomy-manager-terms-list-item.gjs
@@ -51,8 +51,10 @@ export default class SelectableTermsListItemComponent extends Component {
   <template>
     {{#if (or this.isSelected (and @hasActiveParent @term.active))}}
       <button
-        class="taxonomy-manager-terms-list-item taxonomy-manager-terms-list-item-button
-          {{if this.isSelected 'selected'}}"
+        class="taxonomy-manager-terms-list-item taxonomy-manager-terms-list-item-button{{if
+            this.isSelected
+            ' selected'
+          }}"
         type="button"
         data-test-taxonomy-manager-terms-list-item
         data-test-taxonomy-manager-terms-list-item-level={{this.level}}
@@ -81,7 +83,7 @@ export default class SelectableTermsListItemComponent extends Component {
       </button>
     {{else}}
       <div
-        class="taxonomy-manager-terms-list-item {{if this.isSelected 'selected'}}"
+        class="taxonomy-manager-terms-list-item{{if this.isSelected ' selected'}}"
         data-test-taxonomy-manager-terms-list-item
         data-test-taxonomy-manager-terms-list-item-level={{this.level}}
         {{mouseHoverToggle (set this "isHovering")}}

--- a/packages/ilios-common/addon/helpers/join.js
+++ b/packages/ilios-common/addon/helpers/join.js
@@ -3,6 +3,6 @@ import { helper } from '@ember/component/helper';
 import asArray from 'ilios-common/utils/as-array';
 
 export default helper(function join([separator, rawArray]) {
-  let array = asArray(rawArray);
+  let array = asArray(rawArray).filter((elem) => elem !== undefined);
   return array.join(separator);
 });


### PR DESCRIPTION
Noticing several places where an element will have a conditional CSS class applied, but if the condition isn't met then the attribute will have a trailing space, which, while not breaking, looks wrong in the rendered template.

For example, `class="foo bar {{if this.hasBoop 'has-boop'}}`. If we got `hasBoop`, all fine, but if not, then we get the incorrect HTML:

```
<element class="foo bar ">Stuff Stuff</element>
```

Worse yet, if there are multiple conditional classes, and one or all are not applied, you might get something like the following:

For example, `class="{{ if this.hasGoop 'has-goop' }} {{ if this.hasFloomp 'has-floomp' }}"`. If there is neither goop nor floomp, then you get something like the following glop:

```
<element class="
     ">Cool Text</a>
```

I've fixed some in past PRs, but this PR is a concerted effort to fix all the remaining instances (generally with a simple space swap-a-roo, but sometimes more was needed), making rendered HTML look slick and intentional. Devs will appreciate it and curious View Source-rs, if they still exist, will appreciate it, too.