### PR TITLE
Preserve scroll position on LG->Cohort Members

### DIFF
--- a/packages/frontend/app/components/learner-group/cohort-user-manager.gjs
+++ b/packages/frontend/app/components/learner-group/cohort-user-manager.gjs
@@ -18,6 +18,7 @@ import UserStatus from 'ilios-common/components/user-status';
 import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import perform from 'ember-concurrency/helpers/perform';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import preserveScroll from 'ilios-common/modifiers/preserve-scroll';
 
 export default class LearnerGroupCohortUserManagerComponent extends Component {
   @service currentUser;
@@ -25,6 +26,8 @@ export default class LearnerGroupCohortUserManagerComponent extends Component {
   @tracked filter = '';
   @tracked selectedUsers = [];
   @tracked usersBeingMoved = [];
+
+  cohortScroll = 0;
 
   get sortedAscending() {
     return this.args.sortBy.search(/desc/) === -1;
@@ -118,7 +121,11 @@ export default class LearnerGroupCohortUserManagerComponent extends Component {
         </div>
         {{#if @users.length}}
           <div class="learner-group-cohort-user-manager-content">
-            <div class="list">
+            <div
+              class="list"
+              {{on "scroll" (pick "target.scrollTop" (set this "cohortScroll"))}}
+              {{preserveScroll this.filteredUsers this.cohortScroll}}
+            >
               <table class="ilios-table ilios-table-colors ilios-zebra-table sticky-header">
                 <thead data-test-headers>
                   <tr>
@@ -161,8 +168,11 @@ export default class LearnerGroupCohortUserManagerComponent extends Component {
                   </tr>
                 </thead>
                 <tbody data-test-users>
-                  {{#each (sortBy @sortBy this.filteredUsers) as |user index|}}
-                    <tr class={{unless user.enabled "disabled-user-account"}}>
+                  {{#each (sortBy @sortBy this.filteredUsers) key="id" as |user index|}}
+                    <tr
+                      class={{unless user.enabled "disabled-user-account"}}
+                      data-user-id={{user.id}}
+                    >
                       {{#if @canUpdate}}
                         <td class="text-left checks">
                           <input

--- a/packages/frontend/app/components/learner-group/cohort-user-manager.gjs
+++ b/packages/frontend/app/components/learner-group/cohort-user-manager.gjs
@@ -123,7 +123,7 @@ export default class LearnerGroupCohortUserManagerComponent extends Component {
           <div class="learner-group-cohort-user-manager-content">
             <div
               class="list"
-              {{on "scroll" (pick "target.scrollTop" (set this "cohortScroll"))}}
+              {{on "scrollend" (pick "target.scrollTop" (set this "cohortScroll"))}}
               {{preserveScroll this.filteredUsers this.cohortScroll}}
             >
               <table class="ilios-table ilios-table-colors ilios-zebra-table sticky-header">

--- a/packages/ilios-common/addon/modifiers/preserve-scroll.js
+++ b/packages/ilios-common/addon/modifiers/preserve-scroll.js
@@ -1,0 +1,7 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier((element, [users, scrollTop]) => {
+  if (users) {
+    element.scrollTop = scrollTop;
+  }
+});

--- a/packages/ilios-common/app/modifiers/preserve-scroll.js
+++ b/packages/ilios-common/app/modifiers/preserve-scroll.js
@@ -1,0 +1,1 @@
+export { default } from 'ilios-common/modifiers/preserve-scroll';

--- a/packages/test-app/tests/integration/modifiers/preserve-scroll-test.gjs
+++ b/packages/test-app/tests/integration/modifiers/preserve-scroll-test.gjs
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { render } from '@ember/test-helpers';
+import preserveScroll from 'ilios-common/modifiers/preserve-scroll';
+
+module('Integration | Modifier | preserve-scroll', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(
+      <template>
+        <div {{preserveScroll}}></div>
+      </template>,
+    );
+
+    assert.ok(true);
+  });
+});


### PR DESCRIPTION
Fixes ilios/ilios#7305

Lots of time toying with complicated modifiers and scroll event listeners, but finally got a simple one to do the trick that uses the `scrollend` event so that it only triggers when scrolling stops, not on every `scroll` event. It only works with _modern_ ([Dec 2025 or newer](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event)) versions of browsers, but will just be ignored otherwise.

Note: there already exists a `PreserveScroll` service, but that works when transitioning between routes, and this PR adds an element modifier that can remember scroll position within a route.