### PR TITLE
Get Version Ourselves

### DIFF
--- a/packages/frontend/app/controllers/application.js
+++ b/packages/frontend/app/controllers/application.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { cached, tracked } from '@glimmer/tracking';
 import { TrackedAsyncData } from 'ember-async-data';
-import { appVersion } from 'frontend/helpers/app-version';
+import config from 'frontend/config/environment';
 
 export default class ApplicationController extends Controller {
   @service apiVersion;
@@ -36,12 +36,7 @@ export default class ApplicationController extends Controller {
   }
 
   get frontendVersionTag() {
-    const version = appVersion(null, { versionOnly: true });
-    if (version) {
-      return `Frontend: v${version}`;
-    }
-
-    return '';
+    return `Frontend: v${config.APP.VERSION}`;
   }
 
   get useFullLayout() {

--- a/packages/frontend/config/environment.js
+++ b/packages/frontend/config/environment.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { version } = require('../package.json');
+
 module.exports = function (environment) {
   const ENV = {
     modulePrefix: 'frontend',
@@ -46,7 +48,9 @@ module.exports = function (environment) {
       },
     },
 
-    APP: {},
+    APP: {
+      VERSION: version,
+    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
We're getting this helper from ember-cli-version and the way it gets bundled into our app isn't great. Let's ditch the dependency and just extract the version from the config directly.