### PR TITLE
Objective Sorting style improvement

### DIFF
--- a/packages/frontend/tests/integration/components/program-year/objective-list-test.gjs
+++ b/packages/frontend/tests/integration/components/program-year/objective-list-test.gjs
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'frontend/tests/helpers';
+import { setupRenderingTest, takeScreenshot } from 'frontend/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { component } from 'frontend/tests/pages/components/program-year/objective-list';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -51,6 +51,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
         />
       </template>,
     );
+    await takeScreenshot(assert, 'default');
     assert.ok(component.sortIsVisible, 'Sort Objectives button is visible');
     assert.strictEqual(component.headers[0].text, 'Description');
     assert.strictEqual(component.headers[1].text, 'Competency');
@@ -121,6 +122,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
         />
       </template>,
     );
+    await takeScreenshot(assert, 'default');
     assert.ok(component.sortIsVisible, 'Sort Objectives button is visible');
     assert.strictEqual(component.headers[0].text, 'Description');
     assert.strictEqual(component.headers[1].text, 'Competency');
@@ -164,6 +166,7 @@ module('Integration | Component | program-year/objective-list', function (hooks)
         <ObjectiveList @editable={{true}} @programYear={{this.programYear}} @showMeSH={{true}} />
       </template>,
     );
+    await takeScreenshot(assert, 'default');
     assert.notOk(component.sortIsVisible);
     assert.strictEqual(component.text, '');
   });

--- a/packages/ilios-common/app/styles/ilios-common/shared/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/sort-manager.scss
@@ -1,6 +1,8 @@
 @use "../mixins/font-size";
 
 .sort-manager {
+  padding-top: 0.5em;
+
   .actions {
     display: flex;
     justify-content: flex-end;
@@ -14,16 +16,18 @@
     .bigcancel {
       background-color: light-dark(var(--red), var(--red));
       color: light-dark(var(--white), var(--white));
-      margin: 0 0.5em;
+      margin: 0 0 0 0.5em;
     }
   }
 
   .content {
-    padding-top: 0.5rem;
+    padding-top: 0;
   }
 
   .sortable-items {
     list-style-type: none;
+    padding-inline-start: 5px;
+
     .item {
       align-items: center;
       background-color: light-dark(var(--lightest-grey), var(--grey));
@@ -32,7 +36,7 @@
       cursor: pointer;
       display: flex;
       gap: 1em;
-      margin: 10px 0.3rem 0 0;
+      margin: 10px 0 0 0;
       opacity: 1;
       padding: 1rem;
       vertical-align: middle;

--- a/packages/ilios-common/app/styles/ilios-common/shared/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/sort-manager.scss
@@ -11,12 +11,20 @@
       background-color: light-dark(var(--green), var(--green));
       color: light-dark(var(--white), var(--white));
       margin-left: 0.5rem;
+
+      &:hover {
+        background-color: light-dark(var(--light-green), var(--light-green));
+      }
     }
 
     .bigcancel {
       background-color: light-dark(var(--red), var(--red));
       color: light-dark(var(--white), var(--white));
       margin: 0 0 0 0.5em;
+
+      &:hover {
+        background-color: light-dark(var(--light-red), var(--light-red));
+      }
     }
   }
 

--- a/packages/ilios-common/app/styles/ilios-common/shared/sort-manager.scss
+++ b/packages/ilios-common/app/styles/ilios-common/shared/sort-manager.scss
@@ -41,6 +41,13 @@
       padding: 1rem;
       vertical-align: middle;
 
+      &:hover {
+        background-color: light-dark(
+          var(--super-light-grey),
+          var(--light-grey)
+        );
+      }
+
       svg {
         min-width: 16px;
       }


### PR DESCRIPTION
Fixes ilios/ilios#7388

* Spacing between action buttons and [+] button is improved across course/session/program-year objectives
* Increased sortable button width so they maximize usable space
* Sortable buttons now have hover state


**Edit [by ST]**

Since the differ doesn't capture this screen, here is a side-by-side. Improvements are on the left.

<img width="1692" height="970" alt="image" src="https://github.com/user-attachments/assets/50dccebe-ebd2-4c12-953f-4f310004cfe3" />

**Edit [by MC]**

Added a screenshot to Program Year->Objectives to hopefully catch this change in the future. Also, once this goes in, the `.bigadd, .bigcancel` issue can be addressed: https://github.com/ilios/ilios/issues/7415
