### PR TITLE
Update Snapdom

### DIFF
--- a/packages/frontend/tests/integration/components/school/session-type-form-test.gjs
+++ b/packages/frontend/tests/integration/components/school/session-type-form-test.gjs
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest, takeScreenshot } from 'frontend/tests/helpers';
+import { setupRenderingTest, takeComponentScreenshot } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { setupMSW } from 'ilios-common/msw';
 import { component } from 'frontend/tests/pages/components/school/session-type-form';
@@ -63,7 +63,7 @@ module('Integration | Component | school/session-type-form', function (hooks) {
       </template>,
     );
 
-    await takeScreenshot(assert, 'default');
+    await takeComponentScreenshot(assert, 'default');
 
     assert.strictEqual(component.title.value, 'one');
     assert.strictEqual(component.aamcMethod.value, '');
@@ -132,9 +132,9 @@ module('Integration | Component | school/session-type-form', function (hooks) {
     assert.strictEqual(component.aamcMethod.options[1].text, 'lorem ipsum');
     assert.notOk(component.aamcMethod.options[1].selected);
 
-    await takeScreenshot(assert, 'session type assessment toggle unchecked');
+    await takeComponentScreenshot(assert, 'session type assessment toggle unchecked');
     await component.assessment.yesNoToggle.click();
-    await takeScreenshot(assert, 'session type assessment toggle checked');
+    await takeComponentScreenshot(assert, 'session type assessment toggle checked');
 
     assert.strictEqual(component.aamcMethod.value, '');
     assert.strictEqual(component.aamcMethod.options.length, 2);
@@ -162,7 +162,7 @@ module('Integration | Component | school/session-type-form', function (hooks) {
       </template>,
     );
 
-    await takeScreenshot(assert, 'no assessment option');
+    await takeComponentScreenshot(assert, 'no assessment option');
 
     assert.notOk(component.assessment.isAssessment);
     assert.notOk(component.assessmentSelector.isVisible);
@@ -286,7 +286,7 @@ module('Integration | Component | school/session-type-form', function (hooks) {
       </template>,
     );
 
-    await takeScreenshot(assert, 'read-only');
+    await takeComponentScreenshot(assert, 'read-only');
 
     assert.notOk(component.title.inputControlIsVisible);
     assert.notOk(component.aamcMethod.inputControlIsVisible);

--- a/packages/ilios-common/package.json
+++ b/packages/ilios-common/package.json
@@ -39,7 +39,7 @@
     "@glimmer/tracking": "^1.1.2",
     "@msw/data": "^1.1.6",
     "@popperjs/core": ">= 2.1.0",
-    "@zumer/snapdom": "2.0.2",
+    "@zumer/snapdom": "^2.24.10",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-funnel": "^3.0.0",
     "broccoli-merge-trees": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,8 +584,8 @@ importers:
         specifier: '>= 2.1.0'
         version: 2.11.8
       '@zumer/snapdom':
-        specifier: 2.0.2
-        version: 2.0.2
+        specifier: ^2.24.10
+        version: 2.24.10
       broccoli-file-creator:
         specifier: ^2.1.1
         version: 2.1.1
@@ -3394,9 +3394,8 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
-  '@zumer/snapdom@2.0.2':
-    resolution: {integrity: sha512-W6quT4lMcPu8Q9O/Q6witSfc6/+xuY8C8yDoHug/+o7zYKCNE/e0I3//XsWDkyq9C0mDE0TAWF/8bwCR7x3gHQ==}
-    deprecated: Old versions have known fidelity bugs (text re-wrap, width freezing, KaTeX clipping). Upgrade to ^2.22 — drop-in for any 2.x. https://github.com/zumerlab/snapdom/releases
+  '@zumer/snapdom@2.24.10':
+    resolution: {integrity: sha512-yK+5HvcP96aZCG8dcOuJDsOD1TACDeSTI0wlsmQkMeeGaM/JVHdBQZPS4h0Uae6bY/zx+WQCJtOKnrbB6D7NgQ==}
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -12553,7 +12552,7 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  '@zumer/snapdom@2.0.2': {}
+  '@zumer/snapdom@2.24.10': {}
 
   abbrev@1.1.1: {}
 


### PR DESCRIPTION
Bumping up to the latest version to hopefully stabilize our screenshots, fixed an import of the wrong method in a component as the new snapdom fails when it doesn't get a real element.