### PR TITLE
control visibility of MeSH UI based on school configuration

### DIFF
--- a/packages/frontend/app/components/program-year/collapsed-objectives.gjs
+++ b/packages/frontend/app/components/program-year/collapsed-objectives.gjs
@@ -69,9 +69,11 @@ export default class ProgramYearCollapsedObjectivesComponent extends Component {
               <th class="text-center">
                 {{t "general.vocabularyTerms"}}
               </th>
-              <th class="text-center">
-                {{t "general.meshTerms"}}
-              </th>
+              {{#if @showMeSH}}
+                <th class="text-center">
+                  {{t "general.meshTerms"}}
+                </th>
+              {{/if}}
             </tr>
           </thead>
           <tbody>
@@ -99,15 +101,17 @@ export default class ProgramYearCollapsedObjectivesComponent extends Component {
                   <FaIcon @icon={{faBan}} class="no" />
                 {{/if}}
               </td>
-              <td class="text-middle text-center" rowspan="3" data-test-mesh-status>
-                {{#if (eq (get this.objectivesWithMesh "length") (get this.objectives "length"))}}
-                  <FaIcon @icon={{faCircle}} class="yes" />
-                {{else if (gte (get this.objectivesWithMesh "length") 1)}}
-                  <FaIcon @icon={{faCircle}} class="maybe" />
-                {{else}}
-                  <FaIcon @icon={{faBan}} class="no" />
-                {{/if}}
-              </td>
+              {{#if @showMeSH}}
+                <td class="text-middle text-center" rowspan="3" data-test-mesh-status>
+                  {{#if (eq (get this.objectivesWithMesh "length") (get this.objectives "length"))}}
+                    <FaIcon @icon={{faCircle}} class="yes" />
+                  {{else if (gte (get this.objectivesWithMesh "length") 1)}}
+                    <FaIcon @icon={{faCircle}} class="maybe" />
+                  {{else}}
+                    <FaIcon @icon={{faBan}} class="no" />
+                  {{/if}}
+                </td>
+              {{/if}}
             </tr>
             <tr>
               <td data-test-parent-count>
@@ -122,11 +126,13 @@ export default class ProgramYearCollapsedObjectivesComponent extends Component {
                 {{t "general.termCount" count=(get this.objectivesWithTerms "length")}}
               </td>
             </tr>
-            <tr>
-              <td data-test-mesh-count>
-                {{t "general.meshCount" count=(get this.objectivesWithMesh "length")}}
-              </td>
-            </tr>
+            {{#if @showMeSH}}
+              <tr>
+                <td data-test-mesh-count>
+                  {{t "general.meshCount" count=(get this.objectivesWithMesh "length")}}
+                </td>
+              </tr>
+            {{/if}}
           </tbody>
         </table>
       </div>

--- a/packages/frontend/app/components/program-year/details.gjs
+++ b/packages/frontend/app/components/program-year/details.gjs
@@ -43,7 +43,7 @@ export default class ProgramYearDetailsComponent extends Component {
   }
 
   get showMeSH() {
-    return !!this.schoolConfigs.get('showMeSH');
+    return this.schoolConfigs.has('showMeSH') ? this.schoolConfigs.get('showMeSH') : true;
   }
 
   <template>

--- a/packages/frontend/app/components/program-year/details.gjs
+++ b/packages/frontend/app/components/program-year/details.gjs
@@ -1,3 +1,6 @@
+import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { TrackedAsyncData } from 'ember-async-data';
 import LeadershipExpanded from 'ilios-common/components/leadership-expanded';
 import { fn } from '@ember/helper';
 import LeadershipCollapsed from 'ilios-common/components/leadership-collapsed';
@@ -12,74 +15,113 @@ import CollapsedTaxonomies from 'ilios-common/components/collapsed-taxonomies';
 import CourseAssociations from './course-associations';
 import CohortMembers from './cohort-members';
 
-<template>
-  <div class="programyear-details" data-test-program-year-details ...attributes>
-    {{#if @programYearLeadershipDetails}}
-      <LeadershipExpanded
-        @model={{@programYear}}
-        @editable={{@canUpdate}}
-        @collapse={{fn @setProgramYearLeadershipDetails false}}
-        @expand={{fn @setProgramYearLeadershipDetails true}}
-        @isManaging={{@manageProgramYearLeadership}}
-        @setIsManaging={{@setManageProgramYearLeadership}}
-      />
-    {{else}}
-      <LeadershipCollapsed
-        @showAdministrators={{false}}
-        @showDirectors={{true}}
-        @directorsCount={{hasManyLength @programYear "directors"}}
-        @expand={{fn @setProgramYearLeadershipDetails true}}
-      />
+export default class ProgramYearDetailsComponent extends Component {
+  @cached
+  get schoolConfigsData() {
+    return new TrackedAsyncData(this.getSchoolConfigs(this.args.programYear));
+  }
+
+  async getSchoolConfigs(programYear) {
+    const program = await programYear.program;
+    const school = await program.school;
+    return await school.configurations;
+  }
+
+  @cached
+  get schoolConfigs() {
+    const rhett = new Map();
+    if (this.schoolConfigsData.isResolved) {
+      this.schoolConfigsData.value.forEach((config) => {
+        rhett.set(config.name, config.parsedValue);
+      });
+    }
+    return rhett;
+  }
+
+  get schoolConfigsLoaded() {
+    return this.schoolConfigsData.isResolved;
+  }
+
+  get showMeSH() {
+    return !!this.schoolConfigs.get('showMeSH');
+  }
+
+  <template>
+    {{#if this.schoolConfigsLoaded}}
+      <div class="programyear-details" data-test-program-year-details ...attributes>
+        {{#if @programYearLeadershipDetails}}
+          <LeadershipExpanded
+            @model={{@programYear}}
+            @editable={{@canUpdate}}
+            @collapse={{fn @setProgramYearLeadershipDetails false}}
+            @expand={{fn @setProgramYearLeadershipDetails true}}
+            @isManaging={{@manageProgramYearLeadership}}
+            @setIsManaging={{@setManageProgramYearLeadership}}
+          />
+        {{else}}
+          <LeadershipCollapsed
+            @showAdministrators={{false}}
+            @showDirectors={{true}}
+            @directorsCount={{hasManyLength @programYear "directors"}}
+            @expand={{fn @setProgramYearLeadershipDetails true}}
+          />
+        {{/if}}
+        {{#if (or (eq @programYear.competencies.length 0) @pyCompetencyDetails)}}
+          <Competencies
+            @programYear={{@programYear}}
+            @canUpdate={{@canUpdate}}
+            @isManaging={{@managePyCompetencies}}
+            @collapse={{fn @setPyCompetencyDetails false}}
+            @expand={{fn @setPyCompetencyDetails true}}
+            @setIsManaging={{@setManagePyCompetencies}}
+          />
+        {{else}}
+          <CollapsedCompetencies
+            @subject={{@programYear}}
+            @expand={{fn @setPyCompetencyDetails true}}
+          />
+        {{/if}}
+        {{#if (or (eq @programYear.programYearObjectives.length 0) @pyObjectiveDetails)}}
+          <Objectives
+            @programYear={{@programYear}}
+            @editable={{@canUpdate}}
+            @collapse={{fn @setPyObjectiveDetails false}}
+            @expand={{fn @setPyObjectiveDetails true}}
+            @expandedObjectiveIds={{@expandedObjectiveIds}}
+            @setExpandedObjectiveIds={{@setExpandedObjectiveIds}}
+            @showMeSH={{this.showMeSH}}
+          />
+        {{else}}
+          <CollapsedObjectives
+            @programYear={{@programYear}}
+            @expand={{fn @setPyObjectiveDetails true}}
+            @showMeSH={{this.showMeSH}}
+          />
+        {{/if}}
+        {{#if (or (eq @programYear.terms.length 0) @pyTaxonomyDetails)}}
+          <DetailTaxonomies
+            @subject={{@programYear}}
+            @editable={{@canUpdate}}
+            @collapse={{fn @setPyTaxonomyDetails false}}
+            @expand={{fn @setPyTaxonomyDetails true}}
+          />
+        {{else}}
+          <CollapsedTaxonomies
+            @subject={{@programYear}}
+            @expand={{fn @setPyTaxonomyDetails true}}
+          />
+        {{/if}}
+        <CourseAssociations
+          @programYear={{@programYear}}
+          @isExpanded={{@showCourseAssociations}}
+          @setIsExpanded={{@setShowCourseAssociations}}
+        />
+        <CohortMembers
+          @programYear={{@programYear}}
+          @isExpanded={{@showCohortMembers}}
+          @setIsExpanded={{@setShowCohortMembers}}
+        />
+      </div>
     {{/if}}
-    {{#if (or (eq @programYear.competencies.length 0) @pyCompetencyDetails)}}
-      <Competencies
-        @programYear={{@programYear}}
-        @canUpdate={{@canUpdate}}
-        @isManaging={{@managePyCompetencies}}
-        @collapse={{fn @setPyCompetencyDetails false}}
-        @expand={{fn @setPyCompetencyDetails true}}
-        @setIsManaging={{@setManagePyCompetencies}}
-      />
-    {{else}}
-      <CollapsedCompetencies
-        @subject={{@programYear}}
-        @expand={{fn @setPyCompetencyDetails true}}
-      />
-    {{/if}}
-    {{#if (or (eq @programYear.programYearObjectives.length 0) @pyObjectiveDetails)}}
-      <Objectives
-        @programYear={{@programYear}}
-        @editable={{@canUpdate}}
-        @collapse={{fn @setPyObjectiveDetails false}}
-        @expand={{fn @setPyObjectiveDetails true}}
-        @expandedObjectiveIds={{@expandedObjectiveIds}}
-        @setExpandedObjectiveIds={{@setExpandedObjectiveIds}}
-      />
-    {{else}}
-      <CollapsedObjectives
-        @programYear={{@programYear}}
-        @expand={{fn @setPyObjectiveDetails true}}
-      />
-    {{/if}}
-    {{#if (or (eq @programYear.terms.length 0) @pyTaxonomyDetails)}}
-      <DetailTaxonomies
-        @subject={{@programYear}}
-        @editable={{@canUpdate}}
-        @collapse={{fn @setPyTaxonomyDetails false}}
-        @expand={{fn @setPyTaxonomyDetails true}}
-      />
-    {{else}}
-      <CollapsedTaxonomies @subject={{@programYear}} @expand={{fn @setPyTaxonomyDetails true}} />
-    {{/if}}
-    <CourseAssociations
-      @programYear={{@programYear}}
-      @isExpanded={{@showCourseAssociations}}
-      @setIsExpanded={{@setShowCourseAssociations}}
-    />
-    <CohortMembers
-      @programYear={{@programYear}}
-      @isExpanded={{@showCohortMembers}}
-      @setIsExpanded={{@setShowCohortMembers}}
-    />
-  </div>
-</template>
+  </template>
+}

--- a/packages/frontend/app/components/program-year/objective-list-item.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-item.gjs
@@ -264,6 +264,10 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
       rowClasses.push('is-inactive');
     }
 
+    if (!this.args.showMeSH) {
+      rowClasses.push('no-mesh');
+    }
+
     return rowClasses.join(' ');
   }
 
@@ -356,17 +360,17 @@ export default class ProgramYearObjectiveListItemComponent extends Component {
         @isSaving={{this.saveTerms.isRunning}}
         @cancel={{this.cancel}}
       />
-
-      <ObjectiveListItemDescriptors
-        @meshDescriptors={{this.meshDescriptors}}
-        @editable={{and @editable (not this.isManaging) (not this.showRemoveConfirmation)}}
-        @manage={{perform this.manageDescriptors}}
-        @isManaging={{this.isManagingDescriptors}}
-        @save={{perform this.saveDescriptors}}
-        @isSaving={{this.saveDescriptors.isRunning}}
-        @cancel={{this.cancel}}
-      />
-
+      {{#if @showMeSH}}
+        <ObjectiveListItemDescriptors
+          @meshDescriptors={{this.meshDescriptors}}
+          @editable={{and @editable (not this.isManaging) (not this.showRemoveConfirmation)}}
+          @manage={{perform this.manageDescriptors}}
+          @isManaging={{this.isManagingDescriptors}}
+          @save={{perform this.saveDescriptors}}
+          @isSaving={{this.saveDescriptors.isRunning}}
+          @cancel={{this.cancel}}
+        />
+      {{/if}}
       <div class="actions grid-item" data-test-actions>
         {{#if (and @editable (not this.isManaging) (not this.showRemoveConfirmation))}}
           {{#if this.saveIsActive.isRunning}}

--- a/packages/frontend/app/components/program-year/objective-list-loading.gjs
+++ b/packages/frontend/app/components/program-year/objective-list-loading.gjs
@@ -8,7 +8,9 @@ import random from 'ember-math-helpers/helpers/random';
       <span class="grid-item">{{truncate (repeat (random 3 10) "ilios rocks") 100}}</span>
       <span class="grid-item">{{repeat (random 1 3) "loading "}}</span>
       <span class="grid-item">{{repeat (random 1 3) "loading "}}</span>
-      <span class="grid-item">{{repeat (random 1 3) "loading "}}</span>
+      {{#if @showMeSH}}
+        <span class="grid-item">{{repeat (random 1 3) "loading "}}</span>
+      {{/if}}
       <span class="grid-item"></span>
     </div>
   {{/each}}

--- a/packages/frontend/app/components/program-year/objective-list.gjs
+++ b/packages/frontend/app/components/program-year/objective-list.gjs
@@ -126,7 +126,7 @@ export default class ProgramYearObjectiveListComponent extends Component {
           {{t "general.downloadCompetencyMap"}}
         </button>
 
-        <div class="grid-row headers" data-test-headers>
+        <div class="grid-row headers{{unless @showMeSH ' no-mesh'}}" data-test-headers>
           <span class="grid-item">
             <button
               type="button"
@@ -147,7 +147,9 @@ export default class ProgramYearObjectiveListComponent extends Component {
           <span class="grid-item" data-test-header>{{t "general.description"}}</span>
           <span class="grid-item" data-test-header>{{t "general.competency"}}</span>
           <span class="grid-item" data-test-header>{{t "general.vocabularyTerms"}}</span>
-          <span class="grid-item" data-test-header>{{t "general.meshTerms"}}</span>
+          {{#if @showMeSH}}
+            <span class="grid-item" data-test-header>{{t "general.meshTerms"}}</span>
+          {{/if}}
           <span class="actions grid-item" data-test-header>{{t "general.actions"}}</span>
         </div>
         {{#if (isArray this.domainTrees)}}
@@ -159,10 +161,11 @@ export default class ProgramYearObjectiveListComponent extends Component {
               @programYearCompetencies={{this.programYearCompetencies}}
               @expandedObjectiveIds={{@expandedObjectiveIds}}
               @setExpandedObjectiveIds={{@setExpandedObjectiveIds}}
+              @showMeSH={{@showMeSH}}
             />
           {{/each}}
         {{else}}
-          <ObjectiveListLoading @count={{this.programYearObjectiveCount}} />
+          <ObjectiveListLoading @count={{this.programYearObjectiveCount}} @showMeSH={{@showMeSH}} />
         {{/if}}
       {{/if}}
     </div>

--- a/packages/frontend/app/components/program-year/objectives.gjs
+++ b/packages/frontend/app/components/program-year/objectives.gjs
@@ -129,6 +129,7 @@ export default class ProgramYearObjectivesComponent extends Component {
           @editable={{@editable}}
           @expandedObjectiveIds={{@expandedObjectiveIds}}
           @setExpandedObjectiveIds={{@setExpandedObjectiveIds}}
+          @showMeSH={{@showMeSH}}
         />
       </div>
     </section>

--- a/packages/frontend/app/styles/components/program-year/objective-list.scss
+++ b/packages/frontend/app/styles/components/program-year/objective-list.scss
@@ -13,6 +13,10 @@
   .grid-row {
     grid-template-columns: 1fr 10fr 6fr 6fr 6fr 1fr;
 
+    &.no-mesh {
+      grid-template-columns: 1fr 10fr 6fr 6fr 1fr;
+    }
+
     .expand-row {
       @include m.ilios-button-reset;
       display: flex;

--- a/packages/frontend/tests/acceptance/course/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/learningmaterials-test.js
@@ -107,12 +107,14 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     });
   });
 
-  test('list learning materials', async function (assert) {
-    await this.server.create('school-config', {
-      school: this.school,
-      name: 'showMeSH',
-      value: 'true',
-    });
+  test.each('list learning materials', [true, false], async function (assert, flagExists) {
+    if (flagExists) {
+      await this.server.create('school-config', {
+        school: this.school,
+        name: 'showMeSH',
+        value: 'true',
+      });
+    }
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(currentRouteName(), 'course.index');
 
@@ -191,6 +193,11 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('list learning materials without MeSH UI', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'false',
+    });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(currentRouteName(), 'course.index');
 

--- a/packages/frontend/tests/acceptance/course/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/learningmaterials-test.js
@@ -108,68 +108,161 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
   });
 
   test('list learning materials', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(currentRouteName(), 'course.index');
 
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
 
-    assert.strictEqual(page.details.learningMaterials.current[0].title, 'learning material 0');
     assert.strictEqual(
-      page.details.learningMaterials.current[0].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[0].title,
+      'learning material 0',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.notOk(page.details.learningMaterials.current[0].userNameInfo.hasAdditionalInfo);
-    assert.strictEqual(page.details.learningMaterials.current[0].required, 'No');
-    assert.strictEqual(page.details.learningMaterials.current[0].notes, 'No');
-    assert.notOk(page.details.learningMaterials.current[0].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[0].mesh, 'descriptor 1 descriptor 2');
-    assert.strictEqual(page.details.learningMaterials.current[0].status, 'status 0');
-
-    assert.strictEqual(page.details.learningMaterials.current[1].title, 'learning material 1');
+    assert.notOk(page.details.learningMaterials.materials.items[0].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[0].isNotePublic);
     assert.strictEqual(
-      page.details.learningMaterials.current[1].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[0].mesh.text,
+      'descriptor 1 descriptor 2',
+    );
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].status.text, 'status 0');
+
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[1].title,
+      'learning material 1',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[1].userNameInfo.fullName,
       'Clem Chowder',
     );
-    assert.ok(page.details.learningMaterials.current[1].userNameInfo.hasAdditionalInfo);
-    assert.notOk(page.details.learningMaterials.current[1].userNameInfo.isTooltipVisible);
-    await page.details.learningMaterials.current[1].userNameInfo.expandTooltip();
+    assert.ok(page.details.learningMaterials.materials.items[1].userNameInfo.hasAdditionalInfo);
+    assert.notOk(page.details.learningMaterials.materials.items[1].userNameInfo.isTooltipVisible);
+    await page.details.learningMaterials.materials.items[1].userNameInfo.expandTooltip();
     assert.strictEqual(
-      page.details.learningMaterials.current[1].userNameInfo.tooltipContents,
+      page.details.learningMaterials.materials.items[1].userNameInfo.tooltipContents,
       'Campus name of record: 1 guy M, Mc1son',
     );
-    await page.details.learningMaterials.current[1].userNameInfo.closeTooltip();
-    assert.notOk(page.details.learningMaterials.current[1].userNameInfo.isTooltipVisible);
-    assert.strictEqual(page.details.learningMaterials.current[1].required, 'No');
-    assert.strictEqual(page.details.learningMaterials.current[1].notes, 'No');
-    assert.notOk(page.details.learningMaterials.current[1].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[1].mesh, 'None');
-    assert.strictEqual(page.details.learningMaterials.current[1].status, 'status 0');
-    assert.strictEqual(page.details.learningMaterials.current[1].status, 'status 0');
+    await page.details.learningMaterials.materials.items[1].userNameInfo.closeTooltip();
+    assert.notOk(page.details.learningMaterials.materials.items[1].userNameInfo.isTooltipVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[1].isNotePublic);
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].mesh.text, 'None');
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].status.text, 'status 0');
 
-    assert.strictEqual(page.details.learningMaterials.current[2].title, 'learning material 2');
     assert.strictEqual(
-      page.details.learningMaterials.current[2].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[2].title,
+      'learning material 2',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[2].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.notOk(page.details.learningMaterials.current[2].userNameInfo.hasAdditionalInfo);
-    assert.strictEqual(page.details.learningMaterials.current[2].required, 'Yes');
-    assert.strictEqual(page.details.learningMaterials.current[2].notes, 'No');
-    assert.notOk(page.details.learningMaterials.current[2].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[2].mesh, 'None');
-    assert.strictEqual(page.details.learningMaterials.current[2].status, 'status 0');
-    assert.strictEqual(page.details.learningMaterials.current[2].status, 'status 0');
+    assert.notOk(page.details.learningMaterials.materials.items[2].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].required.text, 'Yes');
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[2].isNotePublic);
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].mesh.text, 'None');
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].status.text, 'status 0');
 
-    assert.strictEqual(page.details.learningMaterials.current[3].title, 'learning material 3');
     assert.strictEqual(
-      page.details.learningMaterials.current[3].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[3].title,
+      'learning material 3',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[3].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.notOk(page.details.learningMaterials.current[3].userNameInfo.hasAdditionalInfo);
-    assert.strictEqual(page.details.learningMaterials.current[3].required, 'Yes');
-    assert.strictEqual(page.details.learningMaterials.current[3].notes, 'Yes');
-    assert.ok(page.details.learningMaterials.current[3].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[3].mesh, 'None');
-    assert.strictEqual(page.details.learningMaterials.current[3].status, 'status 0');
+    assert.notOk(page.details.learningMaterials.materials.items[3].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].required.text, 'Yes');
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].notes.text, 'Yes');
+    assert.ok(page.details.learningMaterials.materials.items[3].isNotePublic);
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].mesh.text, 'None');
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].status.text, 'status 0');
+  });
+
+  test('list learning materials without MeSH UI', async function (assert) {
+    await page.visit({ courseId: this.course.id, details: true });
+    assert.strictEqual(currentRouteName(), 'course.index');
+
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].title,
+      'learning material 0',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].userNameInfo.fullName,
+      '0 guy M. Mc0son',
+    );
+    assert.notOk(page.details.learningMaterials.materials.items[0].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[0].isNotePublic);
+    assert.notOk(page.details.learningMaterials.materials.items[0].mesh.isVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].status.text, 'status 0');
+
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[1].title,
+      'learning material 1',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[1].userNameInfo.fullName,
+      'Clem Chowder',
+    );
+    assert.ok(page.details.learningMaterials.materials.items[1].userNameInfo.hasAdditionalInfo);
+    assert.notOk(page.details.learningMaterials.materials.items[1].userNameInfo.isTooltipVisible);
+    await page.details.learningMaterials.materials.items[1].userNameInfo.expandTooltip();
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[1].userNameInfo.tooltipContents,
+      'Campus name of record: 1 guy M, Mc1son',
+    );
+    await page.details.learningMaterials.materials.items[1].userNameInfo.closeTooltip();
+    assert.notOk(page.details.learningMaterials.materials.items[1].userNameInfo.isTooltipVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[1].isNotePublic);
+    assert.notOk(page.details.learningMaterials.materials.items[1].mesh.isVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].status.text, 'status 0');
+
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[2].title,
+      'learning material 2',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[2].userNameInfo.fullName,
+      '0 guy M. Mc0son',
+    );
+    assert.notOk(page.details.learningMaterials.materials.items[2].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].required.text, 'Yes');
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[2].isNotePublic);
+    assert.notOk(page.details.learningMaterials.materials.items[2].mesh.isVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].status.text, 'status 0');
+
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[3].title,
+      'learning material 3',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[3].userNameInfo.fullName,
+      '0 guy M. Mc0son',
+    );
+    assert.notOk(page.details.learningMaterials.materials.items[3].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].required.text, 'Yes');
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].notes.text, 'Yes');
+    assert.ok(page.details.learningMaterials.materials.items[3].isNotePublic);
+    assert.notOk(page.details.learningMaterials.materials.items[3].mesh.isVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].status.text, 'status 0');
   });
 
   test('create new link learning material', async function (assert) {
@@ -180,7 +273,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
     assert.strictEqual((await this.server.db.learningMaterial.all()).length, 5);
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
     assert.ok(page.details.learningMaterials.search.isVisible);
     await page.details.learningMaterials.createNew();
     await page.details.learningMaterials.pickNew('Web Link');
@@ -204,8 +297,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     const learningMaterials = await this.server.db.learningMaterial.all();
     assert.strictEqual(learningMaterials.length, 6);
     assert.strictEqual(learningMaterials[5].link, testUrl);
-    assert.strictEqual(page.details.learningMaterials.current.length, 5);
-    assert.strictEqual(page.details.learningMaterials.current[4].title, testTitle);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 5);
+    assert.strictEqual(page.details.learningMaterials.materials.items[4].title, testTitle);
   });
 
   test('create new citation learning material', async function (assert) {
@@ -216,7 +309,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
     assert.strictEqual((await this.server.db.learningMaterial.all()).length, 5);
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
     assert.ok(page.details.learningMaterials.search.isVisible);
     await page.details.learningMaterials.createNew();
     await page.details.learningMaterials.pickNew('Citation');
@@ -241,13 +334,13 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     assert.strictEqual(learningMaterials.length, 6);
     assert.strictEqual(learningMaterials[5].citation, testCitation);
 
-    assert.strictEqual(page.details.learningMaterials.current.length, 5);
-    assert.strictEqual(page.details.learningMaterials.current[4].title, testTitle);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 5);
+    assert.strictEqual(page.details.learningMaterials.materials.items[4].title, testTitle);
   });
 
   test('can only add one learning-material at a time', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
     assert.ok(page.details.learningMaterials.canCreateNew);
     assert.notOk(page.details.learningMaterials.canCollapse);
     await page.details.learningMaterials.createNew();
@@ -258,19 +351,19 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
   test('cancel new learning material', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
     assert.ok(page.details.learningMaterials.search.isVisible);
     await page.details.learningMaterials.createNew();
     await page.details.learningMaterials.pickNew('Citation');
     await page.details.learningMaterials.newLearningMaterial.cancel();
 
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
   });
 
   test('view copyright file learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
 
     assert.strictEqual(page.details.learningMaterials.manager.name.value, 'learning material 0');
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Jennifer Johnson');
@@ -288,8 +381,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
   test('view rationale file learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[1].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[1].details();
 
     assert.strictEqual(page.details.learningMaterials.manager.name.value, 'learning material 1');
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Jennifer Johnson');
@@ -307,8 +400,12 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
   test('view accessibility file learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items.length,
+      4,
+      'course lm count correct',
+    );
+    await page.details.learningMaterials.materials.items[0].details();
 
     assert.strictEqual(
       page.details.learningMaterials.manager.name.value,
@@ -342,7 +439,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     assert.notOk(page.details.learningMaterials.manager.hasCitation, 'lm does not have citation');
 
     await page.details.learningMaterials.manager.cancel();
-    await page.details.learningMaterials.current[1].details();
+    await page.details.learningMaterials.materials.items[1].details();
 
     assert.strictEqual(
       page.details.learningMaterials.manager.name.value,
@@ -378,8 +475,12 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
   test('toggling accessibility file learning material', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items.length,
+      4,
+      'course lm count correct',
+    );
+    await page.details.learningMaterials.materials.items[0].details();
 
     assert.ok(
       page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
@@ -397,7 +498,7 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     await page.details.learningMaterials.manager.markedAccessibleToggle();
     await page.details.learningMaterials.manager.save();
 
-    await page.details.learningMaterials.current[0].details();
+    await page.details.learningMaterials.materials.items[0].details();
 
     assert.ok(
       page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
@@ -415,8 +516,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
   test('view url file learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[1].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[1].details();
 
     assert.strictEqual(page.details.learningMaterials.manager.name.value, 'learning material 1');
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Jennifer Johnson');
@@ -437,8 +538,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
   test('view link learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[2].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[2].details();
 
     assert.strictEqual(page.details.learningMaterials.manager.name.value, 'learning material 2');
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Hunter Pence');
@@ -465,8 +566,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
   test('view citation learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[3].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[3].details();
 
     assert.strictEqual(page.details.learningMaterials.manager.name.value, 'learning material 3');
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Willie Mays');
@@ -489,8 +590,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     const newDescription = "i'll sleep when i'm dead.";
 
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     await page.details.learningMaterials.manager.required();
     await page.details.learningMaterials.manager.publicNotes();
     await page.details.learningMaterials.manager.status(3);
@@ -499,17 +600,20 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
     await page.details.learningMaterials.manager.save();
 
-    assert.strictEqual(page.details.learningMaterials.current[0].title, 'learning material 0');
     assert.strictEqual(
-      page.details.learningMaterials.current[0].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[0].title,
+      'learning material 0',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.strictEqual(page.details.learningMaterials.current[0].required, 'Yes');
-    assert.notOk(page.details.learningMaterials.current[0].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[0].notes, 'Yes');
-    assert.strictEqual(page.details.learningMaterials.current[0].status, 'status 2');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].required.text, 'Yes');
+    assert.notOk(page.details.learningMaterials.materials.items[0].isNotePublic);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].notes.text, 'Yes');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].status.text, 'status 2');
 
-    await page.details.learningMaterials.current[0].details();
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(
       await page.details.learningMaterials.manager.notes.value(),
       `<p>${newNote}</p>`,
@@ -523,23 +627,31 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
   test('change from required to not required #1249', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[2].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[2].details();
     await page.details.learningMaterials.manager.required();
 
     await page.details.learningMaterials.manager.save();
 
-    assert.strictEqual(page.details.learningMaterials.current[2].title, 'learning material 2');
-    assert.strictEqual(page.details.learningMaterials.current[2].required, 'No');
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[2].title,
+      'learning material 2',
+    );
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].required.text, 'No');
   });
 
   test('cancel editing learning material', async function (assert) {
     const newNote = 'text text. Woo hoo!';
     const newDescription = 'counting sheep';
 
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     await page.details.learningMaterials.manager.required();
     await page.details.learningMaterials.manager.publicNotes();
     await page.details.learningMaterials.manager.status(3);
@@ -548,18 +660,24 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
     await page.details.learningMaterials.manager.cancel();
 
-    assert.strictEqual(page.details.learningMaterials.current[0].title, 'learning material 0');
     assert.strictEqual(
-      page.details.learningMaterials.current[0].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[0].title,
+      'learning material 0',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.strictEqual(page.details.learningMaterials.current[0].required, 'No');
-    assert.strictEqual(page.details.learningMaterials.current[0].notes, 'No');
-    assert.notOk(page.details.learningMaterials.current[0].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[0].mesh, 'descriptor 1 descriptor 2');
-    assert.strictEqual(page.details.learningMaterials.current[0].status, 'status 0');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[0].isNotePublic);
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].mesh.text,
+      'descriptor 1 descriptor 2',
+    );
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].status.text, 'status 0');
 
-    await page.details.learningMaterials.current[0].details();
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(await page.details.learningMaterials.manager.notes.value(), '');
     assert.strictEqual(
       await page.details.learningMaterials.manager.description.editorValue(),
@@ -568,10 +686,15 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     assert.strictEqual(page.details.learningMaterials.manager.statusValue, '1');
   });
 
-  test('manage terms', async function (assert) {
+  test('manage MeSH terms', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(page.details.learningMaterials.manager.meshManager.selectedTerms.length, 2);
     assert.strictEqual(
       page.details.learningMaterials.manager.meshManager.selectedTerms[0].title,
@@ -612,10 +735,15 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     );
   });
 
-  test('save terms', async function (assert) {
+  test('save MeSH terms', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(page.details.learningMaterials.manager.meshManager.selectedTerms.length, 2);
     await page.details.learningMaterials.manager.meshManager.selectedTerms[0].remove();
     await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
@@ -629,13 +757,21 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       'descriptor 2',
     );
     await page.details.learningMaterials.manager.save();
-    assert.strictEqual(page.details.learningMaterials.current[0].mesh, 'descriptor 0 descriptor 2');
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].mesh.text,
+      'descriptor 0 descriptor 2',
+    );
   });
 
-  test('cancel term changes', async function (assert) {
+  test('cancel MeSH term changes', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(page.details.learningMaterials.manager.meshManager.selectedTerms.length, 2);
     await page.details.learningMaterials.manager.meshManager.selectedTerms[0].remove();
     await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
@@ -649,12 +785,15 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       'descriptor 2',
     );
     await page.details.learningMaterials.manager.cancel();
-    assert.strictEqual(page.details.learningMaterials.current[0].mesh, 'descriptor 1 descriptor 2');
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].mesh.text,
+      'descriptor 1 descriptor 2',
+    );
   });
 
   test('find and add learning material', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
     await page.details.learningMaterials.search.search.set('doc');
     assert.strictEqual(page.details.learningMaterials.search.searchResults.length, 1);
 
@@ -677,13 +816,13 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
       'Upload date: 03/03/2016',
     );
     await page.details.learningMaterials.search.searchResults[0].add();
-    assert.strictEqual(page.details.learningMaterials.current.length, 5);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 5);
   });
 
   test('add timed release start date', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     await page.details.learningMaterials.manager.addStartDate();
 
     const newDate = DateTime.fromObject({ hour: 10, minute: 10 }).plus({ days: 1, month: 1 });
@@ -692,8 +831,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     await page.details.learningMaterials.manager.startTime.timePicker.minute.select('10');
     await page.details.learningMaterials.manager.startTime.timePicker.ampm.select('AM');
     await page.details.learningMaterials.manager.save();
-    assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.ok(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     const formattedNewDate = this.intl.formatDate(newDate.toJSDate(), {
       month: '2-digit',
       day: '2-digit',
@@ -715,8 +854,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     const newEndDate = newStartDate.plus({ minutes: 1 });
 
     await page.visit({ courseId: this.course.id, details: true });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     await page.details.learningMaterials.manager.addStartDate();
 
     await page.details.learningMaterials.manager.startDate.datePicker.set(newStartDate.toJSDate());
@@ -731,8 +870,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     await page.details.learningMaterials.manager.endTime.timePicker.ampm.select('AM');
 
     await page.details.learningMaterials.manager.save();
-    assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.ok(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     const formattedStartDate = this.intl.formatDate(newStartDate.toJSDate(), {
       month: '2-digit',
       day: '2-digit',
@@ -755,8 +894,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
   test('add timed release end date', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     await page.details.learningMaterials.manager.addEndDate();
 
     const newDate = DateTime.fromObject({ hour: 10, minute: 10 }).plus({ days: 1, month: 1 });
@@ -765,8 +904,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     await page.details.learningMaterials.manager.endTime.timePicker.minute.select('10');
     await page.details.learningMaterials.manager.endTime.timePicker.ampm.select('AM');
     await page.details.learningMaterials.manager.save();
-    assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.ok(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     const formattedNewDate = this.intl.formatDate(newDate.toJSDate(), {
       month: '2-digit',
       day: '2-digit',
@@ -784,8 +923,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     const newDate = DateTime.fromObject({ hour: 10, minute: 10 }).plus({ days: 1, month: 1 });
 
     await page.visit({ courseId: this.course.id, details: true });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.notOk(page.details.learningMaterials.manager.hasEndDateValidationError);
     await page.details.learningMaterials.manager.addStartDate();
 
@@ -819,23 +958,23 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     const newTitle = 'text text. Woo hoo!';
 
     await page.visit({ courseId: this.course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.ok(page.details.learningMaterials.manager.name.isPresent);
     await page.details.learningMaterials.manager.name.fillIn(newTitle);
 
     await page.details.learningMaterials.manager.save();
 
-    assert.strictEqual(page.details.learningMaterials.current[0].title, newTitle);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].title, newTitle);
 
-    await page.details.learningMaterials.current[0].details();
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(page.details.learningMaterials.manager.name.value, newTitle);
   });
 
   test('title too short', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.notOk(page.details.learningMaterials.manager.hasTitleValidationError);
     await page.details.learningMaterials.manager.name.fillIn('a');
     await page.details.learningMaterials.manager.save();
@@ -844,8 +983,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
 
   test('title too long', async function (assert) {
     await page.visit({ courseId: this.course.id, details: true });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.notOk(page.details.learningMaterials.manager.hasTitleValidationError);
     await page.details.learningMaterials.manager.name.fillIn('0123456789'.repeat(13));
     await page.details.learningMaterials.manager.save();
@@ -896,18 +1035,21 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     await takeScreenshot(assert);
     assert.strictEqual(currentRouteName(), 'course.index');
 
-    assert.strictEqual(page.details.learningMaterials.current.length, 1);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 1);
 
-    assert.strictEqual(page.details.learningMaterials.current[0].title, 'learning material 0');
     assert.strictEqual(
-      page.details.learningMaterials.current[0].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[0].title,
+      'learning material 0',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.notOk(page.details.learningMaterials.current[0].userNameInfo.hasAdditionalInfo);
-    assert.strictEqual(page.details.learningMaterials.current[0].required, 'No');
-    assert.strictEqual(page.details.learningMaterials.current[0].notes, 'No');
-    assert.notOk(page.details.learningMaterials.current[0].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[0].status, 'status 0');
+    assert.notOk(page.details.learningMaterials.materials.items[0].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[0].isNotePublic);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].status.text, 'status 0');
   });
 
   test('view double linked learning material details', async function (assert) {
@@ -923,8 +1065,8 @@ module('Acceptance | Course - Learning Materials', function (hooks) {
     });
 
     await page.visit({ courseId: course.id, details: true });
-    assert.strictEqual(page.details.learningMaterials.current.length, 1);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 1);
+    await page.details.learningMaterials.materials.items[0].details();
 
     assert.strictEqual(page.details.learningMaterials.manager.nameValue, 'learning material 0');
     assert.notOk(page.details.learningMaterials.manager.name.isPresent);

--- a/packages/frontend/tests/acceptance/course/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/mesh-test.js
@@ -7,8 +7,8 @@ import page from 'ilios-common/page-objects/course';
 module('Acceptance | Course - Mesh Terms', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    const school = await this.server.create('school');
-    this.user = await setupAuthentication({ administeredSchools: [school] });
+    this.school = await this.server.create('school');
+    this.user = await setupAuthentication({ administeredSchools: [this.school] });
     await this.server.create('academic-year');
     const trees = await this.server.createList('meshTree', 3);
     const concepts = await this.server.createList('meshConcept', 3);
@@ -30,12 +30,17 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
 
     this.course = await this.server.create('course', {
       year: 2014,
-      school,
+      school: this.school,
       meshDescriptors: [descriptor1, descriptor2, descriptors[0]],
     });
   });
 
   test('list mesh', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');
@@ -43,7 +48,17 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
     assert.strictEqual(page.details.meshTerms.current[2].title, 'descriptor 2');
   });
 
+  test('without MeSH UI', async function (assert) {
+    await page.visit({ courseId: this.course.id, details: true });
+    assert.notOk(page.details.meshTerms.isVisible);
+  });
+
   test('manage terms', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     await page.details.meshTerms.manage();
@@ -75,6 +90,11 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
   });
 
   test('save terms', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     await page.details.meshTerms.manage();
@@ -96,6 +116,11 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
   });
 
   test('cancel term changes', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');

--- a/packages/frontend/tests/acceptance/course/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/mesh-test.js
@@ -35,12 +35,14 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
     });
   });
 
-  test('list mesh', async function (assert) {
-    await this.server.create('school-config', {
-      school: this.school,
-      name: 'showMeSH',
-      value: 'true',
-    });
+  test.each('list mesh', [true, false], async function (assert, flagExists) {
+    if (flagExists) {
+      await this.server.create('school-config', {
+        school: this.school,
+        name: 'showMeSH',
+        value: 'true',
+      });
+    }
     await page.visit({ courseId: this.course.id, details: true });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');
@@ -49,6 +51,11 @@ module('Acceptance | Course - Mesh Terms', function (hooks) {
   });
 
   test('without MeSH UI', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'false',
+    });
     await page.visit({ courseId: this.course.id, details: true });
     assert.notOk(page.details.meshTerms.isVisible);
   });

--- a/packages/frontend/tests/acceptance/course/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivelist-test.js
@@ -10,8 +10,12 @@ module('Acceptance | Course - Objective List', function (hooks) {
     this.user = await setupAuthentication({ administeredSchools: [this.school] });
     await this.server.create('academic-year', { id: 2013 });
   });
-
   test('list objectives', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     const competencies = await this.server.createList('competency', 2, {
       school: this.school,
     });
@@ -132,6 +136,114 @@ module('Acceptance | Course - Objective List', function (hooks) {
       );
       assert.ok(page.details.objectives.objectiveList.objectives[i].parents.empty);
       assert.ok(page.details.objectives.objectiveList.objectives[i].meshDescriptors.empty);
+    }
+  });
+
+  test('list objectives without MeSH UI', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'false',
+    });
+    const competencies = await this.server.createList('competency', 2, {
+      school: this.school,
+    });
+    const vocabulary = await this.server.create('vocabulary', {
+      school: this.school,
+    });
+    const programYearObjectiveWithCompetency = await this.server.create('program-year-objective', {
+      competency: competencies[0],
+    });
+    const programYearObjectiveWithoutCompetency =
+      await this.server.create('program-year-objective');
+    const term1 = await this.server.create('term', { vocabulary, active: true });
+    const term2 = await this.server.create('term', { vocabulary });
+    const course = await this.server.create('course', {
+      year: 2013,
+      school: this.school,
+    });
+    await this.server.create('course-objective', {
+      course,
+      programYearObjectives: [programYearObjectiveWithCompetency],
+      terms: [term1],
+    });
+    await this.server.create('course-objective', {
+      course,
+      programYearObjectives: [programYearObjectiveWithoutCompetency],
+      terms: [term2],
+    });
+
+    await this.server.createList('course-objective', 11, { course });
+
+    await page.visit({
+      courseId: course.id,
+      details: true,
+      courseObjectiveDetails: true,
+    });
+    await takeScreenshot(assert);
+    assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 13);
+
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].description.text,
+      'course objective 0',
+    );
+    assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 1);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].parents.list[0].text,
+      'program-year objective 0',
+    );
+    assert.notOk(page.details.objectives.objectiveList.objectives[0].meshDescriptors.isVisible);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].selectedTerms.list.length,
+      1,
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].selectedTerms.list[0].terms.length,
+      1,
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].selectedTerms.list[0].terms[0].name,
+      'term 0',
+    );
+
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].description.text,
+      'course objective 1',
+    );
+    assert.strictEqual(page.details.objectives.objectiveList.objectives[1].parents.list.length, 1);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].parents.list[0].text,
+      'program-year objective 1',
+    );
+    assert.notOk(page.details.objectives.objectiveList.objectives[1].meshDescriptors.isVisible);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].selectedTerms.list.length,
+      1,
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].selectedTerms.list[0].terms.length,
+      1,
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].selectedTerms.list[0].terms[0].name,
+      'term 1 (inactive)',
+    );
+
+    for (let i = 2; i <= 12; i++) {
+      assert.strictEqual(
+        page.details.objectives.objectiveList.objectives[i].description.text,
+        `course objective ${i}`,
+      );
+      assert.ok(page.details.objectives.objectiveList.objectives[i].parents.empty);
+      assert.notOk(page.details.objectives.objectiveList.objectives[i].meshDescriptors.isVisible);
     }
   });
 

