### PR TITLE
Save Groups in Order

### DIFF
--- a/packages/frontend/app/components/learner-group/bulk-finalize-users.gjs
+++ b/packages/frontend/app/components/learner-group/bulk-finalize-users.gjs
@@ -1,8 +1,7 @@
 import Component from '@glimmer/component';
 import { task, timeout } from 'ember-concurrency';
-import { map } from 'rsvp';
 import { service } from '@ember/service';
-import { findBy, uniqueValues } from 'ilios-common/utils/array-helpers';
+import { findBy } from 'ilios-common/utils/array-helpers';
 import t from 'ember-intl/helpers/t';
 import UserNameInfo from 'ilios-common/components/user-name-info';
 import { on } from '@ember/modifier';
@@ -31,15 +30,14 @@ export default class LearnerGroupBulkFinalizeUsersComponent extends Component {
 
   save = task({ drop: true }, async () => {
     await timeout(10);
-    const treeGroups = await map(this.finalData, async ({ learnerGroup, user }) => {
-      return learnerGroup.addUserToGroupAndAllParents(user);
-    });
 
-    const flat = treeGroups.reduce((flattened, arr) => {
-      return [...flattened, ...arr];
-    }, []);
+    for (const { learnerGroup, user } of this.finalData) {
+      const groups = await learnerGroup.addUserToGroupAndAllParents(user);
+      for (const group of groups) {
+        await group.save();
+      }
+    }
 
-    await Promise.all(uniqueValues(flat).map((o) => o.save()));
     this.flashMessages.success(this.intl.t('general.savedSuccessfully'), {
       capitalize: true,
     });

--- a/packages/frontend/app/components/learner-group/root.gjs
+++ b/packages/frontend/app/components/learner-group/root.gjs
@@ -388,9 +388,13 @@ export default class LearnerGroupRootComponent extends Component {
     const learnerGroup = this.args.learnerGroup;
     const topLevelGroup = await learnerGroup.topLevelGroup;
     const removeGroups = await topLevelGroup.removeUserFromGroupAndAllDescendants(user);
+    for (const group of removeGroups) {
+      await group.save();
+    }
     const addGroups = await learnerGroup.addUserToGroupAndAllParents(user);
-    await Promise.all(removeGroups.map((g) => g.save()));
-    await Promise.all(addGroups.map((g) => g.save()));
+    for (const group of addGroups) {
+      await group.save();
+    }
   });
 
   removeUserToCohort = task({ enqueue: true }, async (user) => {
@@ -406,7 +410,6 @@ export default class LearnerGroupRootComponent extends Component {
   addUsersToGroup = task({ enqueue: true }, async (users) => {
     const learnerGroup = this.args.learnerGroup;
     const topLevelGroup = await learnerGroup.topLevelGroup;
-    let addGroups = [];
     let removeGroups = [];
     for (let i = 0; i < users.length; i++) {
       const user = users[i];
@@ -414,11 +417,18 @@ export default class LearnerGroupRootComponent extends Component {
         ...removeGroups,
         ...(await topLevelGroup.removeUserFromGroupAndAllDescendants(user)),
       ];
+    }
+    for (const group of uniqueValues(removeGroups)) {
+      await group.save();
+    }
+    let addGroups = [];
+    for (let i = 0; i < users.length; i++) {
+      const user = users[i];
       addGroups = [...addGroups, ...(await learnerGroup.addUserToGroupAndAllParents(user))];
     }
-
-    await Promise.all(uniqueValues(removeGroups).map((g) => g.save()));
-    await Promise.all(uniqueValues(addGroups).map((g) => g.save()));
+    for (const group of uniqueValues(addGroups)) {
+      await group.save();
+    }
   });
 
   removeUsersToCohort = task({ enqueue: true }, async (users) => {

--- a/packages/ilios-common/addon/models/learner-group.js
+++ b/packages/ilios-common/addon/models/learner-group.js
@@ -447,7 +447,8 @@ export default class LearnerGroup extends Model {
    */
   async removeUserFromGroupAndAllDescendants({ id: userId }) {
     const allDescendants = await this.getAllDescendants();
-    return await map([this, ...allDescendants], async (group) => {
+    const groups = [this, ...allDescendants].reverse();
+    return await map(groups, async (group) => {
       if (group.hasMany('users').ids().includes(userId)) {
         group.users = (await group.users).filter(({ id }) => id !== userId);
       }
@@ -493,23 +494,21 @@ export default class LearnerGroup extends Model {
   }
 
   /**
-   * Adds a user to a group and then traverses parent groups recursively
-   * to add the user to them as well.  Will only modify groups where the
-   * user currently does not exist.
+   * Starting with the root add user to each group all
+   * the way down to our group and return the entire tree to be saved.
    */
   async addUserToGroupAndAllParents(user) {
-    const modifiedGroups = [];
-    const userId = user.id;
     const allParents = await this.getAllParents();
-    const groups = [this, ...allParents];
-    for (let i = 0; i < groups.length; i++) {
-      const users = await groups[i].users;
-      const ids = mapBy(users, 'id');
-      if (!ids.includes(userId)) {
-        users.push(user);
-        modifiedGroups.push(groups[i]);
+    const groups = [...allParents, this];
+
+    const groupMap = await map(groups, async (group) => {
+      if (!group.hasMany('users').ids().includes(user.id)) {
+        (await group.users).push(user);
+        return group;
       }
-    }
-    return uniqueValues(modifiedGroups);
+    });
+
+    //remove groups that weren't updated (they're undefined in this array)
+    return groupMap.filter(Boolean);
   }
 }

--- a/packages/ilios-common/config/api-version.js
+++ b/packages/ilios-common/config/api-version.js
@@ -1,1 +1,1 @@
-module.exports = 'v3.14';
+module.exports = 'v3.15';

--- a/packages/test-app/tests/unit/models/learner-group-test.js
+++ b/packages/test-app/tests/unit/models/learner-group-test.js
@@ -351,65 +351,94 @@ module('Unit | Model | LearnerGroup', function (hooks) {
   });
 
   test('check removeUserFromGroupAndAllDescendants', async function (assert) {
-    const learnerGroup = this.store.createRecord('learner-group');
+    const user1 = this.store.createRecord('user');
+
+    const learnerGroup = this.store.createRecord('learner-group', {
+      id: '1',
+      users: [user1],
+    });
 
     const groups = await waitForResource(learnerGroup, 'allParents');
     assert.strictEqual(groups.length, 0);
 
-    const user1 = this.store.createRecord('user');
     const subGroup1 = this.store.createRecord('learner-group', {
+      id: '2',
       parent: learnerGroup,
       users: [user1],
     });
     const subGroup2 = this.store.createRecord('learner-group', {
+      id: '3',
       parent: subGroup1,
       users: [user1],
     });
     const subGroup3 = this.store.createRecord('learner-group', {
+      id: '4',
       parent: subGroup2,
       users: [user1],
     });
     const subGroup4 = this.store.createRecord('learner-group', {
+      id: '5',
       parent: subGroup1,
     });
+
+    assert.ok((await learnerGroup.users).includes(user1));
+    assert.ok((await subGroup1.users).includes(user1));
+    assert.ok((await subGroup2.users).includes(user1));
+    assert.ok((await subGroup3.users).includes(user1));
+    assert.notOk((await subGroup4.users).includes(user1));
 
     const groupsToRemove = await subGroup1.removeUserFromGroupAndAllDescendants(user1);
     assert.strictEqual(groupsToRemove.length, 4);
-    assert.notOk(groupsToRemove.includes(learnerGroup));
-    assert.ok(groupsToRemove.includes(subGroup1));
-    assert.ok(groupsToRemove.includes(subGroup2));
-    assert.ok(groupsToRemove.includes(subGroup3));
-    assert.ok(groupsToRemove.includes(subGroup4));
+    assert.deepEqual(
+      groupsToRemove.map(({ id }) => id),
+      ['4', '5', '3', '2'],
+      'groups are removed in the correct order',
+    );
+    assert.ok((await learnerGroup.users).includes(user1));
+    assert.notOk((await subGroup1.users).includes(user1));
+    assert.notOk((await subGroup2.users).includes(user1));
+    assert.notOk((await subGroup3.users).includes(user1));
+    assert.notOk((await subGroup4.users).includes(user1));
   });
 
   test('check addUserToGroupAndAllParents', async function (assert) {
-    const learnerGroup = this.store.createRecord('learner-group');
+    const learnerGroup = this.store.createRecord('learner-group', { id: '1' });
     const groups = await waitForResource(learnerGroup, 'allParents');
     assert.strictEqual(groups.length, 0);
 
     const user1 = this.store.createRecord('user');
     const subGroup1 = this.store.createRecord('learner-group', {
+      id: '2',
       parent: learnerGroup,
       users: [user1],
     });
     const subGroup2 = this.store.createRecord('learner-group', {
+      id: '3',
       parent: subGroup1,
     });
     const subGroup3 = this.store.createRecord('learner-group', {
+      id: '4',
       parent: subGroup2,
     });
-    const subGroup4 = this.store.createRecord('learner-group', {
+    const subgGroup4 = this.store.createRecord('learner-group', {
+      id: '5',
       parent: subGroup1,
     });
 
     const groupsToAdd = await subGroup3.addUserToGroupAndAllParents(user1);
 
     assert.strictEqual(groupsToAdd.length, 3);
-    assert.ok(groupsToAdd.includes(learnerGroup));
-    assert.notOk(groupsToAdd.includes(subGroup1));
-    assert.ok(groupsToAdd.includes(subGroup2));
-    assert.ok(groupsToAdd.includes(subGroup3));
-    assert.notOk(groupsToAdd.includes(subGroup4));
+    assert.deepEqual(
+      groupsToAdd.map(({ id }) => id),
+      ['1', '3', '4'],
+      'groups are added in the correct order',
+    );
+
+    assert.ok((await learnerGroup.users).includes(user1));
+    assert.ok((await subGroup1.users).includes(user1));
+    assert.ok((await subGroup2.users).includes(user1));
+    assert.ok((await subGroup3.users).includes(user1));
+    assert.notOk((await subgGroup4.users).includes(user1));
   });
 
   test('has no learners in group without learners and without subgroups', async function (assert) {


### PR DESCRIPTION
To match our new validation [requirements on the API](https://github.com/ilios/ilios/pull/7290) we need to add and remove groups in specific order instead of making the changes and saving everything at the same time. This will ensure that the group hierarchy tree is respected at each point.