### PR TITLE
Welcome to the Dark(er) Side

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,31 @@ jobs:
         run: pnpm install
       - name: Run Tests
         run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance --write-execution-file --config-file=testem/light-mode-config.js
-      - name: Run Tests in Darkmode
+
+  test-dark:
+    name: Test in Darkmode
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [24]
+        workspace:
+          - frontend
+          - test-app
+          - lti-course-manager
+          - lti-dashboard
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+      - name: Install Dependencies
+        run: pnpm install
+      - name: Run Tests
         run: pnpm --filter ${{matrix.workspace}} exec ember exam --parallel=3 --load-balance --write-execution-file --config-file=testem/dark-mode-config.js
 
   build:

--- a/.github/workflows/visual_diff.yml
+++ b/.github/workflows/visual_diff.yml
@@ -191,6 +191,12 @@ jobs:
           path: candidate-frontend
           merge-multiple: true
       - run: ls -lh baseline-frontend candidate-frontend 2>/dev/null || true
+      - uses: actions/upload-artifact@v7
+        with:
+          name: combined-screenshots
+          path: |
+            baseline-frontend
+            candidate-frontend
       - uses: actions/setup-node@v7
         with:
           node-version: 24

--- a/packages/frontend/app/routes/application.js
+++ b/packages/frontend/app/routes/application.js
@@ -17,6 +17,9 @@ export default class AuthenticatedRoute extends Route {
   @tracked event;
 
   async beforeModel(transition) {
+    if (config.APP.ENABLE_DARK_MODE) {
+      window.document.documentElement.dataset.theme = 'system';
+    }
     await launchWorker();
     await this.session.setup(transition.targetName === 'lti-login');
     this.intl.setFormats(formats);

--- a/packages/frontend/app/styles/components/bulk-new-users.scss
+++ b/packages/frontend/app/styles/components/bulk-new-users.scss
@@ -1,8 +1,8 @@
 @use "../ilios-common/mixins" as m;
 
 .bulk-new-users {
-  background-color: var(--white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin: 0.5rem 0;
   padding: 1rem;
 
@@ -54,8 +54,8 @@
       overflow-y: scroll;
 
       .error {
-        border: 1px solid var(--light-red);
-        color: var(--light-red);
+        border: 1px solid light-dark(var(--light-red), var(--light-red));
+        color: light-dark(var(--light-red), var(--lighter-red));
       }
     }
   }
@@ -69,13 +69,13 @@
 
   .saving-user-errors,
   .saving-authentication-errors {
-    border: 1px solid var(--light-red);
-    border-top: 10px solid var(--light-red);
+    border: 1px solid light-dark(var(--light-red), var(--light-red));
+    border-top: 10px solid light-dark(var(--light-red), var(--red));
     margin: 1rem 4rem;
     padding: 0 1rem 1rem;
 
     p {
-      color: var(--light-red);
+      color: light-dark(var(--light-red), var(--lighter-red));
     }
 
     li {

--- a/packages/frontend/app/styles/components/connection-status.scss
+++ b/packages/frontend/app/styles/components/connection-status.scss
@@ -7,8 +7,8 @@
   flex-direction: column;
 
   &.critical-notice {
-    background-color: var(--dark-yellow);
-    color: var(--black);
+    background-color: light-dark(var(--dark-yellow), var(--dark-yellow));
+    color: light-dark(var(--black), var(--black));
     min-height: 2.5rem;
   }
 
@@ -41,10 +41,10 @@
     }
 
     button {
-      background-color: var(--black);
+      background-color: light-dark(var(--black), var(--black));
       border: 0;
       border-radius: 0;
-      color: var(--white);
+      color: light-dark(var(--white), var(--white));
       display: inline-block;
       padding: 0.25rem;
 

--- a/packages/frontend/app/styles/components/course-director-manager.scss
+++ b/packages/frontend/app/styles/components/course-director-manager.scss
@@ -6,14 +6,14 @@
     justify-content: flex-end;
 
     .bigadd {
-      background-color: var(--green);
-      color: var(--white);
+      background-color: light-dark(var(--green), var(--green));
+      color: light-dark(var(--white), var(--white));
       margin-right: 0.25rem;
     }
 
     .bigcancel {
-      background-color: var(--red);
-      color: var(--white);
+      background-color: light-dark(var(--red), var(--red));
+      color: light-dark(var(--white), var(--white));
     }
   }
 

--- a/packages/frontend/app/styles/components/course-search-result.scss
+++ b/packages/frontend/app/styles/components/course-search-result.scss
@@ -5,10 +5,10 @@
   padding: 0.5rem 0;
 
   .course-flag {
-    background: var(--green);
+    background-color: light-dark(var(--green), var(--lightest-green));
     border-radius: 2px;
     bottom: 2px;
-    color: var(--white);
+    color: light-dark(var(--white), var(--black));
     display: inline-block;
     @include m.font-size("smallest");
     padding: 2px 3px 1px;
@@ -16,10 +16,10 @@
   }
 
   .school-flag {
-    background: var(--green);
+    background-color: light-dark(var(--green), var(--lightest-green));
     border-radius: 2px;
     bottom: 2px;
-    color: var(--white);
+    color: light-dark(var(--white), var(--black));
     display: inline-block;
     @include m.font-size("smallest");
     padding: 2px 3px 1px;
@@ -31,7 +31,7 @@
     padding: 0.25rem 0.75rem 0;
 
     .sessions {
-      color: var(--grey);
+      color: light-dark(var(--grey), var(--lighter-grey));
       @include m.font-size("small");
     }
   }
@@ -58,10 +58,10 @@
     overflow: hidden;
 
     .global-search-tag {
-      background: var(--white);
-      border: 1px solid var(--grey);
+      background-color: light-dark(var(--white), var(--dark-grey));
+      border: 1px solid light-dark(var(--grey), var(--grey));
       border-radius: 0.125rem;
-      color: var(--black);
+      color: light-dark(var(--black), var(--white));
       display: inline-block;
       @include m.font-size("smallest");
       margin-right: 0.375rem;

--- a/packages/frontend/app/styles/components/courses/loading.scss
+++ b/packages/frontend/app/styles/components/courses/loading.scss
@@ -3,7 +3,7 @@
 .courses-loading {
   .toggle-mycourses .multi-buttons label {
     cursor: default;
-    background-color: var(--lightest-grey);
+    background-color: light-dark(var(--lightest-grey), var(--lightest-grey));
     color: transparent;
     text-shadow: var(--very-transparent-black) 0 0 10px;
   }

--- a/packages/frontend/app/styles/components/courses/new.scss
+++ b/packages/frontend/app/styles/components/courses/new.scss
@@ -1,8 +1,8 @@
 @use "../../ilios-common/mixins" as m;
 
 .courses-new {
-  background-color: var(--white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/download-dropdown.scss
+++ b/packages/frontend/app/styles/components/download-dropdown.scss
@@ -19,9 +19,9 @@
     }
 
     .dropdown-item {
-      border: 2px solid var(--super-light-grey);
-      background-color: var(--super-light-grey);
-      color: var(--black);
+      border: 2px solid light-dark(var(--super-light-grey), var(--dark-grey));
+      background-color: light-dark(var(--super-light-grey), var(--dark-grey));
+      color: light-dark(var(--black), var(--white));
       display: block;
       outline: none;
       padding: 0.3rem 1rem;
@@ -36,17 +36,17 @@
       white-space: nowrap;
 
       &:focus {
-        border-color: var(--grey);
+        border-color: light-dark(var(--grey), var(--light-grey));
         border-collapse: separate;
       }
 
       &:hover {
-        background-color: var(--blue);
-        border-color: var(--blue);
-        color: var(--white);
+        background-color: light-dark(var(--blue), var(--bright-blue));
+        border-color: light-dark(var(--blue), var(--bright-blue));
+        color: light-dark(var(--white), var(--black));
 
         &:focus {
-          border-color: var(--lightest-blue);
+          border-color: light-dark(var(--lightest-blue), var(--blue));
         }
       }
     }

--- a/packages/frontend/app/styles/components/flash-messages.scss
+++ b/packages/frontend/app/styles/components/flash-messages.scss
@@ -8,7 +8,7 @@
   z-index: 500;
 
   .flash-message {
-    color: var(--white);
+    color: light-dark(var(--white), var(--white));
     display: block;
     opacity: 1;
     padding: 0.5rem;
@@ -22,7 +22,7 @@
     /* no idea how to order these to avoid the violation */
     /* stylelint-disable no-descending-specificity */
     &.alert-success {
-      background-color: var(--green);
+      background-color: light-dark(var(--green), var(--green));
 
       a {
         color: hsl(from var(--green) h s calc(l + 40));
@@ -35,7 +35,7 @@
     }
 
     &.alert-warning {
-      background-color: var(--dark-yellow);
+      background-color: light-dark(var(--dark-yellow), var(--dark-yellow));
 
       a {
         color: hsl(from var(--dark-yellow) h s calc(l + 40));
@@ -48,7 +48,7 @@
     }
 
     &.alert-info {
-      background-color: var(--light-blue);
+      background-color: light-dark(var(--light-blue), var(--light-blue));
 
       a {
         color: hsl(from var(--light-blue) h s calc(l + 40));
@@ -61,7 +61,7 @@
     }
 
     &.alert-alert {
-      background-color: var(--light-red);
+      background-color: light-dark(var(--light-red), var(--light-red));
 
       a {
         color: hsl(from var(--light-red) h s calc(l + 40));

--- a/packages/frontend/app/styles/components/global-search-box.scss
+++ b/packages/frontend/app/styles/components/global-search-box.scss
@@ -8,16 +8,16 @@
   flex-direction: row-reverse;
 
   &:focus-within {
-    outline: 2px solid var(--light-blue);
+    outline: 2px solid light-dark(var(--light-blue), var(--lightest-blue));
   }
 
   button {
     @include m.ilios-button-reset;
     align-items: center;
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--dark-grey));
     border: 0;
     border-radius: 3px 0 0 3px;
-    color: var(--light-blue);
+    color: light-dark(var(--light-blue), var(--lightest-blue));
     cursor: pointer;
     display: flex;
     height: 100%;
@@ -26,7 +26,7 @@
   }
 
   input[type="search"] {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--dark-grey));
     border: 0;
     border-radius: 0 3px 3px 0;
     flex-grow: 1;

--- a/packages/frontend/app/styles/components/global-search-box.scss
+++ b/packages/frontend/app/styles/components/global-search-box.scss
@@ -12,7 +12,6 @@
   }
 
   button {
-    @include m.ilios-button-reset;
     align-items: center;
     background-color: light-dark(var(--white), var(--dark-grey));
     border: 0;

--- a/packages/frontend/app/styles/components/global-search.scss
+++ b/packages/frontend/app/styles/components/global-search.scss
@@ -21,7 +21,7 @@
     grid-area: search;
     margin: 0.75rem 0 0.5rem 10%;
     width: 80%;
-    border: 1px solid var(--light-grey);
+    border: 1px solid light-dark(var(--light-grey), var(--grey));
 
     &:focus-within {
       border-color: transparent;
@@ -64,7 +64,7 @@
   }
 
   .results {
-    border-right: 1px solid var(--black);
+    border-right: 1px solid light-dark(var(--black), var(--grey));
     grid-area: results;
     list-style-type: none;
     padding: 0 2rem;
@@ -75,7 +75,7 @@
       text-transform: capitalize;
 
       .fa-spinner.orange {
-        color: var(--orange);
+        color: light-dark(var(--orange), var(--dark-orange));
       }
     }
   }

--- a/packages/frontend/app/styles/components/ilios-footer.scss
+++ b/packages/frontend/app/styles/components/ilios-footer.scss
@@ -1,7 +1,7 @@
 @use "../ilios-common/mixins" as cm;
 
 .ilios-footer {
-  background-color: var(--orange);
+  background-color: light-dark(var(--orange), var(--dark-orange));
   display: flex;
   height: 100%;
   justify-content: flex-end;
@@ -9,10 +9,10 @@
 
   .version {
     align-items: center;
-    background-color: var(--super-light-grey);
-    border: 1px solid var(--super-light-grey);
+    background-color: light-dark(var(--super-light-grey), var(--dark-grey));
+    border: 1px solid light-dark(var(--super-light-grey), var(--dark-grey));
     border-radius: 0.2rem;
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     display: flex;
     @include cm.font-size("smallest");
     font-weight: 200;

--- a/packages/frontend/app/styles/components/ilios-header.scss
+++ b/packages/frontend/app/styles/components/ilios-header.scss
@@ -1,7 +1,7 @@
 @use "../ilios-common/mixins" as m;
 
 .ilios-header {
-  background-color: var(--orange);
+  background-color: light-dark(var(--orange), var(--dark-orange));
   align-content: center;
 
   // Elements on the far right

--- a/packages/frontend/app/styles/components/ilios-logo.scss
+++ b/packages/frontend/app/styles/components/ilios-logo.scss
@@ -2,7 +2,7 @@
 @use "../ilios-common/mixins" as m;
 
 .ilios-logo {
-  background-color: var(--orange);
+  background-color: light-dark(var(--orange), var(--dark-orange));
   a {
     display: flex;
     flex-direction: column;

--- a/packages/frontend/app/styles/components/ilios-navigation.scss
+++ b/packages/frontend/app/styles/components/ilios-navigation.scss
@@ -4,7 +4,7 @@
 /* stylelint-disable property-disallowed-list */
 
 .ilios-navigation {
-  background-color: var(--grey);
+  background-color: light-dark(var(--grey), var(--dark-grey));
   display: grid;
   grid-auto-flow: column;
   grid-template-columns: 2rem auto;
@@ -32,7 +32,7 @@
 
         &:first-of-type {
           padding-top: 2px;
-          border-top: 2px solid var(--grey);
+          border-top: 2px solid light-dark(var(--grey), var(--dark-grey));
         }
       }
     }
@@ -51,10 +51,10 @@
       justify-content: center;
 
       .expander {
-        color: var(--white);
+        color: light-dark(var(--white), var(--white));
 
         &:hover {
-          background-color: var(--light-blue);
+          background-color: light-dark(var(--light-blue), var(--grey));
         }
 
         svg {
@@ -88,14 +88,14 @@
 
   @include m.for-smaller-than-laptop {
     a.active {
-      background-color: var(--light-blue);
+      background-color: light-dark(var(--light-blue), var(--grey));
     }
   }
 
   @include m.for-laptop-and-up {
     display: block;
     border-bottom: calc(20px * constants.$golden-ratio-large) solid
-      var(--orange);
+      light-dark(var(--orange), var(--dark-orange));
 
     ul {
       bottom: 0;
@@ -115,7 +115,7 @@
   }
 
   a {
-    color: hsl(0, 0%, 92%);
+    color: var(--lightest-grey);
     display: block;
     height: 100%;
     text-decoration: none;
@@ -132,11 +132,11 @@
 
       .text {
         margin-left: 0.25rem;
-        color: hsl(0, 0%, 92%);
+        color: var(--lightest-grey);
       }
 
       .if-active {
-        color: var(--light-blue);
+        color: light-dark(var(--light-blue), var(--grey));
         justify-self: end;
         font-weight: 600;
       }
@@ -145,20 +145,20 @@
         .if-active {
           display: inline;
         }
-        color: var(--light-blue);
+        color: light-dark(var(--light-blue), var(--bright-blue));
 
         .text {
-          color: hsl(0, 0%, 92%);
+          color: var(--lightest-grey);
         }
       }
     }
 
     &:hover {
-      background-color: var(--light-blue);
-      color: hsl(0, 0%, 92%);
+      background-color: light-dark(var(--light-blue), var(--grey));
+      color: var(--lightest-grey);
 
       .if-active {
-        color: hsl(0, 0%, 92%);
+        color: var(--lightest-grey);
       }
     }
   }

--- a/packages/frontend/app/styles/components/instructor-group/header.scss
+++ b/packages/frontend/app/styles/components/instructor-group/header.scss
@@ -3,7 +3,7 @@
 
 .instructor-group-header {
   .header-bar {
-    border-bottom: 1px solid var(--lightest-grey);
+    border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/packages/frontend/app/styles/components/instructor-groups/new.scss
+++ b/packages/frontend/app/styles/components/instructor-groups/new.scss
@@ -1,8 +1,8 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-instructor-group {
-  background-color: var(--white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
+++ b/packages/frontend/app/styles/components/learner-group/bulk-assignment.scss
@@ -16,7 +16,7 @@
       width: 100%;
 
       i {
-        color: var(--light-blue);
+        color: light-dark(var(--light-blue), var(--light-blue));
         @include m.font-size("xxl");
         font-weight: 600;
         margin: 0;
@@ -25,7 +25,7 @@
     }
 
     .issue {
-      color: var(--grey);
+      color: light-dark(var(--grey), var(--light-grey));
       margin-left: 1rem;
     }
 
@@ -50,7 +50,10 @@
       }
 
       &.matched {
-        background-color: var(--transparent-green);
+        background-color: light-dark(
+          var(--transparent-green),
+          var(--transparent-green)
+        );
       }
     }
   }

--- a/packages/frontend/app/styles/components/learner-group/calendar.scss
+++ b/packages/frontend/app/styles/components/learner-group/calendar.scss
@@ -1,7 +1,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .learner-group-calendar {
-  border: 1px solid var(--black);
+  border: 1px solid light-dark(var(--black), var(--grey));
   border-radius: 5px;
   box-sizing: border-box;
   clear: both;

--- a/packages/frontend/app/styles/components/learner-group/header.scss
+++ b/packages/frontend/app/styles/components/learner-group/header.scss
@@ -3,7 +3,7 @@
 
 .learner-group-header {
   .header-bar {
-    border-bottom: 1px solid var(--lightest-grey);
+    border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/packages/frontend/app/styles/components/learner-group/instructor-manager.scss
+++ b/packages/frontend/app/styles/components/learner-group/instructor-manager.scss
@@ -41,7 +41,10 @@
 
     .removable-instructor-group {
       & > span {
-        background-color: var(--lightest-grey);
+        background-color: light-dark(
+          var(--lightest-grey),
+          var(--lightest-grey)
+        );
         border-radius: 4px;
         cursor: pointer;
         font-weight: 600;

--- a/packages/frontend/app/styles/components/learner-group/new.scss
+++ b/packages/frontend/app/styles/components/learner-group/new.scss
@@ -1,8 +1,8 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-learner-group {
-  background-color: var(--white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/learner-group/root.scss
+++ b/packages/frontend/app/styles/components/learner-group/root.scss
@@ -63,7 +63,7 @@
         button {
           &:disabled {
             cursor: default;
-            background-color: var(--grey);
+            background-color: light-dark(var(--grey), var(--grey));
           }
         }
       }
@@ -97,8 +97,8 @@
       .confirm-copy,
       .confirm-copy:nth-child(even),
       .confirm-copy:nth-child(odd) {
-        background-color: var(--lightest-blue);
-        border: 2px solid var(--light-blue);
+        background-color: light-dark(var(--lightest-blue), var(--dark-grey));
+        border: 2px solid light-dark(var(--light-blue), var(--light-blue));
 
         &.actions-row {
           border-top: 0;

--- a/packages/frontend/app/styles/components/learner-group/user-manager.scss
+++ b/packages/frontend/app/styles/components/learner-group/user-manager.scss
@@ -10,7 +10,7 @@
 
   .title {
     @include m.detail-container-title-style;
-    background: var(--white);
+    background-color: light-dark(var(--white), var(--black));
     height: 2.1rem;
     margin: 0 0.5rem;
     position: sticky;

--- a/packages/frontend/app/styles/components/learner-groups/root.scss
+++ b/packages/frontend/app/styles/components/learner-groups/root.scss
@@ -42,8 +42,8 @@
       .confirm-copy,
       .confirm-copy:nth-child(even),
       .confirm-copy:nth-child(odd) {
-        background-color: var(--lightest-blue);
-        border: 2px solid var(--light-blue);
+        background-color: light-dark(var(--lightest-blue), var(--dark-grey));
+        border: 2px solid light-dark(var(--light-blue), var(--light-blue));
 
         &.content-row {
           border-bottom: 0;

--- a/packages/frontend/app/styles/components/manage-users-summary.scss
+++ b/packages/frontend/app/styles/components/manage-users-summary.scss
@@ -41,8 +41,8 @@
     width: 90%;
 
     input[type="search"] {
-      background-color: var(--white);
-      border: 1px solid var(--blue);
+      background-color: light-dark(var(--white), var(--dark-grey));
+      border: 1px solid light-dark(var(--blue), var(--bright-blue));
       border-radius: 3px;
       height: 2rem;
       width: 100%;
@@ -55,8 +55,8 @@
       }
 
       button:active {
-        background-color: var(--lightest-grey);
-        border-bottom: 1px solid var(--lightest-grey);
+        background-color: light-dark(var(--lightest-grey), var(--grey));
+        border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
       }
     }
   }

--- a/packages/frontend/app/styles/components/my-profile.scss
+++ b/packages/frontend/app/styles/components/my-profile.scss
@@ -7,12 +7,12 @@
   }
 
   .is-student {
-    color: var(--green);
     display: block;
     text-align: center;
     width: 100%;
 
     h2 {
+      color: light-dark(var(--green), var(--lighter-green));
       font-weight: 600;
       margin: 0;
     }

--- a/packages/frontend/app/styles/components/new-directory-user.scss
+++ b/packages/frontend/app/styles/components/new-directory-user.scss
@@ -1,7 +1,7 @@
 @use "../ilios-common/mixins" as m;
 
 .new-directory-user {
-  border-bottom: 1px solid var(--lightest-grey);
+  border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin: 0.5rem;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/new-user.scss
+++ b/packages/frontend/app/styles/components/new-user.scss
@@ -1,8 +1,8 @@
 @use "../ilios-common/mixins" as m;
 
 .new-user {
-  background-color: var(--white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/pagination-links.scss
+++ b/packages/frontend/app/styles/components/pagination-links.scss
@@ -1,7 +1,7 @@
 @use "../ilios-common/mixins" as m;
 
 .pagination-links {
-  color: var(--black);
+  color: light-dark(var(--black), var(--white));
   margin: 2rem 0;
   text-align: center;
 
@@ -9,7 +9,7 @@
     text-transform: uppercase;
 
     &:disabled {
-      color: var(--grey);
+      color: light-dark(var(--grey), var(--light-grey));
       cursor: default;
     }
 
@@ -36,18 +36,18 @@
   }
 
   .page-button {
-    background: var(--white);
-    border: 1px solid var(--grey);
-    color: var(--grey);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    border: 1px solid light-dark(var(--grey), var(--grey));
+    color: light-dark(var(--grey), var(--white));
     display: inline-block;
     min-width: 2rem;
     outline: none;
     padding: 0.125rem 0;
 
     &:hover {
-      background: var(--orange);
-      border: 1px solid var(--orange);
-      color: var(--white);
+      background-color: light-dark(var(--orange), var(--orange));
+      border: 1px solid light-dark(var(--orange), var(--orange));
+      color: light-dark(var(--white), var(--white));
     }
 
     @include m.for-phone-only {
@@ -55,9 +55,9 @@
     }
 
     &:disabled {
-      background: var(--white);
+      background-color: light-dark(var(--white), var(--grey));
       border: none;
-      color: var(--black);
+      color: light-dark(var(--black), var(--white));
       cursor: default;
     }
   }

--- a/packages/frontend/app/styles/components/pending-single-user-updates.scss
+++ b/packages/frontend/app/styles/components/pending-single-user-updates.scss
@@ -6,7 +6,7 @@
   justify-content: space-around;
 
   .update {
-    border: 1px solid var(--orange);
+    border: 1px solid light-dark(var(--orange), var(--dark-orange));
     border-radius: 1rem;
     display: block;
     margin: 1rem auto;

--- a/packages/frontend/app/styles/components/program-year/competencies.scss
+++ b/packages/frontend/app/styles/components/program-year/competencies.scss
@@ -22,7 +22,7 @@
   .competency-list,
   .managed-competency-list {
     @include m.ilios-list-tree;
-    border: 1px solid var(--lightest-grey);
+    border: 1px solid light-dark(var(--lightest-grey), var(--grey));
     border-radius: 3px;
     margin: 2rem;
 

--- a/packages/frontend/app/styles/components/program-year/manage-objective-competency.scss
+++ b/packages/frontend/app/styles/components/program-year/manage-objective-competency.scss
@@ -9,17 +9,17 @@
     height: auto;
 
     .domain {
-      border-left: 10px solid var(--white);
+      border-left: 10px solid light-dark(var(--white), var(--grey));
 
       .domain-title {
         margin: 0.5rem 0 0 0.5rem;
         padding: 0;
       }
       &.selected {
-        border-left: 10px solid var(--orange);
+        border-left: 10px solid light-dark(var(--orange), var(--dark-orange));
 
         .domain-title {
-          color: var(--green);
+          color: light-dark(var(--green), var(--lighter-green));
           font-weight: 600;
         }
       }
@@ -40,7 +40,7 @@
   }
 
   .no-cohorts {
-    color: var(--dark-yellow);
+    color: light-dark(var(--dark-yellow), var(--dark-yellow));
     font-weight: 600;
   }
 }

--- a/packages/frontend/app/styles/components/program-year/new.scss
+++ b/packages/frontend/app/styles/components/program-year/new.scss
@@ -1,8 +1,8 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-program-year {
-  background-color: var(--white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin: 0.5rem 0;
   padding: 1rem;
 
@@ -23,9 +23,9 @@
     @include m.ilios-form-buttons;
 
     button:disabled {
-      background-color: var(--grey);
-      border-color: var(--grey);
-      color: var(--white);
+      background-color: light-dark(var(--grey), var(--grey));
+      border-color: light-dark(var(--grey), var(--grey));
+      color: light-dark(var(--white), var(--white));
       cursor: default;
     }
   }

--- a/packages/frontend/app/styles/components/program-year/objective-list-item-expanded.scss
+++ b/packages/frontend/app/styles/components/program-year/objective-list-item-expanded.scss
@@ -6,12 +6,12 @@
 
   table {
     thead {
-      background-color: var(--lightest-grey);
+      background-color: light-dark(var(--lightest-grey), var(--dark-grey));
     }
 
     tbody tr {
       &:nth-of-type(even) {
-        background-color: var(--lightest-grey);
+        background-color: light-dark(var(--lightest-grey), var(--grey));
       }
 
       ul {
@@ -22,7 +22,7 @@
         }
 
         li {
-          border-top: 1px solid var(--grey);
+          border-top: 1px solid light-dark(var(--grey), var(--light-grey));
           padding-top: 1rem;
         }
 

--- a/packages/frontend/app/styles/components/program-year/objective-list.scss
+++ b/packages/frontend/app/styles/components/program-year/objective-list.scss
@@ -4,7 +4,7 @@
   @include m.objective-list;
 
   .headers {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--black));
     position: sticky;
     top: 0;
     z-index: 1;
@@ -17,15 +17,17 @@
       @include m.ilios-button-reset;
       display: flex;
       justify-content: flex-start;
-      border-bottom: 1px solid var(--grey);
+      border-bottom: 1px solid light-dark(var(--grey), var(--dark-grey));
       padding: 0.5em 0.25em;
     }
   }
 
   .objective-row {
+    border-right: 1px solid transparent;
     &.is-inactive {
+      border-right: 1px solid light-dark(var(--lightest-red), var(--light-red));
       .grid-item {
-        background-color: var(--lightest-red);
+        background-color: light-dark(var(--lightest-red), var(--dark-grey));
       }
     }
     .actions {
@@ -37,7 +39,7 @@
         width: 1rem;
 
         &.active {
-          color: var(--light-blue);
+          color: light-dark(var(--light-blue), var(--bright-blue));
         }
       }
 

--- a/packages/frontend/app/styles/components/program/header.scss
+++ b/packages/frontend/app/styles/components/program/header.scss
@@ -2,7 +2,7 @@
 @use "../../ilios-common/mixins" as m;
 
 .program-header {
-  border-bottom: 1px solid var(--lightest-grey);
+  border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/packages/frontend/app/styles/components/program/new.scss
+++ b/packages/frontend/app/styles/components/program/new.scss
@@ -1,8 +1,8 @@
 @use "../../ilios-common/mixins" as m;
 
 .new-program {
-  background-color: var(--white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/frontend/app/styles/components/programs/list-item.scss
+++ b/packages/frontend/app/styles/components/programs/list-item.scss
@@ -4,7 +4,7 @@
   .actions {
     button {
       @include m.ilios-button-reset;
-      color: var(--red);
+      color: light-dark(var(--red), var(--light-red));
 
       &.disabled {
         cursor: default;

--- a/packages/frontend/app/styles/components/programyear-details.scss
+++ b/packages/frontend/app/styles/components/programyear-details.scss
@@ -1,5 +1,5 @@
 .programyear-details {
-  background-color: var(--white);
+  background-color: light-dark(var(--white), var(--black));
   margin: 0;
   padding: 0 0.5rem;
 }

--- a/packages/frontend/app/styles/components/programyear-overview.scss
+++ b/packages/frontend/app/styles/components/programyear-overview.scss
@@ -1,7 +1,7 @@
 @use "../ilios-common/mixins" as m;
 
 .programyear-overview {
-  background: var(--white);
+  background-color: light-dark(var(--white), var(--black));
   border-top: 1px dotted var(--orange);
   border-bottom: 0;
   margin: 0 0.5rem;
@@ -9,7 +9,7 @@
 
   .actions {
     a {
-      color: var(--light-blue);
+      color: light-dark(var(--light-blue), var(--blue));
       @include m.font-size("medium");
     }
   }

--- a/packages/frontend/app/styles/components/reports/choose-course.scss
+++ b/packages/frontend/app/styles/components/reports/choose-course.scss
@@ -24,7 +24,7 @@
   .deselect-all {
     @include cm.ilios-button-reset;
     @include cm.font-size("small");
-    color: var(--blue);
+    color: light-dark(var(--blue), var(--bright-blue));
   }
 
   .select-all {

--- a/packages/frontend/app/styles/components/reports/curriculum-header.scss
+++ b/packages/frontend/app/styles/components/reports/curriculum-header.scss
@@ -55,7 +55,7 @@
 
       &:disabled {
         cursor: default;
-        background-color: var(--grey);
+        background-color: light-dark(var(--grey), var(--light-grey));
       }
     }
     .loading-results {

--- a/packages/frontend/app/styles/components/reports/curriculum-loading.scss
+++ b/packages/frontend/app/styles/components/reports/curriculum-loading.scss
@@ -3,6 +3,6 @@
 .reports-curriculum-loading {
   .reports-curriculum-header .input-buttons button.done {
     cursor: default;
-    background-color: var(--lightest-grey);
+    background-color: light-dark(var(--lightest-grey), var(--grey));
   }
 }

--- a/packages/frontend/app/styles/components/reports/new-subject.scss
+++ b/packages/frontend/app/styles/components/reports/new-subject.scss
@@ -1,8 +1,8 @@
 @use "../../ilios-common/mixins" as m;
 
 .reports-new-subject {
-  background-color: var(--white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin: 0.5rem 0;
   padding: 1rem 1rem 3rem;
 
@@ -34,8 +34,8 @@
       }
 
       select.error {
-        border: 1px solid var(--light-red);
-        outline-color: var(--light-red);
+        border: 1px solid light-dark(var(--light-red), var(--red));
+        outline-color: light-dark(var(--light-red), var(--red));
       }
 
       .mesh-search {
@@ -47,14 +47,14 @@
 
     button {
       &.disabled {
-        background-color: var(--grey);
+        background-color: light-dark(var(--grey), var(--lighter-grey));
         cursor: default;
       }
 
       &:disabled {
-        background-color: var(--lightest-grey);
-        border-color: var(--grey);
-        color: var(--white);
+        background-color: light-dark(var(--lightest-grey), var(--lighter-grey));
+        border-color: light-dark(var(--grey), var(--grey));
+        color: light-dark(var(--white), var(--black));
         cursor: default;
       }
     }
@@ -67,18 +67,18 @@
       .results {
         @include m.ilios-list-reset;
         grid-column: 2;
-        background: var(--white);
+        background-color: light-dark(var(--white), var(--grey));
         border-width: 0 1px 1px 1px;
         border-style: solid;
-        border-color: var(--white);
+        border-color: light-dark(var(--white), var(--light-grey));
         box-shadow: 0 2px 2px var(--very-transparent-black);
-        color: var(--black);
+        color: light-dark(var(--black), var(--white));
         max-height: 15rem;
         overflow-y: scroll;
         transition: all 0.2s ease-in-out;
 
         li {
-          border-bottom: 1px solid var(--lightest-grey);
+          border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
           width: 100%;
 
           button {
@@ -87,7 +87,7 @@
             padding: 0.6rem 0 0 1rem;
 
             &:hover {
-              background-color: var(--lightest-grey);
+              background-color: light-dark(var(--lightest-grey), var(--grey));
             }
           }
 
@@ -96,7 +96,7 @@
           }
 
           &.results-count {
-            color: var(--green);
+            color: light-dark(var(--green), var(--light-green));
           }
         }
       }

--- a/packages/frontend/app/styles/components/reports/subject-header.scss
+++ b/packages/frontend/app/styles/components/reports/subject-header.scss
@@ -1,7 +1,7 @@
 @use "../../ilios-common/mixins" as cm;
 
 .reports-subject-header {
-  border-bottom: 1px solid var(--lightest-grey);
+  border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
   display: grid;
   grid-template-areas:
     "title"
@@ -54,7 +54,7 @@
     grid-area: download;
     &:disabled {
       cursor: default;
-      background-color: var(--grey);
+      background-color: light-dark(var(--grey), var(--grey));
     }
   }
 

--- a/packages/frontend/app/styles/components/reports/switcher.scss
+++ b/packages/frontend/app/styles/components/reports/switcher.scss
@@ -6,9 +6,9 @@
   margin: 1em;
 
   a {
-    background-color: var(--white);
-    color: var(--blue);
-    border: 1px solid var(--very-transparent-black);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    color: light-dark(var(--blue), var(--bright-blue));
+    border: 1px solid light-dark(var(--very-transparent-black), var(--grey));
     @include cm.font-size("medium");
     font-weight: 600;
     padding: 0.25em 0.5em;
@@ -21,8 +21,8 @@
     }
 
     &.active {
-      background-color: var(--blue);
-      color: var(--white);
+      background-color: light-dark(var(--blue), var(--bright-blue));
+      color: light-dark(var(--white), var(--black));
     }
   }
 }

--- a/packages/frontend/app/styles/components/school/competencies-list.scss
+++ b/packages/frontend/app/styles/components/school/competencies-list.scss
@@ -11,7 +11,7 @@
     margin-right: 0.5rem;
 
     .grid-item {
-      border-bottom: 1px solid var(--grey);
+      border-bottom: 1px solid light-dark(var(--grey), var(--grey));
       padding: 0.5rem 0.25rem;
 
       &.competency {
@@ -35,13 +35,13 @@
       }
 
       .bigadd {
-        background-color: var(--green);
-        color: var(--white);
+        background-color: light-dark(var(--green), var(--green));
+        color: light-dark(var(--white), var(--white));
       }
 
       .bigcancel {
-        background-color: var(--red);
-        color: var(--white);
+        background-color: light-dark(var(--red), var(--red));
+        color: light-dark(var(--white), var(--white));
         margin-left: 0.5rem;
       }
     }
@@ -58,26 +58,29 @@
 
     &.highlight-ok {
       transition: none;
-      background-color: var(--transparent-green);
+      background-color: light-dark(
+        var(--transparent-green),
+        var(--transparent-green)
+      );
     }
 
     &.is-managing {
-      border: 2px solid var(--light-blue);
+      border: 2px solid light-dark(var(--light-blue), var(--light-blue));
       .grid-item {
-        background-color: var(--lightest-grey);
+        background-color: light-dark(var(--lightest-grey), var(--grey));
         border: 0;
       }
     }
 
     &.confirm-removal {
-      background-color: var(--lightest-red);
+      background-color: light-dark(var(--lightest-red), var(--dark-red));
 
       .grid-item {
         border: 0;
       }
 
       .confirm-message {
-        color: var(--light-red);
+        color: light-dark(var(--light-red), var(--lightest-red));
         grid-column: 1 / -1;
         font-weight: 600;
         text-align: center;
@@ -85,11 +88,11 @@
       }
 
       .remove {
-        background-color: var(--white);
-        color: var(--light-red);
+        background-color: light-dark(var(--white), var(--dark-red));
+        color: light-dark(var(--light-red), var(--lightest-red));
 
         &:hover {
-          background-color: var(--light-red);
+          background-color: light-dark(var(--light-red), var(--red));
           color: white;
         }
       }

--- a/packages/frontend/app/styles/components/school/competencies-manager.scss
+++ b/packages/frontend/app/styles/components/school/competencies-manager.scss
@@ -2,8 +2,8 @@
 
 .school-competencies-manager {
   .domain {
-    background-color: var(--lightest-blue);
-    border: 1px solid var(--black);
+    background-color: light-dark(var(--lightest-blue), var(--dark-grey));
+    border: 1px solid light-dark(var(--black), var(--grey));
     margin: 1rem;
     padding: 1rem;
 

--- a/packages/frontend/app/styles/components/school/emails-editor.scss
+++ b/packages/frontend/app/styles/components/school/emails-editor.scss
@@ -28,7 +28,7 @@
     }
 
     .validation-error-message {
-      color: var(--red);
+      color: light-dark(var(--red), var(--lighter-red));
       display: block;
       @include m.font-size("small");
       font-style: italic;

--- a/packages/frontend/app/styles/components/school/institutional-information-manager.scss
+++ b/packages/frontend/app/styles/components/school/institutional-information-manager.scss
@@ -28,7 +28,7 @@
     }
 
     .validation-error-message {
-      color: var(--red);
+      color: light-dark(var(--red), var(--lighter-red));
       display: block;
       @include m.font-size("small");
       font-style: italic;

--- a/packages/frontend/app/styles/components/school/learning-material-attributes-expanded.scss
+++ b/packages/frontend/app/styles/components/school/learning-material-attributes-expanded.scss
@@ -23,7 +23,7 @@
     }
 
     .validation-error-message {
-      color: var(--red);
+      color: light-dark(var(--red), var(--lighter-red));
       display: block;
       @include m.font-size("small");
       font-style: italic;

--- a/packages/frontend/app/styles/components/school/root.scss
+++ b/packages/frontend/app/styles/components/school/root.scss
@@ -7,7 +7,7 @@
   }
 
   .school-overview {
-    border-bottom: 1px solid var(--lightest-grey);
+    border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/packages/frontend/app/styles/components/school/session-type-form.scss
+++ b/packages/frontend/app/styles/components/school/session-type-form.scss
@@ -2,8 +2,8 @@
 
 .school-session-type-form {
   .form {
-    background-color: var(--white);
-    border: 1px solid var(--lightest-grey);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    border: 1px solid light-dark(var(--lightest-grey), var(--grey));
     margin: 0.5rem 0;
 
     @include m.ilios-form {
@@ -25,7 +25,7 @@
       }
 
       .box {
-        border: 1px solid var(--black);
+        border: 1px solid light-dark(var(--black), var(--light-grey));
         display: inline-block;
         height: 1.5rem;
         width: 1.5rem;

--- a/packages/frontend/app/styles/components/school/session-types-list-item.scss
+++ b/packages/frontend/app/styles/components/school/session-types-list-item.scss
@@ -3,7 +3,7 @@
 .school-session-types-list-item {
   .calendar-color {
     .box {
-      border: 1px solid var(--black);
+      border: 1px solid light-dark(var(--black), var(--grey));
       display: inline-block;
       height: 1.5rem;
       width: 1.5rem;

--- a/packages/frontend/app/styles/components/school/vocabularies-expanded.scss
+++ b/packages/frontend/app/styles/components/school/vocabularies-expanded.scss
@@ -19,8 +19,8 @@
     @include m.detail-container-content;
 
     .hierarchical-list {
-      background-color: var(--lightest-grey);
-      border: 1px solid var(--black);
+      background-color: light-dark(var(--lightest-grey), var(--grey));
+      border: 1px solid light-dark(var(--black), var(--dark-grey));
       margin: 1rem;
       padding: 1rem;
 

--- a/packages/frontend/app/styles/components/school/vocabularies-list.scss
+++ b/packages/frontend/app/styles/components/school/vocabularies-list.scss
@@ -2,7 +2,7 @@
 
 .school-vocabularies-list {
   .school-vocabularies-list-header {
-    background-color: var(--lightest-grey);
+    background-color: light-dark(var(--lightest-grey), var(--grey));
     display: flex;
     justify-content: flex-end;
     padding: 0.5rem 1rem;

--- a/packages/frontend/app/styles/components/school/vocabulary-manager.scss
+++ b/packages/frontend/app/styles/components/school/vocabulary-manager.scss
@@ -30,8 +30,8 @@
   }
 
   .terms {
-    background-color: var(--white);
-    border: 1px solid var(--light-blue);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    border: 1px solid light-dark(var(--light-blue), var(--blue));
     height: 10rem;
     margin-bottom: 1rem;
     overflow-y: scroll;
@@ -39,7 +39,7 @@
     width: 80%;
 
     .saved-result {
-      border: 1px solid var(--green);
+      border: 1px solid light-dark(var(--green), var(--green));
       display: flex;
       gap: 0.25rem;
       margin: 1rem;
@@ -50,7 +50,7 @@
       @include m.ilios-selectable-list;
 
       em {
-        color: var(--red);
+        color: light-dark(var(--red), var(--lighter-red));
       }
     }
   }

--- a/packages/frontend/app/styles/components/school/vocabulary-term-manager.scss
+++ b/packages/frontend/app/styles/components/school/vocabulary-term-manager.scss
@@ -37,8 +37,8 @@
   }
 
   .terms {
-    background-color: var(--white);
-    border: 1px solid var(--light-blue);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    border: 1px solid light-dark(var(--light-blue), var(--blue));
     height: 10rem;
     margin-bottom: 1rem;
     overflow-y: scroll;
@@ -70,7 +70,7 @@
       @include m.ilios-selectable-list;
 
       em {
-        color: var(--red);
+        color: light-dark(var(--red), var(--red));
       }
     }
   }

--- a/packages/frontend/app/styles/components/schools/root.scss
+++ b/packages/frontend/app/styles/components/schools/root.scss
@@ -14,8 +14,8 @@
   }
 
   .new {
-    background-color: var(--white);
-    border: 1px solid var(--lightest-grey);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    border: 1px solid light-dark(var(--lightest-grey), var(--grey));
     margin: 0.5rem 0;
     padding: 1rem;
 

--- a/packages/frontend/app/styles/components/simple-chart-tooltip.scss
+++ b/packages/frontend/app/styles/components/simple-chart-tooltip.scss
@@ -2,6 +2,9 @@
 
 .simple-chart-tooltip {
   width: 45%;
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--light-grey), var(--light-grey));
+  color: light-dark(var(--black), var(--white));
 
   @include m.for-smaller-than-laptop {
     width: 90%;

--- a/packages/frontend/app/styles/components/update-notification.scss
+++ b/packages/frontend/app/styles/components/update-notification.scss
@@ -6,10 +6,10 @@
   }
 
   &.critical-notice {
-    background-color: var(--blue);
+    background-color: light-dark(var(--blue), var(--bright-blue));
 
     button {
-      color: var(--white);
+      color: light-dark(var(--white), var(--black));
       min-height: 3rem;
     }
   }

--- a/packages/frontend/app/styles/components/user-guide-link.scss
+++ b/packages/frontend/app/styles/components/user-guide-link.scss
@@ -8,10 +8,10 @@
   }
 
   a {
-    background-color: var(--super-light-grey);
-    border: 1px solid var(--super-light-grey);
+    background-color: light-dark(var(--super-light-grey), var(--dark-grey));
+    border: 1px solid light-dark(var(--super-light-grey), var(--grey));
     border-radius: 0.2rem;
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     @include cm.font-size("small");
     font-weight: 400;
     margin-left: 0.8rem;
@@ -19,7 +19,8 @@
 
     &:hover,
     &:focus {
-      background-color: var(--white);
+      background-color: light-dark(var(--white), var(--grey));
+      color: light-dark(var(--black), var(--white));
     }
 
     @include cm.for-tablet-and-up {

--- a/packages/frontend/app/styles/components/user-profile-bio.scss
+++ b/packages/frontend/app/styles/components/user-profile-bio.scss
@@ -29,7 +29,10 @@
       }
 
       &.synced-from-directory input {
-        background-color: var(--transparent-green);
+        background-color: light-dark(
+          var(--transparent-green),
+          var(--transparent-green)
+        );
         transition: background-color 500ms ease;
       }
     }
@@ -39,7 +42,7 @@
     display: flex;
 
     button {
-      background-color: var(--light-blue);
+      background-color: light-dark(var(--light-blue), var(--blue));
       height: 2rem;
       margin-bottom: 0.25rem;
       margin-left: 0.5rem;

--- a/packages/frontend/app/styles/components/user-profile-calendar.scss
+++ b/packages/frontend/app/styles/components/user-profile-calendar.scss
@@ -1,7 +1,7 @@
 @use "../ilios-common/mixins" as m;
 
 .user-profile-calendar {
-  border: 1px solid var(--black);
+  border: 1px solid light-dark(var(--black), var(--grey));
   border-radius: 5px;
   grid-column: 1 / -1;
   margin-bottom: 1rem;

--- a/packages/frontend/app/styles/components/user-profile-roles.scss
+++ b/packages/frontend/app/styles/components/user-profile-roles.scss
@@ -6,7 +6,7 @@
   }
 
   hr {
-    border-top: 0.5px solid var(--black);
+    border-top: 0.5px solid light-dark(var(--black), var(--grey));
   }
 
   .actions {

--- a/packages/frontend/app/styles/components/user-profile.scss
+++ b/packages/frontend/app/styles/components/user-profile.scss
@@ -16,7 +16,7 @@
     text-align: center;
 
     .user-is-student {
-      color: var(--green);
+      color: light-dark(var(--green), var(--lighter-green));
     }
   }
 }
@@ -41,6 +41,6 @@
   }
 
   .refresh-key {
-    background-color: var(--green);
+    background-color: light-dark(var(--green), var(--light-green));
   }
 }

--- a/packages/frontend/app/styles/layout/_layout.scss
+++ b/packages/frontend/app/styles/layout/_layout.scss
@@ -11,7 +11,7 @@
   grid-template-columns: 2.5rem 1fr;
   min-height: 100vh;
   width: 100%;
-  background-color: var(--white);
+  background-color: light-dark(var(--white), var(--black));
 
   @include m.for-phone-and-up {
     grid-template-columns: 4rem 1fr;
@@ -30,7 +30,7 @@
   }
 
   & > main {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--black));
     grid-area: main;
   }
 

--- a/packages/frontend/app/styles/layout/_noscript.scss
+++ b/packages/frontend/app/styles/layout/_noscript.scss
@@ -2,9 +2,9 @@
 
 noscript {
   p {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--black));
     border: 2px dashed var(--orange);
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     @include m.font-size("xxl");
     font-weight: 600;
     margin: 2rem;

--- a/packages/frontend/app/styles/shared/admin-block.scss
+++ b/packages/frontend/app/styles/shared/admin-block.scss
@@ -10,16 +10,16 @@
 
   .small-component,
   .large-component {
-    background-color: var(--super-light-grey);
-    border: 1px solid var(--light-blue);
+    background-color: light-dark(var(--super-light-grey), var(--dark-grey));
+    border: 1px solid light-dark(var(--light-blue), var(--blue));
     border-radius: 5px;
     margin-bottom: 1rem;
     min-height: 4rem;
     padding: 0.5rem;
 
     &.alert {
-      background-color: var(--white);
-      border: 3px solid var(--dark-yellow);
+      background-color: light-dark(var(--white), var(--grey));
+      border: 3px solid light-dark(var(--dark-yellow), var(--dark-yellow));
     }
 
     p {
@@ -49,7 +49,10 @@
   }
 
   .has-saved {
-    background-color: var(--transparent-green);
+    background-color: light-dark(
+      var(--transparent-green),
+      var(--transparent-green)
+    );
     transition: background-color 0.5s ease-out;
   }
 

--- a/packages/frontend/app/styles/shared/header-menu.scss
+++ b/packages/frontend/app/styles/shared/header-menu.scss
@@ -7,15 +7,15 @@
 
   button {
     background-color: transparent;
-    border: 1px solid var(--super-light-grey);
+    border: 1px solid light-dark(var(--super-light-grey), var(--grey));
     border-radius: 0;
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     font-weight: 400;
     padding: 0.25rem;
   }
 
   .menu {
-    background-color: var(--super-light-grey);
+    background-color: light-dark(var(--super-light-grey), var(--grey));
     box-shadow: 0 2px 2px var(--very-transparent-black);
     display: flex;
     flex-direction: column;
@@ -31,9 +31,9 @@
     }
 
     .header-menu-item {
-      border: 2px solid var(--super-light-grey);
-      background-color: var(--super-light-grey);
-      color: var(--black);
+      border: 2px solid light-dark(var(--super-light-grey), var(--grey));
+      background-color: light-dark(var(--super-light-grey), var(--grey));
+      color: light-dark(var(--black), var(--white));
       display: block;
       outline: none;
       padding: 0.5rem 0.5rem 0.5rem 1.5rem;
@@ -48,40 +48,44 @@
       white-space: nowrap;
 
       &:focus {
-        border-color: var(--grey);
+        border-color: light-dark(var(--grey), var(--dark-grey));
         border-collapse: separate;
       }
 
       &:hover {
-        background-color: var(--blue);
-        border-color: var(--blue);
-        color: var(--white);
+        background-color: light-dark(var(--blue), var(--lighter-grey));
+        border-color: light-dark(var(--blue), var(--lighter-grey));
+        color: light-dark(var(--white), var(--black));
 
         &:focus {
-          border-color: var(--lightest-blue);
+          border-color: light-dark(var(--lightest-blue), var(--lightest-blue));
         }
       }
 
       &[aria-checked="true"],
       &.active {
-        background-color: var(--green);
-        border-color: var(--green);
-        color: var(--white);
+        background-color: light-dark(var(--green), var(--green));
+        border-color: light-dark(var(--green), var(--green));
+        color: light-dark(var(--white), var(--white));
         cursor: default;
 
         &:focus {
-          border-color: var(--lightest-green);
+          border-color: light-dark(
+            var(--lightest-green),
+            var(--lightest-green)
+          );
         }
 
         &:hover {
-          background-color: var(--green);
+          background-color: light-dark(var(--green), var(--green));
         }
       }
     }
   }
 
   .toggle {
-    background-color: var(--super-light-grey);
+    background-color: light-dark(var(--super-light-grey), var(--dark-grey));
+    color: light-dark(var(--black), var(--white));
 
     span {
       display: none;
@@ -94,7 +98,8 @@
 
     &:hover,
     &[aria-expanded="true"] {
-      background-color: var(--white);
+      background-color: light-dark(var(--white), var(--grey));
+      color: light-dark(var(--black), var(--white));
     }
 
     &[aria-expanded="true"] {

--- a/packages/frontend/app/styles/shared/password-validation.scss
+++ b/packages/frontend/app/styles/shared/password-validation.scss
@@ -3,8 +3,8 @@
 .password-validation {
   meter {
     background: none;
-    background-color: var(--white);
-    border: 0.5px solid var(--black);
+    background-color: light-dark(var(--white), var(--black));
+    border: 0.5px solid light-dark(var(--black), var(--grey));
     height: 0.75rem;
     margin: 0.25rem 0;
     width: 60%;
@@ -16,39 +16,39 @@
 
   meter::-webkit-meter-bar {
     background: none;
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--black));
   }
 
   meter[value="0"]::-webkit-meter-optimum-value {
-    background: var(--light-red);
+    background-color: light-dark(var(--light-red), var(--lighter-red));
   }
   meter[value="1"]::-webkit-meter-optimum-value {
-    background: var(--light-red);
+    background-color: light-dark(var(--light-red), var(--lighter-red));
   }
   meter[value="2"]::-webkit-meter-optimum-value {
-    background: var(--orange);
+    background-color: light-dark(var(--orange), var(--orange));
   }
   meter[value="3"]::-webkit-meter-optimum-value {
-    background: var(--dark-yellow);
+    background-color: light-dark(var(--dark-yellow), var(--dark-yellow));
   }
   meter[value="4"]::-webkit-meter-optimum-value {
-    background: var(--green);
+    background-color: light-dark(var(--green), var(--light-green));
   }
 
   meter[value="0"]:-moz-meter-bar {
-    background: var(--light-red);
+    background-color: light-dark(var(--light-red), var(--lighter-red));
   }
   meter[value="1"]:-moz-meter-bar {
-    background: var(--light-red);
+    background-color: light-dark(var(--light-red), var(--lighter-red));
   }
   meter[value="2"]:-moz-meter-bar {
-    background: var(--orange);
+    background-color: light-dark(var(--orange), var(--orange));
   }
   meter[value="3"]:-moz-meter-bar {
-    background: var(--dark-yellow);
+    background-color: light-dark(var(--dark-yellow), var(--dark-yellow));
   }
   meter[value="4"]:-moz-meter-bar {
-    background: var(--green);
+    background-color: light-dark(var(--green), var(--light-green));
   }
 
   .password-strength {
@@ -58,24 +58,24 @@
     width: 10%;
 
     &.strength-0 {
-      color: var(--light-red);
+      color: light-dark(var(--light-red), var(--lighter-red));
       width: 20%;
     }
 
     &.strength-1 {
-      color: var(--light-red);
+      color: light-dark(var(--light-red), var(--lighter-red));
     }
 
     &.strength-2 {
-      color: var(--orange);
+      color: light-dark(var(--orange), var(--orange));
     }
 
     &.strength-3 {
-      color: var(--dark-yellow);
+      color: light-dark(var(--dark-yellow), var(--dark-yellow));
     }
 
     &.strength-4 {
-      color: var(--green);
+      color: light-dark(var(--green), var(--light-green));
     }
   }
 }

--- a/packages/frontend/config/environment.js
+++ b/packages/frontend/config/environment.js
@@ -54,6 +54,7 @@ module.exports = function (environment) {
       },
       LOCAL_STORAGE_KEY: 'ilios',
       SUPPORTED_LOCALES: ['en-us', 'es', 'fr'],
+      ENABLE_DARK_MODE: process.env.ENABLE_PREVIEW_FEATURES ?? false,
     },
   };
 
@@ -67,6 +68,8 @@ module.exports = function (environment) {
 
     //put ember concurrency tasks into debug mode to make errors much easier to spot
     ENV.EmberENV.DEBUG_TASKS = true;
+
+    ENV.APP.ENABLE_DARK_MODE = true;
   }
 
   if (environment === 'test') {
@@ -85,6 +88,7 @@ module.exports = function (environment) {
     ENV.disableServiceWorker = true;
 
     ENV.APP.autoboot = false;
+    ENV.APP.ENABLE_DARK_MODE = true;
   }
 
   return ENV;

--- a/packages/frontend/lib/ilios-loading/index.js
+++ b/packages/frontend/lib/ilios-loading/index.js
@@ -8,7 +8,8 @@ module.exports = {
       return `
         <style type="text/css">
           #ilios-loading-indicator {
-            background: #eee;
+            color-scheme: light;
+            background: light-dark(#eee, hsl(345, 6%, 13%));
             height: 100vh;
             left: 0;
             position: fixed;
@@ -26,10 +27,10 @@ module.exports = {
           }
 
           #ilios-loading-indicator svg {
-            fill: #c60;
+            fill: light-dark(#c60, hsl(30, 100%, 20%));
             height: 50vh;
             overflow: visible;
-            stroke: #c60;
+            stroke: light-dark(#c60, hsl(30, 100%, 20%));
             width: 50vw;
           }
 

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -1,28 +1,38 @@
 :root {
+  color-scheme: light dark;
+
   --white: hsl(0, 0%, 98%);
   --bright-white: hsl(0, 0%, 100%);
 
+  --dark-grey: hsl(0, 0%, 20%);
   --grey: hsl(0, 0%, 30%);
   --light-grey: hsl(0, 0%, 50%);
   --lighter-grey: hsl(0, 0%, 80%);
   --lightest-grey: hsl(0, 0%, 90%);
   --super-light-grey: hsl(0, 0%, 95%);
 
+  --dark-red: hsl(0, 100%, 20%);
   --red: hsl(0, 100%, 30%);
   --light-red: hsl(0, 100%, 40%);
+  --lighter-red: hsl(0, 100%, 80%);
   --lightest-red: hsl(0, 100%, 97%);
 
-  --orange: hsl(30, 100%, 40%);
   --dark-orange: hsl(30, 100%, 20%);
+  --orange: hsl(30, 100%, 40%);
+  --light-orange: hsl(30, 100%, 50%);
 
   --yellow: hsl(45, 100%, 60%);
   --dark-yellow: hsl(45, 100%, 45%);
   --darker-yellow: hsl(45, 100%, 20%);
 
+  --dark-green: hsl(115, 100%, 10%);
   --green: hsl(115, 100%, 20%);
+  --light-green: hsl(115, 100%, 30%);
+  --lighter-green: hsl(115, 50%, 50%);
   --lightest-green: hsl(115, 100%, 92%);
   --transparent-green: hsl(115, 50%, 50%, 20%);
 
+  --bright-blue: hsl(195, 100%, 45%);
   --blue: hsl(195, 50%, 35%);
   --light-blue: hsl(195, 50%, 45%);
   --lighter-blue: hsl(195, 50%, 80%);

--- a/packages/ilios-common/app/styles/ilios-common/colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/colors.scss
@@ -1,5 +1,17 @@
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
+
+  &[data-theme="system"] {
+    color-scheme: light dark;
+  }
+
+  &[data-theme="light"] {
+    color-scheme: light;
+  }
+
+  &[data-theme="dark"] {
+    color-scheme: dark;
+  }
 
   --white: hsl(0, 0%, 98%);
   --bright-white: hsl(0, 0%, 100%);

--- a/packages/ilios-common/app/styles/ilios-common/components/api-version-notice.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/api-version-notice.scss
@@ -4,9 +4,13 @@
   display: none;
   padding: 0.25rem 1rem;
 
+  h2 {
+    color: light-dark(var(--black), var(--black));
+  }
+
   &.critical-notice {
-    background-color: var(--dark-yellow);
-    color: var(--black);
+    background-color: light-dark(var(--dark-yellow), var(--dark-yellow));
+    color: light-dark(var(--black), var(--black));
     min-height: 2.5rem;
   }
 
@@ -16,9 +20,9 @@
 
   .details {
     button {
-      background-color: var(--black);
+      background-color: light-dark(var(--black), var(--black));
       border: 0;
-      color: var(--white);
+      color: light-dark(var(--white), var(--white));
       display: inline-block;
       height: 100%;
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/body.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/body.scss
@@ -12,8 +12,8 @@ html {
 }
 
 body {
-  background-color: var(--white);
-  color: var(--black);
+  background-color: light-dark(var(--white), var(--black));
+  color: light-dark(var(--black), var(--lightest-grey));
   font-family: "Nunito Variable", sans-serif;
   margin: 0;
   padding: 0;
@@ -21,19 +21,19 @@ body {
 
 a,
 .link {
-  color: var(--blue);
+  color: light-dark(var(--blue), var(--bright-blue));
   cursor: pointer;
   font-weight: 600;
   text-decoration: none;
 
   &:visited {
-    color: var(--blue);
+    color: light-dark(var(--blue), var(--bright-blue));
   }
 
   &:hover,
   &:active,
   &:focus {
-    color: var(--light-blue);
+    color: light-dark(var(--light-blue), var(--lighter-blue));
     outline: thin dotted;
     text-decoration: underline;
   }
@@ -52,7 +52,7 @@ button {
 }
 
 input {
-  accent-color: var(--blue);
+  accent-color: light-dark(var(--blue), var(--bright-blue));
 }
 
 h1 {
@@ -80,7 +80,7 @@ h6 {
 }
 
 select {
-  color: var(--black);
+  color: light-dark(var(--black), var(--lightest-grey));
   font-family: "Nunito Variable", sans-serif;
 }
 
@@ -107,22 +107,22 @@ b {
 
 .add,
 .yes {
-  color: var(--green);
+  color: light-dark(var(--green), var(--lighter-green));
 }
 
 .remove,
 .no {
-  color: var(--red);
+  color: light-dark(var(--red), var(--lighter-red));
 }
 
 .error,
 .is-error {
-  color: var(--red);
+  color: light-dark(var(--red), var(--lighter-red));
 }
 
 .warning,
 .is-warning {
-  color: var(--yellow);
+  color: light-dark(var(--yellow), var(--yellow));
 }
 
 .clickable,
@@ -132,19 +132,19 @@ b {
 
 .editable,
 .is-editable {
-  color: var(--blue);
+  color: light-dark(var(--blue), var(--bright-blue));
 }
 
 .published {
-  color: var(--green);
+  color: light-dark(var(--green), var(--lighter-green));
 }
 
 .notpublished {
-  color: var(--grey);
+  color: light-dark(var(--grey), var(--lighter-grey));
 }
 
 .scheduled {
-  color: var(--dark-orange);
+  color: light-dark(var(--dark-orange), var(--light-orange));
 }
 
 .backtolink {

--- a/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/breadcrumbs.scss
@@ -1,5 +1,5 @@
 .breadcrumbs {
-  $border: 1px solid var(--blue);
+  $border: 1px solid light-dark(var(--blue), var(--bright-blue));
   $height: 2rem;
   $h2: calc($height / 2);
   $h4: calc($height / 4);
@@ -11,10 +11,10 @@
 
   /* stylelint-disable property-disallowed-list, scales/font-weights,declaration-property-value-disallowed-list */
   .crumb {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--dark-grey));
     border: $border;
     border-left: 0;
-    color: var(--blue);
+    color: light-dark(var(--blue), var(--bright-blue));
     cursor: pointer;
     display: inline-block;
     font-size: 0.8rem;
@@ -39,14 +39,14 @@
 
     &::before {
       // outer arrow
-      border-left-color: var(--blue);
+      border-left-color: light-dark(var(--blue), var(--bright-blue));
       left: 100%;
       margin-left: 1px;
       z-index: 1;
     }
     &::after {
       // inner arrow
-      border-left-color: var(--white);
+      border-left-color: light-dark(var(--white), var(--dark-grey));
       left: 100%;
       z-index: 2;
     }
@@ -59,10 +59,10 @@
     }
     &:last-child {
       background-color: inherit;
-      border-color: var(--lighter-grey);
+      border-color: light-dark(var(--lighter-grey), var(--grey));
       border-bottom-right-radius: 3px;
       border-top-right-radius: 3px;
-      color: var(--black);
+      color: light-dark(var(--black), var(--white));
       cursor: default;
       font-weight: 700;
       padding-right: $h2;
@@ -80,11 +80,11 @@
 
     &:hover,
     &:focus {
-      background-color: var(--blue);
-      color: var(--white);
+      background-color: light-dark(var(--blue), var(--bright-blue));
+      color: light-dark(var(--white), var(--black));
 
       &::after {
-        border-left-color: var(--blue);
+        border-left-color: light-dark(var(--blue), var(--bright-blue));
       }
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/choose-material-type.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/choose-material-type.scss
@@ -5,15 +5,15 @@
 
   button {
     background-color: transparent;
-    border: 1px solid var(--white);
+    border: 1px solid light-dark(var(--white), var(--dark-grey));
     border-radius: 0.2rem;
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     font-weight: 400;
     padding: 0.25rem 0.5rem;
   }
 
   .menu {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--dark-grey));
     box-shadow: 0 2px 2px var(--slightly-transparent-black);
     display: flex;
     flex-direction: column;
@@ -27,8 +27,8 @@
 
     button {
       border: 0;
-      background-color: var(--white);
-      color: var(--black);
+      background-color: light-dark(var(--white), var(--dark-grey));
+      color: light-dark(var(--black), var(--white));
       display: block;
       outline: none;
       padding: 0.5rem 1rem;
@@ -38,15 +38,15 @@
 
       &:hover,
       &:focus {
-        background-color: var(--blue);
-        color: var(--white);
+        background-color: light-dark(var(--blue), var(--bright-blue));
+        color: light-dark(var(--white), var(--black));
       }
     }
   }
 
   .toggle {
-    background-color: var(--blue);
-    color: var(--white);
+    background-color: light-dark(var(--blue), var(--bright-blue));
+    color: light-dark(var(--white), var(--black));
 
     &[aria-expanded="true"] {
       border-bottom-right-radius: 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/click-choice-buttons.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/click-choice-buttons.scss
@@ -1,13 +1,13 @@
 .click-choice-buttons {
   button {
-    background-color: var(--lightest-grey);
-    border: 1px outset var(--grey);
-    color: var(--black);
+    background-color: light-dark(var(--lightest-grey), var(--dark-grey));
+    border: 1px outset light-dark(var(--grey), var(--light-grey));
+    color: light-dark(var(--black), var(--white));
 
     &.active {
-      background-color: var(--blue);
+      background-color: light-dark(var(--blue), var(--bright-blue));
       border: 1px inset var(--blue);
-      color: var(--white);
+      color: light-dark(var(--white), var(--black));
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/common-dashboard.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/common-dashboard.scss
@@ -1,3 +1,3 @@
 .common-dashboard {
-  border: 1px solid var(--light-blue);
+  border: 1px solid light-dark(var(--light-blue), var(--light-blue));
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/details.scss
@@ -1,9 +1,6 @@
 @use "../../mixins" as m;
 
 .course-details {
-  $collapse-control-shadow-grey: #e2e2e2;
-  $collapse-control-shadow-black: var(--very-transparent-black);
-
   .details-collapse-control {
     display: flex;
     justify-content: center;
@@ -11,13 +8,14 @@
 
     button {
       @include m.ilios-button-reset;
-      background-color: var(--blue);
+      background-color: light-dark(var(--blue), var(--bright-blue));
       border-bottom-left-radius: 5px;
       border-bottom-right-radius: 5px;
       box-shadow:
-        0 2px $collapse-control-shadow-grey,
-        inset 0 1px 2px $collapse-control-shadow-black;
-      color: var(--white);
+        0 2px light-dark(var(--lightest-grey), var(--grey)),
+        inset 0 1px 2px
+          light-dark(var(--very-transparent-black), var(--light-grey));
+      color: light-dark(var(--white), var(--black));
       cursor: pointer;
       padding: 0.25rem 4rem;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/course/loading.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/loading.scss
@@ -26,7 +26,7 @@
   }
 
   .sessions-grid-header-row {
-    background-color: var(--lighter-grey);
+    background-color: light-dark(var(--lighter-grey), var(--dark-grey));
     height: 2rem;
   }
 }
@@ -39,11 +39,11 @@
     width: 100%;
 
     span {
-      background-color: var(--lighter-grey);
+      background-color: light-dark(var(--lighter-grey), var(--dark-grey));
       border-bottom-left-radius: 5px;
       border-bottom-right-radius: 5px;
       padding: 0.25rem 4rem;
-      color: var(--lighter-grey);
+      color: light-dark(var(--lighter-grey), var(--dark-grey));
 
       .expand-collapse-icon {
         margin-left: 0.5rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/course/manage-objective-parents.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/manage-objective-parents.scss
@@ -26,10 +26,10 @@
       }
 
       &.selected {
-        border-left: 10px solid var(--orange);
+        border-left: 10px solid light-dark(var(--orange), var(--dark-orange));
 
         .competency-title {
-          color: var(--green);
+          color: light-dark(var(--green), var(--lighter-green));
           font-weight: 600;
         }
       }
@@ -50,7 +50,7 @@
   }
 
   .no-cohorts {
-    color: var(--dark-orange);
+    color: light-dark(var(--dark-orange), var(--yellow));
     font-weight: 600;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/materials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/materials.scss
@@ -28,6 +28,6 @@
   }
 
   .fa-spinner.orange {
-    color: var(--orange);
+    color: light-dark(var(--orange), var(--dark-orange));
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/objectives.scss
@@ -5,7 +5,7 @@
   @include m.objectives;
 
   .headers {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--dark-grey));
     position: sticky;
     top: 0;
     z-index: 1;

--- a/packages/ilios-common/app/styles/ilios-common/components/course/overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/overview.scss
@@ -15,6 +15,6 @@
   }
 
   .universallocator {
-    color: var(--grey);
+    color: light-dark(var(--grey), var(--grey));
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/publicationcheck.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/publicationcheck.scss
@@ -17,13 +17,13 @@
     }
 
     .fa-link-slash {
-      color: var(--black);
+      color: light-dark(var(--black), var(--white));
       @include m.font-size("small");
     }
 
     button:disabled {
-      background-color: var(--grey);
-      border-color: var(--grey);
+      background-color: light-dark(var(--grey), var(--light-grey));
+      border-color: light-dark(var(--grey), var(--light-grey));
       cursor: default;
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/course/rollover.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/course/rollover.scss
@@ -7,7 +7,7 @@
   }
 
   .rollover-form {
-    border: 1px solid var(--light-blue);
+    border: 1px solid light-dark(var(--light-blue), var(--grey));
     margin-top: 1rem;
 
     @include m.ilios-form {

--- a/packages/ilios-common/app/styles/ilios-common/components/daily-calendar-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/daily-calendar-event.scss
@@ -8,7 +8,7 @@
   flex-direction: column;
   justify-content: start;
   @include m.font-size("small");
-  border: 1px solid var(--white);
+  border: 1px solid light-dark(var(--white), var(--black));
   margin: 1px;
   padding: 0.25rem;
   text-align: left;

--- a/packages/ilios-common/app/styles/ilios-common/components/daily-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/daily-calendar.scss
@@ -59,7 +59,7 @@
       grid-row: 1 / -1;
       grid-template-columns: repeat(50, 1fr);
       grid-template-rows: repeat($minute-rows, $hour-height);
-      border: 1px solid var(--lightest-grey);
+      border: 1px solid light-dark(var(--lightest-grey), var(--grey));
       @for $day from 1 through 7 {
         &.day-#{$day} {
           grid-column: ($day + 1);
@@ -78,7 +78,7 @@
 
     .hour-border,
     .half-hour-border {
-      border-top: 1px solid var(--lightest-grey);
+      border-top: 1px solid light-dark(var(--lightest-grey), var(--grey));
       grid-column: 2 / -1;
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/calendar.scss
@@ -39,7 +39,7 @@
       }
 
       .calendar-filter-list {
-        border: 1px solid var(--light-blue);
+        border: 1px solid light-dark(var(--light-blue), var(--blue));
         float: left;
         @include m.font-size("small");
         margin-bottom: 1em;
@@ -49,8 +49,8 @@
           @include m.ilios-heading;
           @include m.font-size("base");
           display: block;
-          background-color: var(--lightest-grey);
-          border-bottom: 0.5px solid var(--grey);
+          background-color: light-dark(var(--lightest-grey), var(--dark-grey));
+          border-bottom: 0.5px solid light-dark(var(--grey), var(--grey));
           height: 7vh;
           padding: 0.25em;
           width: 100%;
@@ -73,7 +73,7 @@
           @include m.ilios-list-reset;
 
           li {
-            color: var(--blue);
+            color: light-dark(var(--blue), var(--bright-blue));
             cursor: pointer;
           }
         }
@@ -113,8 +113,8 @@
       padding: 5px;
 
       .filters-header {
-        background: var(--lightest-grey);
-        border-bottom: 1px solid var(--grey);
+        background-color: light-dark(var(--lightest-grey), var(--dark-grey));
+        border-bottom: 1px solid light-dark(var(--grey), var(--grey));
         @include m.font-size("small");
       }
 
@@ -127,13 +127,14 @@
         .filter-tag {
           @include m.ilios-button-reset;
           @include m.font-size("small");
+          color: var(--black);
           border-radius: 3px;
           display: inline-block;
           padding: 2px 5px;
         }
 
         .fa-close {
-          color: var(--lightest-grey);
+          color: light-dark(var(--lightest-grey), var(--grey));
         }
 
         .tag-session-type {
@@ -182,7 +183,7 @@
         .filters-clear-filters {
           @include m.ilios-button-reset;
           @include m.font-size("small");
-          color: var(--blue);
+          color: light-dark(var(--blue), var(--bright-blue));
         }
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/materials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/materials.scss
@@ -43,7 +43,7 @@
     }
 
     .lm-type-icon {
-      color: var(--grey);
+      color: light-dark(var(--grey), var(--lighter-grey));
     }
 
     .timed-release-info {
@@ -59,7 +59,7 @@
     }
 
     .fa-spinner.orange {
-      color: var(--orange);
+      color: light-dark(var(--orange), var(--orange));
     }
 
     .paginator {

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
@@ -2,7 +2,7 @@
 @use "../../mixins" as m;
 
 .dashboard-navigation {
-  border-bottom: 1px solid var(--lightest-grey);
+  border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin: 0.5rem 0 0 0.5rem;
 
   ul {
@@ -30,7 +30,7 @@
         .highlight {
           align-items: center;
           display: flex;
-          color: var(--orange);
+          color: light-dark(var(--orange), var(--orange));
           @include m.font-size("large");
 
           @include m.for-phone-only {
@@ -66,7 +66,8 @@
     }
 
     &.active {
-      background-color: var(--green);
+      background-color: light-dark(var(--green), var(--green));
+      color: light-dark(var(--white), var(--white));
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/user-context-filter.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/user-context-filter.scss
@@ -2,7 +2,7 @@
 
 .dashboard-user-context-filter {
   label.active {
-    background-color: var(--blue);
-    color: var(--white);
+    background-color: light-dark(var(--blue), var(--bright-blue));
+    color: light-dark(var(--white), var(--black));
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-cohort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-cohort-manager.scss
@@ -11,8 +11,8 @@
 
   .selectable-cohorts {
     @include m.ilios-selectable-list;
-    background-color: var(--white);
-    border: 1px solid var(--light-blue);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    border: 1px solid light-dark(var(--light-blue), var(--grey));
     height: 10rem;
     margin-bottom: 1rem;
     margin-top: 1rem;

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learnergroups-list-item.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learnergroups-list-item.scss
@@ -1,5 +1,5 @@
 .detail-learnergroups-list-item {
   .muted {
-    color: var(--grey);
+    color: light-dark(var(--grey), var(--lighter-grey));
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learnergroups-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learnergroups-list.scss
@@ -13,8 +13,8 @@
       @include m.ilios-removable-list;
 
       .top-level-group {
-        background-color: var(--dark-yellow);
-        color: var(--black);
+        background-color: light-dark(var(--dark-yellow), var(--dark-yellow));
+        color: light-dark(var(--black), var(--black));
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-learningmaterials.scss
@@ -29,8 +29,8 @@
 
     .lm-search-results {
       @include m.ilios-selectable-list;
-      background-color: var(--white);
-      border: 1px solid var(--light-blue);
+      background-color: light-dark(var(--white), var(--dark-grey));
+      border: 1px solid light-dark(var(--light-blue), var(--light-grey));
       margin: 0;
       max-height: 15rem;
       overflow-y: scroll;
@@ -38,7 +38,7 @@
       z-index: 10;
 
       li {
-        border-bottom: 1px solid var(--lightest-grey);
+        border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
         min-height: 3.25rem;
         position: relative;
 
@@ -66,14 +66,14 @@
       }
 
       .learning-material-description {
-        color: var(--grey);
+        color: light-dark(var(--grey), var(--white));
         display: block;
         @include m.font-size("small");
         margin-left: 1.9em;
       }
 
       .learning-material-status {
-        color: var(--red);
+        color: light-dark(var(--red), var(--lighter-red));
         @include m.font-size("small");
         position: absolute;
         right: 5px;
@@ -85,7 +85,7 @@
 
         li {
           border: 0;
-          color: var(--grey);
+          color: light-dark(var(--grey), var(--white));
           cursor: inherit;
           display: list-item;
           @include m.font-size("small");
@@ -113,7 +113,7 @@
 
     .icon-button {
       @include m.ilios-button-reset;
-      color: var(--light-blue);
+      color: light-dark(var(--light-blue), var(--bright-blue));
 
       &.disabled {
         cursor: default;

--- a/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/detail-terms-list.scss
@@ -5,15 +5,15 @@
   margin-bottom: 1rem;
 
   .inactive {
-    color: var(--red);
+    color: light-dark(var(--red), var(--lightest-red));
   }
 
   .selected-taxonomy-terms {
     @include m.ilios-tag-list;
 
     button {
-      background-color: var(--lightest-grey);
-      color: var(--black);
+      background-color: light-dark(var(--lightest-grey), var(--dark-grey));
+      color: light-dark(var(--black), var(--white));
       padding: calc(constants.$golden-ratio-small * 0.5rem)
         calc(constants.$golden-ratio-large * 0.5rem);
     }
@@ -27,7 +27,7 @@
     }
 
     .muted {
-      color: var(--grey);
+      color: light-dark(var(--grey), var(--lightest-grey));
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/editinplace.scss
@@ -7,10 +7,10 @@
     display: flex;
 
     #{m.$form-input-text-types} {
-      background: var(--bright-white);
-      border: 1px solid var(--lightest-grey);
+      background-color: light-dark(var(--bright-white), var(--dark-grey));
+      border: 1px solid light-dark(var(--lightest-grey), var(--grey));
       border-radius: 3px;
-      color: var(--black);
+      color: light-dark(var(--black), var(--white));
       cursor: pointer;
       display: inline;
       outline: none;
@@ -35,22 +35,22 @@
         padding: 0 0.2rem;
 
         &:enabled:hover {
-          color: var(--white);
+          color: light-dark(var(--white), var(--white));
         }
 
         &.done {
-          color: var(--green);
+          color: light-dark(var(--green), var(--lighter-green));
 
           &:enabled:hover {
-            background-color: var(--green);
+            background-color: light-dark(var(--green), var(--lighter-green));
           }
         }
 
         &.cancel {
-          color: var(--red);
+          color: light-dark(var(--red), var(--lighter-red));
 
           &:enabled:hover {
-            background-color: var(--red);
+            background-color: light-dark(var(--red), var(--lighter-red));
           }
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/flatpickr.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/flatpickr.scss
@@ -4,8 +4,8 @@
   .flatpickr-month,
   .flatpickr-next-month,
   .flatpickr-prev-month {
-    color: var(--white);
-    background: var(--orange);
+    color: light-dark(var(--white), var(--white));
+    background-color: light-dark(var(--orange), var(--dark-orange));
 
     svg {
       fill: var(--white);
@@ -26,7 +26,7 @@
       text-align-last: right;
 
       option {
-        color: var(--black);
+        color: light-dark(var(--black), var(--black));
       }
     }
 
@@ -42,10 +42,25 @@
 .flatpickr-weekdays,
 span.flatpickr-weekday,
 .flatpickr-day.selected {
-  color: var(--white);
-  background: var(--orange);
+  color: light-dark(var(--white), var(--white));
+  background-color: light-dark(var(--orange), var(--dark-orange));
 }
 
 .flatpickr-day.selected {
-  border-color: var(--orange);
+  border-color: light-dark(var(--orange), var(--dark-orange));
+}
+
+.flatpickr-days,
+.flatpickr-day {
+  background-color: light-dark(var(--white), var(--dark-grey));
+  color: light-dark(var(--black), var(--white));
+
+  &.nextMonthDay,
+  &.prevMonthDay {
+    color: light-dark(var(--light-grey), var(--light-grey));
+  }
+
+  &:hover {
+    color: light-dark(var(--black), var(--black));
+  }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/html-editor.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/html-editor.scss
@@ -54,7 +54,7 @@
 
   button {
     background-color: transparent;
-    color: var(--blue);
+    color: light-dark(var(--blue), var(--bright-blue));
     display: flex;
     justify-content: flex-end;
     margin-left: auto;
@@ -62,7 +62,7 @@
     width: auto;
 
     &:hover {
-      background-color: var(--lightest-grey);
+      background-color: light-dark(var(--lightest-grey), var(--dark-grey));
     }
   }
 }
@@ -71,9 +71,17 @@
 .ql-snow .ql-toolbar button {
   padding: 3px 5px !important;
 
+  .ql-stroke,
+  .ql-fill {
+    transition: light-dark(stroke 0.5s, stroke 0);
+  }
+
   .ql-stroke {
-    stroke: var(--black);
-    transition: stroke 0.5s;
+    stroke: light-dark(var(--grey), var(--white));
+  }
+
+  .ql-fill {
+    fill: light-dark(var(--grey), var(--white));
   }
 
   &:disabled {
@@ -88,12 +96,12 @@
 // this gets overridden by our editinplace style
 // so need to re-add
 .ql-snow .ql-tooltip input[type="text"] {
-  border: 1px solid var(--lighter-grey);
+  border: 1px solid light-dark(var(--lighter-grey), var(--lighter-grey));
   display: none;
 }
 
 .ql-container {
-  background-color: var(--bright-white);
+  background-color: light-dark(var(--bright-white), var(--dark-grey));
   /* stylelint-disable property-disallowed-list */
   font-size: 14px;
   height: auto;
@@ -103,7 +111,7 @@
   min-height: 100px;
 }
 .ql-toolbar {
-  background-color: var(--super-light-grey);
+  background-color: light-dark(var(--super-light-grey), var(--grey));
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
   display: flex;

--- a/packages/ilios-common/app/styles/ilios-common/components/ilios-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/ilios-calendar.scss
@@ -30,12 +30,12 @@
     float: right;
 
     .highlight {
-      color: var(--orange);
+      color: light-dark(var(--orange), var(--dark-orange));
       @include m.font-size("medium");
     }
 
     .on {
-      color: var(--green);
+      color: light-dark(var(--green), var(--lighter-green));
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/ilios-tooltip.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/ilios-tooltip.scss
@@ -3,9 +3,9 @@
   z-index: 100;
 
   .content {
-    background: var(--white);
+    background-color: light-dark(var(--white), var(--black));
     padding: 0.25rem 0.5rem;
-    border: 1px solid var(--grey);
+    border: 1px solid light-dark(var(--grey), var(--grey));
     border-radius: 4px;
     max-width: 80%;
 
@@ -20,8 +20,8 @@
     .arrow::before {
       content: "";
       transform: rotate(45deg);
-      background: var(--grey);
-      border: 1px solid var(--grey);
+      background-color: light-dark(var(--grey), var(--dark-grey));
+      border: 1px solid light-dark(var(--grey), var(--white));
     }
   }
   &[data-popper-placement^="top"] .arrow {

--- a/packages/ilios-common/app/styles/ilios-common/components/leadership-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/leadership-manager.scss
@@ -13,8 +13,8 @@
     width: 90%;
 
     input[type="search"] {
-      background-color: var(--white);
-      border: 1px solid var(--blue);
+      background-color: light-dark(var(--white), var(--dark-grey));
+      border: 1px solid light-dark(var(--blue), var(--bright-blue));
       border-radius: 3px;
       height: 2rem;
       width: 100%;

--- a/packages/ilios-common/app/styles/ilios-common/components/leadership-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/leadership-search.scss
@@ -6,8 +6,8 @@
   width: 90%;
 
   input[type="search"] {
-    background-color: var(--white);
-    border: 1px solid var(--blue);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    border: 1px solid light-dark(var(--blue), var(--bright-blue));
     border-radius: 3px;
     height: 2rem;
     width: 100%;

--- a/packages/ilios-common/app/styles/ilios-common/components/learnergroup-selection-cohort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learnergroup-selection-cohort-manager.scss
@@ -1,7 +1,7 @@
 @use "../mixins" as m;
 
 .learnergroup-selection-cohort-manager {
-  border: 1px solid var(--light-blue);
+  border: 1px solid light-dark(var(--light-blue), var(--light-grey));
 
   h4 {
     padding: 0.5rem;
@@ -9,7 +9,7 @@
 
   & > ul {
     @include m.ilios-list-tree;
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--grey));
     height: 15rem;
     overflow-y: scroll;
     padding: 0.5rem 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/learning-material-uploader.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learning-material-uploader.scss
@@ -2,24 +2,24 @@
 
 .learning-material-uploader {
   .upload-button {
-    background: var(--white);
-    border: 1px solid var(--black);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    border: 1px solid light-dark(var(--black), var(--grey));
     border-radius: 3px;
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     cursor: pointer;
     display: inline-block;
     @include m.font-size("base");
     padding: 0.3em 1em;
     &:hover {
-      background-color: var(--grey);
-      color: var(--white);
+      background-color: light-dark(var(--grey), var(--lighter-grey));
+      color: light-dark(var(--white), var(--black));
     }
   }
 
   &.error {
     .upload-button {
-      border: 1px solid var(--red);
-      outline-color: var(--red);
+      border: 1px solid light-dark(var(--red), var(--light-red));
+      outline-color: light-dark(var(--red), var(--light-red));
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/learningmaterial-manager.scss
@@ -51,7 +51,7 @@
   }
 
   .copy-btn {
-    background-color: var(--green);
+    background-color: light-dark(var(--green), var(--green));
   }
 
   .loading {
@@ -64,7 +64,7 @@
 
   h2 {
     @include m.ilios-heading;
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     @include m.font-size("base");
     font-weight: 600;
   }
@@ -108,13 +108,13 @@
     }
 
     .add-date {
-      border: 1px solid var(--green);
-      color: var(--green);
+      border: 1px solid light-dark(var(--green), var(--lightest-green));
+      color: light-dark(var(--green), var(--lightest-green));
     }
 
     .remove-date {
-      border: 1px solid var(--red);
-      color: var(--red);
+      border: 1px solid light-dark(var(--red), var(--lighter-red));
+      color: light-dark(var(--red), var(--lighter-red));
     }
 
     .time-picker {

--- a/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/mesh-manager.scss
@@ -2,7 +2,7 @@
 
 .mesh-manager {
   .deprecated {
-    color: var(--red);
+    color: light-dark(var(--red), var(--lightest-red));
     font-weight: 600;
   }
 
@@ -14,8 +14,8 @@
   .mesh-search-results {
     @include m.ilios-selectable-list;
 
-    background-color: var(--white);
-    border: 1px solid var(--light-blue);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    border: 1px solid light-dark(var(--light-blue), var(--blue));
     height: 10rem;
     margin-bottom: 1rem;
     overflow-y: scroll;
@@ -81,8 +81,8 @@
       @include m.ilios-input;
 
       &.error {
-        border: 1px solid var(--light-red);
-        outline-color: var(--light-red);
+        border: 1px solid light-dark(var(--light-red), var(--dark-red));
+        outline-color: light-dark(var(--light-red), var(--dark-red));
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/monthly-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/monthly-calendar.scss
@@ -43,7 +43,7 @@
     }
 
     .day {
-      border: 1px solid var(--lightest-grey);
+      border: 1px solid light-dark(var(--lightest-grey), var(--grey));
       padding: 5px;
       @for $week from 1 through 6 {
         @for $day from 1 through 7 {
@@ -76,7 +76,7 @@
       }
 
       .month-event {
-        border: 1px solid var(--lightest-grey);
+        border: 1px solid light-dark(var(--lightest-grey), var(--grey));
         border-radius: 3px;
         cursor: default;
         &.clickable {
@@ -102,7 +102,7 @@
       .month-more-events {
         text-align: right;
         margin-top: 1rem;
-        color: var(--blue);
+        color: light-dark(var(--blue), var(--bright-blue));
 
         .fa-ellipsis {
           vertical-align: text-bottom;

--- a/packages/ilios-common/app/styles/ilios-common/components/new-learningmaterial.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/new-learningmaterial.scss
@@ -39,8 +39,8 @@
   input,
   textarea {
     &.error {
-      border: 1px solid var(--red);
-      outline-color: var(--red);
+      border: 1px solid light-dark(var(--red), var(--lighter-red));
+      outline-color: light-dark(var(--red), var(--lighter-red));
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/new-session.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/new-session.scss
@@ -1,8 +1,8 @@
 @use "../mixins" as m;
 
 .new-session {
-  background-color: var(--white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin: 0.5rem 0;
   padding: 1rem;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-calendar.scss
@@ -1,7 +1,7 @@
 @use "../mixins" as m;
 
 .offering-calendar {
-  border: 1px solid var(--black);
+  border: 1px solid light-dark(var(--black), var(--grey));
   border-radius: 5px;
   box-sizing: border-box;
   clear: both;

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-form.scss
@@ -83,13 +83,13 @@
 
           button.cancel {
             background: transparent;
-            color: var(--red);
+            color: light-dark(var(--red), var(--lighter-red));
             margin: 0;
             padding: 0 0.2rem;
 
             &:enabled:hover {
-              color: var(--white);
-              background-color: var(--red);
+              color: light-dark(var(--white), var(--white));
+              background-color: light-dark(var(--red), var(--lighter-red));
             }
           }
         }
@@ -149,7 +149,7 @@
     }
 
     .validation-error-message {
-      color: var(--red);
+      color: light-dark(var(--red), var(--lighter-red));
       display: block;
       @include m.font-size("small");
       font-style: italic;

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-manager.scss
@@ -36,17 +36,17 @@
   }
 
   &.show-remove-confirmation {
-    background-color: var(--lightest-red);
-    border: 1px solid var(--light-red);
+    background-color: light-dark(var(--lightest-red), var(--dark-red));
+    border: 1px solid light-dark(var(--light-red), var(--lightest-red));
   }
 
   .confirm-removal {
-    background-color: var(--lightest-red);
+    background-color: light-dark(var(--lightest-red), var(--dark-red));
     grid-column: 1 / -1;
 
     .confirm-message {
-      background-color: var(--lightest-red);
-      color: var(--red);
+      background-color: light-dark(var(--lightest-red), var(--dark-red));
+      color: light-dark(var(--red), var(--lightest-red));
       font-weight: 600;
       margin: 0;
       padding: 1rem 4rem;
@@ -63,12 +63,12 @@
     }
 
     .remove {
-      background-color: var(--white);
-      color: var(--red);
+      background-color: light-dark(var(--white), var(--light-red));
+      color: light-dark(var(--red), var(--white));
 
       &:hover {
-        background-color: var(--light-red);
-        color: white;
+        background-color: light-dark(var(--light-red), var(--white));
+        color: light-dark(var(--white), var(--light-red));
       }
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/offering-url-display.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/offering-url-display.scss
@@ -5,7 +5,7 @@
     margin-left: 0.25em;
 
     &.copying {
-      color: var(--green);
+      color: light-dark(var(--green), var(--light-green));
     }
   }
 }
@@ -17,7 +17,7 @@
     display: none;
   }
   .content {
-    background-color: var(--green);
-    color: var(--white);
+    background-color: light-dark(var(--green), var(--dark-green));
+    color: light-dark(var(--white), var(--white));
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/print-course.scss
@@ -2,7 +2,7 @@
 
 .print-course {
   .header {
-    background-color: var(--lightest-grey);
+    background-color: light-dark(var(--lightest-grey), var(--dark-grey));
     @include m.course-header {
       padding: 0.5rem;
     }
@@ -10,7 +10,7 @@
 
   .block {
     @include m.detail-container(var(--orange));
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--black));
     padding: 0.5rem;
 
     &:last-of-type {

--- a/packages/ilios-common/app/styles/ilios-common/components/progress-bar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/progress-bar.scss
@@ -1,16 +1,16 @@
 .progress-bar {
-  background-color: var(--super-light-grey);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--super-light-grey), var(--grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   border-radius: 3px;
   box-shadow: inset 0 0 3px 0 var(--very-transparent-black);
   margin: 0 auto;
   width: 100%;
 
   > .meter {
-    background-color: var(--orange);
+    background-color: light-dark(var(--orange), var(--dark-orange));
     background-repeat: repeat-x;
     background-size: 40px 40px;
-    border: 1px solid var(--dark-orange);
+    border: 1px solid light-dark(var(--dark-orange), var(--grey));
     border-radius: 2px;
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
@@ -21,7 +21,7 @@
   }
 
   p {
-    color: var(--white);
+    color: light-dark(var(--white), var(--white));
     margin: 0;
     padding: 0.1rem 0.5rem;
     text-shadow: 0 0 1px var(--black);

--- a/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publication-menu.scss
@@ -11,7 +11,7 @@
   }
 
   .menu {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--dark-grey));
     border-style: solid;
     border-width: 1px;
     display: flex;
@@ -26,8 +26,8 @@
 
     button {
       border: 0;
-      background-color: var(--white);
-      color: var(--black);
+      background-color: light-dark(var(--white), var(--dark-grey));
+      color: light-dark(var(--black), var(--white));
       display: block;
       outline: none;
       padding: 0.5rem 1rem;
@@ -38,33 +38,34 @@
       &.danger {
         &:hover,
         &:focus {
-          background-color: var(--light-red);
-          color: var(--white);
+          background-color: light-dark(var(--light-red), var(--dark-red));
+          color: light-dark(var(--white), var(--white));
         }
       }
 
       &.alert {
         &:hover,
         &:focus {
-          background-color: var(--dark-yellow);
+          background-color: light-dark(var(--dark-yellow), var(--dark-yellow));
+          color: light-dark(var(--black), var(--black));
         }
       }
 
       &.good {
         &:hover,
         &:focus {
-          background-color: var(--green);
-          color: var(--white);
+          background-color: light-dark(var(--green), var(--green));
+          color: light-dark(var(--white), var(--white));
         }
       }
     }
   }
 
   .toggle {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--dark-grey));
     border-style: solid;
     border-width: 1px;
-    color: var(--white);
+    color: light-dark(var(--white), var(--white));
     position: relative;
 
     &[aria-expanded="true"] {
@@ -79,24 +80,24 @@
   &.published {
     .toggle,
     .menu {
-      border-color: var(--green);
-      color: var(--green);
+      border-color: light-dark(var(--green), var(--lighter-green));
+      color: light-dark(var(--green), var(--lighter-green));
     }
   }
 
   &.notpublished {
     .toggle,
     .menu {
-      border-color: var(--grey);
-      color: var(--grey);
+      border-color: light-dark(var(--grey), var(--lighter-grey));
+      color: light-dark(var(--grey), var(--lighter-grey));
     }
   }
 
   &.scheduled {
     .toggle,
     .menu {
-      border-color: var(--dark-orange);
-      color: var(--dark-orange);
+      border-color: light-dark(var(--dark-orange), var(--light-orange));
+      color: light-dark(var(--dark-orange), var(--light-orange));
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/publish-all-sessions.scss
@@ -1,8 +1,8 @@
 @use "../mixins" as m;
 
 .publish-all-sessions {
-  background-color: var(--white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   margin-top: 0.5em;
   padding: 0 1rem 1rem 1rem;
 
@@ -21,7 +21,7 @@
 
     .title {
       @include m.detail-container-title;
-      background: var(--white);
+      background-color: light-dark(var(--white), var(--black));
       height: 2.1rem;
       padding: 0.35em 0;
       position: sticky;
@@ -82,37 +82,37 @@
   }
 
   .publish-all-sessions-review {
-    border: 1px solid var(--green);
+    border: 1px solid light-dark(var(--green), var(--lighter-green));
     clear: both;
     @include m.font-size("large");
     padding: 1rem;
     text-align: center;
 
     .unlinked-warning {
-      color: var(--dark-orange);
+      color: light-dark(var(--dark-orange), var(--dark-orange));
       @include m.font-size("base");
     }
 
     .fa-chart-column {
-      color: var(--light-blue);
+      color: light-dark(var(--light-blue), var(--blue));
       @include m.font-size("small");
     }
 
     p {
-      color: var(--green);
+      color: light-dark(var(--green), var(--lighter-green));
       font-weight: 600;
       margin: 0;
       margin-bottom: 1rem;
     }
 
     button {
-      background: var(--green);
-      color: var(--white);
+      background-color: light-dark(var(--green), var(--lighter-green));
+      color: light-dark(var(--white), var(--black));
     }
   }
 
   .fa-link-slash {
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     @include m.font-size("small");
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/search-box.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/search-box.scss
@@ -11,15 +11,15 @@
       padding-left: 1.5rem;
 
       &.error {
-        border: 1px solid var(--light-red);
-        outline-color: var(--light-red);
+        border: 1px solid light-dark(var(--light-red), var(--light-red));
+        outline-color: light-dark(var(--light-red), var(--red));
       }
     }
   }
 
   .search-icon {
     align-items: center;
-    color: var(--light-blue);
+    color: light-dark(var(--light-blue), var(--lighter-blue));
     display: flex;
     height: 100%;
     left: 0;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-copy.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-copy.scss
@@ -7,7 +7,7 @@
   }
 
   .copy-form {
-    border: 1px solid var(--light-blue);
+    border: 1px solid light-dark(var(--light-blue), var(--blue));
     margin-top: 1rem;
 
     @include m.ilios-form {
@@ -23,9 +23,9 @@
       @include m.ilios-form-buttons;
 
       button:disabled {
-        background-color: var(--grey);
-        border-color: var(--grey);
-        color: var(--white);
+        background-color: light-dark(var(--grey), var(--light-grey));
+        border-color: light-dark(var(--grey), var(--light-grey));
+        color: light-dark(var(--white), var(--black));
         cursor: default;
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-details.scss
@@ -3,8 +3,8 @@
 }
 
 .session-details {
-  background-color: var(--lightest-blue);
-  border-color: var(--lightest-grey);
+  background-color: light-dark(var(--lightest-blue), var(--dark-grey));
+  border-color: light-dark(var(--lightest-grey), var(--grey));
   border-style: solid;
   border-top: 0;
   border-width: 0 2px 2px;
@@ -12,8 +12,8 @@
   table {
     thead,
     th {
-      background-color: var(--blue);
-      color: var(--white);
+      background-color: light-dark(var(--blue), var(--bright-blue));
+      color: light-dark(var(--white), var(--black));
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/session-offerings-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-offerings-list.scss
@@ -16,7 +16,7 @@
       grid-column: 1 / -1;
 
       .offering-block-date-dayofweek {
-        color: var(--dark-orange);
+        color: light-dark(var(--dark-orange), var(--white));
         display: block;
         @include m.font-size("medium");
         font-weight: 600;
@@ -25,7 +25,7 @@
 
       .offering-block-date-dayofmonth,
       .offering-block-date-daymonthyear {
-        color: var(--grey);
+        color: light-dark(var(--grey), var(--lightest-grey));
       }
     }
 
@@ -44,7 +44,7 @@
       .offering-block-time-time-starttime,
       .offering-block-time-time-ends,
       .offering-block-time-time-endtime {
-        color: var(--grey);
+        color: light-dark(var(--grey), var(--lighter-grey));
         display: block;
         font-weight: 600;
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/session-offerings.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-offerings.scss
@@ -1,7 +1,7 @@
 @use "../mixins" as m;
 
 .session-offerings {
-  @include m.detail-container(var(--blue));
+  @include m.detail-container(light-dark(var(--blue), var(--bright-blue)));
 
   .offering-section-top {
     @include m.detail-container-header;
@@ -24,7 +24,7 @@
   }
 
   .session-offerings-header {
-    background-color: var(--lightest-grey);
+    background-color: light-dark(var(--lightest-grey), var(--grey));
     display: grid;
     font-weight: 600;
     grid-template-columns: 3fr repeat(3, 4fr) 2fr;
@@ -32,9 +32,9 @@
     top: 0;
 
     div {
-      background-color: var(--blue);
-      border-right: 1px solid var(--white);
-      color: var(--white);
+      background-color: light-dark(var(--blue), var(--bright-blue));
+      border-right: 1px solid light-dark(var(--white), var(--black));
+      color: light-dark(var(--white), var(--black));
       overflow: hidden;
       padding: 0.5rem 0.25rem;
       white-space: nowrap;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-overview.scss
@@ -2,8 +2,8 @@
 @use "../mixins" as m;
 
 .session-header {
-  border-top: 1px solid var(--lightest-grey);
-  border-bottom: 1px solid var(--blue);
+  border-top: 1px solid light-dark(var(--lightest-grey), var(--grey));
+  border-bottom: 1px solid light-dark(var(--blue), var(--bright-blue));
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -34,7 +34,7 @@
   padding: 0.5rem 0;
 
   .last-update {
-    color: var(--grey);
+    color: light-dark(var(--grey), var(--lighter-grey));
     margin-right: 1rem;
     text-align: right;
   }
@@ -111,7 +111,7 @@
   }
 
   .fa-copy {
-    color: var(--green);
+    color: light-dark(var(--green), var(--light-green));
   }
 
   @include m.for-desktop-and-up {

--- a/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-postrequisite-editor.scss
@@ -9,8 +9,8 @@
       margin: 0;
       position: relative;
       th {
-        background-color: var(--blue);
-        color: var(--white);
+        background-color: light-dark(var(--blue), var(--bright-blue));
+        color: light-dark(var(--white), var(--black));
         position: sticky;
         top: 0;
       }
@@ -21,11 +21,11 @@
 
       tbody tr {
         &.active {
-          background-color: var(--green);
-          color: var(--white);
+          background-color: light-dark(var(--green), var(--lighter-green));
+          color: light-dark(var(--white), var(--black));
         }
         &:hover {
-          outline: 1px solid var(--green);
+          outline: 1px solid light-dark(var(--green), var(--lighter-green));
         }
 
         button {
@@ -37,7 +37,7 @@
     }
   }
   button.remove {
-    color: var(--red);
+    color: light-dark(var(--red), var(--red));
   }
   .info {
     display: flex;

--- a/packages/ilios-common/app/styles/ilios-common/components/session-publicationcheck.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session-publicationcheck.scss
@@ -1,8 +1,8 @@
 @use "../mixins" as m;
 
 .session-publicationcheck {
-  background-color: var(--lightest-blue);
-  border-color: var(--lightest-grey);
+  background-color: light-dark(var(--lightest-blue), var(--dark-grey));
+  border-color: light-dark(var(--lightest-grey), var(--grey));
   border-style: solid;
   border-top: 0;
   border-width: 0 2px 2px;
@@ -16,7 +16,7 @@
   }
 
   .results {
-    background-color: var(--lightest-blue);
+    background-color: light-dark(var(--lightest-blue), var(--dark-grey));
     @include m.detail-container(var(--orange));
     padding: 0 0.5rem;
 
@@ -33,7 +33,7 @@
       @include m.detail-container-content;
 
       thead {
-        background-color: var(--lightest-grey);
+        background-color: light-dark(var(--lightest-grey), var(--grey));
       }
     }
 
@@ -41,15 +41,15 @@
       margin-bottom: 0.5em;
 
       &:disabled {
-        background-color: var(--grey);
-        border-color: var(--grey);
+        background-color: light-dark(var(--grey), var(--light-grey));
+        border-color: light-dark(var(--grey), var(--light-grey));
         cursor: default;
       }
     }
   }
 
   .fa-link-slash {
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     @include m.font-size("small");
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/session/manage-objective-parents.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session/manage-objective-parents.scss
@@ -15,6 +15,6 @@
   }
 
   .no-group {
-    color: var(--darker-yellow);
+    color: light-dark(var(--darker-yellow), var(--yellow));
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/session/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/session/objectives.scss
@@ -5,7 +5,7 @@
   @include m.objectives;
 
   .headers {
-    background-color: var(--lightest-blue);
+    background-color: light-dark(var(--lightest-blue), var(--dark-grey));
     position: sticky;
     top: 0;
     z-index: 1;

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-header-row.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-header-row.scss
@@ -1,9 +1,9 @@
 @use "../mixins" as m;
 
 .sessions-grid-header-row {
-  background-color: var(--blue);
-  border-bottom: 1px solid var(--grey);
-  color: var(--white);
+  background-color: light-dark(var(--blue), var(--bright-blue));
+  border-bottom: 1px solid light-dark(var(--grey), var(--dark-grey));
+  color: light-dark(var(--white), var(--black));
   font-weight: 400;
   top: 0;
   z-index: 1;
@@ -19,7 +19,7 @@
 
   .expand-collapse-control {
     button {
-      color: var(--white);
+      color: light-dark(var(--white), var(--black));
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-last-updated.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-last-updated.scss
@@ -1,5 +1,5 @@
 .sessions-grid-last-updated {
-  color: var(--grey);
+  color: light-dark(var(--grey), var(--lighter-grey));
   margin: auto;
   padding-bottom: 0.5rem;
   text-align: right;

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-loading.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-loading.scss
@@ -3,7 +3,7 @@
 .sessions-grid-loading {
   div {
     &:nth-child(even) {
-      background-color: var(--lightest-grey);
+      background-color: light-dark(var(--lightest-grey), var(--dark-grey));
     }
   }
   span {

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-offering-table.scss
@@ -22,7 +22,7 @@
     padding: 0.2rem 0.5rem;
 
     &.expanded-offering-manager {
-      background-color: var(--lightest-blue);
+      background-color: light-dark(var(--lightest-blue), var(--grey));
       padding: 0;
     }
 
@@ -42,17 +42,20 @@
   }
 
   .offering-block-date {
-    border-top: 1px solid var(--lightest-grey);
+    border-top: 1px solid light-dark(var(--lightest-grey), var(--grey));
     font-weight: 600;
   }
 
   .sessions-grid-offering {
     transition: background-color 0.5s ease-out;
     &.even {
-      background-color: var(--lighter-blue);
+      background-color: light-dark(var(--lighter-blue), var(--grey));
     }
     &.was-updated {
-      background-color: var(--transparent-green);
+      background-color: light-dark(
+        var(--transparent-green),
+        var(--transparent-green)
+      );
     }
     .room {
       overflow-wrap: anywhere;
@@ -68,8 +71,8 @@
   }
 
   .offering-form {
-    background-color: var(--white);
-    border: 1px solid var(--lightest-grey);
+    background-color: light-dark(var(--white), var(--grey));
+    border: 1px solid light-dark(var(--lightest-grey), var(--light-grey));
     padding: 0.5rem;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-session-row.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid-session-row.scss
@@ -4,7 +4,7 @@
   padding: 0.25rem 0;
 
   &.confirm {
-    background-color: var(--lightest-red);
+    background-color: light-dark(var(--lightest-red), var(--dark-red));
   }
 
   .session-grid-status {
@@ -13,7 +13,7 @@
 
     .instructional-notes,
     .prerequisites {
-      color: var(--green);
+      color: light-dark(var(--green), var(--green));
       margin-right: 0.25rem;
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/sessions-grid.scss
@@ -9,18 +9,18 @@
 
   .session {
     &:nth-of-type(even) {
-      background-color: var(--lightest-blue);
+      background-color: light-dark(var(--lightest-blue), var(--dark-grey));
     }
 
     &.is-expanded {
-      border: 1px solid var(--light-blue);
-      background-color: var(--lightest-blue);
+      border: 1px solid light-dark(var(--light-blue), var(--grey));
+      background-color: light-dark(var(--lightest-blue), var(--dark-grey));
       margin: 0.5rem 0;
     }
 
     .confirm-removal {
-      background-color: var(--lightest-red);
-      color: var(--red);
+      background-color: light-dark(var(--lightest-red), var(--dark-red));
+      color: light-dark(var(--red), var(--lightest-red));
       font-weight: 600;
       margin: 0;
       padding: 1rem 4rem;
@@ -35,12 +35,12 @@
         padding-top: 1rem;
 
         .remove {
-          background-color: var(--white);
-          color: var(--red);
+          background-color: light-dark(var(--white), var(--dark-grey));
+          color: light-dark(var(--red), var(--lighter-red));
 
           &:hover {
-            background-color: var(--light-red);
-            color: var(--white);
+            background-color: light-dark(var(--light-red), var(--red));
+            color: light-dark(var(--white), var(--lightest-red));
           }
         }
       }

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event-objective-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event-objective-list.scss
@@ -7,11 +7,13 @@
 
   .display-mode-toggle-btn {
     &.active {
-      background-color: var(--green);
+      background-color: light-dark(var(--green), var(--green));
+      color: light-dark(var(--black), var(--white));
     }
     &.disabled {
       cursor: default;
-      background-color: var(--grey);
+      background-color: light-dark(var(--grey), var(--grey));
+      color: light-dark(var(--black), var(--white));
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/single-event.scss
@@ -36,14 +36,14 @@
       }
 
       .recently-updated-icon {
-        color: var(--red);
+        color: light-dark(var(--red), var(--lighter-red));
         position: absolute;
         right: 2px;
         top: 2px;
       }
 
       .recently-updated-icon-event {
-        color: var(--red);
+        color: light-dark(var(--red), var(--lighter-red));
       }
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/taxonomy-manager-terms-list-item.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/taxonomy-manager-terms-list-item.scss
@@ -5,12 +5,12 @@
 
   &:focus,
   &:hover {
-    background-color: var(--lightest-grey);
+    background-color: light-dark(var(--lightest-grey), var(--grey));
     border: 1px var(--black) solid;
   }
 
   &.selected {
-    background-color: var(--lightest-grey);
+    background-color: light-dark(var(--lightest-grey), var(--grey));
   }
 
   .actions {
@@ -29,11 +29,11 @@
   width: 100%;
 
   &:not(.taxonomy-manager-terms-list-item-button) {
-    color: var(--grey);
+    color: light-dark(var(--grey), var(--grey));
   }
 
   .inactive {
-    color: var(--red);
+    color: light-dark(var(--red), var(--red));
   }
 
   &.top-level {

--- a/packages/ilios-common/app/styles/ilios-common/components/taxonomy-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/taxonomy-manager.scss
@@ -2,7 +2,7 @@
 
 .taxonomy-manager {
   .selected-terms {
-    border: 1px solid var(--grey);
+    border: 1px solid light-dark(var(--grey), var(--grey));
     padding: 10px;
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/toggle-yesno.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/toggle-yesno.scss
@@ -10,15 +10,15 @@
   height: var(--height);
   position: relative;
   width: var(--width);
-  background-color: var(--red);
+  background-color: light-dark(var(--red), var(--light-red));
   padding: 0;
 
   &.yes {
-    background-color: var(--green);
+    background-color: light-dark(var(--green), var(--light-green));
   }
 
   .switch-handle {
-    background: var(--white);
+    background-color: light-dark(var(--white), var(--white));
     border-radius: 10px;
     height: var(--switch);
     left: var(--switch-diff);

--- a/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-search.scss
@@ -5,11 +5,11 @@
 
   .results {
     @include m.ilios-list-reset;
-    background: var(--white);
-    border: 1px solid var(--white);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    border: 1px solid light-dark(var(--white), var(--grey));
     border-radius: 3px;
     box-shadow: 0 2px 2px var(--very-transparent-black);
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     left: 0;
     max-height: 33dvh;
     overflow: scroll;
@@ -18,31 +18,31 @@
     z-index: 100;
 
     li {
-      border-bottom: 1px solid var(--lightest-grey);
+      border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
 
       &.active,
       &:hover {
-        background-color: var(--lightest-blue);
+        background-color: light-dark(var(--lightest-blue), var(--dark-grey));
         cursor: pointer;
       }
 
       &.inactive {
-        color: var(--grey);
+        color: light-dark(var(--grey), var(--lighter-grey));
         cursor: default;
         font-style: italic;
 
         &:hover {
-          background-color: var(--white);
+          background-color: light-dark(var(--white), var(--dark-grey));
         }
       }
 
       &.results-count {
-        color: var(--green);
+        color: light-dark(var(--green), var(--light-green));
       }
     }
 
     .email {
-      color: var(--grey);
+      color: light-dark(var(--grey), var(--lighter-grey));
       font-style: italic;
       padding-right: 0.2rem;
     }

--- a/packages/ilios-common/app/styles/ilios-common/components/user-status.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/user-status.scss
@@ -1,3 +1,3 @@
 .user-status {
-  color: var(--grey);
+  color: light-dark(var(--grey), var(--light-grey));
 }

--- a/packages/ilios-common/app/styles/ilios-common/components/wait-saving.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/wait-saving.scss
@@ -5,13 +5,16 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: var(--slightly-transparent-black);
+  background-color: light-dark(
+    var(--slightly-transparent-black),
+    var(--slightly-transparent-black)
+  );
   display: grid;
   justify-content: center;
   align-content: center;
 
   .content {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--black));
     padding: 2em;
     border-radius: 1em;
 

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -66,10 +66,10 @@
   .event {
     padding: 0 0.25rem;
     margin: 1rem 0;
-    border-left: 3px solid var(--lightest-blue);
+    border-left: 3px solid light-dark(var(--lightest-blue), var(--blue));
 
     &:nth-of-type(even) {
-      border-left: 3px solid var(--lightest-red);
+      border-left: 3px solid light-dark(var(--lightest-red), var(--light-red));
     }
 
     &:first-of-type {

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance/learning-materials.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance/learning-materials.scss
@@ -17,7 +17,7 @@
     }
 
     .fa-external-link-square {
-      color: var(--orange);
+      color: light-dark(var(--orange), var(--dark-orange));
       @include m.font-size("small");
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar-event.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar-event.scss
@@ -8,7 +8,7 @@
   flex-direction: column;
   justify-content: start;
   @include m.font-size("small");
-  border: 1px solid var(--white);
+  border: 1px solid light-dark(var(--white), var(--grey));
   margin: 1px;
   padding: 0.25rem;
   text-align: left;

--- a/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/weekly-calendar.scss
@@ -59,7 +59,7 @@
       grid-row: 1 / -1;
       grid-template-columns: repeat(50, 1fr);
       grid-template-rows: repeat($minute-rows, $hour-height);
-      border: 1px solid var(--lightest-grey);
+      border: 1px solid light-dark(var(--lightest-grey), var(--grey));
       @for $day from 1 through 7 {
         &.day-#{$day} {
           grid-column: ($day + 1);
@@ -78,7 +78,7 @@
 
     .hour-border,
     .half-hour-border {
-      border-top: 1px solid var(--lightest-grey);
+      border-top: 1px solid light-dark(var(--lightest-grey), var(--grey));
       grid-column: 2 / -1;
     }
 

--- a/packages/ilios-common/app/styles/ilios-common/components/weekly-events.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/weekly-events.scss
@@ -19,7 +19,7 @@
   }
 
   .week-glance {
-    border-bottom: 1px solid var(--orange);
+    border-bottom: 1px solid light-dark(var(--orange), var(--dark-orange));
     margin: 0 0 1rem 1rem;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/collapsed-container.scss
@@ -41,16 +41,16 @@
 
   thead,
   th {
-    background-color: var(--lightest-grey);
-    color: var(--black);
+    background-color: light-dark(var(--lightest-grey), var(--dark-grey));
+    color: light-dark(var(--black), var(--white));
   }
 
   td:first-of-type {
-    color: var(--dark-orange);
+    color: light-dark(var(--dark-orange), var(--lightest-grey));
     font-weight: 600;
   }
 
   .maybe {
-    color: var(--dark-yellow);
+    color: light-dark(var(--dark-yellow), var(--dark-yellow));
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/course/header.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/course/header.scss
@@ -5,7 +5,7 @@
 @use "../media";
 
 @mixin course-header {
-  border-bottom: 1px solid var(--lightest-grey);
+  border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/detail-container.scss
@@ -49,18 +49,18 @@
   }
 
   .bigadd {
-    background-color: var(--green);
-    color: var(--white);
+    background-color: light-dark(var(--green), var(--green));
+    color: light-dark(var(--white), var(--white));
 
     &:disabled {
-      background-color: var(--grey);
+      background-color: light-dark(var(--grey), var(--grey));
       cursor: default;
     }
   }
 
   .bigcancel {
-    background-color: var(--red);
-    color: var(--white);
+    background-color: light-dark(var(--red), var(--red));
+    color: light-dark(var(--white), var(--white));
   }
 }
 

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-button.scss
@@ -3,11 +3,11 @@
 
 @mixin ilios-button() {
   appearance: none;
-  background-color: var(--blue);
+  background-color: light-dark(var(--blue), var(--bright-blue));
   border: 0;
   border-radius: 3px;
   box-sizing: border-box;
-  color: var(--white);
+  color: light-dark(var(--white), var(--black));
   cursor: pointer;
   display: inline-block;
   padding: 0.3em 1em;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-fieldset.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-fieldset.scss
@@ -1,7 +1,7 @@
 @use "ilios-heading";
 
 @mixin ilios-fieldset {
-  border: 1px solid var(--light-blue);
+  border: 1px solid light-dark(var(--light-blue), var(--blue));
   border-radius: 10px;
 
   legend {

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-form.scss
@@ -78,31 +78,32 @@
     }
 
     &:enabled:hover {
-      color: var(--white);
+      color: light-dark(var(--white), var(--black));
     }
 
     &.done {
-      background-color: var(--white);
-      border-color: var(--green);
-      color: var(--black);
+      background-color: light-dark(var(--white), var(--dark-grey));
+      border-color: light-dark(var(--green), var(--green));
+      color: light-dark(var(--black), var(--white));
 
       &:enabled {
         &:hover,
         &:active,
         &.active {
-          background-color: var(--green);
-          color: var(--white);
+          background-color: light-dark(var(--green), var(--green));
+          color: light-dark(var(--white), var(--white));
         }
       }
     }
 
     &.cancel {
-      background-color: var(--white);
-      border-color: var(--light-red);
-      color: var(--light-red);
+      background-color: light-dark(var(--white), var(--dark-grey));
+      border-color: light-dark(var(--light-red), var(--lighter-red));
+      color: light-dark(var(--light-red), var(--lighter-red));
 
       &:enabled:hover {
-        background-color: var(--light-red);
+        background-color: light-dark(var(--light-red), var(--lighter-red));
+        color: light-dark(var(--white), var(--black));
       }
     }
   }
@@ -119,13 +120,13 @@
 
 @mixin ilios-form-error {
   .validation-error-message {
-    color: var(--red);
+    color: light-dark(var(--red), var(--lighter-red));
     @include font-size.font-size("small");
   }
 
   input {
     &.has-error {
-      border-color: var(--light-red);
+      border-color: light-dark(var(--light-red), var(--lighter-red));
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-heading.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-heading.scss
@@ -1,7 +1,7 @@
 @use "font-size";
 
 @mixin ilios-heading() {
-  color: var(--black);
+  color: light-dark(var(--black), var(--lightest-grey));
   font-family: "Nunito Variable", sans-serif;
   font-weight: 600;
   margin: 0;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-input.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-input.scss
@@ -4,10 +4,10 @@ $form-input-text-types: 'input[type="text"], input[type="password"], input[type=
 
 @mixin ilios-input {
   @include ilios-select.ilios-select;
-  background: var(--bright-white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--bright-white), var(--dark-grey));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   border-radius: 3px;
-  color: var(--black);
+  color: light-dark(var(--black), var(--white));
   cursor: pointer;
   font-style: italic;
   min-width: 220px;

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-list.scss
@@ -13,8 +13,8 @@
 
 @mixin ilios-static-list() {
   @include ilios-list-reset;
-  background-color: var(--white);
-  border: 1px solid var(--lightest-grey);
+  background-color: light-dark(var(--white), var(--black));
+  border: 1px solid light-dark(var(--lightest-grey), var(--grey));
   border-radius: 3px;
   padding: 1em;
   width: 80%;
@@ -44,7 +44,7 @@
   flex-wrap: wrap;
 
   li {
-    background-color: var(--lightest-grey);
+    background-color: light-dark(var(--lightest-grey), var(--grey));
     border-radius: 4px;
     margin-bottom: 0;
     margin-right: 0.3em;
@@ -62,21 +62,21 @@
   }
 
   li {
-    color: var(--blue);
+    color: light-dark(var(--blue), var(--bright-blue));
     cursor: pointer;
 
     &.active,
     &:hover {
-      background-color: var(--lightest-grey);
+      background-color: light-dark(var(--lightest-grey), var(--grey));
     }
 
     &.static {
-      color: var(--black);
+      color: light-dark(var(--black), var(--white));
       cursor: default;
     }
 
     &.disabled {
-      color: var(--grey);
+      color: light-dark(var(--grey), var(--lightest-grey));
       cursor: default;
     }
   }
@@ -96,7 +96,7 @@
 
   li {
     div {
-      background-color: var(--white);
+      background-color: light-dark(var(--white), var(--black));
       border: 1px var(--lightest-grey) solid;
       border-radius: 4px;
       margin-top: 5px;
@@ -104,7 +104,7 @@
       vertical-align: middle;
 
       &.selected {
-        background-color: var(--lightest-grey);
+        background-color: light-dark(var(--lightest-grey), var(--light-grey));
       }
     }
 
@@ -122,7 +122,7 @@
   @include ilios-list-reset;
 
   li {
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     margin-left: 20px;
 
     &.branch {
@@ -142,7 +142,7 @@
     }
 
     &.disabled {
-      color: var(--grey);
+      color: light-dark(var(--grey), var(--lightest-grey));
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/ilios-overview.scss
@@ -30,7 +30,7 @@
 }
 
 @mixin ilios-overview-title() {
-  color: var(--black);
+  color: light-dark(var(--black), var(--white));
   @include font-size.font-size("base");
   font-weight: 600;
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/main-list.scss
@@ -56,7 +56,7 @@
 }
 
 @mixin main-list-box-header() {
-  border-bottom: 1px solid var(--lightest-grey);
+  border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
   display: flex;
   flex-direction: column;
   padding: 0 0 0.5rem;
@@ -81,7 +81,7 @@
 }
 
 @mixin main-list-saved-new() {
-  border: 1px solid var(--green);
+  border: 1px solid light-dark(var(--green), var(--grey));
   margin: 1rem;
   padding: 1rem;
 }
@@ -97,7 +97,7 @@
 
   table {
     thead {
-      background-color: var(--lightest-grey);
+      background-color: light-dark(var(--lightest-grey), var(--dark-grey));
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -36,8 +36,8 @@
   }
 
   .new-objective {
-    background-color: var(--white);
-    border: 1px solid var(--lightest-grey);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    border: 1px solid light-dark(var(--lightest-grey), var(--grey));
     margin: 0.5rem 0;
     padding: 1rem;
 
@@ -73,7 +73,7 @@
     }
 
     .grid-item {
-      border-bottom: 1px solid var(--grey);
+      border-bottom: 1px solid light-dark(var(--grey), var(--grey));
       padding: 0.5em 0.25em;
 
       &:has(.faded) {
@@ -109,13 +109,16 @@
 
     &.highlight-ok {
       transition: none;
-      background-color: var(--transparent-green);
+      background-color: light-dark(
+        var(--transparent-green),
+        var(--transparent-green)
+      );
     }
 
     &.is-managing {
-      border: 2px solid var(--light-blue);
+      border: 2px solid light-dark(var(--light-blue), var(--lightest-blue));
       .grid-item {
-        background-color: var(--lightest-blue);
+        background-color: light-dark(var(--lightest-blue), var(--dark-grey));
         border: 0;
       }
     }
@@ -143,14 +146,14 @@
     }
 
     &.confirm-removal {
-      background-color: var(--lightest-red);
+      background-color: light-dark(var(--lightest-red), var(--dark-red));
 
       .grid-item {
         border: 0;
       }
 
       .confirm-message {
-        color: var(--red);
+        color: light-dark(var(--red), var(--lightest-red));
         grid-column: 1 / -1;
         font-weight: 600;
         text-align: center;
@@ -167,12 +170,12 @@
       }
 
       .remove {
-        background-color: var(--white);
-        color: var(--red);
+        background-color: light-dark(var(--white), var(--lightest-red));
+        color: light-dark(var(--red), var(--dark-red));
 
         &:hover {
-          background-color: var(--light-red);
-          color: white;
+          background-color: light-dark(var(--light-red), var(--dark-red));
+          color: light-dark(var(--white), var(--lightest-red));
         }
       }
     }
@@ -205,13 +208,13 @@
   }
 
   .bigadd {
-    background-color: var(--green);
-    color: var(--white);
+    background-color: light-dark(var(--green), var(--green));
+    color: light-dark(var(--white), var(--white));
   }
 
   .bigcancel {
-    background-color: var(--red);
-    color: var(--white);
+    background-color: light-dark(var(--red), var(--red));
+    color: light-dark(var(--white), var(--white));
     margin-left: 0.5em;
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/shared/button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/button.scss
@@ -4,14 +4,14 @@ button {
     border: 0;
     border-radius: 0;
     background-color: transparent;
-    color: var(--blue);
+    color: light-dark(var(--blue), var(--bright-blue));
     cursor: pointer;
     font: inherit;
     text-align: left;
     white-space: normal;
 
     &:disabled {
-      color: var(--black);
+      color: light-dark(var(--black), var(--white));
       cursor: default;
     }
   }

--- a/packages/ilios-common/app/styles/ilios-common/shared/graph-with-data-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/graph-with-data-table.scss
@@ -13,7 +13,7 @@
 
     table {
       thead {
-        background-color: var(--lightest-grey);
+        background-color: light-dark(var(--lightest-grey), var(--dark-grey));
       }
 
       td {

--- a/packages/ilios-common/app/styles/ilios-common/shared/icons.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/icons.scss
@@ -1,15 +1,15 @@
 // font awesome icons
 .svg-inline--fa {
   &.enabled {
-    color: var(--light-blue);
+    color: light-dark(var(--light-blue), var(--bright-blue));
 
     &.remove {
-      color: var(--red);
+      color: light-dark(var(--red), var(--light-red));
     }
   }
 
   &.disabled {
-    color: var(--grey);
+    color: light-dark(var(--grey), var(--light-grey));
     cursor: default;
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/ilios-overview.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/ilios-overview.scss
@@ -30,7 +30,7 @@
   }
 
   .overview-title {
-    color: var(--black);
+    color: light-dark(var(--black), var(--white));
     @include font-size.font-size("base");
     font-weight: 600;
   }

--- a/packages/ilios-common/app/styles/ilios-common/shared/ilios-removable-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/ilios-removable-table.scss
@@ -4,16 +4,16 @@
   tbody {
     tr:nth-child(even) {
       &.confirm-removal {
-        background-color: var(--lightest-red);
+        background-color: light-dark(var(--lightest-red), var(--dark-red));
       }
     }
 
     .confirm-removal {
-      background-color: var(--lightest-red);
+      background-color: light-dark(var(--lightest-red), var(--dark-red));
 
       .confirm-message {
-        background-color: var(--lightest-red);
-        color: var(--red);
+        background-color: light-dark(var(--lightest-red), var(--dark-red));
+        color: light-dark(var(--red), var(--lightest-red));
         font-weight: 600;
         padding-bottom: 0;
         padding-top: 0.75em;
@@ -34,12 +34,12 @@
       }
 
       .remove:not(.disabled) {
-        background-color: var(--white);
-        color: var(--red);
+        background-color: light-dark(var(--white), var(--dark-grey));
+        color: light-dark(var(--red), var(--lighter-red));
 
         &:hover {
-          background-color: var(--light-red);
-          color: var(--white);
+          background-color: light-dark(var(--light-red), var(--red));
+          color: light-dark(var(--white), var(--lightest-red));
         }
       }
     }

--- a/packages/ilios-common/app/styles/ilios-common/shared/ilios-table-colors.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/ilios-table-colors.scss
@@ -1,11 +1,11 @@
 .ilios-table-colors {
   thead {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--grey));
   }
 
   th {
-    border-bottom: 1px solid var(--lighter-grey);
-    background-color: var(--white);
+    border-bottom: 1px solid light-dark(var(--lighter-grey), var(--grey));
+    background-color: light-dark(var(--white), var(--dark-grey));
   }
 
   tbody {

--- a/packages/ilios-common/app/styles/ilios-common/shared/ilios-zebra-list.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/ilios-zebra-list.scss
@@ -1,7 +1,7 @@
 .ilios-zebra-list {
   li {
     &:nth-child(even) {
-      background-color: var(--super-light-grey);
+      background-color: light-dark(var(--super-light-grey), var(--dark-grey));
     }
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/ilios-zebra-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/ilios-zebra-table.scss
@@ -1,5 +1,5 @@
 .ilios-zebra-table {
   tbody tr:nth-child(even) {
-    background-color: var(--super-light-grey);
+    background-color: light-dark(var(--super-light-grey), var(--dark-grey));
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/loading-box.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/loading-box.scss
@@ -1,6 +1,6 @@
 .loading-box {
   animation: 2s fadein;
-  background-color: var(--lightest-grey);
+  background-color: light-dark(var(--lightest-grey), var(--dark-grey));
   border: 1px dotted var(--grey);
 }
 

--- a/packages/ilios-common/app/styles/ilios-common/shared/loading-shimmer.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/loading-shimmer.scss
@@ -1,6 +1,11 @@
 .loading-shimmer {
   animation: loading-shimmer 2s infinite;
-  background: linear-gradient(to right, #eff1f3 4%, #e2e2e2 25%, #eff1f3 36%);
+  background: linear-gradient(
+    to right,
+    light-dark(var(--super-light-grey), var(--black)) 4%,
+    light-dark(var(--lightest-grey), var(--dark-grey)) 25%,
+    light-dark(var(--super-light-grey), var(--black)) 36%
+  );
   background-size: 1000px 100%;
 
   @media (prefers-reduced-motion: reduce) {

--- a/packages/ilios-common/app/styles/ilios-common/shared/multi-button.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/multi-button.scss
@@ -14,9 +14,9 @@
   }
 
   label {
-    background-color: var(--white);
-    color: var(--blue);
-    border: 1px solid var(--very-transparent-black);
+    background-color: light-dark(var(--white), var(--dark-grey));
+    color: light-dark(var(--blue), var(--bright-blue));
+    border: 1px solid light-dark(var(--very-transparent-black), var(--grey));
     display: inline-block;
     @include font-size.font-size("base");
     font-weight: 600;
@@ -44,7 +44,7 @@
   }
 
   input:checked + label {
-    background-color: var(--blue);
-    color: var(--white);
+    background-color: light-dark(var(--blue), var(--bright-blue));
+    color: light-dark(var(--white), var(--black));
   }
 }

--- a/packages/ilios-common/app/styles/ilios-common/shared/sessions-grid-row.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/sessions-grid-row.scss
@@ -54,12 +54,12 @@
     justify-content: space-around;
 
     & > .active {
-      color: var(--light-blue);
+      color: light-dark(var(--light-blue), var(--blue));
       cursor: pointer;
     }
 
     & > .disabled {
-      color: var(--grey);
+      color: light-dark(var(--grey), var(--light-grey));
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/shared/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/sort-manager.scss
@@ -6,14 +6,14 @@
     justify-content: flex-end;
 
     .bigadd {
-      background-color: var(--green);
-      color: var(--white);
+      background-color: light-dark(var(--green), var(--green));
+      color: light-dark(var(--white), var(--white));
       margin-left: 0.5rem;
     }
 
     .bigcancel {
-      background-color: var(--red);
-      color: var(--white);
+      background-color: light-dark(var(--red), var(--red));
+      color: light-dark(var(--white), var(--white));
       margin: 0 0.5em;
     }
   }
@@ -26,7 +26,7 @@
     list-style-type: none;
     .item {
       align-items: center;
-      background-color: var(--lightest-grey);
+      background-color: light-dark(var(--lightest-grey), var(--grey));
       border-radius: 4px;
       box-sizing: border-box;
       cursor: pointer;
@@ -64,13 +64,14 @@
         opacity: 0.3;
       }
       &.dragged-above {
-        border-top: 0.7rem solid var(--orange);
+        border-top: 0.7rem solid light-dark(var(--orange), var(--dark-orange));
         border-top-left-radius: 0;
         border-top-right-radius: 0;
         padding: 0.3rem 1rem 1rem 1rem;
       }
       &.dragged-below {
-        border-bottom: 0.7rem solid var(--orange);
+        border-bottom: 0.7rem solid
+          light-dark(var(--orange), var(--dark-orange));
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
         padding: 1rem 1rem 0.3rem 1rem;

--- a/packages/ilios-common/app/styles/ilios-common/shared/user-search.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/user-search.scss
@@ -2,11 +2,11 @@
 @use "../mixins/media";
 
 .user-search-results {
-  background: var(--white);
-  border: 1px solid var(--white);
+  background-color: light-dark(var(--white), var(--dark-grey));
+  border: 1px solid light-dark(var(--white), var(--dark-grey));
   border-radius: 3px;
   box-shadow: 0 2px 2px var(--very-transparent-black);
-  color: var(--black);
+  color: light-dark(var(--black), var(--white));
   max-height: 23rem;
   overflow-y: scroll;
   position: absolute;
@@ -19,26 +19,29 @@
   }
 
   li {
-    border-bottom: 1px solid var(--lightest-grey);
-    color: var(--light-blue);
+    border-bottom: 1px solid light-dark(var(--lightest-grey), var(--grey));
+    color: light-dark(var(--light-blue), var(--bright-blue));
     display: block;
     margin: 0.1rem 0;
     padding: 0.2rem;
     width: 100%;
 
     &.inactive {
-      color: var(--light-grey);
+      color: light-dark(var(--light-grey), var(--grey));
       font-style: italic;
     }
 
     &.summary {
-      color: var(--green);
+      color: light-dark(var(--green), var(--light-green));
     }
 
     a,
     &.clickable {
       &:hover {
-        background-color: var(--lightest-blue);
+        background-color: light-dark(
+          var(--lightest-blue),
+          var(--lightest-blue)
+        );
       }
     }
 
@@ -57,7 +60,7 @@
     }
 
     .email {
-      color: var(--grey);
+      color: light-dark(var(--grey), var(--white));
       font-style: italic;
     }
   }

--- a/packages/test-app/app/routes/application.js
+++ b/packages/test-app/app/routes/application.js
@@ -7,6 +7,7 @@ export default class ApplicationRoute extends Route {
   @service intl;
 
   async beforeModel(transition) {
+    window.document.documentElement.dataset.theme = 'system';
     await this.session.setup();
     this.session.requireAuthentication(transition, 'login');
     this.intl.setFormats(formats);

--- a/packages/test-app/app/styles/app.scss
+++ b/packages/test-app/app/styles/app.scss
@@ -11,7 +11,7 @@
 
   height: 100vh;
   width: 100%;
-  background-color: var(--white);
+  background-color: light-dark(var(--white), var(--black));
 
   @include m.for-tablet-and-up {
     grid-template-rows: 42px 2rem 1fr 20px;
@@ -29,21 +29,21 @@
 
   & > nav {
     grid-area: nav;
-    background-color: var(--grey);
+    background-color: light-dark(var(--grey), var(--dark-grey));
   }
 
   & > .logo {
     grid-area: logo;
-    background-color: var(--orange);
+    background-color: light-dark(var(--orange), var(--dark-orange));
   }
 
   & > header {
     grid-area: header;
-    background-color: var(--orange);
+    background-color: light-dark(var(--orange), var(--dark-orange));
   }
 
   & > main {
-    background-color: var(--white);
+    background-color: light-dark(var(--white), var(--black));
     grid-area: main;
   }
 


### PR DESCRIPTION
To support a better reading experience and allow users to match Ilios to their overall theme we're adding a dark mode ilios experience.

Adding the `color-scheme` option indicates that we support both a light
and dark color scheme.

I've tended towards a slightly softer dark mode than absolute white on
absolute black. We were able to re-use most of our existing colors so we
still get excellent balance and relationships between the colors in use.

Fixes ilios/ilios#7300


Wip:
- [x] I've applied a global --PINK to unfinished areas to make them easier to see, remove all instances
- [x] Fix any a11y issues
- [x] Check generate screenshots
- [x] Lots and lots of feedback