### PR TITLE
Course->Publish missing details button bugfix

### DIFF
--- a/packages/frontend/app/components/courses/list-item.gjs
+++ b/packages/frontend/app/components/courses/list-item.gjs
@@ -9,7 +9,7 @@ import LoadingSpinner from 'ilios-common/components/loading-spinner';
 import PublicationStatus from 'ilios-common/components/publication-status';
 import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
-import { fn, hash } from '@ember/helper';
+import { fn } from '@ember/helper';
 import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { faLock, faLockOpen, faTrash } from '@fortawesome/free-solid-svg-icons';
 
@@ -53,7 +53,7 @@ export default class CoursesListItemComponent extends Component {
       data-test-courses-list-item
     >
       <td class="text-left" colspan="8" data-test-course-title>
-        <LinkTo @route="course" @model={{@course}} @query={{hash detailsCollapseControl=true}}>
+        <LinkTo @route="course" @model={{@course}}>
           {{@course.title}}
           {{#if @course.externalId}}
             ({{@course.externalId}})

--- a/packages/frontend/tests/acceptance/course/publish-all-sessions-test.js
+++ b/packages/frontend/tests/acceptance/course/publish-all-sessions-test.js
@@ -521,8 +521,6 @@ module('Acceptance | Course - Publish All Sessions', function (hooks) {
 
     // test 3/3 section: Unpublished/Overridable Sessions
 
-    // await this.pauseTest();
-
     assert.ok(pubReview.overridableSessions.table.headers.title.isSortedOn);
     assert.ok(pubReview.overridableSessions.table.headers.title.isSortedAscending);
     assert.notOk(pubReview.overridableSessions.table.headers.offerings.isSortedOn);

--- a/packages/frontend/tests/acceptance/course/publish-test.js
+++ b/packages/frontend/tests/acceptance/course/publish-test.js
@@ -131,6 +131,8 @@ module('Acceptance | Course - Publish', function (hooks) {
 
     await pubcheck.publishWithMissingItems.click();
     assert.strictEqual(page.details.header.publicationMenu.toggle.text, 'Published');
+    assert.strictEqual(currentURL(), '/courses/1?details=true', 'course published url is correct');
+    assert.ok(page.details.hasCollapseControl, 'course has collapse control again');
   });
 
   test('check publish draft course, all items set', async function (assert) {
@@ -190,6 +192,8 @@ module('Acceptance | Course - Publish', function (hooks) {
 
     await pubcheck.publish.click();
     assert.strictEqual(page.details.header.publicationMenu.toggle.text, 'Published');
+    assert.strictEqual(currentURL(), '/courses/1?details=true', 'course published url is correct');
+    assert.ok(page.details.hasCollapseControl, 'course has collapse control again');
   });
 
   test('check schedule draft course', async function (assert) {
@@ -282,6 +286,8 @@ module('Acceptance | Course - Publish', function (hooks) {
 
     await pubcheck.publishWithMissingItems.click();
     assert.strictEqual(page.details.header.publicationMenu.toggle.text, 'Published');
+    assert.strictEqual(currentURL(), '/courses/1?details=true', 'course published url is correct');
+    assert.ok(page.details.hasCollapseControl, 'course has collapse control again');
   });
 
   test('check publish scheduled course, all items set', async function (assert) {
@@ -320,6 +326,8 @@ module('Acceptance | Course - Publish', function (hooks) {
 
     await pubcheck.publish.click();
     assert.strictEqual(page.details.header.publicationMenu.toggle.text, 'Published');
+    assert.strictEqual(currentURL(), '/courses/1?details=true', 'course published url is correct');
+    assert.ok(page.details.hasCollapseControl, 'course has collapse control again');
   });
 
   test('check unpublish scheduled course', async function (assert) {

--- a/packages/frontend/tests/acceptance/course/publish-test.js
+++ b/packages/frontend/tests/acceptance/course/publish-test.js
@@ -37,7 +37,7 @@ module('Acceptance | Course - Publish', function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      '/courses/1/publicationcheck?details=true&detailsCollapseControl=false',
+      '/courses/1/publicationcheck?details=true',
       'course publicationcheck url is correct',
     );
     assert.notOk(page.details.hasCollapseControl, 'course does not have collapse control anymore');
@@ -89,7 +89,7 @@ module('Acceptance | Course - Publish', function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      '/courses/1/publicationcheck?details=true&detailsCollapseControl=false',
+      '/courses/1/publicationcheck?details=true',
       'course publicationcheck url is correct',
     );
     assert.notOk(page.details.hasCollapseControl, 'course does not have collapse control anymore');
@@ -147,7 +147,7 @@ module('Acceptance | Course - Publish', function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      '/courses/1/publicationcheck?details=true&detailsCollapseControl=false',
+      '/courses/1/publicationcheck?details=true',
       'course publicationcheck url is correct',
     );
     assert.notOk(page.details.hasCollapseControl, 'course does not have collapse control anymore');
@@ -212,7 +212,7 @@ module('Acceptance | Course - Publish', function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      '/courses/1/publicationcheck?details=true&detailsCollapseControl=false',
+      '/courses/1/publicationcheck?details=true',
       'course publicationcheck url is correct',
     );
     assert.notOk(page.details.hasCollapseControl);
@@ -252,7 +252,7 @@ module('Acceptance | Course - Publish', function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      '/courses/1/publicationcheck?details=true&detailsCollapseControl=false',
+      '/courses/1/publicationcheck?details=true',
       'course publicationcheck url is correct',
     );
     assert.notOk(page.details.hasCollapseControl);
@@ -295,7 +295,7 @@ module('Acceptance | Course - Publish', function (hooks) {
 
     assert.strictEqual(
       currentURL(),
-      '/courses/1/publicationcheck?details=true&detailsCollapseControl=false',
+      '/courses/1/publicationcheck?details=true',
       'course publicationcheck url is correct',
     );
     assert.notOk(page.details.hasCollapseControl);

--- a/packages/frontend/tests/acceptance/course/publish-test.js
+++ b/packages/frontend/tests/acceptance/course/publish-test.js
@@ -59,14 +59,6 @@ module('Acceptance | Course - Publish', function (hooks) {
     assert.strictEqual(pubcheck.terms, 'No', 'course terms count correct');
     assert.strictEqual(pubcheck.objectives, 'No', 'course objectives count correct');
 
-    // await this.pauseTest();
-
-    // assert.notOk(
-    //   pubcheck.publishWithMissingItems,
-    //   'publish with misssing items button not visible',
-    // );
-    // assert.notOk(pubcheck.publish, 'publish button not visible');
-
     assert.ok(pubcheck.publishMissingRequirements, 'publish missing requirements button visible');
     assert.ok(pubcheck.publishMissingRequirements.isDisabled, 'publish course button disabled');
     assert.strictEqual(
@@ -118,9 +110,6 @@ module('Acceptance | Course - Publish', function (hooks) {
     assert.strictEqual(pubcheck.cohorts, 'Yes (1)', 'course cohort count correct');
     assert.strictEqual(pubcheck.terms, 'No', 'course terms count correct');
     assert.strictEqual(pubcheck.objectives, 'No', 'course objectives count correct');
-
-    // assert.notOk(pubcheck.publishMissingRequirements);
-    // assert.notOk(pubcheck.publish);
 
     assert.ok(pubcheck.publishWithMissingItems, 'publish with missing items button visible');
     assert.strictEqual(
@@ -179,9 +168,6 @@ module('Acceptance | Course - Publish', function (hooks) {
     assert.strictEqual(pubcheck.cohorts, 'Yes (1)', 'course cohort count correct');
     assert.strictEqual(pubcheck.terms, 'Yes (1)', 'course terms count correct');
     assert.strictEqual(pubcheck.objectives, 'Yes (1)', 'course objectives count correct');
-
-    // assert.notOk(pubcheck.publishMissingRequirements);
-    // assert.notOk(pubcheck.publishWithMissingItems);
 
     assert.ok(pubcheck.publish);
     assert.strictEqual(

--- a/packages/ilios-common/addon/components/course/details.gjs
+++ b/packages/ilios-common/addon/components/course/details.gjs
@@ -68,8 +68,6 @@ export default class CourseDetailsComponent extends Component {
           @academicYear={{this.academicYearDisplay}}
           @showDetails={{@showDetails}}
           @setShowDetails={{@setShowDetails}}
-          @showDetailsCollapseControl={{@showDetailsCollapseControl}}
-          @setShowDetailsCollapseControl={{@setShowDetailsCollapseControl}}
         />
         <Overview @course={{@course}} @editable={{and @editable this.notRolloverRoute}} />
         {{#if @showDetails}}

--- a/packages/ilios-common/addon/components/course/header.gjs
+++ b/packages/ilios-common/addon/components/course/header.gjs
@@ -97,8 +97,6 @@ export default class CourseHeaderComponent extends Component {
             @course={{@course}}
             @showDetails={{@showDetails}}
             @setShowDetails={{@setShowDetails}}
-            @showDetailsCollapseControl={{@showDetailsCollapseControl}}
-            @setShowDetailsCollapseControl={{@setShowDetailsCollapseControl}}
           />
         {{else}}
           <PublicationStatus @item={{@course}} @showText={{true}} />

--- a/packages/ilios-common/addon/components/course/loader.gjs
+++ b/packages/ilios-common/addon/components/course/loader.gjs
@@ -24,7 +24,6 @@ export default class CourseLoaderComponent extends Component {
           @showDetails={{@showDetails}}
           @setShowDetails={{@setShowDetails}}
           @showDetailsCollapseControl={{@showDetailsCollapseControl}}
-          @setShowDetailsCollapseControl={{@setShowDetailsCollapseControl}}
           @courseLeadershipDetails={{@courseLeadershipDetails}}
           @courseObjectiveDetails={{@courseObjectiveDetails}}
           @courseTaxonomyDetails={{@courseTaxonomyDetails}}

--- a/packages/ilios-common/addon/components/course/publication-menu.gjs
+++ b/packages/ilios-common/addon/components/course/publication-menu.gjs
@@ -135,7 +135,7 @@ export default class CoursePublicationMenuComponent extends Component {
   scrollToCoursePublication() {
     this.isOpen = false;
     this.router.transitionTo('course.publication-check', this.args.course, {
-      queryParams: { details: true, detailsCollapseControl: false },
+      queryParams: { details: true },
     });
   }
   @action

--- a/packages/ilios-common/addon/components/course/publicationcheck.gjs
+++ b/packages/ilios-common/addon/components/course/publicationcheck.gjs
@@ -48,7 +48,11 @@ export default class CoursePublicationCheckComponent extends Component {
     this.args.course.set('published', true);
     await this.args.course.save();
     this.flashMessages.success(this.intl.t('general.publishedSuccessfully'));
-    this.router.transitionTo('course', this.args.course);
+    this.router.transitionTo('course', this.args.course, {
+      queryParams: {
+        detailsCollapseControl: true,
+      },
+    });
   }
 
   <template>

--- a/packages/ilios-common/addon/components/course/publicationcheck.gjs
+++ b/packages/ilios-common/addon/components/course/publicationcheck.gjs
@@ -48,11 +48,7 @@ export default class CoursePublicationCheckComponent extends Component {
     this.args.course.set('published', true);
     await this.args.course.save();
     this.flashMessages.success(this.intl.t('general.publishedSuccessfully'));
-    this.router.transitionTo('course', this.args.course, {
-      queryParams: {
-        detailsCollapseControl: true,
-      },
-    });
+    this.router.transitionTo('course', this.args.course);
   }
 
   <template>
@@ -62,12 +58,7 @@ export default class CoursePublicationCheckComponent extends Component {
       {{scrollIntoView delay=10}}
     >
       <div class="back-to-course">
-        <LinkTo
-          @route="course"
-          @model={{@course}}
-          @query={{hash detailsCollapseControl=true}}
-          data-test-back-to-course
-        >
+        <LinkTo @route="course" @model={{@course}} data-test-back-to-course>
           <FaIcon @icon={{faArrowRotateLeft}} />
           {{t "general.backToTitle" title=@course.title}}
         </LinkTo>

--- a/packages/ilios-common/addon/controllers/course.js
+++ b/packages/ilios-common/addon/controllers/course.js
@@ -1,9 +1,11 @@
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 
 export default class CourseController extends Controller {
+  @service router;
+
   queryParams = [
     'details',
-    'detailsCollapseControl',
     'courseLeadershipDetails',
     'courseObjectiveDetails',
     'courseTaxonomyDetails',
@@ -12,11 +14,14 @@ export default class CourseController extends Controller {
   ];
 
   details = false;
-  detailsCollapseControl = true;
   editable = false;
   courseLeadershipDetails = false;
   courseObjectiveDetails = false;
   courseTaxonomyDetails = false;
   courseCompetencyDetails = false;
   courseManageLeadership = false;
+
+  get showDetailsCollapseControl() {
+    return this.router.currentRouteName !== 'course.publication-check';
+  }
 }

--- a/packages/ilios-common/addon/routes/course.js
+++ b/packages/ilios-common/addon/routes/course.js
@@ -12,9 +12,6 @@ export default class CourseRoute extends Route {
     details: {
       replace: true,
     },
-    detailsCollapseControl: {
-      replace: true,
-    },
     courseLeadershipDetails: {
       replace: true,
     },

--- a/packages/ilios-common/addon/templates/course.gjs
+++ b/packages/ilios-common/addon/templates/course.gjs
@@ -6,8 +6,7 @@ import set from 'ember-set-helper/helpers/set';
     @editable={{@controller.editable}}
     @showDetails={{@controller.details}}
     @setShowDetails={{set @controller "details"}}
-    @showDetailsCollapseControl={{@controller.detailsCollapseControl}}
-    @setShowDetailsCollapseControl={{set @controller "detailsCollapseControl"}}
+    @showDetailsCollapseControl={{@controller.showDetailsCollapseControl}}
     @courseLeadershipDetails={{@controller.courseLeadershipDetails}}
     @courseObjectiveDetails={{@controller.courseObjectiveDetails}}
     @courseTaxonomyDetails={{@controller.courseTaxonomyDetails}}


### PR DESCRIPTION
Fixes ilios/ilios#7340

Fixes bug where after publishing a course the "Hide/Show Details" button was hidden.