### PR TITLE
Remove Visual Diff Approval for New Code

### DIFF
--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -1,0 +1,21 @@
+name: Reset Visual Diff Approval
+
+on:
+  pull_request_target:
+    types:
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  remove-approval:
+    if: contains(github.event.pull_request.labels.*.name, 'approve visual diff')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Remove Label
+        run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --remove-label "approve visual diff"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When a PR gets updated this task will run to remove the `approve visual diff` label. This will then require a re-check of screenshots if there are any problems and avoid merging (or automerging) the PR if there are new issues that pop up.

I had to use the `pull_request_target` type here to support forks so this won't run until after it is merged.


For reference: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=synchronize#pull_request