### PR TITLE
lint Glimmer components and templates againts class-spacing formatting mistakes.

### DIFF
--- a/packages/frontend/eslint.config.mjs
+++ b/packages/frontend/eslint.config.mjs
@@ -19,7 +19,7 @@ import ember from 'eslint-plugin-ember/recommended';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
-
+import html from '@html-eslint/eslint-plugin';
 import babelParser from '@babel/eslint-parser';
 
 const esmParserOptions = {
@@ -124,6 +124,19 @@ export default [
       globals: {
         ...globals.node,
       },
+    },
+  },
+  /**
+   * Lint HTML in and Glimmer components and templates.
+   */
+  {
+    files: ['**/*.gjs'],
+    ...html.configs['flat/recommended'],
+    plugins: {
+      '@html-eslint': html,
+    },
+    rules: {
+      '@html-eslint/class-spacing': 'error',
     },
   },
 ];

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -52,6 +52,8 @@
     "@fortawesome/free-solid-svg-icons": "6.7.2",
     "@glimmer/component": "^2.0.0",
     "@glimmer/tracking": "^1.1.2",
+    "@html-eslint/eslint-plugin": "^0.64.0",
+    "@html-eslint/parser": "^0.64.0",
     "@sentry/ember": "^10.56.0",
     "@warp-drive/build-config": "~5.8.1",
     "@warp-drive/core-types": "~5.8.1",

--- a/packages/ilios-common/eslint.config.mjs
+++ b/packages/ilios-common/eslint.config.mjs
@@ -19,7 +19,7 @@ import ember from 'eslint-plugin-ember/recommended';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
-
+import html from '@html-eslint/eslint-plugin';
 import babelParser from '@babel/eslint-parser';
 
 const esmParserOptions = {
@@ -123,6 +123,19 @@ export default [
       globals: {
         ...globals.node,
       },
+    },
+  },
+  /**
+   * Lint HTML in and Glimmer components and templates.
+   */
+  {
+    files: ['**/*.gjs'],
+    ...html.configs['flat/recommended'],
+    plugins: {
+      '@html-eslint': html,
+    },
+    rules: {
+      '@html-eslint/class-spacing': 'error',
     },
   },
 ];

--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -121,6 +121,8 @@
     "@embroider/macros": "^1.19.6",
     "@embroider/test-setup": "^4.0.0",
     "@eslint/js": "^9.39.2",
+    "@html-eslint/eslint-plugin": "^0.64.0",
+    "@html-eslint/parser": "^0.64.0",
     "@msw/data": "^1.1.2",
     "@warp-drive/build-config": "~5.8.1",
     "@warp-drive/core-types": "~5.8.1",

--- a/packages/lti-course-manager/eslint.config.mjs
+++ b/packages/lti-course-manager/eslint.config.mjs
@@ -19,7 +19,7 @@ import ember from 'eslint-plugin-ember/recommended';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
-
+import html from '@html-eslint/eslint-plugin';
 import babelParser from '@babel/eslint-parser';
 
 const esmParserOptions = {
@@ -123,6 +123,19 @@ export default [
       globals: {
         ...globals.node,
       },
+    },
+  },
+  /**
+   * Lint HTML in and Glimmer components and templates.
+   */
+  {
+    files: ['**/*.gjs'],
+    ...html.configs['flat/recommended'],
+    plugins: {
+      '@html-eslint': html,
+    },
+    rules: {
+      '@html-eslint/class-spacing': 'error',
     },
   },
 ];

--- a/packages/lti-course-manager/package.json
+++ b/packages/lti-course-manager/package.json
@@ -49,6 +49,8 @@
     "@eslint/js": "^9.39.2",
     "@glimmer/component": "^2.0.0",
     "@glimmer/tracking": "^1.1.2",
+    "@html-eslint/eslint-plugin": "^0.64.0",
+    "@html-eslint/parser": "^0.64.0",
     "@warp-drive/build-config": "~5.8.1",
     "@warp-drive/core-types": "~5.8.1",
     "@warp-drive/ember": "~5.8.1",

--- a/packages/lti-dashboard/eslint.config.mjs
+++ b/packages/lti-dashboard/eslint.config.mjs
@@ -19,7 +19,7 @@ import ember from 'eslint-plugin-ember/recommended';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
-
+import html from '@html-eslint/eslint-plugin';
 import babelParser from '@babel/eslint-parser';
 
 const esmParserOptions = {
@@ -124,6 +124,19 @@ export default [
       globals: {
         ...globals.node,
       },
+    },
+  },
+  /**
+   * Lint HTML in and Glimmer components and templates.
+   */
+  {
+    files: ['**/*.gjs'],
+    ...html.configs['flat/recommended'],
+    plugins: {
+      '@html-eslint': html,
+    },
+    rules: {
+      '@html-eslint/class-spacing': 'error',
     },
   },
 ];

--- a/packages/lti-dashboard/package.json
+++ b/packages/lti-dashboard/package.json
@@ -49,6 +49,8 @@
     "@eslint/js": "^9.39.2",
     "@glimmer/component": "^2.0.0",
     "@glimmer/tracking": "^1.1.2",
+    "@html-eslint/eslint-plugin": "^0.64.0",
+    "@html-eslint/parser": "^0.64.0",
     "@warp-drive/build-config": "~5.8.1",
     "@warp-drive/core-types": "~5.8.1",
     "@warp-drive/ember": "~5.8.1",

--- a/packages/test-app/eslint.config.mjs
+++ b/packages/test-app/eslint.config.mjs
@@ -19,7 +19,7 @@ import ember from 'eslint-plugin-ember/recommended';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
-
+import html from '@html-eslint/eslint-plugin';
 import babelParser from '@babel/eslint-parser';
 
 const esmParserOptions = {
@@ -124,6 +124,19 @@ export default [
       globals: {
         ...globals.node,
       },
+    },
+  },
+  /**
+   * Lint HTML in and Glimmer components and templates.
+   */
+  {
+    files: ['**/*.gjs'],
+    ...html.configs['flat/recommended'],
+    plugins: {
+      '@html-eslint': html,
+    },
+    rules: {
+      '@html-eslint/class-spacing': 'error',
     },
   },
 ];

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -47,6 +47,8 @@
     "@eslint/js": "^9.39.2",
     "@glimmer/component": "^2.0.0",
     "@glimmer/tracking": "^1.1.2",
+    "@html-eslint/eslint-plugin": "^0.64.0",
+    "@html-eslint/parser": "^0.64.0",
     "@warp-drive/build-config": "~5.8.1",
     "@warp-drive/core-types": "~5.8.1",
     "@warp-drive/ember": "~5.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,68 +215,68 @@ importers:
     dependencies:
       ember-auto-import:
         specifier: ^2.12.0
-        version: 2.13.1(webpack@5.108.4(postcss@8.5.19))
+        version: 2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
     devDependencies:
       '@babel/core':
         specifier: ^7.28.6
         version: 7.29.7(supports-color@8.1.1)
       '@babel/eslint-parser':
         specifier: ^7.28.6
-        version: 7.29.7(@babel/core@7.29.7)(eslint@9.39.5)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))
       '@babel/plugin-proposal-decorators':
         specifier: ^7.28.6
