### PR TITLE
Add test helpers to augment Publication Menu integration tests when GUI window not active

### DIFF
--- a/packages/ilios-common/addon-test-support/ilios-common/helpers/focused-text.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/helpers/focused-text.js
@@ -1,0 +1,14 @@
+import { findOne } from 'ember-cli-page-object/extend';
+
+export function focusedText(selector = null, userOptions = {}) {
+  return {
+    isDescriptor: true,
+
+    get(key) {
+      const options = { pageObjectKey: key, ...userOptions };
+      const scope = findOne(this, selector, options);
+      const active = document.activeElement;
+      return scope && active && scope.contains(active) ? active.textContent.trim() : '';
+    },
+  };
+}

--- a/packages/ilios-common/addon-test-support/ilios-common/helpers/key-on-focus.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/helpers/key-on-focus.js
@@ -1,0 +1,13 @@
+import { triggerKeyEvent } from '@ember/test-helpers';
+
+export function keyOnFocus(key) {
+  return {
+    isDescriptor: true,
+
+    get() {
+      return function () {
+        return triggerKeyEvent(document.activeElement, 'keydown', key);
+      };
+    },
+  };
+}

--- a/packages/ilios-common/addon-test-support/ilios-common/index.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/index.js
@@ -11,4 +11,6 @@ export {
 } from './helpers/quill-editor';
 export { getText, getElementText } from './helpers/custom-helpers';
 export { hasFocus } from './helpers/has-focus';
