### PR TITLE
Fix Calendar Event divide by zero bug

### DIFF
--- a/packages/ilios-common/addon/components/daily-calendar-event.gjs
+++ b/packages/ilios-common/addon/components/daily-calendar-event.gjs
@@ -105,7 +105,7 @@ export default class DailyCalendarEventComponent extends Component {
     const minutes = this.minutes.slice(start, end - 1);
     const max = Math.max(...minutes);
 
-    return Math.floor(50 / max);
+    return Math.floor(50 / (max > 0 ? max : 1));
   }
 
   get style() {

--- a/packages/ilios-common/addon/components/weekly-calendar-event.gjs
+++ b/packages/ilios-common/addon/components/weekly-calendar-event.gjs
@@ -114,7 +114,7 @@ export default class WeeklyCalendarEventComponent extends Component {
     const minutes = this.minutes.slice(start, end - 1);
     const max = Math.max(...minutes);
 
-    return Math.floor(50 / max);
+    return Math.floor(50 / (max > 0 ? max : 1));
   }
 
   get style() {


### PR DESCRIPTION
<img width="480" height="279" alt="sliver" src="https://github.com/user-attachments/assets/64e62fb9-10b1-4637-89f4-e7678f4ffb5f" />

Fixes ilios/ilios#3590

Calendar events can sometimes display as narrow slivers even when there aren't enough events at the same time to compress them. This feels like a bug, and this PR will fix that...eventually.

This PR fixes the divide by zero issue that would cause a span of `Infinity`.

Future PR will address the "two events happening at the same time, but taking up same space and causing everything else to sliver" bug