-        version: 7.29.7(@babel/core@7.29.7)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/adapter':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/json-api':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/legacy-compat':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/model':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/request':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/request-utils':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(ember-inflector@5.0.2(@babel/core@7.29.7))
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(ember-inflector@5.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/serializer':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/store':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-intl/lint':
         specifier: ^1.0.0
         version: 1.4.0
       '@ember-intl/v1-compat':
         specifier: ^1.0.5
-        version: 1.2.2(webpack@5.108.4(postcss@8.5.19))
+        version: 1.2.2(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       '@ember/optional-features':
         specifier: ^2.3.0
-        version: 2.3.0
+        version: 2.3.0(supports-color@8.1.1)
       '@ember/string':
         specifier: ^4.0.1
         version: 4.0.1
       '@ember/test-helpers':
         specifier: ^5.4.1
-        version: 5.4.3(@babel/core@7.29.7)
+        version: 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/compat':
         specifier: ~3.8.0
-        version: 3.8.5(@embroider/core@3.5.10)
+        version: 3.8.5(@embroider/core@3.5.10(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/core':
         specifier: ~3.5.0
-        version: 3.5.10
+        version: 3.5.10(supports-color@8.1.1)
       '@embroider/macros':
         specifier: ^1.19.6
-        version: 1.20.5(@babel/core@7.29.7)
+        version: 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/webpack':
         specifier: ~4.1.0
-        version: 4.1.2(@embroider/core@3.5.10)(webpack@5.108.4(postcss@8.5.19))
+        version: 4.1.2(@embroider/core@3.5.10(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.5
@@ -285,34 +285,40 @@ importers:
         version: 6.7.2
       '@glimmer/component':
         specifier: ^2.0.0
-        version: 2.1.1
+        version: 2.1.1(supports-color@8.1.1)
       '@glimmer/tracking':
         specifier: ^1.1.2
         version: 1.1.2
+      '@html-eslint/eslint-plugin':
+        specifier: ^0.64.0
+        version: 0.64.0(eslint@9.39.5(supports-color@8.1.1))
+      '@html-eslint/parser':
+        specifier: ^0.64.0
+        version: 0.64.0
       '@sentry/ember':
         specifier: ^10.56.0
-        version: 10.65.0(ember-cli@6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8))(webpack@5.108.4(postcss@8.5.19))
+        version: 10.65.0(ember-cli@6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       '@warp-drive/build-config':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@warp-drive/core-types':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@warp-drive/ember':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)
       axe-core:
         specifier: ^4.12.0
         version: 4.12.1
       broccoli-asset-rev:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(supports-color@8.1.1)
       broccoli-file-creator:
         specifier: ^2.1.1
         version: 2.1.1
       broccoli-merge-trees:
         specifier: ^4.2.0
-        version: 4.2.0
+        version: 4.2.0(supports-color@8.1.1)
       browserslist:
         specifier: ^4.26.3
         version: 4.28.6
@@ -321,43 +327,43 @@ importers:
         version: 1.0.30001805
       ember-a11y-refocus:
         specifier: 5.2.1
-        version: 5.2.1(@babel/core@7.29.7)
+        version: 5.2.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-a11y-testing:
         specifier: ^8.0.0
-        version: 8.0.1(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(@ember/test-waiters@4.1.2)(axe-core@4.12.1)(qunit@2.26.0)
+        version: 8.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(axe-core@4.12.1)(qunit@2.26.0)(supports-color@8.1.1)
       ember-async-data:
         specifier: ^2.0.0
-        version: 2.0.1(@babel/core@7.29.7)
+        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli:
         specifier: ~6.10.0
-        version: 6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+        version: 6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
       ember-cli-app-version:
         specifier: ^7.0.0
-        version: 7.0.0(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 7.0.0(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-babel:
         specifier: ^8.2.0
-        version: 8.3.1(@babel/core@7.29.7)
+        version: 8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-bundle-analyzer:
         specifier: ^1.0.0
-        version: 1.0.0
+        version: 1.0.0(supports-color@8.1.1)
       ember-cli-dependency-checker:
         specifier: ^3.3.3
-        version: 3.3.3(ember-cli@6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8))
+        version: 3.3.3(ember-cli@6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8))
       ember-cli-dependency-lint:
         specifier: 2.0.1
         version: 2.0.1
       ember-cli-deploy:
         specifier: 2.0.0
-        version: 2.0.0
+        version: 2.0.0(supports-color@8.1.1)
       ember-cli-deploy-archive:
         specifier: 1.0.0
-        version: 1.0.0
+        version: 1.0.0(supports-color@8.1.1)
       ember-cli-deploy-brotli:
         specifier: ^0.5.1
-        version: 0.5.1
+        version: 0.5.1(supports-color@8.1.1)
       ember-cli-deploy-build:
         specifier: 3.0.0
-        version: 3.0.0(@babel/core@7.29.7)(eslint@9.39.5)
+        version: 3.0.0(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))
       ember-cli-deploy-cloudfront:
         specifier: ^6.0.0
         version: 6.0.0
@@ -366,91 +372,91 @@ importers:
         version: 3.0.0
       ember-cli-deploy-gzip:
         specifier: ^3.0.0
-        version: 3.0.0(@babel/core@7.29.7)(eslint@9.39.5)
+        version: 3.0.0(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-deploy-json-config:
         specifier: 1.0.1
         version: 1.0.1
       ember-cli-deploy-revision-data:
         specifier: 3.0.0
-        version: 3.0.0
+        version: 3.0.0(supports-color@8.1.1)
       ember-cli-deploy-s3-index:
         specifier: 4.0.3
         version: 4.0.3
       ember-cli-deprecation-workflow:
         specifier: ^4.0.0
-        version: 4.0.1(@babel/core@7.29.7)
+        version: 4.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-htmlbars:
         specifier: ^6.3.0
-        version: 6.3.0
+        version: 6.3.0(supports-color@8.1.1)
       ember-cli-inject-live-reload:
         specifier: ^2.1.0
         version: 2.1.0
       ember-cli-page-object:
         specifier: ^2.3.0
-        version: 2.3.2(@ember/test-helpers@5.4.3(@babel/core@7.29.7))
+        version: 2.3.2(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-sass:
         specifier: ^11.0.1
-        version: 11.0.1
+        version: 11.0.1(supports-color@8.1.1)
       ember-cli-terser:
         specifier: ^4.0.2
-        version: 4.0.2
+        version: 4.0.2(supports-color@8.1.1)
       ember-concurrency:
         specifier: ^5.1.0
-        version: 5.2.0(@babel/core@7.29.7)
+        version: 5.2.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-exam:
         specifier: ^10.0.0
-        version: 10.1.0(ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0))(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.26.0)(webpack@5.108.4(postcss@8.5.19))
+        version: 10.1.0(ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       ember-focus-trap:
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.29.7)
+        version: 2.0.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-keyboard:
         specifier: ^9.0.4
-        version: 9.0.4(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7))
+        version: 9.0.4(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))
       ember-modifier:
         specifier: 4.2.2
-        version: 4.2.2(@babel/core@7.29.7)
+        version: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-noscript:
         specifier: ^4.1.0
         version: 4.1.0
       ember-page-title:
         specifier: ^9.0.3
-        version: 9.0.3
+        version: 9.0.3(supports-color@8.1.1)
       ember-qunit:
         specifier: ^9.0.4
-        version: 9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0)
+        version: 9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1)
       ember-resolver:
         specifier: ^13.1.1
         version: 13.2.0
       ember-source:
         specifier: ~6.10.0
-        version: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+        version: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
       ember-template-imports:
         specifier: ^4.4.0
-        version: 4.4.0
+        version: 4.4.0(supports-color@8.1.1)
       ember-template-lint:
         specifier: ^6.1.0
-        version: 6.1.0
+        version: 6.1.0(supports-color@8.1.1)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.5
+        version: 9.39.5(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: ^9.1.2
-        version: 9.1.2(eslint@9.39.5)
+        version: 9.1.2(eslint@9.39.5(supports-color@8.1.1))
       eslint-plugin-ember:
         specifier: ^12.7.5
-        version: 12.7.5(@babel/core@7.29.7)(eslint@9.39.5)(typescript@6.0.3)
+        version: 12.7.5(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3)
       eslint-plugin-n:
         specifier: ^17.23.2
-        version: 17.24.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 17.24.0(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3)
       eslint-plugin-qunit:
         specifier: ^8.2.5
-        version: 8.2.6(eslint@9.39.5)
+        version: 8.2.6(eslint@9.39.5(supports-color@8.1.1))
       eslint-plugin-yml:
         specifier: ^3.1.2
-        version: 3.6.0(eslint@9.39.5)
+        version: 3.6.0(eslint@9.39.5(supports-color@8.1.1))
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -480,7 +486,7 @@ importers:
         version: 3.9.5
       prettier-plugin-ember-template-tag:
         specifier: ^2.1.2
-        version: 2.1.7(prettier@3.9.5)
+        version: 2.1.7(prettier@3.9.5)(supports-color@8.1.1)
       query-string:
         specifier: ^9.1.0
         version: 9.4.1
@@ -501,40 +507,40 @@ importers:
         version: 3.2.0
       stylelint:
         specifier: ^16.26.1
-        version: 16.26.1(typescript@6.0.3)
+        version: 16.26.1(supports-color@8.1.1)(typescript@6.0.3)
       stylelint-config-recommended-scss:
         specifier: ^17.0.1
-        version: 17.0.1(postcss@8.5.19)(stylelint@16.26.1(typescript@6.0.3))
+        version: 17.0.1(postcss@8.5.19)(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       stylelint-config-standard:
         specifier: ^36.0.1
-        version: 36.0.1(stylelint@16.26.1(typescript@6.0.3))
+        version: 36.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       stylelint-scales:
         specifier: ^5.0.0
         version: 5.0.0(postcss@8.5.19)
       stylelint-scss:
         specifier: ^7.2.0
-        version: 7.2.0(stylelint@16.26.1(typescript@6.0.3))
+        version: 7.2.0(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       terser-webpack-plugin:
         specifier: ^5.3.14
-        version: 5.6.1(postcss@8.5.19)(webpack@5.108.4(postcss@8.5.19))
+        version: 5.6.1(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       testem-failure-only-reporter:
         specifier: ^1.0.0
-        version: 1.0.0(@babel/core@7.29.7)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+        version: 1.0.0(@babel/core@7.29.7(supports-color@8.1.1))(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
       tracked-built-ins:
         specifier: ^3.4.0
-        version: 3.4.0(@babel/core@7.29.7)
+        version: 3.4.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       validator:
         specifier: ^13.12.0
         version: 13.15.35
       webpack:
         specifier: ^5.104.1
-        version: 5.108.4(postcss@8.5.19)
+        version: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
       webpack-bundle-analyzer:
         specifier: ^5.1.1
         version: 5.3.1
       webpack-retry-chunk-load-plugin:
         specifier: ^3.0.0
-        version: 3.1.1(webpack@5.108.4(postcss@8.5.19))
+        version: 3.1.1(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       yup:
         specifier: ^1.4.0
         version: 1.7.1
@@ -552,19 +558,19 @@ importers:
         version: 4.0.1
       '@ember/test-waiters':
         specifier: ^4.0.0
-        version: 4.1.2
+        version: 4.1.2(supports-color@8.1.1)
       '@embroider/macros':
         specifier: ^1.19.6
-        version: 1.20.5(@babel/core@7.29.7)
+        version: 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/util':
         specifier: ^1.13.0
-        version: 1.13.5(@babel/core@7.29.7)(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 1.13.5(@babel/core@7.29.7(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)
       '@fontsource-variable/nunito':
         specifier: ^5.2.7
         version: 5.2.7
       '@fortawesome/ember-fontawesome':
         specifier: ^3.1.0
-        version: 3.1.0(@babel/core@7.29.7)(@fortawesome/fontawesome-svg-core@6.7.2)(@glimmer/component@2.1.1)
+        version: 3.1.0(@babel/core@7.29.7(supports-color@8.1.1))(@fortawesome/fontawesome-svg-core@6.7.2)(@glimmer/component@2.1.1(supports-color@8.1.1))(supports-color@8.1.1)
       '@fortawesome/fontawesome-svg-core':
         specifier: 6.7.2
         version: 6.7.2
@@ -576,7 +582,7 @@ importers:
         version: 6.7.2
       '@glimmer/component':
         specifier: ^2.0.0
-        version: 2.1.1
+        version: 2.1.1(supports-color@8.1.1)
       '@glimmer/tracking':
         specifier: ^1.1.2
         version: 1.1.2
@@ -594,88 +600,88 @@ importers:
         version: 2.1.1
       broccoli-funnel:
         specifier: ^3.0.0
-        version: 3.0.8
+        version: 3.0.8(supports-color@8.1.1)
       broccoli-merge-trees:
         specifier: ^4.0.0
-        version: 4.2.0
+        version: 4.2.0(supports-color@8.1.1)
       color:
         specifier: ^5.0.0
         version: 5.0.3
       ember-async-data:
         specifier: ^2.0.0
-        version: 2.0.1(@babel/core@7.29.7)
+        version: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-auto-import:
         specifier: ^2.12.0
-        version: 2.13.1(webpack@5.108.4(postcss@8.5.19))
+        version: 2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       ember-cli-babel:
         specifier: ^8.2.0
-        version: 8.3.1(@babel/core@7.29.7)
+        version: 8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-flash:
         specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.29.7)(@embroider/macros@1.20.5(@babel/core@7.29.7))(ember-modifier@4.2.2(@babel/core@7.29.7))
+        version: 7.0.0(@babel/core@7.29.7(supports-color@8.1.1))(@embroider/macros@1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(ember-modifier@4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-htmlbars:
         specifier: ^6.3.0
-        version: 6.3.0
+        version: 6.3.0(supports-color@8.1.1)
       ember-cli-page-object:
         specifier: ^2.3.0
-        version: 2.3.2(@ember/test-helpers@5.4.3(@babel/core@7.29.7))
+        version: 2.3.2(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       ember-click-outside:
         specifier: ^6.0.0
-        version: 6.1.1(@babel/core@7.29.7)
+        version: 6.1.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-concurrency:
         specifier: ^5.1.0
-        version: 5.2.0(@babel/core@7.29.7)
+        version: 5.2.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-file-upload:
         specifier: ^10.0.0
-        version: 10.1.0(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(@glimmer/component@2.1.1)(ember-modifier@4.2.2(@babel/core@7.29.7))(tracked-built-ins@3.4.0(@babel/core@7.29.7))
+        version: 10.1.0(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@glimmer/component@2.1.1(supports-color@8.1.1))(ember-modifier@4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)(tracked-built-ins@3.4.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))
       ember-focus-trap:
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.29.7)
+        version: 2.0.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-in-element-polyfill:
         specifier: ^1.0.0
-        version: 1.0.1
+        version: 1.0.1(supports-color@8.1.1)
       ember-in-viewport:
         specifier: ^4.0.0
-        version: 4.1.0(@babel/core@7.29.7)(webpack@5.108.4(postcss@8.5.19))
+        version: 4.1.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       ember-inflector:
         specifier: ^5.0.2
-        version: 5.0.2(@babel/core@7.29.7)
+        version: 5.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-intl:
         specifier: ^8.2.1
-        version: 8.3.0(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7))
+        version: 8.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       ember-keyboard:
         specifier: ^9.0.4
-        version: 9.0.4(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7))
+        version: 9.0.4(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       ember-math-helpers:
         specifier: ^5.0.0
-        version: 5.0.0(@babel/core@7.29.7)(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 5.0.0(@babel/core@7.29.7(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)
       ember-modifier:
         specifier: ^4.0.0
-        version: 4.2.2(@babel/core@7.29.7)
+        version: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-popper-modifier:
         specifier: ^4.1.0
-        version: 4.1.1(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.108.4(postcss@8.5.19))
+        version: 4.1.1(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       ember-primitives:
         specifier: ^0.59.1
-        version: 0.59.1(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(@ember/test-waiters@4.1.2)(@glimmer/component@2.1.1)(ember-modifier@4.2.2(@babel/core@7.29.7))(ember-resources@7.1.0(@glimmer/component@2.1.1))
+        version: 0.59.1(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(@glimmer/component@2.1.1(supports-color@8.1.1))(ember-modifier@4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(ember-resources@7.1.0(@glimmer/component@2.1.1(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       ember-set-helper:
         specifier: ^3.1.0
-        version: 3.1.0(@babel/core@7.29.7)
+        version: 3.1.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-simple-auth:
         specifier: ^8.0.0
-        version: 8.3.1(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 8.3.1(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)
       ember-simple-charts:
         specifier: ^12.2.2
-        version: 12.2.2(@babel/core@7.29.7)(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.108.4(postcss@8.5.19))
+        version: 12.2.2(@babel/core@7.29.7(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       ember-template-imports:
         specifier: ^4.4.0
-        version: 4.4.0
+        version: 4.4.0(supports-color@8.1.1)
       ember-test-selectors:
         specifier: ^7.0.0
-        version: 7.1.0
+        version: 7.1.0(supports-color@8.1.1)
       ember-truth-helpers:
         specifier: ^5.0.0
-        version: 5.0.0
+        version: 5.0.0(supports-color@8.1.1)
       flatpickr:
         specifier: '>= 4.0.0'
         version: 4.6.13
@@ -718,112 +724,118 @@ importers:
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.28.6
-        version: 7.29.7(@babel/core@7.29.7)(eslint@9.39.5)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))
       '@babel/plugin-proposal-decorators':
         specifier: ^7.28.6
-        version: 7.29.7(@babel/core@7.29.7)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/adapter':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/json-api':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/legacy-compat':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/model':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/request':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/request-utils':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(ember-inflector@5.0.2(@babel/core@7.29.7))
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(ember-inflector@5.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/serializer':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/store':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-intl/lint':
         specifier: ^1.0.0
         version: 1.4.0
       '@ember/optional-features':
         specifier: ^2.3.0
-        version: 2.3.0
+        version: 2.3.0(supports-color@8.1.1)
       '@ember/test-helpers':
         specifier: ^5.4.1
-        version: 5.4.3(@babel/core@7.29.7)
+        version: 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/test-setup':
         specifier: ^4.0.0
-        version: 4.0.0(@embroider/compat@3.8.5(@embroider/core@3.5.10))(@embroider/core@3.5.10)(@embroider/webpack@4.1.2(@embroider/core@3.5.10)(webpack@5.108.4(postcss@8.5.19)))
+        version: 4.0.0(@embroider/compat@3.8.5(@embroider/core@3.5.10(supports-color@8.1.1))(supports-color@8.1.1))(@embroider/core@3.5.10(supports-color@8.1.1))(@embroider/webpack@4.1.2(@embroider/core@3.5.10(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)))
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.5
+      '@html-eslint/eslint-plugin':
+        specifier: ^0.64.0
+        version: 0.64.0(eslint@9.39.5(supports-color@8.1.1))
+      '@html-eslint/parser':
+        specifier: ^0.64.0
+        version: 0.64.0
       '@warp-drive/build-config':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@warp-drive/core-types':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@warp-drive/ember':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)
       broccoli-asset-rev:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(supports-color@8.1.1)
       ember-cli:
         specifier: ~6.10.0
-        version: 6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+        version: 6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
       ember-cli-dependency-checker:
         specifier: ^3.3.3
-        version: 3.3.3(ember-cli@6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8))
+        version: 3.3.3(ember-cli@6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8))
       ember-cli-deprecation-workflow:
         specifier: ^4.0.0
-        version: 4.0.1(@babel/core@7.29.7)
+        version: 4.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-inject-live-reload:
         specifier: ^2.1.0
         version: 2.1.0
       ember-cli-sass:
         specifier: 11.0.1
-        version: 11.0.1
+        version: 11.0.1(supports-color@8.1.1)
       ember-cli-terser:
         specifier: ^4.0.2
-        version: 4.0.2
+        version: 4.0.2(supports-color@8.1.1)
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))
       ember-page-title:
         specifier: ^9.0.3
-        version: 9.0.3
+        version: 9.0.3(supports-color@8.1.1)
       ember-resolver:
         specifier: ^13.1.1
         version: 13.2.0
       ember-source:
         specifier: ~6.10.0
-        version: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+        version: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
       ember-template-lint:
         specifier: ^6.1.0
-        version: 6.1.0
+        version: 6.1.0(supports-color@8.1.1)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.5
+        version: 9.39.5(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: ^9.1.2
-        version: 9.1.2(eslint@9.39.5)
+        version: 9.1.2(eslint@9.39.5(supports-color@8.1.1))
       eslint-plugin-ember:
         specifier: ^12.7.5
-        version: 12.7.5(@babel/core@7.29.7)(eslint@9.39.5)(typescript@6.0.3)
+        version: 12.7.5(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3)
       eslint-plugin-n:
         specifier: ^17.23.2
-        version: 17.24.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 17.24.0(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3)
       eslint-plugin-qunit:
         specifier: ^8.2.5
-        version: 8.2.6(eslint@9.39.5)
+        version: 8.2.6(eslint@9.39.5(supports-color@8.1.1))
       eslint-plugin-yml:
         specifier: ^3.1.2
-        version: 3.6.0(eslint@9.39.5)
+        version: 3.6.0(eslint@9.39.5(supports-color@8.1.1))
       globals:
         specifier: ^15.15.0
         version: 15.15.0
@@ -835,7 +847,7 @@ importers:
         version: 3.9.5
       prettier-plugin-ember-template-tag:
         specifier: ^2.1.2
-        version: 2.1.7(prettier@3.9.5)
+        version: 2.1.7(prettier@3.9.5)(supports-color@8.1.1)
       qs:
         specifier: ^6.15.2
         version: 6.15.3
@@ -844,25 +856,25 @@ importers:
         version: 1.101.0
       stylelint:
         specifier: ^16.26.1
-        version: 16.26.1(typescript@6.0.3)
+        version: 16.26.1(supports-color@8.1.1)(typescript@6.0.3)
       stylelint-config-recommended-scss:
         specifier: ^17.0.1
-        version: 17.0.1(postcss@8.5.19)(stylelint@16.26.1(typescript@6.0.3))
+        version: 17.0.1(postcss@8.5.19)(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       stylelint-config-standard:
         specifier: ^36.0.1
-        version: 36.0.1(stylelint@16.26.1(typescript@6.0.3))
+        version: 36.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       stylelint-scales:
         specifier: ^5.0.0
         version: 5.0.0(postcss@8.5.19)
       stylelint-scss:
         specifier: ^7.2.0
-        version: 7.2.0(stylelint@16.26.1(typescript@6.0.3))
+        version: 7.2.0(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       tracked-built-ins:
         specifier: ^3.1.1
-        version: 3.4.0(@babel/core@7.29.7)
+        version: 3.4.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       webpack:
         specifier: ^5.104.1
-        version: 5.108.4(postcss@8.5.19)
+        version: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
   packages/lti-course-manager:
     devDependencies:
@@ -871,88 +883,94 @@ importers:
         version: 7.29.7(supports-color@8.1.1)
       '@babel/eslint-parser':
         specifier: ^7.28.6
-        version: 7.29.7(@babel/core@7.29.7)(eslint@9.39.5)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))
       '@babel/plugin-proposal-decorators':
         specifier: ^7.28.6
-        version: 7.29.7(@babel/core@7.29.7)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/adapter':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/json-api':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/legacy-compat':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/model':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/request':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/request-utils':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(ember-inflector@5.0.2(@babel/core@7.29.7))
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(ember-inflector@5.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/serializer':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/store':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-intl/lint':
         specifier: ^1.0.0
         version: 1.4.0
       '@ember-intl/v1-compat':
         specifier: ^1.0.5
-        version: 1.2.2(webpack@5.108.4(postcss@8.5.19))
+        version: 1.2.2(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       '@ember/optional-features':
         specifier: ^2.3.0
-        version: 2.3.0
+        version: 2.3.0(supports-color@8.1.1)
       '@ember/string':
         specifier: ^4.0.1
         version: 4.0.1
       '@ember/test-helpers':
         specifier: ^5.4.1
-        version: 5.4.3(@babel/core@7.29.7)
+        version: 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/compat':
         specifier: ~3.8.0
-        version: 3.8.5(@embroider/core@3.5.10)
+        version: 3.8.5(@embroider/core@3.5.10(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/core':
         specifier: ~3.5.0
-        version: 3.5.10
+        version: 3.5.10(supports-color@8.1.1)
       '@embroider/macros':
         specifier: ^1.19.6
-        version: 1.20.5(@babel/core@7.29.7)
+        version: 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/webpack':
         specifier: ~4.1.0
-        version: 4.1.2(@embroider/core@3.5.10)(webpack@5.108.4(postcss@8.5.19))
+        version: 4.1.2(@embroider/core@3.5.10(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.5
       '@glimmer/component':
         specifier: ^2.0.0
-        version: 2.1.1
+        version: 2.1.1(supports-color@8.1.1)
       '@glimmer/tracking':
         specifier: ^1.1.2
         version: 1.1.2
+      '@html-eslint/eslint-plugin':
+        specifier: ^0.64.0
+        version: 0.64.0(eslint@9.39.5(supports-color@8.1.1))
+      '@html-eslint/parser':
+        specifier: ^0.64.0
+        version: 0.64.0
       '@warp-drive/build-config':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@warp-drive/core-types':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@warp-drive/ember':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)
       broccoli-asset-rev:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(supports-color@8.1.1)
       broccoli-file-creator:
         specifier: ^2.1.1
         version: 2.1.1
       broccoli-merge-trees:
         specifier: ^4.2.0
-        version: 4.2.0
+        version: 4.2.0(supports-color@8.1.1)
       browserslist:
         specifier: ^4.26.3
         version: 4.28.6
@@ -961,88 +979,88 @@ importers:
         version: 1.0.30001805
       ember-auto-import:
         specifier: ^2.12.0
-        version: 2.13.1(webpack@5.108.4(postcss@8.5.19))
+        version: 2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       ember-cli:
         specifier: ~6.10.0
-        version: 6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+        version: 6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
       ember-cli-app-version:
         specifier: ^7.0.0
-        version: 7.0.0(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 7.0.0(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-babel:
         specifier: ^8.2.0
-        version: 8.3.1(@babel/core@7.29.7)
+        version: 8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-dependency-checker:
         specifier: ^3.3.3
-        version: 3.3.3(ember-cli@6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8))
+        version: 3.3.3(ember-cli@6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8))
       ember-cli-dependency-lint:
         specifier: 2.0.1
         version: 2.0.1
       ember-cli-deploy:
         specifier: ^2.0.0
-        version: 2.0.0
+        version: 2.0.0(supports-color@8.1.1)
       ember-cli-deploy-aws-pack:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(supports-color@8.1.1)
       ember-cli-deprecation-workflow:
         specifier: ^4.0.0
-        version: 4.0.1(@babel/core@7.29.7)
+        version: 4.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-htmlbars:
         specifier: ^6.3.0
-        version: 6.3.0
+        version: 6.3.0(supports-color@8.1.1)
       ember-cli-inject-live-reload:
         specifier: ^2.1.0
         version: 2.1.0
       ember-cli-sass:
         specifier: ^11.0.1
-        version: 11.0.1
+        version: 11.0.1(supports-color@8.1.1)
       ember-cli-terser:
         specifier: ^4.0.2
-        version: 4.0.2
+        version: 4.0.2(supports-color@8.1.1)
       ember-exam:
         specifier: ^10.0.0
-        version: 10.1.0(ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0))(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.26.0)(webpack@5.108.4(postcss@8.5.19))
+        version: 10.1.0(ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))
       ember-modifier:
         specifier: 4.2.2
-        version: 4.2.2(@babel/core@7.29.7)
+        version: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-page-title:
         specifier: ^9.0.3
-        version: 9.0.3
+        version: 9.0.3(supports-color@8.1.1)
       ember-qunit:
         specifier: ^9.0.4
-        version: 9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0)
+        version: 9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1)
       ember-resolver:
         specifier: ^13.1.1
         version: 13.2.0
       ember-source:
         specifier: ~6.10.0
-        version: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+        version: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
       ember-template-imports:
         specifier: ^4.4.0
-        version: 4.4.0
+        version: 4.4.0(supports-color@8.1.1)
       ember-template-lint:
         specifier: ^6.1.0
-        version: 6.1.0
+        version: 6.1.0(supports-color@8.1.1)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.5
+        version: 9.39.5(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: ^9.1.2
-        version: 9.1.2(eslint@9.39.5)
+        version: 9.1.2(eslint@9.39.5(supports-color@8.1.1))
       eslint-plugin-ember:
         specifier: ^12.7.5
-        version: 12.7.5(@babel/core@7.29.7)(eslint@9.39.5)(typescript@6.0.3)
+        version: 12.7.5(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3)
       eslint-plugin-n:
         specifier: ^17.23.2
-        version: 17.24.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 17.24.0(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3)
       eslint-plugin-qunit:
         specifier: ^8.2.5
-        version: 8.2.6(eslint@9.39.5)
+        version: 8.2.6(eslint@9.39.5(supports-color@8.1.1))
       eslint-plugin-yml:
         specifier: ^3.1.2
-        version: 3.6.0(eslint@9.39.5)
+        version: 3.6.0(eslint@9.39.5(supports-color@8.1.1))
       globals:
         specifier: ^15.15.0
         version: 15.15.0
@@ -1060,7 +1078,7 @@ importers:
         version: 3.9.5
       prettier-plugin-ember-template-tag:
         specifier: ^2.1.2
-        version: 2.1.7(prettier@3.9.5)
+        version: 2.1.7(prettier@3.9.5)(supports-color@8.1.1)
       quill:
         specifier: ^2.0.3
         version: 2.0.3
@@ -1075,28 +1093,28 @@ importers:
         version: 1.101.0
       stylelint:
         specifier: ^16.26.1
-        version: 16.26.1(typescript@6.0.3)
+        version: 16.26.1(supports-color@8.1.1)(typescript@6.0.3)
       stylelint-config-recommended-scss:
         specifier: ^17.0.1
-        version: 17.0.1(postcss@8.5.19)(stylelint@16.26.1(typescript@6.0.3))
+        version: 17.0.1(postcss@8.5.19)(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       stylelint-config-standard:
         specifier: ^36.0.1
-        version: 36.0.1(stylelint@16.26.1(typescript@6.0.3))
+        version: 36.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       stylelint-scales:
         specifier: ^5.0.0
         version: 5.0.0(postcss@8.5.19)
       stylelint-scss:
         specifier: ^7.2.0
-        version: 7.2.0(stylelint@16.26.1(typescript@6.0.3))
+        version: 7.2.0(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       testem-failure-only-reporter:
         specifier: ^1.0.0
-        version: 1.0.0(@babel/core@7.29.7)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+        version: 1.0.0(@babel/core@7.29.7(supports-color@8.1.1))(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
       tracked-built-ins:
         specifier: ^3.4.0
-        version: 3.4.0(@babel/core@7.29.7)
+        version: 3.4.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       webpack:
         specifier: ^5.104.1
-        version: 5.108.4(postcss@8.5.19)
+        version: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
   packages/lti-dashboard:
     devDependencies:
@@ -1105,85 +1123,91 @@ importers:
         version: 7.29.7(supports-color@8.1.1)
       '@babel/eslint-parser':
         specifier: ^7.28.6
-        version: 7.29.7(@babel/core@7.29.7)(eslint@9.39.5)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))
       '@babel/plugin-proposal-decorators':
         specifier: ^7.28.6
-        version: 7.29.7(@babel/core@7.29.7)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/adapter':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/json-api':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/legacy-compat':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/model':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/request':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/request-utils':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(ember-inflector@5.0.2(@babel/core@7.29.7))
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(ember-inflector@5.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/serializer':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/store':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-intl/lint':
         specifier: ^1.0.0
         version: 1.4.0
       '@ember-intl/v1-compat':
         specifier: ^1.0.5
-        version: 1.2.2(webpack@5.108.4(postcss@8.5.19))
+        version: 1.2.2(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       '@ember/optional-features':
         specifier: ^2.3.0
-        version: 2.3.0
+        version: 2.3.0(supports-color@8.1.1)
       '@ember/string':
         specifier: ^4.0.1
         version: 4.0.1
       '@ember/test-helpers':
         specifier: ^5.4.1
-        version: 5.4.3(@babel/core@7.29.7)
+        version: 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/compat':
         specifier: ~3.8.0
-        version: 3.8.5(@embroider/core@3.5.10)
+        version: 3.8.5(@embroider/core@3.5.10(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/macros':
         specifier: ^1.19.6
-        version: 1.20.5(@babel/core@7.29.7)
+        version: 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/webpack':
         specifier: ~4.1.0
-        version: 4.1.2(@embroider/core@3.5.10)(webpack@5.108.4(postcss@8.5.19))
+        version: 4.1.2(@embroider/core@3.5.10(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.5
       '@glimmer/component':
         specifier: ^2.0.0
-        version: 2.1.1
+        version: 2.1.1(supports-color@8.1.1)
       '@glimmer/tracking':
         specifier: ^1.1.2
         version: 1.1.2
+      '@html-eslint/eslint-plugin':
+        specifier: ^0.64.0
+        version: 0.64.0(eslint@9.39.5(supports-color@8.1.1))
+      '@html-eslint/parser':
+        specifier: ^0.64.0
+        version: 0.64.0
       '@warp-drive/build-config':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@warp-drive/core-types':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@warp-drive/ember':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)
       broccoli-asset-rev:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(supports-color@8.1.1)
       broccoli-file-creator:
         specifier: ^2.1.1
         version: 2.1.1
       broccoli-merge-trees:
         specifier: ^4.2.0
-        version: 4.2.0
+        version: 4.2.0(supports-color@8.1.1)
       browserslist:
         specifier: ^4.26.3
         version: 4.28.6
@@ -1192,88 +1216,88 @@ importers:
         version: 1.0.30001805
       ember-auto-import:
         specifier: ^2.12.0
-        version: 2.13.1(webpack@5.108.4(postcss@8.5.19))
+        version: 2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       ember-cli:
         specifier: ~6.10.0
-        version: 6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+        version: 6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
       ember-cli-app-version:
         specifier: ^7.0.0
-        version: 7.0.0(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 7.0.0(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-babel:
         specifier: ^8.2.0
-        version: 8.3.1(@babel/core@7.29.7)
+        version: 8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-dependency-checker:
         specifier: ^3.3.3
-        version: 3.3.3(ember-cli@6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8))
+        version: 3.3.3(ember-cli@6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8))
       ember-cli-dependency-lint:
         specifier: 2.0.1
         version: 2.0.1
       ember-cli-deploy:
         specifier: ^2.0.0
-        version: 2.0.0
+        version: 2.0.0(supports-color@8.1.1)
       ember-cli-deploy-aws-pack:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(supports-color@8.1.1)
       ember-cli-deprecation-workflow:
         specifier: ^4.0.0
-        version: 4.0.1(@babel/core@7.29.7)
+        version: 4.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-htmlbars:
         specifier: ^6.3.0
-        version: 6.3.0
+        version: 6.3.0(supports-color@8.1.1)
       ember-cli-inject-live-reload:
         specifier: ^2.1.0
         version: 2.1.0
       ember-cli-sass:
         specifier: ^11.0.1
-        version: 11.0.1
+        version: 11.0.1(supports-color@8.1.1)
       ember-cli-terser:
         specifier: ^4.0.2
-        version: 4.0.2
+        version: 4.0.2(supports-color@8.1.1)
       ember-exam:
         specifier: ^10.0.0
-        version: 10.1.0(ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0))(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.26.0)(webpack@5.108.4(postcss@8.5.19))
+        version: 10.1.0(ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))
       ember-modifier:
         specifier: 4.2.2
-        version: 4.2.2(@babel/core@7.29.7)
+        version: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-page-title:
         specifier: ^9.0.3
-        version: 9.0.3
+        version: 9.0.3(supports-color@8.1.1)
       ember-qunit:
         specifier: ^9.0.4
-        version: 9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0)
+        version: 9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1)
       ember-resolver:
         specifier: ^13.1.1
         version: 13.2.0
       ember-source:
         specifier: ~6.10.0
-        version: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+        version: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
       ember-template-imports:
         specifier: ^4.4.0
-        version: 4.4.0
+        version: 4.4.0(supports-color@8.1.1)
       ember-template-lint:
         specifier: ^6.1.0
-        version: 6.1.0
+        version: 6.1.0(supports-color@8.1.1)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.5
+        version: 9.39.5(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: ^9.1.2
-        version: 9.1.2(eslint@9.39.5)
+        version: 9.1.2(eslint@9.39.5(supports-color@8.1.1))
       eslint-plugin-ember:
         specifier: ^12.7.5
-        version: 12.7.5(@babel/core@7.29.7)(eslint@9.39.5)(typescript@6.0.3)
+        version: 12.7.5(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3)
       eslint-plugin-n:
         specifier: ^17.23.2
-        version: 17.24.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 17.24.0(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3)
       eslint-plugin-qunit:
         specifier: ^8.2.5
-        version: 8.2.6(eslint@9.39.5)
+        version: 8.2.6(eslint@9.39.5(supports-color@8.1.1))
       eslint-plugin-yml:
         specifier: ^3.1.2
-        version: 3.6.0(eslint@9.39.5)
+        version: 3.6.0(eslint@9.39.5(supports-color@8.1.1))
       globals:
         specifier: ^15.15.0
         version: 15.15.0
@@ -1291,7 +1315,7 @@ importers:
         version: 3.9.5
       prettier-plugin-ember-template-tag:
         specifier: ^2.1.2
-        version: 2.1.7(prettier@3.9.5)
+        version: 2.1.7(prettier@3.9.5)(supports-color@8.1.1)
       quill:
         specifier: ^2.0.3
         version: 2.0.3
@@ -1306,28 +1330,28 @@ importers:
         version: 1.101.0
       stylelint:
         specifier: ^16.26.1
-        version: 16.26.1(typescript@6.0.3)
+        version: 16.26.1(supports-color@8.1.1)(typescript@6.0.3)
       stylelint-config-recommended-scss:
         specifier: ^17.0.1
-        version: 17.0.1(postcss@8.5.19)(stylelint@16.26.1(typescript@6.0.3))
+        version: 17.0.1(postcss@8.5.19)(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       stylelint-config-standard:
         specifier: ^36.0.1
-        version: 36.0.1(stylelint@16.26.1(typescript@6.0.3))
+        version: 36.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       stylelint-scales:
         specifier: ^5.0.0
         version: 5.0.0(postcss@8.5.19)
       stylelint-scss:
         specifier: ^7.2.0
-        version: 7.2.0(stylelint@16.26.1(typescript@6.0.3))
+        version: 7.2.0(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       testem-failure-only-reporter:
         specifier: ^1.0.0
-        version: 1.0.0(@babel/core@7.29.7)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+        version: 1.0.0(@babel/core@7.29.7(supports-color@8.1.1))(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
       tracked-built-ins:
         specifier: ^3.4.0
-        version: 3.4.0(@babel/core@7.29.7)
+        version: 3.4.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       webpack:
         specifier: ^5.104.1
-        version: 5.108.4(postcss@8.5.19)
+        version: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
   packages/test-app:
     devDependencies:
@@ -1336,166 +1360,172 @@ importers:
         version: 7.29.7(supports-color@8.1.1)
       '@babel/eslint-parser':
         specifier: ^7.28.6
-        version: 7.29.7(@babel/core@7.29.7)(eslint@9.39.5)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))
       '@babel/plugin-proposal-decorators':
         specifier: ^7.28.6
-        version: 7.29.7(@babel/core@7.29.7)
+        version: 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/adapter':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/json-api':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/legacy-compat':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/model':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/request':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/request-utils':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(ember-inflector@5.0.2(@babel/core@7.29.7))
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(ember-inflector@5.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/serializer':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-data/store':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)
       '@ember-intl/lint':
         specifier: ^1.0.0
         version: 1.4.0
       '@ember-intl/v1-compat':
         specifier: ^1.0.5
-        version: 1.2.2(webpack@5.108.4(postcss@8.5.19))
+        version: 1.2.2(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       '@ember/optional-features':
         specifier: ^2.3.0
-        version: 2.3.0
+        version: 2.3.0(supports-color@8.1.1)
       '@ember/string':
         specifier: ^4.0.1
         version: 4.0.1
       '@ember/test-helpers':
         specifier: ^5.4.1
-        version: 5.4.3(@babel/core@7.29.7)
+        version: 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/compat':
         specifier: ^3.8.0
-        version: 3.8.5(@embroider/core@3.5.10)
+        version: 3.8.5(@embroider/core@3.5.10(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/macros':
         specifier: ^1.19.6
-        version: 1.20.5(@babel/core@7.29.7)
+        version: 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/test-setup':
         specifier: ^4.0.0
-        version: 4.0.0(@embroider/compat@3.8.5(@embroider/core@3.5.10))(@embroider/core@3.5.10)(@embroider/webpack@4.1.2(@embroider/core@3.5.10)(webpack@5.108.4(postcss@8.5.19)))
+        version: 4.0.0(@embroider/compat@3.8.5(@embroider/core@3.5.10(supports-color@8.1.1))(supports-color@8.1.1))(@embroider/core@3.5.10(supports-color@8.1.1))(@embroider/webpack@4.1.2(@embroider/core@3.5.10(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)))
       '@embroider/webpack':
         specifier: ~4.1.0
-        version: 4.1.2(@embroider/core@3.5.10)(webpack@5.108.4(postcss@8.5.19))
+        version: 4.1.2(@embroider/core@3.5.10(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.5
       '@glimmer/component':
         specifier: ^2.0.0
-        version: 2.1.1
+        version: 2.1.1(supports-color@8.1.1)
       '@glimmer/tracking':
         specifier: ^1.1.2
         version: 1.1.2
+      '@html-eslint/eslint-plugin':
+        specifier: ^0.64.0
+        version: 0.64.0(eslint@9.39.5(supports-color@8.1.1))
+      '@html-eslint/parser':
+        specifier: ^0.64.0
+        version: 0.64.0
       '@warp-drive/build-config':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@warp-drive/core-types':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@warp-drive/ember':
         specifier: ~5.8.1
-        version: 5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)
+        version: 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)
       axe-core:
         specifier: ^4.12.0
         version: 4.12.1
       broccoli-asset-rev:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(supports-color@8.1.1)
       ember-a11y-testing:
         specifier: ^8.0.0
-        version: 8.0.1(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(@ember/test-waiters@4.1.2)(axe-core@4.12.1)(qunit@2.26.0)
+        version: 8.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(axe-core@4.12.1)(qunit@2.26.0)(supports-color@8.1.1)
       ember-auto-import:
         specifier: ^2.12.0
-        version: 2.13.1(webpack@5.108.4(postcss@8.5.19))
+        version: 2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       ember-cli:
         specifier: ~6.10.0
-        version: 6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+        version: 6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
       ember-cli-app-version:
         specifier: ^7.0.0
-        version: 7.0.0(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 7.0.0(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-babel:
         specifier: ^8.2.0
-        version: 8.3.1(@babel/core@7.29.7)
+        version: 8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-dependency-checker:
         specifier: ^3.3.3
-        version: 3.3.3(ember-cli@6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8))
+        version: 3.3.3(ember-cli@6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8))
       ember-cli-deprecation-workflow:
         specifier: ^4.0.0
-        version: 4.0.1(@babel/core@7.29.7)
+        version: 4.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-htmlbars:
         specifier: ^6.3.0
-        version: 6.3.0
+        version: 6.3.0(supports-color@8.1.1)
       ember-cli-inject-live-reload:
         specifier: ^2.1.0
         version: 2.1.0
       ember-cli-sass:
         specifier: 11.0.1
-        version: 11.0.1
+        version: 11.0.1(supports-color@8.1.1)
       ember-cli-terser:
         specifier: ^4.0.2
-        version: 4.0.2
+        version: 4.0.2(supports-color@8.1.1)
       ember-concurrency:
         specifier: ^5.1.0
-        version: 5.2.0(@babel/core@7.29.7)
+        version: 5.2.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-exam:
         specifier: ^10.0.0
-        version: 10.1.0(ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0))(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.26.0)(webpack@5.108.4(postcss@8.5.19))
+        version: 10.1.0(ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))
       ember-modifier:
         specifier: 4.2.2
-        version: 4.2.2(@babel/core@7.29.7)
+        version: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-page-title:
         specifier: ^9.0.3
-        version: 9.0.3
+        version: 9.0.3(supports-color@8.1.1)
       ember-qunit:
         specifier: ^9.0.4
-        version: 9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0)
+        version: 9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1)
       ember-resolver:
         specifier: ^13.1.1
         version: 13.2.0
       ember-source:
         specifier: ~6.10.0
-        version: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+        version: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
       ember-template-imports:
         specifier: ^4.4.0
-        version: 4.4.0
+        version: 4.4.0(supports-color@8.1.1)
       ember-template-lint:
         specifier: ^6.1.0
-        version: 6.1.0
+        version: 6.1.0(supports-color@8.1.1)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.5
+        version: 9.39.5(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: ^9.1.2
-        version: 9.1.2(eslint@9.39.5)
+        version: 9.1.2(eslint@9.39.5(supports-color@8.1.1))
       eslint-plugin-ember:
         specifier: ^12.7.5
-        version: 12.7.5(@babel/core@7.29.7)(eslint@9.39.5)(typescript@6.0.3)
+        version: 12.7.5(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3)
       eslint-plugin-n:
         specifier: ^17.23.2
-        version: 17.24.0(eslint@9.39.5)(typescript@6.0.3)
+        version: 17.24.0(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3)
       eslint-plugin-qunit:
         specifier: ^8.2.5
-        version: 8.2.6(eslint@9.39.5)
+        version: 8.2.6(eslint@9.39.5(supports-color@8.1.1))
       eslint-plugin-yml:
         specifier: ^3.1.2
-        version: 3.6.0(eslint@9.39.5)
+        version: 3.6.0(eslint@9.39.5(supports-color@8.1.1))
       globals:
         specifier: ^15.15.0
         version: 15.15.0
@@ -1516,7 +1546,7 @@ importers:
         version: 3.9.5
       prettier-plugin-ember-template-tag:
         specifier: ^2.1.2
-        version: 2.1.7(prettier@3.9.5)
+        version: 2.1.7(prettier@3.9.5)(supports-color@8.1.1)
       query-string:
         specifier: '>= 9.1.0'
         version: 9.4.1
@@ -1531,28 +1561,28 @@ importers:
         version: 3.6.0
       stylelint:
         specifier: ^16.26.1
-        version: 16.26.1(typescript@6.0.3)
+        version: 16.26.1(supports-color@8.1.1)(typescript@6.0.3)
       stylelint-config-recommended-scss:
         specifier: ^17.0.1
-        version: 17.0.1(postcss@8.5.19)(stylelint@16.26.1(typescript@6.0.3))
+        version: 17.0.1(postcss@8.5.19)(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       stylelint-config-standard:
         specifier: ^36.0.1
-        version: 36.0.1(stylelint@16.26.1(typescript@6.0.3))
+        version: 36.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       stylelint-scales:
         specifier: ^5.0.0
         version: 5.0.0(postcss@8.5.19)
       stylelint-scss:
         specifier: ^7.2.0
-        version: 7.2.0(stylelint@16.26.1(typescript@6.0.3))
+        version: 7.2.0(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
       testem-failure-only-reporter:
         specifier: ^1.0.0
-        version: 1.0.0(@babel/core@7.29.7)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+        version: 1.0.0(@babel/core@7.29.7(supports-color@8.1.1))(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
       tracked-built-ins:
         specifier: ^3.4.0
-        version: 3.4.0(@babel/core@7.29.7)
+        version: 3.4.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       webpack:
         specifier: ^5.104.1
-        version: 5.108.4(postcss@8.5.19)
+        version: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
 packages:
 
@@ -2699,6 +2729,28 @@ packages:
     resolution: {integrity: sha512-n/SZW+12rwikx/f8YcSv9JCi5p9vn1Bnts9ZtVvfErG4h0gbjHI1H1ZMhVUnaOC7yzFc6PtsCKIK8XeTnL90Gw==}
     engines: {node: ^18 || ^20 || ^22 || >=24}
 
+  '@html-eslint/core@0.64.0':
+    resolution: {integrity: sha512-Iz5x4jRDmcmpdYsYjcw213J/pXZjB8RZ7wIpAmtqGuf7IJX2JwyhfJvTqvuSFYtvHKMMl7Jt0LzmmTklaMuFsQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@html-eslint/eslint-plugin@0.64.0':
+    resolution: {integrity: sha512-Il2z0Pd28/NrHtgALeHiB6uGxRLxxh7WGAOo9k1x18hzN8ibzVXMvswODE3SDrxIzNS2CLJHtqd4VXjU77lL9w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=8.0.0 || ^10.0.0-0'
+
+  '@html-eslint/parser@0.64.0':
+    resolution: {integrity: sha512-DHRfli8lMagO/JwTbg+O5UwDUX2fkNw120BprpPMooVpDIjpi8lv+SK5WzKKW/Dt8j+KRwX3XgTg4ljaYk6tlw==}
+
+  '@html-eslint/template-parser@0.64.0':
+    resolution: {integrity: sha512-sFtxhC6prn50D3bkhV38DGl1BH3iyyONNM4VTbXGpE6AMYNsFx/t5W0im4UznZbCXGEeDwolF0d6ehELEBqiDA==}
+
+  '@html-eslint/template-syntax-parser@0.64.0':
+    resolution: {integrity: sha512-gD5gdJhfz67V91ah+YrwoClKlZIEXfs0xet2UJGo0LHC++AFSCedeMD81EUr9G8TPqHtn0Ke18fdW+wPXRwWvQ==}
+
+  '@html-eslint/types@0.64.0':
+    resolution: {integrity: sha512-cZrtIXdsnDotdJ8ZPKDyn7d8M6d1TBtBzzCQ+flYSgNY17JtUdBx9Y/QbJlMUdmx0nOWYIniY4PErpygwxt8VA==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -3060,6 +3112,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rviscomi/capo.js@2.2.0':
+    resolution: {integrity: sha512-bf3EFPKV4uQQ+66MkolrYh0axOgSn6XHq8kZbu/aoiI/OFjk6Rcz6N48l822vhvNcOQpI8Pfe2sa0AUd+3PjMQ==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -3172,6 +3227,9 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/css-tree@2.3.11':
+    resolution: {integrity: sha512-aEokibJOI77uIlqoBOkVbaQGC9zII0A+JH1kcTNKW2CwyYWD8KM6qdo+4c77wD3wZOQfJuNWAr9M4hdk+YhDIg==}
+
   '@types/eslint@8.56.12':
     resolution: {integrity: sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==}
 
@@ -3256,6 +3314,9 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
+
+  '@vscode/l10n@0.0.18':
+    resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
 
   '@warp-drive/build-config@5.8.2':
     resolution: {integrity: sha512-QU/6tSexAi/t149upEK3P04yGXdEwieTfQ5ihBON3A/3xGipveGIVJx6B8EYCot0AC2n91GmTc8ezzQmAK64/g==}
@@ -3402,6 +3463,7 @@ packages:
 
   '@zumer/snapdom@2.0.2':
     resolution: {integrity: sha512-W6quT4lMcPu8Q9O/Q6witSfc6/+xuY8C8yDoHug/+o7zYKCNE/e0I3//XsWDkyq9C0mDE0TAWF/8bwCR7x3gHQ==}
+    deprecated: Old versions have known fidelity bugs (text re-wrap, width freezing, KaTeX clipping). Upgrade to ^2.22 — drop-in for any 2.x. https://github.com/zumerlab/snapdom/releases
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -5608,6 +5670,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-html-parser@0.3.1:
+    resolution: {integrity: sha512-YTEasG4xt7FEN4b6qJIPbFo/fzQ5kjRMEQ33QMqSXTvfXqAbC2rHxo32x2/1Rhq7Mlu6wI3MIpM5Kf2VHPXrUQ==}
+
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
@@ -6525,6 +6590,9 @@ packages:
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  html-standard@0.0.13:
+    resolution: {integrity: sha512-6oNfW3c1t44O7jVXu0tp4E5MbHifWlXrHlZBPt6y7vFdgLOUUh8hyzoRhfUgozlBUK6oLLYhqP1uIqbZ8ggcBA==}
 
   html-tags@3.3.1:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
@@ -9665,6 +9733,18 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
+  vscode-css-languageservice@6.3.10:
+    resolution: {integrity: sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -10185,7 +10265,7 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -10200,11 +10280,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@9.39.5)':
+  '@babel/eslint-parser@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.5
+      eslint: 9.39.5(supports-color@8.1.1)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
@@ -10228,27 +10308,27 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
@@ -10275,7 +10355,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
@@ -10290,7 +10370,7 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
@@ -10299,7 +10379,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
@@ -10338,7 +10418,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
@@ -10346,17 +10426,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
@@ -10364,16 +10444,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
@@ -10381,149 +10461,149 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.7)':
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.7)':
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.29.7)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-globals': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
 
-  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
@@ -10531,47 +10611,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+
+  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
@@ -10579,7 +10659,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
@@ -10588,106 +10668,106 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
@@ -10695,67 +10775,67 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)(supports-color@8.1.1)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
@@ -10763,53 +10843,53 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/polyfill@7.12.1':
@@ -10817,84 +10897,84 @@ snapshots:
       core-js: 2.6.12
       regenerator-runtime: 0.13.11
 
-  '@babel/preset-env@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
+  '@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)
-      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7)
-      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-block-scoped-functions': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-dotall-regex': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-duplicate-keys': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-dynamic-import': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-exponentiation-operator': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-json-strings': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-logical-assignment-operators': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-member-expression-literals': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-modules-systemjs': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-modules-umd': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-new-target': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-numeric-separator': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-object-super': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-property-literals': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-regenerator': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-regexp-modifiers': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-reserved-words': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-spread': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-typeof-symbol': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-unicode-escapes': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-unicode-property-regex': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@7.29.7)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)(supports-color@8.1.1)
-      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7)(supports-color@8.1.1)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-block-scoped-functions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-dotall-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-duplicate-keys': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-dynamic-import': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-exponentiation-operator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-json-strings': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-logical-assignment-operators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-member-expression-literals': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-systemjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-umd': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-new-target': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-numeric-separator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-object-super': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-property-literals': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-regenerator': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-regexp-modifiers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-reserved-words': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-spread': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-typeof-symbol': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-escapes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-property-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.49.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
@@ -11022,13 +11102,13 @@ snapshots:
 
   '@dual-bundle/import-meta-resolve@4.2.1': {}
 
-  '@ember-data/adapter@5.8.2(@babel/core@7.29.7)':
+  '@ember-data/adapter@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
-      '@warp-drive/legacy': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))(@warp-drive/utilities@5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7)))
-      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/legacy': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@warp-drive/utilities@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
@@ -11037,35 +11117,35 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/json-api@5.8.2(@babel/core@7.29.7)':
+  '@ember-data/json-api@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
-      '@warp-drive/json-api': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))
-      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/json-api': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/legacy-compat@5.8.2(@babel/core@7.29.7)':
+  '@ember-data/legacy-compat@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
-      '@warp-drive/legacy': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))(@warp-drive/utilities@5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7)))
-      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/legacy': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@warp-drive/utilities@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/model@5.8.2(@babel/core@7.29.7)':
+  '@ember-data/model@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
-      '@warp-drive/legacy': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))(@warp-drive/utilities@5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7)))
-      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/legacy': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@warp-drive/utilities@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
       inflection: 3.0.2
@@ -11074,22 +11154,22 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/request-utils@5.8.2(@babel/core@7.29.7)(ember-inflector@5.0.2(@babel/core@7.29.7))':
+  '@ember-data/request-utils@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(ember-inflector@5.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
-      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
     optionalDependencies:
-      ember-inflector: 5.0.2(@babel/core@7.29.7)
+      ember-inflector: 5.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember-data/request@5.8.2(@babel/core@7.29.7)':
+  '@ember-data/request@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -11097,13 +11177,13 @@ snapshots:
 
   '@ember-data/rfc395-data@0.0.4': {}
 
-  '@ember-data/serializer@5.8.2(@babel/core@7.29.7)':
+  '@ember-data/serializer@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
-      '@warp-drive/legacy': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))(@warp-drive/utilities@5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7)))
-      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/legacy': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@warp-drive/utilities@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
@@ -11112,12 +11192,12 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/store@5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)':
+  '@ember-data/store@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     optionalDependencies:
-      '@ember/test-waiters': 4.1.2
+      '@ember/test-waiters': 4.1.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -11135,16 +11215,16 @@ snapshots:
       js-yaml: 5.2.1
       yargs: 18.0.0
 
-  '@ember-intl/v1-compat@1.2.2(webpack@5.108.4(postcss@8.5.19))':
+  '@ember-intl/v1-compat@1.2.2(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      broccoli-caching-writer: 3.1.0
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
+      broccoli-caching-writer: 3.1.0(supports-color@8.1.1)
+      broccoli-funnel: 3.0.8(supports-color@8.1.1)
+      broccoli-merge-trees: 4.2.0(supports-color@8.1.1)
       broccoli-source: 3.0.1
       calculate-cache-key-for-tree: 2.0.0
-      ember-auto-import: 2.13.1(webpack@5.108.4(postcss@8.5.19))
-      ember-cli-babel: 8.3.1(@babel/core@7.29.7)
+      ember-auto-import: 2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
+      ember-cli-babel: 8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       extend: 3.0.2
       js-yaml: 5.2.1
       json-stable-stringify: 1.3.0
@@ -11155,7 +11235,7 @@ snapshots:
 
   '@ember-tooling/blueprint-blueprint@0.2.1': {}
 
-  '@ember-tooling/blueprint-model@0.5.0':
+  '@ember-tooling/blueprint-model@0.5.0(supports-color@8.1.1)':
     dependencies:
       chalk: 4.1.2
       diff: 7.0.0
@@ -11163,27 +11243,27 @@ snapshots:
       lodash: 4.18.1
       promise.hash.helper: 1.0.8
       quick-temp: 0.1.9
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@ember-tooling/classic-build-addon-blueprint@6.10.1':
+  '@ember-tooling/classic-build-addon-blueprint@6.10.1(supports-color@8.1.1)':
     dependencies:
-      '@ember-tooling/blueprint-model': 0.5.0
+      '@ember-tooling/blueprint-model': 0.5.0(supports-color@8.1.1)
       chalk: 5.6.2
-      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-normalize-entity-name: 1.0.0(supports-color@8.1.1)
       ember-cli-string-utils: 1.1.0
       fs-extra: 11.3.6
       lodash: 4.18.1
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
       sort-package-json: 2.15.1
       walk-sync: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@ember-tooling/classic-build-app-blueprint@6.10.1':
+  '@ember-tooling/classic-build-app-blueprint@6.10.1(supports-color@8.1.1)':
     dependencies:
-      '@ember-tooling/blueprint-model': 0.5.0
+      '@ember-tooling/blueprint-model': 0.5.0(supports-color@8.1.1)
       chalk: 5.6.2
       ember-cli-string-utils: 1.1.0
     transitivePeerDependencies:
@@ -11200,67 +11280,67 @@ snapshots:
 
   '@ember/edition-utils@1.2.0': {}
 
-  '@ember/optional-features@2.3.0':
+  '@ember/optional-features@2.3.0(supports-color@8.1.1)':
     dependencies:
       chalk: 4.1.2
-      ember-cli-version-checker: 5.1.2
+      ember-cli-version-checker: 5.1.2(supports-color@8.1.1)
       glob: 7.2.3
       inquirer: 7.3.3
       mkdirp: 1.0.4
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@ember/string@4.0.1': {}
 
-  '@ember/test-helpers@5.4.3(@babel/core@7.29.7)':
+  '@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@ember/test-waiters': 4.1.2
-      '@embroider/addon-shim': 1.10.3
+      '@ember/test-waiters': 4.1.2(supports-color@8.1.1)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
       '@simple-dom/interface': 1.4.0
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
       dom-element-descriptors: 0.5.1
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@ember/test-waiters@4.1.2':
+  '@ember/test-waiters@4.1.2(supports-color@8.1.1)':
     dependencies:
-      '@embroider/addon-shim': 1.10.3
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/addon-shim@1.10.3':
+  '@embroider/addon-shim@1.10.3(supports-color@8.1.1)':
     dependencies:
-      '@embroider/shared-internals': 3.1.1
-      broccoli-funnel: 3.0.8
+      '@embroider/shared-internals': 3.1.1(supports-color@8.1.1)
+      broccoli-funnel: 3.0.8(supports-color@8.1.1)
       common-ancestor-path: 1.0.1
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/babel-loader-9@3.1.3(@embroider/core@3.5.10)(supports-color@8.1.1)(webpack@5.108.4(postcss@8.5.19))':
+  '@embroider/babel-loader-9@3.1.3(@embroider/core@3.5.10(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@embroider/core': 3.5.10
-      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.108.4(postcss@8.5.19))
+      '@embroider/core': 3.5.10(supports-color@8.1.1)
+      babel-loader: 9.2.1(@babel/core@7.29.7(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
     transitivePeerDependencies:
       - supports-color
       - webpack
 
-  '@embroider/compat@3.8.5(@embroider/core@3.5.10)':
+  '@embroider/compat@3.8.5(@embroider/core@3.5.10(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7)
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/runtime': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
-      '@embroider/core': 3.5.10
-      '@embroider/macros': 1.16.12
+      '@embroider/core': 3.5.10(supports-color@8.1.1)
+      '@embroider/macros': 1.16.12(supports-color@8.1.1)
       '@types/babel__code-frame': 7.27.0
       '@types/yargs': 17.0.35
       assert-never: 1.4.0
@@ -11269,20 +11349,20 @@ snapshots:
       babel-plugin-syntax-dynamic-import: 6.18.0
       babylon: 6.18.0
       bind-decorator: 1.0.11
-      broccoli: 3.5.2
-      broccoli-concat: 4.2.7
+      broccoli: 3.5.2(supports-color@8.1.1)
+      broccoli-concat: 4.2.7(supports-color@8.1.1)
       broccoli-file-creator: 2.1.1
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
-      broccoli-persistent-filter: 3.1.3
-      broccoli-plugin: 4.0.7
+      broccoli-funnel: 3.0.8(supports-color@8.1.1)
+      broccoli-merge-trees: 4.2.0(supports-color@8.1.1)
+      broccoli-persistent-filter: 3.1.3(supports-color@8.1.1)
+      broccoli-plugin: 4.0.7(supports-color@8.1.1)
       broccoli-source: 3.0.1
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
-      fast-sourcemap-concat: 2.1.1
+      fast-sourcemap-concat: 2.1.1(supports-color@8.1.1)
       fs-extra: 9.1.0
-      fs-tree-diff: 2.0.1
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
       jsdom: 25.0.1(supports-color@8.1.1)
       lodash: 4.18.1
       pkg-up: 3.1.0
@@ -11290,7 +11370,7 @@ snapshots:
       resolve-package-path: 4.0.3
       semver: 7.8.5
       symlink-or-copy: 1.3.1
-      tree-sync: 2.1.0
+      tree-sync: 2.1.0(supports-color@8.1.1)
       typescript-memoize: 1.1.1
       walk-sync: 3.0.0
       yargs: 17.7.3
@@ -11301,24 +11381,24 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/core@3.5.10':
+  '@embroider/core@3.5.10(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/shared-internals': 2.9.2(supports-color@8.1.1)
       assert-never: 1.4.0
       babel-plugin-ember-template-compilation: 2.4.1
       broccoli-node-api: 1.7.0
-      broccoli-persistent-filter: 3.1.3
-      broccoli-plugin: 4.0.7
+      broccoli-persistent-filter: 3.1.3(supports-color@8.1.1)
+      broccoli-plugin: 4.0.7(supports-color@8.1.1)
       broccoli-source: 3.0.1
       debug: 4.4.3(supports-color@8.1.1)
-      fast-sourcemap-concat: 2.1.1
+      fast-sourcemap-concat: 2.1.1(supports-color@8.1.1)
       filesize: 10.1.6
       fs-extra: 9.1.0
-      fs-tree-diff: 2.0.1
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
       handlebars: 4.7.9
       js-string-escape: 1.0.1
       jsdom: 25.0.1(supports-color@8.1.1)
@@ -11335,17 +11415,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/hbs-loader@3.0.5(@embroider/core@3.5.10)(webpack@5.108.4(postcss@8.5.19))':
+  '@embroider/hbs-loader@3.0.5(@embroider/core@3.5.10(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))':
     dependencies:
-      '@embroider/core': 3.5.10
-      webpack: 5.108.4(postcss@8.5.19)
+      '@embroider/core': 3.5.10(supports-color@8.1.1)
+      webpack: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
-  '@embroider/macros@1.16.12':
+  '@embroider/macros@1.16.12(supports-color@8.1.1)':
     dependencies:
-      '@embroider/shared-internals': 2.9.0
+      '@embroider/shared-internals': 2.9.0(supports-color@8.1.1)
       assert-never: 1.4.0
       babel-import-util: 2.1.1
-      ember-cli-babel: 7.26.11
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
       find-up: 5.0.0
       lodash: 4.18.1
       resolve: 1.22.12
@@ -11353,12 +11433,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/macros@1.20.5(@babel/core@7.29.7)':
+  '@embroider/macros@1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/shared-internals': 3.1.1
+      '@embroider/shared-internals': 3.1.1(supports-color@8.1.1)
       assert-never: 1.4.0
       babel-import-util: 3.0.1
-      ember-cli-babel: 8.3.1(@babel/core@7.29.7)
+      ember-cli-babel: 8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       find-up: 5.0.0
       lodash: 4.18.1
       resolve: 1.22.12
@@ -11383,7 +11463,7 @@ snapshots:
       semver: 7.8.5
       typescript-memoize: 1.1.1
 
-  '@embroider/shared-internals@2.9.0':
+  '@embroider/shared-internals@2.9.0(supports-color@8.1.1)':
     dependencies:
       babel-import-util: 2.1.1
       debug: 4.4.3(supports-color@8.1.1)
@@ -11417,7 +11497,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/shared-internals@3.1.1':
+  '@embroider/shared-internals@3.1.1(supports-color@8.1.1)':
     dependencies:
       babel-import-util: 3.0.1
       debug: 4.4.3(supports-color@8.1.1)
@@ -11435,64 +11515,64 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/test-setup@4.0.0(@embroider/compat@3.8.5(@embroider/core@3.5.10))(@embroider/core@3.5.10)(@embroider/webpack@4.1.2(@embroider/core@3.5.10)(webpack@5.108.4(postcss@8.5.19)))':
+  '@embroider/test-setup@4.0.0(@embroider/compat@3.8.5(@embroider/core@3.5.10(supports-color@8.1.1))(supports-color@8.1.1))(@embroider/core@3.5.10(supports-color@8.1.1))(@embroider/webpack@4.1.2(@embroider/core@3.5.10(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)))':
     dependencies:
       lodash: 4.18.1
       resolve: 1.22.12
     optionalDependencies:
-      '@embroider/compat': 3.8.5(@embroider/core@3.5.10)
-      '@embroider/core': 3.5.10
-      '@embroider/webpack': 4.1.2(@embroider/core@3.5.10)(webpack@5.108.4(postcss@8.5.19))
+      '@embroider/compat': 3.8.5(@embroider/core@3.5.10(supports-color@8.1.1))(supports-color@8.1.1)
+      '@embroider/core': 3.5.10(supports-color@8.1.1)
+      '@embroider/webpack': 4.1.2(@embroider/core@3.5.10(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
 
-  '@embroider/util@1.13.5(@babel/core@7.29.7)(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))':
+  '@embroider/util@1.13.5(@babel/core@7.29.7(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      broccoli-funnel: 3.0.8
-      ember-cli-babel: 7.26.11
-      ember-source: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      broccoli-funnel: 3.0.8(supports-color@8.1.1)
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
+      ember-source: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@embroider/webpack@4.1.2(@embroider/core@3.5.10)(webpack@5.108.4(postcss@8.5.19))':
+  '@embroider/webpack@4.1.2(@embroider/core@3.5.10(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@embroider/babel-loader-9': 3.1.3(@embroider/core@3.5.10)(supports-color@8.1.1)(webpack@5.108.4(postcss@8.5.19))
-      '@embroider/core': 3.5.10
-      '@embroider/hbs-loader': 3.0.5(@embroider/core@3.5.10)(webpack@5.108.4(postcss@8.5.19))
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@embroider/babel-loader-9': 3.1.3(@embroider/core@3.5.10(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
+      '@embroider/core': 3.5.10(supports-color@8.1.1)
+      '@embroider/hbs-loader': 3.0.5(@embroider/core@3.5.10(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       '@embroider/shared-internals': 2.9.2(supports-color@8.1.1)
       '@types/supports-color': 8.1.3
       assert-never: 1.4.0
-      babel-loader: 8.4.1(@babel/core@7.29.7)(webpack@5.108.4(postcss@8.5.19))
-      css-loader: 5.2.7(webpack@5.108.4(postcss@8.5.19))
+      babel-loader: 8.4.1(@babel/core@7.29.7(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
+      css-loader: 5.2.7(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       csso: 4.2.0
       debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       fs-extra: 9.1.0
       jsdom: 25.0.1(supports-color@8.1.1)
       lodash: 4.18.1
-      mini-css-extract-plugin: 2.10.2(webpack@5.108.4(postcss@8.5.19))
+      mini-css-extract-plugin: 2.10.2(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       semver: 7.8.5
       source-map-url: 0.4.1
-      style-loader: 2.0.0(webpack@5.108.4(postcss@8.5.19))
+      style-loader: 2.0.0(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       supports-color: 8.1.1
       terser: 5.49.0
-      thread-loader: 3.0.4(webpack@5.108.4(postcss@8.5.19))
-      webpack: 5.108.4(postcss@8.5.19)
+      thread-loader: 3.0.4(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
+      webpack: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
     transitivePeerDependencies:
       - bufferutil
       - canvas
       - utf-8-validate
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5(supports-color@8.1.1))':
     dependencies:
-      eslint: 9.39.5
+      eslint: 9.39.5(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@8.1.1)
@@ -11512,7 +11592,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.6':
+  '@eslint/eslintrc@3.3.6(supports-color@8.1.1)':
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -11567,12 +11647,12 @@ snapshots:
       '@formatjs/icu-messageformat-parser': 3.5.14
       intl-messageformat: 11.2.11
 
-  '@fortawesome/ember-fontawesome@3.1.0(@babel/core@7.29.7)(@fortawesome/fontawesome-svg-core@6.7.2)(@glimmer/component@2.1.1)':
+  '@fortawesome/ember-fontawesome@3.1.0(@babel/core@7.29.7(supports-color@8.1.1))(@fortawesome/fontawesome-svg-core@6.7.2)(@glimmer/component@2.1.1(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@fortawesome/fontawesome-svg-core': 6.7.2
-      '@glimmer/component': 2.1.1
+      '@glimmer/component': 2.1.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -11599,9 +11679,9 @@ snapshots:
       '@glimmer/util': 0.94.8
       '@glimmer/wire-format': 0.94.8
 
-  '@glimmer/component@2.1.1':
+  '@glimmer/component@2.1.1(supports-color@8.1.1)':
     dependencies:
-      '@embroider/addon-shim': 1.10.3
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
       '@glimmer/env': 0.1.7
     transitivePeerDependencies:
       - supports-color
@@ -11740,9 +11820,9 @@ snapshots:
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
 
-  '@glimmer/vm-babel-plugins@0.93.5(@babel/core@7.29.7)':
+  '@glimmer/vm-babel-plugins@0.93.5(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.29.7)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - '@babel/core'
 
@@ -11757,6 +11837,45 @@ snapshots:
   '@handlebars/parser@2.0.0': {}
 
   '@handlebars/parser@2.2.2': {}
+
+  '@html-eslint/core@0.64.0':
+    dependencies:
+      '@html-eslint/types': 0.64.0
+      html-standard: 0.0.13
+
+  '@html-eslint/eslint-plugin@0.64.0(eslint@9.39.5(supports-color@8.1.1))':
+    dependencies:
+      '@eslint/plugin-kit': 0.4.1
+      '@html-eslint/core': 0.64.0
+      '@html-eslint/parser': 0.64.0
+      '@html-eslint/template-parser': 0.64.0
+      '@html-eslint/template-syntax-parser': 0.64.0
+      '@html-eslint/types': 0.64.0
+      '@rviscomi/capo.js': 2.2.0
+      eslint: 9.39.5(supports-color@8.1.1)
+      html-standard: 0.0.13
+
+  '@html-eslint/parser@0.64.0':
+    dependencies:
+      '@html-eslint/template-syntax-parser': 0.64.0
+      '@html-eslint/types': 0.64.0
+      css-tree: 3.2.1
+      es-html-parser: 0.3.1
+
+  '@html-eslint/template-parser@0.64.0':
+    dependencies:
+      '@html-eslint/types': 0.64.0
+      es-html-parser: 0.3.1
+
+  '@html-eslint/template-syntax-parser@0.64.0':
+    dependencies:
+      '@html-eslint/types': 0.64.0
+
+  '@html-eslint/types@0.64.0':
+    dependencies:
+      '@types/css-tree': 2.3.11
+      '@types/estree': 1.0.9
+      es-html-parser: 0.3.1
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -11934,7 +12053,7 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@kwsites/file-exists@1.1.1':
+  '@kwsites/file-exists@1.1.1(supports-color@8.1.1)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -12089,6 +12208,8 @@ snapshots:
   '@rollup/rollup-linux-x64-gnu@4.9.5':
     optional: true
 
+  '@rviscomi/capo.js@2.2.0': {}
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sentry/browser-utils@10.65.0':
@@ -12111,18 +12232,18 @@ snapshots:
     dependencies:
       '@sentry/conventions': 0.15.1
 
-  '@sentry/ember@10.65.0(ember-cli@6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8))(webpack@5.108.4(postcss@8.5.19))':
+  '@sentry/ember@10.65.0(ember-cli@6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@sentry/browser': 10.65.0
       '@sentry/core': 10.65.0
-      ember-auto-import: 2.13.1(webpack@5.108.4(postcss@8.5.19))
-      ember-cli-babel: 8.3.1(@babel/core@7.29.7)
-      ember-cli-htmlbars: 6.3.0
-      ember-cli-typescript: 5.3.0
+      ember-auto-import: 2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
+      ember-cli-babel: 8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-cli-htmlbars: 6.3.0(supports-color@8.1.1)
+      ember-cli-typescript: 5.3.0(supports-color@8.1.1)
     optionalDependencies:
-      ember-cli: 6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+      ember-cli: 6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -12217,6 +12338,8 @@ snapshots:
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 26.1.1
+
+  '@types/css-tree@2.3.11': {}
 
   '@types/eslint@8.56.12':
     dependencies:
@@ -12313,50 +12436,52 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@warp-drive/build-config@5.8.2(@babel/core@7.29.7)':
+  '@vscode/l10n@0.0.18': {}
+
+  '@warp-drive/build-config@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       babel-import-util: 2.1.1
-      babel-plugin-debug-macros: 2.0.0(@babel/core@7.29.7)
+      babel-plugin-debug-macros: 2.0.0(@babel/core@7.29.7(supports-color@8.1.1))
       semver: 7.8.5
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/core-types@5.8.2(@babel/core@7.29.7)':
+  '@warp-drive/core-types@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/core@5.8.2(@babel/core@7.29.7)':
+  '@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/build-config': 5.8.2(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/build-config': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/ember@5.8.2(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)':
+  '@warp-drive/ember@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@ember/test-waiters': 4.1.2
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
+      '@ember/test-waiters': 4.1.2(supports-color@8.1.1)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/json-api@5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))':
+  '@warp-drive/json-api@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       fuse.js: 7.1.0
       json-to-ast: 2.1.0
     transitivePeerDependencies:
@@ -12364,12 +12489,12 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/legacy@5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))(@warp-drive/utilities@5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7)))':
+  '@warp-drive/legacy@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@warp-drive/utilities@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
-      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/utilities': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
       inflection: 3.0.2
@@ -12378,10 +12503,10 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/utilities@5.8.2(@babel/core@7.29.7)(@warp-drive/core@5.8.2(@babel/core@7.29.7))':
+  '@warp-drive/utilities@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(@warp-drive/core@5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@warp-drive/core': 5.8.2(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@warp-drive/core': 5.8.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -12590,7 +12715,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -12674,9 +12799,9 @@ snapshots:
 
   ansicolors@0.2.1: {}
 
-  anymatch@2.0.0:
+  anymatch@2.0.0(supports-color@8.1.1):
     dependencies:
-      micromatch: 3.1.10
+      micromatch: 3.1.10(supports-color@8.1.1)
       normalize-path: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -12752,9 +12877,9 @@ snapshots:
 
   astral-regex@2.0.0: {}
 
-  async-disk-cache@1.3.5:
+  async-disk-cache@1.3.5(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       heimdalljs: 0.2.6
       istextorbinary: 2.1.0
       mkdirp: 0.5.6
@@ -12764,7 +12889,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  async-disk-cache@2.1.0:
+  async-disk-cache@2.1.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       heimdalljs: 0.2.6
@@ -12781,10 +12906,10 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  async-promise-queue@1.0.5:
+  async-promise-queue@1.0.5(supports-color@8.1.1):
     dependencies:
       async: 2.6.4
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12830,20 +12955,20 @@ snapshots:
       esutils: 2.0.3
       js-tokens: 3.0.2
 
-  babel-core@6.26.3:
+  babel-core@6.26.3(supports-color@8.1.1):
     dependencies:
       babel-code-frame: 6.26.0
       babel-generator: 6.26.1
-      babel-helpers: 6.24.1
+      babel-helpers: 6.24.1(supports-color@8.1.1)
       babel-messages: 6.23.0
-      babel-register: 6.26.0
+      babel-register: 6.26.0(supports-color@8.1.1)
       babel-runtime: 6.26.0
-      babel-template: 6.26.0
-      babel-traverse: 6.26.0
+      babel-template: 6.26.0(supports-color@8.1.1)
+      babel-traverse: 6.26.0(supports-color@8.1.1)
       babel-types: 6.26.0
       babylon: 6.18.0
       convert-source-map: 1.9.0
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       json5: 0.5.1
       lodash: 4.18.1
       minimatch: 3.1.5
@@ -12865,10 +12990,10 @@ snapshots:
       source-map: 0.5.7
       trim-right: 1.0.1
 
-  babel-helpers@6.24.1:
+  babel-helpers@6.24.1(supports-color@8.1.1):
     dependencies:
       babel-runtime: 6.26.0
-      babel-template: 6.26.0
+      babel-template: 6.26.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12880,46 +13005,46 @@ snapshots:
 
   babel-import-util@3.0.1: {}
 
-  babel-loader@8.4.1(@babel/core@7.29.7)(webpack@4.47.0):
+  babel-loader@8.4.1(@babel/core@7.29.7(supports-color@8.1.1))(webpack@4.47.0(supports-color@8.1.1)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 4.47.0
+      webpack: 4.47.0(supports-color@8.1.1)
 
-  babel-loader@8.4.1(@babel/core@7.29.7)(webpack@5.108.4(postcss@8.5.19)):
+  babel-loader@8.4.1(@babel/core@7.29.7(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.108.4(postcss@8.5.19)
+      webpack: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
-  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.108.4(postcss@8.5.19)):
+  babel-loader@9.2.1(@babel/core@7.29.7(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.108.4(postcss@8.5.19)
+      webpack: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
   babel-messages@6.23.0:
     dependencies:
       babel-runtime: 6.26.0
 
-  babel-plugin-debug-macros@0.2.0(@babel/core@7.29.7):
+  babel-plugin-debug-macros@0.2.0(@babel/core@7.29.7(supports-color@8.1.1)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       semver: 5.7.2
 
-  babel-plugin-debug-macros@0.3.4(@babel/core@7.29.7):
+  babel-plugin-debug-macros@0.3.4(@babel/core@7.29.7(supports-color@8.1.1)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       semver: 5.7.2
 
-  babel-plugin-debug-macros@2.0.0(@babel/core@7.29.7):
+  babel-plugin-debug-macros@2.0.0(@babel/core@7.29.7(supports-color@8.1.1)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       babel-import-util: 2.1.1
@@ -12964,43 +13089,43 @@ snapshots:
       reselect: 4.1.8
       resolve: 1.22.12
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7)(supports-color@8.1.1):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7)(supports-color@8.1.1):
+  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7)(supports-color@8.1.1):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-syntax-dynamic-import@6.18.0: {}
 
-  babel-register@6.26.0:
+  babel-register@6.26.0(supports-color@8.1.1):
     dependencies:
-      babel-core: 6.26.3
+      babel-core: 6.26.3(supports-color@8.1.1)
       babel-runtime: 6.26.0
       core-js: 2.6.12
       home-or-tmp: 2.0.0
@@ -13010,11 +13135,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-remove-types@1.1.0:
+  babel-remove-types@1.1.0(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       prettier: 2.8.8
     transitivePeerDependencies:
       - supports-color
@@ -13024,24 +13149,24 @@ snapshots:
       core-js: 2.6.12
       regenerator-runtime: 0.11.1
 
-  babel-template@6.26.0:
+  babel-template@6.26.0(supports-color@8.1.1):
     dependencies:
       babel-runtime: 6.26.0
-      babel-traverse: 6.26.0
+      babel-traverse: 6.26.0(supports-color@8.1.1)
       babel-types: 6.26.0
       babylon: 6.18.0
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-traverse@6.26.0:
+  babel-traverse@6.26.0(supports-color@8.1.1):
     dependencies:
       babel-code-frame: 6.26.0
       babel-messages: 6.23.0
       babel-runtime: 6.26.0
       babel-types: 6.26.0
       babylon: 6.18.0
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       globals: 9.18.0
       invariant: 2.2.4
       lodash: 4.18.1
@@ -13124,7 +13249,7 @@ snapshots:
 
   bn.js@5.2.5: {}
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
@@ -13162,7 +13287,7 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  braces@2.3.2:
+  braces@2.3.2(supports-color@8.1.1):
     dependencies:
       arr-flatten: 1.1.0
       array-unique: 0.3.2
@@ -13170,7 +13295,7 @@ snapshots:
       fill-range: 4.0.0
       isobject: 3.0.1
       repeat-element: 1.1.4
-      snapdragon: 0.8.2
+      snapdragon: 0.8.2(supports-color@8.1.1)
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
@@ -13181,99 +13306,99 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  broccoli-asset-rev@3.0.0:
+  broccoli-asset-rev@3.0.0(supports-color@8.1.1):
     dependencies:
-      broccoli-asset-rewrite: 2.0.0
-      broccoli-filter: 1.3.0
-      broccoli-persistent-filter: 1.4.6
+      broccoli-asset-rewrite: 2.0.0(supports-color@8.1.1)
+      broccoli-filter: 1.3.0(supports-color@8.1.1)
+      broccoli-persistent-filter: 1.4.6(supports-color@8.1.1)
       json-stable-stringify: 1.3.0
       minimatch: 3.1.5
       rsvp: 3.6.2
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-asset-rewrite@2.0.0:
+  broccoli-asset-rewrite@2.0.0(supports-color@8.1.1):
     dependencies:
-      broccoli-filter: 1.3.0
+      broccoli-filter: 1.3.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-babel-transpiler@7.8.1:
+  broccoli-babel-transpiler@7.8.1(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/polyfill': 7.12.1
-      broccoli-funnel: 2.0.2
-      broccoli-merge-trees: 3.0.2
-      broccoli-persistent-filter: 2.3.1
+      broccoli-funnel: 2.0.2(supports-color@8.1.1)
+      broccoli-merge-trees: 3.0.2(supports-color@8.1.1)
+      broccoli-persistent-filter: 2.3.1(supports-color@8.1.1)
       clone: 2.1.2
-      hash-for-dep: 1.5.2
+      hash-for-dep: 1.5.2(supports-color@8.1.1)
       heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       json-stable-stringify: 1.3.0
       rsvp: 4.8.5
-      workerpool: 3.1.2
+      workerpool: 3.1.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-babel-transpiler@8.0.2(@babel/core@7.29.7):
+  broccoli-babel-transpiler@8.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      broccoli-persistent-filter: 3.1.3
+      broccoli-persistent-filter: 3.1.3(supports-color@8.1.1)
       clone: 2.1.2
-      hash-for-dep: 1.5.2
+      hash-for-dep: 1.5.2(supports-color@8.1.1)
       heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       json-stable-stringify: 1.3.0
       rsvp: 4.8.5
       workerpool: 6.5.1
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-caching-writer@3.1.0:
+  broccoli-caching-writer@3.1.0(supports-color@8.1.1):
     dependencies:
       broccoli-plugin: 1.3.1
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       rimraf: 2.7.1
       rsvp: 3.6.2
       walk-sync: 0.3.4
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-concat@4.2.7:
+  broccoli-concat@4.2.7(supports-color@8.1.1):
     dependencies:
-      broccoli-debug: 0.6.5
-      broccoli-plugin: 4.0.7
+      broccoli-debug: 0.6.5(supports-color@8.1.1)
+      broccoli-plugin: 4.0.7(supports-color@8.1.1)
       ensure-posix-path: 1.1.1
-      fast-sourcemap-concat: 2.1.1
+      fast-sourcemap-concat: 2.1.1(supports-color@8.1.1)
       find-index: 1.1.1
       fs-extra: 8.1.0
-      fs-tree-diff: 2.0.1
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-config-loader@1.0.1:
+  broccoli-config-loader@1.0.1(supports-color@8.1.1):
     dependencies:
-      broccoli-caching-writer: 3.1.0
+      broccoli-caching-writer: 3.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-config-replace@1.1.3:
+  broccoli-config-replace@1.1.3(supports-color@8.1.1):
     dependencies:
       broccoli-plugin: 1.3.1
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       fs-extra: 0.24.0
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-debug@0.6.5:
+  broccoli-debug@0.6.5(supports-color@8.1.1):
     dependencies:
       broccoli-plugin: 1.3.1
-      fs-tree-diff: 0.5.9
+      fs-tree-diff: 0.5.9(supports-color@8.1.1)
       heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       symlink-or-copy: 1.3.1
-      tree-sync: 1.4.0
+      tree-sync: 1.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13282,12 +13407,12 @@ snapshots:
       broccoli-plugin: 1.3.1
       mkdirp: 0.5.6
 
-  broccoli-filter@1.3.0:
+  broccoli-filter@1.3.0(supports-color@8.1.1):
     dependencies:
       broccoli-kitchen-sink-helpers: 0.3.1
       broccoli-plugin: 1.3.1
       copy-dereference: 1.0.0
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       mkdirp: 0.5.6
       promise-map-series: 0.2.3
       rsvp: 3.6.2
@@ -13298,14 +13423,14 @@ snapshots:
 
   broccoli-funnel-reducer@1.0.0: {}
 
-  broccoli-funnel@2.0.2:
+  broccoli-funnel@2.0.2(supports-color@8.1.1):
     dependencies:
       array-equal: 1.0.2
       blank-object: 1.0.2
       broccoli-plugin: 1.3.1
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       fast-ordered-set: 1.0.3
-      fs-tree-diff: 0.5.9
+      fs-tree-diff: 0.5.9(supports-color@8.1.1)
       heimdalljs: 0.2.6
       minimatch: 3.1.5
       mkdirp: 0.5.6
@@ -13316,12 +13441,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-funnel@3.0.8:
+  broccoli-funnel@3.0.8(supports-color@8.1.1):
     dependencies:
       array-equal: 1.0.2
-      broccoli-plugin: 4.0.7
+      broccoli-plugin: 4.0.7(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
-      fs-tree-diff: 2.0.1
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
       heimdalljs: 0.2.6
       minimatch: 3.1.5
       walk-sync: 2.2.0
@@ -13333,17 +13458,17 @@ snapshots:
       glob: 5.0.15
       mkdirp: 0.5.6
 
-  broccoli-merge-trees@3.0.2:
+  broccoli-merge-trees@3.0.2(supports-color@8.1.1):
     dependencies:
       broccoli-plugin: 1.3.1
-      merge-trees: 2.0.0
+      merge-trees: 2.0.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-merge-trees@4.2.0:
+  broccoli-merge-trees@4.2.0(supports-color@8.1.1):
     dependencies:
-      broccoli-plugin: 4.0.7
-      merge-trees: 2.0.0
+      broccoli-plugin: 4.0.7(supports-color@8.1.1)
+      merge-trees: 2.0.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13358,29 +13483,29 @@ snapshots:
 
   broccoli-node-info@2.2.0: {}
 
-  broccoli-output-wrapper@2.0.0:
+  broccoli-output-wrapper@2.0.0(supports-color@8.1.1):
     dependencies:
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-output-wrapper@3.2.5:
+  broccoli-output-wrapper@3.2.5(supports-color@8.1.1):
     dependencies:
       fs-extra: 8.1.0
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       symlink-or-copy: 1.3.1
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-persistent-filter@1.4.6:
+  broccoli-persistent-filter@1.4.6(supports-color@8.1.1):
     dependencies:
-      async-disk-cache: 1.3.5
-      async-promise-queue: 1.0.5
+      async-disk-cache: 1.3.5(supports-color@8.1.1)
+      async-promise-queue: 1.0.5(supports-color@8.1.1)
       broccoli-plugin: 1.3.1
-      fs-tree-diff: 0.5.9
-      hash-for-dep: 1.5.2
+      fs-tree-diff: 0.5.9(supports-color@8.1.1)
+      hash-for-dep: 1.5.2(supports-color@8.1.1)
       heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       mkdirp: 0.5.6
       promise-map-series: 0.2.3
       rimraf: 2.7.1
@@ -13390,38 +13515,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-persistent-filter@2.3.1:
+  broccoli-persistent-filter@2.3.1(supports-color@8.1.1):
     dependencies:
-      async-disk-cache: 1.3.5
-      async-promise-queue: 1.0.5
+      async-disk-cache: 1.3.5(supports-color@8.1.1)
+      async-promise-queue: 1.0.5(supports-color@8.1.1)
       broccoli-plugin: 1.3.1
-      fs-tree-diff: 2.0.1
-      hash-for-dep: 1.5.2
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
+      hash-for-dep: 1.5.2(supports-color@8.1.1)
       heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       mkdirp: 0.5.6
       promise-map-series: 0.2.3
       rimraf: 2.7.1
       rsvp: 4.8.5
       symlink-or-copy: 1.3.1
-      sync-disk-cache: 1.3.4
+      sync-disk-cache: 1.3.4(supports-color@8.1.1)
       walk-sync: 1.1.4
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-persistent-filter@3.1.3:
+  broccoli-persistent-filter@3.1.3(supports-color@8.1.1):
     dependencies:
-      async-disk-cache: 2.1.0
-      async-promise-queue: 1.0.5
-      broccoli-plugin: 4.0.7
-      fs-tree-diff: 2.0.1
-      hash-for-dep: 1.5.2
+      async-disk-cache: 2.1.0(supports-color@8.1.1)
+      async-promise-queue: 1.0.5(supports-color@8.1.1)
+      broccoli-plugin: 4.0.7(supports-color@8.1.1)
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
+      hash-for-dep: 1.5.2(supports-color@8.1.1)
       heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       promise-map-series: 0.2.3
       rimraf: 3.0.2
       symlink-or-copy: 1.3.1
-      sync-disk-cache: 2.1.0
+      sync-disk-cache: 2.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13439,11 +13564,11 @@ snapshots:
       rimraf: 2.7.1
       symlink-or-copy: 1.3.1
 
-  broccoli-plugin@3.1.0:
+  broccoli-plugin@3.1.0(supports-color@8.1.1):
     dependencies:
       broccoli-node-api: 1.7.0
-      broccoli-output-wrapper: 2.0.0
-      fs-merger: 3.2.1
+      broccoli-output-wrapper: 2.0.0(supports-color@8.1.1)
+      fs-merger: 3.2.1(supports-color@8.1.1)
       promise-map-series: 0.2.3
       quick-temp: 0.1.9
       rimraf: 2.7.1
@@ -13451,11 +13576,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-plugin@4.0.7:
+  broccoli-plugin@4.0.7(supports-color@8.1.1):
     dependencies:
       broccoli-node-api: 1.7.0
-      broccoli-output-wrapper: 3.2.5
-      fs-merger: 3.2.1
+      broccoli-output-wrapper: 3.2.5(supports-color@8.1.1)
+      fs-merger: 3.2.1(supports-color@8.1.1)
       promise-map-series: 0.3.0
       quick-temp: 0.1.9
       rimraf: 3.0.2
@@ -13463,9 +13588,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-sass-source-maps@4.3.0:
+  broccoli-sass-source-maps@4.3.0(supports-color@8.1.1):
     dependencies:
-      broccoli-caching-writer: 3.1.0
+      broccoli-caching-writer: 3.1.0(supports-color@8.1.1)
       include-path-searcher: 0.1.0
       rsvp: 4.8.5
     transitivePeerDependencies:
@@ -13481,12 +13606,12 @@ snapshots:
     dependencies:
       broccoli-node-api: 1.7.0
 
-  broccoli-stew@3.0.0:
+  broccoli-stew@3.0.0(supports-color@8.1.1):
     dependencies:
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 2.0.2
-      broccoli-merge-trees: 3.0.2
-      broccoli-persistent-filter: 2.3.1
+      broccoli-debug: 0.6.5(supports-color@8.1.1)
+      broccoli-funnel: 2.0.2(supports-color@8.1.1)
+      broccoli-merge-trees: 3.0.2(supports-color@8.1.1)
+      broccoli-persistent-filter: 2.3.1(supports-color@8.1.1)
       broccoli-plugin: 2.1.0
       chalk: 2.4.2
       debug: 4.4.3(supports-color@8.1.1)
@@ -13500,10 +13625,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-terser-sourcemap@4.1.1:
+  broccoli-terser-sourcemap@4.1.1(supports-color@8.1.1):
     dependencies:
-      async-promise-queue: 1.0.5
-      broccoli-plugin: 4.0.7
+      async-promise-queue: 1.0.5(supports-color@8.1.1)
+      broccoli-plugin: 4.0.7(supports-color@8.1.1)
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
       lodash.defaultsdeep: 4.6.1
@@ -13515,7 +13640,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli@3.5.2:
+  broccoli@3.5.2(supports-color@8.1.1):
     dependencies:
       '@types/chai': 4.3.20
       '@types/chai-as-promised': 7.1.8
@@ -13525,45 +13650,45 @@ snapshots:
       broccoli-slow-trees: 3.1.0
       broccoli-source: 3.0.1
       commander: 4.1.1
-      connect: 3.7.0
+      connect: 3.7.0(supports-color@8.1.1)
       console-ui: 3.1.2
       esm: 3.2.25
       findup-sync: 4.0.0
       handlebars: 4.7.9
       heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       https: 1.0.0
       mime-types: 2.1.35
       resolve-path: 1.4.0
       rimraf: 3.0.2
-      sane: 4.1.0
+      sane: 4.1.0(supports-color@8.1.1)
       tmp: 0.0.33
-      tree-sync: 2.1.0
+      tree-sync: 2.1.0(supports-color@8.1.1)
       underscore.string: 3.3.6
-      watch-detector: 1.0.2
+      watch-detector: 1.0.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  broccoli@4.0.0:
+  broccoli@4.0.0(supports-color@8.1.1):
     dependencies:
       ansi-html: 0.0.9
       broccoli-node-info: 2.2.0
       broccoli-source: 3.0.1
       commander: 14.0.3
-      connect: 3.7.0
+      connect: 3.7.0(supports-color@8.1.1)
       console-ui: 3.1.2
       findup-sync: 5.0.0
       handlebars: 4.7.9
       heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       mime-types: 3.0.2
       resolve-path: 1.4.0
       rimraf: 6.1.3
       sane: 5.0.1
       tmp: 0.2.7
-      tree-sync: 2.1.0
+      tree-sync: 2.1.0(supports-color@8.1.1)
       underscore.string: 3.3.6
-      watch-detector: 1.0.2
+      watch-detector: 1.0.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13782,18 +13907,18 @@ snapshots:
       lodash.reject: 4.6.0
       lodash.some: 4.6.0
 
-  chokidar@2.1.8:
+  chokidar@2.1.8(supports-color@8.1.1):
     dependencies:
-      anymatch: 2.0.0
+      anymatch: 2.0.0(supports-color@8.1.1)
       async-each: 1.0.6
-      braces: 2.3.2
+      braces: 2.3.2(supports-color@8.1.1)
       glob-parent: 3.1.0
       inherits: 2.0.4
       is-binary-path: 1.0.1
       is-glob: 4.0.3
       normalize-path: 3.0.0
       path-is-absolute: 1.0.1
-      readdirp: 2.2.1
+      readdirp: 2.2.1(supports-color@8.1.1)
       upath: 1.2.0
     optionalDependencies:
       fsevents: 1.2.13
@@ -13967,11 +14092,11 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression@1.8.1:
+  compression@1.8.1(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -13995,10 +14120,10 @@ snapshots:
       graceful-fs: 4.2.11
       xdg-basedir: 5.1.0
 
-  connect@3.7.0:
+  connect@3.7.0(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
-      finalhandler: 1.1.2
+      debug: 2.6.9(supports-color@8.1.1)
+      finalhandler: 1.1.2(supports-color@8.1.1)
       parseurl: 1.3.3
       utils-merge: 1.0.1
     transitivePeerDependencies:
@@ -14016,7 +14141,7 @@ snapshots:
       ora: 3.4.0
       through2: 3.0.2
 
-  consolidate@1.0.4(@babel/core@7.29.7)(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(mustache@4.2.0)(underscore@1.13.8):
+  consolidate@1.0.4(@babel/core@7.29.7(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(mustache@4.2.0)(underscore@1.13.8):
     optionalDependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       ejs: 3.1.10
@@ -14149,7 +14274,7 @@ snapshots:
 
   css-functions-list@3.3.3: {}
 
-  css-loader@5.2.7(webpack@5.108.4(postcss@8.5.19)):
+  css-loader@5.2.7(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.19)
       loader-utils: 2.0.4
@@ -14161,7 +14286,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.8.5
-      webpack: 5.108.4(postcss@8.5.19)
+      webpack: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
   css-select@1.2.0:
     dependencies:
@@ -14284,13 +14409,17 @@ snapshots:
 
   dayjs@1.11.21: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@8.1.1):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@3.2.7:
+  debug@3.2.7(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
@@ -14304,21 +14433,21 @@ snapshots:
 
   decode-uri-component@0.4.1: {}
 
-  decorator-transforms@1.2.1(@babel/core@7.29.7):
+  decorator-transforms@1.2.1(@babel/core@7.29.7(supports-color@8.1.1)):
     dependencies:
-      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       babel-import-util: 2.1.1
     transitivePeerDependencies:
       - '@babel/core'
 
-  decorator-transforms@2.3.1(@babel/core@7.29.7):
+  decorator-transforms@2.3.1(@babel/core@7.29.7(supports-color@8.1.1)):
     dependencies:
-      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       babel-import-util: 3.0.1
     transitivePeerDependencies:
       - '@babel/core'
 
-  decorator-transforms@2.4.0(@babel/core@7.29.7):
+  decorator-transforms@2.4.0(@babel/core@7.29.7(supports-color@8.1.1)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       babel-import-util: 3.0.1
@@ -14521,56 +14650,56 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
-  ember-a11y-refocus@5.2.1(@babel/core@7.29.7):
+  ember-a11y-refocus@5.2.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-a11y-testing@8.0.1(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(@ember/test-waiters@4.1.2)(axe-core@4.12.1)(qunit@2.26.0):
+  ember-a11y-testing@8.0.1(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(axe-core@4.12.1)(qunit@2.26.0)(supports-color@8.1.1):
     dependencies:
-      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7)
-      '@ember/test-waiters': 4.1.2
-      '@embroider/addon-shim': 1.10.3
+      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@ember/test-waiters': 4.1.2(supports-color@8.1.1)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
       axe-core: 4.12.1
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
     optionalDependencies:
       qunit: 2.26.0
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-async-data@2.0.1(@babel/core@7.29.7):
+  ember-async-data@2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@ember/test-waiters': 4.1.2
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+      '@ember/test-waiters': 4.1.2(supports-color@8.1.1)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-auto-import@1.12.2:
+  ember-auto-import@1.12.2(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
       '@embroider/shared-internals': 1.8.3
-      babel-core: 6.26.3
-      babel-loader: 8.4.1(@babel/core@7.29.7)(webpack@4.47.0)
+      babel-core: 6.26.3(supports-color@8.1.1)
+      babel-loader: 8.4.1(@babel/core@7.29.7(supports-color@8.1.1))(webpack@4.47.0(supports-color@8.1.1))
       babel-plugin-syntax-dynamic-import: 6.18.0
       babylon: 6.18.0
-      broccoli-debug: 0.6.5
+      broccoli-debug: 0.6.5(supports-color@8.1.1)
       broccoli-node-api: 1.7.0
-      broccoli-plugin: 4.0.7
+      broccoli-plugin: 4.0.7(supports-color@8.1.1)
       broccoli-source: 3.0.1
-      debug: 3.2.7
-      ember-cli-babel: 7.26.11
+      debug: 3.2.7(supports-color@8.1.1)
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
       enhanced-resolve: 4.5.0
       fs-extra: 6.0.1
-      fs-tree-diff: 2.0.1
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
       handlebars: 4.7.9
       js-string-escape: 1.0.1
       lodash: 4.18.1
@@ -14581,49 +14710,49 @@ snapshots:
       symlink-or-copy: 1.3.1
       typescript-memoize: 1.1.1
       walk-sync: 0.3.4
-      webpack: 4.47.0
+      webpack: 4.47.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - webpack-cli
       - webpack-command
 
-  ember-auto-import@2.13.1(webpack@5.108.4(postcss@8.5.19)):
+  ember-auto-import@2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7)
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.7)
-      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@embroider/reverse-exports': 0.2.0
       '@embroider/shared-internals': 2.9.2(supports-color@8.1.1)
-      babel-loader: 8.4.1(@babel/core@7.29.7)(webpack@5.108.4(postcss@8.5.19))
+      babel-loader: 8.4.1(@babel/core@7.29.7(supports-color@8.1.1))(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-ember-template-compilation: 2.4.1
       babel-plugin-htmlbars-inline-precompile: 5.3.1
       babel-plugin-syntax-dynamic-import: 6.18.0
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
-      broccoli-plugin: 4.0.7
+      broccoli-debug: 0.6.5(supports-color@8.1.1)
+      broccoli-funnel: 3.0.8(supports-color@8.1.1)
+      broccoli-merge-trees: 4.2.0(supports-color@8.1.1)
+      broccoli-plugin: 4.0.7(supports-color@8.1.1)
       broccoli-source: 3.0.1
-      css-loader: 5.2.7(webpack@5.108.4(postcss@8.5.19))
+      css-loader: 5.2.7(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
-      fs-tree-diff: 2.0.1
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
       handlebars: 4.7.9
       is-subdir: 1.2.0
       js-string-escape: 1.0.1
       lodash: 4.18.1
-      mini-css-extract-plugin: 2.10.2(webpack@5.108.4(postcss@8.5.19))
+      mini-css-extract-plugin: 2.10.2(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       minimatch: 3.1.5
       parse5: 6.0.1
       pkg-entry-points: 1.1.2
       resolve: 1.22.12
       resolve-package-path: 4.0.3
       semver: 7.8.5
-      style-loader: 2.0.0(webpack@5.108.4(postcss@8.5.19))
+      style-loader: 2.0.0(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       typescript-memoize: 1.1.1
       walk-sync: 3.0.0
     transitivePeerDependencies:
@@ -14631,43 +14760,43 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-cli-app-version@7.0.0(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)):
+  ember-cli-app-version@7.0.0(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      ember-cli-babel: 7.26.11
-      ember-source: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
+      ember-source: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
       git-repo-info: 2.1.1
     transitivePeerDependencies:
       - supports-color
 
   ember-cli-babel-plugin-helpers@1.1.1: {}
 
-  ember-cli-babel@7.26.11:
+  ember-cli-babel@7.26.11(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7)
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.7)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.29.7)
-      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/polyfill': 7.12.1
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/runtime': 7.12.18
       amd-name-resolver: 1.3.1
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.29.7)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.29.7(supports-color@8.1.1))
       babel-plugin-ember-data-packages-polyfill: 0.1.2
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-module-resolver: 3.2.0
-      broccoli-babel-transpiler: 7.8.1
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 2.0.2
+      broccoli-babel-transpiler: 7.8.1(supports-color@8.1.1)
+      broccoli-debug: 0.6.5(supports-color@8.1.1)
+      broccoli-funnel: 2.0.2(supports-color@8.1.1)
       broccoli-source: 2.1.2
       calculate-cache-key-for-tree: 2.0.0
       clone: 2.1.2
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-cli-version-checker: 4.1.1
+      ember-cli-version-checker: 4.1.1(supports-color@8.1.1)
       ensure-posix-path: 1.1.1
       fixturify-project: 1.10.0
       resolve-package-path: 3.1.0
@@ -14676,53 +14805,53 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-babel@8.3.1(@babel/core@7.29.7):
+  ember-cli-babel@8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/runtime': 7.12.18
       amd-name-resolver: 1.3.1
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.29.7)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.29.7(supports-color@8.1.1))
       babel-plugin-ember-data-packages-polyfill: 0.1.2
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-module-resolver: 5.0.3
-      broccoli-babel-transpiler: 8.0.2(@babel/core@7.29.7)
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
+      broccoli-babel-transpiler: 8.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      broccoli-debug: 0.6.5(supports-color@8.1.1)
+      broccoli-funnel: 3.0.8(supports-color@8.1.1)
       broccoli-source: 3.0.1
       calculate-cache-key-for-tree: 2.0.0
       clone: 2.1.2
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-cli-version-checker: 5.1.2
+      ember-cli-version-checker: 5.1.2(supports-color@8.1.1)
       ensure-posix-path: 1.1.1
       resolve-package-path: 4.0.3
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-bundle-analyzer@1.0.0:
+  ember-cli-bundle-analyzer@1.0.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      fast-glob: 2.2.7
+      fast-glob: 2.2.7(supports-color@8.1.1)
       intercept-stdout: 0.1.2
       node-html-light: 1.4.0
       source-map-explorer: 2.5.3
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-dependency-checker@3.3.3(ember-cli@6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)):
+  ember-cli-dependency-checker@3.3.3(ember-cli@6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)):
     dependencies:
       chalk: 2.4.2
-      ember-cli: 6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+      ember-cli: 6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
       find-yarn-workspace-root: 2.0.0
       is-git-url: 1.0.0
       resolve: 1.22.12
@@ -14735,9 +14864,9 @@ snapshots:
       chalk: 2.4.2
       semver: 5.7.2
 
-  ember-cli-deploy-archive@1.0.0:
+  ember-cli-deploy-archive@1.0.0(supports-color@8.1.1):
     dependencies:
-      ember-cli-babel: 7.26.11
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
       ember-cli-deploy-plugin: 0.2.9
       fs-extra: 10.1.0
       rsvp: 4.8.5
@@ -14745,21 +14874,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-deploy-aws-pack@3.0.0:
+  ember-cli-deploy-aws-pack@3.0.0(supports-color@8.1.1):
     dependencies:
       ember-cli-deploy-build: 2.0.0
       ember-cli-deploy-cloudfront: 4.0.0
       ember-cli-deploy-gzip: 2.0.1
       ember-cli-deploy-manifest: 2.0.0
-      ember-cli-deploy-s3: 3.3.0
+      ember-cli-deploy-s3: 3.3.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-deploy-brotli@0.5.1:
+  ember-cli-deploy-brotli@0.5.1(supports-color@8.1.1):
     dependencies:
       chalk: 2.3.0
       core-object: 3.1.5
-      ember-cli-babel: 7.26.11
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
       ember-cli-deploy-plugin: 0.2.9
       minimatch: 3.1.5
       rsvp: 4.7.0
@@ -14773,9 +14902,9 @@ snapshots:
       glob: 7.2.3
       rsvp: 3.6.2
 
-  ember-cli-deploy-build@3.0.0(@babel/core@7.29.7)(eslint@9.39.5):
+  ember-cli-deploy-build@3.0.0(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1)):
     dependencies:
-      '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.39.5)
+      '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))
       chalk: 4.1.2
       ember-cli-deploy-plugin: 0.2.9
       glob: 10.5.0
@@ -14817,10 +14946,10 @@ snapshots:
       minimatch: 3.1.5
       rsvp: 4.8.5
 
-  ember-cli-deploy-gzip@3.0.0(@babel/core@7.29.7)(eslint@9.39.5):
+  ember-cli-deploy-gzip@3.0.0(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.39.5)
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       chalk: 4.1.2
       core-object: 3.1.5
       ember-cli-deploy-plugin: 0.2.9
@@ -14853,7 +14982,7 @@ snapshots:
 
   ember-cli-deploy-progress@1.3.0: {}
 
-  ember-cli-deploy-revision-data@3.0.0:
+  ember-cli-deploy-revision-data@3.0.0(supports-color@8.1.1):
     dependencies:
       chalk: 4.1.2
       core-object: 3.1.5
@@ -14861,7 +14990,7 @@ snapshots:
       git-repo-info: 2.1.1
       minimatch: 3.1.5
       rsvp: 4.8.5
-      simple-git: 3.36.0
+      simple-git: 3.36.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14874,7 +15003,7 @@ snapshots:
       mime-types: 2.1.35
       rsvp: 4.8.5
 
-  ember-cli-deploy-s3@3.3.0:
+  ember-cli-deploy-s3@3.3.0(supports-color@8.1.1):
     dependencies:
       aws-sdk: 2.1693.0
       chalk: 4.1.2
@@ -14883,12 +15012,12 @@ snapshots:
       lodash: 4.18.1
       mime: 2.6.0
       minimatch: 3.1.5
-      proxy-agent: 5.0.0
+      proxy-agent: 5.0.0(supports-color@8.1.1)
       rsvp: 4.8.5
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-deploy@2.0.0:
+  ember-cli-deploy@2.0.0(supports-color@8.1.1):
     dependencies:
       chalk: 1.1.3
       core-object: 2.1.1
@@ -14897,42 +15026,42 @@ snapshots:
       ember-cli-deploy-progress: 1.3.0
       lodash: 4.18.1
       rsvp: 3.6.2
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-deprecation-workflow@4.0.1(@babel/core@7.29.7):
+  ember-cli-deprecation-workflow@4.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-cli-flash@7.0.0(@babel/core@7.29.7)(@embroider/macros@1.20.5(@babel/core@7.29.7))(ember-modifier@4.2.2(@babel/core@7.29.7)):
+  ember-cli-flash@7.0.0(@babel/core@7.29.7(supports-color@8.1.1))(@embroider/macros@1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(ember-modifier@4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
-      ember-modifier: 4.2.2(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
+      ember-modifier: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
   ember-cli-get-component-path-option@1.0.0: {}
 
-  ember-cli-htmlbars@4.5.0:
+  ember-cli-htmlbars@4.5.0(supports-color@8.1.1):
     dependencies:
       '@ember/edition-utils': 1.2.0
       babel-plugin-htmlbars-inline-precompile: 3.2.0
-      broccoli-debug: 0.6.5
-      broccoli-persistent-filter: 2.3.1
-      broccoli-plugin: 3.1.0
+      broccoli-debug: 0.6.5(supports-color@8.1.1)
+      broccoli-persistent-filter: 2.3.1(supports-color@8.1.1)
+      broccoli-plugin: 3.1.0(supports-color@8.1.1)
       common-tags: 1.8.2
       ember-cli-babel-plugin-helpers: 1.1.1
-      fs-tree-diff: 2.0.1
-      hash-for-dep: 1.5.2
-      heimdalljs-logger: 0.1.10
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
+      hash-for-dep: 1.5.2(supports-color@8.1.1)
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       json-stable-stringify: 1.3.0
       semver: 6.3.1
       strip-bom: 4.0.0
@@ -14940,42 +15069,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-htmlbars@5.7.2:
+  ember-cli-htmlbars@5.7.2(supports-color@8.1.1):
     dependencies:
       '@ember/edition-utils': 1.2.0
       babel-plugin-htmlbars-inline-precompile: 5.3.1
-      broccoli-debug: 0.6.5
-      broccoli-persistent-filter: 3.1.3
-      broccoli-plugin: 4.0.7
+      broccoli-debug: 0.6.5(supports-color@8.1.1)
+      broccoli-persistent-filter: 3.1.3(supports-color@8.1.1)
+      broccoli-plugin: 4.0.7(supports-color@8.1.1)
       common-tags: 1.8.2
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-cli-version-checker: 5.1.2
-      fs-tree-diff: 2.0.1
-      hash-for-dep: 1.5.2
-      heimdalljs-logger: 0.1.10
+      ember-cli-version-checker: 5.1.2(supports-color@8.1.1)
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
+      hash-for-dep: 1.5.2(supports-color@8.1.1)
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       json-stable-stringify: 1.3.0
       semver: 7.8.5
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
       strip-bom: 4.0.0
       walk-sync: 2.2.0
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-htmlbars@6.3.0:
+  ember-cli-htmlbars@6.3.0(supports-color@8.1.1):
     dependencies:
       '@ember/edition-utils': 1.2.0
       babel-plugin-ember-template-compilation: 2.4.1
       babel-plugin-htmlbars-inline-precompile: 5.3.1
-      broccoli-debug: 0.6.5
-      broccoli-persistent-filter: 3.1.3
-      broccoli-plugin: 4.0.7
-      ember-cli-version-checker: 5.1.2
-      fs-tree-diff: 2.0.1
-      hash-for-dep: 1.5.2
-      heimdalljs-logger: 0.1.10
+      broccoli-debug: 0.6.5(supports-color@8.1.1)
+      broccoli-persistent-filter: 3.1.3(supports-color@8.1.1)
+      broccoli-plugin: 4.0.7(supports-color@8.1.1)
+      ember-cli-version-checker: 5.1.2(supports-color@8.1.1)
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
+      hash-for-dep: 1.5.2(supports-color@8.1.1)
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       js-string-escape: 1.0.1
       semver: 7.8.5
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
       walk-sync: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -14987,16 +15116,16 @@ snapshots:
 
   ember-cli-is-package-missing@1.0.0: {}
 
-  ember-cli-normalize-entity-name@1.0.0:
+  ember-cli-normalize-entity-name@1.0.0(supports-color@8.1.1):
     dependencies:
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-page-object@2.3.2(@ember/test-helpers@5.4.3(@babel/core@7.29.7)):
+  ember-cli-page-object@2.3.2(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7)
-      '@embroider/addon-shim': 1.10.3
+      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
       '@ro0gr/ceibo': 2.2.0
       '@types/jquery': 3.5.34
       jquery: 3.7.1
@@ -15005,27 +15134,27 @@ snapshots:
 
   ember-cli-path-utils@1.0.0: {}
 
-  ember-cli-preprocess-registry@5.0.1:
+  ember-cli-preprocess-registry@5.0.1(supports-color@8.1.1):
     dependencies:
-      broccoli-funnel: 3.0.8
+      broccoli-funnel: 3.0.8(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-sass@11.0.1:
+  ember-cli-sass@11.0.1(supports-color@8.1.1):
     dependencies:
-      broccoli-funnel: 2.0.2
-      broccoli-merge-trees: 3.0.2
-      broccoli-sass-source-maps: 4.3.0
+      broccoli-funnel: 2.0.2(supports-color@8.1.1)
+      broccoli-merge-trees: 3.0.2(supports-color@8.1.1)
+      broccoli-sass-source-maps: 4.3.0(supports-color@8.1.1)
       ember-cli-version-checker: 2.2.0
     transitivePeerDependencies:
       - supports-color
 
   ember-cli-string-utils@1.1.0: {}
 
-  ember-cli-terser@4.0.2:
+  ember-cli-terser@4.0.2(supports-color@8.1.1):
     dependencies:
-      broccoli-terser-sourcemap: 4.1.1
+      broccoli-terser-sourcemap: 4.1.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15033,24 +15162,24 @@ snapshots:
     dependencies:
       ember-cli-string-utils: 1.1.0
 
-  ember-cli-typescript-blueprint-polyfill@0.1.0:
+  ember-cli-typescript-blueprint-polyfill@0.1.0(supports-color@8.1.1):
     dependencies:
       chalk: 4.1.2
-      remove-types: 1.0.0
+      remove-types: 1.0.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-typescript@5.3.0:
+  ember-cli-typescript@5.3.0(supports-color@8.1.1):
     dependencies:
       ansi-to-html: 0.6.15
-      broccoli-stew: 3.0.0
+      broccoli-stew: 3.0.0(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
       execa: 4.1.0
       fs-extra: 9.1.0
       resolve: 1.22.12
       rsvp: 4.8.5
       semver: 7.8.5
-      stagehand: 1.0.1
+      stagehand: 1.0.1(supports-color@8.1.1)
       walk-sync: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -15065,49 +15194,49 @@ snapshots:
       resolve-package-path: 1.2.7
       semver: 5.7.2
 
-  ember-cli-version-checker@4.1.1:
+  ember-cli-version-checker@4.1.1(supports-color@8.1.1):
     dependencies:
       resolve-package-path: 2.0.0
       semver: 6.3.1
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-version-checker@5.1.2:
+  ember-cli-version-checker@5.1.2(supports-color@8.1.1):
     dependencies:
       resolve-package-path: 3.1.0
       semver: 7.8.5
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli@6.10.3(@babel/core@7.29.7)(@types/node@26.1.1)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8):
+  ember-cli@6.10.3(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.1)(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8):
     dependencies:
       '@ember-tooling/blueprint-blueprint': 0.2.1
-      '@ember-tooling/blueprint-model': 0.5.0
-      '@ember-tooling/classic-build-addon-blueprint': 6.10.1
-      '@ember-tooling/classic-build-app-blueprint': 6.10.1
+      '@ember-tooling/blueprint-model': 0.5.0(supports-color@8.1.1)
+      '@ember-tooling/classic-build-addon-blueprint': 6.10.1(supports-color@8.1.1)
+      '@ember-tooling/classic-build-app-blueprint': 6.10.1(supports-color@8.1.1)
       '@ember/app-blueprint': 6.10.5
       '@pnpm/find-workspace-dir': 1000.1.5
-      babel-remove-types: 1.1.0
-      broccoli: 4.0.0
-      broccoli-concat: 4.2.7
-      broccoli-config-loader: 1.0.1
-      broccoli-config-replace: 1.1.3
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
+      babel-remove-types: 1.1.0(supports-color@8.1.1)
+      broccoli: 4.0.0(supports-color@8.1.1)
+      broccoli-concat: 4.2.7(supports-color@8.1.1)
+      broccoli-config-loader: 1.0.1(supports-color@8.1.1)
+      broccoli-config-replace: 1.1.3(supports-color@8.1.1)
+      broccoli-debug: 0.6.5(supports-color@8.1.1)
+      broccoli-funnel: 3.0.8(supports-color@8.1.1)
       broccoli-funnel-reducer: 1.0.0
-      broccoli-merge-trees: 4.2.0
+      broccoli-merge-trees: 4.2.0(supports-color@8.1.1)
       broccoli-middleware: 2.1.2
       broccoli-slow-trees: 3.1.0
       broccoli-source: 3.0.1
-      broccoli-stew: 3.0.0
+      broccoli-stew: 3.0.0(supports-color@8.1.1)
       calculate-cache-key-for-tree: 2.0.0
       capture-exit: 2.0.0
       chalk: 5.6.2
       ci-info: 4.4.0
       clean-base-url: 1.0.0
-      compression: 1.8.1
+      compression: 1.8.1(supports-color@8.1.1)
       configstore: 7.1.0
       console-ui: 3.1.2
       content-tag: 4.2.0
@@ -15115,26 +15244,26 @@ snapshots:
       dag-map: 2.0.2
       diff: 8.0.4
       ember-cli-is-package-missing: 1.0.0
-      ember-cli-normalize-entity-name: 1.0.0
-      ember-cli-preprocess-registry: 5.0.1
+      ember-cli-normalize-entity-name: 1.0.0(supports-color@8.1.1)
+      ember-cli-preprocess-registry: 5.0.1(supports-color@8.1.1)
       ember-cli-string-utils: 1.1.0
       ensure-posix-path: 1.1.1
       execa: 9.6.1
       exit: 0.1.2
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
       filesize: 11.0.22
       find-up: 8.0.0
       find-yarn-workspace-root: 2.0.0
       fs-extra: 11.3.6
-      fs-tree-diff: 2.0.1
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
       get-caller-file: 2.0.5
       git-repo-info: 2.1.1
       glob: 13.0.6
       heimdalljs: 0.2.6
-      heimdalljs-fs-monitor: 1.1.2
+      heimdalljs-fs-monitor: 1.1.2(supports-color@8.1.1)
       heimdalljs-graph: 1.0.0
-      heimdalljs-logger: 0.1.10
-      http-proxy: 1.18.1
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
+      http-proxy: 1.18.1(debug@4.4.3(supports-color@8.1.1))
       inflection: 3.0.2
       inquirer: 13.4.3(@types/node@26.1.1)
       is-git-url: 1.0.0
@@ -15143,12 +15272,12 @@ snapshots:
       markdown-it: 14.3.0
       markdown-it-terminal: 0.4.0(markdown-it@14.3.0)
       minimatch: 10.2.5
-      morgan: 1.11.0
+      morgan: 1.11.0(supports-color@8.1.1)
       nopt: 3.0.6
       npm-package-arg: 13.0.2
       os-locale: 6.0.2
       p-defer: 4.0.1
-      portfinder: 1.0.38
+      portfinder: 1.0.38(supports-color@8.1.1)
       promise-map-series: 0.3.0
       promise.hash.helper: 1.0.8
       quick-temp: 0.1.9
@@ -15157,15 +15286,15 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sane: 5.0.1
       semver: 7.8.5
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
       sort-package-json: 3.7.1
       symlink-or-copy: 1.3.1
       temp: 0.9.4
-      testem: 3.20.1(@babel/core@7.29.7)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
-      tiny-lr: 2.0.0
-      tree-sync: 2.1.0
+      testem: 3.20.1(@babel/core@7.29.7(supports-color@8.1.1))(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
+      tiny-lr: 2.0.0(supports-color@8.1.1)
+      tree-sync: 2.1.0(supports-color@8.1.1)
       walk-sync: 4.0.2
-      watch-detector: 1.0.2
+      watch-detector: 1.0.2(supports-color@8.1.1)
       workerpool: 10.0.3
       yam: 1.0.0
     transitivePeerDependencies:
@@ -15221,18 +15350,18 @@ snapshots:
       - walrus
       - whiskers
 
-  ember-click-outside@6.1.1(@babel/core@7.29.7):
+  ember-click-outside@6.1.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      ember-modifier: 4.2.2(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      ember-modifier: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-compatibility-helpers@1.2.7(@babel/core@7.29.7):
+  ember-compatibility-helpers@1.2.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      babel-plugin-debug-macros: 0.2.0(@babel/core@7.29.7)
-      ember-cli-version-checker: 5.1.2
+      babel-plugin-debug-macros: 0.2.0(@babel/core@7.29.7(supports-color@8.1.1))
+      ember-cli-version-checker: 5.1.2(supports-color@8.1.1)
       find-up: 5.0.0
       fs-extra: 9.1.0
       semver: 5.7.2
@@ -15240,43 +15369,43 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-concurrency@5.2.0(@babel/core@7.29.7):
+  ember-concurrency@5.2.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/types': 7.29.7
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 1.2.1(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 1.2.1(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-cookies@1.4.1(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)):
+  ember-cookies@1.4.1(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      ember-source: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      ember-source: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-destroyable-polyfill@2.0.3(@babel/core@7.29.7):
+  ember-destroyable-polyfill@2.0.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 5.1.2
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.29.7)
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
+      ember-cli-version-checker: 5.1.2(supports-color@8.1.1)
+      ember-compatibility-helpers: 1.2.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-element-helper@0.8.8:
+  ember-element-helper@0.8.8(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-eslint-parser@0.5.13(@babel/core@7.29.7)(eslint@9.39.5)(typescript@6.0.3):
+  ember-eslint-parser@0.5.13(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.39.5)
+      '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))
       '@glimmer/syntax': 0.95.0
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
       content-tag: 2.0.3
@@ -15288,16 +15417,16 @@ snapshots:
       - eslint
       - typescript
 
-  ember-exam@10.1.0(ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0))(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.26.0)(webpack@5.108.4(postcss@8.5.19)):
+  ember-exam@10.1.0(ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       chalk: 5.6.2
       cli-table3: 0.6.5
       debug: 4.4.3(supports-color@8.1.1)
-      ember-auto-import: 2.13.1(webpack@5.108.4(postcss@8.5.19))
-      ember-cli-babel: 8.3.1(@babel/core@7.29.7)
-      ember-qunit: 9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0)
-      ember-source: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+      ember-auto-import: 2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
+      ember-cli-babel: 8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-qunit: 9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1)
+      ember-source: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
       execa: 8.0.1
       fs-extra: 11.3.6
       js-yaml: 4.3.0
@@ -15305,51 +15434,51 @@ snapshots:
       qunit: 2.26.0
       rimraf: 5.0.10
       semver: 7.8.5
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
       - webpack
 
-  ember-file-upload@10.1.0(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(@glimmer/component@2.1.1)(ember-modifier@4.2.2(@babel/core@7.29.7))(tracked-built-ins@3.4.0(@babel/core@7.29.7)):
+  ember-file-upload@10.1.0(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@glimmer/component@2.1.1(supports-color@8.1.1))(ember-modifier@4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1)(tracked-built-ins@3.4.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)):
     dependencies:
-      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7)
-      '@ember/test-waiters': 4.1.2
-      '@embroider/addon-shim': 1.10.3
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      '@glimmer/component': 2.1.1
-      ember-modifier: 4.2.2(@babel/core@7.29.7)
-      tracked-built-ins: 3.4.0(@babel/core@7.29.7)
+      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@ember/test-waiters': 4.1.2(supports-color@8.1.1)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@glimmer/component': 2.1.1(supports-color@8.1.1)
+      ember-modifier: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      tracked-built-ins: 3.4.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  ember-focus-trap@2.0.0(@babel/core@7.29.7):
+  ember-focus-trap@2.0.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
       focus-trap: 8.2.2
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-in-element-polyfill@1.0.1:
+  ember-in-element-polyfill@1.0.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 5.7.2
-      ember-cli-version-checker: 5.1.2
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
+      ember-cli-htmlbars: 5.7.2(supports-color@8.1.1)
+      ember-cli-version-checker: 5.1.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-in-viewport@4.1.0(@babel/core@7.29.7)(webpack@5.108.4(postcss@8.5.19)):
+  ember-in-viewport@4.1.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
-      '@embroider/macros': 1.20.5(@babel/core@7.29.7)
-      ember-auto-import: 2.13.1(webpack@5.108.4(postcss@8.5.19))
-      ember-cli-babel: 7.26.11
-      ember-destroyable-polyfill: 2.0.3(@babel/core@7.29.7)
-      ember-modifier: 4.2.2(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-auto-import: 2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
+      ember-destroyable-polyfill: 2.0.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-modifier: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       fast-deep-equal: 2.0.1
       intersection-observer-admin: 0.3.4
       raf-pool: 0.1.4
@@ -15359,53 +15488,53 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-inflector@5.0.2(@babel/core@7.29.7):
+  ember-inflector@5.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-intl@8.3.0(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7)):
+  ember-intl@8.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
       '@formatjs/intl': 4.1.16
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
     optionalDependencies:
-      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7)
+      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-keyboard@9.0.4(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7)):
+  ember-keyboard@9.0.4(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      ember-modifier: 4.2.2(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      ember-modifier: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     optionalDependencies:
-      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7)
+      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-load-initializers@3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)):
+  ember-load-initializers@3.0.1(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)):
     dependencies:
-      ember-source: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+      ember-source: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
 
-  ember-math-helpers@5.0.0(@babel/core@7.29.7)(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)):
+  ember-math-helpers@5.0.0(@babel/core@7.29.7(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
-      ember-source: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
+      ember-source: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-modifier@4.2.2(@babel/core@7.29.7):
+  ember-modifier@4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
-      ember-cli-normalize-entity-name: 1.0.0
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
+      ember-cli-normalize-entity-name: 1.0.0(supports-color@8.1.1)
       ember-cli-string-utils: 1.1.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -15413,104 +15542,104 @@ snapshots:
 
   ember-noscript@4.1.0: {}
 
-  ember-on-resize-modifier@2.0.2(@babel/core@7.29.7)(webpack@5.108.4(postcss@8.5.19)):
+  ember-on-resize-modifier@2.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
-      ember-auto-import: 2.13.1(webpack@5.108.4(postcss@8.5.19))
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 5.7.2
-      ember-modifier: 4.2.2(@babel/core@7.29.7)
-      ember-resize-observer-service: 1.1.0
+      ember-auto-import: 2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
+      ember-cli-htmlbars: 5.7.2(supports-color@8.1.1)
+      ember-modifier: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-resize-observer-service: 1.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
       - webpack
 
-  ember-page-title@9.0.3:
+  ember-page-title@9.0.3(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
       '@simple-dom/document': 1.4.0
     transitivePeerDependencies:
       - supports-color
 
-  ember-popper-modifier@4.1.1(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.108.4(postcss@8.5.19)):
+  ember-popper-modifier@4.1.1(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@popperjs/core': 2.11.8
-      ember-auto-import: 2.13.1(webpack@5.108.4(postcss@8.5.19))
-      ember-cli-babel: 8.3.1(@babel/core@7.29.7)
-      ember-cli-htmlbars: 6.3.0
-      ember-modifier: 4.2.2(@babel/core@7.29.7)
-      ember-source: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+      ember-auto-import: 2.13.1(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
+      ember-cli-babel: 8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-cli-htmlbars: 6.3.0(supports-color@8.1.1)
+      ember-modifier: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-source: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
       - webpack
 
-  ember-primitives@0.59.1(@babel/core@7.29.7)(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(@ember/test-waiters@4.1.2)(@glimmer/component@2.1.1)(ember-modifier@4.2.2(@babel/core@7.29.7))(ember-resources@7.1.0(@glimmer/component@2.1.1)):
+  ember-primitives@0.59.1(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(@glimmer/component@2.1.1(supports-color@8.1.1))(ember-modifier@4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(ember-resources@7.1.0(@glimmer/component@2.1.1(supports-color@8.1.1))(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/runtime': 7.29.7
-      '@ember/test-waiters': 4.1.2
-      '@embroider/addon-shim': 1.10.3
+      '@ember/test-waiters': 4.1.2(supports-color@8.1.1)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
       '@floating-ui/dom': 1.8.0
-      '@glimmer/component': 2.1.1
-      decorator-transforms: 2.3.1(@babel/core@7.29.7)
-      ember-element-helper: 0.8.8
-      ember-modifier: 4.2.2(@babel/core@7.29.7)
-      ember-resources: 7.1.0(@glimmer/component@2.1.1)
+      '@glimmer/component': 2.1.1(supports-color@8.1.1)
+      decorator-transforms: 2.3.1(@babel/core@7.29.7(supports-color@8.1.1))
+      ember-element-helper: 0.8.8(supports-color@8.1.1)
+      ember-modifier: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-resources: 7.1.0(@glimmer/component@2.1.1(supports-color@8.1.1))(supports-color@8.1.1)
       form-data-utils: 0.6.0
-      reactiveweb: 1.9.3(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)(@glimmer/component@2.1.1)
+      reactiveweb: 1.9.3(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(@glimmer/component@2.1.1(supports-color@8.1.1))(supports-color@8.1.1)
       should-handle-link: 1.3.0
       tabster: 8.8.0
-      tracked-built-ins: 4.1.2(@babel/core@7.29.7)
-      tracked-toolbox: 3.0.0(@babel/core@7.29.7)
+      tracked-built-ins: 4.1.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      tracked-toolbox: 3.0.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       which-heading-do-i-need: 0.2.7
     optionalDependencies:
-      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7)
+      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0):
+  ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(qunit@2.26.0)(supports-color@8.1.1):
     dependencies:
-      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7)
-      '@embroider/addon-shim': 1.10.3
+      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
       qunit: 2.26.0
       qunit-theme-ember: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
-  ember-resize-observer-polyfill@0.0.1:
+  ember-resize-observer-polyfill@0.0.1(supports-color@8.1.1):
     dependencies:
-      ember-auto-import: 1.12.2
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 4.5.0
+      ember-auto-import: 1.12.2(supports-color@8.1.1)
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
+      ember-cli-htmlbars: 4.5.0(supports-color@8.1.1)
       resize-observer-polyfill: 1.5.1
     transitivePeerDependencies:
       - supports-color
       - webpack-cli
       - webpack-command
 
-  ember-resize-observer-service@1.1.0:
+  ember-resize-observer-service@1.1.0(supports-color@8.1.1):
     dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 5.7.2
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
+      ember-cli-htmlbars: 5.7.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   ember-resolver@13.2.0: {}
 
-  ember-resources@7.1.0(@glimmer/component@2.1.1):
+  ember-resources@7.1.0(@glimmer/component@2.1.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
     optionalDependencies:
-      '@glimmer/component': 2.1.1
+      '@glimmer/component': 2.1.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   ember-rfc176-data@0.3.18: {}
 
-  ember-router-generator@2.0.0:
+  ember-router-generator@2.0.0(supports-color@8.1.1):
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
@@ -15518,29 +15647,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-set-helper@3.1.0(@babel/core@7.29.7):
+  ember-set-helper@3.1.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 1.2.1(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 1.2.1(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-simple-auth@8.3.1(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)):
+  ember-simple-auth@8.3.1(@ember/test-helpers@5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@ember/test-waiters': 4.1.2
-      '@embroider/addon-shim': 1.10.3
-      ember-cookies: 1.4.1(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
-      ember-source: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+      '@ember/test-waiters': 4.1.2(supports-color@8.1.1)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      ember-cookies: 1.4.1(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-source: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
     optionalDependencies:
-      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7)
+      '@ember/test-helpers': 5.4.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-simple-charts@12.2.2(@babel/core@7.29.7)(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.108.4(postcss@8.5.19)):
+  ember-simple-charts@12.2.2(@babel/core@7.29.7(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      '@embroider/util': 1.13.5(@babel/core@7.29.7)(ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5))
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      '@embroider/util': 1.13.5(@babel/core@7.29.7(supports-color@8.1.1))(ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1))(supports-color@8.1.1)
       '@popperjs/core': 2.11.8
       d3-ease: 3.0.1
       d3-hierarchy: 3.1.2
@@ -15550,14 +15679,14 @@ snapshots:
       d3-selection: 3.0.0
       d3-shape: 3.2.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
-      ember-async-data: 2.0.1(@babel/core@7.29.7)
-      ember-concurrency: 5.2.0(@babel/core@7.29.7)
-      ember-in-element-polyfill: 1.0.1
-      ember-modifier: 4.2.2(@babel/core@7.29.7)
-      ember-on-resize-modifier: 2.0.2(@babel/core@7.29.7)(webpack@5.108.4(postcss@8.5.19))
-      ember-resize-observer-polyfill: 0.0.1
-      ember-source: 6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
+      ember-async-data: 2.0.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-concurrency: 5.2.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-in-element-polyfill: 1.0.1(supports-color@8.1.1)
+      ember-modifier: 4.2.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      ember-on-resize-modifier: 2.0.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
+      ember-resize-observer-polyfill: 0.0.1(supports-color@8.1.1)
+      ember-source: 6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/environment-ember-loose'
@@ -15567,13 +15696,13 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  ember-source@6.10.1(@glimmer/component@2.1.1)(rsvp@4.8.5):
+  ember-source@6.10.1(@glimmer/component@2.1.1(supports-color@8.1.1))(rsvp@4.8.5)(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@ember/edition-utils': 1.2.0
-      '@embroider/addon-shim': 1.10.3
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
       '@glimmer/compiler': 0.94.11
-      '@glimmer/component': 2.1.1
+      '@glimmer/component': 2.1.1(supports-color@8.1.1)
       '@glimmer/destroyable': 0.94.8
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
@@ -15588,38 +15717,38 @@ snapshots:
       '@glimmer/util': 0.94.8
       '@glimmer/validator': 0.95.0
       '@glimmer/vm': 0.94.8
-      '@glimmer/vm-babel-plugins': 0.93.5(@babel/core@7.29.7)
+      '@glimmer/vm-babel-plugins': 0.93.5(@babel/core@7.29.7(supports-color@8.1.1))
       '@simple-dom/interface': 1.4.0
       backburner.js: 2.8.0
       broccoli-file-creator: 2.1.1
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
+      broccoli-funnel: 3.0.8(supports-color@8.1.1)
+      broccoli-merge-trees: 4.2.0(supports-color@8.1.1)
       chalk: 4.1.2
-      ember-cli-babel: 8.3.1(@babel/core@7.29.7)
+      ember-cli-babel: 8.3.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-is-package-missing: 1.0.0
-      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-normalize-entity-name: 1.0.0(supports-color@8.1.1)
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-cli-typescript-blueprint-polyfill: 0.1.0
-      ember-cli-version-checker: 5.1.2
-      ember-router-generator: 2.0.0
+      ember-cli-typescript-blueprint-polyfill: 0.1.0(supports-color@8.1.1)
+      ember-cli-version-checker: 5.1.2(supports-color@8.1.1)
+      ember-router-generator: 2.0.0(supports-color@8.1.1)
       inflection: 2.0.1
       route-recognizer: 0.3.4
       router_js: 8.0.6(route-recognizer@0.3.4)(rsvp@4.8.5)
       semver: 7.8.5
-      silent-error: 1.1.1
+      silent-error: 1.1.1(supports-color@8.1.1)
       simple-html-tokenizer: 0.5.11
     transitivePeerDependencies:
       - rsvp
       - supports-color
 
-  ember-template-imports@3.4.2:
+  ember-template-imports@3.4.2(supports-color@8.1.1):
     dependencies:
       babel-import-util: 0.2.0
-      broccoli-stew: 3.0.0
+      broccoli-stew: 3.0.0(supports-color@8.1.1)
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-cli-version-checker: 5.1.2
+      ember-cli-version-checker: 5.1.2(supports-color@8.1.1)
       line-column: 1.0.2
       magic-string: 0.25.9
       parse-static-imports: 1.1.0
@@ -15628,23 +15757,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-template-imports@4.4.0:
+  ember-template-imports@4.4.0(supports-color@8.1.1):
     dependencies:
-      broccoli-stew: 3.0.0
+      broccoli-stew: 3.0.0(supports-color@8.1.1)
       content-tag: 4.2.0
-      ember-cli-version-checker: 5.1.2
+      ember-cli-version-checker: 5.1.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-template-lint@6.1.0:
+  ember-template-lint@6.1.0(supports-color@8.1.1):
     dependencies:
       '@lint-todo/utils': 13.1.1
       aria-query: 5.3.2
       chalk: 5.6.2
       ci-info: 4.4.0
       date-fns: 3.6.0
-      ember-template-imports: 3.4.2
-      ember-template-recast: 6.1.5
+      ember-template-imports: 3.4.2(supports-color@8.1.1)
+      ember-template-recast: 6.1.5(supports-color@8.1.1)
       eslint-formatter-kakoune: 1.0.0
       find-up: 7.0.0
       fuse.js: 7.5.0
@@ -15659,12 +15788,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-template-recast@6.1.5:
+  ember-template-recast@6.1.5(supports-color@8.1.1):
     dependencies:
       '@glimmer/reference': 0.84.3
       '@glimmer/syntax': 0.84.3
       '@glimmer/validator': 0.84.3
-      async-promise-queue: 1.0.5
+      async-promise-queue: 1.0.5(supports-color@8.1.1)
       colors: 1.4.0
       commander: 8.3.0
       globby: 11.1.0
@@ -15675,24 +15804,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-test-selectors@7.1.0:
+  ember-test-selectors@7.1.0(supports-color@8.1.1):
     dependencies:
       calculate-cache-key-for-tree: 2.0.0
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 5.1.2
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
+      ember-cli-version-checker: 5.1.2(supports-color@8.1.1)
       strip-test-selectors: 0.1.0
     transitivePeerDependencies:
       - supports-color
 
-  ember-tracked-storage-polyfill@1.0.1:
+  ember-tracked-storage-polyfill@1.0.1(supports-color@8.1.1):
     dependencies:
-      ember-cli-babel: 7.26.11
+      ember-cli-babel: 7.26.11(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-truth-helpers@5.0.0:
+  ember-truth-helpers@5.0.0(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15714,7 +15843,7 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.9:
+  engine.io@6.6.9(supports-color@8.1.1):
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 26.1.1
@@ -15838,6 +15967,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-html-parser@0.3.1: {}
+
   es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.2:
@@ -15881,25 +16012,25 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.39.5):
+  eslint-compat-utils@0.5.1(eslint@9.39.5(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.5
+      eslint: 9.39.5(supports-color@8.1.1)
       semver: 7.8.5
 
-  eslint-config-prettier@9.1.2(eslint@9.39.5):
+  eslint-config-prettier@9.1.2(eslint@9.39.5(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.5
+      eslint: 9.39.5(supports-color@8.1.1)
 
   eslint-formatter-kakoune@1.0.0: {}
 
-  eslint-plugin-ember@12.7.5(@babel/core@7.29.7)(eslint@9.39.5)(typescript@6.0.3):
+  eslint-plugin-ember@12.7.5(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3):
     dependencies:
       '@ember-data/rfc395-data': 0.0.4
       css-tree: 3.2.1
-      ember-eslint-parser: 0.5.13(@babel/core@7.29.7)(eslint@9.39.5)(typescript@6.0.3)
+      ember-eslint-parser: 0.5.13(@babel/core@7.29.7(supports-color@8.1.1))(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3)
       ember-rfc176-data: 0.3.18
-      eslint: 9.39.5
-      eslint-utils: 3.0.0(eslint@9.39.5)
+      eslint: 9.39.5(supports-color@8.1.1)
+      eslint-utils: 3.0.0(eslint@9.39.5(supports-color@8.1.1))
       estraverse: 5.3.0
       lodash.camelcase: 4.3.0
       lodash.kebabcase: 4.1.1
@@ -15909,19 +16040,19 @@ snapshots:
       - '@babel/core'
       - typescript
 
-  eslint-plugin-es-x@7.8.0(eslint@9.39.5):
+  eslint-plugin-es-x@7.8.0(eslint@9.39.5(supports-color@8.1.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      eslint: 9.39.5
-      eslint-compat-utils: 0.5.1(eslint@9.39.5)
+      eslint: 9.39.5(supports-color@8.1.1)
+      eslint-compat-utils: 0.5.1(eslint@9.39.5(supports-color@8.1.1))
 
-  eslint-plugin-n@17.24.0(eslint@9.39.5)(typescript@6.0.3):
+  eslint-plugin-n@17.24.0(eslint@9.39.5(supports-color@8.1.1))(typescript@6.0.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(supports-color@8.1.1))
       enhanced-resolve: 5.24.2
-      eslint: 9.39.5
-      eslint-plugin-es-x: 7.8.0(eslint@9.39.5)
+      eslint: 9.39.5(supports-color@8.1.1)
+      eslint-plugin-es-x: 7.8.0(eslint@9.39.5(supports-color@8.1.1))
       get-tsconfig: 4.14.0
       globals: 15.15.0
       globrex: 0.1.2
@@ -15931,20 +16062,20 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-qunit@8.2.6(eslint@9.39.5):
+  eslint-plugin-qunit@8.2.6(eslint@9.39.5(supports-color@8.1.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5)
-      eslint: 9.39.5
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(supports-color@8.1.1))
+      eslint: 9.39.5(supports-color@8.1.1)
       requireindex: 1.2.0
 
-  eslint-plugin-yml@3.6.0(eslint@9.39.5):
+  eslint-plugin-yml@3.6.0(eslint@9.39.5(supports-color@8.1.1)):
     dependencies:
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@ota-meshi/ast-token-store': 0.3.0
       diff-sequences: 29.6.3
       escape-string-regexp: 5.0.0
-      eslint: 9.39.5
+      eslint: 9.39.5(supports-color@8.1.1)
       natural-compare: 1.4.0
       yaml-eslint-parser: 2.1.0
 
@@ -15968,9 +16099,9 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-utils@3.0.0(eslint@9.39.5):
+  eslint-utils@3.0.0(eslint@9.39.5(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.5
+      eslint: 9.39.5(supports-color@8.1.1)
       eslint-visitor-keys: 2.1.0
 
   eslint-visitor-keys@2.1.0: {}
@@ -15981,14 +16112,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.5:
+  eslint@9.39.5(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@8.1.1)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.6
+      '@eslint/eslintrc': 3.3.6(supports-color@8.1.1)
       '@eslint/js': 9.39.5
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -16116,14 +16247,14 @@ snapshots:
 
   exit@0.1.2: {}
 
-  expand-brackets@2.1.4:
+  expand-brackets@2.1.4(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       define-property: 0.2.5
       extend-shallow: 2.0.1
       posix-character-classes: 0.1.1
       regex-not: 1.0.2
-      snapdragon: 0.8.2
+      snapdragon: 0.8.2(supports-color@8.1.1)
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -16132,10 +16263,10 @@ snapshots:
     dependencies:
       homedir-polyfill: 1.0.3
 
-  express@5.2.1:
+  express@5.2.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@8.1.1)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -16145,7 +16276,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -16156,9 +16287,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
+      serve-static: 2.2.1(supports-color@8.1.1)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -16182,15 +16313,15 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
-  extglob@2.0.4:
+  extglob@2.0.4(supports-color@8.1.1):
     dependencies:
       array-unique: 0.3.2
       define-property: 1.0.0
-      expand-brackets: 2.1.4
+      expand-brackets: 2.1.4(supports-color@8.1.1)
       extend-shallow: 2.0.1
       fragment-cache: 0.2.1
       regex-not: 1.0.2
-      snapdragon: 0.8.2
+      snapdragon: 0.8.2(supports-color@8.1.1)
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -16203,14 +16334,14 @@ snapshots:
 
   fast-diff@1.3.0: {}
 
-  fast-glob@2.2.7:
+  fast-glob@2.2.7(supports-color@8.1.1):
     dependencies:
       '@mrmlnc/readdir-enhanced': 2.2.1
       '@nodelib/fs.stat': 1.1.3
       glob-parent: 3.1.0
       is-glob: 4.0.3
       merge2: 1.4.1
-      micromatch: 3.1.10
+      micromatch: 3.1.10(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16230,11 +16361,11 @@ snapshots:
     dependencies:
       blank-object: 1.0.2
 
-  fast-sourcemap-concat@2.1.1:
+  fast-sourcemap-concat@2.1.1(supports-color@8.1.1):
     dependencies:
       chalk: 2.4.2
       fs-extra: 5.0.0
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       memory-streams: 0.1.3
       mkdirp: 0.5.6
       source-map: 0.4.4
@@ -16322,9 +16453,9 @@ snapshots:
 
   filter-obj@5.1.0: {}
 
-  finalhandler@1.1.2:
+  finalhandler@1.1.2(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
@@ -16334,7 +16465,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -16462,7 +16593,9 @@ snapshots:
     dependencies:
       tabbable: 6.5.0
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -16554,12 +16687,12 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
-  fs-merger@3.2.1:
+  fs-merger@3.2.1(supports-color@8.1.1):
     dependencies:
       broccoli-node-api: 1.7.0
       broccoli-node-info: 2.2.0
       fs-extra: 8.1.0
-      fs-tree-diff: 2.0.1
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
       walk-sync: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -16568,31 +16701,31 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
-  fs-tree-diff@0.5.9:
+  fs-tree-diff@0.5.9(supports-color@8.1.1):
     dependencies:
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       object-assign: 4.1.1
       path-posix: 1.0.0
       symlink-or-copy: 1.3.1
     transitivePeerDependencies:
       - supports-color
 
-  fs-tree-diff@2.0.1:
+  fs-tree-diff@2.0.1(supports-color@8.1.1):
     dependencies:
       '@types/symlink-or-copy': 1.2.2
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       object-assign: 4.1.1
       path-posix: 1.0.0
       symlink-or-copy: 1.3.1
     transitivePeerDependencies:
       - supports-color
 
-  fs-updater@1.0.4:
+  fs-updater@1.0.4(supports-color@8.1.1):
     dependencies:
       can-symlink: 1.0.0
       clean-up-path: 1.0.0
       heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       rimraf: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -16704,7 +16837,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@3.0.2:
+  get-uri@3.0.2(supports-color@8.1.1):
     dependencies:
       '@tootallnate/once': 1.1.2
       data-uri-to-buffer: 3.0.1
@@ -16922,10 +17055,10 @@ snapshots:
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
 
-  hash-for-dep@1.5.2:
+  hash-for-dep@1.5.2(supports-color@8.1.1):
     dependencies:
       heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
       resolve: 1.22.12
       resolve-package-path: 1.2.7
     transitivePeerDependencies:
@@ -16949,21 +17082,21 @@ snapshots:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.2
 
-  heimdalljs-fs-monitor@1.1.2:
+  heimdalljs-fs-monitor@1.1.2(supports-color@8.1.1):
     dependencies:
       callsites: 3.1.0
       clean-stack: 2.2.0
       extract-stack: 2.0.0
       heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   heimdalljs-graph@1.0.0: {}
 
-  heimdalljs-logger@0.1.10:
+  heimdalljs-logger@0.1.10(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       heimdalljs: 0.2.6
     transitivePeerDependencies:
       - supports-color
@@ -17000,6 +17133,11 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   html-escaper@3.0.3: {}
+
+  html-standard@0.0.13:
+    dependencies:
+      vscode-css-languageservice: 6.3.10
+      vscode-languageserver-textdocument: 1.0.12
 
   html-tags@3.3.1: {}
 
@@ -17043,10 +17181,10 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-agent@4.0.1:
+  http-proxy-agent@4.0.1(supports-color@8.1.1):
     dependencies:
       '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -17058,19 +17196,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy@1.18.1:
+  http-proxy@1.18.1(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
 
   https-browserify@1.0.0: {}
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -17875,29 +18013,29 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
-  merge-trees@2.0.0:
+  merge-trees@2.0.0(supports-color@8.1.1):
     dependencies:
-      fs-updater: 1.0.4
+      fs-updater: 1.0.4(supports-color@8.1.1)
       heimdalljs: 0.2.6
     transitivePeerDependencies:
       - supports-color
 
   merge2@1.4.1: {}
 
-  micromatch@3.1.10:
+  micromatch@3.1.10(supports-color@8.1.1):
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
-      braces: 2.3.2
+      braces: 2.3.2(supports-color@8.1.1)
       define-property: 2.0.2
       extend-shallow: 3.0.2
-      extglob: 2.0.4
+      extglob: 2.0.4(supports-color@8.1.1)
       fragment-cache: 0.2.1
       kind-of: 6.0.3
-      nanomatch: 1.2.13
+      nanomatch: 1.2.13(supports-color@8.1.1)
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.2
+      snapdragon: 0.8.2(supports-color@8.1.1)
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -17934,11 +18072,11 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.108.4(postcss@8.5.19)):
+  mini-css-extract-plugin@2.10.2(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.108.4(postcss@8.5.19)
+      webpack: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
   minimalistic-assert@1.0.1: {}
 
@@ -17966,15 +18104,17 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(postcss@8.5.19)(webpack@5.108.4(postcss@8.5.19)):
+  minimizer-webpack-plugin@5.6.1(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.108.4(postcss@8.5.19)
+      webpack: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
     optionalDependencies:
+      csso: 4.2.0
       postcss: 8.5.19
+      uglify-js: 3.19.3
 
   minipass@3.3.6:
     dependencies:
@@ -18021,10 +18161,10 @@ snapshots:
 
   mockdate@3.0.5: {}
 
-  morgan@1.11.0:
+  morgan@1.11.0(supports-color@8.1.1):
     dependencies:
       basic-auth: 2.0.1
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       on-finished: 2.4.1
       on-headers: 1.1.0
@@ -18086,7 +18226,7 @@ snapshots:
 
   nanoid@3.3.16: {}
 
-  nanomatch@1.2.13:
+  nanomatch@1.2.13(supports-color@8.1.1):
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
@@ -18097,7 +18237,7 @@ snapshots:
       kind-of: 6.0.3
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.2
+      snapdragon: 0.8.2(supports-color@8.1.1)
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -18376,17 +18516,17 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pac-proxy-agent@5.0.0:
+  pac-proxy-agent@5.0.0(supports-color@8.1.1):
     dependencies:
       '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
-      get-uri: 3.0.2
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
+      get-uri: 3.0.2(supports-color@8.1.1)
+      http-proxy-agent: 4.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       pac-resolver: 5.0.1
       raw-body: 2.5.3
-      socks-proxy-agent: 5.0.1
+      socks-proxy-agent: 5.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18538,7 +18678,7 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  portfinder@1.0.38:
+  portfinder@1.0.38(supports-color@8.1.1):
     dependencies:
       async: 3.2.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -18606,7 +18746,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-ember-template-tag@2.1.7(prettier@3.9.5):
+  prettier-plugin-ember-template-tag@2.1.7(prettier@3.9.5)(supports-color@8.1.1):
     dependencies:
       '@babel/traverse': 7.29.7(supports-color@8.1.1)
       content-tag: 4.2.0
@@ -18657,16 +18797,16 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-agent@5.0.0:
+  proxy-agent@5.0.0(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
+      http-proxy-agent: 4.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       lru-cache: 5.1.1
-      pac-proxy-agent: 5.0.0
+      pac-proxy-agent: 5.0.0(supports-color@8.1.1)
       proxy-from-env: 1.1.0
-      socks-proxy-agent: 5.0.1
+      socks-proxy-agent: 5.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18793,12 +18933,12 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
-  reactiveweb@1.9.3(@babel/core@7.29.7)(@ember/test-waiters@4.1.2)(@glimmer/component@2.1.1):
+  reactiveweb@1.9.3(@babel/core@7.29.7(supports-color@8.1.1))(@ember/test-waiters@4.1.2(supports-color@8.1.1))(@glimmer/component@2.1.1(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@ember/test-waiters': 4.1.2
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
-      ember-resources: 7.1.0(@glimmer/component@2.1.1)
+      '@ember/test-waiters': 4.1.2(supports-color@8.1.1)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
+      ember-resources: 7.1.0(@glimmer/component@2.1.1(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glimmer/component'
@@ -18835,10 +18975,10 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  readdirp@2.2.1:
+  readdirp@2.2.1(supports-color@8.1.1):
     dependencies:
       graceful-fs: 4.2.11
-      micromatch: 3.1.10
+      micromatch: 3.1.10(supports-color@8.1.1)
       readable-stream: 2.3.8
     transitivePeerDependencies:
       - supports-color
@@ -18922,11 +19062,11 @@ snapshots:
 
   remove-trailing-separator@1.1.0: {}
 
-  remove-types@1.0.0:
+  remove-types@1.0.0(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       prettier: 2.8.8
     transitivePeerDependencies:
       - supports-color
@@ -19047,7 +19187,7 @@ snapshots:
 
   route-recognizer@0.3.4: {}
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
@@ -19128,15 +19268,15 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sane@4.1.0:
+  sane@4.1.0(supports-color@8.1.1):
     dependencies:
       '@cnakazawa/watch': 1.0.4
-      anymatch: 2.0.0
+      anymatch: 2.0.0(supports-color@8.1.1)
       capture-exit: 2.0.0
       exec-sh: 0.3.6
       execa: 1.0.0
       fb-watchman: 2.0.2
-      micromatch: 3.1.10
+      micromatch: 3.1.10(supports-color@8.1.1)
       minimist: 1.2.8
       walker: 1.0.8
     transitivePeerDependencies:
@@ -19209,7 +19349,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -19229,12 +19369,12 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19331,15 +19471,15 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  silent-error@1.1.1:
+  silent-error@1.1.1(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  simple-git@3.36.0:
+  simple-git@3.36.0(supports-color@8.1.1):
     dependencies:
-      '@kwsites/file-exists': 1.1.1
+      '@kwsites/file-exists': 1.1.1(supports-color@8.1.1)
       '@kwsites/promise-deferred': 1.1.1
       '@simple-git/args-pathspec': 1.0.3
       '@simple-git/argv-parser': 1.1.1
@@ -19384,10 +19524,10 @@ snapshots:
     dependencies:
       kind-of: 3.2.2
 
-  snapdragon@0.8.2:
+  snapdragon@0.8.2(supports-color@8.1.1):
     dependencies:
       base: 0.11.2
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       define-property: 0.2.5
       extend-shallow: 2.0.1
       map-cache: 0.2.2
@@ -19397,7 +19537,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socket.io-adapter@2.5.8:
+  socket.io-adapter@2.5.8(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       ws: 8.21.0
@@ -19406,30 +19546,30 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6:
+  socket.io-parser@4.2.6(supports-color@8.1.1):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@4.8.3:
+  socket.io@4.8.3(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.6
       debug: 4.4.3(supports-color@8.1.1)
-      engine.io: 6.6.9
-      socket.io-adapter: 2.5.8
-      socket.io-parser: 4.2.6
+      engine.io: 6.6.9(supports-color@8.1.1)
+      socket.io-adapter: 2.5.8(supports-color@8.1.1)
+      socket.io-parser: 4.2.6(supports-color@8.1.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socks-proxy-agent@5.0.1:
+  socks-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
       socks: 2.8.9
     transitivePeerDependencies:
@@ -19531,7 +19671,7 @@ snapshots:
     dependencies:
       figgy-pudding: 3.5.2
 
-  stagehand@1.0.1:
+  stagehand@1.0.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -19690,35 +19830,35 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
-  style-loader@2.0.0(webpack@5.108.4(postcss@8.5.19)):
+  style-loader@2.0.0(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.108.4(postcss@8.5.19)
+      webpack: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
   styled_string@0.0.1: {}
 
-  stylelint-config-recommended-scss@17.0.1(postcss@8.5.19)(stylelint@16.26.1(typescript@6.0.3)):
+  stylelint-config-recommended-scss@17.0.1(postcss@8.5.19)(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.19)
-      stylelint: 16.26.1(typescript@6.0.3)
-      stylelint-config-recommended: 18.0.0(stylelint@16.26.1(typescript@6.0.3))
-      stylelint-scss: 7.2.0(stylelint@16.26.1(typescript@6.0.3))
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@6.0.3)
+      stylelint-config-recommended: 18.0.0(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
+      stylelint-scss: 7.2.0(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
     optionalDependencies:
       postcss: 8.5.19
 
-  stylelint-config-recommended@14.0.1(stylelint@16.26.1(typescript@6.0.3)):
+  stylelint-config-recommended@14.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@6.0.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@6.0.3)
 
-  stylelint-config-recommended@18.0.0(stylelint@16.26.1(typescript@6.0.3)):
+  stylelint-config-recommended@18.0.0(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@6.0.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@6.0.3)
 
-  stylelint-config-standard@36.0.1(stylelint@16.26.1(typescript@6.0.3)):
+  stylelint-config-standard@36.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@6.0.3)
-      stylelint-config-recommended: 14.0.1(stylelint@16.26.1(typescript@6.0.3))
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@6.0.3)
+      stylelint-config-recommended: 14.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3))
 
   stylelint-scales@5.0.0(postcss@8.5.19):
     dependencies:
@@ -19726,7 +19866,7 @@ snapshots:
     transitivePeerDependencies:
       - postcss
 
-  stylelint-scss@7.2.0(stylelint@16.26.1(typescript@6.0.3)):
+  stylelint-scss@7.2.0(stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3)):
     dependencies:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -19739,9 +19879,9 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
-      stylelint: 16.26.1(typescript@6.0.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@6.0.3)
 
-  stylelint@16.26.1(typescript@6.0.3):
+  stylelint@16.26.1(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
@@ -19817,9 +19957,9 @@ snapshots:
 
   symlink-or-copy@1.3.1: {}
 
-  sync-disk-cache@1.3.4:
+  sync-disk-cache@1.3.4(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       heimdalljs: 0.2.6
       mkdirp: 0.5.6
       rimraf: 2.7.1
@@ -19827,7 +19967,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  sync-disk-cache@2.1.0:
+  sync-disk-cache@2.1.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       heimdalljs: 0.2.6
@@ -19882,7 +20022,7 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.6.3
 
-  terser-webpack-plugin@1.4.6(webpack@4.47.0):
+  terser-webpack-plugin@1.4.6(webpack@4.47.0(supports-color@8.1.1)):
     dependencies:
       cacache: 12.0.4
       find-cache-dir: 2.1.0
@@ -19891,19 +20031,21 @@ snapshots:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.1
-      webpack: 4.47.0
+      webpack: 4.47.0(supports-color@8.1.1)
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
 
-  terser-webpack-plugin@5.6.1(postcss@8.5.19)(webpack@5.108.4(postcss@8.5.19)):
+  terser-webpack-plugin@5.6.1(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.108.4(postcss@8.5.19)
+      webpack: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
     optionalDependencies:
+      csso: 4.2.0
       postcss: 8.5.19
+      uglify-js: 3.19.3
 
   terser@4.8.1:
     dependencies:
@@ -19919,9 +20061,9 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  testem-failure-only-reporter@1.0.0(@babel/core@7.29.7)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8):
+  testem-failure-only-reporter@1.0.0(@babel/core@7.29.7(supports-color@8.1.1))(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8):
     dependencies:
-      testem: 3.20.1(@babel/core@7.29.7)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8)
+      testem: 3.20.1(@babel/core@7.29.7(supports-color@8.1.1))(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8)
     transitivePeerDependencies:
       - '@babel/core'
       - arc-templates
@@ -19974,19 +20116,19 @@ snapshots:
       - walrus
       - whiskers
 
-  testem@3.20.1(@babel/core@7.29.7)(ejs@3.1.10)(handlebars@4.7.9)(underscore@1.13.8):
+  testem@3.20.1(@babel/core@7.29.7(supports-color@8.1.1))(debug@4.4.3(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(supports-color@8.1.1)(underscore@1.13.8):
     dependencies:
       '@xmldom/xmldom': 0.9.10
       backbone: 1.6.1
       charm: 1.0.2
       chokidar: 5.0.0
       commander: 14.0.3
-      compression: 1.8.1
-      consolidate: 1.0.4(@babel/core@7.29.7)(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(mustache@4.2.0)(underscore@1.13.8)
+      compression: 1.8.1(supports-color@8.1.1)
+      consolidate: 1.0.4(@babel/core@7.29.7(supports-color@8.1.1))(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(mustache@4.2.0)(underscore@1.13.8)
       execa: 9.6.1
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
       glob: 13.0.6
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.4.3(supports-color@8.1.1))
       js-yaml: 4.3.0
       lodash: 4.18.1
       minimatch: 10.2.5
@@ -19995,7 +20137,7 @@ snapshots:
       printf: 0.6.1
       proc-log: 6.1.0
       rimraf: 6.1.3
-      socket.io: 4.8.3
+      socket.io: 4.8.3(supports-color@8.1.1)
       spawn-args: 0.2.0
       styled_string: 0.0.1
       tap-parser: 18.3.4
@@ -20054,14 +20196,14 @@ snapshots:
 
   textextensions@2.6.0: {}
 
-  thread-loader@3.0.4(webpack@5.108.4(postcss@8.5.19)):
+  thread-loader@3.0.4(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.2
       loader-utils: 2.0.4
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      webpack: 5.108.4(postcss@8.5.19)
+      webpack: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
   through2@2.0.5:
     dependencies:
@@ -20088,10 +20230,10 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
-  tiny-lr@2.0.0:
+  tiny-lr@2.0.0(supports-color@8.1.1):
     dependencies:
       body: 5.1.0
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       faye-websocket: 0.11.4
       livereload-js: 3.4.1
       object-assign: 4.1.1
@@ -20188,45 +20330,45 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  tracked-built-ins@3.4.0(@babel/core@7.29.7):
+  tracked-built-ins@3.4.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
-      ember-tracked-storage-polyfill: 1.0.1
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
+      ember-tracked-storage-polyfill: 1.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  tracked-built-ins@4.1.2(@babel/core@7.29.7):
+  tracked-built-ins@4.1.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  tracked-toolbox@3.0.0(@babel/core@7.29.7):
+  tracked-toolbox@3.0.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@embroider/addon-shim': 1.10.3
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+      '@embroider/addon-shim': 1.10.3(supports-color@8.1.1)
+      decorator-transforms: 2.4.0(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  tree-sync@1.4.0:
+  tree-sync@1.4.0(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
-      fs-tree-diff: 0.5.9
+      debug: 2.6.9(supports-color@8.1.1)
+      fs-tree-diff: 0.5.9(supports-color@8.1.1)
       mkdirp: 0.5.6
       quick-temp: 0.1.9
       walk-sync: 0.3.4
     transitivePeerDependencies:
       - supports-color
 
-  tree-sync@2.1.0:
+  tree-sync@2.1.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      fs-tree-diff: 2.0.1
+      fs-tree-diff: 2.0.1(supports-color@8.1.1)
       mkdirp: 0.5.6
       quick-temp: 0.1.9
       walk-sync: 0.3.4
@@ -20450,6 +20592,19 @@ snapshots:
       acorn: 8.17.0
       acorn-walk: 8.3.5
 
+  vscode-css-languageservice@6.3.10:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.1.0
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-uri@3.1.0: {}
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -20489,28 +20644,28 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
-  watch-detector@1.0.2:
+  watch-detector@1.0.2(supports-color@8.1.1):
     dependencies:
-      heimdalljs-logger: 0.1.10
-      silent-error: 1.1.1
+      heimdalljs-logger: 0.1.10(supports-color@8.1.1)
+      silent-error: 1.1.1(supports-color@8.1.1)
       tmp: 0.1.0
     transitivePeerDependencies:
       - supports-color
 
-  watchpack-chokidar2@2.0.1:
+  watchpack-chokidar2@2.0.1(supports-color@8.1.1):
     dependencies:
-      chokidar: 2.1.8
+      chokidar: 2.1.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  watchpack@1.7.5:
+  watchpack@1.7.5(supports-color@8.1.1):
     dependencies:
       graceful-fs: 4.2.11
       neo-async: 2.6.2
     optionalDependencies:
       chokidar: 3.6.0
-      watchpack-chokidar2: 2.0.1
+      watchpack-chokidar2: 2.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -20540,10 +20695,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-retry-chunk-load-plugin@3.1.1(webpack@5.108.4(postcss@8.5.19)):
+  webpack-retry-chunk-load-plugin@3.1.1(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)):
     dependencies:
       prettier: 2.8.8
-      webpack: 5.108.4(postcss@8.5.19)
+      webpack: 5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)
 
   webpack-sources@1.4.3:
     dependencies:
@@ -20552,7 +20707,7 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
-  webpack@4.47.0:
+  webpack@4.47.0(supports-color@8.1.1):
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -20568,19 +20723,19 @@ snapshots:
       loader-runner: 2.4.0
       loader-utils: 1.4.2
       memory-fs: 0.4.1
-      micromatch: 3.1.10
+      micromatch: 3.1.10(supports-color@8.1.1)
       mkdirp: 0.5.6
       neo-async: 2.6.2
       node-libs-browser: 2.2.1
       schema-utils: 1.0.0
       tapable: 1.1.3
-      terser-webpack-plugin: 1.4.6(webpack@4.47.0)
-      watchpack: 1.7.5
+      terser-webpack-plugin: 1.4.6(webpack@4.47.0(supports-color@8.1.1))
+      watchpack: 1.7.5(supports-color@8.1.1)
       webpack-sources: 1.4.3
     transitivePeerDependencies:
       - supports-color
 
-  webpack@5.108.4(postcss@8.5.19):
+  webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -20598,7 +20753,7 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(postcss@8.5.19)(webpack@5.108.4(postcss@8.5.19))
+      minimizer-webpack-plugin: 5.6.1(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3)(webpack@5.108.4(csso@4.2.0)(postcss@8.5.19)(uglify-js@3.19.3))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -20704,7 +20859,7 @@ snapshots:
 
   workerpool@10.0.3: {}
 
-  workerpool@3.1.2:
+  workerpool@3.1.2(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       object-assign: 4.1.1


### PR DESCRIPTION
refs https://github.com/ilios/ilios/issues/7304

this works as intended, those lists of class names on components get now linted for redundant white-space.

unfortunately, it also clashes with the ember plugin for eslint. ~~i have yet to figure out what the actual problem is, and how to resolve/evade it.~~ see comment below.


here's an example of the warnings emitted. 

```
packages/frontend lint:js:   0:0  warning 
packages/frontend lint:js: To lint Gjs/Gts files please follow the setup guide at https://github.com/ember-cli/eslint-plugin-ember#gtsgjs
packages/frontend lint:js: Note that this error can also happen if you have multiple versions of eslint-plugin-ember in your node_modules
packages/frontend lint:js: /home/stefan/dev/projects/frontend/packages/frontend/app/components/learner-group/user-manager.gjs
```