### PR TITLE
Give table cells room so header hover does not crowd the text

### DIFF
--- a/packages/ilios-common/app/styles/ilios-common/shared/ilios-table.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/ilios-table.scss
@@ -18,7 +18,7 @@
   tr,
   td,
   th {
-    padding: 0.25rem 0.1rem;
+    padding: 0.25rem 0.5rem;
     vertical-align: middle;
   }
 
@@ -61,7 +61,7 @@
     td,
     th {
       margin: 0;
-      padding: 0 0.1rem;
+      padding: 0 0.5rem;
     }
   }
 


### PR DESCRIPTION
Addresses ilios/ilios#7428.

## Why the text is touching the edge

`.ilios-table` gives every cell `padding: 0.25rem 0.1rem`. That horizontal value is about 1.6px, so label text sits effectively flush against the cell edge. It was always tight; the hover state added in #9438 made it obvious, because `ilios-table-colors` hovers the whole `th`, and the newly painted background stops right where the text starts.

The second screenshot on the issue shows the other half of the same problem, with no hover involved: the last column runs its label straight into the right edge of the table.

## The change

Two values in `shared/ilios-table.scss`, `0.1rem` to `0.5rem`: once on the shared cell rule and once on the `.condensed` variant so the two stay in step.

**The padding goes on `td` as well as `th`, and it has to.** They share one rule, and separating them would be wrong anyway: padding only the headers would indent every column label away from the values beneath it, so header and body text would stop lining up. Widening both keeps the columns aligned and gives the hover background room around its text.

## What it looks like

I mocked both screenshots from the issue at the old and new values, since I could not run the app here:

- **Sessions header, middle column hovered.** Before, `Title` sits hard against the left edge of the hover block and `Groups` against the right edge of the table. After, both have room, and `Title` still lines up with the row text below it.
- **Light list header.** Before, `Status` touches the left edge and `Course :: Session` the right. After, both clear the edge.

`0.5rem` is the knob here. It is a conventional cell padding and it reads well in the mock, but it is a taste call and I do not have your eyes on the real screens. The Visual Diff workflow will show it across every table, and I am happy to dial it to whatever you prefer.

## Scope and risk

`.ilios-table` is used by around 67 templates, so this is deliberately a shared-style change rather than something scoped to sortable headers. Worth knowing: the table is `table-layout: fixed`, so each cell now has 0.8rem less room for content, which could introduce wrapping in the densest columns. That is the main thing to look for in the visual diff.

## Verification

- Stylelint passes on the changed file using this package's exact `.stylelintrc.js` rule set. None of its rules touch `padding`.
- No test asserts these values, and nothing else in the stylesheets overrides `.ilios-table` cell padding, so there is no rule competing with this one.

I did not run the Ember suite. The repo asks for Node >= 24 and this machine tops out at Node 22, and a padding value has no test coverage to exercise anyway. CI and the visual diff are the real check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