--- a/packages/frontend/tests/acceptance/course/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/objectivemesh-test.js
@@ -9,6 +9,11 @@ module('Acceptance | Course - Objective Mesh Descriptors', function (hooks) {
     const school = await this.server.create('school');
     this.user = await setupAuthentication({ administeredSchools: [school] });
     await this.server.create('academic-year', { id: 2013 });
+    await this.server.create('school-config', {
+      school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await this.server.createList('program', 2);
     await this.server.createList('programYear', 2);
     await this.server.createList('cohort', 2);

--- a/packages/frontend/tests/acceptance/course/printcourse-test.js
+++ b/packages/frontend/tests/acceptance/course/printcourse-test.js
@@ -11,11 +11,6 @@ module('Acceptance | Course - Print Course', function (hooks) {
     const program = await this.server.create('program', { school: this.school });
     const programYear = await this.server.create('program-year', { program });
     await this.server.create('academic-year');
-    await this.server.create('school-config', {
-      school: this.school,
-      name: 'showMeSH',
-      value: 'true',
-    });
     const cohort = await this.server.create('cohort', { programYear });
     const userRole = (this.learningMaterialUserRole = await this.server.create(
       'learning-material-user-role',
@@ -92,8 +87,18 @@ module('Acceptance | Course - Print Course', function (hooks) {
   });
 
   test('print course mesh terms', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await visit('/course/1/print');
     assert.dom('[data-test-course-mesh] ul li').hasText('Flux Capacitor');
+  });
+
+  test('print course without MeSH UI', async function (assert) {
+    await visit('/course/1/print');
+    assert.dom('[data-test-course-mesh]').doesNotExist();
   });
 
   test('print course learning materials', async function (assert) {
@@ -171,6 +176,11 @@ module('Acceptance | Course - Print Course', function (hooks) {
   });
 
   test('test print session objectives', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     const session = await this.server.create('session', {
       course: this.course,
       published: true,
@@ -219,6 +229,11 @@ module('Acceptance | Course - Print Course', function (hooks) {
   });
 
   test('test print course objectives', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     const competency = await this.server.create('competency', {
       school: this.school,
       title: 'Competency 1',

--- a/packages/frontend/tests/acceptance/course/printcourse-test.js
+++ b/packages/frontend/tests/acceptance/course/printcourse-test.js
@@ -11,6 +11,11 @@ module('Acceptance | Course - Print Course', function (hooks) {
     const program = await this.server.create('program', { school: this.school });
     const programYear = await this.server.create('program-year', { program });
     await this.server.create('academic-year');
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     const cohort = await this.server.create('cohort', { programYear });
     const userRole = (this.learningMaterialUserRole = await this.server.create(
       'learning-material-user-role',

--- a/packages/frontend/tests/acceptance/course/printcourse-test.js
+++ b/packages/frontend/tests/acceptance/course/printcourse-test.js
@@ -86,17 +86,24 @@ module('Acceptance | Course - Print Course', function (hooks) {
     assert.verifySteps(['API called']);
   });
 
-  test('print course mesh terms', async function (assert) {
-    await this.server.create('school-config', {
-      school: this.school,
-      name: 'showMeSH',
-      value: 'true',
-    });
+  test.each('print course mesh terms', [true, false], async function (assert, flagExists) {
+    if (flagExists) {
+      await this.server.create('school-config', {
+        school: this.school,
+        name: 'showMeSH',
+        value: 'true',
+      });
+    }
     await visit('/course/1/print');
     assert.dom('[data-test-course-mesh] ul li').hasText('Flux Capacitor');
   });
 
   test('print course without MeSH UI', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'false',
+    });
     await visit('/course/1/print');
     assert.dom('[data-test-course-mesh]').doesNotExist();
   });

--- a/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
@@ -12,8 +12,11 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   hooks.beforeEach(async function () {
     this.intl = this.owner.lookup('service:intl');
-    const school = await this.server.create('school');
-    this.user = await setupAuthentication({ school, administeredSchools: [school] });
+    this.school = await this.server.create('school');
+    this.user = await setupAuthentication({
+      school: this.school,
+      administeredSchools: [this.school],
+    });
     this.user2 = await this.server.create('user', { displayName: 'Clem Chowder' });
     await this.server.create('academic-year');
 
@@ -75,10 +78,10 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
     this.course = await this.server.create('course', {
       year: 2013,
-      school,
+      school: this.school,
     });
 
-    this.sessionType = await this.server.create('session-type', { school });
+    this.sessionType = await this.server.create('session-type', { school: this.school });
     this.session = await this.server.create('session', {
       course: this.course,
       sessionType: this.sessionType,
@@ -112,72 +115,163 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('list learning materials', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
     await takeScreenshot(assert);
     assert.strictEqual(currentRouteName(), 'session.index');
 
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
 
-    assert.strictEqual(page.details.learningMaterials.current[0].title, 'learning material 0');
     assert.strictEqual(
-      page.details.learningMaterials.current[0].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[0].title,
+      'learning material 0',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.notOk(page.details.learningMaterials.current[0].userNameInfo.hasAdditionalInfo);
-    assert.strictEqual(page.details.learningMaterials.current[0].required, 'No');
-    assert.strictEqual(page.details.learningMaterials.current[0].notes, 'No');
-    assert.notOk(page.details.learningMaterials.current[0].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[0].mesh, 'descriptor 1 descriptor 2');
-    assert.strictEqual(page.details.learningMaterials.current[0].status, 'status 0');
+    assert.notOk(page.details.learningMaterials.materials.items[0].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[0].isNotePublic);
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].mesh.text,
+      'descriptor 1 descriptor 2',
+    );
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].status.text, 'status 0');
 
     assert.strictEqual(
-      page.details.learningMaterials.current[1].title,
+      page.details.learningMaterials.materials.items[1].title,
       'http://example.com/subdir1/subdir2/long_file_name.pdf',
     );
     assert.strictEqual(
-      page.details.learningMaterials.current[1].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[1].userNameInfo.fullName,
       'Clem Chowder',
     );
-    assert.ok(page.details.learningMaterials.current[1].userNameInfo.hasAdditionalInfo);
-    assert.notOk(page.details.learningMaterials.current[1].userNameInfo.isTooltipVisible);
-    await page.details.learningMaterials.current[1].userNameInfo.expandTooltip();
+    assert.ok(page.details.learningMaterials.materials.items[1].userNameInfo.hasAdditionalInfo);
+    assert.notOk(page.details.learningMaterials.materials.items[1].userNameInfo.isTooltipVisible);
+    await page.details.learningMaterials.materials.items[1].userNameInfo.expandTooltip();
     assert.strictEqual(
-      page.details.learningMaterials.current[1].userNameInfo.tooltipContents,
+      page.details.learningMaterials.materials.items[1].userNameInfo.tooltipContents,
       'Campus name of record: 1 guy M, Mc1son',
     );
-    await page.details.learningMaterials.current[1].userNameInfo.closeTooltip();
-    assert.notOk(page.details.learningMaterials.current[1].userNameInfo.isTooltipVisible);
-    assert.strictEqual(page.details.learningMaterials.current[1].required, 'No');
-    assert.strictEqual(page.details.learningMaterials.current[1].notes, 'No');
-    assert.notOk(page.details.learningMaterials.current[1].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[1].mesh, 'None');
-    assert.strictEqual(page.details.learningMaterials.current[1].status, 'status 0');
-    assert.strictEqual(page.details.learningMaterials.current[1].status, 'status 0');
+    await page.details.learningMaterials.materials.items[1].userNameInfo.closeTooltip();
+    assert.notOk(page.details.learningMaterials.materials.items[1].userNameInfo.isTooltipVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[1].isNotePublic);
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].mesh.text, 'None');
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].status.text, 'status 0');
 
-    assert.strictEqual(page.details.learningMaterials.current[2].title, 'learning material 2');
     assert.strictEqual(
-      page.details.learningMaterials.current[2].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[2].title,
+      'learning material 2',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[2].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.notOk(page.details.learningMaterials.current[2].userNameInfo.hasAdditionalInfo);
-    assert.strictEqual(page.details.learningMaterials.current[2].required, 'Yes');
-    assert.strictEqual(page.details.learningMaterials.current[2].notes, 'No');
-    assert.notOk(page.details.learningMaterials.current[2].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[2].mesh, 'None');
-    assert.strictEqual(page.details.learningMaterials.current[2].status, 'status 0');
-    assert.strictEqual(page.details.learningMaterials.current[2].status, 'status 0');
+    assert.notOk(page.details.learningMaterials.materials.items[2].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].required.text, 'Yes');
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[2].isNotePublic);
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].mesh.text, 'None');
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].status.text, 'status 0');
 
-    assert.strictEqual(page.details.learningMaterials.current[3].title, 'learning material 3');
     assert.strictEqual(
-      page.details.learningMaterials.current[3].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[3].title,
+      'learning material 3',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[3].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.notOk(page.details.learningMaterials.current[3].userNameInfo.hasAdditionalInfo);
-    assert.strictEqual(page.details.learningMaterials.current[3].required, 'Yes');
-    assert.strictEqual(page.details.learningMaterials.current[3].notes, 'Yes');
-    assert.ok(page.details.learningMaterials.current[3].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[3].mesh, 'None');
-    assert.strictEqual(page.details.learningMaterials.current[3].status, 'status 0');
+    assert.notOk(page.details.learningMaterials.materials.items[3].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].required.text, 'Yes');
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].notes.text, 'Yes');
+    assert.ok(page.details.learningMaterials.materials.items[3].isNotePublic);
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].mesh.text, 'None');
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].status.text, 'status 0');
+  });
+
+  test('list learning materials without MeSH UI', async function (assert) {
+    await page.visit({ courseId: this.course.id, sessionId: this.session.id });
+    await takeScreenshot(assert);
+    assert.strictEqual(currentRouteName(), 'session.index');
+
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].title,
+      'learning material 0',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].userNameInfo.fullName,
+      '0 guy M. Mc0son',
+    );
+    assert.notOk(page.details.learningMaterials.materials.items[0].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[0].isNotePublic);
+    assert.notOk(page.details.learningMaterials.materials.items[0].mesh.isVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].status.text, 'status 0');
+
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[1].title,
+      'http://example.com/subdir1/subdir2/long_file_name.pdf',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[1].userNameInfo.fullName,
+      'Clem Chowder',
+    );
+    assert.ok(page.details.learningMaterials.materials.items[1].userNameInfo.hasAdditionalInfo);
+    assert.notOk(page.details.learningMaterials.materials.items[1].userNameInfo.isTooltipVisible);
+    await page.details.learningMaterials.materials.items[1].userNameInfo.expandTooltip();
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[1].userNameInfo.tooltipContents,
+      'Campus name of record: 1 guy M, Mc1son',
+    );
+    await page.details.learningMaterials.materials.items[1].userNameInfo.closeTooltip();
+    assert.notOk(page.details.learningMaterials.materials.items[1].userNameInfo.isTooltipVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[1].isNotePublic);
+    assert.notOk(page.details.learningMaterials.materials.items[1].mesh.isVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[1].status.text, 'status 0');
+
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[2].title,
+      'learning material 2',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[2].userNameInfo.fullName,
+      '0 guy M. Mc0son',
+    );
+    assert.notOk(page.details.learningMaterials.materials.items[2].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].required.text, 'Yes');
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[2].isNotePublic);
+    assert.notOk(page.details.learningMaterials.materials.items[2].mesh.isVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].status.text, 'status 0');
+
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[3].title,
+      'learning material 3',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[3].userNameInfo.fullName,
+      '0 guy M. Mc0son',
+    );
+    assert.notOk(page.details.learningMaterials.materials.items[3].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].required.text, 'Yes');
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].notes.text, 'Yes');
+    assert.ok(page.details.learningMaterials.materials.items[3].isNotePublic);
+    assert.notOk(page.details.learningMaterials.materials.items[3].mesh.isVisible);
+    assert.strictEqual(page.details.learningMaterials.materials.items[3].status.text, 'status 0');
   });
 
   test('create new link learning material', async function (assert) {
@@ -189,7 +283,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     let lms = await this.server.db.learningMaterial.all();
     assert.strictEqual(lms.length, 5);
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
     assert.ok(page.details.learningMaterials.search.isVisible);
     await page.details.learningMaterials.createNew();
     await page.details.learningMaterials.pickNew('Web Link');
@@ -213,8 +307,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     lms = await this.server.db.learningMaterial.all();
     assert.strictEqual(lms.length, 6);
     assert.strictEqual(lms[5].link, testUrl);
-    assert.strictEqual(page.details.learningMaterials.current.length, 5);
-    assert.strictEqual(page.details.learningMaterials.current[4].title, testTitle);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 5);
+    assert.strictEqual(page.details.learningMaterials.materials.items[4].title, testTitle);
   });
 
   test('create new citation learning material', async function (assert) {
@@ -226,7 +320,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     let lms = await this.server.db.learningMaterial.all();
     assert.strictEqual(lms.length, 5);
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
     assert.ok(page.details.learningMaterials.search.isVisible);
     await page.details.learningMaterials.createNew();
     await page.details.learningMaterials.pickNew('Citation');
@@ -250,13 +344,13 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     lms = await this.server.db.learningMaterial.all();
     assert.strictEqual(lms.length, 6);
     assert.strictEqual(lms[5].citation, testCitation);
-    assert.strictEqual(page.details.learningMaterials.current.length, 5);
-    assert.strictEqual(page.details.learningMaterials.current[4].title, testTitle);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 5);
+    assert.strictEqual(page.details.learningMaterials.materials.items[4].title, testTitle);
   });
 
   test('can only add one learning-material at a time', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
     assert.ok(page.details.learningMaterials.canCreateNew);
     assert.notOk(page.details.learningMaterials.canCollapse);
     await page.details.learningMaterials.createNew();
@@ -267,19 +361,19 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   test('cancel new learning material', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
     assert.ok(page.details.learningMaterials.search.isVisible);
     await page.details.learningMaterials.createNew();
     await page.details.learningMaterials.pickNew('Citation');
     await page.details.learningMaterials.newLearningMaterial.cancel();
 
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
   });
 
   test('view copyright file learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(page.details.learningMaterials.manager.name.value, 'learning material 0');
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Jennifer Johnson');
     assert.strictEqual(
@@ -296,8 +390,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   test('view rationale file learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[1].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[1].details();
 
     assert.strictEqual(
       page.details.learningMaterials.manager.name.value,
@@ -318,8 +412,12 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   test('view accessibility file learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items.length,
+      4,
+      'course lm count correct',
+    );
+    await page.details.learningMaterials.materials.items[0].details();
 
     assert.strictEqual(
       page.details.learningMaterials.manager.name.value,
@@ -354,7 +452,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     assert.notOk(page.details.learningMaterials.manager.hasCitation, 'lm does not have citation');
 
     await page.details.learningMaterials.manager.cancel();
-    await page.details.learningMaterials.current[1].details();
+    await page.details.learningMaterials.materials.items[1].details();
 
     assert.strictEqual(
       page.details.learningMaterials.manager.name.value,
@@ -390,8 +488,12 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   test('toggling accessibility file learning material', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4, 'course lm count correct');
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items.length,
+      4,
+      'course lm count correct',
+    );
+    await page.details.learningMaterials.materials.items[0].details();
 
     assert.ok(
       page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
@@ -409,7 +511,7 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     await page.details.learningMaterials.manager.markedAccessibleToggle();
     await page.details.learningMaterials.manager.save();
 
-    await page.details.learningMaterials.current[0].details();
+    await page.details.learningMaterials.materials.items[0].details();
 
     assert.ok(
       page.details.learningMaterials.manager.hasMarkedAccessibleToggle,
@@ -427,8 +529,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   test('view url file learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[1].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[1].details();
 
     assert.strictEqual(
       page.details.learningMaterials.manager.name.value,
@@ -452,8 +554,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   test('view link learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[2].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[2].details();
 
     assert.strictEqual(page.details.learningMaterials.manager.name.value, 'learning material 2');
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Hunter Pence');
@@ -480,8 +582,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   test('view citation learning material details', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[3].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[3].details();
 
     assert.strictEqual(page.details.learningMaterials.manager.name.value, 'learning material 3');
     assert.strictEqual(page.details.learningMaterials.manager.author, 'Willie Mays');
@@ -504,8 +606,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     const newDescription = 'high altitude training';
 
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     await page.details.learningMaterials.manager.required();
     await page.details.learningMaterials.manager.publicNotes();
     await page.details.learningMaterials.manager.status(3);
@@ -514,17 +616,20 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
     await page.details.learningMaterials.manager.save();
 
-    assert.strictEqual(page.details.learningMaterials.current[0].title, 'learning material 0');
     assert.strictEqual(
-      page.details.learningMaterials.current[0].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[0].title,
+      'learning material 0',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.strictEqual(page.details.learningMaterials.current[0].required, 'Yes');
-    assert.notOk(page.details.learningMaterials.current[0].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[0].notes, 'Yes');
-    assert.strictEqual(page.details.learningMaterials.current[0].status, 'status 2');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].required.text, 'Yes');
+    assert.notOk(page.details.learningMaterials.materials.items[0].isNotePublic);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].notes.text, 'Yes');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].status.text, 'status 2');
 
-    await page.details.learningMaterials.current[0].details();
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(
       await page.details.learningMaterials.manager.notes.value(),
       `<p>${newNote}</p>`,
@@ -539,23 +644,31 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   test('change from required to not required #1249', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[2].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[2].details();
     await page.details.learningMaterials.manager.required();
 
     await page.details.learningMaterials.manager.save();
 
-    assert.strictEqual(page.details.learningMaterials.current[2].title, 'learning material 2');
-    assert.strictEqual(page.details.learningMaterials.current[2].required, 'No');
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[2].title,
+      'learning material 2',
+    );
+    assert.strictEqual(page.details.learningMaterials.materials.items[2].required.text, 'No');
   });
 
   test('cancel editing learning material', async function (assert) {
     const newNote = 'text text. Woo hoo!';
     const newDescription = 'the sun is shining.';
 
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     await page.details.learningMaterials.manager.required();
     await page.details.learningMaterials.manager.publicNotes();
     await page.details.learningMaterials.manager.status(3);
@@ -564,18 +677,24 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
     await page.details.learningMaterials.manager.cancel();
 
-    assert.strictEqual(page.details.learningMaterials.current[0].title, 'learning material 0');
     assert.strictEqual(
-      page.details.learningMaterials.current[0].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[0].title,
+      'learning material 0',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.strictEqual(page.details.learningMaterials.current[0].required, 'No');
-    assert.strictEqual(page.details.learningMaterials.current[0].notes, 'No');
-    assert.notOk(page.details.learningMaterials.current[0].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[0].mesh, 'descriptor 1 descriptor 2');
-    assert.strictEqual(page.details.learningMaterials.current[0].status, 'status 0');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[0].isNotePublic);
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].mesh.text,
+      'descriptor 1 descriptor 2',
+    );
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].status.text, 'status 0');
 
-    await page.details.learningMaterials.current[0].details();
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(await page.details.learningMaterials.manager.notes.value(), '');
     assert.strictEqual(page.details.learningMaterials.manager.statusValue, '1');
     assert.strictEqual(
@@ -584,10 +703,15 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     );
   });
 
-  test('manage terms', async function (assert) {
+  test('manage MeSH terms', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(page.details.learningMaterials.manager.meshManager.selectedTerms.length, 2);
     assert.strictEqual(
       page.details.learningMaterials.manager.meshManager.selectedTerms[0].title,
@@ -628,10 +752,15 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     );
   });
 
-  test('save terms', async function (assert) {
+  test('save MeSH terms', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(page.details.learningMaterials.manager.meshManager.selectedTerms.length, 2);
     await page.details.learningMaterials.manager.meshManager.selectedTerms[0].remove();
     await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
@@ -647,13 +776,21 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     );
 
     await page.details.learningMaterials.manager.save();
-    assert.strictEqual(page.details.learningMaterials.current[0].mesh, 'descriptor 0 descriptor 2');
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].mesh.text,
+      'descriptor 0 descriptor 2',
+    );
   });
 
