### PR TITLE
Expire Screenshot Cache Every Day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,12 +176,15 @@ jobs:
       MOZ_HEADLESS_WIDTH: ${{ matrix.width }}
     steps:
       - uses: actions/checkout@v7
+      - name: Get cache date
+        id: cache-date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
       - name: Cache Screenshots
         id: screenshot-cache
         uses: actions/cache@v6
         with:
           path: build
-          key: screenshots-${{ github.sha }}-${{ matrix.name }}
+          key: screenshots-${{ steps.cache-date.outputs.date }}-${{ github.sha }}-${{ matrix.name }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/visual_diff.yml
+++ b/.github/workflows/visual_diff.yml
@@ -41,12 +41,15 @@ jobs:
         run: |
           echo "$(git rev-parse HEAD)"
           echo "ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Get cache date
+        id: cache-date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
       - name: Cache Screenshots
         id: screenshot-cache
         uses: actions/cache@v6
         with:
           path: build
-          key: screenshots-${{ steps.ref.outputs.ref }}-${{ matrix.name }}
+          key: screenshots-${{ steps.cache-date.outputs.date }}-${{ steps.ref.outputs.ref }}-${{ matrix.name }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
@@ -113,12 +116,15 @@ jobs:
         run: |
           echo "$(git rev-parse HEAD)"
           echo "ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Get cache date
+        id: cache-date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
       - name: Cache Screenshots
         id: screenshot-cache
         uses: actions/cache@v6
         with:
           path: build
-          key: screenshots-${{ steps.ref.outputs.ref }}-${{ matrix.name }}
+          key: screenshots-${{ steps.cache-date.outputs.date }}-${{ steps.ref.outputs.ref }}-${{ matrix.name }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
When the cache is created the day before we get diffs on the date elements what aren't valid. I've added the current date to the screenshot cache so we don't get a hit.