### PR TITLE
streamline lookup of school configuration

### DIFF
--- a/packages/frontend/app/components/program-year/details.gjs
+++ b/packages/frontend/app/components/program-year/details.gjs
@@ -14,36 +14,25 @@ import DetailTaxonomies from 'ilios-common/components/detail-taxonomies';
 import CollapsedTaxonomies from 'ilios-common/components/collapsed-taxonomies';
 import CourseAssociations from './course-associations';
 import CohortMembers from './cohort-members';
+import getSchoolConfigs from 'ilios-common/utils/get-school-config.js';
 
 export default class ProgramYearDetailsComponent extends Component {
   @cached
   get schoolConfigsData() {
-    return new TrackedAsyncData(this.getSchoolConfigs(this.args.programYear));
-  }
-
-  async getSchoolConfigs(programYear) {
-    const program = await programYear.program;
-    const school = await program.school;
-    return await school.configurations;
-  }
-
-  @cached
-  get schoolConfigs() {
-    const rhett = new Map();
-    if (this.schoolConfigsData.isResolved) {
-      this.schoolConfigsData.value.forEach((config) => {
-        rhett.set(config.name, config.parsedValue);
-      });
-    }
-    return rhett;
+    return new TrackedAsyncData(
+      getSchoolConfigs(async (programYear) => {
+        const program = await programYear.program;
+        return program.school;
+      }, this.args.programYear),
+    );
   }
 
   get schoolConfigsLoaded() {
     return this.schoolConfigsData.isResolved;
   }
 
-  get showMeSH() {
-    return this.schoolConfigs.has('showMeSH') ? this.schoolConfigs.get('showMeSH') : true;
+  get schoolConfigs() {
+    return this.schoolConfigsLoaded ? this.schoolConfigsData.value : {};
   }
 
   <template>
@@ -81,6 +70,7 @@ export default class ProgramYearDetailsComponent extends Component {
             @expand={{fn @setPyCompetencyDetails true}}
           />
         {{/if}}
+
         {{#if (or (eq @programYear.programYearObjectives.length 0) @pyObjectiveDetails)}}
           <Objectives
             @programYear={{@programYear}}
@@ -89,13 +79,13 @@ export default class ProgramYearDetailsComponent extends Component {
             @expand={{fn @setPyObjectiveDetails true}}
             @expandedObjectiveIds={{@expandedObjectiveIds}}
             @setExpandedObjectiveIds={{@setExpandedObjectiveIds}}
-            @showMeSH={{this.showMeSH}}
+            @showMeSH={{this.schoolConfigs.showMeSH}}
           />
         {{else}}
           <CollapsedObjectives
             @programYear={{@programYear}}
             @expand={{fn @setPyObjectiveDetails true}}
-            @showMeSH={{this.showMeSH}}
+            @showMeSH={{this.schoolConfigs.showMeSH}}
           />
         {{/if}}
         {{#if (or (eq @programYear.terms.length 0) @pyTaxonomyDetails)}}

--- a/packages/ilios-common/addon/components/course/details.gjs
+++ b/packages/ilios-common/addon/components/course/details.gjs
@@ -16,6 +16,7 @@ import FaIcon from '@fortawesome/ember-fontawesome/components/fa-icon';
 import { fn } from '@ember/helper';
 import { pageTitle } from 'ember-page-title';
 import { faSquareMinus, faSquarePlus } from '@fortawesome/free-solid-svg-icons';
+import getSchoolConfigs from 'ilios-common/utils/get-school-config.js';
 
 export default class CourseDetailsComponent extends Component {
   @service router;
@@ -49,39 +50,28 @@ export default class CourseDetailsComponent extends Component {
 
   @cached
   get schoolConfigsData() {
-    return new TrackedAsyncData(this.getSchoolConfigs(this.args.course));
+    return new TrackedAsyncData(
+      getSchoolConfigs(async (course) => course.school, this.args.course),
+    );
   }
 
-  async getSchoolConfigs(course) {
-    const school = await course.school;
-    return await school.configurations;
+  get schoolConfigsLoaded() {
+    return this.schoolConfigsData.isResolved;
   }
 
-  @cached
   get schoolConfigs() {
-    const rhett = new Map();
-    if (this.schoolConfigsData.isResolved) {
-      this.schoolConfigsData.value.forEach((config) => {
-        rhett.set(config.name, config.parsedValue);
-      });
-    }
-    return rhett;
-  }
-
-  get showMeSH() {
-    return this.schoolConfigs.has('showMeSH') ? this.schoolConfigs.get('showMeSH') : true;
+    return this.schoolConfigsLoaded ? this.schoolConfigsData.value : {};
   }
 
   get configLoaded() {
     return (
-      this.academicYearCrossesCalendarYearBoundariesData.isResolved &&
-      this.schoolConfigsData.isResolved
+      this.academicYearCrossesCalendarYearBoundariesData.isResolved && this.schoolConfigsLoaded
     );
   }
-
   get notRolloverRoute() {
     return this.router.currentRouteName !== 'course.rollover';
   }
+
   <template>
     {{#if this.configLoaded}}
       {{pageTitle "Courses | " @course.title " " this.academicYearDisplay}}
@@ -116,7 +106,7 @@ export default class CourseDetailsComponent extends Component {
             @setCourseTaxonomyDetails={{@setCourseTaxonomyDetails}}
             @setCourseCompetencyDetails={{@setCourseCompetencyDetails}}
             @setCourseManageLeadership={{@setCourseManageLeadership}}
-            @showMeSH={{this.showMeSH}}
+            @showMeSH={{this.schoolConfigs.showMeSH}}
           />
           {{#if @showDetailsCollapseControl}}
             <div class="details-collapse-control">

--- a/packages/ilios-common/addon/components/course/details.gjs
+++ b/packages/ilios-common/addon/components/course/details.gjs
@@ -107,6 +107,8 @@ export default class CourseDetailsComponent extends Component {
             @setCourseCompetencyDetails={{@setCourseCompetencyDetails}}
             @setCourseManageLeadership={{@setCourseManageLeadership}}
             @showMeSH={{this.schoolConfigs.showMeSH}}
+            @learningMaterialAccessibilityRequired={{this.schoolConfigs.learningMaterialAccessibilityRequired}}
+            @learningMaterialAccessibilityRequirementsLink={{this.schoolConfigs.learningMaterialAccessibilityRequirementsLink}}
           />
           {{#if @showDetailsCollapseControl}}
             <div class="details-collapse-control">

--- a/packages/ilios-common/addon/components/course/editing.gjs
+++ b/packages/ilios-common/addon/components/course/editing.gjs
@@ -53,6 +53,8 @@ import DetailCohorts from 'ilios-common/components/detail-cohorts';
       @subject={{@course}}
       @isCourse={{true}}
       @editable={{@editable}}
+      @accessibilityRequired={{@learningMaterialAccessibilityRequired}}
+      @accessibilityRequirementsLink={{@learningMaterialAccessibilityRequirementsLink}}
       @showMeSH={{@showMeSH}}
     />
     {{#if (or (eq (get @course.competencies "length") 0) @courseCompetencyDetails)}}

--- a/packages/ilios-common/addon/components/detail-learning-materials.gjs
+++ b/packages/ilios-common/addon/components/detail-learning-materials.gjs
@@ -237,6 +237,8 @@ export default class DetailLearningMaterialsComponent extends Component {
             @closeManager={{this.closeLearningmaterialManager}}
             @learningMaterialStatuses={{this.learningMaterialStatuses}}
             @showMeSH={{@showMeSH}}
+            @accessibilityRequired={{@accessibilityRequired}}
+            @accessibilityRequirementsLink={{@accessibilityRequirementsLink}}
           />
         {{else if this.isSorting}}
           <LearningMaterialsSortManager
@@ -253,6 +255,8 @@ export default class DetailLearningMaterialsComponent extends Component {
             @learningMaterialUserRoles={{this.learningMaterialUserRoles}}
             @save={{perform this.saveNewLearningMaterial}}
             @cancel={{this.closeNewLearningmaterial}}
+            @accessibilityRequired={{@accessibilityRequired}}
+            @accessibilityRequirementsLink={{@accessibilityRequirementsLink}}
           />
         {{else if this.materials.length}}
           {{#if (and @editable this.hasMoreThanOneLearningMaterial)}}

--- a/packages/ilios-common/addon/components/learningmaterial-manager.gjs
+++ b/packages/ilios-common/addon/components/learningmaterial-manager.gjs
@@ -66,23 +66,6 @@ export default class LearningmaterialManagerComponent extends Component {
     return new TrackedAsyncData(null);
   }
 
-  @cached
-  get accessibilityRequirementsLinkData() {
-    if (this.schoolData.isResolved) {
-      return new TrackedAsyncData(
-        this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequirementsLink'),
-      );
-    }
-
-    return new TrackedAsyncData(null);
-  }
-
-  get accessibilityRequirementsLink() {
-    return this.accessibilityRequirementsLinkData.isResolved
-      ? this.accessibilityRequirementsLinkData.value
-      : null;
-  }
-
   validations = new YupValidations(this, {
     title: string().required().min(4).max(120),
     startDate: date().notRequired(),
@@ -570,17 +553,16 @@ export default class LearningmaterialManagerComponent extends Component {
               </span>
             </div>
           {{/if}}
-
-          <div class="item">
-            {{#if @editable}}
-              {{#if this.accessibilityRequirementsLinkData.isResolved}}
+          {{#if @accessibilityRequired}}
+            <div class="item">
+              {{#if @editable}}
                 <div class="marked-accessible-toggle">
                   <label>
                     {{t "general.accessibilityAgreement"}}:
                   </label>
-                  {{#if this.accessibilityRequirementsLink}}
+                  {{#if @accessibilityRequirementsLink}}
                     <a
-                      href="{{this.accessibilityRequirementsLink}}"
+                      href="{{@accessibilityRequirementsLink}}"
                       target="_blank"
                       rel="noopener noreferrer"
                       title={{t "general.accessibilityRequirementsLink"}}
@@ -594,23 +576,23 @@ export default class LearningmaterialManagerComponent extends Component {
                     @toggle={{set this "markedAccessible"}}
                   />
                 </div>
+              {{else if this.markedAccessible}}
+                <label>
+                  {{t "general.markedAccessible"}}:
+                </label>
+                <span class="markedaccessible add" data-test-marked-accessible-value>
+                  {{t "general.yes"}}
+                </span>
+              {{else}}
+                <label>
+                  {{t "general.markedAccessible"}}:
+                </label>
+                <span class="markedaccessible remove" data-test-marked-accessible-value>
+                  {{t "general.no"}}
+                </span>
               {{/if}}
-            {{else if this.markedAccessible}}
-              <label>
-                {{t "general.markedAccessible"}}:
-              </label>
-              <span class="markedaccessible add" data-test-marked-accessible-value>
-                {{t "general.yes"}}
-              </span>
-            {{else}}
-              <label>
-                {{t "general.markedAccessible"}}:
-              </label>
-              <span class="markedaccessible remove" data-test-marked-accessible-value>
-                {{t "general.no"}}
-              </span>
-            {{/if}}
-          </div>
+            </div>
+          {{/if}}
 
           <div class="item timed-release">
             <label>

--- a/packages/ilios-common/addon/components/new-learningmaterial.gjs
+++ b/packages/ilios-common/addon/components/new-learningmaterial.gjs
@@ -146,39 +146,6 @@ export default class NewLearningmaterialComponent extends Component {
     return new TrackedAsyncData(null);
   }
 
-  // https://www.ada.gov/law-and-regs/regulations/title-ii-2010-regulations/#-35200-requirements-for-web-and-mobile-accessibility
-  @cached
-  get accessibilityRequiredData() {
-    if (this.schoolData.isResolved) {
-      return new TrackedAsyncData(
-        this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequired'),
-      );
-    }
-
-    return new TrackedAsyncData(null);
-  }
-
-  get accessibilityRequired() {
-    return this.accessibilityRequiredData.isResolved ? this.accessibilityRequiredData.value : false;
-  }
-
-  @cached
-  get accessibilityRequirementsLinkData() {
-    if (this.schoolData.isResolved) {
-      return new TrackedAsyncData(
-        this.schoolData.value?.getConfigValue('learningMaterialAccessibilityRequirementsLink'),
-      );
-    }
-
-    return new TrackedAsyncData(null);
-  }
-
-  get accessibilityRequirementsLink() {
-    return this.accessibilityRequirementsLinkData.isResolved
-      ? this.accessibilityRequirementsLinkData.value
-      : '';
-  }
-
   get uniqueId() {
     return guidFor(this);
   }
@@ -539,7 +506,7 @@ export default class NewLearningmaterialComponent extends Component {
             </span>
           </div>
         {{/unless}}
-        {{#if this.accessibilityRequiredData.isResolved}}
+        {{#if @accessibilityRequired}}
           <div class="item accessibility" data-test-marked-accessible>
             <span>
               <p id="lm-accessibility-permissions-text">
@@ -557,7 +524,7 @@ export default class NewLearningmaterialComponent extends Component {
                 <label for="marked-accessible-{{this.uniqueId}}">
                   {{t "general.accessibilityAgreement"}}
                 </label>
-                {{#if this.accessibilityRequirementsLink}}
+                {{#if @accessibilityRequirementsLink}}
                   <a
                     href="{{this.accessibilityRequirementsLink}}"
                     target="_blank"
@@ -578,7 +545,6 @@ export default class NewLearningmaterialComponent extends Component {
           </div>
         {{/if}}
       {{/if}}
-
       <div class="buttons">
         <button class="done text" type="button" {{on "click" (perform this.prepareSave)}}>
           {{#if this.prepareSave.isRunning}}

--- a/packages/ilios-common/addon/components/print-course-session.gjs
+++ b/packages/ilios-common/addon/components/print-course-session.gjs
@@ -45,49 +45,8 @@ export default class PrintCourseSessionComponent extends Component {
   }
 
   @cached
-  get showAttendanceRequiredData() {
-    return new TrackedAsyncData(
-      this.schoolData.isResolved
-        ? this.schoolData.value?.getConfigValue('showSessionAttendanceRequired')
-        : false,
-    );
-  }
-
-  @cached
   get courseData() {
     return new TrackedAsyncData(this.args.session.course);
-  }
-
-  @cached
-  get schoolData() {
-    return new TrackedAsyncData(this.courseData.isResolved ? this.courseData.value.school : null);
-  }
-
-  @cached
-  get showSupplementalData() {
-    return new TrackedAsyncData(
-      this.schoolData.isResolved
-        ? this.schoolData.value?.getConfigValue('showSessionSupplemental')
-        : false,
-    );
-  }
-
-  @cached
-  get showSpecialAttireRequiredData() {
-    return new TrackedAsyncData(
-      this.schoolData.isResolved
-        ? this.schoolData.value?.getConfigValue('showSessionSpecialAttireRequired')
-        : false,
-    );
-  }
-
-  @cached
-  get showSpecialEquipmentRequiredData() {
-    return new TrackedAsyncData(
-      this.schoolData.isResolved
-        ? this.schoolData.value?.getConfigValue('showSessionSpecialEquipmentRequired')
-        : false,
-    );
   }
 
   get sessionObjectives() {
@@ -112,28 +71,6 @@ export default class PrintCourseSessionComponent extends Component {
 
   get prerequisites() {
     return this.prerequisitesData.isResolved ? this.prerequisitesData.value : null;
-  }
-
-  get showAttendanceRequired() {
-    return this.showAttendanceRequiredData.isResolved
-      ? this.showAttendanceRequiredData.value
-      : false;
-  }
-
-  get showSupplemental() {
-    return this.showSupplementalData.isResolved ? this.showSupplementalData.value : false;
-  }
-
-  get showSpecialAttireRequired() {
-    return this.showSpecialAttireRequiredData.isResolved
-      ? this.showSpecialAttireRequiredData.value
-      : false;
-  }
-
-  get showSpecialEquipmentRequired() {
-    return this.showSpecialEquipmentRequiredData.isResolved
-      ? this.showSpecialEquipmentRequiredData.value
-      : false;
   }
 
   get uniqueId() {
@@ -186,7 +123,7 @@ export default class PrintCourseSessionComponent extends Component {
             </div>
           </div>
           <br />
-          {{#if this.showSupplemental}}
+          {{#if @showSupplemental}}
             <div class="inline-label-data-block">
               <label for="supplemental-curriculum-{{this.uniqueId}}">
                 {{t "general.supplementalCurriculum"}}:
@@ -201,7 +138,7 @@ export default class PrintCourseSessionComponent extends Component {
               </div>
             </div>
           {{/if}}
-          {{#if this.showSpecialAttireRequired}}
+          {{#if @showSpecialAttireRequired}}
             <div class="inline-label-data-block">
               <label for="special-attire-{{this.uniqueId}}">
                 {{t "general.specialAttireRequired"}}:
@@ -216,7 +153,7 @@ export default class PrintCourseSessionComponent extends Component {
               </div>
             </div>
           {{/if}}
-          {{#if this.showSpecialEquipmentRequired}}
+          {{#if @showSpecialEquipmentRequired}}
             <div class="inline-label-data-block">
               <label for="special-equipment-{{this.uniqueId}}">
                 {{t "general.specialEquipmentRequired"}}:
@@ -231,7 +168,7 @@ export default class PrintCourseSessionComponent extends Component {
               </div>
             </div>
           {{/if}}
-          {{#if this.showAttendanceRequired}}
+          {{#if @showAttendanceRequired}}
             <div class="inline-label-data-block">
               <label for="attendance-{{this.uniqueId}}">
                 {{t "general.attendanceRequired"}}:

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -14,6 +14,7 @@ import DetailTermsList from 'ilios-common/components/detail-terms-list';
 import ObjectiveList from 'ilios-common/components/course/objective-list';
 import removeHtmlTags from 'ilios-common/helpers/remove-html-tags';
 import PrintCourseSession from 'ilios-common/components/print-course-session';
+import getSchoolConfigs from 'ilios-common/utils/get-school-config.js';
 
 export default class PrintCourseComponent extends Component {
   @service store;
@@ -114,36 +115,20 @@ export default class PrintCourseComponent extends Component {
 
     return this.sessionsRelationship;
   }
+
   @cached
   get schoolConfigsData() {
-    return new TrackedAsyncData(this.getSchoolConfigs(this.args.course));
-  }
-
-  async getSchoolConfigs(course) {
-    const school = await course.school;
-    return await school.configurations;
-  }
-
-  @cached
-  get schoolConfigs() {
-    const rhett = new Map();
-    if (this.schoolConfigsData.isResolved) {
-      this.schoolConfigsData.value.forEach((config) => {
-        rhett.set(config.name, config.parsedValue);
-      });
-    }
-    return rhett;
-  }
-
-  get showMeSH() {
-    return this.schoolConfigs.has('showMeSH') ? this.schoolConfigs.get('showMeSH') : true;
+    return new TrackedAsyncData(
+      getSchoolConfigs(async (course) => course.school, this.args.course),
+    );
   }
 
   get schoolConfigsLoaded() {
-    return (
-      this.academicYearCrossesCalendarYearBoundariesData.isResolved &&
-      this.schoolConfigsData.isResolved
-    );
+    return this.schoolConfigsData.isResolved;
+  }
+
+  get schoolConfigs() {
+    return this.schoolConfigsLoaded ? this.schoolConfigsData.value : {};
   }
 
   <template>
@@ -274,7 +259,7 @@ export default class PrintCourseComponent extends Component {
                 @course={{@course}}
                 @editable={{false}}
                 @printable={{true}}
-                @showMeSH={{this.showMeSH}}
+                @showMeSH={{this.schoolConfigs.showMeSH}}
               />
             </div>
           {{/if}}
@@ -349,7 +334,7 @@ export default class PrintCourseComponent extends Component {
             </div>
           {{/if}}
         </section>
-        {{#if this.showMeSH}}
+        {{#if this.schoolConfigs.showMeSH}}
           <section class="block" data-test-course-mesh>
             <div class="title">
               {{t "general.mesh"}}
@@ -372,7 +357,7 @@ export default class PrintCourseComponent extends Component {
           <PrintCourseSession
             @session={{session}}
             @editable={{false}}
-            @showMeSH={{this.showMeSH}}
+            @showMeSH={{this.schoolConfigs.showMeSH}}
           />
         {{/each}}
       </section>

--- a/packages/ilios-common/addon/components/print-course.gjs
+++ b/packages/ilios-common/addon/components/print-course.gjs
@@ -358,6 +358,10 @@ export default class PrintCourseComponent extends Component {
             @session={{session}}
             @editable={{false}}
             @showMeSH={{this.schoolConfigs.showMeSH}}
+            @showAttendanceRequired={{this.schoolConfigs.showSessionAttendanceRequired}}
+            @showSupplemental={{this.schoolConfigs.showSessionSupplemental}}
+            @showSpecialAttireRequired={{this.schoolConfigs.showSessionSpecialAttireRequired}}
+            @showSpecialEquipmentRequired={{this.schoolConfigs.showSessionSpecialEquipmentRequired}}
           />
         {{/each}}
       </section>

--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -117,6 +117,8 @@ export default class SessionDetailsComponent extends Component {
           @isCourse={{false}}
           @editable={{@editable}}
           @showMeSH={{this.schoolConfigs.showMeSH}}
+          @accessibilityRequired={{this.schoolConfigs.learningMaterialAccessibilityRequired}}
+          @accessibilityRequirementsLink={{this.schoolConfigs.learningMaterialAccessibilityRequirementsLink}}
         />
         {{#if (or (eq @session.terms.length 0) @sessionTaxonomyDetails)}}
           <DetailTaxonomies

--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -20,7 +20,7 @@ import CollapsedTaxonomies from 'ilios-common/components/collapsed-taxonomies';
 import DetailMesh from 'ilios-common/components/detail-mesh';
 import SessionOfferings from 'ilios-common/components/session-offerings';
 import { pageTitle } from 'ember-page-title';
-
+import getSchoolConfigs from 'ilios-common/utils/get-school-config.js';
 export default class SessionDetailsComponent extends Component {
   @cached
   get courseData() {
@@ -42,32 +42,20 @@ export default class SessionDetailsComponent extends Component {
 
   @cached
   get schoolConfigsData() {
-    return new TrackedAsyncData(this.getSchoolConfigs(this.args.session));
-  }
-
-  async getSchoolConfigs(session) {
-    const course = await session.course;
-    const school = await course.school;
-    return await school.configurations;
-  }
-
-  @cached
-  get schoolConfigs() {
-    const rhett = new Map();
-    if (this.schoolConfigsData.isResolved) {
-      this.schoolConfigsData.value.forEach((config) => {
-        rhett.set(config.name, config.parsedValue);
-      });
-    }
-    return rhett;
+    return new TrackedAsyncData(
+      getSchoolConfigs(async (session) => {
+        const course = await session.course;
+        return course.school;
+      }, this.args.session),
+    );
   }
 
   get schoolConfigsLoaded() {
     return this.schoolConfigsData.isResolved;
   }
 
-  get showMeSH() {
-    return this.schoolConfigs.has('showMeSH') ? this.schoolConfigs.get('showMeSH') : true;
+  get schoolConfigs() {
+    return this.schoolConfigsLoaded ? this.schoolConfigsData.value : {};
   }
 
   <template>
@@ -114,21 +102,21 @@ export default class SessionDetailsComponent extends Component {
             @editable={{@editable}}
             @collapse={{fn @setSessionObjectiveDetails false}}
             @expand={{fn @setSessionObjectiveDetails true}}
-            @showMeSH={{this.showMeSH}}
+            @showMeSH={{this.schoolConfigs.showMeSH}}
           />
         {{else}}
           <CollapsedObjectives
             @session={{@session}}
             @editable={{@editable}}
             @expand={{fn @setSessionObjectiveDetails true}}
-            @showMeSH={{this.showMeSH}}
+            @showMeSH={{this.schoolConfigs.showMeSH}}
           />
         {{/if}}
         <DetailLearningMaterials
           @subject={{@session}}
           @isCourse={{false}}
           @editable={{@editable}}
-          @showMeSH={{this.showMeSH}}
+          @showMeSH={{this.schoolConfigs.showMeSH}}
         />
         {{#if (or (eq @session.terms.length 0) @sessionTaxonomyDetails)}}
           <DetailTaxonomies
@@ -143,7 +131,7 @@ export default class SessionDetailsComponent extends Component {
             @expand={{fn @setSessionTaxonomyDetails true}}
           />
         {{/if}}
-        {{#if this.showMeSH}}
+        {{#if this.schoolConfigs.showMeSH}}
           <DetailMesh @subject={{@session}} @isSession={{true}} @editable={{@editable}} />
         {{/if}}
         <SessionOfferings

--- a/packages/ilios-common/addon/components/session-details.gjs
+++ b/packages/ilios-common/addon/components/session-details.gjs
@@ -68,7 +68,14 @@ export default class SessionDetailsComponent extends Component {
       </div>
 
       <section class="session-details" data-test-session-details>
-        <Overview @session={{@session}} @editable={{@editable}} />
+        <Overview
+          @session={{@session}}
+          @editable={{@editable}}
+          @showAttendanceRequired={{this.schoolConfigs.showSessionAttendanceRequired}}
+          @showSupplemental={{this.schoolConfigs.showSessionSupplemental}}
+          @showSpecialAttireRequired={{this.schoolConfigs.showSessionSpecialAttireRequired}}
+          @showSpecialEquipmentRequired={{this.schoolConfigs.showSessionSpecialEquipmentRequired}}
+        />
         {{#if @sessionLeadershipDetails}}
           <LeadershipExpanded
             @model={{@session}}

--- a/packages/ilios-common/addon/components/session/overview.gjs
+++ b/packages/ilios-common/addon/components/session/overview.gjs
@@ -95,70 +95,12 @@ export default class SessionOverviewComponent extends Component {
   }
 
   @cached
-  get showAttendanceRequiredData() {
-    return new TrackedAsyncData(
-      this.schoolData.isResolved
-        ? this.schoolData.value?.getConfigValue('showSessionAttendanceRequired')
-        : false,
-    );
-  }
-
-  @cached
-  get showSupplementalData() {
-    return new TrackedAsyncData(
-      this.schoolData.isResolved
-        ? this.schoolData.value?.getConfigValue('showSessionSupplemental')
-        : false,
-    );
-  }
-
-  @cached
-  get showSpecialAttireRequiredData() {
-    return new TrackedAsyncData(
-      this.schoolData.isResolved
-        ? this.schoolData.value?.getConfigValue('showSessionSpecialAttireRequired')
-        : false,
-    );
-  }
-
-  @cached
-  get showSpecialEquipmentRequiredData() {
-    return new TrackedAsyncData(
-      this.schoolData.isResolved
-        ? this.schoolData.value?.getConfigValue('showSessionSpecialEquipmentRequired')
-        : false,
-    );
-  }
-
-  get showAttendanceRequired() {
-    return this.showAttendanceRequiredData.isResolved
-      ? this.showAttendanceRequiredData.value
-      : false;
-  }
-
-  get showSupplemental() {
-    return this.showSupplementalData.isResolved ? this.showSupplementalData.value : false;
-  }
-
-  get showSpecialAttireRequired() {
-    return this.showSpecialAttireRequiredData.isResolved
-      ? this.showSpecialAttireRequiredData.value
-      : false;
-  }
-
-  get showSpecialEquipmentRequired() {
-    return this.showSpecialEquipmentRequiredData.isResolved
-      ? this.showSpecialEquipmentRequiredData.value
-      : false;
-  }
-
-  @cached
   get showAttributes() {
     return (
-      this.showAttendanceRequired ||
-      this.showSupplemental ||
-      this.showSpecialAttireRequired ||
-      this.showSpecialEquipmentRequired
+      this.args.showAttendanceRequired ||
+      this.args.showSupplemental ||
+      this.args.showSpecialAttireRequired ||
+      this.args.showSpecialEquipmentRequired
     );
   }
 
@@ -227,10 +169,6 @@ export default class SessionOverviewComponent extends Component {
     return (
       this.sessionTypesData.isResolved &&
       this.sessionTypeData.isResolved &&
-      this.showAttendanceRequiredData.isResolved &&
-      this.showSupplementalData.isResolved &&
-      this.showSpecialAttireRequiredData.isResolved &&
-      this.showSpecialEquipmentRequiredData.isResolved &&
       this.showCopyData.isResolved
     );
   }
@@ -449,7 +387,7 @@ export default class SessionOverviewComponent extends Component {
                 data-test-attributes
               >
                 <legend>{{t "general.sessionAttributes"}}</legend>
-                {{#if this.showSupplemental}}
+                {{#if @showSupplemental}}
                   <label data-test-supplemental>
                     <input
                       type="checkbox"
@@ -460,7 +398,7 @@ export default class SessionOverviewComponent extends Component {
                     {{t "general.supplementalCurriculum"}}
                   </label>
                 {{/if}}
-                {{#if this.showSpecialAttireRequired}}
+                {{#if @showSpecialAttireRequired}}
                   <label data-test-special-attire>
                     <input
                       type="checkbox"
@@ -471,7 +409,7 @@ export default class SessionOverviewComponent extends Component {
                     {{t "general.specialAttireRequired"}}
                   </label>
                 {{/if}}
-                {{#if this.showSpecialEquipmentRequired}}
+                {{#if @showSpecialEquipmentRequired}}
                   <label data-test-special-equipment>
                     <input
                       type="checkbox"
@@ -482,7 +420,7 @@ export default class SessionOverviewComponent extends Component {
                     {{t "general.specialEquipmentRequired"}}
                   </label>
                 {{/if}}
-                {{#if this.showAttendanceRequired}}
+                {{#if @showAttendanceRequired}}
                   <label data-test-attendance-required>
                     <input
                       type="checkbox"

--- a/packages/ilios-common/addon/utils/get-school-config.js
+++ b/packages/ilios-common/addon/utils/get-school-config.js
@@ -1,0 +1,53 @@
+/**
+ * A list of school config items that we will be backfilled as TRUE if missing.
+ * @type {Set<string>}
+ */
+const treatMissingValueAsTrue = new Set(['showMeSH']);
+
+/**
+ * An async callback function that returns a Promise resolving to the school
+ * that owns the given model object.
+ * @callback schoolLoaderCallback The callback function.
+ * @param {Object} o The data model object.
+ * @return {Promise<Object[]>} The promise resolving to a school model object.
+ */
+/**
+ * Retrieves school configuration settings for the school associated with a given data model.
+ * The model/school association will be resolved through a given callback function.
+ *
+ * @param {schoolLoaderCallback} cb A callback function.
+ * @param {Object} o A data model object.
+ * @returns {Promise<Object>} A plain object holding key/value pairs of school configuration settings.
+ */
+export default async function getSchoolConfigs(cb, o) {
+  // some light type checking
+  if (typeof cb !== 'function') {
+    throw new Error('Given callback is not a function.');
+  }
+
+  // invoke the callback, get the school.
+  const school = await cb(o);
+  if (!school) {
+    throw new Error('Unable to load school from the given object.');
+  }
+
+  // now get the school config.
+  // todo: Consider adding caching of config values by school here. [ST 2026/09/10]
+  const configs = await school.configurations;
+
+  // map config values by their names.
+  const rhett = new Map();
+  configs.forEach((config) => {
+    rhett.set(config.name, config.parsedValue);
+  });
+
+  // backfill missing config data and set them to true.
+  treatMissingValueAsTrue.forEach((key) => {
+    if (!rhett.has(key)) {
+      rhett.set(key, true);
+    }
+  });
+
+  // convert the map back to an object so we can use it in templates.
+  return Object.fromEntries(rhett);
+}


### PR DESCRIPTION
a (partial) counter proposal to https://github.com/ilios/frontend/pull/9519

updating school config values is out of scope, this change-set aims to deal with streamlining the lookup of these values only.
a utility function will suffice to get that job done. invoked at top level components only, these values can be passed down into sub-components as applicable. _read once, pass data down._
no need to inject a service all over the place. this keeps it simple and traceable.

- [x] new utility method that does the lookup and data processing
- [x] MeSH controls visibility
- [x] LM attrs
- [x] Special ession attrs
- [ ] add/update test coverage