-  test('cancel term changes', async function (assert) {
+  test('cancel MeSH term changes', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(page.details.learningMaterials.manager.meshManager.selectedTerms.length, 2);
     await page.details.learningMaterials.manager.meshManager.selectedTerms[0].remove();
     await page.details.learningMaterials.manager.meshManager.search.set('descriptor');
@@ -669,12 +806,15 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     );
 
     await page.details.learningMaterials.manager.cancel();
-    assert.strictEqual(page.details.learningMaterials.current[0].mesh, 'descriptor 1 descriptor 2');
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].mesh.text,
+      'descriptor 1 descriptor 2',
+    );
   });
 
   test('find and add learning material', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
     await page.details.learningMaterials.search.search.set('doc');
     assert.strictEqual(page.details.learningMaterials.search.searchResults.length, 1);
 
@@ -697,13 +837,13 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       'Upload date: 03/03/2016',
     );
     await page.details.learningMaterials.search.searchResults[0].add();
-    assert.strictEqual(page.details.learningMaterials.current.length, 5);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 5);
   });
 
   test('add timed release start date', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     await page.details.learningMaterials.manager.addStartDate();
 
     const newDate = DateTime.fromObject({ hour: 10, minute: 10 }).plus({ days: 1, month: 1 });
@@ -712,8 +852,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     await page.details.learningMaterials.manager.startTime.timePicker.minute.select('10');
     await page.details.learningMaterials.manager.startTime.timePicker.ampm.select('AM');
     await page.details.learningMaterials.manager.save();
-    assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.ok(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     const formattedNewDate = this.intl.formatDate(newDate.toJSDate(), {
       month: '2-digit',
       day: '2-digit',
@@ -735,8 +875,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     const newEndDate = newStartDate.plus({ minutes: 1 });
 
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     await page.details.learningMaterials.manager.addStartDate();
 
     await page.details.learningMaterials.manager.startDate.datePicker.set(newStartDate.toJSDate());
@@ -751,8 +891,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     await page.details.learningMaterials.manager.endTime.timePicker.ampm.select('AM');
 
     await page.details.learningMaterials.manager.save();
-    assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.ok(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     const formattedStartDate = this.intl.formatDate(newStartDate.toJSDate(), {
       month: '2-digit',
       day: '2-digit',
@@ -775,8 +915,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   test('add timed release end date', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     await page.details.learningMaterials.manager.addEndDate();
 
     const newDate = DateTime.fromObject({ hour: 10, minute: 10 }).plus({ days: 1, month: 1 });
@@ -785,8 +925,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     await page.details.learningMaterials.manager.endTime.timePicker.minute.select('10');
     await page.details.learningMaterials.manager.endTime.timePicker.ampm.select('AM');
     await page.details.learningMaterials.manager.save();
-    assert.ok(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.ok(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     const formattedNewDate = this.intl.formatDate(newDate.toJSDate(), {
       month: '2-digit',
       day: '2-digit',
@@ -804,8 +944,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     const newDate = DateTime.fromObject({ hour: 10, minute: 10 }).plus({ days: 1, month: 1 });
 
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.notOk(page.details.learningMaterials.manager.hasEndDateValidationError);
     await page.details.learningMaterials.manager.addStartDate();
 
@@ -839,23 +979,23 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     const newTitle = 'text text. Woo hoo!';
 
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 4);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 4);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.ok(page.details.learningMaterials.manager.name.isPresent);
     await page.details.learningMaterials.manager.name.fillIn(newTitle);
 
     await page.details.learningMaterials.manager.save();
 
-    assert.strictEqual(page.details.learningMaterials.current[0].title, newTitle);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].title, newTitle);
 
-    await page.details.learningMaterials.current[0].details();
+    await page.details.learningMaterials.materials.items[0].details();
     assert.strictEqual(page.details.learningMaterials.manager.name.value, newTitle);
   });
 
   test('title too short', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.notOk(page.details.learningMaterials.manager.hasTitleValidationError);
     await page.details.learningMaterials.manager.name.fillIn('a');
     await page.details.learningMaterials.manager.save();
@@ -864,8 +1004,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
 
   test('title too long', async function (assert) {
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
-    assert.notOk(page.details.learningMaterials.current[0].isTimedRelease);
-    await page.details.learningMaterials.current[0].details();
+    assert.notOk(page.details.learningMaterials.materials.items[0].isTimedRelease);
+    await page.details.learningMaterials.materials.items[0].details();
     assert.notOk(page.details.learningMaterials.manager.hasTitleValidationError);
     await page.details.learningMaterials.manager.name.fillIn('0123456789'.repeat(13));
     await page.details.learningMaterials.manager.save();
@@ -915,18 +1055,21 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     await page.visit({ courseId: this.course.id, sessionId: session.id });
     assert.strictEqual(currentRouteName(), 'session.index');
 
-    assert.strictEqual(page.details.learningMaterials.current.length, 1);
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 1);
 
-    assert.strictEqual(page.details.learningMaterials.current[0].title, 'learning material 0');
     assert.strictEqual(
-      page.details.learningMaterials.current[0].userNameInfo.fullName,
+      page.details.learningMaterials.materials.items[0].title,
+      'learning material 0',
+    );
+    assert.strictEqual(
+      page.details.learningMaterials.materials.items[0].userNameInfo.fullName,
       '0 guy M. Mc0son',
     );
-    assert.notOk(page.details.learningMaterials.current[0].userNameInfo.hasAdditionalInfo);
-    assert.strictEqual(page.details.learningMaterials.current[0].required, 'No');
-    assert.strictEqual(page.details.learningMaterials.current[0].notes, 'No');
-    assert.notOk(page.details.learningMaterials.current[0].isNotePublic);
-    assert.strictEqual(page.details.learningMaterials.current[0].status, 'status 0');
+    assert.notOk(page.details.learningMaterials.materials.items[0].userNameInfo.hasAdditionalInfo);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].required.text, 'No');
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].notes.text, 'No');
+    assert.notOk(page.details.learningMaterials.materials.items[0].isNotePublic);
+    assert.strictEqual(page.details.learningMaterials.materials.items[0].status.text, 'status 0');
   });
 
   test('view double linked learning material details', async function (assert) {
@@ -941,8 +1084,8 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
       position: 0,
     });
     await page.visit({ courseId: this.course.id, sessionId: session.id });
-    assert.strictEqual(page.details.learningMaterials.current.length, 1);
-    await page.details.learningMaterials.current[0].details();
+    assert.strictEqual(page.details.learningMaterials.materials.items.length, 1);
+    await page.details.learningMaterials.materials.items[0].details();
 
     assert.strictEqual(page.details.learningMaterials.manager.nameValue, 'learning material 0');
     assert.notOk(page.details.learningMaterials.manager.name.isPresent);

--- a/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
+++ b/packages/frontend/tests/acceptance/course/session/learningmaterials-test.js
@@ -114,12 +114,14 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
     });
   });
 
