### PR TITLE
Highlight today's Week at a Glance day

### DIFF
--- a/packages/ilios-common/addon/components/week-glance.gjs
+++ b/packages/ilios-common/addon/components/week-glance.gjs
@@ -120,12 +120,14 @@ export default class WeeklyGlanceComponent extends Component {
     // This transforms the list of events
     // into a map that groups events by the same start date.
     const eventsByDate = new Map();
+    const today = DateTime.now();
     this.nonIlmPreWorkEvents.forEach((event) => {
       const startDate = DateTime.fromISO(event.startDate);
       const date = startDate.toISODate();
       if (!eventsByDate.has(date)) {
         eventsByDate.set(date, {
           events: [],
+          isToday: startDate.hasSame(today, 'day'),
           startDate,
         });
       }
@@ -166,7 +168,7 @@ export default class WeeklyGlanceComponent extends Component {
         {{#if this.eventsLoaded}}
           {{#if (gt this.nonIlmPreWorkEvents.length 0)}}
             {{#each this.nonPreWorkEventsByDay as |date|}}
-              <div class="events-by-date" data-test-events-by-date>
+              <div class="events-by-date{{if date.isToday ' today'}}" data-test-events-by-date>
                 <h3 class="day long" data-test-day>{{formatDate date.startDate weekday="long"}}</h3>
                 <h3 class="day short" data-test-day>{{formatDate
                     date.startDate

--- a/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
+++ b/packages/ilios-common/app/styles/ilios-common/components/week-glance.scss
@@ -21,6 +21,10 @@
     flex-direction: row-reverse;
     justify-content: space-between;
 
+    &.today .day {
+      color: light-dark(var(--green), var(--light-green));
+    }
+
     .day {
       @include m.ilios-heading-h4;
       align-self: flex-start;

--- a/packages/test-app/tests/integration/components/week-glance-test.gjs
+++ b/packages/test-app/tests/integration/components/week-glance-test.gjs
@@ -9,6 +9,7 @@ import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setLocale, setupIntl } from 'ember-intl/test-support';
 import WeekGlance from 'ilios-common/components/week-glance';
 import formatDate from 'ember-intl/helpers/format-date';
+import { freezeDateAt, unfreezeDate } from 'ilios-common';
 
 module('Integration | Component | week-glance', function (hooks) {
   setupRenderingTest(hooks);
@@ -117,6 +118,10 @@ module('Integration | Component | week-glance', function (hooks) {
     };
   });
 
+  hooks.afterEach(() => {
+    unfreezeDate();
+  });
+
   test('it renders with events', async function (assert) {
     setupUserEvents(this);
     this.set('today', testDate.toJSDate());
@@ -149,6 +154,30 @@ module('Integration | Component | week-glance', function (hooks) {
 
     await a11yAudit(this.element);
     assert.ok(true, 'no a11y errors found!');
+  });
+
+  test("it highlights today's day", async function (assert) {
+    setupUserEvents(this);
+    freezeDateAt(testDate.plus({ day: 1 }).toJSDate());
+    this.set('today', testDate.toJSDate());
+    this.set('week', testDate.weekNumber);
+
+    await render(
+      <template>
+        <WeekGlance
+          @collapsible={{false}}
+          @collapsed={{false}}
+          @showFullTitle={{true}}
+          @year={{formatDate this.today year="numeric"}}
+          @week={{this.week}}
+        />
+      </template>,
+    );
+
+    const days = this.element.querySelectorAll('[data-test-events-by-date]');
+    assert.strictEqual(days.length, 2);
+    assert.dom(days[0]).doesNotHaveClass('today');
+    assert.dom(days[1]).hasClass('today');
   });
 
   test('it renders blank', async function (assert) {

--- a/packages/test-app/tests/integration/components/week-glance-test.gjs
+++ b/packages/test-app/tests/integration/components/week-glance-test.gjs
@@ -118,10 +118,6 @@ module('Integration | Component | week-glance', function (hooks) {
     };
   });
 
-  hooks.afterEach(() => {
-    unfreezeDate();
-  });
-
   test('it renders with events', async function (assert) {
     setupUserEvents(this);
     this.set('today', testDate.toJSDate());
@@ -178,6 +174,7 @@ module('Integration | Component | week-glance', function (hooks) {
     assert.strictEqual(days.length, 2);
     assert.dom(days[0]).doesNotHaveClass('today');
     assert.dom(days[1]).hasClass('today');
+    unfreezeDate();
   });
 
   test('it renders blank', async function (assert) {


### PR DESCRIPTION
## Summary

- identify the event group whose date matches today
- highlight its responsive day heading with the theme's accessible blue color
- add integration coverage for current and non-current date groups

Closes ilios/ilios#7375

## Testing

- `ember test --launch "Headless Edge" --filter "Integration | Component | week-glance"` (23 passed)
- Prettier, ESLint, Stylelint, and Ember Template Lint on all changed files