### PR TITLE
Reload During Logout

### DIFF
--- a/packages/frontend/app/services/session.js
+++ b/packages/frontend/app/services/session.js
@@ -44,7 +44,7 @@ export default class SessionService extends ESASessionService {
         if (response.status === 'redirect') {
           window.location.replace(response.logoutUrl);
         } else {
-          this.router.replaceWith(config.rootURL);
+          window.location.replace(config.rootURL);
         }
       });
     }

--- a/packages/ilios-common/addon/services/current-user.js
+++ b/packages/ilios-common/addon/services/current-user.js
@@ -27,17 +27,16 @@ export default class CurrentUserService extends Service {
   }
 
   async getModel() {
-    const currentUserId = this.currentUserId;
-    if (!currentUserId) {
+    if (!this.currentUserId) {
       return null;
     }
-    const user = this.store.peekRecord('user', currentUserId);
+    const user = this.store.peekRecord('user', this.currentUserId);
     if (user) {
       return user;
     }
 
     if (!this._userPromise) {
-      this._userPromise = this.store.findRecord('user', currentUserId, {
+      this._userPromise = this.store.findRecord('user', this.currentUserId, {
         include: 'sessionMaterialStatuses',
       });
     }


### PR DESCRIPTION
Reverting this ux fix to logout to improve security. When we replace the route and leave the application booted some state necessarily remains. That will, in most cases, include some form of the user who logged out as we store this in the currentUser _userPromise property. When the window isn't reloaded this property (and many others) remain set.

The token itself isn't stored this way, so it isn't possible to access data with the previous user, it just presents as UI weirdness and errors.

This will probably require a rewrite of #9418 as the message will no longer appear.