-  test('list learning materials', async function (assert) {
-    await this.server.create('school-config', {
-      school: this.school,
-      name: 'showMeSH',
-      value: 'true',
-    });
+  test.each('list learning materials', [true, false], async function (assert, flagExists) {
+    if (flagExists) {
+      await this.server.create('school-config', {
+        school: this.school,
+        name: 'showMeSH',
+        value: 'true',
+      });
+    }
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
     await takeScreenshot(assert);
     assert.strictEqual(currentRouteName(), 'session.index');
@@ -199,6 +201,11 @@ module('Acceptance | Session - Learning Materials', function (hooks) {
   });
 
   test('list learning materials without MeSH UI', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'false',
+    });
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
     await takeScreenshot(assert);
     assert.strictEqual(currentRouteName(), 'session.index');

--- a/packages/frontend/tests/acceptance/course/session/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/mesh-test.js
@@ -7,8 +7,11 @@ import page from 'ilios-common/page-objects/session';
 module('Acceptance | Session - Mesh Terms', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(async function () {
-    const school = await this.server.create('school');
-    this.user = await setupAuthentication({ school, administeredSchools: [school] });
+    this.school = await this.server.create('school');
+    this.user = await setupAuthentication({
+      school: this.school,
+      administeredSchools: [this.school],
+    });
     await this.server.create('academic-year');
     const trees = await this.server.createList('meshTree', 3);
     const concepts = await this.server.createList('meshConcept', 3);
@@ -27,9 +30,9 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
 
     this.course = await this.server.create('course', {
       year: 2014,
-      school,
+      school: this.school,
     });
-    const sessionType = await this.server.create('session-type', { school });
+    const sessionType = await this.server.create('session-type', { school: this.school });
     this.session = await this.server.create('session', {
       course: this.course,
       meshDescriptors: [descriptor1, descriptor2, descriptors[0]],
@@ -38,6 +41,11 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
   });
 
   test('list mesh', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');
@@ -45,7 +53,17 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
     assert.strictEqual(page.details.meshTerms.current[2].title, 'descriptor 2');
   });
 
+  test('without MeSH UI', async function (assert) {
+    await page.visit({ courseId: this.course.id, sessionId: this.session.id });
+    assert.notOk(page.details.meshTerms.isVisible);
+  });
+
   test('manage terms', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     await page.details.meshTerms.manage();
@@ -77,6 +95,11 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
   });
 
   test('save terms', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     await page.details.meshTerms.manage();
@@ -98,6 +121,11 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
   });
 
   test('cancel term changes', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');

--- a/packages/frontend/tests/acceptance/course/session/mesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/mesh-test.js
@@ -40,12 +40,14 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
     });
   });
 
-  test('list mesh', async function (assert) {
-    await this.server.create('school-config', {
-      school: this.school,
-      name: 'showMeSH',
-      value: 'true',
-    });
+  test.each('list mesh', [true, false], async function (assert, flagExists) {
+    if (flagExists) {
+      await this.server.create('school-config', {
+        school: this.school,
+        name: 'showMeSH',
+        value: 'true',
+      });
+    }
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
     assert.strictEqual(page.details.meshTerms.current.length, 3);
     assert.strictEqual(page.details.meshTerms.current[0].title, 'descriptor 0');
@@ -54,6 +56,11 @@ module('Acceptance | Session - Mesh Terms', function (hooks) {
   });
 
   test('without MeSH UI', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'false',
+    });
     await page.visit({ courseId: this.course.id, sessionId: this.session.id });
     assert.notOk(page.details.meshTerms.isVisible);
   });

--- a/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivelist-test.js
@@ -21,6 +21,11 @@ module('Acceptance | Session - Objective List', function (hooks) {
   });
 
   test('list objectives', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     const course = await this.server.create('course', {
       year: 2013,
       school: this.school,
@@ -133,6 +138,106 @@ module('Acceptance | Session - Objective List', function (hooks) {
       );
       assert.ok(page.details.objectives.objectiveList.objectives[i].parents.empty);
       assert.ok(page.details.objectives.objectiveList.objectives[i].meshDescriptors.empty);
+    }
+  });
+
+  test('list objectives without MeSH UI', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'false',
+    });
+    const course = await this.server.create('course', {
+      year: 2013,
+      school: this.school,
+    });
+    const session = await this.server.create('session', { course, sessionType: this.sessionType });
+    const vocabulary = await this.server.create('vocabulary', {
+      school: this.school,
+    });
+    const courseObjectives = await this.server.createList('course-objective', 2);
+    const term1 = await this.server.create('term', { vocabulary, active: true });
+    const term2 = await this.server.create('term', { vocabulary });
+    await this.server.create('session-objective', {
+      session,
+      courseObjectives: [courseObjectives.shift()],
+      terms: [term1],
+    });
+    await this.server.create('session-objective', {
+      session,
+      courseObjectives,
+      terms: [term2],
+    });
+    await this.server.createList('session-objective', 11, { session });
+    await page.visit({
+      courseId: 1,
+      sessionId: 1,
+      sessionObjectiveDetails: true,
+    });
+    await takeScreenshot(assert);
+    assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 13);
+
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].description.text,
+      'session objective 0',
+    );
+    assert.strictEqual(page.details.objectives.objectiveList.objectives[0].parents.list.length, 1);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].parents.list[0].text,
+      'course objective 0',
+    );
+    assert.notOk(page.details.objectives.objectiveList.objectives[0].meshDescriptors.isVisible);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].selectedTerms.list.length,
+      1,
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].selectedTerms.list[0].terms.length,
+      1,
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].selectedTerms.list[0].terms[0].name,
+      'term 0',
+    );
+
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].description.text,
+      'session objective 1',
+    );
+    assert.strictEqual(page.details.objectives.objectiveList.objectives[1].parents.list.length, 1);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].parents.list[0].text,
+      'course objective 1',
+    );
+    assert.notOk(page.details.objectives.objectiveList.objectives[1].meshDescriptors.isVisible);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].selectedTerms.list.length,
+      1,
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].selectedTerms.list[0].terms.length,
+      1,
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].selectedTerms.list[0].terms[0].name,
+      'term 1 (inactive)',
+    );
+
+    for (let i = 2; i <= 12; i++) {
+      assert.strictEqual(
+        page.details.objectives.objectiveList.objectives[i].description.text,
+        `session objective ${i}`,
+      );
+      assert.ok(page.details.objectives.objectiveList.objectives[i].parents.empty);
+      assert.notOk(page.details.objectives.objectiveList.objectives[i].meshDescriptors.isVisible);
     }
   });
 

--- a/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
+++ b/packages/frontend/tests/acceptance/course/session/objectivemesh-test.js
@@ -9,6 +9,11 @@ module('Acceptance | Session - Objective Mesh Descriptors', function (hooks) {
     const school = await this.server.create('school');
     this.user = await setupAuthentication({ administeredSchools: [school] });
     await this.server.create('academic-year', { id: 2013 });
+    await this.server.create('school-config', {
+      school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await this.server.createList('program', 2);
     await this.server.createList('programYear', 2);
     await this.server.createList('cohort', 2);

--- a/packages/frontend/tests/acceptance/program-year/objectives-test.js
+++ b/packages/frontend/tests/acceptance/program-year/objectives-test.js
@@ -63,9 +63,15 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
       course,
       programYearObjectives: [programYearObjective],
     });
+    this.school = school;
   });
 
   test('list editable', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     await takeScreenshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
@@ -143,6 +149,11 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('list not editable', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     await takeScreenshot(assert);
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
@@ -194,7 +205,128 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     assert.ok(page.details.objectives.objectiveList.objectives[2].meshDescriptors.isEmpty);
   });
 
+  test('list editable without MeSH UI', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'false',
+    });
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    await takeScreenshot(assert);
+    assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].description.text,
+      'program-year objective 0',
+    );
+    assert.ok(page.details.objectives.objectiveList.objectives[0].competency.hasCompetency);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].competency.competencyTitle,
+      'competency 1',
+    );
+    assert.ok(page.details.objectives.objectiveList.objectives[0].competency.hasDomain);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].competency.domainTitle,
+      '(competency 0)',
+    );
+    assert.notOk(page.details.objectives.objectiveList.objectives[0].meshDescriptors.isVisible);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].selectedTerms.list.length,
+      1,
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].selectedTerms.list[0].terms[0].name,
+      'term 0',
+    );
+
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].description.text,
+      'program-year objective 1',
+    );
+    assert.ok(page.details.objectives.objectiveList.objectives[1].competency.hasCompetency);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].competency.competencyTitle,
+      'competency 3',
+    );
+    assert.notOk(page.details.objectives.objectiveList.objectives[1].competency.hasDomain);
+    assert.notOk(page.details.objectives.objectiveList.objectives[1].meshDescriptors.isVisible);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].selectedTerms.list.length,
+      1,
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].selectedTerms.list[0].terms[0].name,
+      'term 1 (inactive)',
+    );
+
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[2].description.text,
+      'program-year objective 2',
+    );
+    assert.notOk(page.details.objectives.objectiveList.objectives[2].competency.hasCompetency);
+    assert.notOk(page.details.objectives.objectiveList.objectives[2].competency.hasDomain);
+    assert.notOk(page.details.objectives.objectiveList.objectives[2].meshDescriptors.isVisible);
+    assert.notOk(page.details.objectives.objectiveList.objectives[2].selectedTerms.list.isPresent);
+  });
+
+  test('list not editable without MeSH UI', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'false',
+    });
+    await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
+    await takeScreenshot(assert);
+    assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].description.text,
+      'program-year objective 0',
+    );
+    assert.ok(page.details.objectives.objectiveList.objectives[0].competency.hasCompetency);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].competency.competencyTitle,
+      'competency 1',
+    );
+    assert.ok(page.details.objectives.objectiveList.objectives[0].competency.hasDomain);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[0].competency.domainTitle,
+      '(competency 0)',
+    );
+    assert.notOk(page.details.objectives.objectiveList.objectives[0].meshDescriptors.isVisible);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].description.text,
+      'program-year objective 1',
+    );
+    assert.ok(page.details.objectives.objectiveList.objectives[1].competency.hasCompetency);
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[1].competency.competencyTitle,
+      'competency 3',
+    );
+    assert.notOk(page.details.objectives.objectiveList.objectives[1].competency.hasDomain);
+    assert.notOk(page.details.objectives.objectiveList.objectives[1].meshDescriptors.isVisible);
+
+    assert.strictEqual(
+      page.details.objectives.objectiveList.objectives[2].description.text,
+      'program-year objective 2',
+    );
+    assert.notOk(page.details.objectives.objectiveList.objectives[2].competency.hasCompetency);
+    assert.notOk(page.details.objectives.objectiveList.objectives[2].competency.hasDomain);
+    assert.notOk(page.details.objectives.objectiveList.objectives[2].meshDescriptors.isVisible);
+  });
+
   test('manage MeSH terms', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
@@ -244,6 +376,11 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
   });
 
   test('save MeSH terms', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 
@@ -284,7 +421,12 @@ module('Acceptance | Program Year - Objectives', function (hooks) {
     );
   });
 
