### PR TITLE
Fix ICS Feed icon color when in dark mode

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/dashboard/navigation.scss
@@ -23,15 +23,18 @@
       }
 
       .ilios-calendar-ics-feed {
-        padding: 0;
+        background-color: light-dark(transparent, var(--white));
         text-align: center;
         width: 90%;
 
         .highlight {
           align-items: center;
           display: flex;
-          color: light-dark(var(--orange), var(--orange));
+          color: light-dark(var(--orange), var(--dark-orange));
           @include m.font-size("large");
+          // exact height/width needed for dark mode white bg to create inner details
+          height: 14px;
+          width: 16px;
 
           @include m.for-phone-only {
             @include m.font-size("medium");


### PR DESCRIPTION
Fixes ilios/ilios#7372

Changed ICS Feed icon color in dark mode to match darker orange header color. Added white background so that details of icon are white (they aren't explicitly colored, but are just transparent).