+export { focusedText } from './helpers/focused-text';
+export { keyOnFocus } from './helpers/key-on-focus';
 export { default as jwtEncode } from './helpers/jwt-encode';

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/publication-menu.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/publication-menu.js
@@ -1,17 +1,18 @@
-import { clickable, create, triggerable, isVisible, isHidden, text } from 'ember-cli-page-object';
+import { clickable, create, triggerable, isVisible, isHidden } from 'ember-cli-page-object';
+import { focusedText, keyOnFocus } from 'ilios-common';
 
 const definition = {
   scope: '[data-test-course-publication-menu]',
   toggle: {
     scope: '[data-test-toggle]',
     enter: triggerable('keydown', '', { eventProperties: { key: 'Enter' } }),
-    down: triggerable('keydown', '', { eventProperties: { key: 'ArrowDown' } }),
+    down: keyOnFocus('ArrowDown'),
     esc: triggerable('keydown', '', { eventProperties: { key: 'Escape' } }),
   },
   menu: {
     scope: '[data-test-menu]',
-    down: triggerable('keydown', 'button:focus', { eventProperties: { key: 'ArrowDown' } }),
-    up: triggerable('keydown', 'button:focus', { eventProperties: { key: 'ArrowUp' } }),
+    down: keyOnFocus('ArrowDown'),
+    up: keyOnFocus('ArrowUp'),
   },
   menuClosed: isHidden('[data-test-menu]'),
   menuOpen: isVisible('[data-test-menu]'),
@@ -23,7 +24,7 @@ const definition = {
   reviewMisingItems: clickable('[data-test-review]'),
   markAsScheduled: clickable('[data-test-tbd]'),
   unpublishCourse: clickable('[data-test-un-publish]'),
-  selectedMenuItem: text('[data-test-menu] button:focus'),
+  selectedMenuItem: focusedText('[data-test-menu]'),
 };
 
 export default definition;

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/publication-menu.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/publication-menu.js
@@ -1,13 +1,13 @@
-import { clickable, create, triggerable, isVisible, isHidden } from 'ember-cli-page-object';
+import { clickable, create, isVisible, isHidden } from 'ember-cli-page-object';
 import { focusedText, keyOnFocus } from 'ilios-common';
 
 const definition = {
   scope: '[data-test-course-publication-menu]',
   toggle: {
     scope: '[data-test-toggle]',
-    enter: triggerable('keydown', '', { eventProperties: { key: 'Enter' } }),
+    enter: keyOnFocus('Enter'),
     down: keyOnFocus('ArrowDown'),
-    esc: triggerable('keydown', '', { eventProperties: { key: 'Escape' } }),
+    esc: keyOnFocus('Escape'),
   },
   menu: {
     scope: '[data-test-menu]',

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/publication-menu.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/publication-menu.js
@@ -1,13 +1,13 @@
-import { clickable, create, isVisible, isHidden } from 'ember-cli-page-object';
+import { clickable, create, isVisible, isHidden, triggerable } from 'ember-cli-page-object';
 import { focusedText, keyOnFocus } from 'ilios-common';
 
 const definition = {
   scope: '[data-test-course-publication-menu]',
   toggle: {
     scope: '[data-test-toggle]',
-    enter: keyOnFocus('Enter'),
-    down: keyOnFocus('ArrowDown'),
-    esc: keyOnFocus('Escape'),
+    enter: triggerable('keydown', '', { eventProperties: { key: 'Enter' } }),
+    down: triggerable('keydown', '', { eventProperties: { key: 'ArrowDown' } }),
+    esc: triggerable('keydown', '', { eventProperties: { key: 'Escape' } }),
   },
   menu: {
     scope: '[data-test-menu]',

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session/publication-menu.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session/publication-menu.js
@@ -1,13 +1,20 @@
-import { collection, clickable, create, isVisible, isHidden } from 'ember-cli-page-object';
+import {
+  collection,
+  clickable,
+  create,
+  isVisible,
+  isHidden,
+  triggerable,
+} from 'ember-cli-page-object';
 import { focusedText, keyOnFocus } from 'ilios-common';
 
 const definition = {
   scope: '[data-test-session-publication-menu]',
   toggle: {
     scope: '[data-test-toggle]',
-    enter: keyOnFocus('Enter'),
-    down: keyOnFocus('ArrowDown'),
-    esc: keyOnFocus('Escape'),
+    enter: triggerable('keydown', '', { eventProperties: { key: 'Enter' } }),
+    down: triggerable('keydown', '', { eventProperties: { key: 'ArrowDown' } }),
+    esc: triggerable('keydown', '', { eventProperties: { key: 'Escape' } }),
   },
   menu: {
     scope: '[data-test-menu]',

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session/publication-menu.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session/publication-menu.js
@@ -5,21 +5,21 @@ import {
   triggerable,
   isVisible,
   isHidden,
-  text,
 } from 'ember-cli-page-object';
+import { focusedText, keyOnFocus } from 'ilios-common';
 
 const definition = {
   scope: '[data-test-session-publication-menu]',
   toggle: {
     scope: '[data-test-toggle]',
     enter: triggerable('keydown', '', { eventProperties: { key: 'Enter' } }),
-    down: triggerable('keydown', '', { eventProperties: { key: 'ArrowDown' } }),
+    down: keyOnFocus('ArrowDown'),
     esc: triggerable('keydown', '', { eventProperties: { key: 'Escape' } }),
   },
   menu: {
     scope: '[data-test-menu]',
-    down: triggerable('keydown', 'button:focus', { eventProperties: { key: 'ArrowDown' } }),
-    up: triggerable('keydown', 'button:focus', { eventProperties: { key: 'ArrowUp' } }),
+    down: keyOnFocus('ArrowDown'),
+    up: keyOnFocus('ArrowUp'),
   },
   buttons: collection('[data-test-menu] button'),
   menuClosed: isHidden('[data-test-menu]'),
@@ -32,7 +32,7 @@ const definition = {
   reviewMisingItems: clickable('[data-test-review]'),
   markAsScheduled: clickable('[data-test-tbd]'),
   unpublishSession: clickable('[data-test-un-publish]'),
-  selectedMenuItem: text('[data-test-menu] button:focus'),
+  selectedMenuItem: focusedText('[data-test-menu]'),
 };
 
 export default definition;

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session/publication-menu.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session/publication-menu.js
@@ -1,20 +1,13 @@
-import {
-  collection,
-  clickable,
-  create,
-  triggerable,
-  isVisible,
-  isHidden,
-} from 'ember-cli-page-object';
+import { collection, clickable, create, isVisible, isHidden } from 'ember-cli-page-object';
 import { focusedText, keyOnFocus } from 'ilios-common';
 
 const definition = {
   scope: '[data-test-session-publication-menu]',
   toggle: {
     scope: '[data-test-toggle]',
-    enter: triggerable('keydown', '', { eventProperties: { key: 'Enter' } }),
+    enter: keyOnFocus('Enter'),
     down: keyOnFocus('ArrowDown'),
-    esc: triggerable('keydown', '', { eventProperties: { key: 'Escape' } }),
+    esc: keyOnFocus('Escape'),
   },
   menu: {
     scope: '[data-test-menu]',

--- a/packages/test-app/tests/integration/components/course/publication-menu-test.gjs
+++ b/packages/test-app/tests/integration/components/course/publication-menu-test.gjs
@@ -158,9 +158,9 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     this.set('course', courseModel);
     await render(<template><PublicationMenu @course={{this.course}} /></template>);
 
-    assert.ok(component.menuClosed);
+    assert.ok(component.menuClosed, 'menu is closed');
     await component.toggle.down();
-    assert.ok(component.menuOpen);
+    assert.ok(component.menuOpen, 'hitting ArrowDown made menu open');
   });
 
   test('escape closes menu', async function (assert) {
@@ -170,9 +170,9 @@ module('Integration | Component | course/publication-menu', function (hooks) {
     await render(<template><PublicationMenu @course={{this.course}} /></template>);
 
     await component.toggle.down();
-    assert.ok(component.menuOpen);
+    assert.ok(component.menuOpen, 'hitting ArrowDown made menu open');
     await component.toggle.esc();
-    assert.ok(component.menuClosed);
+    assert.ok(component.menuClosed, 'hitting Escape made menu close');
   });
 
   test('dropdown options are accessible for unpublished course', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/publication-menu-test.gjs
+++ b/packages/test-app/tests/integration/components/session/publication-menu-test.gjs
@@ -126,9 +126,9 @@ module('Integration | Component | session/publication-menu', function (hooks) {
     this.set('session', sessionModel);
     await render(<template><PublicationMenu @session={{this.session}} /></template>);
 
-    assert.ok(component.menuClosed);
+    assert.ok(component.menuClosed, 'menu is closed');
     await component.toggle.down();
-    assert.ok(component.menuOpen);
+    assert.ok(component.menuOpen, 'hitting ArrowDown made menu open');
   });
 
   test('escape closes menu', async function (assert) {
@@ -138,9 +138,9 @@ module('Integration | Component | session/publication-menu', function (hooks) {
     await render(<template><PublicationMenu @session={{this.session}} /></template>);
 
     await component.toggle.down();
-    assert.ok(component.menuOpen);
+    assert.ok(component.menuOpen, 'hitting ArrowDown made menu open');
     await component.toggle.esc();
-    assert.ok(component.menuClosed);
+    assert.ok(component.menuClosed, 'hitting Escape made menu close');
   });
 
   test('dropdown options are accessible for unpublished session', async function (assert) {


### PR DESCRIPTION
Fixes ilios/ilios#7043

Needed Claude to finally figure out how to fix this annoying issue (at least to me) when running Course/Session Publication Menu integration GUI tests. If the window/tab is not active, then navigating the dropdown menu and getting the correctly focused text does not work. These new test helpers are smarter about it and work even when the window is not active.