### PR TITLE
Set a11y Test Options in a Hook

### DIFF
--- a/packages/frontend/tests/helpers/index.js
+++ b/packages/frontend/tests/helpers/index.js
@@ -36,13 +36,18 @@ function setupRenderingTest(hooks, options) {
 
   // Additional setup for rendering tests can be done here.
 
-  setRunOptions({
-    rules: {
-      //disable color-contrast check on integration tests as we don't have a full background or styles
-      'color-contrast': { enabled: false },
-      listitem: { enabled: false },
-      'heading-order': { enabled: false },
-    },
+  /**
+   * These tests are run in issolation without a full application shell, so many items
+   * will appear out of source order and with no styles (such as background color)
+   */
+  hooks.before(() => {
+    setRunOptions({
+      rules: {
+        'color-contrast': { enabled: false },
+        listitem: { enabled: false },
+        'heading-order': { enabled: false },
+      },
+    });
   });
 }
 

--- a/packages/test-app/tests/helpers/index.js
+++ b/packages/test-app/tests/helpers/index.js
@@ -35,13 +35,18 @@ function setupRenderingTest(hooks, options) {
   setupIntl(hooks, 'en-us'); // ember-intl
 
   // Additional setup for rendering tests can be done here.
-  setRunOptions({
-    rules: {
-      //disable color-contrast check on integration tests as we don't have a full background or styles
-      'color-contrast': { enabled: false },
-      listitem: { enabled: false },
-      'heading-order': { enabled: false },
-    },
+  /**
+   * These tests are run in issolation without a full application shell, so many items
+   * will appear out of source order and with no styles (such as background color)
+   */
+  hooks.before(() => {
+    setRunOptions({
+      rules: {
+        'color-contrast': { enabled: false },
+        listitem: { enabled: false },
+        'heading-order': { enabled: false },
+      },
+    });
   });
 }
 


### PR DESCRIPTION
I inadvertently discovered that our application tests were not checking color contrast because they were picking up the options from integration tests on every import. Putting these in a before hook causes the options to be run for the test file but rest after each run.