### PR TITLE
Curriculum Reports Header revamp

### DIFF
--- a/packages/frontend/app/components/reports/curriculum/header.gjs
+++ b/packages/frontend/app/components/reports/curriculum/header.gjs
@@ -173,8 +173,11 @@ export default class ReportsCurriculumHeaderComponent extends Component {
     return window.location.href;
   };
   <template>
-    <div class="reports-curriculum-header" data-test-reports-curriculum-header>
-      <div class="type-and-summary">
+    <div
+      class="reports-curriculum-header{{if @showReportResults ' results'}}"
+      data-test-reports-curriculum-header
+    >
+      <div class="selection">
         {{#unless @showReportResults}}
           <label data-test-report-selector>
             <span data-test-report-selector-label>
@@ -195,23 +198,9 @@ export default class ReportsCurriculumHeaderComponent extends Component {
             </select>
           </label>
         {{/unless}}
-        <div data-test-run-summary>
-          {{#if this.selectedReport}}
-            {{#if @countSelectedCourses}}
-              <div data-test-selected-report-label-summary>
-                {{t "general.run"}}
-                {{this.selectedReport.label}}
-                {{this.selectedReport.summary}}
-              </div>
-            {{else}}
-              <div data-test-selected-report-label-summary>
-                {{t "general.selectCoursesToRunReport"}}
-              </div>
-            {{/if}}
-          {{/if}}
-        </div>
       </div>
-      <div class="input-buttons">
+
+      <div class="actions">
         {{#if (and @countSelectedCourses this.selectedReport)}}
           <CopyButton
             @getClipboardText={{this.getReportUrl}}
@@ -276,6 +265,22 @@ export default class ReportsCurriculumHeaderComponent extends Component {
             >
               {{t "general.runReport"}}
             </IliosTooltip>
+          {{/if}}
+        {{/if}}
+      </div>
+
+      <div class="summary" data-test-run-summary>
+        {{#if this.selectedReport}}
+          {{#if @countSelectedCourses}}
+            <div data-test-selected-report-label-summary>
+              {{t "general.run"}}
+              {{this.selectedReport.label}}
+              {{this.selectedReport.summary}}
+            </div>
+          {{else}}
+            <div data-test-selected-report-label-summary>
+              {{t "general.selectCoursesToRunReport"}}
+            </div>
           {{/if}}
         {{/if}}
       </div>

--- a/packages/frontend/app/components/reports/curriculum/header.gjs
+++ b/packages/frontend/app/components/reports/curriculum/header.gjs
@@ -174,6 +174,43 @@ export default class ReportsCurriculumHeaderComponent extends Component {
   };
   <template>
     <div class="reports-curriculum-header" data-test-reports-curriculum-header>
+      <div class="type-and-summary">
+        {{#unless @showReportResults}}
+          <label data-test-report-selector>
+            <span data-test-report-selector-label>
+              {{t "general.selectCurriculumReportType"}}:
+            </span>
+            <select {{on "change" this.changeSelectedReport}}>
+              <option selected={{isEmpty this.selectedReport}} value>
+                {{t "general.selectPolite"}}
+              </option>
+              {{#each (sortBy "label" this.reportList) as |report|}}
+                <option
+                  value={{report.value}}
+                  selected={{eq report.value this.selectedReport.value}}
+                >
+                  {{report.label}}
+                </option>
+              {{/each}}
+            </select>
+          </label>
+        {{/unless}}
+        <div data-test-run-summary>
+          {{#if this.selectedReport}}
+            {{#if @countSelectedCourses}}
+              <div data-test-selected-report-label-summary>
+                {{t "general.run"}}
+                {{this.selectedReport.label}}
+                {{this.selectedReport.summary}}
+              </div>
+            {{else}}
+              <div data-test-selected-report-label-summary>
+                {{t "general.selectCoursesToRunReport"}}
+              </div>
+            {{/if}}
+          {{/if}}
+        </div>
+      </div>
       <div class="input-buttons">
         {{#if (and @countSelectedCourses this.selectedReport)}}
           <CopyButton
@@ -241,45 +278,6 @@ export default class ReportsCurriculumHeaderComponent extends Component {
             </IliosTooltip>
           {{/if}}
         {{/if}}
-      </div>
-      <div class="run">
-        <p>
-          {{#unless @showReportResults}}
-            <label data-test-report-selector>
-              <span data-test-report-selector-label>
-                {{t "general.selectCurriculumReportType"}}:
-              </span>
-              <select {{on "change" this.changeSelectedReport}}>
-                <option selected={{isEmpty this.selectedReport}} value>
-                  {{t "general.selectPolite"}}
-                </option>
-                {{#each (sortBy "label" this.reportList) as |report|}}
-                  <option
-                    value={{report.value}}
-                    selected={{eq report.value this.selectedReport.value}}
-                  >
-                    {{report.label}}
-                  </option>
-                {{/each}}
-              </select>
-            </label>
-          {{/unless}}
-          <div data-test-run-summary>
-            {{#if this.selectedReport}}
-              {{#if @countSelectedCourses}}
-                <div data-test-selected-report-label-summary>
-                  {{t "general.run"}}
-                  {{this.selectedReport.label}}
-                  {{this.selectedReport.summary}}
-                </div>
-              {{else}}
-                <div data-test-selected-report-label-summary>
-                  {{t "general.selectCoursesToRunReport"}}
-                </div>
-              {{/if}}
-            {{/if}}
-          </div>
-        </p>
       </div>
     </div>
   </template>

--- a/packages/frontend/app/styles/components/reports/curriculum-header.scss
+++ b/packages/frontend/app/styles/components/reports/curriculum-header.scss
@@ -3,54 +3,60 @@
 .reports-curriculum-header {
   margin: 0 0.8rem 0.25rem 0;
   padding-bottom: 0.25rem;
-  min-height: 2rem;
 
   @include cm.for-tablet-and-up {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "selection actions"
+      "summary summary";
     @include cm.font-size("medium");
-    display: flex;
     justify-content: space-between;
+    row-gap: 0.25rem;
   }
 
-  .type-and-summary {
-    margin: 0;
+  &.results {
+    display: block;
 
-    label {
-      display: inline-block;
-      margin-bottom: 0.5em;
+    .selection {
+      display: none;
     }
+
+    .actions {
+      margin-bottom: 1rem;
+
+      @include cm.for-tablet-and-up {
+        float: right;
+        margin-bottom: 0;
+        margin-left: 1rem;
+        width: auto;
+      }
+    }
+  }
+
+  .selection {
+    grid-area: "selection";
+    margin: 0;
+  }
+
+  .actions {
+    // keep buttons from vertically stretching when other column wraps to multiple lines
+    align-items: baseline;
+    margin: 0.5rem 0;
+    width: 100%;
 
     @include cm.for-tablet-and-up {
       display: flex;
-      flex-basis: min-content;
-      flex-direction: column;
-      flex-grow: 1;
-      flex-shrink: 0;
-      min-width: 0;
+      gap: 5px;
+      grid-area: "actions";
+      margin: 0;
     }
-  }
-
-  .input-buttons {
-    margin: 0.5rem 0 0;
-    min-width: 0;
-    width: 100%;
 
     .tagged-terms-mode {
       align-items: center;
       display: flex;
       gap: 0.5em;
       margin-bottom: 0.25rem;
-    }
-
-    @include cm.for-tablet-and-up {
-      align-items: flex-start;
-      display: inline-flex;
-      flex-basis: content;
-      flex-direction: row;
-      flex-grow: 0;
-      flex-shrink: 1;
-      gap: 0.5em;
-      justify-content: flex-end;
-      margin: 0 0 0 0.5em;
     }
 
     button,
@@ -71,10 +77,22 @@
         background-color: light-dark(var(--grey), var(--light-grey));
       }
     }
+
     .loading-results {
       @include cm.ilios-button {
         cursor: default;
       }
+    }
+  }
+
+  .summary {
+    grid-area: "summary";
+    grid-column: 1 / 3;
+    margin: 0.5rem 0;
+
+    label {
+      display: inline-block;
+      margin-bottom: 0.5em;
     }
   }
 }

--- a/packages/frontend/app/styles/components/reports/curriculum-header.scss
+++ b/packages/frontend/app/styles/components/reports/curriculum-header.scss
@@ -1,30 +1,38 @@
 @use "../../ilios-common/mixins" as cm;
 
 .reports-curriculum-header {
-  display: grid;
-  row-gap: 0.25rem;
   margin: 0 0.8rem 0.25rem 0;
   padding-bottom: 0.25rem;
+  min-height: 2rem;
 
   @include cm.for-tablet-and-up {
-    grid-template-columns: 4fr;
+    @include cm.font-size("medium");
+    display: flex;
     justify-content: space-between;
-    row-gap: 0;
   }
 
-  .run {
-    @include cm.font-size("medium");
-    min-height: 2rem;
+  .type-and-summary {
+    margin: 0;
 
-    p {
-      margin: 0;
+    label {
+      display: inline-block;
+      margin-bottom: 0.5em;
+    }
+
+    @include cm.for-tablet-and-up {
+      display: flex;
+      flex-basis: min-content;
+      flex-direction: column;
+      flex-grow: 1;
+      flex-shrink: 0;
+      min-width: 0;
     }
   }
 
   .input-buttons {
+    margin: 0.5rem 0 0;
+    min-width: 0;
     width: 100%;
-    margin-top: 0.5rem;
-    justify-content: flex-end;
 
     .tagged-terms-mode {
       align-items: center;
@@ -34,10 +42,15 @@
     }
 
     @include cm.for-tablet-and-up {
-      align-items: center;
-      display: flex;
+      align-items: flex-start;
+      display: inline-flex;
+      flex-basis: content;
       flex-direction: row;
+      flex-grow: 0;
+      flex-shrink: 1;
       gap: 0.5em;
+      justify-content: flex-end;
+      margin: 0;
     }
 
     button,

--- a/packages/frontend/app/styles/components/reports/curriculum-header.scss
+++ b/packages/frontend/app/styles/components/reports/curriculum-header.scss
@@ -50,7 +50,7 @@
       flex-shrink: 1;
       gap: 0.5em;
       justify-content: flex-end;
-      margin: 0;
+      margin: 0 0 0 0.5em;
     }
 
     button,


### PR DESCRIPTION
Fixes ilios/ilios#7117

Attempt at reducing curriculum report header vertical whitespace, and simplifying template a bit. Switched from action buttons being on their own line to a second element in a flexbox with the report type selector and run summary text. It's not perfect (the summary text is boxed in by the flexbox, so it doesn't flow under the buttons), but trying either a `float` or `position: fixed` situation did not really work well. Open to comments!

Note: this only affects tablet and up. Mobile still just vertically stacks everything like before.

Old
<img width="762" height="180" alt="oldcur1" src="https://github.com/user-attachments/assets/1b612153-2645-4991-b1fe-c5d6247416b7" />
<img width="762" height="218" alt="oldcur2" src="https://github.com/user-attachments/assets/28ca1758-dd0e-42c8-a0e7-9ab504cabce1" />
<img width="763" height="187" alt="oldcur3" src="https://github.com/user-attachments/assets/85954788-9c5a-4da8-8e77-34aa9c9aa05c" />

New
<img width="768" height="136" alt="newcur1" src="https://github.com/user-attachments/assets/4266b351-42c0-4676-8ec3-fa0911606fe2" />
<img width="761" height="212" alt="newcur2" src="https://github.com/user-attachments/assets/c0fca7c4-69ed-4280-849d-a81ca6836ef5" />
<img width="760" height="184" alt="newcur3" src="https://github.com/user-attachments/assets/fc3d62fe-d890-4a0d-b693-8f19260ce3e4" />