-  test('cancel changes', async function (assert) {
+  test('cancel MeSH changes', async function (assert) {
+    await this.server.create('school-config', {
+      school: this.school,
+      name: 'showMeSH',
+      value: 'true',
+    });
     await page.visit({ programId: 1, programYearId: 1, pyObjectiveDetails: true });
     assert.strictEqual(page.details.objectives.objectiveList.objectives.length, 3);
 

--- a/packages/frontend/tests/integration/components/program-year/collapsed-objectives-test.gjs
+++ b/packages/frontend/tests/integration/components/program-year/collapsed-objectives-test.gjs
@@ -40,18 +40,57 @@ module('Integration | Component | program-year/collapsed-objectives', function (
     this.set('programYear', programYearModel);
     await render(
       <template>
-        <CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
+        <CollapsedObjectives
+          @programYear={{this.programYear}}
+          @expand={{(noop)}}
+          @showMeSH={{true}}
+        />
       </template>,
     );
 
     assert.strictEqual(component.title, 'Objectives (4)');
     assert.ok(component.hasExpandIcon);
-    assert.strictEqual(component.objectiveCount, 'There are 4 objectives');
-    assert.strictEqual(component.parentCount, '1 has a linked competency');
-    assert.strictEqual(component.meshCount, '1 has MeSH');
-    assert.strictEqual(component.termCount, '1 has vocabulary terms');
+    assert.strictEqual(component.objectiveCount.text, 'There are 4 objectives');
+    assert.strictEqual(component.parentCount.text, '1 has a linked competency');
+    assert.strictEqual(component.meshCount.text, '1 has MeSH');
+    assert.strictEqual(component.termCount.text, '1 has vocabulary terms');
     assert.ok(component.parentStatus.partial);
     assert.ok(component.meshStatus.partial);
+    assert.ok(component.termStatus.partial);
+  });
+
+  test('displays summary data without MeSH UI', async function (assert) {
+    const programYear = await this.server.create('program-year', {
+      programYearObjectives: [
+        this.objective,
+        this.objectiveWithMesh,
+        this.objectiveWithCompetency,
+        this.objectiveWithTerms,
+      ],
+    });
+    const programYearModel = await this.owner
+      .lookup('service:store')
+      .findRecord('program-year', programYear.id);
+
+    this.set('programYear', programYearModel);
+    await render(
+      <template>
+        <CollapsedObjectives
+          @programYear={{this.programYear}}
+          @expand={{(noop)}}
+          @showMeSH={{false}}
+        />
+      </template>,
+    );
+
+    assert.strictEqual(component.title, 'Objectives (4)');
+    assert.ok(component.hasExpandIcon);
+    assert.strictEqual(component.objectiveCount.text, 'There are 4 objectives');
+    assert.strictEqual(component.parentCount.text, '1 has a linked competency');
+    assert.notOk(component.meshCount.isVisible);
+    assert.strictEqual(component.termCount.text, '1 has vocabulary terms');
+    assert.ok(component.parentStatus.partial);
+    assert.notOk(component.meshStatus.isVisible);
     assert.ok(component.termStatus.partial);
   });
 
@@ -67,7 +106,11 @@ module('Integration | Component | program-year/collapsed-objectives', function (
     });
     await render(
       <template>
-        <CollapsedObjectives @programYear={{this.programYear}} @expand={{this.click}} />
+        <CollapsedObjectives
+          @programYear={{this.programYear}}
+          @expand={{this.click}}
+          @showMeSH={{true}}
+        />
       </template>,
     );
 
@@ -87,7 +130,11 @@ module('Integration | Component | program-year/collapsed-objectives', function (
     this.set('programYear', programYearModel);
     await render(
       <template>
-        <CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
+        <CollapsedObjectives
+          @programYear={{this.programYear}}
+          @expand={{(noop)}}
+          @showMeSH={{true}}
+        />
       </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
@@ -105,7 +152,11 @@ module('Integration | Component | program-year/collapsed-objectives', function (
     this.set('programYear', programYearModel);
     await render(
       <template>
-        <CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
+        <CollapsedObjectives
+          @programYear={{this.programYear}}
+          @expand={{(noop)}}
+          @showMeSH={{true}}
+        />
       </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
@@ -123,7 +174,11 @@ module('Integration | Component | program-year/collapsed-objectives', function (
     this.set('programYear', programYearModel);
     await render(
       <template>
-        <CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
+        <CollapsedObjectives
+          @programYear={{this.programYear}}
+          @expand={{(noop)}}
+          @showMeSH={{true}}
+        />
       </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
@@ -141,7 +196,11 @@ module('Integration | Component | program-year/collapsed-objectives', function (
     this.set('programYear', programYearModel);
     await render(
       <template>
-        <CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
+        <CollapsedObjectives
+          @programYear={{this.programYear}}
+          @expand={{(noop)}}
+          @showMeSH={{true}}
+        />
       </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
@@ -159,7 +218,11 @@ module('Integration | Component | program-year/collapsed-objectives', function (
     this.set('programYear', programYearModel);
     await render(
       <template>
-        <CollapsedObjectives @programYear={{this.programYear}} @expand={{(noop)}} />
+        <CollapsedObjectives
+          @programYear={{this.programYear}}
+          @expand={{(noop)}}
+          @showMeSH={{true}}
+        />
       </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');

--- a/packages/frontend/tests/integration/components/program-year/objective-list-item-test.gjs
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-item-test.gjs
@@ -35,6 +35,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
           @programYearCompetencies={{(array)}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -42,6 +43,31 @@ module('Integration | Component | program-year/objective-list-item', function (h
     assert.strictEqual(component.description.text, 'program-year objective 0');
     assert.strictEqual(component.competency.text, 'Add New');
     assert.strictEqual(component.meshDescriptors.text, 'Add New');
+    assert.ok(component.isActive);
+    assert.ok(component.canBeRemoved);
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders without MeSH UI', async function (assert) {
+    this.set('programYearObjective', this.model);
+    await render(
+      <template>
+        <ObjectiveListItem
+          @programYearObjective={{this.programYearObjective}}
+          @editable={{true}}
+          @domainTrees={{(array)}}
+          @programYearCompetencies={{(array)}}
+          @expandedObjectiveIds={{(array)}}
+          @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{false}}
+        />
+      </template>,
+    );
+    assert.notOk(component.hasRemoveConfirmation);
+    assert.strictEqual(component.description.text, 'program-year objective 0');
+    assert.strictEqual(component.competency.text, 'Add New');
+    assert.notOk(component.meshDescriptors.isVisible);
     assert.ok(component.isActive);
     assert.ok(component.canBeRemoved);
     await a11yAudit(this.element);
@@ -57,6 +83,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
           @editable={{true}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -79,6 +106,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
           @programYearCompetencies={{(array)}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -97,6 +125,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
           @programYearCompetencies={{(array)}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -115,6 +144,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
           @programYearCompetencies={{(array)}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -134,6 +164,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
           @programYearCompetencies={{(array)}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -152,6 +183,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
           @programYearCompetencies={{(array)}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -172,6 +204,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
           @programYearCompetencies={{(array)}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -195,6 +228,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
           @programYearCompetencies={{(array)}}
           @expandedObjectiveIds={{this.expandedObjectiveIds}}
           @setExpandedObjectiveIds={{this.setExpandedObjectiveIds}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -216,6 +250,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
           @programYearCompetencies={{(array)}}
           @expandedObjectiveIds={{this.expandedObjectiveIds}}
           @setExpandedObjectiveIds={{this.setExpandedObjectiveIds}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -231,6 +266,7 @@ module('Integration | Component | program-year/objective-list-item', function (h
           @editable={{true}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );

--- a/packages/frontend/tests/integration/components/program-year/objective-list-loading-test.gjs
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-loading-test.gjs
@@ -7,8 +7,16 @@ module('Integration | Component | program-year/objective-list-loading', function
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    await render(<template><ObjectiveListLoading @count={{9}} /></template>);
+    await render(<template><ObjectiveListLoading @count={{9}} @showMeSH={{true}} /></template>);
 
     assert.dom('.grid-row').exists({ count: 9 });
+    assert.dom('.grid-item').exists({ count: 9 * 5 });
+  });
+
+  test('it renders without MeSH UI', async function (assert) {
+    await render(<template><ObjectiveListLoading @count={{9}} @showMeSH={{false}} /></template>);
+
+    assert.dom('.grid-row').exists({ count: 9 });
+    assert.dom('.grid-item').exists({ count: 9 * 4 });
   });
 });

--- a/packages/frontend/tests/integration/components/program-year/objective-list-test.gjs
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-test.gjs
@@ -19,6 +19,78 @@ module('Integration | Component | program-year/objective-list', function (hooks)
     const vocabulary = await this.server.create('vocabulary', { school });
     const term1 = await this.server.create('term', { vocabulary, active: true });
     const term2 = await this.server.create('term', { vocabulary });
+    const meshDescriptors = await this.server.createList('mesh-descriptor', 2);
+    await this.server.create('program-year-objective', {
+      programYear,
+      title: 'Objective A',
+      position: 0,
+      terms: [term1],
+      meshDescriptors,
+    });
+    await this.server.create('program-year-objective', {
+      programYear,
+      title: 'Objective B',
+      position: 0,
+      terms: [term2],
+    });
+    const programYearModel = await this.owner
+      .lookup('service:store')
+      .findRecord('program-year', programYear.id);
+    this.set('programYear', programYearModel);
+
+    await render(
+      <template>
+        <ObjectiveList
+          @editable={{true}}
+          @programYear={{this.programYear}}
+          @allObjectivesExpanded={{false}}
+          @toggleExpandAll={{(noop)}}
+          @expandedObjectiveIds={{(array)}}
+          @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
+        />
+      </template>,
+    );
+    assert.ok(component.sortIsVisible, 'Sort Objectives button is visible');
+    assert.strictEqual(component.headers[0].text, 'Description');
+    assert.strictEqual(component.headers[1].text, 'Competency');
+    assert.strictEqual(component.headers[2].text, 'Vocabulary Terms');
+    assert.strictEqual(component.headers[3].text, 'MeSH Terms');
+    assert.strictEqual(component.headers[4].text, 'Actions');
+
+    assert.strictEqual(component.objectives.length, 2);
+    assert.strictEqual(component.objectives[0].description.text, 'Objective B');
+    assert.strictEqual(
+      component.objectives[0].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(
+      component.objectives[0].selectedTerms.list[0].terms[0].name,
+      'term 1 (inactive)',
+    );
+    assert.strictEqual(component.objectives[0].meshDescriptors.list.length, 1);
+    assert.strictEqual(component.objectives[0].meshDescriptors.list[0].title, 'Add New');
+    assert.strictEqual(component.objectives[1].description.text, 'Objective A');
+    assert.strictEqual(
+      component.objectives[1].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(component.objectives[1].selectedTerms.list[0].terms[0].name, 'term 0');
+    assert.strictEqual(component.objectives[1].meshDescriptors.list.length, 2);
+    assert.strictEqual(component.objectives[1].meshDescriptors.list[0].title, 'descriptor 0');
+    assert.strictEqual(component.objectives[1].meshDescriptors.list[1].title, 'descriptor 1');
+
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders without MeSH UI', async function (assert) {
+    const school = await this.server.create('school');
+    const program = await this.server.create('program', { school });
+    const programYear = await this.server.create('program-year', { program });
+    const vocabulary = await this.server.create('vocabulary', { school });
+    const term1 = await this.server.create('term', { vocabulary, active: true });
+    const term2 = await this.server.create('term', { vocabulary });
     await this.server.create('program-year-objective', {
       programYear,
       title: 'Objective A',
@@ -45,6 +117,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
           @toggleExpandAll={{(noop)}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{false}}
         />
       </template>,
     );
@@ -52,8 +125,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
     assert.strictEqual(component.headers[0].text, 'Description');
     assert.strictEqual(component.headers[1].text, 'Competency');
     assert.strictEqual(component.headers[2].text, 'Vocabulary Terms');
-    assert.strictEqual(component.headers[3].text, 'MeSH Terms');
-    assert.strictEqual(component.headers[4].text, 'Actions');
+    assert.strictEqual(component.headers[3].text, 'Actions');
 
     assert.strictEqual(component.objectives.length, 2);
     assert.strictEqual(component.objectives[0].description.text, 'Objective B');
@@ -65,6 +137,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
       component.objectives[0].selectedTerms.list[0].terms[0].name,
       'term 1 (inactive)',
     );
+    assert.notOk(component.objectives[0].meshDescriptors.isVisible);
     assert.strictEqual(component.objectives[1].description.text, 'Objective A');
     assert.strictEqual(
       component.objectives[1].selectedTerms.list[0].title,
@@ -72,6 +145,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
     );
     assert.strictEqual(component.objectives[1].selectedTerms.list[0].terms[0].name, 'term 0');
 
+    assert.notOk(component.objectives[1].meshDescriptors.isVisible);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -86,7 +160,9 @@ module('Integration | Component | program-year/objective-list', function (hooks)
     this.set('programYear', programYearModel);
 
     await render(
-      <template><ObjectiveList @editable={{true}} @programYear={{this.programYear}} /></template>,
+      <template>
+        <ObjectiveList @editable={{true}} @programYear={{this.programYear}} @showMeSH={{true}} />
+      </template>,
     );
     assert.notOk(component.sortIsVisible);
     assert.strictEqual(component.text, '');
@@ -111,6 +187,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
           @toggleExpandAll={{(noop)}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -147,6 +224,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
           @toggleExpandAll={{(noop)}}
           @expandedObjectiveIds={{(array)}}
           @setExpandedObjectiveIds={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );

--- a/packages/frontend/tests/pages/components/program-year/collapsed-objectives.js
+++ b/packages/frontend/tests/pages/components/program-year/collapsed-objectives.js
@@ -8,10 +8,18 @@ const definition = {
   },
   expand: clickable('[data-test-title]'),
   headers: collection('thead th'),
-  objectiveCount: text('[data-test-objective-count]'),
-  parentCount: text('[data-test-parent-count]'),
-  meshCount: text('[data-test-mesh-count]'),
-  termCount: text('[data-test-term-count]'),
+  objectiveCount: {
+    scope: '[data-test-objective-count]',
+  },
+  parentCount: {
+    scope: '[data-test-parent-count]',
+  },
+  meshCount: {
+    scope: '[data-test-mesh-count]',
+  },
+  termCount: {
+    scope: '[data-test-term-count]',
+  },
   parentStatus: {
     scope: '[data-test-parent-status] svg',
     complete: hasClass('yes'),

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/collapsed-objectives.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/course/collapsed-objectives.js
@@ -5,10 +5,18 @@ const definition = {
   title: text('[data-test-title]'),
   expand: clickable('[data-test-title]'),
   headers: collection('thead th'),
-  objectiveCount: text('[data-test-objective-count]'),
-  parentCount: text('[data-test-parent-count]'),
-  meshCount: text('[data-test-mesh-count]'),
-  termCount: text('[data-test-term-count]'),
+  objectiveCount: {
+    scope: '[data-test-objective-count]',
+  },
+  parentCount: {
+    scope: '[data-test-parent-count]',
+  },
+  meshCount: {
+    scope: '[data-test-mesh-count]',
+  },
+  termCount: {
+    scope: '[data-test-term-count]',
+  },
   parentStatus: {
     scope: '[data-test-parent-status] svg',
     complete: hasClass('yes'),

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials-item.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials-item.js
@@ -8,10 +8,18 @@ const definition = {
   title: text('[data-test-title]'),
   userNameInfo,
   typeIcon,
-  required: text('[data-test-required]'),
-  notes: text('[data-test-notes]'),
-  mesh: text('[data-test-mesh]'),
-  status: text('[data-test-status]'),
+  required: {
+    scope: '[data-test-required]',
+  },
+  notes: {
+    scope: '[data-test-notes]',
+  },
+  mesh: {
+    scope: '[data-test-mesh]',
+  },
+  status: {
+    scope: '[data-test-status]',
+  },
   isNotePublic: isVisible('[data-test-visible-to-students]'),
   isTimedRelease: isVisible('[data-test-timed-release]'),
   details: clickable('button', { at: 0 }),

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/detail-learning-materials.js
@@ -32,7 +32,11 @@ const definition = {
   canCollapse: isVisible('.detail-learningmaterials-actions .collapse-button'),
   canSort: isVisible('[data-test-sort-button]'),
   sort: clickable('[data-test-sort-button]'),
-  current: collection('[data-test-detail-learning-materials-item]', items),
+  materials: {
+    scope: '[data-test-materials]',
+    headers: collection('th'),
+    items: collection('[data-test-detail-learning-materials-item]', items),
+  },
   newLearningMaterial,
   manager: {
     scope: '.learningmaterial-manager',

--- a/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session/collapsed-objectives.js
+++ b/packages/ilios-common/addon-test-support/ilios-common/page-objects/components/session/collapsed-objectives.js
@@ -5,10 +5,18 @@ const definition = {
   title: text('[data-test-title]'),
   expand: clickable('[data-test-title]'),
   headers: collection('thead th'),
-  objectiveCount: text('[data-test-objective-count]'),
-  parentCount: text('[data-test-parent-count]'),
-  meshCount: text('[data-test-mesh-count]'),
-  termCount: text('[data-test-term-count]'),
+  objectiveCount: {
+    scope: '[data-test-objective-count]',
+  },
+  parentCount: {
+    scope: '[data-test-parent-count]',
+  },
+  meshCount: {
+    scope: '[data-test-mesh-count]',
+  },
+  termCount: {
+    scope: '[data-test-term-count]',
+  },
   parentStatus: {
     scope: '[data-test-parent-status] svg',
     complete: hasClass('yes'),

--- a/packages/ilios-common/addon/components/course/collapsed-objectives.gjs
+++ b/packages/ilios-common/addon/components/course/collapsed-objectives.gjs
@@ -65,9 +65,11 @@ export default class CourseCollapsedObjectivesComponent extends Component {
                 <th class="text-center">
                   {{t "general.vocabularyTerms"}}
                 </th>
-                <th class="text-center">
-                  {{t "general.meshTerms"}}
-                </th>
+                {{#if @showMeSH}}
+                  <th class="text-center">
+                    {{t "general.meshTerms"}}
+                  </th>
+                {{/if}}
               </tr>
             </thead>
             <tbody>
@@ -93,15 +95,17 @@ export default class CourseCollapsedObjectivesComponent extends Component {
                     <FaIcon @icon={{faBan}} class="no" />
                   {{/if}}
                 </td>
-                <td class="text-middle text-center" rowspan="3" data-test-mesh-status>
-                  {{#if (eq this.objectivesWithMesh.length this.objectives.length)}}
-                    <FaIcon @icon={{faCircle}} class="yes" />
-                  {{else if (gte (get this.objectivesWithMesh "length") 1)}}
-                    <FaIcon @icon={{faCircle}} class="maybe" />
-                  {{else}}
-                    <FaIcon @icon={{faBan}} class="no" />
-                  {{/if}}
-                </td>
+                {{#if @showMeSH}}
+                  <td class="text-middle text-center" rowspan="3" data-test-mesh-status>
+                    {{#if (eq this.objectivesWithMesh.length this.objectives.length)}}
+                      <FaIcon @icon={{faCircle}} class="yes" />
+                    {{else if (gte (get this.objectivesWithMesh "length") 1)}}
+                      <FaIcon @icon={{faCircle}} class="maybe" />
+                    {{else}}
+                      <FaIcon @icon={{faBan}} class="no" />
+                    {{/if}}
+                  </td>
+                {{/if}}
               </tr>
               <tr>
                 <td data-test-parent-count class="count">
@@ -113,11 +117,13 @@ export default class CourseCollapsedObjectivesComponent extends Component {
                   {{t "general.termCount" count=this.objectivesWithTerms.length}}
                 </td>
               </tr>
-              <tr>
-                <td data-test-mesh-count class="count">
-                  {{t "general.meshCount" count=this.objectivesWithMesh.length}}
-                </td>
-              </tr>
+              {{#if @showMeSH}}
+                <tr>
+                  <td data-test-mesh-count class="count">
+                    {{t "general.meshCount" count=this.objectivesWithMesh.length}}
+                  </td>
+                </tr>
+              {{/if}}
             </tbody>
           </table>
         </div>

--- a/packages/ilios-common/addon/components/course/details.gjs
+++ b/packages/ilios-common/addon/components/course/details.gjs
@@ -69,7 +69,7 @@ export default class CourseDetailsComponent extends Component {
   }
 
   get showMeSH() {
-    return !!this.schoolConfigs.get('showMeSH');
+    return this.schoolConfigs.has('showMeSH') ? this.schoolConfigs.get('showMeSH') : true;
   }
 
   get configLoaded() {

--- a/packages/ilios-common/addon/components/course/details.gjs
+++ b/packages/ilios-common/addon/components/course/details.gjs
@@ -47,11 +47,43 @@ export default class CourseDetailsComponent extends Component {
     this.args.setShowDetails(false);
   }
 
+  @cached
+  get schoolConfigsData() {
+    return new TrackedAsyncData(this.getSchoolConfigs(this.args.course));
+  }
+
+  async getSchoolConfigs(course) {
+    const school = await course.school;
+    return await school.configurations;
+  }
+
+  @cached
+  get schoolConfigs() {
+    const rhett = new Map();
+    if (this.schoolConfigsData.isResolved) {
+      this.schoolConfigsData.value.forEach((config) => {
+        rhett.set(config.name, config.parsedValue);
+      });
+    }
+    return rhett;
+  }
+
+  get showMeSH() {
+    return !!this.schoolConfigs.get('showMeSH');
+  }
+
+  get configLoaded() {
+    return (
+      this.academicYearCrossesCalendarYearBoundariesData.isResolved &&
+      this.schoolConfigsData.isResolved
+    );
+  }
+
   get notRolloverRoute() {
     return this.router.currentRouteName !== 'course.rollover';
   }
   <template>
-    {{#if this.academicYearCrossesCalendarYearBoundariesData.isResolved}}
+    {{#if this.configLoaded}}
       {{pageTitle "Courses | " @course.title " " this.academicYearDisplay}}
       <BackToCourses @course={{@course}} />
 
@@ -84,6 +116,7 @@ export default class CourseDetailsComponent extends Component {
             @setCourseTaxonomyDetails={{@setCourseTaxonomyDetails}}
             @setCourseCompetencyDetails={{@setCourseCompetencyDetails}}
             @setCourseManageLeadership={{@setCourseManageLeadership}}
+            @showMeSH={{this.showMeSH}}
           />
           {{#if @showDetailsCollapseControl}}
             <div class="details-collapse-control">

--- a/packages/ilios-common/addon/components/course/editing.gjs
+++ b/packages/ilios-common/addon/components/course/editing.gjs
@@ -49,7 +49,12 @@ import DetailCohorts from 'ilios-common/components/detail-cohorts';
         @showMeSH={{@showMeSH}}
       />
     {{/if}}
-    <DetailLearningMaterials @subject={{@course}} @isCourse={{true}} @editable={{@editable}} />
+    <DetailLearningMaterials
+      @subject={{@course}}
+      @isCourse={{true}}
+      @editable={{@editable}}
+      @showMeSH={{@showMeSH}}
+    />
     {{#if (or (eq (get @course.competencies "length") 0) @courseCompetencyDetails)}}
       <DetailCompetencies
         @course={{@course}}

--- a/packages/ilios-common/addon/components/course/editing.gjs
+++ b/packages/ilios-common/addon/components/course/editing.gjs
@@ -76,7 +76,9 @@ import DetailCohorts from 'ilios-common/components/detail-cohorts';
     {{else}}
       <CollapsedTaxonomies @subject={{@course}} @expand={{fn @setCourseTaxonomyDetails true}} />
     {{/if}}
-    <DetailMesh @subject={{@course}} @isCourse={{true}} @editable={{@editable}} />
+    {{#if @showMeSH}}
+      <DetailMesh @subject={{@course}} @isCourse={{true}} @editable={{@editable}} />
+    {{/if}}
     <DetailCohorts @course={{@course}} @editable={{@editable}} />
   </div>
 </template>

--- a/packages/ilios-common/addon/components/course/editing.gjs
+++ b/packages/ilios-common/addon/components/course/editing.gjs
@@ -40,9 +40,14 @@ import DetailCohorts from 'ilios-common/components/detail-cohorts';
         @editable={{@editable}}
         @collapse={{fn @setCourseObjectiveDetails false}}
         @expand={{fn @setCourseObjectiveDetails true}}
+        @showMeSH={{@showMeSH}}
       />
     {{else}}
-      <CollapsedObjectives @course={{@course}} @expand={{fn @setCourseObjectiveDetails true}} />
+      <CollapsedObjectives
+        @course={{@course}}
+        @expand={{fn @setCourseObjectiveDetails true}}
+        @showMeSH={{@showMeSH}}
+      />
     {{/if}}
     <DetailLearningMaterials @subject={{@course}} @isCourse={{true}} @editable={{@editable}} />
     {{#if (or (eq (get @course.competencies "length") 0) @courseCompetencyDetails)}}

--- a/packages/ilios-common/addon/components/course/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-item.gjs
@@ -204,7 +204,10 @@ export default class CourseObjectiveListItemComponent extends Component {
       class="grid-row objective-row{{if this.showRemoveConfirmation ' confirm-removal'}}{{unless
           @editable
           ' no-actions'
-        }}{{if this.highlightSave.isRunning ' highlight-ok'}}{{if this.isManaging ' is-managing'}}"
+        }}{{unless @showMeSH ' no-mesh'}}{{if this.highlightSave.isRunning ' highlight-ok'}}{{if
+          this.isManaging
+          ' is-managing'
+        }}"
       data-test-course-objective-list-item
     >
       <div class="description grid-item" data-test-description>
@@ -267,16 +270,17 @@ export default class CourseObjectiveListItemComponent extends Component {
         @cancel={{this.cancel}}
       />
 
-      <ObjectiveListItemDescriptors
-        @meshDescriptors={{this.meshDescriptors}}
-        @editable={{and @editable (not this.isManaging) (not this.showRemoveConfirmation)}}
-        @manage={{perform this.manageDescriptors}}
-        @isManaging={{this.isManagingDescriptors}}
-        @save={{perform this.saveDescriptors}}
-        @isSaving={{this.saveDescriptors.isRunning}}
-        @cancel={{this.cancel}}
-      />
-
+      {{#if @showMeSH}}
+        <ObjectiveListItemDescriptors
+          @meshDescriptors={{this.meshDescriptors}}
+          @editable={{and @editable (not this.isManaging) (not this.showRemoveConfirmation)}}
+          @manage={{perform this.manageDescriptors}}
+          @isManaging={{this.isManagingDescriptors}}
+          @save={{perform this.saveDescriptors}}
+          @isSaving={{this.saveDescriptors.isRunning}}
+          @cancel={{this.cancel}}
+        />
+      {{/if}}
       {{#if @editable}}
         <div class="actions grid-item" data-test-actions>
           {{#if this.isManaging}}

--- a/packages/ilios-common/addon/components/course/objective-list-loading.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list-loading.gjs
@@ -7,7 +7,9 @@ import random from 'ember-math-helpers/helpers/random';
     <div class="grid-row loading-text loading-shimmer">
       <span class="grid-item">{{truncate (repeat (random 3 10) "ilios rocks") 100}}</span>
       <span class="grid-item">{{repeat (random 1 3) "loading "}}</span>
-      <span class="grid-item">{{repeat (random 1 3) "loading "}}</span>
+      {{#if @showMeSH}}
+        <span class="grid-item">{{repeat (random 1 3) "loading "}}</span>
+      {{/if}}
       <span class="grid-item"></span>
     </div>
   {{/each}}

--- a/packages/ilios-common/addon/components/course/objective-list.gjs
+++ b/packages/ilios-common/addon/components/course/objective-list.gjs
@@ -146,11 +146,16 @@ export default class CourseObjectiveListComponent extends Component {
             {{t "general.sortObjectives"}}
           </button>
         {{/if}}
-        <div class="grid-row headers{{unless @editable ' no-actions'}}" data-test-headers>
+        <div
+          class="grid-row headers{{unless @editable ' no-actions'}}{{unless @showMeSH ' no-mesh'}}"
+          data-test-headers
+        >
           <span class="grid-item" data-test-header>{{t "general.description"}}</span>
           <span class="grid-item" data-test-header>{{t "general.parentObjectives"}}</span>
           <span class="grid-item" data-test-header>{{t "general.vocabularyTerms"}}</span>
-          <span class="grid-item" data-test-header>{{t "general.meshTerms"}}</span>
+          {{#if @showMeSH}}
+            <span class="grid-item" data-test-header>{{t "general.meshTerms"}}</span>
+          {{/if}}
           {{#if @editable}}
             <span class="actions grid-item" data-test-header>{{t "general.actions"}}</span>
           {{/if}}
@@ -163,10 +168,11 @@ export default class CourseObjectiveListComponent extends Component {
               @cohortObjectives={{this.cohortObjectives}}
               @course={{@course}}
               @printable={{@printable}}
+              @showMeSH={{@showMeSH}}
             />
           {{/each}}
         {{else}}
-          <ObjectiveListLoading @count={{this.courseObjectiveCount}} />
+          <ObjectiveListLoading @count={{this.courseObjectiveCount}} @showMeSH={{@showMeSH}} />
         {{/if}}
       {{/if}}
     </div>

--- a/packages/ilios-common/addon/components/course/objectives.gjs
+++ b/packages/ilios-common/addon/components/course/objectives.gjs
@@ -122,7 +122,7 @@ export default class CourseObjectivesComponent extends Component {
             @cancel={{this.toggleNewObjectiveEditor}}
           />
         {{/if}}
-        <ObjectiveList @course={{@course}} @editable={{@editable}} />
+        <ObjectiveList @course={{@course}} @editable={{@editable}} @showMeSH={{@showMeSH}} />
       </div>
     </section>
   </template>

--- a/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials-item.gjs
@@ -106,21 +106,23 @@ export default class DetailLearningMaterialsItemComponent extends Component {
           </span>
         {{/if}}
       </td>
-      <td class="text-center" colspan="2" data-test-mesh>
-        {{#if this.meshDescriptorsLoaded}}
-          {{#if this.meshDescriptors.length}}
-            <ul>
-              {{#each (sortBy "name" this.meshDescriptors) as |descriptor|}}
-                <li>
-                  {{descriptor.name}}
-                </li>
-              {{/each}}
-            </ul>
-          {{else}}
-            <em>{{t "general.none"}}</em>
+      {{#if @showMeSH}}
+        <td class="text-center" colspan="2" data-test-mesh>
+          {{#if this.meshDescriptorsLoaded}}
+            {{#if this.meshDescriptors.length}}
+              <ul>
+                {{#each (sortBy "name" this.meshDescriptors) as |descriptor|}}
+                  <li>
+                    {{descriptor.name}}
+                  </li>
+                {{/each}}
+              </ul>
+            {{else}}
+              <em>{{t "general.none"}}</em>
+            {{/if}}
           {{/if}}
-        {{/if}}
-      </td>
+        </td>
+      {{/if}}
       <td class="text-center" colspan="2">
         <span data-test-status>
           {{@lm.learningMaterial.status.title}}

--- a/packages/ilios-common/addon/components/detail-learning-materials.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials.gjs
@@ -236,6 +236,7 @@ export default class DetailLearningMaterialsComponent extends Component {
             @editable={{@editable}}
             @closeManager={{this.closeLearningmaterialManager}}
             @learningMaterialStatuses={{this.learningMaterialStatuses}}
+            @showMeSH={{@showMeSH}}
           />
         {{else if this.isSorting}}
           <LearningMaterialsSortManager
@@ -269,6 +270,7 @@ export default class DetailLearningMaterialsComponent extends Component {
                 (gt this.materials.length 10)
                 ' sticky-header'
               }}"
+            data-test-materials
           >
             <thead>
               <tr>
@@ -284,9 +286,11 @@ export default class DetailLearningMaterialsComponent extends Component {
                 <th class="text-center" colspan="2">
                   {{t "general.notes"}}
                 </th>
-                <th class="text-center" colspan="2">
-                  {{t "general.mesh"}}
-                </th>
+                {{#if @showMeSH}}
+                  <th class="text-center" colspan="2">
+                    {{t "general.mesh"}}
+                  </th>
+                {{/if}}
                 <th class="text-center" colspan="2">
                   {{t "general.status"}}
                 </th>
@@ -302,6 +306,7 @@ export default class DetailLearningMaterialsComponent extends Component {
                   @lm={{lm}}
                   @setManagedMaterial={{this.setManagedMaterial}}
                   @remove={{this.remove}}
+                  @showMeSH={{@showMeSH}}
                 />
               {{/each}}
             </tbody>

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -745,14 +745,15 @@ export default class LearningmaterialManagerComponent extends Component {
               </div>
             </div>
           </div>
-
-          <MeshManager
-            @terms={{this.terms}}
-            @editable={{@editable}}
-            @add={{this.addTerm}}
-            @remove={{this.removeTerm}}
-            @targetItemTitle={{this.title}}
-          />
+          {{#if @showMeSH}}
+            <MeshManager
+              @terms={{this.terms}}
+              @editable={{@editable}}
+              @add={{this.addTerm}}
+              @remove={{this.removeTerm}}
+              @targetItemTitle={{this.title}}
+            />
+          {{/if}}
           <div class="buttons">
             {{#if @editable}}
               <button

--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -312,7 +312,7 @@ export default class PrintCourseSessionComponent extends Component {
         </div>
         {{#if this.sessionObjectives.length}}
           <div class="content">
-            <ObjectiveList @session={{@session}} @editable={{false}} />
+            <ObjectiveList @session={{@session}} @editable={{false}} @showMeSH={{@showMeSH}} />
           </div>
         {{/if}}
       </section>

--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -391,23 +391,25 @@ export default class PrintCourseSessionComponent extends Component {
           </div>
         {{/if}}
       </section>
-      <section class="block" data-test-session-mesh-terms>
-        <div class="title">
-          {{t "general.mesh"}}
-          ({{this.meshDescriptors.length}})
-        </div>
-        {{#if this.meshDescriptors.length}}
-          <div class="content">
-            <ul class="inline-list">
-              {{#each (sortBy "title" this.meshDescriptors) as |descriptor|}}
-                <li>
-                  {{descriptor.name}}
-                </li>
-              {{/each}}
-            </ul>
+      {{#if @showMeSH}}
+        <section class="block" data-test-session-mesh-terms>
+          <div class="title">
+            {{t "general.mesh"}}
+            ({{this.meshDescriptors.length}})
           </div>
-        {{/if}}
-      </section>
+          {{#if this.meshDescriptors.length}}
+            <div class="content">
+              <ul class="inline-list">
+                {{#each (sortBy "title" this.meshDescriptors) as |descriptor|}}
+                  <li>
+                    {{descriptor.name}}
+                  </li>
+                {{/each}}
+              </ul>
+            </div>
+          {{/if}}
+        </section>
+      {{/if}}
       <section class="block" data-test-session-offerings>
         <div class="title">
           {{t "general.offerings"}}

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -136,7 +136,7 @@ export default class PrintCourseComponent extends Component {
   }
 
   get showMeSH() {
-    return !!this.schoolConfigs.get('showMeSH');
+    return this.schoolConfigs.has('showMeSH') ? this.schoolConfigs.get('showMeSH') : true;
   }
 
   get schoolConfigsLoaded() {

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -114,223 +114,266 @@ export default class PrintCourseComponent extends Component {
 
     return this.sessionsRelationship;
   }
+  @cached
+  get schoolConfigsData() {
+    return new TrackedAsyncData(this.getSchoolConfigs(this.args.course));
+  }
+
+  async getSchoolConfigs(course) {
+    const school = await course.school;
+    return await school.configurations;
+  }
+
+  @cached
+  get schoolConfigs() {
+    const rhett = new Map();
+    if (this.schoolConfigsData.isResolved) {
+      this.schoolConfigsData.value.forEach((config) => {
+        rhett.set(config.name, config.parsedValue);
+      });
+    }
+    return rhett;
+  }
+
+  get showMeSH() {
+    return !!this.schoolConfigs.get('showMeSH');
+  }
+
+  get schoolConfigsLoaded() {
+    return (
+      this.academicYearCrossesCalendarYearBoundariesData.isResolved &&
+      this.schoolConfigsData.isResolved
+    );
+  }
+
   <template>
-    <section class="print-course" ...attributes>
-      <div class="header" data-test-course-header>
-        <h2 data-test-course-title>
-          {{@course.title}}
-        </h2>
-        <h3 data-test-course-year>
-          {{#if this.academicYearCrossesCalendarYearBoundaries}}
-            {{@course.year}}
-            -
-            {{add @course.year 1}}
-          {{else}}
-            {{@course.year}}
-          {{/if}}
-        </h3>
-        <PublicationStatus @item={{@course}} @showText={{true}} />
-      </div>
-      <section class="overview block" data-test-course-overview>
-        <div class="content">
-          <div class="inline-label-data-block">
-            <label>
-              {{t "general.start"}}:
-            </label>
-            <div>
-              {{formatDate @course.startDate day="2-digit" month="2-digit" year="numeric"}}
+    {{#if this.schoolConfigsLoaded}}
+      <section class="print-course" ...attributes>
+        <div class="header" data-test-course-header>
+          <h2 data-test-course-title>
+            {{@course.title}}
+          </h2>
+          <h3 data-test-course-year>
+            {{#if this.academicYearCrossesCalendarYearBoundaries}}
+              {{@course.year}}
+              -
+              {{add @course.year 1}}
+            {{else}}
+              {{@course.year}}
+            {{/if}}
+          </h3>
+          <PublicationStatus @item={{@course}} @showText={{true}} />
+        </div>
+        <section class="overview block" data-test-course-overview>
+          <div class="content">
+            <div class="inline-label-data-block">
+              <label>
+                {{t "general.start"}}:
+              </label>
+              <div>
+                {{formatDate @course.startDate day="2-digit" month="2-digit" year="numeric"}}
+              </div>
             </div>
-          </div>
-          <div class="inline-label-data-block">
-            <label>
-              {{t "general.externalId"}}:
-            </label>
-            <div>
-              {{@course.externalId}}
+            <div class="inline-label-data-block">
+              <label>
+                {{t "general.externalId"}}:
+              </label>
+              <div>
+                {{@course.externalId}}
+              </div>
             </div>
-          </div>
-          <div class="inline-label-data-block">
-            <label>
-              {{t "general.level"}}:
-            </label>
-            <div>
-              {{@course.level}}
+            <div class="inline-label-data-block">
+              <label>
+                {{t "general.level"}}:
+              </label>
+              <div>
+                {{@course.level}}
+              </div>
             </div>
-          </div>
-          <div class="inline-label-data-block">
-            <label>
-              {{t "general.end"}}:
-            </label>
-            <div>
-              {{formatDate @course.endDate day="2-digit" month="2-digit" year="numeric"}}
+            <div class="inline-label-data-block">
+              <label>
+                {{t "general.end"}}:
+              </label>
+              <div>
+                {{formatDate @course.endDate day="2-digit" month="2-digit" year="numeric"}}
+              </div>
             </div>
-          </div>
-          <div class="inline-label-data-block">
-            <label>
-              {{t "general.clerkshipType"}}:
-            </label>
-            <div>
-              {{#if @course.clerkshipType}}
-                {{@course.clerkshipType.title}}
-              {{else}}
-                {{t "general.notAClerkship"}}
+            <div class="inline-label-data-block">
+              <label>
+                {{t "general.clerkshipType"}}:
+              </label>
+              <div>
+                {{#if @course.clerkshipType}}
+                  {{@course.clerkshipType.title}}
+                {{else}}
+                  {{t "general.notAClerkship"}}
+                {{/if}}
+              </div>
+            </div>
+            <br />
+            <br />
+            <div class="inline-label-data-block">
+              <label>
+                {{t "general.directors"}}:
+              </label>
+              {{#if (and this.directorsData.isResolved this.directorsData.value.length)}}
+                <div>
+                  <span>{{this.directors}}</span>
+                </div>
               {{/if}}
             </div>
           </div>
-          <br />
-          <br />
-          <div class="inline-label-data-block">
-            <label>
-              {{t "general.directors"}}:
-            </label>
-            {{#if (and this.directorsData.isResolved this.directorsData.value.length)}}
-              <div>
-                <span>{{this.directors}}</span>
-              </div>
-            {{/if}}
+        </section>
+        <section class="block" data-test-course-competencies>
+          <div class="title">
+            {{t "general.competencies"}}
+            ({{this.competencies.length}})
           </div>
-        </div>
-      </section>
-      <section class="block" data-test-course-competencies>
-        <div class="title">
-          {{t "general.competencies"}}
-          ({{this.competencies.length}})
-        </div>
-        {{#if this.competencies.length}}
-          <div class="content">
-            <ul class="static-list">
-              {{#each @course.domainsWithSubcompetencies as |domain|}}
-                <li>
-                  {{domain.title}}
-                  {{#if domain.subCompetencies}}
-                    <ul>
-                      {{#each domain.subCompetencies as |competency|}}
-                        <li>
-                          {{competency.title}}
-                        </li>
-                      {{/each}}
-                    </ul>
-                  {{/if}}
-                </li>
-              {{/each}}
-            </ul>
-          </div>
-        {{/if}}
-      </section>
-      <section class="block" data-test-course-terms>
-        <div class="title">
-          {{t "general.terms"}}
-          ({{@course.terms.length}})
-        </div>
-        {{#if @course.associatedVocabularies.length}}
-          <div class="content">
-            {{#each @course.associatedVocabularies as |vocab|}}
-              <DetailTermsList @vocabulary={{vocab}} @terms={{this.terms}} @canEdit={{false}} />
-            {{/each}}
-          </div>
-        {{/if}}
-      </section>
-      <section class="block" data-test-course-objectives>
-        <div class="title">
-          {{t "general.objectives"}}
-          ({{@course.courseObjectives.length}})
-        </div>
-        {{#if @course.courseObjectives.length}}
-          <div class="content">
-            <ObjectiveList @course={{@course}} @editable={{false}} @printable={{true}} />
-          </div>
-        {{/if}}
-      </section>
-      <section class="block" data-test-course-learningmaterials>
-        <div class="title">
-          {{t "general.learningMaterials"}}
-          ({{this.courseLearningMaterials.length}})
-        </div>
-        {{#if this.courseLearningMaterials}}
-          <div class="content">
-            <table class="ilios-table">
-              <thead>
-                <tr>
-                  <th class="text-left" colspan="2">
-                    {{t "general.displayName"}}
-                  </th>
-                  <th class="text-center">
-                    {{t "general.type"}}
-                  </th>
-                  <th class="text-center">
-                    {{t "general.required"}}
-                  </th>
-                  <th class="text-left">
-                    {{t "general.notes"}}
-                  </th>
-                  <th class="text-left description" colspan="4">
-                    {{t "general.description"}}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {{#each this.courseLearningMaterials as |lm|}}
-                  <tr>
-                    <td class="text-left text-top" colspan="2">
-                      {{lm.learningMaterial.title}}
-                    </td>
-                    <td class="text-center text-top">
-                      {{lm.learningMaterial.type}}
-                    </td>
-                    <td class="text-center text-top">
-                      {{#if lm.required}}
-                        <span class="add">
-                          {{t "general.yes"}}
-                        </span>
-                      {{else}}
-                        <span class="remove">
-                          {{t "general.no"}}
-                        </span>
-                      {{/if}}
-                    </td>
-                    <td class="text-left text-top">
-                      {{#if lm.notes}}
-                        <span class="add">
-                          {{t "general.yes"}}
-                        </span>
-                      {{else}}
-                        <span class="remove">
-                          {{t "general.no"}}
-                        </span>
-                      {{/if}}
-                    </td>
-                    <td class="text-left text-top" colspan="4">
-                      {{removeHtmlTags lm.learningMaterial.description}}
-                      <p></p>
-                      {{lm.learningMaterial.citation}}
-                    </td>
-                  </tr>
+          {{#if this.competencies.length}}
+            <div class="content">
+              <ul class="static-list">
+                {{#each @course.domainsWithSubcompetencies as |domain|}}
+                  <li>
+                    {{domain.title}}
+                    {{#if domain.subCompetencies}}
+                      <ul>
+                        {{#each domain.subCompetencies as |competency|}}
+                          <li>
+                            {{competency.title}}
+                          </li>
+                        {{/each}}
+                      </ul>
+                    {{/if}}
+                  </li>
                 {{/each}}
-              </tbody>
-            </table>
+              </ul>
+            </div>
+          {{/if}}
+        </section>
+        <section class="block" data-test-course-terms>
+          <div class="title">
+            {{t "general.terms"}}
+            ({{@course.terms.length}})
           </div>
-        {{/if}}
-      </section>
-      <section class="block" data-test-course-mesh>
-        <div class="title">
-          {{t "general.mesh"}}
-          ({{@course.meshDescriptors.length}})
-        </div>
-        {{#if @course.meshDescriptors.length}}
-          <div class="content">
-            <ul class="inline-list">
-              {{#each (sortBy "title" this.meshDescriptors) as |descriptor|}}
-                <li>
-                  {{descriptor.name}}
-                </li>
+          {{#if @course.associatedVocabularies.length}}
+            <div class="content">
+              {{#each @course.associatedVocabularies as |vocab|}}
+                <DetailTermsList @vocabulary={{vocab}} @terms={{this.terms}} @canEdit={{false}} />
               {{/each}}
-            </ul>
+            </div>
+          {{/if}}
+        </section>
+        <section class="block" data-test-course-objectives>
+          <div class="title">
+            {{t "general.objectives"}}
+            ({{@course.courseObjectives.length}})
           </div>
-        {{/if}}
+          {{#if @course.courseObjectives.length}}
+            <div class="content">
+              <ObjectiveList
+                @course={{@course}}
+                @editable={{false}}
+                @printable={{true}}
+                @showMeSH={{this.showMeSH}}
+              />
+            </div>
+          {{/if}}
+        </section>
+        <section class="block" data-test-course-learningmaterials>
+          <div class="title">
+            {{t "general.learningMaterials"}}
+            ({{this.courseLearningMaterials.length}})
+          </div>
+          {{#if this.courseLearningMaterials}}
+            <div class="content">
+              <table class="ilios-table">
+                <thead>
+                  <tr>
+                    <th class="text-left" colspan="2">
+                      {{t "general.displayName"}}
+                    </th>
+                    <th class="text-center">
+                      {{t "general.type"}}
+                    </th>
+                    <th class="text-center">
+                      {{t "general.required"}}
+                    </th>
+                    <th class="text-left">
+                      {{t "general.notes"}}
+                    </th>
+                    <th class="text-left description" colspan="4">
+                      {{t "general.description"}}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {{#each this.courseLearningMaterials as |lm|}}
+                    <tr>
+                      <td class="text-left text-top" colspan="2">
+                        {{lm.learningMaterial.title}}
+                      </td>
+                      <td class="text-center text-top">
+                        {{lm.learningMaterial.type}}
+                      </td>
+                      <td class="text-center text-top">
+                        {{#if lm.required}}
+                          <span class="add">
+                            {{t "general.yes"}}
+                          </span>
+                        {{else}}
+                          <span class="remove">
+                            {{t "general.no"}}
+                          </span>
+                        {{/if}}
+                      </td>
+                      <td class="text-left text-top">
+                        {{#if lm.notes}}
+                          <span class="add">
+                            {{t "general.yes"}}
+                          </span>
+                        {{else}}
+                          <span class="remove">
+                            {{t "general.no"}}
+                          </span>
+                        {{/if}}
+                      </td>
+                      <td class="text-left text-top" colspan="4">
+                        {{removeHtmlTags lm.learningMaterial.description}}
+                        <p></p>
+                        {{lm.learningMaterial.citation}}
+                      </td>
+                    </tr>
+                  {{/each}}
+                </tbody>
+              </table>
+            </div>
+          {{/if}}
+        </section>
+        <section class="block" data-test-course-mesh>
+          <div class="title">
+            {{t "general.mesh"}}
+            ({{@course.meshDescriptors.length}})
+          </div>
+          {{#if @course.meshDescriptors.length}}
+            <div class="content">
+              <ul class="inline-list">
+                {{#each (sortBy "title" this.meshDescriptors) as |descriptor|}}
+                  <li>
+                    {{descriptor.name}}
+                  </li>
+                {{/each}}
+              </ul>
+            </div>
+          {{/if}}
+        </section>
+        {{#each (sortBy "title" this.sessions) as |session|}}
+          <PrintCourseSession
+            @session={{session}}
+            @editable={{false}}
+            @showMeSH={{this.showMeSH}}
+          />
+        {{/each}}
       </section>
-      {{#each (sortBy "title" this.sessions) as |session|}}
-        <PrintCourseSession @session={{session}} @editable={{false}} />
-      {{/each}}
-    </section>
+    {{/if}}
   </template>
 }

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -349,23 +349,25 @@ export default class PrintCourseComponent extends Component {
             </div>
           {{/if}}
         </section>
-        <section class="block" data-test-course-mesh>
-          <div class="title">
-            {{t "general.mesh"}}
-            ({{@course.meshDescriptors.length}})
-          </div>
-          {{#if @course.meshDescriptors.length}}
-            <div class="content">
-              <ul class="inline-list">
-                {{#each (sortBy "title" this.meshDescriptors) as |descriptor|}}
-                  <li>
-                    {{descriptor.name}}
-                  </li>
-                {{/each}}
-              </ul>
+        {{#if this.showMeSH}}
+          <section class="block" data-test-course-mesh>
+            <div class="title">
+              {{t "general.mesh"}}
+              ({{@course.meshDescriptors.length}})
             </div>
-          {{/if}}
-        </section>
+            {{#if @course.meshDescriptors.length}}
+              <div class="content">
+                <ul class="inline-list">
+                  {{#each (sortBy "title" this.meshDescriptors) as |descriptor|}}
+                    <li>
+                      {{descriptor.name}}
+                    </li>
+                  {{/each}}
+                </ul>
+              </div>
+            {{/if}}
+          </section>
+        {{/if}}
         {{#each (sortBy "title" this.sessions) as |session|}}
           <PrintCourseSession
             @session={{session}}

--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -143,7 +143,9 @@ export default class SessionDetailsComponent extends Component {
             @expand={{fn @setSessionTaxonomyDetails true}}
           />
         {{/if}}
-        <DetailMesh @subject={{@session}} @isSession={{true}} @editable={{@editable}} />
+        {{#if this.showMeSH}}
+          <DetailMesh @subject={{@session}} @isSession={{true}} @editable={{@editable}} />
+        {{/if}}
         <SessionOfferings
           @session={{@session}}
           @editable={{@editable}}

--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -39,76 +39,117 @@ export default class SessionDetailsComponent extends Component {
   get cohorts() {
     return this.cohortsData.isResolved ? this.cohortsData.value : null;
   }
+
+  @cached
+  get schoolConfigsData() {
+    return new TrackedAsyncData(this.getSchoolConfigs(this.args.session));
+  }
+
+  async getSchoolConfigs(session) {
+    const course = await session.course;
+    const school = await course.school;
+    return await school.configurations;
+  }
+
+  @cached
+  get schoolConfigs() {
+    const rhett = new Map();
+    if (this.schoolConfigsData.isResolved) {
+      this.schoolConfigsData.value.forEach((config) => {
+        rhett.set(config.name, config.parsedValue);
+      });
+    }
+    return rhett;
+  }
+
+  get schoolConfigsLoaded() {
+    return this.schoolConfigsData.isResolved;
+  }
+
+  get showMeSH() {
+    return !!this.schoolConfigs.get('showMeSH');
+  }
+
   <template>
     {{pageTitle " | Session: " @session.title}}
+    {{#if this.schoolConfigsLoaded}}
+      <div class="back-to-session" {{scrollIntoView delay=10}}>
+        <LinkTo @route="course" @model={{@session.course}} data-test-back-to-sessions>
+          {{t "general.backToSessionList"}}
+        </LinkTo>
+      </div>
 
-    <div class="back-to-session" {{scrollIntoView delay=10}}>
-      <LinkTo @route="course" @model={{@session.course}} data-test-back-to-sessions>
-        {{t "general.backToSessionList"}}
-      </LinkTo>
-    </div>
-
-    <section class="session-details" data-test-session-details>
-      <Overview @session={{@session}} @editable={{@editable}} />
-      {{#if @sessionLeadershipDetails}}
-        <LeadershipExpanded
-          @model={{@session}}
-          @editable={{@editable}}
-          @collapse={{fn @setSessionLeadershipDetails false}}
-          @expand={{fn @setSessionLeadershipDetails true}}
-          @isManaging={{@sessionManageLeadership}}
-          @setIsManaging={{@setSessionManageLeadership}}
-        />
-      {{else}}
-        <LeadershipCollapsed
-          @showDirectors={{false}}
-          @showAdministrators={{true}}
-          @showStudentAdvisors={{true}}
-          @administratorsCount={{hasManyLength @session "administrators"}}
-          @studentAdvisorsCount={{hasManyLength @session "studentAdvisors"}}
-          @expand={{fn @setSessionLeadershipDetails true}}
-        />
-      {{/if}}
-      {{#if @session.isIndependentLearning}}
-        <DetailLearnersAndLearnerGroups
-          @session={{@session}}
-          @editable={{@editable}}
-          @cohorts={{this.cohorts}}
-        />
-        <DetailInstructors @session={{@session}} @editable={{@editable}} />
-      {{/if}}
-      {{#if (or (eq @session.sessionObjectives.length 0) @sessionObjectiveDetails)}}
-        <Objectives
-          @session={{@session}}
-          @editable={{@editable}}
-          @collapse={{fn @setSessionObjectiveDetails false}}
-          @expand={{fn @setSessionObjectiveDetails true}}
-        />
-      {{else}}
-        <CollapsedObjectives
-          @session={{@session}}
-          @editable={{@editable}}
-          @expand={{fn @setSessionObjectiveDetails true}}
-        />
-      {{/if}}
-      <DetailLearningMaterials @subject={{@session}} @isCourse={{false}} @editable={{@editable}} />
-      {{#if (or (eq @session.terms.length 0) @sessionTaxonomyDetails)}}
-        <DetailTaxonomies
+      <section class="session-details" data-test-session-details>
+        <Overview @session={{@session}} @editable={{@editable}} />
+        {{#if @sessionLeadershipDetails}}
+          <LeadershipExpanded
+            @model={{@session}}
+            @editable={{@editable}}
+            @collapse={{fn @setSessionLeadershipDetails false}}
+            @expand={{fn @setSessionLeadershipDetails true}}
+            @isManaging={{@sessionManageLeadership}}
+            @setIsManaging={{@setSessionManageLeadership}}
+          />
+        {{else}}
+          <LeadershipCollapsed
+            @showDirectors={{false}}
+            @showAdministrators={{true}}
+            @showStudentAdvisors={{true}}
+            @administratorsCount={{hasManyLength @session "administrators"}}
+            @studentAdvisorsCount={{hasManyLength @session "studentAdvisors"}}
+            @expand={{fn @setSessionLeadershipDetails true}}
+          />
+        {{/if}}
+        {{#if @session.isIndependentLearning}}
+          <DetailLearnersAndLearnerGroups
+            @session={{@session}}
+            @editable={{@editable}}
+            @cohorts={{this.cohorts}}
+          />
+          <DetailInstructors @session={{@session}} @editable={{@editable}} />
+        {{/if}}
+        {{#if (or (eq @session.sessionObjectives.length 0) @sessionObjectiveDetails)}}
+          <Objectives
+            @session={{@session}}
+            @editable={{@editable}}
+            @collapse={{fn @setSessionObjectiveDetails false}}
+            @expand={{fn @setSessionObjectiveDetails true}}
+            @showMeSH={{this.showMeSH}}
+          />
+        {{else}}
+          <CollapsedObjectives
+            @session={{@session}}
+            @editable={{@editable}}
+            @expand={{fn @setSessionObjectiveDetails true}}
+            @showMeSH={{this.showMeSH}}
+          />
+        {{/if}}
+        <DetailLearningMaterials
           @subject={{@session}}
+          @isCourse={{false}}
           @editable={{@editable}}
-          @collapse={{fn @setSessionTaxonomyDetails false}}
-          @expand={{fn @setSessionTaxonomyDetails true}}
         />
-      {{else}}
-        <CollapsedTaxonomies @subject={{@session}} @expand={{fn @setSessionTaxonomyDetails true}} />
-      {{/if}}
-      <DetailMesh @subject={{@session}} @isSession={{true}} @editable={{@editable}} />
-      <SessionOfferings
-        @session={{@session}}
-        @editable={{@editable}}
-        @showNewOfferingForm={{@showNewOfferingForm}}
-        @toggleShowNewOfferingForm={{@toggleShowNewOfferingForm}}
-      />
-    </section>
+        {{#if (or (eq @session.terms.length 0) @sessionTaxonomyDetails)}}
+          <DetailTaxonomies
+            @subject={{@session}}
+            @editable={{@editable}}
+            @collapse={{fn @setSessionTaxonomyDetails false}}
+            @expand={{fn @setSessionTaxonomyDetails true}}
+          />
+        {{else}}
+          <CollapsedTaxonomies
+            @subject={{@session}}
+            @expand={{fn @setSessionTaxonomyDetails true}}
+          />
+        {{/if}}
+        <DetailMesh @subject={{@session}} @isSession={{true}} @editable={{@editable}} />
+        <SessionOfferings
+          @session={{@session}}
+          @editable={{@editable}}
+          @showNewOfferingForm={{@showNewOfferingForm}}
+          @toggleShowNewOfferingForm={{@toggleShowNewOfferingForm}}
+        />
+      </section>
+    {{/if}}
   </template>
 }

--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -128,6 +128,7 @@ export default class SessionDetailsComponent extends Component {
           @subject={{@session}}
           @isCourse={{false}}
           @editable={{@editable}}
+          @showMeSH={{this.showMeSH}}
         />
         {{#if (or (eq @session.terms.length 0) @sessionTaxonomyDetails)}}
           <DetailTaxonomies

--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -67,7 +67,7 @@ export default class SessionDetailsComponent extends Component {
   }
 
   get showMeSH() {
-    return !!this.schoolConfigs.get('showMeSH');
+    return this.schoolConfigs.has('showMeSH') ? this.schoolConfigs.get('showMeSH') : true;
   }
 
   <template>

--- a/packages/ilios-common/addon/components/session/collapsed-objectives.gjs
+++ b/packages/ilios-common/addon/components/session/collapsed-objectives.gjs
@@ -65,9 +65,11 @@ export default class SessionCollapsedObjectivesComponent extends Component {
                 <th class="text-center">
                   {{t "general.vocabularyTerms"}}
                 </th>
-                <th class="text-center">
-                  {{t "general.meshTerms"}}
-                </th>
+                {{#if @showMeSH}}
+                  <th class="text-center">
+                    {{t "general.meshTerms"}}
+                  </th>
+                {{/if}}
               </tr>
             </thead>
             <tbody>
@@ -97,15 +99,19 @@ export default class SessionCollapsedObjectivesComponent extends Component {
                     <FaIcon @icon={{faBan}} class="no" />
                   {{/if}}
                 </td>
-                <td class="text-middle text-center" rowspan="3" data-test-mesh-status>
-                  {{#if (eq (get this.objectivesWithMesh "length") (get this.objectives "length"))}}
-                    <FaIcon @icon={{faCircle}} class="yes" />
-                  {{else if (gte (get this.objectivesWithMesh "length") 1)}}
-                    <FaIcon @icon={{faCircle}} class="maybe" />
-                  {{else}}
-                    <FaIcon @icon={{faBan}} class="no" />
-                  {{/if}}
-                </td>
+                {{#if @showMeSH}}
+                  <td class="text-middle text-center" rowspan="3" data-test-mesh-status>
+                    {{#if
+                      (eq (get this.objectivesWithMesh "length") (get this.objectives "length"))
+                    }}
+                      <FaIcon @icon={{faCircle}} class="yes" />
+                    {{else if (gte (get this.objectivesWithMesh "length") 1)}}
+                      <FaIcon @icon={{faCircle}} class="maybe" />
+                    {{else}}
+                      <FaIcon @icon={{faBan}} class="no" />
+                    {{/if}}
+                  </td>
+                {{/if}}
               </tr>
               <tr>
                 <td data-test-parent-count class="count">
@@ -117,11 +123,13 @@ export default class SessionCollapsedObjectivesComponent extends Component {
                   {{t "general.termCount" count=(get this.objectivesWithTerms "length")}}
                 </td>
               </tr>
-              <tr>
-                <td data-test-mesh-count class="count">
-                  {{t "general.meshCount" count=(get this.objectivesWithMesh "length")}}
-                </td>
-              </tr>
+              {{#if @showMeSH}}
+                <tr>
+                  <td data-test-mesh-count class="count">
+                    {{t "general.meshCount" count=(get this.objectivesWithMesh "length")}}
+                  </td>
+                </tr>
+              {{/if}}
             </tbody>
           </table>
         </div>

--- a/packages/ilios-common/addon/components/session/objective-list-item.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-item.gjs
@@ -187,7 +187,10 @@ export default class SessionObjectiveListItemComponent extends Component {
       class="grid-row objective-row{{if this.showRemoveConfirmation ' confirm-removal'}}{{unless
           @editable
           ' no-actions'
-        }}{{if this.highlightSave.isRunning ' highlight-ok'}}{{if this.isManaging ' is-managing'}}"
+        }}{{unless @showMeSH ' no-mesh'}}{{if this.highlightSave.isRunning ' highlight-ok'}}{{if
+          this.isManaging
+          ' is-managing'
+        }}"
       data-test-session-objective-list-item
     >
       <div class="description grid-item" data-test-description>
@@ -250,15 +253,17 @@ export default class SessionObjectiveListItemComponent extends Component {
         @cancel={{this.cancel}}
       />
 
-      <ObjectiveListItemDescriptors
-        @meshDescriptors={{this.meshDescriptors}}
-        @editable={{and @editable (not this.isManaging) (not this.showRemoveConfirmation)}}
-        @manage={{perform this.manageDescriptors}}
-        @isManaging={{this.isManagingDescriptors}}
-        @save={{perform this.saveDescriptors}}
-        @isSaving={{this.saveDescriptors.isRunning}}
-        @cancel={{this.cancel}}
-      />
+      {{#if @showMeSH}}
+        <ObjectiveListItemDescriptors
+          @meshDescriptors={{this.meshDescriptors}}
+          @editable={{and @editable (not this.isManaging) (not this.showRemoveConfirmation)}}
+          @manage={{perform this.manageDescriptors}}
+          @isManaging={{this.isManagingDescriptors}}
+          @save={{perform this.saveDescriptors}}
+          @isSaving={{this.saveDescriptors.isRunning}}
+          @cancel={{this.cancel}}
+        />
+      {{/if}}
 
       {{#if @editable}}
         <div class="actions grid-item" data-test-actions>

--- a/packages/ilios-common/addon/components/session/objective-list-loading.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list-loading.gjs
@@ -7,7 +7,9 @@ import random from 'ember-math-helpers/helpers/random';
     <div class="grid-row loading-text loading-shimmer">
       <span class="grid-item">{{truncate (repeat (random 3 10) "ilios rocks") 100}}</span>
       <span class="grid-item">{{repeat (random 1 3) "loading "}}</span>
-      <span class="grid-item">{{repeat (random 1 3) "loading "}}</span>
+      {{#if @showMeSH}}
+        <span class="grid-item">{{repeat (random 1 3) "loading "}}</span>
+      {{/if}}
       <span class="grid-item"></span>
     </div>
   {{/each}}

--- a/packages/ilios-common/addon/components/session/objective-list.gjs
+++ b/packages/ilios-common/addon/components/session/objective-list.gjs
@@ -27,7 +27,6 @@ export default class SessionObjectiveListComponent extends Component {
   get sessionObjectivesData() {
     return new TrackedAsyncData(this.args.session.sortedSessionObjectives);
   }
-
   get course() {
     return this.courseData.isResolved ? this.courseData.value : null;
   }
@@ -60,11 +59,16 @@ export default class SessionObjectiveListComponent extends Component {
             {{t "general.sortObjectives"}}
           </button>
         {{/if}}
-        <div class="grid-row headers{{unless @editable ' no-actions'}}" data-test-headers>
+        <div
+          class="grid-row headers{{unless @editable ' no-actions'}}{{unless @showMeSH ' no-mesh'}}"
+          data-test-headers
+        >
           <span class="grid-item" data-test-header>{{t "general.description"}}</span>
           <span class="grid-item" data-test-header>{{t "general.parentObjectives"}}</span>
           <span class="grid-item" data-test-header>{{t "general.vocabularyTerms"}}</span>
-          <span class="grid-item" data-test-header>{{t "general.meshTerms"}}</span>
+          {{#if @showMeSH}}
+            <span class="grid-item" data-test-header>{{t "general.meshTerms"}}</span>
+          {{/if}}
           {{#if @editable}}
             <span class="actions grid-item" data-test-header>{{t "general.actions"}}</span>
           {{/if}}
@@ -77,10 +81,11 @@ export default class SessionObjectiveListComponent extends Component {
               @courseObjectives={{this.courseObjectives}}
               @courseTitle={{this.course.title}}
               @session={{@session}}
+              @showMeSH={{@showMeSH}}
             />
           {{/each}}
         {{else}}
-          <ObjectiveListLoading @count={{this.sessionObjectiveCount}} />
+          <ObjectiveListLoading @count={{this.sessionObjectiveCount}} @showMeSH={{@showMeSH}} />
         {{/if}}
       {{/if}}
     </div>

--- a/packages/ilios-common/addon/components/session/objectives.gjs
+++ b/packages/ilios-common/addon/components/session/objectives.gjs
@@ -106,7 +106,7 @@ export default class SessionObjectivesComponent extends Component {
             @cancel={{this.toggleNewObjectiveEditor}}
           />
         {{/if}}
-        <ObjectiveList @session={{@session}} @editable={{@editable}} />
+        <ObjectiveList @session={{@session}} @editable={{@editable}} @showMeSH={{@showMeSH}} />
       </div>
     </section>
   </template>

--- a/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
+++ b/packages/ilios-common/app/styles/ilios-common/mixins/objectives.scss
@@ -72,6 +72,14 @@
       grid-template-columns: 5fr 3fr 3fr 3fr;
     }
 
+    &.no-mesh {
+      grid-template-columns: 5fr 3fr 3fr 1fr;
+    }
+
+    &.no-mesh.no-actions {
+      grid-template-columns: 5fr 3fr 3fr;
+    }
+
     .grid-item {
       border-bottom: 1px solid light-dark(var(--grey), var(--grey));
       padding: 0.5em 0.25em;

--- a/packages/test-app/tests/integration/components/course/collapsed-objectives-test.gjs
+++ b/packages/test-app/tests/integration/components/course/collapsed-objectives-test.gjs
@@ -39,17 +39,44 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
 
     this.set('course', courseModel);
     await render(
-      <template><CollapsedObjectives @course={{this.course}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @course={{this.course}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
-
     assert.strictEqual(component.title, 'Objectives (4)');
-    assert.strictEqual(component.objectiveCount, 'There are 4 objectives');
-    assert.strictEqual(component.parentCount, '1 has a parent');
-    assert.strictEqual(component.meshCount, '1 has MeSH');
-    assert.strictEqual(component.termCount, '1 has vocabulary terms');
-
+    assert.strictEqual(component.objectiveCount.text, 'There are 4 objectives');
+    assert.strictEqual(component.parentCount.text, '1 has a parent');
+    assert.strictEqual(component.meshCount.text, '1 has MeSH');
+    assert.strictEqual(component.termCount.text, '1 has vocabulary terms');
     assert.ok(component.parentStatus.partial);
     assert.ok(component.meshStatus.partial);
+    assert.ok(component.termStatus.partial);
+  });
+
+  test('displays summary data without MeSH UI', async function (assert) {
+    const course = await this.server.create('course', {
+      courseObjectives: [
+        this.objective,
+        this.objectiveWithMesh,
+        this.objectiveWithProgramYearObjectives,
+        this.objectiveWithTerms,
+      ],
+    });
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+
+    this.set('course', courseModel);
+    await render(
+      <template>
+        <CollapsedObjectives @course={{this.course}} @expand={{(noop)}} @showMeSH={{false}} />
+      </template>,
+    );
+    assert.strictEqual(component.title, 'Objectives (4)');
+    assert.strictEqual(component.objectiveCount.text, 'There are 4 objectives');
+    assert.strictEqual(component.parentCount.text, '1 has a parent');
+    assert.notOk(component.meshCount.isVisible);
+    assert.strictEqual(component.termCount.text, '1 has vocabulary terms');
+    assert.ok(component.parentStatus.partial);
+    assert.notOk(component.meshStatus.isVisible);
     assert.ok(component.termStatus.partial);
   });
 
@@ -62,7 +89,9 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
       assert.step('click called');
     });
     await render(
-      <template><CollapsedObjectives @course={{this.course}} @expand={{this.click}} /></template>,
+      <template>
+        <CollapsedObjectives @course={{this.course}} @expand={{this.click}} @showMeSH={{true}} />
+      </template>,
     );
 
     assert.strictEqual(component.title, 'Objectives (0)');
@@ -78,7 +107,9 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
 
     this.set('course', courseModel);
     await render(
-      <template><CollapsedObjectives @course={{this.course}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @course={{this.course}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.parentStatus.complete);
@@ -92,7 +123,9 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
 
     this.set('course', courseModel);
     await render(
-      <template><CollapsedObjectives @course={{this.course}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @course={{this.course}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.parentStatus.none);
@@ -106,7 +139,9 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
 
     this.set('course', courseModel);
     await render(
-      <template><CollapsedObjectives @course={{this.course}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @course={{this.course}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.meshStatus.complete);
@@ -120,7 +155,9 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
 
     this.set('course', courseModel);
     await render(
-      <template><CollapsedObjectives @course={{this.course}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @course={{this.course}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.meshStatus.none);
@@ -134,7 +171,9 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
 
     this.set('course', courseModel);
     await render(
-      <template><CollapsedObjectives @course={{this.course}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @course={{this.course}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.termStatus.complete);
@@ -148,7 +187,9 @@ module('Integration | Component | course/collapsed-objectives', function (hooks)
 
     this.set('course', courseModel);
     await render(
-      <template><CollapsedObjectives @course={{this.course}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @course={{this.course}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.termStatus.none);

--- a/packages/test-app/tests/integration/components/course/objective-list-item-test.gjs
+++ b/packages/test-app/tests/integration/components/course/objective-list-item-test.gjs
@@ -27,6 +27,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
           @editable={{true}}
           @cohortObjectives={{(array)}}
           @course={{this.course}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -34,6 +35,35 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
     assert.strictEqual(component.description.text, 'course objective 0');
     assert.strictEqual(component.parents.text, 'Add New');
     assert.strictEqual(component.meshDescriptors.text, 'Add New');
+    assert.ok(component.hasTrashCan);
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders without MeSH UI', async function (assert) {
+    const school = await this.server.create('school');
+    const course = await this.server.create('course', { school });
+    const courseObjective = await this.server.create('course-objective', { course });
+    const store = this.owner.lookup('service:store');
+    const courseModel = await store.findRecord('course', course.id);
+    const courseObjectiveModel = await store.findRecord('course-objective', courseObjective.id);
+    this.set('course', courseModel);
+    this.set('courseObjective', courseObjectiveModel);
+    await render(
+      <template>
+        <ObjectiveListItem
+          @courseObjective={{this.courseObjective}}
+          @editable={{true}}
+          @cohortObjectives={{(array)}}
+          @course={{this.course}}
+          @showMeSH={{false}}
+        />
+      </template>,
+    );
+    assert.notOk(component.hasRemoveConfirmation);
+    assert.strictEqual(component.description.text, 'course objective 0');
+    assert.strictEqual(component.parents.text, 'Add New');
+    assert.notOk(component.meshDescriptors.isVisible);
     assert.ok(component.hasTrashCan);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -55,6 +85,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
           @editable={{true}}
           @cohortObjectives={{(array)}}
           @course={{this.course}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -82,6 +113,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
           @editable={{true}}
           @cohortObjectives={{(array)}}
           @manageParents={{this.manageParents}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -105,6 +137,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
           @editable={{true}}
           @cohortObjectives={{(array)}}
           @course={{this.course}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -128,6 +161,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
           @editable={{true}}
           @cohortObjectives={{(array)}}
           @course={{this.course}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -152,6 +186,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
           @editable={{true}}
           @cohortObjectives={{(array)}}
           @course={{this.course}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -175,6 +210,7 @@ module('Integration | Component | course/objective-list-item', function (hooks) 
           @editable={{true}}
           @cohortObjectives={{(array)}}
           @course={{this.course}}
+          @showMeSH={{true}}
         />
       </template>,
     );

--- a/packages/test-app/tests/integration/components/course/objective-list-loading-test.gjs
+++ b/packages/test-app/tests/integration/components/course/objective-list-loading-test.gjs
@@ -7,8 +7,16 @@ module('Integration | Component | course/objective-list-loading', function (hook
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    await render(<template><ObjectiveListLoading @count={{9}} /></template>);
+    await render(<template><ObjectiveListLoading @count={{9}} @showMeSH={{true}} /></template>);
 
     assert.dom('.grid-row').exists({ count: 9 });
+    assert.dom('.grid-item').exists({ count: 9 * 4 });
+  });
+
+  test('it renders without MeSH UI', async function (assert) {
+    await render(<template><ObjectiveListLoading @count={{9}} @showMeSH={{false}} /></template>);
+
+    assert.dom('.grid-row').exists({ count: 9 });
+    assert.dom('.grid-item').exists({ count: 9 * 3 });
   });
 });

--- a/packages/test-app/tests/integration/components/course/objective-list-test.gjs
+++ b/packages/test-app/tests/integration/components/course/objective-list-test.gjs
@@ -16,11 +16,13 @@ module('Integration | Component | course/objective-list', function (hooks) {
     const vocabulary = await this.server.create('vocabulary', { school });
     const term1 = await this.server.create('term', { vocabulary, active: true });
     const term2 = await this.server.create('term', { vocabulary });
+    const meshDescriptors = await this.server.createList('mesh-descriptor', 2);
     await this.server.create('course-objective', {
       course,
       title: 'Objective A',
       position: 0,
       terms: [term1],
+      meshDescriptors,
     });
     await this.server.create('course-objective', {
       course,
@@ -32,7 +34,11 @@ module('Integration | Component | course/objective-list', function (hooks) {
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
-    await render(<template><ObjectiveList @editable={{true}} @course={{this.course}} /></template>);
+    await render(
+      <template>
+        <ObjectiveList @editable={{true}} @course={{this.course}} @showMeSH={{true}} />
+      </template>,
+    );
     assert.ok(component.sortIsVisible, 'Sort Objectives button is visible');
     assert.strictEqual(component.headers[0].text, 'Description');
     assert.strictEqual(component.headers[1].text, 'Parent Objectives');
@@ -50,13 +56,73 @@ module('Integration | Component | course/objective-list', function (hooks) {
       component.objectives[0].selectedTerms.list[0].terms[0].name,
       'term 1 (inactive)',
     );
+    assert.strictEqual(component.objectives[0].meshDescriptors.list.length, 1);
+    assert.strictEqual(component.objectives[0].meshDescriptors.list[0].title, 'Add New');
     assert.strictEqual(component.objectives[1].description.text, 'Objective A');
     assert.strictEqual(
       component.objectives[1].selectedTerms.list[0].title,
       'Vocabulary 1 (school 0)',
     );
     assert.strictEqual(component.objectives[1].selectedTerms.list[0].terms[0].name, 'term 0');
+    assert.strictEqual(component.objectives[1].meshDescriptors.list.length, 2);
+    assert.strictEqual(component.objectives[1].meshDescriptors.list[0].title, 'descriptor 0');
+    assert.strictEqual(component.objectives[1].meshDescriptors.list[1].title, 'descriptor 1');
 
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders without MeSH UI', async function (assert) {
+    const school = await this.server.create('school');
+    const course = await this.server.create('course');
+    const vocabulary = await this.server.create('vocabulary', { school });
+    const term1 = await this.server.create('term', { vocabulary, active: true });
+    const term2 = await this.server.create('term', { vocabulary });
+    await this.server.create('course-objective', {
+      course,
+      title: 'Objective A',
+      position: 0,
+      terms: [term1],
+    });
+    await this.server.create('course-objective', {
+      course,
+      title: 'Objective B',
+      position: 0,
+      terms: [term2],
+    });
+
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+    this.set('course', courseModel);
+
+    await render(
+      <template>
+        <ObjectiveList @editable={{true}} @course={{this.course}} @showMeSH={{false}} />
+      </template>,
+    );
+    assert.ok(component.sortIsVisible, 'Sort Objectives button is visible');
+    assert.strictEqual(component.headers[0].text, 'Description');
+    assert.strictEqual(component.headers[1].text, 'Parent Objectives');
+    assert.strictEqual(component.headers[2].text, 'Vocabulary Terms');
+    assert.strictEqual(component.headers[3].text, 'Actions');
+
+    assert.strictEqual(component.objectives.length, 2);
+    assert.strictEqual(component.objectives[0].description.text, 'Objective B');
+    assert.strictEqual(
+      component.objectives[0].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(
+      component.objectives[0].selectedTerms.list[0].terms[0].name,
+      'term 1 (inactive)',
+    );
+    assert.notOk(component.objectives[0].meshDescriptors.isVisible);
+    assert.strictEqual(component.objectives[1].description.text, 'Objective A');
+    assert.strictEqual(
+      component.objectives[1].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(component.objectives[1].selectedTerms.list[0].terms[0].name, 'term 0');
+    assert.notOk(component.objectives[1].meshDescriptors.isVisible);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -66,7 +132,11 @@ module('Integration | Component | course/objective-list', function (hooks) {
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
-    await render(<template><ObjectiveList @editable={{true}} @course={{this.course}} /></template>);
+    await render(
+      <template>
+        <ObjectiveList @editable={{true}} @course={{this.course}} @showMeSH={{true}} />
+      </template>,
+    );
     assert.notOk(component.sortIsVisible);
     assert.strictEqual(component.text, '');
   });
@@ -77,7 +147,11 @@ module('Integration | Component | course/objective-list', function (hooks) {
     const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
     this.set('course', courseModel);
 
-    await render(<template><ObjectiveList @editable={{true}} @course={{this.course}} /></template>);
+    await render(
+      <template>
+        <ObjectiveList @editable={{true}} @course={{this.course}} @showMeSH={{true}} />
+      </template>,
+    );
     assert.notOk(component.sortIsVisible, 'Sort Objectives button is visible');
     assert.strictEqual(component.objectives.length, 1);
 

--- a/packages/test-app/tests/integration/components/detail-learning-materials-item-test.gjs
+++ b/packages/test-app/tests/integration/components/detail-learning-materials-item-test.gjs
@@ -6,7 +6,7 @@ import { component } from 'ilios-common/page-objects/components/detail-learning-
 import DetailLearningMaterialsItem from 'ilios-common/components/detail-learning-materials-item';
 import noop from 'ilios-common/helpers/noop';
 
-module('Integration | Component | detail-learning-materials-item', function (hooks) {
+module('Integration | Component | detail learning materials item', function (hooks) {
   setupRenderingTest(hooks);
   setupMSW(hooks);
 
@@ -41,16 +41,42 @@ module('Integration | Component | detail-learning-materials-item', function (hoo
           @editable={{true}}
           @lm={{this.lm}}
           @setManagedMaterial={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );
     assert.ok(component.typeIcon.isCitation);
     assert.strictEqual(component.title, 'test title');
     assert.strictEqual(component.userNameInfo.fullName, '0 guy M. Mc0son');
-    assert.strictEqual(component.required, 'Yes');
-    assert.strictEqual(component.notes, 'Yes');
-    assert.strictEqual(component.mesh, 'descriptor 0 descriptor 1');
-    assert.strictEqual(component.status, 'status 1');
+    assert.strictEqual(component.required.text, 'Yes');
+    assert.strictEqual(component.notes.text, 'Yes');
+    assert.strictEqual(component.mesh.text, 'descriptor 0 descriptor 1');
+    assert.strictEqual(component.status.text, 'status 1');
+    assert.ok(component.isNotePublic);
+    assert.ok(component.actions.edit.isVisible);
+    assert.ok(component.actions.remove.isVisible);
+    assert.notOk(component.actions.remove.isDisabled);
+  });
+
+  test('it renders without MeSH UI', async function (assert) {
+    this.set('lm', this.lm);
+    await render(
+      <template>
+        <DetailLearningMaterialsItem
+          @editable={{true}}
+          @lm={{this.lm}}
+          @setManagedMaterial={{(noop)}}
+          @showMeSH={{false}}
+        />
+      </template>,
+    );
+    assert.ok(component.typeIcon.isCitation);
+    assert.strictEqual(component.title, 'test title');
+    assert.strictEqual(component.userNameInfo.fullName, '0 guy M. Mc0son');
+    assert.strictEqual(component.required.text, 'Yes');
+    assert.strictEqual(component.notes.text, 'Yes');
+    assert.notOk(component.mesh.isVisible);
+    assert.strictEqual(component.status.text, 'status 1');
     assert.ok(component.isNotePublic);
     assert.ok(component.actions.edit.isVisible);
     assert.ok(component.actions.remove.isVisible);
@@ -65,16 +91,42 @@ module('Integration | Component | detail-learning-materials-item', function (hoo
           @editable={{false}}
           @lm={{this.lm}}
           @setManagedMaterial={{(noop)}}
+          @showMeSH={{true}}
         />
       </template>,
     );
     assert.ok(component.typeIcon.isCitation);
     assert.strictEqual(component.title, 'test title');
     assert.strictEqual(component.userNameInfo.fullName, '0 guy M. Mc0son');
-    assert.strictEqual(component.required, 'Yes');
-    assert.strictEqual(component.notes, 'Yes');
-    assert.strictEqual(component.mesh, 'descriptor 0 descriptor 1');
-    assert.strictEqual(component.status, 'status 1');
+    assert.strictEqual(component.required.text, 'Yes');
+    assert.strictEqual(component.notes.text, 'Yes');
+    assert.strictEqual(component.mesh.text, 'descriptor 0 descriptor 1');
+    assert.strictEqual(component.status.text, 'status 1');
+    assert.ok(component.isNotePublic);
+    assert.notOk(component.actions.edit.isVisible, 'edit icon is not visible');
+    assert.ok(component.actions.remove.isVisible, 'remove icon is visible');
+    assert.ok(component.actions.remove.isDisabled, 'remove icon is disabled');
+  });
+
+  test('read-only without MeSH UI', async function (assert) {
+    this.set('lm', this.lm);
+    await render(
+      <template>
+        <DetailLearningMaterialsItem
+          @editable={{false}}
+          @lm={{this.lm}}
+          @setManagedMaterial={{(noop)}}
+          @showMeSH={{false}}
+        />
+      </template>,
+    );
+    assert.ok(component.typeIcon.isCitation);
+    assert.strictEqual(component.title, 'test title');
+    assert.strictEqual(component.userNameInfo.fullName, '0 guy M. Mc0son');
+    assert.strictEqual(component.required.text, 'Yes');
+    assert.strictEqual(component.notes.text, 'Yes');
+    assert.notOk(component.mesh.isVisible);
+    assert.strictEqual(component.status.text, 'status 1');
     assert.ok(component.isNotePublic);
     assert.notOk(component.actions.edit.isVisible, 'edit icon is not visible');
     assert.ok(component.actions.remove.isVisible, 'remove icon is visible');

--- a/packages/test-app/tests/integration/components/detail-learning-materials-test.gjs
+++ b/packages/test-app/tests/integration/components/detail-learning-materials-test.gjs
@@ -40,19 +40,83 @@ module('Integration | Component | detail learning materials', function (hooks) {
 
     await render(
       <template>
-        <DetailLearningMaterials @subject={{this.subject}} @isCourse={{true}} @editable={{true}} />
+        <DetailLearningMaterials
+          @subject={{this.subject}}
+          @isCourse={{true}}
+          @editable={{true}}
+          @showMeSH={{true}}
+        />
       </template>,
     );
-    assert.strictEqual(component.current.length, 1);
-    assert.ok(component.current[0].typeIcon.isCitation);
-    assert.strictEqual(component.current[0].title, 'test title');
-    assert.strictEqual(component.current[0].userNameInfo.fullName, '0 guy M. Mc0son');
-    assert.strictEqual(component.current[0].required, 'Yes');
-    assert.strictEqual(component.current[0].notes, 'Yes');
-    assert.strictEqual(component.current[0].mesh, 'None');
-    assert.strictEqual(component.current[0].status, 'status 1');
-    assert.ok(component.current[0].isNotePublic);
-    assert.notOk(component.current[0].isTimedRelease);
+    assert.strictEqual(component.materials.items.length, 1);
+    assert.ok(component.materials.items[0].typeIcon.isCitation);
+    assert.strictEqual(component.materials.headers.length, 7);
+    assert.strictEqual(component.materials.headers[0].text, 'Display Name');
+    assert.strictEqual(component.materials.headers[1].text, 'Owner');
+    assert.strictEqual(component.materials.headers[2].text, 'Required');
+    assert.strictEqual(component.materials.headers[3].text, 'Notes');
+    assert.strictEqual(component.materials.headers[4].text, 'MeSH');
+    assert.strictEqual(component.materials.headers[5].text, 'Status');
+    assert.strictEqual(component.materials.headers[6].text, 'Actions');
+    assert.strictEqual(component.materials.items[0].title, 'test title');
+    assert.strictEqual(component.materials.items[0].userNameInfo.fullName, '0 guy M. Mc0son');
+    assert.strictEqual(component.materials.items[0].required.text, 'Yes');
+    assert.strictEqual(component.materials.items[0].notes.text, 'Yes');
+    assert.strictEqual(component.materials.items[0].mesh.text, 'None');
+    assert.strictEqual(component.materials.items[0].status.text, 'status 1');
+    assert.ok(component.materials.items[0].isNotePublic);
+    assert.notOk(component.materials.items[0].isTimedRelease);
+  });
+
+  test('lm table items without MeSH UI', async function (assert) {
+    const learningMaterial = await this.server.create('learning-material', {
+      title: 'test title',
+      citation: 'some text',
+      owningUser: this.user,
+      status: this.status[1],
+      userRole: this.roles[0],
+    });
+
+    const clm = await this.server.create('course-learning-material', {
+      learningMaterial,
+      required: true,
+      notes: 'notes',
+    });
+
+    const course = await this.server.create('course', {
+      learningMaterials: [clm],
+    });
+    const courseModel = await this.owner.lookup('service:store').findRecord('course', course.id);
+
+    this.set('subject', courseModel);
+
+    await render(
+      <template>
+        <DetailLearningMaterials
+          @subject={{this.subject}}
+          @isCourse={{true}}
+          @editable={{true}}
+          @showMeSH={{false}}
+        />
+      </template>,
+    );
+    assert.strictEqual(component.materials.items.length, 1);
+    assert.ok(component.materials.items[0].typeIcon.isCitation);
+    assert.strictEqual(component.materials.headers.length, 6);
+    assert.strictEqual(component.materials.headers[0].text, 'Display Name');
+    assert.strictEqual(component.materials.headers[1].text, 'Owner');
+    assert.strictEqual(component.materials.headers[2].text, 'Required');
+    assert.strictEqual(component.materials.headers[3].text, 'Notes');
+    assert.strictEqual(component.materials.headers[4].text, 'Status');
+    assert.strictEqual(component.materials.headers[5].text, 'Actions');
+    assert.strictEqual(component.materials.items[0].title, 'test title');
+    assert.strictEqual(component.materials.items[0].userNameInfo.fullName, '0 guy M. Mc0son');
+    assert.strictEqual(component.materials.items[0].required.text, 'Yes');
+    assert.strictEqual(component.materials.items[0].notes.text, 'Yes');
+    assert.notOk(component.materials.items[0].mesh.isVisible);
+    assert.strictEqual(component.materials.items[0].status.text, 'status 1');
+    assert.ok(component.materials.items[0].isNotePublic);
+    assert.notOk(component.materials.items[0].isTimedRelease);
   });
 
   test('custom user display name', async function (assert) {
@@ -84,16 +148,16 @@ module('Integration | Component | detail learning materials', function (hooks) {
         <DetailLearningMaterials @subject={{this.subject}} @isCourse={{true}} @editable={{true}} />
       </template>,
     );
-    assert.strictEqual(component.current[0].userNameInfo.fullName, 'Clem Chowder');
-    assert.notOk(component.current[0].userNameInfo.isTooltipVisible);
-    await component.current[0].userNameInfo.expandTooltip();
-    assert.ok(component.current[0].userNameInfo.isTooltipVisible);
+    assert.strictEqual(component.materials.items[0].userNameInfo.fullName, 'Clem Chowder');
+    assert.notOk(component.materials.items[0].userNameInfo.isTooltipVisible);
+    await component.materials.items[0].userNameInfo.expandTooltip();
+    assert.ok(component.materials.items[0].userNameInfo.isTooltipVisible);
     assert.strictEqual(
-      component.current[0].userNameInfo.tooltipContents,
+      component.materials.items[0].userNameInfo.tooltipContents,
       'Campus name of record: 1 guy M, Mc1son',
     );
-    await component.current[0].userNameInfo.closeTooltip();
-    assert.notOk(component.current[0].userNameInfo.isTooltipVisible);
+    await component.materials.items[0].userNameInfo.closeTooltip();
+    assert.notOk(component.materials.items[0].userNameInfo.isTooltipVisible);
   });
 
   test('sort button visible when lm list has 2+ items and editing is allowed', async function (assert) {

--- a/packages/test-app/tests/integration/components/session/collapsed-objectives-test.gjs
+++ b/packages/test-app/tests/integration/components/session/collapsed-objectives-test.gjs
@@ -39,17 +39,46 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
 
     this.set('session', sessionModel);
     await render(
-      <template><CollapsedObjectives @session={{this.session}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @session={{this.session}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
 
     assert.strictEqual(component.title, 'Objectives (4)');
-    assert.strictEqual(component.objectiveCount, 'There are 4 objectives');
-    assert.strictEqual(component.parentCount, '1 has a parent');
-    assert.strictEqual(component.meshCount, '1 has MeSH');
-    assert.strictEqual(component.termCount, '1 has vocabulary terms');
-
+    assert.strictEqual(component.objectiveCount.text, 'There are 4 objectives');
+    assert.strictEqual(component.parentCount.text, '1 has a parent');
+    assert.strictEqual(component.meshCount.text, '1 has MeSH');
+    assert.strictEqual(component.termCount.text, '1 has vocabulary terms');
     assert.ok(component.parentStatus.partial);
     assert.ok(component.meshStatus.partial);
+    assert.ok(component.termStatus.partial);
+  });
+
+  test('displays summary data without MeSH', async function (assert) {
+    const session = await this.server.create('session', {
+      sessionObjectives: [
+        this.objective,
+        this.objectiveWithMesh,
+        this.objectiveWithCourseObjectives,
+        this.objectiveWithTerms,
+      ],
+    });
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+
+    this.set('session', sessionModel);
+    await render(
+      <template>
+        <CollapsedObjectives @session={{this.session}} @expand={{(noop)}} @showMeSH={{false}} />
+      </template>,
+    );
+
+    assert.strictEqual(component.title, 'Objectives (4)');
+    assert.strictEqual(component.objectiveCount.text, 'There are 4 objectives');
+    assert.strictEqual(component.parentCount.text, '1 has a parent');
+    assert.notOk(component.meshCount.isVisible);
+    assert.strictEqual(component.termCount.text, '1 has vocabulary terms');
+    assert.ok(component.parentStatus.partial);
+    assert.notOk(component.meshStatus.isVisible);
     assert.ok(component.termStatus.partial);
   });
 
@@ -62,7 +91,9 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
       assert.step('click called');
     });
     await render(
-      <template><CollapsedObjectives @session={{this.session}} @expand={{this.click}} /></template>,
+      <template>
+        <CollapsedObjectives @session={{this.session}} @expand={{this.click}} @showMeSH={{true}} />
+      </template>,
     );
 
     assert.strictEqual(component.title, 'Objectives (0)');
@@ -78,7 +109,9 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
 
     this.set('session', sessionModel);
     await render(
-      <template><CollapsedObjectives @session={{this.session}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @session={{this.session}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.parentStatus.complete);
@@ -92,7 +125,9 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
 
     this.set('session', sessionModel);
     await render(
-      <template><CollapsedObjectives @session={{this.session}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @session={{this.session}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.parentStatus.none);
@@ -106,7 +141,9 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
 
     this.set('session', sessionModel);
     await render(
-      <template><CollapsedObjectives @session={{this.session}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @session={{this.session}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.meshStatus.complete);
@@ -120,7 +157,9 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
 
     this.set('session', sessionModel);
     await render(
-      <template><CollapsedObjectives @session={{this.session}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @session={{this.session}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.meshStatus.none);
@@ -134,7 +173,9 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
 
     this.set('session', sessionModel);
     await render(
-      <template><CollapsedObjectives @session={{this.session}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @session={{this.session}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.termStatus.complete);
@@ -148,7 +189,9 @@ module('Integration | Component | session/collapsed-objectives', function (hooks
 
     this.set('session', sessionModel);
     await render(
-      <template><CollapsedObjectives @session={{this.session}} @expand={{(noop)}} /></template>,
+      <template>
+        <CollapsedObjectives @session={{this.session}} @expand={{(noop)}} @showMeSH={{true}} />
+      </template>,
     );
     assert.strictEqual(component.title, 'Objectives (1)');
     assert.ok(component.termStatus.none);

--- a/packages/test-app/tests/integration/components/session/objective-list-item-test.gjs
+++ b/packages/test-app/tests/integration/components/session/objective-list-item-test.gjs
@@ -30,6 +30,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
           @editable={{true}}
           @courseObjectives={{(array)}}
           @session={{this.sessionModel}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -37,6 +38,38 @@ module('Integration | Component | session/objective-list-item', function (hooks)
     assert.strictEqual(component.description.text, 'session objective 0');
     assert.strictEqual(component.parents.text, 'Add New');
     assert.strictEqual(component.meshDescriptors.text, 'Add New');
+    assert.ok(component.hasTrashCan);
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders without MeSH UI', async function (assert) {
+    const school = await this.server.create('school');
+    const course = await this.server.create('course', { school });
+    const session = await this.server.create('session', { course });
+    const sessionObjective = await this.server.create('session-objective', {
+      session,
+    });
+    const store = await this.owner.lookup('service:store');
+    const sessionModel = await store.findRecord('session', session.id);
+    const sessionObjectiveModel = await store.findRecord('session-objective', sessionObjective.id);
+    this.set('sessionObjective', sessionObjectiveModel);
+    this.set('sessionModel', sessionModel);
+    await render(
+      <template>
+        <ObjectiveListItem
+          @sessionObjective={{this.sessionObjective}}
+          @editable={{true}}
+          @courseObjectives={{(array)}}
+          @session={{this.sessionModel}}
+          @showMeSH={{false}}
+        />
+      </template>,
+    );
+    assert.notOk(component.hasRemoveConfirmation);
+    assert.strictEqual(component.description.text, 'session objective 0');
+    assert.strictEqual(component.parents.text, 'Add New');
+    assert.notOk(component.meshDescriptors.isVisible);
     assert.ok(component.hasTrashCan);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
@@ -59,6 +92,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
           @editable={{true}}
           @courseObjectives={{(array)}}
           @session={{this.sessionModel}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -89,6 +123,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
           @editable={{true}}
           @courseObjectives={{(array)}}
           @session={{this.sessionModel}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -113,6 +148,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
           @editable={{true}}
           @courseObjectives={{(array)}}
           @session={{this.sessionModel}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -139,6 +175,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
           @editable={{true}}
           @courseObjectives={{(array)}}
           @session={{this.sessionModel}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -164,6 +201,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
           @editable={{true}}
           @courseObjectives={{(array)}}
           @session={{this.sessionModel}}
+          @showMeSH={{true}}
         />
       </template>,
     );
@@ -188,6 +226,7 @@ module('Integration | Component | session/objective-list-item', function (hooks)
           @editable={{true}}
           @courseObjectives={{(array)}}
           @session={{this.sessionModel}}
+          @showMeSH={{true}}
         />
       </template>,
     );

--- a/packages/test-app/tests/integration/components/session/objective-list-loading-test.gjs
+++ b/packages/test-app/tests/integration/components/session/objective-list-loading-test.gjs
@@ -7,8 +7,16 @@ module('Integration | Component | session/objective-list-loading', function (hoo
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    await render(<template><ObjectiveListLoading @count={{9}} /></template>);
+    await render(<template><ObjectiveListLoading @count={{9}} @showMeSH={{true}} /></template>);
 
     assert.dom('.grid-row').exists({ count: 9 });
+    assert.dom('.grid-item').exists({ count: 9 * 4 });
+  });
+
+  test('it renders without MeSH UI', async function (assert) {
+    await render(<template><ObjectiveListLoading @count={{9}} @showMeSH={{false}} /></template>);
+
+    assert.dom('.grid-row').exists({ count: 9 });
+    assert.dom('.grid-item').exists({ count: 9 * 3 });
   });
 });

--- a/packages/test-app/tests/integration/components/session/objective-list-test.gjs
+++ b/packages/test-app/tests/integration/components/session/objective-list-test.gjs
@@ -17,11 +17,13 @@ module('Integration | Component | session/objective-list', function (hooks) {
     const vocabulary = await this.server.create('vocabulary', { school });
     const term1 = await this.server.create('term', { vocabulary, active: true });
     const term2 = await this.server.create('term', { vocabulary });
+    const meshDescriptors = await this.server.createList('mesh-descriptor', 2);
     await this.server.create('session-objective', {
       session,
       title: 'Objective A',
       position: 0,
       terms: [term1],
+      meshDescriptors,
     });
     await this.server.create('session-objective', {
       session,
@@ -33,7 +35,9 @@ module('Integration | Component | session/objective-list', function (hooks) {
     this.set('session', sessionModel);
 
     await render(
-      <template><ObjectiveList @editable={{true}} @session={{this.session}} /></template>,
+      <template>
+        <ObjectiveList @editable={{true}} @session={{this.session}} @showMeSH={{true}} />
+      </template>,
     );
     assert.ok(component.sortIsVisible, 'Sort Objectives button is visible');
     assert.strictEqual(component.headers[0].text, 'Description');
@@ -52,13 +56,74 @@ module('Integration | Component | session/objective-list', function (hooks) {
       component.objectives[0].selectedTerms.list[0].terms[0].name,
       'term 1 (inactive)',
     );
+    assert.strictEqual(component.objectives[0].meshDescriptors.list.length, 1);
+    assert.strictEqual(component.objectives[0].meshDescriptors.list[0].title, 'Add New');
     assert.strictEqual(component.objectives[1].description.text, 'Objective A');
     assert.strictEqual(
       component.objectives[1].selectedTerms.list[0].title,
       'Vocabulary 1 (school 0)',
     );
     assert.strictEqual(component.objectives[1].selectedTerms.list[0].terms[0].name, 'term 0');
+    assert.strictEqual(component.objectives[1].meshDescriptors.list.length, 2);
+    assert.strictEqual(component.objectives[1].meshDescriptors.list[0].title, 'descriptor 0');
+    assert.strictEqual(component.objectives[1].meshDescriptors.list[1].title, 'descriptor 1');
 
+    await a11yAudit(this.element);
+    assert.ok(true, 'no a11y errors found!');
+  });
+
+  test('it renders without MeSH UI', async function (assert) {
+    const school = await this.server.create('school');
+    const course = await this.server.create('course');
+    const session = await this.server.create('session', { course });
+    const vocabulary = await this.server.create('vocabulary', { school });
+    const term1 = await this.server.create('term', { vocabulary, active: true });
+    const term2 = await this.server.create('term', { vocabulary });
+    await this.server.create('session-objective', {
+      session,
+      title: 'Objective A',
+      position: 0,
+      terms: [term1],
+    });
+    await this.server.create('session-objective', {
+      session,
+      title: 'Objective B',
+      position: 0,
+      terms: [term2],
+    });
+    const sessionModel = await this.owner.lookup('service:store').findRecord('session', session.id);
+    this.set('session', sessionModel);
+
+    await render(
+      <template>
+        <ObjectiveList @editable={{true}} @session={{this.session}} @showMeSH={{false}} />
+      </template>,
+    );
+    assert.ok(component.sortIsVisible, 'Sort Objectives button is visible');
+    assert.strictEqual(component.headers[0].text, 'Description');
+    assert.strictEqual(component.headers[1].text, 'Parent Objectives');
+    assert.strictEqual(component.headers[2].text, 'Vocabulary Terms');
+    assert.strictEqual(component.headers[3].text, 'Actions');
+
+    assert.strictEqual(component.objectives.length, 2);
+    assert.strictEqual(component.objectives[0].description.text, 'Objective B');
+    assert.strictEqual(
+      component.objectives[0].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(
+      component.objectives[0].selectedTerms.list[0].terms[0].name,
+      'term 1 (inactive)',
+    );
+
+    assert.notOk(component.objectives[0].meshDescriptors.isVisible);
+    assert.strictEqual(component.objectives[1].description.text, 'Objective A');
+    assert.strictEqual(
+      component.objectives[1].selectedTerms.list[0].title,
+      'Vocabulary 1 (school 0)',
+    );
+    assert.strictEqual(component.objectives[1].selectedTerms.list[0].terms[0].name, 'term 0');
+    assert.notOk(component.objectives[1].meshDescriptors.isVisible);
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
   });
@@ -70,7 +135,9 @@ module('Integration | Component | session/objective-list', function (hooks) {
     this.set('session', sessionModel);
 
     await render(
-      <template><ObjectiveList @editable={{true}} @session={{this.session}} /></template>,
+      <template>
+        <ObjectiveList @editable={{true}} @session={{this.session}} @showMeSH={{true}} />
+      </template>,
     );
     assert.notOk(component.sortIsVisible);
     assert.strictEqual(component.text, '');
@@ -84,7 +151,9 @@ module('Integration | Component | session/objective-list', function (hooks) {
     this.set('session', sessionModel);
 
     await render(
-      <template><ObjectiveList @editable={{true}} @session={{this.session}} /></template>,
+      <template>
+        <ObjectiveList @editable={{true}} @session={{this.session}} @showMeSH={{true}} />
+      </template>,
     );
     assert.notOk(component.sortIsVisible, 'Sort Objectives button is visible');
     assert.strictEqual(component.objectives.length, 1);


### PR DESCRIPTION
refs ilios/ilios#3549

i added visibility switches for MeSH UI components in the following areas
- program-year/course/session objective management
- course/session learning materials management
- course/session MeSH management
- print course

the school config check happens at top level components, then the value gets passed down into the relevant sub-components.